### PR TITLE
Wait on futures in preemptibles test

### DIFF
--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -6,7 +6,7 @@ object Dependencies {
   val akkaHttpV = "10.0.5"
 
   val workbenchModelV   = "0.10-6800f3a"
-  val workbenchGoogleV  = "0.15-2fc79a3"
+  val workbenchGoogleV  = "0.16-16e3aab"
   val serviceTestV = "0.5-f1b0c7b"
 
   val excludeWorkbenchModel =   ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = "workbench-model_2.11")

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/ClusterMonitoringSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/ClusterMonitoringSpec.scala
@@ -112,12 +112,12 @@ class ClusterMonitoringSpec extends FreeSpec with LeonardoTestUtils with Paralle
         withNewGoogleBucket(project) { bucket =>
           val srcPath = parseGcsPath("gs://genomics-public-data/1000-genomes/vcf/ALL.chr20.integrated_phase1_v3.20101123.snps_indels_svs.genotypes.vcf").right.get
           val destPath = GcsPath(bucket, GcsObjectName("chr20.vcf"))
-          googleStorageDAO.copyObject(srcPath.bucketName, srcPath.objectName, destPath.bucketName, destPath.objectName)
+          googleStorageDAO.copyObject(srcPath.bucketName, srcPath.objectName, destPath.bucketName, destPath.objectName).futureValue
 
           implicit val token = ronAuthToken
           val ronProxyGroup = Sam.user.proxyGroup(ronEmail)
           val ronPetEntity = GcsEntity(ronProxyGroup, Group)
-          googleStorageDAO.setObjectAccessControl(destPath.bucketName, destPath.objectName, ronPetEntity, Reader)
+          googleStorageDAO.setObjectAccessControl(destPath.bucketName, destPath.objectName, ronPetEntity, Reader).futureValue
 
           val request = ClusterRequest(machineConfig = Option(MachineConfig(
             // need at least 2 regular workers to enable preemptibles

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/ClusterMonitoringSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/ClusterMonitoringSpec.scala
@@ -100,7 +100,7 @@ class ClusterMonitoringSpec extends FreeSpec with LeonardoTestUtils with Paralle
       }
     }
 
-    // TODO: this test fails intermittently. Ignoring until it's stable.
+    // TODO: we've noticed intermittent failures for this test. See:
     // https://github.com/DataBiosphere/leonardo/issues/204
     // https://github.com/DataBiosphere/leonardo/issues/228
     "should execute Hail with correct permissions on a cluster with preemptible workers" ignore withWebDriver { implicit driver =>
@@ -110,6 +110,8 @@ class ClusterMonitoringSpec extends FreeSpec with LeonardoTestUtils with Paralle
         Orchestration.billing.addUserToBillingProject(projectName, ronEmail, Orchestration.billing.BillingProjectRole.User)(hermioneAuthToken)
 
         withNewGoogleBucket(project) { bucket =>
+          implicit val patienceConfig: PatienceConfig = storagePatience
+
           val srcPath = parseGcsPath("gs://genomics-public-data/1000-genomes/vcf/ALL.chr20.integrated_phase1_v3.20101123.snps_indels_svs.genotypes.vcf").right.get
           val destPath = GcsPath(bucket, GcsObjectName("chr20.vcf"))
           googleStorageDAO.copyObject(srcPath.bucketName, srcPath.objectName, destPath.bucketName, destPath.objectName).futureValue

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
@@ -22,7 +22,8 @@ import org.scalatest.{Matchers, Suite}
 import org.scalatest.concurrent.{Eventually, ScalaFutures}
 import org.scalatest.time.{Minutes, Seconds, Span}
 
-import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.duration._
+import scala.language.postfixOps
 import scala.util.{Random, Try}
 
 trait LeonardoTestUtils extends WebBrowserSpec with Matchers with Eventually with LocalFileUtil with LazyLogging with ScalaFutures {
@@ -288,6 +289,7 @@ trait LeonardoTestUtils extends WebBrowserSpec with Matchers with Eventually wit
 
 
   def verifyHailImport(notebookPage: NotebookPage, vcfPath: GcsPath, clusterName: ClusterName): Unit = {
+    val hailTimeout = 5 minutes
     val welcomeToHail =
       """Welcome to
         |     __  __     <>__
@@ -313,9 +315,9 @@ trait LeonardoTestUtils extends WebBrowserSpec with Matchers with Eventually wit
     notebookPage.executeCell("hc = HailContext(sc)").get should include(welcomeToHail)
 
     notebookPage.executeCell(s"chr20vcf = '${vcfPath.toUri}'") shouldBe None
-    notebookPage.executeCell("imported = hc.import_vcf(chr20vcf)").get should include("Hail: INFO: Coerced almost-sorted dataset")
+    notebookPage.executeCell("imported = hc.import_vcf(chr20vcf)", hailTimeout).get should include("Hail: INFO: Coerced almost-sorted dataset")
 
-    notebookPage.executeCell("imported.summarize().report()").get should include(vcfSummary)
+    notebookPage.executeCell("imported.summarize().report()", hailTimeout).get should include(vcfSummary)
 
     // show that the Hail log contains jobs that were run on preemptible nodes
 

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/NotebookPage.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/NotebookPage.scala
@@ -6,6 +6,8 @@ import org.openqa.selenium.{By, WebDriver, WebElement}
 import org.openqa.selenium.interactions.Actions
 
 import scala.collection.JavaConverters._
+import scala.concurrent.duration._
+import scala.language.postfixOps
 
 class NotebookPage(override val url: String)(override implicit val authToken: AuthToken, override implicit val webDriver: WebDriver)
   extends JupyterPage {
@@ -88,13 +90,13 @@ class NotebookPage(override val url: String)(override implicit val authToken: Au
     outputs.asScala.headOption.map(_.getText)
   }
 
-  def executeCell(code: String, timeoutSeconds: Long = 60): Option[String] = {
+  def executeCell(code: String, timeout: FiniteDuration = 1 minute): Option[String] = {
     await enabled cells
     val cell = lastCell
     val jsEscapedCode = StringEscapeUtils.escapeEcmaScript(code)
     executeScript(s"""arguments[0].CodeMirror.setValue("$jsEscapedCode");""", cell)
     click on runCellButton
-    await condition (!cellsAreRunning, timeoutSeconds)
+    await condition (!cellsAreRunning, timeout.toSeconds)
     cellOutput(cell)
   }
 


### PR DESCRIPTION
I think this was probably causing https://github.com/DataBiosphere/leonardo/issues/204. Our calls to `googleStorageDAO.copyObject` and `googleStorageDAO.setObjectAccessControl` were racy, which probably made the latter fail intermittently, which manifested as 403 errors in a notebook.

Note we've encountered some other errors related to this test (see https://github.com/DataBiosphere/leonardo/issues/228). I haven't been able to reproduce those locally, I'm going to run it a bunch of times in Jenkins.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
