### PR TITLE
s/FCtoken/LeoToken

### DIFF
--- a/automation/src/test/resources/dummy-notebook-client.html
+++ b/automation/src/test/resources/dummy-notebook-client.html
@@ -44,8 +44,6 @@
                         // postMessage handshake with the notebook extension
                         window.addEventListener("message", function(e) {
                             console.info("Received message " + e.data.type);
-                            if (e.source !== notebook)
-                                return;
                             if (e.origin !== leoBaseUrl)
                                 return;
                             if (e.data.type !== 'bootstrap-auth.request')

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/Leonardo.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/Leonardo.scala
@@ -137,14 +137,14 @@ object Leonardo extends WorkbenchClient with LazyLogging {
     def localize(googleProject: GoogleProject, clusterName: ClusterName, locMap: Map[String, String])(implicit token: AuthToken): String = {
       val path = localizePath(googleProject, clusterName)
       logger.info(s"Localize notebook files: POST /$path")
-      val cookie = Cookie(HttpCookiePair("FCtoken", token.value))
+      val cookie = Cookie(HttpCookiePair("LeoToken", token.value))
       postRequest(url + path, locMap, httpHeaders = List(cookie))
     }
 
     def getContentItem(googleProject: GoogleProject, clusterName: ClusterName, contentPath: String, includeContent: Boolean = true)(implicit token: AuthToken): ContentItem = {
       val path = contentsPath(googleProject, clusterName, contentPath) + (if(includeContent) "?content=1" else "")
       logger.info(s"Get notebook contents: GET /$path")
-      val cookie = Cookie(HttpCookiePair("FCtoken", token.value))
+      val cookie = Cookie(HttpCookiePair("LeoToken", token.value))
       handleContentItemResponse(parseResponse(getRequest(url + path, httpHeaders = List(cookie))))
     }
   }

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/page/CookieAuthedPage.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/page/CookieAuthedPage.scala
@@ -11,7 +11,7 @@ trait CookieAuthedPage[P <: Page] extends Page with PageUtil[P] with WebBrowserU
   // always use open() to access a CookieAuthedPage - `go to` will not set the cookie
   override def open(implicit webDriver: WebDriver): P = {
     go to this
-    addCookie("FCtoken", authToken.value)
+    addCookie("LeoToken", authToken.value)
     super.open
   }
 }

--- a/src/main/resources/jupyter/google_sign_in.js
+++ b/src/main/resources/jupyter/google_sign_in.js
@@ -66,7 +66,7 @@ function startTimer() {
 function set_cookie(token, expires_in) {
     var expiresDate = new Date();
     expiresDate.setSeconds(expiresDate.getSeconds() + expires_in);
-    document.cookie = "FCtoken="+token+";secure;expires="+expiresDate.toUTCString()+";path=/";
+    document.cookie = "LeoToken="+token+";secure;expires="+expiresDate.toUTCString()+";path=/";
 }
 
 function init() {

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/ProxyRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/ProxyRoutes.scala
@@ -17,7 +17,7 @@ trait ProxyRoutes extends UserInfoDirectives with CorsSupport { self: LazyLoggin
   val proxyService: ProxyService
   implicit val executionContext: ExecutionContext
 
-  protected val tokenCookieName = "FCtoken"
+  protected val tokenCookieName = "LeoToken"
 
   protected val proxyRoutes: Route =
     pathPrefix("notebooks") {

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/ProxyRoutesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/ProxyRoutesSpec.scala
@@ -27,9 +27,9 @@ class ProxyRoutesSpec extends FlatSpec with Matchers with BeforeAndAfterAll with
 
   val clusterName = "test"
   val googleProject = "dsp-leo-test"
-  val tokenCookie = HttpCookiePair("FCtoken", "me")
-  val unauthorizedTokenCookie = HttpCookiePair("FCtoken", "unauthorized")
-  val expiredTokenCookie = HttpCookiePair("FCtoken", "expired")
+  val tokenCookie = HttpCookiePair("LeoToken", "me")
+  val unauthorizedTokenCookie = HttpCookiePair("LeoToken", "unauthorized")
+  val expiredTokenCookie = HttpCookiePair("LeoToken", "expired")
   val serviceAccountEmail = WorkbenchEmail("pet-1234567890@test-project.iam.gserviceaccount.com")
   val userEmail = WorkbenchEmail("user1@example.com")
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/AuthProviderSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/AuthProviderSpec.scala
@@ -71,7 +71,7 @@ class AuthProviderSpec extends FreeSpec with ScalatestRouteTest with Matchers wi
   val gdDAO = new MockGoogleDataprocDAO(dataprocConfig, proxyConfig, clusterDefaultsConfig)
   val iamDAO = new MockGoogleIamDAO
   val samDAO = new MockSamDAO
-  val tokenCookie = HttpCookiePair("FCtoken", "me")
+  val tokenCookie = HttpCookiePair("LeoToken", "me")
 
   override def beforeAll(): Unit = {
     super.beforeAll()


### PR DESCRIPTION
`FCtoken` is a UI/Orch cookie which is now in a different domain than Leo's cookie. Weird things happen when there are 2 cookies with the same name in different domains (the browser seems to arbitrarily choose which one to send to the server). So I'm renaming Leo's token to `LeoToken`. This should be transparent to the user if they're using the UI to open notebooks.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment

  