### PR TITLE
GAWB-2924 Upgrade version of Docker we install on Dataproc node

### DIFF
--- a/src/main/resources/jupyter/cluster-docker-compose.yaml
+++ b/src/main/resources/jupyter/cluster-docker-compose.yaml
@@ -1,32 +1,34 @@
-proxy:
-  container_name: "${PROXY_SERVER_NAME}"
-  image: "${PROXY_DOCKER_IMAGE}"
-  net: host
-  volumes:
-    - /certs/jupyter-server.crt:/etc/ssl/certs/server.crt:ro
-    - /certs/jupyter-server.key:/etc/ssl/private/server.key:ro
-    - /certs/rootCA.pem:/etc/ssl/certs/ca-bundle.crt:ro
-    - /etc/cluster-site.conf:/etc/apache2/sites-enabled/site.conf
-    - /auth_openidc.conf:/etc/apache2/mods-enabled/auth_openidc.conf
-  restart: always
-  environment:
-    HTTPD_PORT: '80'
-    SSL_HTTPD_PORT: '443'
+version: '2'
+services:
+  proxy:
+    container_name: "${PROXY_SERVER_NAME}"
+    image: "${PROXY_DOCKER_IMAGE}"
+    network_mode: host
+    volumes:
+      - /certs/jupyter-server.crt:/etc/ssl/certs/server.crt:ro
+      - /certs/jupyter-server.key:/etc/ssl/private/server.key:ro
+      - /certs/rootCA.pem:/etc/ssl/certs/ca-bundle.crt:ro
+      - /etc/cluster-site.conf:/etc/apache2/sites-enabled/site.conf
+      - /auth_openidc.conf:/etc/apache2/mods-enabled/auth_openidc.conf
+    restart: always
+    environment:
+      HTTPD_PORT: '80'
+      SSL_HTTPD_PORT: '443'
 
-jupyter:
-  container_name: "${JUPYTER_SERVER_NAME}"
-  image: "${JUPYTER_DOCKER_IMAGE}"
-  net: host
-  volumes:
-    - /work:/home/user/work
-    - /etc/hadoop/conf:/etc/hadoop/conf
-    - /hadoop_gcs_connector_metadata_cache:/hadoop_gcs_connector_metadata_cache
-    - /etc/install-jupyter-extension.sh:/etc/install-jupyter-extension.sh
-    - /etc/custom.js:/home/jupyter-user/.jupyter/custom/custom.js
-    - /etc/google_sign_in.js:/home/jupyter-user/.jupyter/custom/google_sign_in.js
-  restart: always
-  environment:
-    GOOGLE_PROJECT: "${GOOGLE_PROJECT}"
-    CLUSTER_NAME: "${CLUSTER_NAME}"
-  env_file:
-    - /etc/google_application_credentials.env
+  jupyter:
+    container_name: "${JUPYTER_SERVER_NAME}"
+    image: "${JUPYTER_DOCKER_IMAGE}"
+    network_mode: host
+    volumes:
+      - /work:/home/user/work
+      - /etc/hadoop/conf:/etc/hadoop/conf
+      - /hadoop_gcs_connector_metadata_cache:/hadoop_gcs_connector_metadata_cache
+      - /etc/install-jupyter-extension.sh:/etc/install-jupyter-extension.sh
+      - /etc/custom.js:/home/jupyter-user/.jupyter/custom/custom.js
+      - /etc/google_sign_in.js:/home/jupyter-user/.jupyter/custom/google_sign_in.js
+    restart: always
+    environment:
+      GOOGLE_PROJECT: "${GOOGLE_PROJECT}"
+      CLUSTER_NAME: "${CLUSTER_NAME}"
+    env_file:
+      - /etc/google_application_credentials.env


### PR DESCRIPTION
Caveat: I have yet to get a Swat run to pass, I think because clusters are taking a while to spin up. But the two runs I've tried have failed in different places.

https://github.com/DataBiosphere/leonardo/pull/115/files?w=1 <-- click here for the less confusing but un-commentable whitespace-insensitive diff.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
