### PR TITLE
Dataproc Worker concurrency bug

### DIFF
--- a/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changelog.xml
+++ b/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changelog.xml
@@ -13,4 +13,5 @@
     <include file="changesets/20171101_cluster-serviceAccountKeyId.xml" relativeToChangelogFile="true" />
     <include file="changesets/20171129_cluster-creator.xml" relativeToChangelogFile="true" />
     <include file="changesets/20171205_cluster-split-up-service-accounts.xml" relativeToChangelogFile="true" />
+    <include file="changesets/20171218_cluster_indexes_serviceAccount_and_status.xml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/20171218_cluster_indexes_serviceAccount_and_status.xml
+++ b/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/20171218_cluster_indexes_serviceAccount_and_status.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog logicalFilePath="leonardo" xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+    <changeSet logicalFilePath="leonardo" author="rtitle" id="idx_cluster_status">
+        <createIndex indexName="IDX_CLUSTER_STATUS"
+                     tableName="CLUSTER"
+                     unique="false">
+            <column name="status" type="varchar(254)"/>
+        </createIndex>
+    </changeSet>
+
+    <changeSet logicalFilePath="leonardo" author="rtitle" id="idx_cluster_clusterServiceAccount">
+        <createIndex indexName="IDX_CLUSTER_CLUSTER_SERVICE_ACCOUNT"
+                     tableName="CLUSTER"
+                     unique="false">
+            <column name="clusterServiceAccount" type="varchar(254)"/>
+        </createIndex>
+    </changeSet>
+
+    <changeSet logicalFilePath="leonardo" author="rtitle" id="idx_cluster_notebookServiceAccount">
+        <createIndex indexName="IDX_CLUSTER_NOTEBOOK_SERVICE_ACCOUNT"
+                     tableName="CLUSTER"
+                     unique="false">
+            <column name="notebookServiceAccount" type="varchar(254)"/>
+        </createIndex>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponent.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponent.scala
@@ -128,6 +128,12 @@ trait ClusterComponent extends LeoComponent {
       }
     }
 
+    def listByClusterServiceAccount(clusterServiceAccount: WorkbenchEmail) = {
+      clusterQueryWithLabels.filter { _._1.clusterServiceAccount === Option(clusterServiceAccount.value) }.result map { recs =>
+        unmarshalClustersWithLabels(recs)
+      }
+    }
+
     def findByName(project: GoogleProject, name: ClusterName) = {
       clusterQueryWithLabels.filter { _._1.googleProject === project.value }.filter { _._1.clusterName === name.string }
     }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponent.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponent.scala
@@ -128,10 +128,12 @@ trait ClusterComponent extends LeoComponent {
       }
     }
 
