### PR TITLE
Issue - 141- Save error details for errored clusters

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/Leonardo.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/Leonardo.scala
@@ -51,7 +51,8 @@ object Leonardo extends RestClient with LazyLogging {
                                     labels: LabelMap,
                                     jupyterExtensionUri: Option[String],
                                     jupyterUserScriptUri: Option[String],
-                                    stagingBucket: String) {
+                                    stagingBucket: String,
+                                    errors:List[ClusterError]) {
 
       def toCluster = Cluster(clusterName,
         googleId,
@@ -68,7 +69,8 @@ object Leonardo extends RestClient with LazyLogging {
         labels,
         jupyterExtensionUri map (parseGcsPath(_).right.get),
         jupyterUserScriptUri map (parseGcsPath(_).right.get),
-        Some(GcsBucketName(stagingBucket))
+        Some(GcsBucketName(stagingBucket)),
+        errors
       )
     }
 

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoModelCopy.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoModelCopy.scala
@@ -65,13 +65,19 @@ case class Cluster(clusterName: ClusterName,
                    labels: LabelMap,
                    jupyterExtensionUri: Option[GcsPath],
                    jupyterUserScriptUri: Option[GcsPath],
-                   stagingBucket:Option[GcsBucketName]
+                   stagingBucket:Option[GcsBucketName],
+                   errors:List[ClusterError]
                   )
 
 case class ClusterRequest(labels: LabelMap = Map(),
                           jupyterExtensionUri: Option[String] = None,
                           jupyterUserScriptUri: Option[String] = None,
                           machineConfig: Option[MachineConfig] = None)
+
+case class ClusterError(errorMessage: String,
+                        errorCode: Int,
+                        timestamp: String
+                       )
 
 case class DefaultLabels(clusterName: ClusterName,
                          googleProject: GoogleProject,

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
@@ -229,6 +229,7 @@ trait LeonardoTestUtils extends WebBrowserSpec with Matchers with Eventually wit
     val testResult: Try[T] = Try {
       val cluster = createAndMonitor(googleProject, name, request)
       cluster.status shouldBe ClusterStatus.Error
+      cluster.errors should have size 1
       testCode(cluster)
     }
 

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
@@ -230,6 +230,8 @@ trait LeonardoTestUtils extends WebBrowserSpec with Matchers with Eventually wit
       val cluster = createAndMonitor(googleProject, name, request)
       cluster.status shouldBe ClusterStatus.Error
       cluster.errors should have size 1
+      cluster.errors.head.errorMessage should include ("gs://")
+      cluster.errors.head.errorCode should be (3)
       testCode(cluster)
     }
 

--- a/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changelog.xml
+++ b/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changelog.xml
@@ -17,4 +17,5 @@
     <include file="changesets/20171230_remove_googlebucket.xml" relativeToChangelogFile="true" />
     <include file="changesets/20180124_cluster-stagingBucket-column.xml" relativeToChangelogFile="true" />
     <include file="changesets/20180130_cluster-jupyterUserScriptUri-column.xml" relativeToChangelogFile="true" />
+    <include file="changesets/20180205_cluster-error.xml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/20180205_cluster-error.xml
+++ b/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/20180205_cluster-error.xml
@@ -18,5 +18,9 @@
                 <constraints nullable="false"/>
             </column>
         </createTable>
+        <createIndex indexName="FK_CLUSTER_ERROR_CLUSTER_ID" tableName="CLUSTER_ERROR">
+            <column name="clusterId"/>
+        </createIndex>
+        <addForeignKeyConstraint baseColumnNames="clusterId" baseTableName="CLUSTER_ERROR" constraintName="FK_CLUSTER_ERROR_CLUSTER_ID" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="id" referencedTableName="CLUSTER"/>
     </changeSet>
 </databaseChangeLog>

--- a/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/20180205_cluster-error.xml
+++ b/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/20180205_cluster-error.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog logicalFilePath="leonardo" xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+    <changeSet logicalFilePath="leonardo" author="vkumra" id="clusterError">
+        <createTable tableName="CLUSTER_ERROR">
+            <column name="id" type="BIGINT" autoIncrement="true">
+                <constraints primaryKey="true"/>
+            </column>
+            <column name="clusterId" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="errorCode" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="errorMessage" type="VARCHAR(1024)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="timestamp" type="TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -487,6 +487,11 @@ definitions:
       labels:
         type: object
         description: The labels to be placed on the cluster. Of type Map[String,String]
+      errors:
+        type: array
+        description: The list of errors that were encountered on cluster create. Each error consists of the error message, code and timestamp
+        items:
+          $ref: "#/definitions/ClusterError"
 
   ClusterRequest:
     description: ''
@@ -508,6 +513,19 @@ definitions:
       machineConfig:
         description: The machine configurations for the master and worker nodes
         $ref: '#/definitions/MachineConfig'
+
+  ClusterError:
+    description: 'Errors encountered on cluster create'
+    properties:
+      errorMessage:
+        type: string
+        description: Error message
+      errorCode:
+        type: integer
+        description: Error code
+      timestamp:
+        type: string
+        description: timestamp for error in ISO 8601 format
 
   MachineConfig:
     description: 'The configuration for a single Dataproc cluster'

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/AllComponents.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/AllComponents.scala
@@ -1,4 +1,4 @@
 package org.broadinstitute.dsde.workbench.leonardo.db
 
 // a trait combining all of the individual LeoComponent traits
-trait AllComponents extends ClusterComponent with LabelComponent
+trait AllComponents extends ClusterComponent with LabelComponent with ClusterErrorComponent

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponent.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponent.scala
@@ -295,8 +295,9 @@ trait ClusterComponent extends LeoComponent {
         val errorList = errorOpt.toList
         Map(clusterRecord -> (labelMap, errorList))
       }
-      // Unmarshal each (ClusterRecord, Map[labelKey, labelValue]) to a Cluster object
-      clusterLabelMap.map { case (clusterRec,(labelMap, error)) =>
+
+      clusterLabelMap.map {
+        case (clusterRec,(labelMap, error)) =>
         unmarshalCluster(clusterRec, labelMap, error.groupBy(_.timestamp).map(_._2.head).toList)
       }.toSeq
     }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterErrorComponent.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterErrorComponent.scala
@@ -43,10 +43,6 @@ trait ClusterErrorComponent extends LeoComponent {
       }
     }
 
