### PR TITLE
Really unignore preemptibles test

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/ClusterMonitoringSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/ClusterMonitoringSpec.scala
@@ -103,7 +103,7 @@ class ClusterMonitoringSpec extends FreeSpec with LeonardoTestUtils with Paralle
     // TODO: we've noticed intermittent failures for this test. See:
     // https://github.com/DataBiosphere/leonardo/issues/204
     // https://github.com/DataBiosphere/leonardo/issues/228
-    "should execute Hail with correct permissions on a cluster with preemptible workers" ignore withWebDriver { implicit driver =>
+    "should execute Hail with correct permissions on a cluster with preemptible workers" in withWebDriver { implicit driver =>
       withCleanBillingProject(hermioneCreds) { projectName =>
         val project = GoogleProject(projectName)
 


### PR DESCRIPTION
I meant to unignore this test as part of https://github.com/DataBiosphere/leonardo/pull/238.

I think a merge conflict resolution probably put the ignore back (hard to tell `in` from `ignore`).

Will run a few builds off this branch to make sure it's really passing reliably.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
