### PR TITLE
We do not install the AoU library by default anymore

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/NotebookInteractionSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/NotebookInteractionSpec.scala
@@ -115,21 +115,6 @@ class NotebookInteractionSpec extends FreeSpec with LeonardoTestUtils with Befor
       }
     }
 
-    "should import AoU library" in withWebDriver { implicit driver =>
-      withNewNotebook(ronCluster) { notebookPage =>
-        val importAoU =
-          """import sys
-            |import aou_workbench_client
-            |modulename = 'aou_workbench_client'
-            |if modulename not in sys.modules:
-            |    print 'You have not imported the {} module'.format(modulename)
-            |else:
-            |    print 'AoU library installed'""".stripMargin
-
-        notebookPage.executeCell(importAoU) shouldBe Some("AoU library installed")
-      }
-    }
-
     "should do cross domain cookie auth" in withWebDriver { implicit driver =>
       withDummyClientPage(ronCluster) { dummyClientPage =>
         // opens the notebook list page without setting a cookie


### PR DESCRIPTION
This PR broke this test in dev: https://github.com/DataBiosphere/leonardo/pull/250

Unfortunately tests still passed at PR time because of this: https://github.com/DataBiosphere/leonardo/issues/157. Oops :(

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
