### PR TITLE
Getting pet SA token from Sam

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/auth/SamAuthProvider.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/auth/SamAuthProvider.scala
@@ -1,29 +1,95 @@
 package org.broadinstitute.dsde.workbench.leonardo.auth
 
+import com.google.api.client.auth.oauth2.Credential
+import com.google.api.client.googleapis.auth.oauth2.GoogleCredential
+import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport
+import com.google.api.client.json.jackson2.JacksonFactory
+import com.google.api.services.plus.PlusScopes
 import com.typesafe.config.Config
 import com.typesafe.scalalogging.LazyLogging
 import net.ceedubs.ficus.Ficus._
 import io.swagger.client.ApiClient
-import org.broadinstitute.dsde.workbench.leonardo.model.{LeoAuthProvider, NotebookClusterActions, ProjectActions}
-import org.broadinstitute.dsde.workbench.model.UserInfo
+import org.broadinstitute.dsde.workbench.leonardo.model.{LeoAuthProvider, NotebookClusterActions, ProjectActions, ServiceAccountProvider}
+import org.broadinstitute.dsde.workbench.model.{UserInfo, WorkbenchEmail}
 import io.swagger.client.api.ResourcesApi
 import org.broadinstitute.dsde.workbench.leonardo.model.NotebookClusterActions._
 import org.broadinstitute.dsde.workbench.leonardo.model.ProjectActions._
 import org.broadinstitute.dsde.workbench.leonardo.model.Actions._
+import org.broadinstitute.dsde.workbench.model.google.GoogleProject
+
+import scala.collection.JavaConverters._
+import java.io.File
+import java.time.Instant
+import java.util.concurrent.TimeUnit
+
+import com.google.common.cache.{CacheBuilder, CacheLoader}
+
 import scala.concurrent.{ExecutionContext, Future}
 
