### PR TITLE
GAWB-3082: Fix intermittent unit test failure in ProxyRoutesSpec

### DIFF
--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/TestProxy.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/TestProxy.scala
@@ -9,18 +9,16 @@ import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
 import akka.http.scaladsl.model.ws.{BinaryMessage, Message, TextMessage}
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.Route
-import akka.http.scaladsl.testkit.{RouteTest}
+import akka.http.scaladsl.testkit.RouteTest
 import akka.http.scaladsl.{ConnectionContext, Http, HttpsConnectionContext}
 import akka.stream.scaladsl.{Flow, Sink, Source}
-import org.broadinstitute.dsde.workbench.leonardo.api.LeoRoutes
 import org.broadinstitute.dsde.workbench.leonardo.config.ProxyConfig
 import org.broadinstitute.dsde.workbench.leonardo.service.TestProxy.Data
+import org.scalatest.concurrent.ScalaFutures
 import spray.json.DefaultJsonProtocol._
 import spray.json.RootJsonFormat
 
-import scala.concurrent.Future
-
-trait TestProxy {
+trait TestProxy { this: ScalaFutures =>
   val googleProject: String
   val clusterName: String
   val proxyConfig: ProxyConfig
@@ -29,7 +27,7 @@ trait TestProxy {
   import routeTest._
 
   // The backend server behind the proxy
-  var bindingFuture: Future[ServerBinding] = _
+  var serverBinding: ServerBinding = _
 
   def startProxyServer() = {
     val password = "leo-test".toCharArray
@@ -50,11 +48,11 @@ trait TestProxy {
     sslContext.init(keyManagerFactory.getKeyManagers, tmf.getTrustManagers, new SecureRandom)
     val https: HttpsConnectionContext = ConnectionContext.https(sslContext)
 
-    bindingFuture = Http().bindAndHandle(backendRoute, "0.0.0.0", proxyConfig.jupyterPort, https)
+    serverBinding = Http().bindAndHandle(backendRoute, "0.0.0.0", proxyConfig.jupyterPort, https).futureValue
   }
 
   def shutdownProxyServer() = {
-    bindingFuture.flatMap(_.unbind())
+    serverBinding.unbind().futureValue
   }
 
   // The backend route (i.e. the route behind the proxy)


### PR DESCRIPTION
I suspect the reason for this is we weren't actually waiting on `bindingFuture`, which completes when the TCP binding is ready and the server is ready to accept requests. So it was possible for the proxy tests to run before the backend server was actually up.

Will kick off a few Travis runs to test.. 

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
