### PR TITLE
Auto tests: log cluster errors and save init script logs as build artifacts

### DIFF
--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -6,7 +6,7 @@ object Dependencies {
   val akkaHttpV = "10.0.5"
 
   val workbenchModelV   = "0.10-6800f3a"
-  val workbenchGoogleV  = "0.16-16e3aab"
+  val workbenchGoogleV  = "0.16-2947b3a-SNAP"
   val serviceTestV = "0.5-f1b0c7b"
 
   val excludeWorkbenchModel =   ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = "workbench-model_2.11")

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/ClusterMonitoringSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/ClusterMonitoringSpec.scala
@@ -11,7 +11,7 @@ import org.scalatest.{FreeSpec, ParallelTestExecution}
 class ClusterMonitoringSpec extends FreeSpec with LeonardoTestUtils with ParallelTestExecution with BillingFixtures {
   "Leonardo clusters" - {
 
-    "should create, monitor, delete, recreate, and re-delete a cluster" in {
+    "foo should create, monitor, delete, recreate, and re-delete a cluster" in {
       withCleanBillingProject(hermioneCreds) { projectName =>
         Orchestration.billing.addUserToBillingProject(projectName, ronEmail, Orchestration.billing.BillingProjectRole.User)(hermioneAuthToken)
         val project = GoogleProject(projectName)

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/ClusterMonitoringSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/ClusterMonitoringSpec.scala
@@ -11,7 +11,7 @@ import org.scalatest.{FreeSpec, ParallelTestExecution}
 class ClusterMonitoringSpec extends FreeSpec with LeonardoTestUtils with ParallelTestExecution with BillingFixtures {
   "Leonardo clusters" - {
 
-    "foo should create, monitor, delete, recreate, and re-delete a cluster" in {
+    "should create, monitor, delete, recreate, and re-delete a cluster" in {
       withCleanBillingProject(hermioneCreds) { projectName =>
         Orchestration.billing.addUserToBillingProject(projectName, ronEmail, Orchestration.billing.BillingProjectRole.User)(hermioneAuthToken)
         val project = GoogleProject(projectName)

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
@@ -377,10 +377,9 @@ trait LeonardoTestUtils extends WebBrowserSpec with Matchers with Eventually wit
   }
 
   def saveClusterInitLogFile(cluster: Cluster)(implicit executionContext: ExecutionContext): Future[Option[File]] = {
-    def downloadLogFile(stagingBucketName: GcsBucketName, logFile: GcsObjectName, contentStream: ByteArrayOutputStream): File = {
+    def downloadLogFile(contentStream: ByteArrayOutputStream): File = {
       // .log suffix is needed so it shows up as a Jenkins build artifact
-      //val downloadFile = new File(clusterDir, s"${Instant.now().toString}-${new File(logFile.value).getName}.log")
-      val downloadFile = new File(logDir, s"${cluster.googleProject}-${cluster.clusterName}-init.log")
+      val downloadFile = new File(logDir, s"${cluster.googleProject.value}-${cluster.clusterName.string}-init.log")
       val fos = new FileOutputStream(downloadFile)
       fos.write(contentStream.toByteArray)
       fos.close()
@@ -392,7 +391,7 @@ trait LeonardoTestUtils extends WebBrowserSpec with Matchers with Eventually wit
       stagingBucketObjects <- OptionT.liftF[Future, List[GcsObjectName]](googleStorageDAO.listObjectsWithPrefix(stagingBucketName, "google-cloud-dataproc-metainfo"))
       logFile <- OptionT.fromOption[Future](stagingBucketObjects.filter(_.value.endsWith("dataproc-initialization-script-0_output")).headOption)
       contentStream <- OptionT(googleStorageDAO.getObject(stagingBucketName, logFile))
-    } yield downloadLogFile(stagingBucketName, logFile, contentStream)
+    } yield downloadLogFile(contentStream)
 
     transformed.value
   }

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
@@ -35,7 +35,7 @@ trait LeonardoTestUtils extends WebBrowserSpec with Matchers with Eventually wit
   // must align with run-tests.sh and hub-compose-fiab.yml
   val downloadDir = "chrome/downloads"
 
-  val logDir = new File("logs")
+  val logDir = new File("target/cluster-logs")
   logDir.mkdirs
 
   // Ron and Hermione are on the dev Leo whitelist, and Hermione is a Project Owner

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
@@ -85,6 +85,11 @@ trait LeonardoTestUtils extends WebBrowserSpec with Matchers with Eventually wit
                    expectedStatuses: Iterable[ClusterStatus],
                    clusterRequest: ClusterRequest): Cluster = {
 
+    // Always log cluster errors
+    if (cluster.errors.nonEmpty) {
+      logger.warn(s"Cluster ${cluster.googleProject}/${cluster.clusterName} returned the following errors: ${cluster.errors}")
+    }
+
     withClue(s"Cluster ${cluster.googleProject}/${cluster.clusterName}: ") {
       expectedStatuses should contain (cluster.status)
     }
@@ -118,12 +123,7 @@ trait LeonardoTestUtils extends WebBrowserSpec with Matchers with Eventually wit
       }
     }
 
-    // Log cluster errors
-    if (actualCluster.isSuccess && actualCluster.get.errors.nonEmpty) {
-      logger.warn(s"Cluster ${actualCluster.get.googleProject}/${actualCluster.get.clusterName} returned the following errors: ${actualCluster.get.errors}")
-    }
-
-    // Save cluster init log file whether or not the cluster created successfully
+    // Save the cluster init log file whether or not the cluster created successfully
     implicit val ec = ExecutionContext.global
     saveClusterInitLogFile(creatingCluster).recover { case e =>
       logger.error(s"Error occurred saving log file for cluster ${cluster.googleProject}/${cluster.clusterName}", e)

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
@@ -381,7 +381,8 @@ trait LeonardoTestUtils extends WebBrowserSpec with Matchers with Eventually wit
       val clusterDir = new File(logDir, stagingBucketName.value)
       clusterDir.mkdirs()
       // .log suffix is needed so it shows up as a Jenkins build artifact
-      val downloadFile = new File(clusterDir, s"${Instant.now().toString}-${new File(logFile.value).getName}.log")
+      //val downloadFile = new File(clusterDir, s"${Instant.now().toString}-${new File(logFile.value).getName}.log")
+      val downloadFile = new File(clusterDir, s"${cluster.googleProject}-${cluster.clusterName}-init.log")
       val fos = new FileOutputStream(downloadFile)
       fos.write(contentStream.toByteArray)
       fos.close()

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
@@ -37,7 +37,7 @@ trait LeonardoTestUtils extends WebBrowserSpec with Matchers with Eventually wit
   // must align with run-tests.sh and hub-compose-fiab.yml
   val downloadDir = "chrome/downloads"
 
-  val logDir = new File("target")
+  val logDir = new File("output")
   logDir.mkdirs
 
   // Ron and Hermione are on the dev Leo whitelist, and Hermione is a Project Owner

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
@@ -35,7 +35,7 @@ trait LeonardoTestUtils extends WebBrowserSpec with Matchers with Eventually wit
   // must align with run-tests.sh and hub-compose-fiab.yml
   val downloadDir = "chrome/downloads"
 
-  val logDir = new File("target/cluster-logs")
+  val logDir = new File("cluster-logs")
   logDir.mkdirs
 
   // Ron and Hermione are on the dev Leo whitelist, and Hermione is a Project Owner

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
@@ -85,7 +85,10 @@ trait LeonardoTestUtils extends WebBrowserSpec with Matchers with Eventually wit
                    expectedStatuses: Iterable[ClusterStatus],
                    clusterRequest: ClusterRequest): Cluster = {
 
-    expectedStatuses should contain (cluster.status)
+    withClue(s"Cluster ${cluster.googleProject}/${cluster.clusterName}: ") {
+      expectedStatuses should contain (cluster.status)
+    }
+
     cluster.googleProject shouldBe expectedProject
     cluster.clusterName shouldBe expectedName
     cluster.stagingBucket shouldBe 'defined

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
@@ -378,11 +378,9 @@ trait LeonardoTestUtils extends WebBrowserSpec with Matchers with Eventually wit
 
   def saveClusterInitLogFile(cluster: Cluster)(implicit executionContext: ExecutionContext): Future[Option[File]] = {
     def downloadLogFile(stagingBucketName: GcsBucketName, logFile: GcsObjectName, contentStream: ByteArrayOutputStream): File = {
-      val clusterDir = new File(logDir, stagingBucketName.value)
-      clusterDir.mkdirs()
       // .log suffix is needed so it shows up as a Jenkins build artifact
       //val downloadFile = new File(clusterDir, s"${Instant.now().toString}-${new File(logFile.value).getName}.log")
-      val downloadFile = new File(clusterDir, s"${cluster.googleProject}-${cluster.clusterName}-init.log")
+      val downloadFile = new File(logDir, s"${cluster.googleProject}-${cluster.clusterName}-init.log")
       val fos = new FileOutputStream(downloadFile)
       fos.write(contentStream.toByteArray)
       fos.close()

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
@@ -23,7 +23,9 @@ import org.scalatest.{Matchers, Suite}
 import org.scalatest.concurrent.{Eventually, ScalaFutures}
 import org.scalatest.time.{Minutes, Seconds, Span}
 
-import scala.concurrent.duration.FiniteDuration
+import scala.concurrent._
+import scala.concurrent.duration._
+import scala.language.postfixOps
 import scala.util.{Random, Try}
 
 trait LeonardoTestUtils extends WebBrowserSpec with Matchers with Eventually with LocalFileUtil with LazyLogging with ScalaFutures {

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
@@ -37,7 +37,7 @@ trait LeonardoTestUtils extends WebBrowserSpec with Matchers with Eventually wit
   // must align with run-tests.sh and hub-compose-fiab.yml
   val downloadDir = "chrome/downloads"
 
-  val logDir = new File("cluster-logs")
+  val logDir = new File("target")
   logDir.mkdirs
 
   // Ron and Hermione are on the dev Leo whitelist, and Hermione is a Project Owner


### PR DESCRIPTION
This should help make automation tests easier to debug.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
