### PR TITLE
Retry apt-get update in init script because it's flakey

### DIFF
--- a/src/main/resources/jupyter/init-actions.sh
+++ b/src/main/resources/jupyter/init-actions.sh
@@ -4,6 +4,16 @@ set -e -x
 
 # adapted from https://github.com/GoogleCloudPlatform/dataproc-initialization-actions/blob/master/datalab/datalab.sh
 
+function update_apt_get() {
+  for ((i = 0; i < 10; i++)); do
+    if apt-get update; then
+      return 0
+    fi
+    sleep 5
+  done
+  return 1
+}
+
 # Initialize the dataproc cluster with Jupyter and apache proxy docker images
 # Uses cluster-docker-compose.yaml
 
@@ -46,7 +56,7 @@ if [[ "${ROLE}" == 'Master' ]]; then
 
     # install Docker
     export DOCKER_CE_VERSION="17.12.0~ce-0~debian"
-    apt-get update
+    update_apt_get
     apt-get install -y \
      apt-transport-https \
      ca-certificates \


### PR DESCRIPTION
`apt-get update` failures have caused intermittent cluster creation errors in automation tests.

Note: Google DataLab does the same thing in their init script: https://github.com/GoogleCloudPlatform/dataproc-initialization-actions/blob/master/datalab/datalab.sh#L21-L29

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
