### PR TITLE
docker/build.sh; update flags, allow GCR images.

### DIFF
--- a/docker/build.sh
+++ b/docker/build.sh
@@ -88,7 +88,7 @@ while [ "$1" != "" ]; do
 done
 
 # Print help after all flags are parsed successfully
-if PRINT_HELP; then
+if $PRINT_HELP; then
   echo -e "${HELP_TEXT}"
   exit 0
 fi

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -9,24 +9,132 @@
 # Jenkins build job should run with all options, for example,
 #   ./docker/build.sh jar -d push
 
-set -ex
-PROJECT=leonardo
+HELP_TEXT="$(cat <<EOF
+
+ Build the Leonardo code and docker images.
+   jar : build Leonardo jar
+   -d | --docker : (default: no action) provide either "build" or "push" to
+           build or push a docker image.  "push" will also perform build.
+   -r | --registry: (default: dockerhub) can be either "dockerhub" or "gcr".
+           Users of gcr should have the gcloud tool installed and configured.
+   -p | --project: set the project used at either dockerhub or with gcr
+           container registries.
+   -h | --help: print help text.
+
+ Examples:
+   Jenkins build job should run with all options, for example,
+     ./docker/build.sh jar -d push
+   To build the jar, the image, and push it to a gcr repository.
+     ./docker/build.sh jar -d build -r gcr --project "my-awesome-project"
+\t
+EOF
+)"
+
+# Enable strict evaluation semantics.
+set -e
+
+# Set default variables used while parsing command line options.
+TARGET="${TARGET:-leonardo}"
+GIT_BRANCH="${GIT_BRANCH:-$(git rev-parse --abbrev-ref HEAD)}"
+DOCKER_REGISTRY="dockerhub"  # Must be either "dockerhub" or "gcr"
+DOCKER_CMD=""
+ENV=${ENV:-""}  # if env is not set, push an image with branch name
+
+MAKE_JAR=false
+RUN_DOCKER=false
+PRINT_HELP=false
+
+
+if [ -z "$1" ]; then
+    echo "No argument supplied!"
+    echo "run '${0} -h' to see available arguments."
+    exit 1
+fi
+
+while [ "$1" != "" ]; do
+    case $1 in
+        jar)
+            MAKE_JAR=true
+            ;;
+        -d | --docker)
+            shift
+            echo "docker command = $1"
+            RUN_DOCKER=true
+            DOCKER_CMD="$1"
+            ;;
+        -r | --registry)
+            shift
+            echo "registry == $1"
+            DOCKER_REGISTRY=$1
+            ;;
+        -p | --project)
+            shift
+            echo "project = $1"
+            PROJECT=$1
+            ;;
+        -h | --help)
+            PRINT_HELP=true
+            ;;
+        *)
+            echo "Unrecognized argument '${1}'."
+            echo "run '${0} -h' to see available arguments."
+            if grep -Fq "=" <<< "${1}"; then
+                echo "note: separate args from flags with a space, not '='."
+            fi
+            exit 1
+            ;;
+    esac
+    shift
+done
+
+# Print help after all flags are parsed successfully
+if PRINT_HELP; then
+  echo -e "${HELP_TEXT}"
+  exit 0
+fi
+
+# Configure script using arguments.
+if [[ $DOCKER_REGISTRY == "dockerhub" ]]; then
+  PROJECT="${PROJECT:-broadinstitute}"
+  REPO="${PROJECT}"
+  IMAGE="${REPO}/${TARGET}"
+  DOCKER_REMOTES_BINARY="docker"
+elif [[ $DOCKER_REGISTRY == "gcr" ]]; then
+  PROJECT="${PROJECT:-$(gcloud config get-value project)}"
+  # Domain scoped project IDs need to be modified to work with GCR.
+  REPO="gcr.io/$(sed "s_:_/_" <<< "${PROJECT}")"
+  IMAGE="${REPO}/${TARGET}"
+  DOCKER_REMOTES_BINARY="gcloud docker --"
+else
+  echo "The docker registry must be either 'dockerhub' or 'gcr'"
+  echo "Provided value: ${DOCKER_REGISTRY} is not allowed."
+  exit 1
+fi
+
+TESTS_IMAGE=$IMAGE-tests
+
 
 function make_jar()
 {
     echo "building jar..."
     # start test db
-    bash ./docker/run-mysql.sh start ${PROJECT}
+    bash ./docker/run-mysql.sh start ${TARGET}
 
     # Get the last commit hash and set it as an environment variable
     GIT_HASH=$(git log -n 1 --pretty=format:%h)
 
-    # make jar.  cache sbt dependencies.
-    JAR_CMD=`docker run --rm --link mysql:mysql -e GIT_HASH=$GIT_HASH -v $PWD:/working -v jar-cache:/root/.ivy -v jar-cache:/root/.ivy2 broadinstitute/scala-baseimage /working/docker/install.sh /working`
+    # Make jar & cache sbt dependencies.
+    JAR_CMD="$(docker run --rm --link mysql:mysql \
+                          -e GIT_HASH=$GIT_HASH \
+                          -v $PWD:/working \
+                          -v jar-cache:/root/.ivy \
+                          -v jar-cache:/root/.ivy2 \
+                          broadinstitute/scala-baseimage \
+                          /working/docker/install.sh /working)"
     EXIT_CODE=$?
  
     # stop test db
-    bash ./docker/run-mysql.sh stop ${PROJECT}
+    bash ./docker/run-mysql.sh stop ${TARGET}
 
     if [ $EXIT_CODE != 0 ]; then
 	exit $EXIT_CODE
@@ -37,58 +145,43 @@ function make_jar()
 function docker_cmd()
 {
     if [ $DOCKER_CMD = "build" ] || [ $DOCKER_CMD = "push" ]; then
-        echo "building $PROJECT docker image..."
+        echo "building $IMAGE docker image..."
         if [ "$ENV" != "dev" ] && [ "$ENV" != "alpha" ] && [ "$ENV" != "staging" ] && [ "$ENV" != "perf" ]; then
-            DOCKER_TAG=${BRANCH}
-            DOCKER_TAG_TESTS=${BRANCH}
+            DOCKER_TAG=${GIT_BRANCH}
+            DOCKER_TAG_TESTS=${GIT_BRANCH}
         else
-            GIT_SHA=$(git rev-parse origin/${BRANCH})
+            GIT_SHA=$(git rev-parse origin/${GIT_BRANCH})
             echo GIT_SHA=$GIT_SHA > env.properties
             DOCKER_TAG=${GIT_SHA:0:12}
             DOCKER_TAG_TESTS=latest
         fi
 
         # builds the juptyer notebooks docker image that goes on dataproc clusters
-        bash ./jupyter-docker/build.sh build ${DOCKER_TAG}
+        bash ./jupyter-docker/build.sh build "${REPO}" "${DOCKER_TAG}"
 
-        echo "building $PROJECT-tests docker image..."
-        docker build -t $REPO:${DOCKER_TAG} .
+        docker build -t "${IMAGE}:${DOCKER_TAG}" .
         cd automation
-        docker build -f Dockerfile-tests -t $TESTS_REPO:${DOCKER_TAG_TESTS} .
+        echo "building $TESTS_IMAGE docker image..."
+        docker build -f Dockerfile-tests -t "${TESTS_IMAGE}:${DOCKER_TAG_TESTS}" .
         cd ..
 
         if [ $DOCKER_CMD = "push" ]; then
             echo "pushing $PROJECT docker image..."
-            docker push $REPO:${DOCKER_TAG}
-            echo "pushing $PROJECT-tests docker image..."
-            docker push $TESTS_REPO:${DOCKER_TAG_TESTS}
+            $DOCKER_REMOTES_BINARY push $IMAGE:${DOCKER_TAG}
+            echo "pushing $TESTS_IMAGE docker image..."
+            $DOCKER_REMOTES_BINARY push $TESTS_IMAGE:${DOCKER_TAG_TESTS}
             # pushes the juptyer notebooks docker image that goes on dataproc clusters
-            bash ./jupyter-docker/build.sh push ${DOCKER_TAG}
+            bash ./jupyter-docker/build.sh push "${REPO}" "${DOCKER_TAG}"
         fi
     else
         echo "Not a valid docker option!  Choose either build or push (which includes build)"
     fi
 }
 
-# parse command line options
-DOCKER_CMD=
-BRANCH=${BRANCH:-$(git rev-parse --abbrev-ref HEAD)}  # default to current branch
-REPO=${REPO:-broadinstitute/$PROJECT}
-TESTS_REPO=$REPO-tests
-ENV=${ENV:-""}  # if env is not set, push an image with branch name
-
-if [ -z "$1" ]; then
-    echo "No argument supplied!  Available choices are jar to build the jar and -d followed by a docker option (build or push)"
+if $MAKE_JAR; then
+  make_jar
 fi
 
-while [ "$1" != "" ]; do
-    case $1 in
-        jar) make_jar ;;
-        -d | --docker) shift
-                       echo $1
-                       DOCKER_CMD=$1
-                       docker_cmd
-                       ;;
-    esac
-    shift
-done
+if $RUN_DOCKER; then
+  docker_cmd
+fi