-class SamAuthProvider(authConfig: Config) extends LeoAuthProvider(authConfig) with LazyLogging {
+class SamAuthProvider(authConfig: Config, serviceAccountProvider: ServiceAccountProvider) extends LeoAuthProvider(authConfig, serviceAccountProvider) with LazyLogging {
 
   val notebookClusterResourceTypeName = "notebook-cluster"
   val billingProjectResourceTypeName = "billing-project"
 
+  private val httpTransport = GoogleNetHttpTransport.newTrustedTransport
+  private val jsonFactory = JacksonFactory.getDefaultInstance
+  val saScopes = Seq(PlusScopes.USERINFO_EMAIL, PlusScopes.USERINFO_PROFILE)
 
-  //is this how we do this???
-  private[auth] def resourcesApi(userInfo: UserInfo): ResourcesApi = {
+  //Cache lookup of pet tokens
+  val cacheExpiryTime = authConfig.getInt("cacheExpiryTime")
+  val cacheMaxSize = authConfig.getInt("cacheMaxSize")
+
+  private[leonardo] val petTokenCache = CacheBuilder.newBuilder()
+    .expireAfterWrite(cacheExpiryTime, TimeUnit.MINUTES)
+    .maximumSize(cacheMaxSize)
+    .build(
+      new CacheLoader[WorkbenchEmail, String] {
+        def load(userEmail: WorkbenchEmail) = {
+          getPetAccessTokenFromSam(userEmail)
+        }
+      }
+    )
+
+  //Leo SA details -- needed to get pet keyfiles
+  val (leoEmail, leoPem) : (WorkbenchEmail, File) = serviceAccountProvider.getLeoServiceAccountAndKey
+
+  //Given some credentials, gets an access token
+  private def getAccessTokenUsingCredential(email: WorkbenchEmail, pem: File): String = {
+    val credential = new GoogleCredential.Builder()
+      .setTransport(httpTransport)
+      .setJsonFactory(jsonFactory)
+      .setServiceAccountId(leoEmail.value)
+      .setServiceAccountScopes(saScopes.asJava)
+      .setServiceAccountPrivateKeyFromPemFile(leoPem)
+      .build()
+
+    credential.refreshToken
+    credential.getAccessToken
+  }
+
+  //"Slow" lookup of pet's access token. The cache calls this when it needs to.
+  private def getPetAccessTokenFromSam(userEmail: WorkbenchEmail): String = {
+    val samAPI = resourcesApi(getAccessTokenUsingCredential(leoEmail, leoPem))
+    val (petEmail, petKey): (WorkbenchEmail, File) = samAPI.gimmeThisUsersPetsKey(userEmail)
+    getAccessTokenUsingCredential(petEmail, petKey)
+  }
+
+  //"Fast" lookup of pet's access token, using the cache.
+  private def getCachedPetAccessToken(userEmail: WorkbenchEmail): String = {
+    petTokenCache.get(userEmail)
+  }
+
+  //A resources API if you already have a token
+  private[auth] def resourcesApi(accessToken: String): ResourcesApi = {
     val apiClient = new ApiClient()
-    apiClient.setAccessToken(userInfo.accessToken.token)
+    apiClient.setAccessToken(accessToken)
     apiClient.setBasePath(authConfig.as[String]("samServer"))
     new ResourcesApi(apiClient)
+  }
+
+  //A resources API as the given user's pet SA
+  private[auth] def resourcesApiAsPet(userEmail: WorkbenchEmail): ResourcesApi = {
+    resourcesApi(getCachedPetAccessToken(userEmail))
   }
 
   protected def getClusterResourceId(googleProject: String, clusterName: String): String = {

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/auth/WhitelistAuthProvider.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/auth/WhitelistAuthProvider.scala
@@ -4,14 +4,14 @@ import java.util.UUID
 
 import com.typesafe.config.Config
 import net.ceedubs.ficus.Ficus._
-import org.broadinstitute.dsde.workbench.leonardo.model.LeoAuthProvider
+import org.broadinstitute.dsde.workbench.leonardo.model.{LeoAuthProvider, ServiceAccountProvider}
 import org.broadinstitute.dsde.workbench.leonardo.model.NotebookClusterActions.NotebookClusterAction
 import org.broadinstitute.dsde.workbench.leonardo.model.ProjectActions.ProjectAction
 import org.broadinstitute.dsde.workbench.model.{UserInfo, WorkbenchEmail}
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class WhitelistAuthProvider(authConfig: Config) extends LeoAuthProvider(authConfig) {
+class WhitelistAuthProvider(authConfig: Config, serviceAccountProvider: ServiceAccountProvider) extends LeoAuthProvider(authConfig, serviceAccountProvider) {
 
   val whitelist = authConfig.as[(Set[String])]("whitelist").map(_.toLowerCase)
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeoAuthProvider.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeoAuthProvider.scala
@@ -30,7 +30,7 @@ object NotebookClusterActions {
 
 }
 
-abstract class LeoAuthProvider(authConfig: Config) {
+abstract class LeoAuthProvider(authConfig: Config, serviceAccountProvider: ServiceAccountProvider) {
   /**
     * @param userInfo The user in question
     * @param action The project-level action (above) the user is requesting

--- a/src/test/resources/reference.conf
+++ b/src/test/resources/reference.conf
@@ -90,8 +90,14 @@ swagger {
 }
 
 auth {
-  providerClass = "org.broadinstitute.dsde.workbench.leonardo.auth.WhitelistAuthProvider"
+  providerClass = "org.broadinstitute.dsde.workbench.leonardo.auth.SamAuthProvider"
   providerConfig = {
+    //Sam config goes here
+    cacheExpiryTime = 60
+    cacheMaxSize = 100
+  }
+
+  whitelistProviderConfig = {
     whitelist = ["user1@example.com"]
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/CommonTestData.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/CommonTestData.scala
@@ -37,12 +37,13 @@ trait CommonTestData { this: ScalaFutures =>
   val swaggerConfig = config.as[SwaggerConfig]("swagger")
 
   val defaultUserInfo = UserInfo(OAuth2BearerToken("accessToken"), WorkbenchUserId("user1"), WorkbenchEmail("user1@example.com"), 0)
-  val whitelistAuthProvider = new WhitelistAuthProvider(config.getConfig("auth.providerConfig"))
 
   // TODO look into parameterized tests so both provider impls can both be tested
   // Also remove code duplication with LeonardoServiceSpec, TestLeoRoutes, and CommonTestData
   //val serviceAccountProvider = new MockPetServiceAccountProvider(config.getConfig("serviceAccounts.config"))
   val serviceAccountProvider = new MockPetsPerProjectServiceAccountProvider(config.getConfig("serviceAccounts.config"))
+
+  val whitelistAuthProvider = new WhitelistAuthProvider(config.getConfig("auth.whitelistProviderConfig"), serviceAccountProvider)
 
   val samDAO = new MockSamDAO
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/TestLeoRoutes.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/TestLeoRoutes.scala
@@ -32,11 +32,12 @@ trait TestLeoRoutes { this: ScalatestRouteTest with ScalaFutures =>
   val mockSamDAO = new MockSamDAO
   val clusterDefaultsConfig = config.as[ClusterDefaultsConfig]("clusterDefaults")
   val mockGoogleDataprocDAO = new MockGoogleDataprocDAO(dataprocConfig, proxyConfig, clusterDefaultsConfig)
-  val whitelistAuthProvider = new WhitelistAuthProvider(config.getConfig("auth.providerConfig"))
 
   // TODO look into parameterized tests so both provider impls can both be tested
   //val serviceAccountProvider = new MockPetServiceAccountProvider(config.getConfig("serviceAccounts.config"))
   val serviceAccountProvider = new MockPetsPerProjectServiceAccountProvider(config.getConfig("serviceAccounts.config"))
+
+  val whitelistAuthProvider = new WhitelistAuthProvider(config.getConfig("auth.whitelistProviderConfig"), serviceAccountProvider)
 
   // Route tests don't currently do cluster monitoring, so use NoopActor
   val clusterMonitorSupervisor = system.actorOf(NoopActor.props)

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/auth/MockLeoAuthProvider.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/auth/MockLeoAuthProvider.scala
@@ -8,7 +8,7 @@ import org.broadinstitute.dsde.workbench.model.UserInfo
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class MockLeoAuthProvider(authConfig: Config, notifySucceeds: Boolean = true) extends LeoAuthProvider(authConfig) {
+class MockLeoAuthProvider(authConfig: Config, serviceAccountProvider: ServiceAccountProvider, notifySucceeds: Boolean = true) extends LeoAuthProvider(authConfig, serviceAccountProvider) {
   //behaviour defined in test\...\reference.conf
   val projectPermissions: Map[ProjectActions.ProjectAction, Boolean] =
     (ProjectActions.allActions map (action => action -> authConfig.getBoolean(action.toString) )).toMap

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/AuthProviderSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/AuthProviderSpec.scala
@@ -48,9 +48,9 @@ class AuthProviderSpec extends FreeSpec with ScalatestRouteTest with Matchers wi
   val routeTest = this
 
   private val testClusterRequest = ClusterRequest(Map("bam" -> "yes", "vcf" -> "no", "foo" -> "bar"), None)
-  private val alwaysYesProvider = new MockLeoAuthProvider(config.getConfig("auth.alwaysYesProviderConfig"))
-  private val alwaysNoProvider = new MockLeoAuthProvider(config.getConfig("auth.alwaysNoProviderConfig"))
   private val serviceAccountProvider = new MockPetsPerProjectServiceAccountProvider(config.getConfig("serviceAccounts.config"))
+  private val alwaysYesProvider = new MockLeoAuthProvider(config.getConfig("auth.alwaysYesProviderConfig"), serviceAccountProvider)
+  private val alwaysNoProvider = new MockLeoAuthProvider(config.getConfig("auth.alwaysNoProviderConfig"), serviceAccountProvider)
 
   val c1 = Cluster(
     clusterName = name1,
@@ -167,7 +167,7 @@ class AuthProviderSpec extends FreeSpec with ScalatestRouteTest with Matchers wi
     }
 
     "should give you a 401 if you can see a cluster's details but can't do the more specific action" in isolatedDbTest {
-      val readOnlyProvider = new MockLeoAuthProvider(config.getConfig("auth.readOnlyProviderConfig"))
+      val readOnlyProvider = new MockLeoAuthProvider(config.getConfig("auth.readOnlyProviderConfig"), serviceAccountProvider)
       val spyProvider = spy(readOnlyProvider)
       val leo = leoWithAuthProvider(spyProvider)
       val proxy = proxyWithAuthProvider(spyProvider)
@@ -204,7 +204,7 @@ class AuthProviderSpec extends FreeSpec with ScalatestRouteTest with Matchers wi
     }
 
     "should not create a cluster if auth provider notifyClusterCreated returns failure" in isolatedDbTest {
-      val badNotifyProvider = new MockLeoAuthProvider(config.getConfig("auth.alwaysYesProviderConfig"), notifySucceeds = false)
+      val badNotifyProvider = new MockLeoAuthProvider(config.getConfig("auth.alwaysYesProviderConfig"), serviceAccountProvider, notifySucceeds = false)
       val spyProvider = spy(badNotifyProvider)
       val leo = leoWithAuthProvider(spyProvider)
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoServiceSpec.scala
@@ -51,12 +51,12 @@ class LeonardoServiceSpec extends TestKit(ActorSystem("leonardotest")) with Flat
     gdDAO = new MockGoogleDataprocDAO(dataprocConfig, proxyConfig, clusterDefaultsConfig)
     iamDAO = new MockGoogleIamDAO
     samDAO = new MockSamDAO
-    authProvider = new WhitelistAuthProvider(configFactory.getConfig("auth.providerConfig"))
-    //authProvider = new SamAuthProvider(configFactory.getConfig("auth.providerConfig"))
 
     // TODO look into parameterized tests so both provider impls can both be tested
     //serviceAccountProvider = new MockPetServiceAccountProvider(configFactory.getConfig("serviceAccounts.config"))
     serviceAccountProvider = new MockPetsPerProjectServiceAccountProvider(configFactory.getConfig("serviceAccounts.config"))
+
+    authProvider = new WhitelistAuthProvider(configFactory.getConfig("auth.whitelistProviderConfig"), serviceAccountProvider)
 
     leo = new LeonardoService(dataprocConfig, clusterFilesConfig, clusterResourcesConfig, proxyConfig, swaggerConfig, gdDAO, iamDAO, DbSingleton.ref, system.actorOf(NoopActor.props), authProvider, serviceAccountProvider)
   }


### PR DESCRIPTION
This probably isn't exactly right (I haven't tested it, it doesn't compile, and it's waiting on a new Sam API that doesn't exist yet!), but it's in roughly the right ballpark, I think.

The idea is to use the Leo SA to call Sam, asking for the pet's keys for a particular user. From there we can build a credential and create a token from that credential. I cached the token because why not.

This means the AuthProvider needs to take an instance of a ServiceAccountProvider so I went ahead and did that too.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
