### PR TITLE
Peg tornado at version 4.5.3

### DIFF
--- a/jupyter-docker/Dockerfile
+++ b/jupyter-docker/Dockerfile
@@ -140,7 +140,7 @@ RUN apt-get install -yq --no-install-recommends python3 \
  && python3 get-pip.py \
  # install the python 3 kernel
  && pip3 install tornado==4.5.3 \
- && pip3 install ipykernel \
+ && pip3 install ipykernel==4.8.2 \
  && python3 -m ipykernel install --name python3 --display-name "Python 3" \
  # python 3 packages
  && pip3 install seaborn \

--- a/jupyter-docker/Dockerfile
+++ b/jupyter-docker/Dockerfile
@@ -139,6 +139,7 @@ RUN apt-get install -yq --no-install-recommends python3 \
         python3-numpy \
  && python3 get-pip.py \
  # install the python 3 kernel
+ && pip3 install tornado==4.5.3 \
  && pip3 install ipykernel \
  && python3 -m ipykernel install --name python3 --display-name "Python 3" \
  # python 3 packages


### PR DESCRIPTION
Tornado 5.0 was just released which breaks with our python3 version: http://www.tornadoweb.org/en/stable/releases/v5.0.0.html#mar-5-2018

This pegs it at the previous version, 4.5.3.

Note we need to peg ALL our dependencies (see https://github.com/DataBiosphere/leonardo/issues/148). This PR is just a quick fix.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