-    def delete(clusterId: Long): DBIO[Int] = {
-      clusterErrorQuery.filter(_.clusterId === clusterId).delete
-    }
-
     def unmarshallClusterErrorRecord(clusterErrorRecord: ClusterErrorRecord) : ClusterError = {
       ClusterError(clusterErrorRecord.errorMessage, clusterErrorRecord.errorCode, clusterErrorRecord.timestamp.toInstant)
     }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterErrorComponent.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterErrorComponent.scala
@@ -5,7 +5,7 @@ import java.time.Instant
 
 import org.broadinstitute.dsde.workbench.leonardo.model.ClusterError
 
-case class ClusterErrorRecord(id:Long, clusterId: Long, errorMessage: String,errorCode:Int,timestamp:Timestamp)
+case class ClusterErrorRecord(id: Long, clusterId: Long, errorMessage: String, errorCode: Int, timestamp: Timestamp)
 
 trait ClusterErrorComponent extends LeoComponent {
   this: ClusterComponent =>
@@ -13,11 +13,15 @@ trait ClusterErrorComponent extends LeoComponent {
   import profile.api._
 
   class ClusterErrorTable(tag: Tag) extends Table[ClusterErrorRecord](tag, "CLUSTER_ERROR") {
-    def id            = column[Long]      ("id", O.AutoInc)
-    def clusterId     = column[Long]      ("clusterId")
-    def errorMessage  = column[String]    ("errorMessage",  O.Length(1024))
-    def errorCode     = column[Int]       ("errorCode")
-    def timestamp     = column[Timestamp] ("timestamp",    O.SqlType("TIMESTAMP(6)"))
+    def id = column[Long]("id", O.AutoInc)
+
+    def clusterId = column[Long]("clusterId")
+
+    def errorMessage = column[String]("errorMessage", O.Length(1024))
+
+    def errorCode = column[Int]("errorCode")
+
+    def timestamp = column[Timestamp]("timestamp", O.SqlType("TIMESTAMP(6)"))
 
     def cluster = foreignKey("FK_CLUSTER_ID", clusterId, clusterQuery)(_.id)
 
@@ -26,22 +30,27 @@ trait ClusterErrorComponent extends LeoComponent {
 
   object clusterErrorQuery extends TableQuery(new ClusterErrorTable(_)) {
 
-    def save(clusterId: Long, clusterError: ClusterError):DBIO[Int] = {
+    def save(clusterId: Long, clusterError: ClusterError): DBIO[Int] = {
       clusterErrorQuery += ClusterErrorRecord(0, clusterId, clusterError.errorMessage, clusterError.errorCode, Timestamp.from(clusterError.timestamp))
     }
 
-    def get(clusterId: Long):DBIO[List[ClusterError]] = {
+    def get(clusterId: Long): DBIO[List[ClusterError]] = {
       clusterErrorQuery.filter(_.clusterId === clusterId).result map { recs =>
         val errors = recs map { rec =>
-          ClusterError(rec.errorMessage, rec.errorCode, rec.timestamp.toInstant)
+          unmarshallClusterErrorRecord(rec)
         }
         errors.toList
       }
     }
 
-    def delete(clusterId: Long):DBIO[Int] = {
+    def delete(clusterId: Long): DBIO[Int] = {
       clusterErrorQuery.filter(_.clusterId === clusterId).delete
     }
 
+    def unmarshallClusterErrorRecord(clusterErrorRecord: ClusterErrorRecord) : ClusterError = {
+      ClusterError(clusterErrorRecord.errorMessage, clusterErrorRecord.errorCode, clusterErrorRecord.timestamp.toInstant)
+    }
+
   }
+
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterErrorComponent.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterErrorComponent.scala
@@ -1,0 +1,47 @@
+package org.broadinstitute.dsde.workbench.leonardo.db
+
+import java.sql.Timestamp
+import java.time.Instant
+
+import org.broadinstitute.dsde.workbench.leonardo.model.ClusterError
+
+case class ClusterErrorRecord(id:Long, clusterId: Long, errorMessage: String,errorCode:Int,timestamp:Timestamp)
+
+trait ClusterErrorComponent extends LeoComponent {
+  this: ClusterComponent =>
+
+  import profile.api._
+
+  class ClusterErrorTable(tag: Tag) extends Table[ClusterErrorRecord](tag, "CLUSTER_ERROR") {
+    def id            = column[Long]      ("id", O.AutoInc)
+    def clusterId     = column[Long]      ("clusterId")
+    def errorMessage  = column[String]    ("errorMessage",  O.Length(1024))
+    def errorCode     = column[Int]       ("errorCode")
+    def timestamp     = column[Timestamp] ("timestamp",    O.SqlType("TIMESTAMP(6)"))
+
+    def cluster = foreignKey("FK_CLUSTER_ID", clusterId, clusterQuery)(_.id)
+
+    def * = (id, clusterId, errorMessage, errorCode, timestamp) <> (ClusterErrorRecord.tupled, ClusterErrorRecord.unapply)
+  }
+
+  object clusterErrorQuery extends TableQuery(new ClusterErrorTable(_)) {
+
+    def save(clusterId: Long, clusterError: ClusterError):DBIO[Int] = {
+      clusterErrorQuery += ClusterErrorRecord(0, clusterId, clusterError.errorMessage, clusterError.errorCode, Timestamp.from(clusterError.timestamp))
+    }
+
+    def get(clusterId: Long):DBIO[List[ClusterError]] = {
+      clusterErrorQuery.filter(_.clusterId === clusterId).result map { recs =>
+        val errors = recs map { rec =>
+          ClusterError(rec.errorMessage, rec.errorCode, rec.timestamp.toInstant)
+        }
+        errors.toList
+      }
+    }
+
+    def delete(clusterId: Long):DBIO[Int] = {
+      clusterErrorQuery.filter(_.clusterId === clusterId).delete
+    }
+
+  }
+}

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/DbReference.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/DbReference.scala
@@ -73,7 +73,7 @@ class DataAccess(val profile: JdbcProfile)(implicit val executionContext: Execut
 
     // important to keep the right order for referential integrity !
     // if table X has a Foreign Key to table Y, delete table X first
-    TableQuery[LabelTable].delete andThen TableQuery[ClusterTable].delete
+    TableQuery[LabelTable].delete andThen TableQuery[ClusterErrorTable].delete andThen TableQuery[ClusterTable].delete
   }
 
   def sqlDBStatus() = {

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeonardoModel.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeonardoModel.scala
@@ -264,11 +264,11 @@ object LeonardoJsonSupport extends SprayJsonSupport with DefaultJsonProtocol {
 
   implicit val ServiceAccountInfoFormat = jsonFormat2(ServiceAccountInfo)
 
+  implicit val ClusterErrorFormat = jsonFormat3(ClusterError.apply)
+
   implicit val ClusterFormat = jsonFormat17(Cluster.apply)
 
   implicit val DefaultLabelsFormat = jsonFormat7(DefaultLabels.apply)
 
   implicit val ClusterInitValuesFormat = jsonFormat17(ClusterInitValues.apply)
-
-  implicit val clusterErrorFormat = jsonFormat3(ClusterError.apply)
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeonardoModel.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeonardoModel.scala
@@ -51,9 +51,17 @@ case class Cluster(clusterName: ClusterName,
                    labels: LabelMap,
                    jupyterExtensionUri: Option[GcsPath],
                    jupyterUserScriptUri: Option[GcsPath],
-                   stagingBucket: Option[GcsBucketName]) {
+                   stagingBucket: Option[GcsBucketName],
+                   errors: List[ClusterError]) {
   def projectNameString: String = s"${googleProject.value}/${clusterName.value}"
 }
+
+
+case class ClusterError(errorMessage: String,
+                        errorCode: Int,
+                        timestamp: Instant
+                       )
+
 object Cluster {
   type LabelMap = Map[String, String]
 
@@ -82,7 +90,8 @@ object Cluster {
         labels = clusterRequest.labels,
         jupyterExtensionUri = clusterRequest.jupyterExtensionUri,
         jupyterUserScriptUri = clusterRequest.jupyterUserScriptUri,
-        stagingBucket = Some(stagingBucket)
+        stagingBucket = Some(stagingBucket),
+        errors = List.empty
       )
   }
 
@@ -107,7 +116,8 @@ object Cluster {
       labels = clusterRequest.labels,
       jupyterExtensionUri = clusterRequest.jupyterExtensionUri,
       jupyterUserScriptUri = clusterRequest.jupyterUserScriptUri,
-      stagingBucket = None
+      stagingBucket = None,
+      errors = List.empty
     )
   }
 
@@ -254,9 +264,11 @@ object LeonardoJsonSupport extends SprayJsonSupport with DefaultJsonProtocol {
 
   implicit val ServiceAccountInfoFormat = jsonFormat2(ServiceAccountInfo)
 
-  implicit val ClusterFormat = jsonFormat16(Cluster.apply)
+  implicit val ClusterFormat = jsonFormat17(Cluster.apply)
 
   implicit val DefaultLabelsFormat = jsonFormat7(DefaultLabels.apply)
 
   implicit val ClusterInitValuesFormat = jsonFormat17(ClusterInitValues.apply)
+
+  implicit val clusterErrorFormat = jsonFormat3(ClusterError.apply)
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorActor.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorActor.scala
@@ -165,18 +165,19 @@ class ClusterMonitorActor(val cluster: Cluster,
       gdDAO.deleteCluster(cluster.googleProject, cluster.clusterName),
       // Remove the service account key in Google, if present.
       // Only happens if the cluster was NOT created with the pet service account.
-      removeServiceAccountKey
-    ))
-    dbRef.inTransaction { dataAccess =>
-      val clusterId = dataAccess.clusterQuery.getIdByGoogleId(cluster.googleId)
-      clusterId flatMap {
-        case Some(a) => dataAccess.clusterErrorQuery.save(a, ClusterError(errorDetails.message.getOrElse("Error not available"), errorDetails.code, Instant.now))
-        case None => {
-          logger.info(s"Could not find Id for Cluster ${cluster.projectNameString}  with google cluster ID ${cluster.googleId}.")
-          DBIOAction.successful(0)
+      removeServiceAccountKey,
+      dbRef.inTransaction { dataAccess =>
+        val clusterId = dataAccess.clusterQuery.getIdByGoogleId(cluster.googleId)
+        clusterId flatMap {
+          case Some(a) => dataAccess.clusterErrorQuery.save(a, ClusterError(errorDetails.message.getOrElse("Error not available"), errorDetails.code, Instant.now))
+          case None => {
+            logger.warn(s"Could not find Id for Cluster ${cluster.projectNameString}  with google cluster ID ${cluster.googleId}.")
+            DBIOAction.successful(0)
+          }
         }
       }
-    }
+    ))
+
     deleteFuture.flatMap { _ =>
       // Decide if we should try recreating the cluster
       if (shouldRecreateCluster(errorDetails.code, errorDetails.message)) {

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/CommonTestData.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/CommonTestData.scala
@@ -51,7 +51,7 @@ trait CommonTestData { this: ScalaFutures =>
 
 
   val serviceAccountInfo = new ServiceAccountInfo(Option(WorkbenchEmail("testServiceAccount1@example.com")), Option(WorkbenchEmail("testServiceAccount2@example.com")))
-  val testCluster = new Cluster(name1, new UUID(1, 1), project, serviceAccountInfo, MachineConfig(), Cluster.getClusterUrl(project, name1, clusterUrlBase), OperationName("op"), ClusterStatus.Running, None, userEmail, Instant.now(), None, Map(), Option(GcsPath(GcsBucketName("bucketName"), GcsObjectName("extension"))),Option(GcsPath(GcsBucketName("bucketName"), GcsObjectName("userScript"))), Some(GcsBucketName("testStagingBucket1")))
+  val testCluster = new Cluster(name1, new UUID(1, 1), project, serviceAccountInfo, MachineConfig(), Cluster.getClusterUrl(project, name1, clusterUrlBase), OperationName("op"), ClusterStatus.Running, None, userEmail, Instant.now(), None, Map(), Option(GcsPath(GcsBucketName("bucketName"), GcsObjectName("extension"))),Option(GcsPath(GcsBucketName("bucketName"), GcsObjectName("userScript"))), Some(GcsBucketName("testStagingBucket1")), List.empty)
 
 
   // TODO look into parameterized tests so both provider impls can both be tested

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterErrorComponentSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterErrorComponentSpec.scala
@@ -1,0 +1,47 @@
+package org.broadinstitute.dsde.workbench.leonardo.db
+
+import java.time.Instant
+import java.time.temporal.{ChronoUnit, TemporalUnit}
+import java.util.UUID
+
+import org.broadinstitute.dsde.workbench.google.gcs.GcsBucketName
+import org.broadinstitute.dsde.workbench.leonardo.{CommonTestData, GcsPathUtils}
+import org.broadinstitute.dsde.workbench.leonardo.model._
+import org.scalatest.FlatSpecLike
+
+
+class ClusterErrorComponentSpec extends TestComponent with FlatSpecLike with CommonTestData with GcsPathUtils {
+
+  "ClusterErrorComponent" should "save, and get" in isolatedDbTest {
+    val c1 = Cluster(
+      clusterName = name1,
+      googleId = UUID.randomUUID(),
+      googleProject = project,
+      serviceAccountInfo = ServiceAccountInfo(None, Some(serviceAccountEmail)),
+      machineConfig = MachineConfig(Some(0), Some(""), Some(500)),
+      clusterUrl = Cluster.getClusterUrl(project, name1),
+      operationName = OperationName("op1"),
+      status = ClusterStatus.Creating,
+      hostIp = None,
+      creator = userEmail,
+      createdDate = Instant.now(),
+      destroyedDate = Option(Instant.now()),
+      labels = Map.empty,
+      jupyterExtensionUri = jupyterExtensionUri,
+      jupyterUserScriptUri = jupyterUserScriptUri,
+      Some(GcsBucketName("testStagingBucket1")),
+      List.empty)
+
+    lazy val timestamp = Instant.now().truncatedTo(ChronoUnit.SECONDS)
+    val clusterError = ClusterError("Some Error", 10, timestamp)
+
+    dbFutureValue { _.clusterQuery.save(c1, gcsPath("gs://bucket1"), Some(serviceAccountKey.id)) } shouldEqual c1
+    val c1Id = dbFutureValue {
+      _.clusterQuery.getIdByGoogleId(c1.googleId)
+    }.get
+
+    dbFutureValue {_.clusterErrorQuery.get(c1Id)} shouldEqual List.empty
+    dbFutureValue {_.clusterErrorQuery.save(c1Id, clusterError)}
+    dbFutureValue {_.clusterErrorQuery.get(c1Id)} shouldEqual List(clusterError)
+  }
+}

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterErrorComponentSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterErrorComponentSpec.scala
@@ -1,13 +1,15 @@
 package org.broadinstitute.dsde.workbench.leonardo.db
 
 import java.time.Instant
-import java.time.temporal.{ChronoUnit, TemporalUnit}
+import java.time.temporal.ChronoUnit
 import java.util.UUID
 
-import org.broadinstitute.dsde.workbench.google.gcs.GcsBucketName
 import org.broadinstitute.dsde.workbench.leonardo.{CommonTestData, GcsPathUtils}
 import org.broadinstitute.dsde.workbench.leonardo.model._
+import org.broadinstitute.dsde.workbench.leonardo.model.google._
+import org.broadinstitute.dsde.workbench.model.google.GcsBucketName
 import org.scalatest.FlatSpecLike
+
 
 
 class ClusterErrorComponentSpec extends TestComponent with FlatSpecLike with CommonTestData with GcsPathUtils {
@@ -27,8 +29,8 @@ class ClusterErrorComponentSpec extends TestComponent with FlatSpecLike with Com
       createdDate = Instant.now(),
       destroyedDate = Option(Instant.now()),
       labels = Map.empty,
-      jupyterExtensionUri = jupyterExtensionUri,
-      jupyterUserScriptUri = jupyterUserScriptUri,
+      jupyterExtensionUri = Some(jupyterExtensionUri),
+      jupyterUserScriptUri = Some(jupyterUserScriptUri),
       Some(GcsBucketName("testStagingBucket1")),
       List.empty)
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/LabelComponentSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/LabelComponentSpec.scala
@@ -31,7 +31,8 @@ class LabelComponentSpec extends TestComponent with FlatSpecLike with CommonTest
       labels = Map.empty,
       jupyterExtensionUri = Some(jupyterExtensionUri),
       jupyterUserScriptUri = Some(jupyterUserScriptUri),
-      Some(GcsBucketName("testStagingBucket1")))
+      Some(GcsBucketName("testStagingBucket1")),
+      List.empty)
 
     val c2 = Cluster(
       clusterName = name2,
@@ -49,7 +50,8 @@ class LabelComponentSpec extends TestComponent with FlatSpecLike with CommonTest
       labels = Map.empty,
       None,
       None,
-      Some(GcsBucketName("testStagingBucket2")))
+      Some(GcsBucketName("testStagingBucket2")),
+      List.empty)
 
     val c2Map = Map("bam" -> "true", "sample" -> "NA12878")
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dns/ClusterDnsCacheSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dns/ClusterDnsCacheSpec.scala
@@ -47,7 +47,7 @@ class ClusterDnsCacheSpec extends TestKit(ActorSystem("leonardotest")) with Flat
     labels = Map("bam" -> "yes", "vcf" -> "no"),
     jupyterExtensionUri = Some(jupyterExtensionUri),
     jupyterUserScriptUri = Some(jupyterUserScriptUri),
-    Some(GcsBucketName("testStagingBucket1")))
+    Some(GcsBucketName("testStagingBucket1")), List.empty)
 
   val c2 = Cluster(
     clusterName = name2,
@@ -65,7 +65,7 @@ class ClusterDnsCacheSpec extends TestKit(ActorSystem("leonardotest")) with Flat
     labels = Map.empty,
     None,
     None,
-    Some(GcsBucketName("testStagingBucket2")))
+    Some(GcsBucketName("testStagingBucket2")), List.empty)
 
   it should "update maps and return clusters" in isolatedDbTest {
     val actorRef = TestActorRef[ClusterDnsCache](ClusterDnsCache.props(proxyConfig, DbSingleton.ref))

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorSpec.scala
@@ -47,8 +47,8 @@ class ClusterMonitorSpec extends TestKit(ActorSystem("leonardotest")) with FlatS
     destroyedDate = None,
     labels = Map("bam" -> "yes", "vcf" -> "no"),
     None,
-    None,
-    Some(GcsBucketName("testStagingBucket1")))
+    None,Some(GcsBucketName("testStagingBucket1"))
+  , List.empty)
 
   val deletingCluster = Cluster(
     clusterName = name2,
@@ -66,7 +66,8 @@ class ClusterMonitorSpec extends TestKit(ActorSystem("leonardotest")) with FlatS
     labels = Map("bam" -> "yes", "vcf" -> "no"),
     jupyterExtensionUri = Some(jupyterExtensionUri),
     jupyterUserScriptUri = Some(jupyterUserScriptUri),
-    Some(GcsBucketName("testStagingBucket1")))
+    Some(GcsBucketName("testStagingBucket1"))
+  , List.empty)
 
   override def afterAll(): Unit = {
     TestKit.shutdownActorSystem(system)
@@ -283,6 +284,7 @@ class ClusterMonitorSpec extends TestKit(ActorSystem("leonardotest")) with FlatS
     val updatedCluster = dbFutureValue { _.clusterQuery.getActiveClusterByName(creatingCluster.googleProject, creatingCluster.clusterName) }
     updatedCluster shouldBe 'defined
     updatedCluster.map(_.status) shouldBe Some(ClusterStatus.Error)
+    updatedCluster.map(_.errors).get should have length 1
     updatedCluster.flatMap(_.hostIp) shouldBe None
 
     verify(storageDAO, never).deleteBucket(any[GcsBucketName], any[Boolean])

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/AuthProviderSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/AuthProviderSpec.scala
@@ -74,7 +74,7 @@ class AuthProviderSpec extends FreeSpec with ScalatestRouteTest with Matchers wi
     labels = Map("bam" -> "yes", "vcf" -> "no"),
     jupyterExtensionUri = None,
     jupyterUserScriptUri = None,
-    stagingBucket = Some(GcsBucketName("testStagingBucket1")))
+    stagingBucket = Some(GcsBucketName("testStagingBucket1")), List.empty)
 
   val gdDAO = new MockGoogleDataprocDAO
   val iamDAO = new MockGoogleIamDAO


### PR DESCRIPTION
Added a new table to store the error details for errored clusters. 

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
