### PR TITLE
Leo/Sam auth: handle Sam API exceptions in SamAuthProvider

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/auth/LeoAuthProviderHelper.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/auth/LeoAuthProviderHelper.scala
@@ -42,6 +42,7 @@ class LeoAuthProviderHelper(wrappedAuthProvider: LeoAuthProvider, authConfig: Co
         Future.failed(AuthProviderException(wrappedClassName))
     }
 
+    // recover from failed futures AND catch thrown exceptions
     try { future.recoverWith(exceptionHandler) } catch exceptionHandler
   }
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/auth/LeoAuthProviderHelper.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/auth/LeoAuthProviderHelper.scala
@@ -1,0 +1,67 @@
+package org.broadinstitute.dsde.workbench.leonardo.auth
+
+import akka.http.scaladsl.model.StatusCodes
+import com.typesafe.config.Config
+import org.broadinstitute.dsde.workbench.leonardo.model._
+import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
+import org.broadinstitute.dsde.workbench.model.google.GoogleProject
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.control.NonFatal
+
+case class AuthProviderException(authProviderClassName: String)
+  extends LeoException(s"Call to $authProviderClassName auth provider failed", StatusCodes.InternalServerError)
+
+object LeoAuthProviderHelper {
+  def create(className: String, config: Config, serviceAccountProvider: ServiceAccountProvider): LeoAuthProvider = {
+    val authProvider = Class.forName(className)
+      .getConstructor(classOf[Config], classOf[ServiceAccountProvider])
+      .newInstance(config, serviceAccountProvider)
+      .asInstanceOf[LeoAuthProvider]
+
+    new LeoAuthProviderHelper(authProvider, config, serviceAccountProvider)
+  }
+}
+
+/**
+  * Wraps a LeoAuthProvider and provides error handling so provider-thrown errors don't bubble up our app.
+  */
+class LeoAuthProviderHelper(wrappedAuthProvider: LeoAuthProvider, authConfig: Config, serviceAccountProvider: ServiceAccountProvider) extends LeoAuthProvider(authConfig, serviceAccountProvider) {
+
+  private def safeCall[T](future: => Future[T]): Future[T] = {
+    future.recover {
+      case e: LeoException => throw e
+      case NonFatal(_) => throw AuthProviderException(wrappedAuthProvider.getClass.getSimpleName)
+    }
+  }
+
+  override def hasProjectPermission(userEmail: WorkbenchEmail, action: ProjectActions.ProjectAction, googleProject: GoogleProject)(implicit executionContext: ExecutionContext): Future[Boolean] = {
+    safeCall {
+      wrappedAuthProvider.hasProjectPermission(userEmail, action, googleProject)
+    }
+  }
+
+  override def canSeeAllClustersInProject(userEmail: WorkbenchEmail, googleProject: GoogleProject)(implicit executionContext: ExecutionContext): Future[Boolean] = {
+    safeCall {
+      wrappedAuthProvider.canSeeAllClustersInProject(userEmail, googleProject)
+    }
+  }
+
+  override def hasNotebookClusterPermission(userEmail: WorkbenchEmail, action: NotebookClusterActions.NotebookClusterAction, googleProject: GoogleProject, clusterName: ClusterName)(implicit executionContext: ExecutionContext): Future[Boolean] = {
+    safeCall {
+      wrappedAuthProvider.hasNotebookClusterPermission(userEmail, action, googleProject, clusterName)
+    }
+  }
+
+  override def notifyClusterCreated(creatorEmail: WorkbenchEmail, googleProject: GoogleProject, clusterName: ClusterName)(implicit executionContext: ExecutionContext): Future[Unit] = {
+    safeCall {
+      wrappedAuthProvider.notifyClusterCreated(creatorEmail, googleProject, clusterName)
+    }
+  }
+
+  override def notifyClusterDeleted(userEmail: WorkbenchEmail, creatorEmail: WorkbenchEmail, googleProject: GoogleProject, clusterName: ClusterName)(implicit executionContext: ExecutionContext): Future[Unit] = {
+    safeCall {
+      wrappedAuthProvider.notifyClusterDeleted(userEmail, creatorEmail, googleProject, clusterName)
+    }
+  }
+}

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/auth/LeoAuthProviderHelper.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/auth/LeoAuthProviderHelper.scala
@@ -19,7 +19,11 @@ object LeoAuthProviderHelper {
       .newInstance(config, serviceAccountProvider)
       .asInstanceOf[LeoAuthProvider]
 
-    new LeoAuthProviderHelper(authProvider, config, serviceAccountProvider)
+    apply(authProvider, config, serviceAccountProvider)
+  }
+
+  def apply(wrappedAuthProvider: LeoAuthProvider, config: Config, serviceAccountProvider: ServiceAccountProvider): LeoAuthProvider = {
+    new LeoAuthProviderHelper(wrappedAuthProvider, config, serviceAccountProvider)
   }
 }
 