-    def listByClusterServiceAccount(clusterServiceAccount: WorkbenchEmail) = {
-      clusterQueryWithLabels.filter { _._1.clusterServiceAccount === Option(clusterServiceAccount.value) }.result map { recs =>
-        unmarshalClustersWithLabels(recs)
-      }
+    def countByClusterServiceAccountAndStatus(clusterServiceAccount: WorkbenchEmail, status: ClusterStatus) = {
+      clusterQueryWithLabels
+        .filter { _._1.clusterServiceAccount === Option(clusterServiceAccount.value) }
+        .filter { _._1.status === status.toString }
+        .length
+        .result
     }
 
     def findByName(project: GoogleProject, name: ClusterName) = {
@@ -334,14 +336,6 @@ trait ClusterComponent extends LeoComponent {
       else
         None
     }
-    private def updateClusterName(googleId: UUID, newName: String): DBIO[Int] = {
-      clusterQuery.filter { _.googleId === googleId }.map(_.clusterName).update(newName)
-    }
-
-    private def appendRandomSuffix(str: String, n: Int = 6): String = {
-      s"${str}_${Random.alphanumeric.take(n).mkString}"
-    }
-
   }
 
   // select * from cluster c left join label l on c.id = l.clusterId

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorActor.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorActor.scala
@@ -241,8 +241,8 @@ class ClusterMonitorActor(val cluster: Cluster,
       case None => Future.successful(())
       case Some(serviceAccountEmail) =>
         // Only remove the Dataproc Worker role if there are no other clusters with the same owner
-        // in the DB with CREATING status. This prevents situations where pet SA roles are yanked from
-        // underneath creating clusters.
+        // in the DB with CREATING status. This prevents situations where we prematurely yank pet SA
+        // roles when the same user is creating multiple clusters.
         dbRef.inTransaction { dataAccess =>
           dataAccess.clusterQuery.listByClusterServiceAccount(serviceAccountEmail)
         } flatMap { clusters =>

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorActor.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorActor.scala
@@ -16,6 +16,7 @@ import org.broadinstitute.dsde.workbench.leonardo.model._
 import org.broadinstitute.dsde.workbench.leonardo.monitor.ClusterMonitorActor._
 import org.broadinstitute.dsde.workbench.leonardo.monitor.ClusterMonitorSupervisor.ClusterDeleted
 import org.broadinstitute.dsde.workbench.util.addJitter
+
 import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.util.Failure
@@ -123,10 +124,6 @@ class ClusterMonitorActor(val cluster: Cluster,
     for {
       // Delete the init bucket
       _ <- deleteInitBucket
-      // Remove the Dataproc Worker IAM role for the cluster service account.
-      // Only happens if the cluster was created with a service account other
-      // than the compute engine default service account.
-      _ <- removeIamRolesForUser
       // Remove credentials from instance metadata.
       // Only happens if an notebook service account was used.
       _ <- removeCredentialsFromMetadata
@@ -139,6 +136,10 @@ class ClusterMonitorActor(val cluster: Cluster,
       _ <- dbRef.inTransaction { dataAccess =>
         dataAccess.clusterQuery.setToRunning(cluster.googleId, publicIp)
       }
+      // Remove the Dataproc Worker IAM role for the cluster service account.
+      // Only happens if the cluster was created with a service account other
+      // than the compute engine default service account.
+      _ <- removeIamRolesForUser
     } yield {
       // Finally pipe a shutdown message to this actor
       logger.info(s"Cluster ${cluster.googleProject}/${cluster.clusterName} is ready for use!")
@@ -157,9 +158,6 @@ class ClusterMonitorActor(val cluster: Cluster,
     val deleteFuture = Future.sequence(Seq(
       // Delete the cluster in Google
       gdDAO.deleteCluster(cluster.googleProject, cluster.clusterName),
-      // Remove the Dataproc Worker IAM role for the pet service account
-      // Only do this if the cluster was created with the pet service account.
-      removeIamRolesForUser,
       // Remove the service account key in Google, if present.
       // Only happens if the cluster was NOT created with the pet service account.
       removeServiceAccountKey
@@ -179,11 +177,12 @@ class ClusterMonitorActor(val cluster: Cluster,
       } else {
         // Update the database record to Error and shutdown this actor.
         logger.warn(s"Cluster ${cluster.projectNameString} is in an error state with $errorDetails'. Unable to recreate cluster.")
-        dbRef.inTransaction { dataAccess =>
-          dataAccess.clusterQuery.updateClusterStatus(cluster.googleId, ClusterStatus.Error)
-        } map { _ =>
-          ShutdownActor()
-        }
+        for {
+          _ <- dbRef.inTransaction { _.clusterQuery.updateClusterStatus(cluster.googleId, ClusterStatus.Error) }
+          // Remove the Dataproc Worker IAM role for the pet service account
+          // Only happens if the cluster was created with the pet service account.
+          _ <-  removeIamRolesForUser
+        } yield ShutdownActor()
       }
     }
   }
@@ -236,12 +235,23 @@ class ClusterMonitorActor(val cluster: Cluster,
     }
   }
 
-  private def removeIamRolesForUser(): Future[Unit] = {
+  private def removeIamRolesForUser: Future[Unit] = {
     // Remove the Dataproc Worker IAM role for the cluster service account
     cluster.serviceAccountInfo.clusterServiceAccount match {
       case None => Future.successful(())
       case Some(serviceAccountEmail) =>
-        googleIamDAO.removeIamRolesForUser(cluster.googleProject, serviceAccountEmail, Set("roles/dataproc.worker"))
+        // Only remove the Dataproc Worker role if there are no other clusters with the same owner
+        // in the DB with CREATING status. This prevents situations where pet SA roles are yanked from
+        // underneath creating clusters.
+        dbRef.inTransaction { dataAccess =>
+          dataAccess.clusterQuery.listByClusterServiceAccount(serviceAccountEmail)
+        } flatMap { clusters =>
+          if (clusters.map(_.status).toSet.contains(ClusterStatus.Creating)) {
+            Future.successful(())
+          } else {
+            googleIamDAO.removeIamRolesForUser(cluster.googleProject, serviceAccountEmail, Set("roles/dataproc.worker"))
+          }
+        }
     }
   }
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorActor.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorActor.scala
@@ -244,9 +244,9 @@ class ClusterMonitorActor(val cluster: Cluster,
         // in the DB with CREATING status. This prevents situations where we prematurely yank pet SA
         // roles when the same user is creating multiple clusters.
         dbRef.inTransaction { dataAccess =>
-          dataAccess.clusterQuery.listByClusterServiceAccount(serviceAccountEmail)
-        } flatMap { clusters =>
-          if (clusters.map(_.status).toSet.contains(ClusterStatus.Creating)) {
+          dataAccess.clusterQuery.countByClusterServiceAccountAndStatus(serviceAccountEmail, ClusterStatus.Creating)
+        } flatMap { count =>
+          if (count > 0) {
             Future.successful(())
           } else {
             googleIamDAO.removeIamRolesForUser(cluster.googleProject, serviceAccountEmail, Set("roles/dataproc.worker"))

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorSupervisor.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorSupervisor.scala
@@ -10,7 +10,6 @@ import org.broadinstitute.dsde.workbench.leonardo.db.DbReference
 import org.broadinstitute.dsde.workbench.leonardo.model.{Cluster, ClusterRequest}
 import org.broadinstitute.dsde.workbench.leonardo.monitor.ClusterMonitorSupervisor._
 import org.broadinstitute.dsde.workbench.leonardo.service.LeonardoService
-import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
 
 object ClusterMonitorSupervisor {
   def props(monitorConfig: MonitorConfig, dataprocConfig: DataprocConfig, gdDAO: DataprocDAO, googleIamDAO: GoogleIamDAO, dbRef: DbReference, clusterDnsCache: ActorRef): Props =

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponentSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponentSpec.scala
@@ -80,7 +80,8 @@ class ClusterComponentSpec extends TestComponent with FlatSpecLike with CommonTe
     dbFutureValue { _.clusterQuery.getServiceAccountKeyId(c1.googleProject, c1.clusterName) } shouldEqual None
     dbFutureValue { _.clusterQuery.getServiceAccountKeyId(c2.googleProject, c2.clusterName) } shouldEqual Some(serviceAccountKey.id)
     dbFutureValue { _.clusterQuery.getServiceAccountKeyId(c3.googleProject, c3.clusterName) } shouldEqual Some(serviceAccountKey.id)
-    dbFutureValue { _.clusterQuery.listByClusterServiceAccount(serviceAccountEmail) }.toSet shouldEqual Set(c1, c2)
+    dbFutureValue { _.clusterQuery.countByClusterServiceAccountAndStatus(serviceAccountEmail, ClusterStatus.Creating) } shouldEqual 1
+    dbFutureValue { _.clusterQuery.countByClusterServiceAccountAndStatus(serviceAccountEmail, ClusterStatus.Running) } shouldEqual 0
 
     // (project, name) unique key test
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponentSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponentSpec.scala
@@ -19,7 +19,7 @@ class ClusterComponentSpec extends TestComponent with FlatSpecLike with CommonTe
       clusterName = name1,
       googleId = UUID.randomUUID(),
       googleProject = project,
-      serviceAccountInfo = ServiceAccountInfo(None, Some(serviceAccountEmail)),
+      serviceAccountInfo = ServiceAccountInfo(Some(serviceAccountEmail), Some(serviceAccountEmail)),
       googleBucket = GcsBucketName("bucket1"),
       machineConfig = MachineConfig(Some(0),Some(""), Some(500)),
       clusterUrl = Cluster.getClusterUrl(project, name1),
@@ -36,7 +36,7 @@ class ClusterComponentSpec extends TestComponent with FlatSpecLike with CommonTe
       clusterName = name2,
       googleId = UUID.randomUUID(),
       googleProject = project,
-      serviceAccountInfo = ServiceAccountInfo(None, Some(serviceAccountEmail)),
+      serviceAccountInfo = ServiceAccountInfo(Some(serviceAccountEmail), Some(serviceAccountEmail)),
       googleBucket = GcsBucketName("bucket2"),
       machineConfig = MachineConfig(Some(0),Some(""), Some(500)),
       clusterUrl = Cluster.getClusterUrl(project, name2),
@@ -80,6 +80,7 @@ class ClusterComponentSpec extends TestComponent with FlatSpecLike with CommonTe
     dbFutureValue { _.clusterQuery.getServiceAccountKeyId(c1.googleProject, c1.clusterName) } shouldEqual None
     dbFutureValue { _.clusterQuery.getServiceAccountKeyId(c2.googleProject, c2.clusterName) } shouldEqual Some(serviceAccountKey.id)
     dbFutureValue { _.clusterQuery.getServiceAccountKeyId(c3.googleProject, c3.clusterName) } shouldEqual Some(serviceAccountKey.id)
+    dbFutureValue { _.clusterQuery.listByClusterServiceAccount(serviceAccountEmail) }.toSet shouldEqual Set(c1, c2)
 
     // (project, name) unique key test
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorSpec.scala
@@ -404,7 +404,7 @@ class ClusterMonitorSpec extends TestKit(ActorSystem("leonardotest")) with FlatS
     verify(gdDAO).deleteBucket(mockitoEq(dataprocConfig.leoGoogleProject), vcEq(newClusterBucket.get.bucketName))(any[ExecutionContext])
     // should add/remove the dataproc.worker role 2 times
     verify(iamDAO, if (clusterServiceAccount(creatingCluster.googleProject).isDefined) times(1) else never()).addIamRolesForUser(any[GoogleProject], any[WorkbenchEmail], mockitoEq(Set("roles/dataproc.worker")))
-    verify(iamDAO, if (clusterServiceAccount(creatingCluster.googleProject).isDefined) times(2) else never()).removeIamRolesForUser(any[GoogleProject], any[WorkbenchEmail], mockitoEq(Set("roles/dataproc.worker")))
+    verify(iamDAO, if (clusterServiceAccount(creatingCluster.googleProject).isDefined) times(1) else never()).removeIamRolesForUser(any[GoogleProject], any[WorkbenchEmail], mockitoEq(Set("roles/dataproc.worker")))
     verify(iamDAO, if (notebookServiceAccount(creatingCluster.googleProject).isDefined) times(1) else never()).removeServiceAccountKey(any[GoogleProject], any[WorkbenchEmail], any[ServiceAccountKeyId])
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorSpec.scala
@@ -402,7 +402,7 @@ class ClusterMonitorSpec extends TestKit(ActorSystem("leonardotest")) with FlatS
     newCluster.flatMap(_.hostIp) shouldBe Some(IP("1.2.3.4"))
 
     verify(gdDAO).deleteBucket(mockitoEq(dataprocConfig.leoGoogleProject), vcEq(newClusterBucket.get.bucketName))(any[ExecutionContext])
-    // should add/remove the dataproc.worker role 2 times
+    // should only add/remove the dataproc.worker role 1 time
     verify(iamDAO, if (clusterServiceAccount(creatingCluster.googleProject).isDefined) times(1) else never()).addIamRolesForUser(any[GoogleProject], any[WorkbenchEmail], mockitoEq(Set("roles/dataproc.worker")))
     verify(iamDAO, if (clusterServiceAccount(creatingCluster.googleProject).isDefined) times(1) else never()).removeIamRolesForUser(any[GoogleProject], any[WorkbenchEmail], mockitoEq(Set("roles/dataproc.worker")))
     verify(iamDAO, if (notebookServiceAccount(creatingCluster.googleProject).isDefined) times(1) else never()).removeServiceAccountKey(any[GoogleProject], any[WorkbenchEmail], any[ServiceAccountKeyId])

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorSpec.scala
@@ -436,4 +436,74 @@ class ClusterMonitorSpec extends TestKit(ActorSystem("leonardotest")) with FlatS
     verify(iamDAO, never()).removeIamRolesForUser(any[GoogleProject], any[WorkbenchEmail], mockitoEq(Set("roles/dataproc.worker")))
     verify(iamDAO, never()).removeServiceAccountKey(any[GoogleProject], any[WorkbenchEmail], any[ServiceAccountKeyId])
   }
+
+  it should "create two clusters for the same user" in isolatedDbTest {
+    dbFutureValue { _.clusterQuery.save(creatingCluster, gcsPath("gs://bucket"), Some(serviceAccountKey.id)) } shouldEqual creatingCluster
+    val creatingCluster2 = creatingCluster.copy(
+      clusterName = creatingCluster.clusterName + "_2",
+      googleId = UUID.randomUUID(),
+      hostIp = Option(IP("5.6.7.8"))
+    )
+    dbFutureValue { _.clusterQuery.save(creatingCluster2, gcsPath("gs://bucket"), Some(serviceAccountKey.id)) } shouldEqual creatingCluster2
+
+    val gdDAO = mock[DataprocDAO]
+    when {
+      gdDAO.getClusterStatus(mockitoEq(creatingCluster.googleProject), vcEq(creatingCluster.clusterName))(any[ExecutionContext])
+    } thenReturn Future.successful(ClusterStatus.Running)
+    when {
+      gdDAO.getClusterStatus(mockitoEq(creatingCluster2.googleProject), vcEq(creatingCluster2.clusterName))(any[ExecutionContext])
+    } thenReturn Future.successful(ClusterStatus.Running)
+
+    when {
+      gdDAO.getClusterMasterInstanceIp(mockitoEq(creatingCluster.googleProject), vcEq(creatingCluster.clusterName))(any[ExecutionContext])
+    } thenReturn Future.successful(Some(IP("1.2.3.4")))
+    when {
+      gdDAO.getClusterMasterInstanceIp(mockitoEq(creatingCluster2.googleProject), vcEq(creatingCluster2.clusterName))(any[ExecutionContext])
+    } thenReturn Future.successful(Some(IP("5.6.7.8")))
+
+    when {
+      gdDAO.deleteBucket(mockitoEq(dataprocConfig.leoGoogleProject), vcAny(GcsBucketName))(any[ExecutionContext])
+    } thenReturn Future.successful(())
+
+    when {
+      gdDAO.setStagingBucketOwnership(mockitoEq(creatingCluster))
+    } thenReturn Future.successful(())
+    when {
+      gdDAO.setStagingBucketOwnership(mockitoEq(creatingCluster2))
+    } thenReturn Future.successful(())
+
+    val iamDAO = mock[GoogleIamDAO]
+    when {
+      iamDAO.removeIamRolesForUser(any[GoogleProject], any[WorkbenchEmail], mockitoEq(Set("roles/dataproc.worker")))
+    } thenReturn Future.successful(())
+
+    // Create the first cluster
+    val supervisor = createClusterSupervisor(gdDAO, iamDAO)
+    supervisor ! ClusterCreated(creatingCluster)
+    expectMsgClass(1 second, classOf[Terminated])
+
+    val updatedCluster = dbFutureValue { _.clusterQuery.getActiveClusterByName(creatingCluster.googleProject, creatingCluster.clusterName) }
+    updatedCluster shouldBe 'defined
+    updatedCluster.map(_.status) shouldBe Some(ClusterStatus.Running)
+    updatedCluster.flatMap(_.hostIp) shouldBe Some(IP("1.2.3.4"))
+
+    verify(gdDAO, times(1)).deleteBucket(mockitoEq(dataprocConfig.leoGoogleProject), vcAny(GcsBucketName))(any[ExecutionContext])
+    // removeIamRolesForUser should not have been called because there is still a creating cluster in the DB
+    verify(iamDAO, never()).removeIamRolesForUser(any[GoogleProject], any[WorkbenchEmail], mockitoEq(Set("roles/dataproc.worker")))
+    verify(iamDAO, never()).removeServiceAccountKey(any[GoogleProject], any[WorkbenchEmail], any[ServiceAccountKeyId])
+
+    // Create the second cluster
+    supervisor ! ClusterCreated(creatingCluster2)
+    expectMsgClass(1 second, classOf[Terminated])
+
+    val updatedCluster2 = dbFutureValue { _.clusterQuery.getActiveClusterByName(creatingCluster2.googleProject, creatingCluster2.clusterName) }
+    updatedCluster2 shouldBe 'defined
+    updatedCluster2.map(_.status) shouldBe Some(ClusterStatus.Running)
+    updatedCluster2.flatMap(_.hostIp) shouldBe Some(IP("5.6.7.8"))
+
+    verify(gdDAO, times(2)).deleteBucket(mockitoEq(dataprocConfig.leoGoogleProject), vcAny(GcsBucketName))(any[ExecutionContext])
+    // removeIamRolesForUser should have been called once now
+    verify(iamDAO, if (clusterServiceAccount(creatingCluster.googleProject).isDefined) times(1) else never()).removeIamRolesForUser(any[GoogleProject], any[WorkbenchEmail], mockitoEq(Set("roles/dataproc.worker")))
+    verify(iamDAO, never()).removeServiceAccountKey(any[GoogleProject], any[WorkbenchEmail], any[ServiceAccountKeyId])
+  }
 }


### PR DESCRIPTION
Fixes a concurrency bug, helpfully exposed by Leo-swat.

Currently we add the Dataproc Worker IAM role to the pet SA on cluster creation, and remove it when the cluster reaches a terminal state (either Running or Error). However if the user creates 2 clusters at the same time we can reach a situation where the role is removed when the _first_ cluster finishes, leaving cluster 2 in a bad state. (It also seems to leave the pet's IAM roles in a bad state in general, preventing future cluster creation -- not exactly sure why).

The fix is to remove the IAM role only if there are no other clusters for that user with CREATING status. That way the role is only removed after the _last_ cluster is created. I verified with unit tests and watching the IAM console during a swat run (passing swat link: https://fc-jenkins.dsp-techops.broadinstitute.org/job/swatomation-pipeline/497/display/redirect).

Implementation note: I did this in `ClusterMonitorActor` which I think is safe because we're doing it _after_ the DB is updated with cluster status. Effectively we're synchronizing on cluster state in the DB. I thought about doing it in the supervisor but it didn't seem necessary.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
