### PR TITLE
Remove AoU client library because it's outdated

### DIFF
--- a/jupyter-docker/Dockerfile
+++ b/jupyter-docker/Dockerfile
@@ -126,8 +126,7 @@ RUN apt-get install -yq --no-install-recommends \
  && pip install biopython \
  && pip install bx-python \
  && pip install fastinterval \
- && pip install matplotlib-venn \
- && pip install "https://github.com/all-of-us/workbench/archive/pyclient-v0-1-rc3.zip#egg=aou_workbench_client&subdirectory=client/py"
+ && pip install matplotlib-venn
 
 
 # Python 3 Kernel
@@ -155,8 +154,7 @@ RUN apt-get install -yq --no-install-recommends python3 \
  && pip3 install biopython \
  && pip3 install bx-python \
  && pip3 install fastinterval \
- && pip3 install matplotlib-venn \
- && pip3 install "https://github.com/all-of-us/workbench/archive/pyclient-v0-1-rc3.zip#egg=aou_workbench_client&subdirectory=client/py" 
+ && pip3 install matplotlib-venn
 
 
 #######################


### PR DESCRIPTION
The library we're installing is an old version. The AoU integration is going to install this via a user script, or just in a notebook via `!pip install`.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