--- a/docker/run-mysql.sh
+++ b/docker/run-mysql.sh
@@ -9,11 +9,23 @@ start() {
 
     # start up mysql
     echo "starting up mysql container..."
-    docker run --name $CONTAINER -e MYSQL_ROOT_PASSWORD=leonardo-test -e MYSQL_USER=leonardo-test -e MYSQL_PASSWORD=leonardo-test -e MYSQL_DATABASE=leotestdb -d -p 3311:3306 mysql/mysql-server:$MYSQL_VERSION
+    docker run --name $CONTAINER \
+               -e MYSQL_ROOT_PASSWORD=leonardo-test \
+               -e MYSQL_USER=leonardo-test \
+               -e MYSQL_PASSWORD=leonardo-test \
+               -e MYSQL_DATABASE=leotestdb \
+               -d \
+               -p 3311:3306 \
+               mysql/mysql-server:$MYSQL_VERSION
 
     # validate mysql
     echo "running mysql validation..."
-    docker run --rm --link $CONTAINER:mysql -v $PWD/docker/sql_validate.sh:/working/sql_validate.sh mysql:$MYSQL_VERSION /working/sql_validate.sh leonardo
+    docker run --rm \
+               --link $CONTAINER:mysql \
+               -v $PWD/docker/sql_validate.sh:/working/sql_validate.sh \
+               mysql:$MYSQL_VERSION \
+               /working/sql_validate.sh leonardo
+
     if [ 0 -eq $? ]; then
         echo "mysql validation succeeded."
     else

--- a/jupyter-docker/build.sh
+++ b/jupyter-docker/build.sh
@@ -1,24 +1,36 @@
 #!/usr/bin/env bash
 
-cd jupyter-docker
+# Note: in most cases this script should be invoked by
+# the build script in "leonardo/docker/build.sh".
+
+# Ensure that commands are run from this directory.
+cd "$(dirname "${0}")"
+
+# Get command line options.
+JUPYTER_COMMAND="${1}"
+DOCKER_REPOSITORY="${2}"
+JUPYTER_TAG="${3}"
+
+# Set up docker binary - use gcloud docker if pushing to gcr.
+DOCKER_BINARY="docker"
+if grep -Fq "gcr.io" <<< "${DOCKER_REPOSITORY}" ; then
+	DOCKER_BINARY="gcloud docker --"
+fi
 
 build() {
     echo "building jupyter docker image..."
-    docker build -t broadinstitute/leonardo-notebooks:$JUPYTER_TAG .
+    $DOCKER_BINARY build -t "${DOCKER_REPOSITORY}/leonardo-notebooks:${JUPYTER_TAG}" .
 }
 
 push() {
     echo "pushing jupyter docker image..."
-    docker push broadinstitute/leonardo-notebooks:$JUPYTER_TAG
+    $DOCKER_BINARY push "${DOCKER_REPOSITORY}/leonardo-notebooks:${JUPYTER_TAG}"
 }
 
-JUPYTER_COMMAND=$1
-
-JUPYTER_TAG=$2
-
-if [ $JUPYTER_COMMAND = "build" ]; then
+echo "${JUPYTER_COMMAND}ing the jupyter docker image"
+if [[ $JUPYTER_COMMAND == "build" ]]; then
     build
-elif [ $JUPYTER_COMMAND = "push" ]; then
+elif [[ $JUPYTER_COMMAND == "push" ]]; then
     push
 else
     exit 1


### PR DESCRIPTION
Make it easier for users of Google Container Registry to build
images. Also make the command line parsing a little less sensitive
to order and less dependent on environmental vars for config.