### PR TITLE
Clean up mysql containers

### DIFF
--- a/docker/run-mysql.sh
+++ b/docker/run-mysql.sh
@@ -6,6 +6,7 @@ start() {
 
     echo "attempting to remove old $CONTAINER container..."
     docker rm -f $CONTAINER || echo "docker rm failed. nothing to rm."
+    docker rm -f $CONTAINER2 || echo "docker rm failed. nothing to rm."
 
     # start up mysql
     echo "starting up mysql container..."
@@ -39,9 +40,13 @@ stop() {
     echo "Stopping docker $CONTAINER container..."
     docker stop $CONTAINER || echo "mysql stop failed. container already stopped."
     docker rm -v $CONTAINER || echo "mysql rm -v failed.  container already destroyed."
+
+    docker stop $CONTAINER2 || echo "mysql stop failed. container already stopped."
+    docker rm -v $CONTAINER2 || echo "mysql rm -v failed.  container already destroyed."
 }
 
 CONTAINER=mysql
+CONTAINER2=leonardo-mysql
 
 if [ ${#@} == 0 ]; then
     echo "Usage: $0 stop|start <service>"


### PR DESCRIPTION
Jenkins instances keep getting in a bad state because there are 2 mysql containers running. It may be due to this PR: https://github.com/DataBiosphere/leonardo/pull/233/

For now let's just try and clean up both names.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