@@ -28,7 +32,7 @@ object LeoAuthProviderHelper {
   */
 class LeoAuthProviderHelper(wrappedAuthProvider: LeoAuthProvider, authConfig: Config, serviceAccountProvider: ServiceAccountProvider) extends LeoAuthProvider(authConfig, serviceAccountProvider) {
 
-  private def safeCall[T](future: => Future[T]): Future[T] = {
+  private def safeCall[T](future: => Future[T])(implicit executionContext: ExecutionContext): Future[T] = {
     future.recover {
       case e: LeoException => throw e
       case NonFatal(_) => throw AuthProviderException(wrappedAuthProvider.getClass.getSimpleName)

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/auth/PetsPerProjectServiceAccountProvider.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/auth/PetsPerProjectServiceAccountProvider.scala
@@ -4,19 +4,19 @@ import com.typesafe.config.Config
 import org.broadinstitute.dsde.workbench.model.{UserInfo, WorkbenchEmail}
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 
 /**
   * Created by rtitle on 12/8/17.
   */
 class PetsPerProjectServiceAccountProvider(config: Config) extends SamServiceAccountProvider(config) {
 
-  override def getClusterServiceAccount(userInfo: UserInfo, googleProject: GoogleProject): Future[Option[WorkbenchEmail]] = {
+  override def getClusterServiceAccount(userInfo: UserInfo, googleProject: GoogleProject)(implicit executionContext: ExecutionContext): Future[Option[WorkbenchEmail]] = {
     // Ask Sam for a pet service account for the given (user, project)
     samDAO.getPetServiceAccountForProject(userInfo, googleProject).map(Option(_))
   }
 
-  override def getNotebookServiceAccount(userInfo: UserInfo, googleProject: GoogleProject): Future[Option[WorkbenchEmail]] = {
+  override def getNotebookServiceAccount(userInfo: UserInfo, googleProject: GoogleProject)(implicit executionContext: ExecutionContext): Future[Option[WorkbenchEmail]] = {
     Future(None)
   }
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/auth/ServiceAccountProviderHelper.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/auth/ServiceAccountProviderHelper.scala
@@ -6,7 +6,7 @@ import org.broadinstitute.dsde.workbench.leonardo.model.{LeoException, ServiceAc
 import org.broadinstitute.dsde.workbench.model.{UserInfo, WorkbenchEmail}
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 import scala.util.control.NonFatal
 
 case class ServiceAccountProviderException(serviceAccountProviderClassName: String)
@@ -28,20 +28,20 @@ object ServiceAccountProviderHelper {
   */
 class ServiceAccountProviderHelper(wrappedServiceAccountProvider: ServiceAccountProvider, config: Config) extends ServiceAccountProvider(config) {
 
-  private def safeCall[T](future: => Future[T]): Future[T] = {
+  private def safeCall[T](future: => Future[T])(implicit executionContext: ExecutionContext): Future[T] = {
     future.recover {
       case e: LeoException => throw e
       case NonFatal(_) => throw ServiceAccountProviderException(wrappedServiceAccountProvider.getClass.getSimpleName)
     }
   }
 
-  override def getClusterServiceAccount(userInfo: UserInfo, googleProject: GoogleProject): Future[Option[WorkbenchEmail]] = {
+  override def getClusterServiceAccount(userInfo: UserInfo, googleProject: GoogleProject)(implicit executionContext: ExecutionContext): Future[Option[WorkbenchEmail]] = {
     safeCall {
       wrappedServiceAccountProvider.getClusterServiceAccount(userInfo, googleProject)
     }
   }
 
-  override def getNotebookServiceAccount(userInfo: UserInfo, googleProject: GoogleProject): Future[Option[WorkbenchEmail]] = {
+  override def getNotebookServiceAccount(userInfo: UserInfo, googleProject: GoogleProject)(implicit executionContext: ExecutionContext): Future[Option[WorkbenchEmail]] = {
     safeCall {
       wrappedServiceAccountProvider.getNotebookServiceAccount(userInfo, googleProject)
     }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/auth/ServiceAccountProviderHelper.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/auth/ServiceAccountProviderHelper.scala
@@ -42,6 +42,7 @@ class ServiceAccountProviderHelper(wrappedServiceAccountProvider: ServiceAccount
         Future.failed(ServiceAccountProviderException(wrappedClassName))
     }
 
+    // recover from failed futures AND catch thrown exceptions
     try { future.recoverWith(exceptionHandler) } catch exceptionHandler
   }
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/auth/ServiceAccountProviderHelper.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/auth/ServiceAccountProviderHelper.scala
@@ -1,0 +1,49 @@
+package org.broadinstitute.dsde.workbench.leonardo.auth
+
+import akka.http.scaladsl.model.StatusCodes
+import com.typesafe.config.Config
+import org.broadinstitute.dsde.workbench.leonardo.model.{LeoException, ServiceAccountProvider}
+import org.broadinstitute.dsde.workbench.model.{UserInfo, WorkbenchEmail}
+import org.broadinstitute.dsde.workbench.model.google.GoogleProject
+
+import scala.concurrent.Future
+import scala.util.control.NonFatal
+
+case class ServiceAccountProviderException(serviceAccountProviderClassName: String)
+  extends LeoException(s"Call to $serviceAccountProviderClassName service account provider failed", StatusCodes.InternalServerError)
+
+object ServiceAccountProviderHelper {
+  def create(className: String, config: Config): ServiceAccountProvider = {
+    val serviceAccountProvider = Class.forName(className)
+      .getConstructor(classOf[Config])
+      .newInstance(config)
+      .asInstanceOf[ServiceAccountProvider]
+
+    new ServiceAccountProviderHelper(serviceAccountProvider, config)
+  }
+}
+
+/**
+  * Wraps a ServiceAccountProvider and provides error handling so provider-thrown errors don't bubble up our app.
+  */
+class ServiceAccountProviderHelper(wrappedServiceAccountProvider: ServiceAccountProvider, config: Config) extends ServiceAccountProvider(config) {
+
+  private def safeCall[T](future: => Future[T]): Future[T] = {
+    future.recover {
+      case e: LeoException => throw e
+      case NonFatal(_) => throw ServiceAccountProviderException(wrappedServiceAccountProvider.getClass.getSimpleName)
+    }
+  }
+
+  override def getClusterServiceAccount(userInfo: UserInfo, googleProject: GoogleProject): Future[Option[WorkbenchEmail]] = {
+    safeCall {
+      wrappedServiceAccountProvider.getClusterServiceAccount(userInfo, googleProject)
+    }
+  }
+
+  override def getNotebookServiceAccount(userInfo: UserInfo, googleProject: GoogleProject): Future[Option[WorkbenchEmail]] = {
+    safeCall {
+      wrappedServiceAccountProvider.getNotebookServiceAccount(userInfo, googleProject)
+    }
+  }
+}

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeoException.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeoException.scala
@@ -5,11 +5,25 @@ import org.broadinstitute.dsde.workbench.model.{ErrorReport, WorkbenchException,
 import org.broadinstitute.dsde.workbench.leonardo.errorReportSource
 import org.broadinstitute.dsde.workbench.model.ErrorReport._
 
+import scala.concurrent.Future
+
 abstract class LeoException(
                         val message: String = null,
                         val statusCode: StatusCode = StatusCodes.InternalServerError,
                         val cause: Throwable = null) extends WorkbenchException(message) {
   def toErrorReport: ErrorReport = {
     ErrorReport(Option(getMessage).getOrElse(""), Some(statusCode), Seq(), Seq(), Some(this.getClass))
+  }
+}
+
+object LeoException {
+  implicit class RecoverToLeoExceptionSupport[A](future: Future[A]) {
+    def recoverToLeoException(pf: PartialFunction[Throwable, Nothing] = PartialFunction.empty, default: => LeoException): Future[A] = {
+      val x: PartialFunction[LeoException, Nothing] = { case e: LeoException => throw e }
+
+      future.recover { e =>
+        val x = x.applyOrElse(e, default)
+      }
+    }
   }
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeoException.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeoException.scala
@@ -5,8 +5,6 @@ import org.broadinstitute.dsde.workbench.model.{ErrorReport, WorkbenchException,
 import org.broadinstitute.dsde.workbench.leonardo.errorReportSource
 import org.broadinstitute.dsde.workbench.model.ErrorReport._
 
-import scala.concurrent.Future
-
 abstract class LeoException(
                         val message: String = null,
                         val statusCode: StatusCode = StatusCodes.InternalServerError,

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeoException.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeoException.scala
@@ -15,15 +15,3 @@ abstract class LeoException(
     ErrorReport(Option(getMessage).getOrElse(""), Some(statusCode), Seq(), Seq(), Some(this.getClass))
   }
 }
-
-object LeoException {
-  implicit class RecoverToLeoExceptionSupport[A](future: Future[A]) {
-    def recoverToLeoException(pf: PartialFunction[Throwable, Nothing] = PartialFunction.empty, default: => LeoException): Future[A] = {
-      val x: PartialFunction[LeoException, Nothing] = { case e: LeoException => throw e }
-
-      future.recover { e =>
-        val x = x.applyOrElse(e, default)
-      }
-    }
-  }
-}

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/ServiceAccountProvider.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/ServiceAccountProvider.scala
@@ -6,7 +6,7 @@ import com.typesafe.config.Config
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.broadinstitute.dsde.workbench.model.{UserInfo, WorkbenchEmail}
 
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 
 /**
   * Provides service accounts needed by Leo.
@@ -42,7 +42,7 @@ abstract class ServiceAccountProvider(config: Config) {
     * @param googleProject the Google project the cluster is created in
     * @return service account email
     */
-  def getClusterServiceAccount(userInfo: UserInfo, googleProject: GoogleProject): Future[Option[WorkbenchEmail]]
+  def getClusterServiceAccount(userInfo: UserInfo, googleProject: GoogleProject)(implicit executionContext: ExecutionContext): Future[Option[WorkbenchEmail]]
 
   /**
     * Optional. The service account email that will be localized into the user environment
@@ -56,5 +56,5 @@ abstract class ServiceAccountProvider(config: Config) {
     * @param googleProject the Google project the cluster is created in
     * @return service account email
     */
-  def getNotebookServiceAccount(userInfo: UserInfo, googleProject: GoogleProject): Future[Option[WorkbenchEmail]]
+  def getNotebookServiceAccount(userInfo: UserInfo, googleProject: GoogleProject)(implicit executionContext: ExecutionContext): Future[Option[WorkbenchEmail]]
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoService.scala
@@ -207,7 +207,7 @@ class LeonardoService(protected val dataprocConfig: DataprocConfig,
       visibleClusters <- clustersByProject.toList.flatTraverse[Future, Cluster] { case (googleProject, clusters) =>
         val clusterList = clusters.toList
         authProvider.canSeeAllClustersInProject(userInfo.userEmail, googleProject).recover { case NonFatal(e) =>
-          logger.warn(s"Sam returned an exception for resource ${googleProject.value}. Filtering out from list results.", e)
+          logger.warn(s"The auth provider returned an exception for resource ${googleProject.value}. Filtering out from list results.", e)
           false
         } flatMap {
           case true => Future.successful(clusterList)
@@ -216,7 +216,7 @@ class LeonardoService(protected val dataprocConfig: DataprocConfig,
               case false => None
               case true => Some(cluster)
             } recover { case NonFatal(e) =>
-              logger.warn(s"Sam returned an exception for resource ${googleProject.value}/${cluster.clusterName.string}. Filtering out from list results.", e)
+              logger.warn(s"The auth provider returned an exception for resource ${googleProject.value}/${cluster.clusterName.string}. Filtering out from list results.", e)
               None
             }
           }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoService.scala
@@ -207,7 +207,7 @@ class LeonardoService(protected val dataprocConfig: DataprocConfig,
       visibleClusters <- clustersByProject.toList.flatTraverse[Future, Cluster] { case (googleProject, clusters) =>
         val clusterList = clusters.toList
         authProvider.canSeeAllClustersInProject(userInfo.userEmail, googleProject).recover { case NonFatal(e) =>
-          logger.warn(s"The auth provider returned an exception for resource ${googleProject.value}. Filtering out from list results.", e)
+          logger.warn(s"The auth provider returned an exception calling canSeeAllClustersInProject for resource ${googleProject.value}. Filtering out this project from list results.", e)
           false
         } flatMap {
           case true => Future.successful(clusterList)

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoService.scala
@@ -4,7 +4,6 @@ import akka.actor.ActorRef
 import akka.http.scaladsl.model.StatusCodes
 import com.typesafe.scalalogging.LazyLogging
 import java.io.File
-
 import scala.collection.Map
 import cats.data.OptionT
 import cats.implicits._
@@ -49,9 +48,6 @@ case class ParseLabelsException(labelString: String)
 
 case class IllegalLabelKeyException(labelKey: String)
   extends LeoException(s"Labels cannot have a key of '$labelKey'", StatusCodes.NotAcceptable)
-
-case class AuthProviderException(authProviderClassName: String)
-  extends LeoException(s"Call to $authProviderClassName auth provider failed", StatusCodes.InternalServerError)
 
 class LeonardoService(protected val dataprocConfig: DataprocConfig,
                       protected val clusterFilesConfig: ClusterFilesConfig,

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/CommonTestData.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/CommonTestData.scala
@@ -17,6 +17,8 @@ import org.broadinstitute.dsde.workbench.model.{WorkbenchEmail, WorkbenchUserId}
 import org.broadinstitute.dsde.workbench.model.google.{GoogleProject, ServiceAccountKey, ServiceAccountKeyId, ServiceAccountPrivateKeyData}
 import org.scalatest.concurrent.ScalaFutures
 
+import scala.concurrent.ExecutionContext
+
 // values common to multiple tests, to reduce boilerplate
 
 trait CommonTestData { this: ScalaFutures =>
@@ -53,11 +55,11 @@ trait CommonTestData { this: ScalaFutures =>
 
   val samDAO = new MockSamDAO
 
-  protected def clusterServiceAccount(googleProject: GoogleProject): Option[WorkbenchEmail] = {
+  protected def clusterServiceAccount(googleProject: GoogleProject)(implicit executionContext: ExecutionContext): Option[WorkbenchEmail] = {
     serviceAccountProvider.getClusterServiceAccount(defaultUserInfo, googleProject).futureValue
   }
 
-  protected def notebookServiceAccount(googleProject: GoogleProject): Option[WorkbenchEmail] = {
+  protected def notebookServiceAccount(googleProject: GoogleProject)(implicit executionContext: ExecutionContext): Option[WorkbenchEmail] = {
     serviceAccountProvider.getNotebookServiceAccount(defaultUserInfo, googleProject).futureValue
   }
 }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/auth/LeoAuthProviderHelperSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/auth/LeoAuthProviderHelperSpec.scala
@@ -31,6 +31,8 @@ class LeoAuthProviderHelperSpec extends TestKit(ActorSystem("leonardotest")) wit
     helper.hasNotebookClusterPermission(userEmail, NotebookClusterActions.ConnectToCluster, project, name1).futureValue shouldBe true
   }
 
+  // The next 3 tests verify that an exception thrown in LeoAuthProvider gets translated to LeoException in LeoAuthProviderHelper
+
   it should "pass through LeoExceptions" in {
     val mockProvider = new MockLeoAuthProvider(config.getConfig("auth.alwaysYesProviderConfig"), serviceAccountProvider) {
       override def hasProjectPermission(userEmail: WorkbenchEmail, action: ProjectActions.ProjectAction, googleProject: GoogleProject)(implicit executionContext: ExecutionContext): Future[Boolean] = {

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/auth/LeoAuthProviderHelperSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/auth/LeoAuthProviderHelperSpec.scala
@@ -1,0 +1,51 @@
+package org.broadinstitute.dsde.workbench.leonardo.auth
+
+import akka.actor.ActorSystem
+import akka.testkit.TestKit
+import org.broadinstitute.dsde.workbench.leonardo.CommonTestData
+import org.broadinstitute.dsde.workbench.leonardo.model.{NotebookClusterActions, ProjectActions}
+import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
+import org.broadinstitute.dsde.workbench.model.google.GoogleProject
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, FlatSpecLike, Matchers}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+/**
+  * Created by rtitle on 1/25/18.
+  */
+class LeoAuthProviderHelperSpec extends TestKit(ActorSystem("leonardotest")) with FlatSpecLike with Matchers with CommonTestData with ScalaFutures with BeforeAndAfterAll {
+  import system.dispatcher
+
+  override def afterAll(): Unit = {
+    TestKit.shutdownActorSystem(system)
+    super.afterAll()
+  }
+
+  "LeoAuthProviderHelper" should "delegate provider calls" in {
+    val mockProvider = new MockLeoAuthProvider(config.getConfig("auth.alwaysYesProviderConfig"), serviceAccountProvider)
+    val helper = LeoAuthProviderHelper(mockProvider, config.getConfig("auth.samAuthProviderConfig"), serviceAccountProvider)
+
+    helper.hasProjectPermission(userEmail, ProjectActions.CreateClusters, project).futureValue shouldBe true
+    helper.hasNotebookClusterPermission(userEmail, NotebookClusterActions.ConnectToCluster, project, name1).futureValue shouldBe true
+  }
+
+  it should "pass through LeoExceptions" in {
+    val mockProvider = new MockLeoAuthProvider(config.getConfig("auth.alwaysYesProviderConfig"), serviceAccountProvider) {
+      override def hasProjectPermission(userEmail: WorkbenchEmail, action: ProjectActions.ProjectAction, googleProject: GoogleProject)(implicit executionContext: ExecutionContext): Future[Boolean] = {
+        Future.failed(SamApiException(404))
+      }
+    }
+
+    val helper = LeoAuthProviderHelper(mockProvider, config.getConfig("auth.samAuthProviderConfig"), serviceAccountProvider)
+    helper.hasProjectPermission(userEmail, ProjectActions.CreateClusters, project).failed.futureValue shouldBe a [SamApiException]
+  }
+
+  it should "map non-LeoExceptions to LeoExceptions" in {
+    val mockProvider = new MockLeoAuthProvider(config.getConfig("auth.alwaysYesProviderConfig"), serviceAccountProvider, false)
+    val helper = LeoAuthProviderHelper(mockProvider, config.getConfig("auth.samAuthProviderConfig"), serviceAccountProvider)
+
+    helper.notifyClusterCreated(userEmail, project, name1).failed.futureValue shouldBe a [AuthProviderException]
+  }
+
+}

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/auth/LeoAuthProviderHelperSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/auth/LeoAuthProviderHelperSpec.scala
@@ -49,4 +49,15 @@ class LeoAuthProviderHelperSpec extends TestKit(ActorSystem("leonardotest")) wit
     helper.notifyClusterCreated(userEmail, project, name1).failed.futureValue shouldBe a [AuthProviderException]
   }
 
+  it should "handle thrown exceptions" in {
+    val mockProvider = new MockLeoAuthProvider(config.getConfig("auth.alwaysYesProviderConfig"), serviceAccountProvider) {
+      override def hasProjectPermission(userEmail: WorkbenchEmail, action: ProjectActions.ProjectAction, googleProject: GoogleProject)(implicit executionContext: ExecutionContext): Future[Boolean] = {
+        throw new RuntimeException
+      }
+    }
+
+    val helper = LeoAuthProviderHelper(mockProvider, config.getConfig("auth.samAuthProviderConfig"), serviceAccountProvider)
+    helper.hasProjectPermission(userEmail, ProjectActions.CreateClusters, project).failed.futureValue shouldBe a [AuthProviderException]
+  }
+
 }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/auth/MockPetServiceAccountProvider.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/auth/MockPetServiceAccountProvider.scala
@@ -6,7 +6,7 @@ import org.broadinstitute.dsde.workbench.leonardo.model.ServiceAccountProvider
 import org.broadinstitute.dsde.workbench.model.{UserInfo, WorkbenchEmail}
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 
 /**
   * Created by rtitle on 12/4/17.
@@ -15,12 +15,12 @@ class MockPetServiceAccountProvider(config: Config) extends ServiceAccountProvid
   private val mockSamDAO = new MockSamDAO
   private implicit val ec = scala.concurrent.ExecutionContext.global
 
-  override def getClusterServiceAccount(userInfo: UserInfo, googleProject: GoogleProject): Future[Option[WorkbenchEmail]] = {
+  override def getClusterServiceAccount(userInfo: UserInfo, googleProject: GoogleProject)(implicit executionContext: ExecutionContext): Future[Option[WorkbenchEmail]] = {
     // Pretend we're using the compute engine default SA
     Future.successful(None)
   }
 
-  override def getNotebookServiceAccount(userInfo: UserInfo, googleProject: GoogleProject): Future[Option[WorkbenchEmail]] = {
+  override def getNotebookServiceAccount(userInfo: UserInfo, googleProject: GoogleProject)(implicit executionContext: ExecutionContext): Future[Option[WorkbenchEmail]] = {
     // Pretend we're asking Sam for the pet
     mockSamDAO.getPetServiceAccountForProject(userInfo, googleProject).map(Option(_))
   }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/auth/MockPetsPerProjectServiceAccountProvider.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/auth/MockPetsPerProjectServiceAccountProvider.scala
@@ -6,7 +6,7 @@ import org.broadinstitute.dsde.workbench.leonardo.model.ServiceAccountProvider
 import org.broadinstitute.dsde.workbench.model.{UserInfo, WorkbenchEmail}
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 
 /**
   * Created by rtitle on 12/11/17.
@@ -15,12 +15,12 @@ class MockPetsPerProjectServiceAccountProvider(config: Config) extends ServiceAc
   private val mockSamDAO = new MockSamDAO
   private implicit val ec = scala.concurrent.ExecutionContext.global
 
-  override def getClusterServiceAccount(userInfo: UserInfo, googleProject: GoogleProject): Future[Option[WorkbenchEmail]] = {
+  override def getClusterServiceAccount(userInfo: UserInfo, googleProject: GoogleProject)(implicit executionContext: ExecutionContext): Future[Option[WorkbenchEmail]] = {
     // Pretend we're asking Sam for the pet
     mockSamDAO.getPetServiceAccountForProject(userInfo, googleProject).map(Option(_))
   }
 
-  override def getNotebookServiceAccount(userInfo: UserInfo, googleProject: GoogleProject): Future[Option[WorkbenchEmail]] = {
+  override def getNotebookServiceAccount(userInfo: UserInfo, googleProject: GoogleProject)(implicit executionContext: ExecutionContext): Future[Option[WorkbenchEmail]] = {
     Future(None)
   }
 }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/auth/SamAuthProviderSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/auth/SamAuthProviderSpec.scala
@@ -26,7 +26,7 @@ class SamAuthProviderSpec extends TestKit(ActorSystem("leonardotest")) with Free
     TestKit.shutdownActorSystem(system)
     super.afterAll()
   }
-  
+
   private def getSamAuthProvider: TestSamAuthProvider = new TestSamAuthProvider(config.getConfig("auth.samAuthProviderConfig"),serviceAccountProvider)
 
   val gdDAO = new MockGoogleDataprocDAO(dataprocConfig, proxyConfig, clusterDefaultsConfig)

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/auth/SamAuthProviderSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/auth/SamAuthProviderSpec.scala
@@ -3,7 +3,6 @@ package org.broadinstitute.dsde.workbench.leonardo.auth
 import akka.actor.ActorSystem
 import akka.testkit.TestKit
 import com.typesafe.config.Config
-import io.swagger.client.ApiException
 import org.broadinstitute.dsde.workbench.google.mock.MockGoogleIamDAO
 import org.broadinstitute.dsde.workbench.leonardo.CommonTestData
 import org.broadinstitute.dsde.workbench.leonardo.dao.MockGoogleDataprocDAO
@@ -130,18 +129,6 @@ class SamAuthProviderSpec extends TestKit(ActorSystem("leonardotest")) with Free
 
     samAuthProvider.notifyClusterDeleted(userInfo.userEmail, userInfo.userEmail, project, name1).futureValue
     samAuthProvider.samClient.notebookClusters should not contain ((project, name1, userInfo.userEmail) -> Set("connect", "read_policies", "status", "delete", "sync"))
-  }
-
-  "should catch swagger ApiExceptions and turn them into SamApiExceptions" in isolatedDbTest {
-    val throwingSamClient = new MockSwaggerSamClient {
-      override def hasActionOnBillingProjectResource(userEmail: WorkbenchEmail, googleProject: GoogleProject, action: String): Boolean = {
-        throw new ApiException(500, "internal error")
-      }
-    }
-    val authProvider = new SamAuthProvider(config.getConfig("auth.samAuthProviderConfig"), serviceAccountProvider) {
-      override val samClient = throwingSamClient
-    }
-    authProvider.hasProjectPermission(userInfo.userEmail, CreateClusters, project).failed.futureValue shouldBe a [SamApiException]
   }
 
 }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/auth/ServiceAccountProviderHelperSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/auth/ServiceAccountProviderHelperSpec.scala
@@ -28,6 +28,8 @@ class ServiceAccountProviderHelperSpec extends TestKit(ActorSystem("leonardotest
     helper.getNotebookServiceAccount(userInfo, project).futureValue shouldBe serviceAccountProvider.getNotebookServiceAccount(userInfo, project).futureValue
   }
 
+  // The next 3 tests verify that an exception thrown in ServiceAccountProvider gets translated to LeoException in ServiceAccountProviderHelper
+
   it should "pass through LeoExceptions" in {
     val mockProvider = new MockPetsPerProjectServiceAccountProvider(config.getConfig("serviceAccounts.config")) {
       override def getNotebookServiceAccount(userInfo: UserInfo, googleProject: GoogleProject)(implicit executionContext: ExecutionContext): Future[Option[WorkbenchEmail]] = {

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/auth/ServiceAccountProviderHelperSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/auth/ServiceAccountProviderHelperSpec.scala
@@ -1,0 +1,64 @@
+package org.broadinstitute.dsde.workbench.leonardo.auth
+
+import akka.actor.ActorSystem
+import akka.testkit.TestKit
+import org.broadinstitute.dsde.workbench.leonardo.CommonTestData
+import org.broadinstitute.dsde.workbench.leonardo.model.ProjectActions
+import org.broadinstitute.dsde.workbench.leonardo.service.ClusterNotFoundException
+import org.broadinstitute.dsde.workbench.model.{UserInfo, WorkbenchEmail}
+import org.broadinstitute.dsde.workbench.model.google.GoogleProject
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.{BeforeAndAfterAll, FlatSpecLike, Matchers}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class ServiceAccountProviderHelperSpec extends TestKit(ActorSystem("leonardotest")) with FlatSpecLike with Matchers with CommonTestData with ScalaFutures with BeforeAndAfterAll {
+  import system.dispatcher
+
+  override def afterAll(): Unit = {
+    TestKit.shutdownActorSystem(system)
+    super.afterAll()
+  }
+
+  "ServiceAccountProviderHelper" should "delegate provider calls" in {
+    val helper = ServiceAccountProviderHelper(serviceAccountProvider, config.getConfig("serviceAccounts.config"))
+
+    helper.getLeoServiceAccountAndKey shouldBe serviceAccountProvider.getLeoServiceAccountAndKey
+    helper.getClusterServiceAccount(userInfo, project).futureValue shouldBe serviceAccountProvider.getClusterServiceAccount(userInfo, project).futureValue
+    helper.getNotebookServiceAccount(userInfo, project).futureValue shouldBe serviceAccountProvider.getNotebookServiceAccount(userInfo, project).futureValue
+  }
+
+  it should "pass through LeoExceptions" in {
+    val mockProvider = new MockPetsPerProjectServiceAccountProvider(config.getConfig("serviceAccounts.config")) {
+      override def getNotebookServiceAccount(userInfo: UserInfo, googleProject: GoogleProject)(implicit executionContext: ExecutionContext): Future[Option[WorkbenchEmail]] = {
+        Future.failed(ClusterNotFoundException(googleProject, name1))
+      }
+    }
+
+    val helper = ServiceAccountProviderHelper(mockProvider, config.getConfig("serviceAccounts.config"))
+    helper.getNotebookServiceAccount(userInfo, project).failed.futureValue shouldBe a [ClusterNotFoundException]
+  }
+
+  it should "map non-LeoExceptions to LeoExceptions" in {
+    val mockProvider = new MockPetsPerProjectServiceAccountProvider(config.getConfig("serviceAccounts.config")) {
+      override def getNotebookServiceAccount(userInfo: UserInfo, googleProject: GoogleProject)(implicit executionContext: ExecutionContext): Future[Option[WorkbenchEmail]] = {
+        Future.failed(new RuntimeException)
+      }
+    }
+
+    val helper = ServiceAccountProviderHelper(mockProvider, config.getConfig("serviceAccounts.config"))
+    helper.getNotebookServiceAccount(userInfo, project).failed.futureValue shouldBe a [ServiceAccountProviderException]
+  }
+
+  it should "handle thrown exceptions" in {
+    val mockProvider = new MockPetsPerProjectServiceAccountProvider(config.getConfig("serviceAccounts.config")) {
+      override def getNotebookServiceAccount(userInfo: UserInfo, googleProject: GoogleProject)(implicit executionContext: ExecutionContext): Future[Option[WorkbenchEmail]] = {
+        throw new RuntimeException
+      }
+    }
+
+    val helper = ServiceAccountProviderHelper(mockProvider, config.getConfig("serviceAccounts.config"))
+    helper.getNotebookServiceAccount(userInfo, project).failed.futureValue shouldBe a [ServiceAccountProviderException]
+  }
+
+}

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/AuthProviderSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/AuthProviderSpec.scala
@@ -252,7 +252,5 @@ class AuthProviderSpec extends FreeSpec with ScalatestRouteTest with Matchers wi
       verify(spyProvider).canSeeAllClustersInProject(userInfo.userEmail, visibleClusterProject)
       verify(spyProvider, Mockito.never).hasNotebookClusterPermission(userInfo.userEmail, GetClusterStatus, visibleClusterProject, visibleClusterName)
     }
-
-
   }
 }


### PR DESCRIPTION
I made a `LeoAuthProviderHelper` and `ServiceAccountProviderHelper` which wrap `LeoAuthProvider` and `ServiceAccountProvider` respectively and recover all thrown exceptions to `LeoException`. I was thinking this would be a better approach than assuming the providers are doing exception handling themselves (because they may not be written by us).

Also added some specs to make sure exception handling is working. I don't think additional auto tests are needed for this. I haven't run auto tests yet. :)

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
