### PR TITLE
Fix ProxyRoutesSpec for real

### DIFF
--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/ProxyRoutesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/ProxyRoutesSpec.scala
@@ -51,6 +51,7 @@ class ProxyRoutesSpec extends FlatSpec with Matchers with BeforeAndAfterAll with
 
   "ProxyRoutes" should "listen on /notebooks/{project}/{name}/..." in {
     Get(s"/notebooks/$googleProject/$clusterName").addHeader(Cookie(tokenCookie)) ~> leoRoutes.route ~> check {
+      println(s"got response $response and status $status")
       handled shouldBe true
       status shouldEqual StatusCodes.OK
       validateCors()

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/ProxyRoutesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/ProxyRoutesSpec.scala
@@ -4,7 +4,7 @@ import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.headers._
 import akka.http.scaladsl.model.ws.{TextMessage, WebSocketRequest}
-import akka.http.scaladsl.testkit.ScalatestRouteTest
+import akka.http.scaladsl.testkit.{RouteTestTimeout, ScalatestRouteTest}
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.model.HttpMethods._
 import akka.stream.scaladsl.{Keep, Sink, Source}
@@ -18,12 +18,14 @@ import org.scalatest.time.{Seconds, Span}
 import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, FlatSpec, Matchers}
 
 import scala.collection.immutable
+import scala.concurrent.duration._
 
 /**
   * Created by rtitle on 8/10/17.
   */
 class ProxyRoutesSpec extends FlatSpec with Matchers with BeforeAndAfterAll with BeforeAndAfter with ScalatestRouteTest with ScalaFutures with TestLeoRoutes with TestProxy with TestComponent with GcsPathUtils {
   implicit val patience = PatienceConfig(timeout = scaled(Span(10, Seconds)))
+  implicit val routeTimeout = RouteTestTimeout(10 seconds)
 
   val clusterName = "test"
   val googleProject = "dsp-leo-test"
@@ -51,7 +53,6 @@ class ProxyRoutesSpec extends FlatSpec with Matchers with BeforeAndAfterAll with
 
   "ProxyRoutes" should "listen on /notebooks/{project}/{name}/..." in {
     Get(s"/notebooks/$googleProject/$clusterName").addHeader(Cookie(tokenCookie)) ~> leoRoutes.route ~> check {
-      println(s"got response $response and status $status")
       handled shouldBe true
       status shouldEqual StatusCodes.OK
       validateCors()


### PR DESCRIPTION
Maybe this will do it. The `PatienceConfig` isn't affecting the route timeouts; there is a separate implicit field called `RouteTestTimeout`.

Up to 7 passing Jenkins builds, haven't yet seen a failure..

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
