### PR TITLE
[NOTYET] Cache notebook auth from Sam, and enforce a Sam timeout

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/Boot.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/Boot.scala
@@ -50,6 +50,11 @@ object Boot extends App with LazyLogging {
     val monitorConfig = config.as[MonitorConfig]("monitor")
     val samConfig = config.as[SamConfig]("sam")
 
+    // we need an ActorSystem to host our application in
+    implicit val system = ActorSystem("leonardo")
+    implicit val materializer = ActorMaterializer()
+    import system.dispatcher
+
     val serviceAccountProviderClass = config.as[String]("serviceAccounts.providerClass")
     val serviceAccountConfig = config.getConfig("serviceAccounts.providerConfig")
     val serviceAccountProvider = ServiceAccountProviderHelper.create(serviceAccountProviderClass, serviceAccountConfig)
@@ -57,11 +62,6 @@ object Boot extends App with LazyLogging {
     val authProviderClass = config.as[String]("auth.providerClass")
     val authConfig = config.getConfig("auth.providerConfig")
     val authProvider = LeoAuthProviderHelper.create(authProviderClass, authConfig, serviceAccountProvider)
-
-    // we need an ActorSystem to host our application in
-    implicit val system = ActorSystem("leonardo")
-    implicit val materializer = ActorMaterializer()
-    import system.dispatcher
 
     val dbRef = DbReference.init(config)
     system.registerOnTermination {

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/auth/LeoAuthProviderHelper.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/auth/LeoAuthProviderHelper.scala
@@ -41,7 +41,7 @@ class LeoAuthProviderHelper(val wrappedProvider: LeoAuthProvider, authConfig: Co
   // Cache notebook auth results from Sam as this is called very often by the proxy and the "list clusters" endpoint.
   // Project-level auth is not called as frequently so it's not as important to cache it.
   private val notebookAuthCache = CacheBuilder.newBuilder()
-    .expireAfterWrite(5, TimeUnit.MINUTES)
+    .expireAfterAccess(5, TimeUnit.MINUTES)
     .maximumSize(1000)
     .build(
       new CacheLoader[NotebookAuthCacheKey, Future[Boolean]] {

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/auth/SamProviderHelper.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/auth/SamProviderHelper.scala
@@ -1,0 +1,40 @@
+package org.broadinstitute.dsde.workbench.leonardo.auth
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.model.StatusCodes
+import com.typesafe.scalalogging.LazyLogging
+import org.broadinstitute.dsde.workbench.leonardo.model.LeoException
+import org.broadinstitute.dsde.workbench.util.FutureSupport
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.duration._
+import scala.util.control.NonFatal
+
+case class SamProviderException(providerClassName: String)
+  extends LeoException(s"Call to Sam provider $providerClassName failed", StatusCodes.InternalServerError)
+
+/**
+  * Created by rtitle on 2/9/18.
+  */
+trait SamProviderHelper[T] extends LazyLogging with FutureSupport {
+  val system: ActorSystem
+  val wrappedProvider: T
+
+  private val samTimeout = 15 seconds
+  private implicit val scheduler = system.scheduler
+
+  protected def safeCallSam[T](future: => Future[T])(implicit executionContext: ExecutionContext): Future[T] = {
+    val exceptionHandler: PartialFunction[Throwable, Future[Nothing]] = {
+      case e: LeoException => Future.failed(e)
+      case NonFatal(e) =>
+        val wrappedProviderClassName = wrappedProvider.getClass.getSimpleName
+        logger.error(s"Sam provider $wrappedProviderClassName throw an exception", e)
+        Future.failed(SamProviderException(wrappedProviderClassName))
+    }
+
+    // recover from failed futures AND catch thrown exceptions
+    // Also enforce a Sam timeout to ensure Sam unavailability doesn't cause Leo to time out.
+    try { future.recoverWith(exceptionHandler).withTimeout(samTimeout, s"Call to Sam timed out after $samTimeout") } catch exceptionHandler
+  }
+
+}

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/auth/LeoAuthProviderHelperSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/auth/LeoAuthProviderHelperSpec.scala
@@ -48,7 +48,7 @@ class LeoAuthProviderHelperSpec extends TestKit(ActorSystem("leonardotest")) wit
     val mockProvider = new MockLeoAuthProvider(config.getConfig("auth.alwaysYesProviderConfig"), serviceAccountProvider, false)
     val helper = LeoAuthProviderHelper(mockProvider, config.getConfig("auth.samAuthProviderConfig"), serviceAccountProvider)
 
-    helper.notifyClusterCreated(userEmail, project, name1).failed.futureValue shouldBe a [AuthProviderException]
+    helper.notifyClusterCreated(userEmail, project, name1).failed.futureValue shouldBe a [SamProviderException]
   }
 
   it should "handle thrown exceptions" in {
@@ -59,7 +59,7 @@ class LeoAuthProviderHelperSpec extends TestKit(ActorSystem("leonardotest")) wit
     }
 
     val helper = LeoAuthProviderHelper(mockProvider, config.getConfig("auth.samAuthProviderConfig"), serviceAccountProvider)
-    helper.hasProjectPermission(userEmail, ProjectActions.CreateClusters, project).failed.futureValue shouldBe a [AuthProviderException]
+    helper.hasProjectPermission(userEmail, ProjectActions.CreateClusters, project).failed.futureValue shouldBe a [SamProviderException]
   }
 
 }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/auth/ServiceAccountProviderHelperSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/auth/ServiceAccountProviderHelperSpec.scala
@@ -49,7 +49,7 @@ class ServiceAccountProviderHelperSpec extends TestKit(ActorSystem("leonardotest
     }
 
     val helper = ServiceAccountProviderHelper(mockProvider, config.getConfig("serviceAccounts.config"))
-    helper.getNotebookServiceAccount(userInfo.userEmail, project).failed.futureValue shouldBe a [ServiceAccountProviderException]
+    helper.getNotebookServiceAccount(userInfo.userEmail, project).failed.futureValue shouldBe a [SamProviderException]
   }
 
   it should "handle thrown exceptions" in {
@@ -60,7 +60,7 @@ class ServiceAccountProviderHelperSpec extends TestKit(ActorSystem("leonardotest
     }
 
     val helper = ServiceAccountProviderHelper(mockProvider, config.getConfig("serviceAccounts.config"))
-    helper.getNotebookServiceAccount(userInfo.userEmail, project).failed.futureValue shouldBe a [ServiceAccountProviderException]
+    helper.getNotebookServiceAccount(userInfo.userEmail, project).failed.futureValue shouldBe a [SamProviderException]
   }
 
 }


### PR DESCRIPTION
Looking for early feedback here, specifically "is this a good idea?"

There are really 2 things here:

1. We call Sam `hasNotebookClusterPermission` _a lot_: for every request to the proxy, and for every cluster returned from the database during a "list clusters" request. I think it's reasonable to add some caching here. So the first time you hit "list clusters" it would still be slow, but would be fast thereafter.
Note I'm _not_ caching `hasProjectPermission` as that is called a lot less frequently (e.g. just when you create/delete a cluster).

2. We've seen instances of Sam timeouts taking down Leo. This enforces a 15s timeout on all Sam calls. If it times out it will generate a failed future and the service layer should handle it.

I also refactored some duplicate code into a common `SamProviderHelper` trait so there is a little bit of noise -- but the 2 things above are what I'm trying to achieve.


Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
