### PR TITLE
Improvements for obtaining a token-based DAO

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/Boot.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/Boot.scala
@@ -7,9 +7,8 @@ import com.typesafe.config.ConfigFactory
 import com.typesafe.scalalogging.LazyLogging
 import net.ceedubs.ficus.Ficus._
 import org.broadinstitute.dsde.workbench.google.GoogleCredentialModes.{Pem, Token}
-import org.broadinstitute.dsde.workbench.google.{GoogleCredentialModes, GoogleStorageDAO, HttpGoogleIamDAO, HttpGoogleStorageDAO}
+import org.broadinstitute.dsde.workbench.google.{GoogleStorageDAO, HttpGoogleIamDAO, HttpGoogleStorageDAO}
 import org.broadinstitute.dsde.workbench.leonardo.api.{LeoRoutes, StandardUserInfoDirectives}
-import org.broadinstitute.dsde.workbench.leonardo.auth.sam.SwaggerSamClient
 import org.broadinstitute.dsde.workbench.leonardo.auth.{LeoAuthProviderHelper, ServiceAccountProviderHelper}
 import org.broadinstitute.dsde.workbench.leonardo.config.{ClusterDefaultsConfig, ClusterFilesConfig, ClusterResourcesConfig, DataprocConfig, MonitorConfig, ProxyConfig, SamConfig, SwaggerConfig}
 import org.broadinstitute.dsde.workbench.leonardo.dao.HttpSamDAO
@@ -20,8 +19,6 @@ import org.broadinstitute.dsde.workbench.leonardo.model.google.{ClusterStatus, N
 import org.broadinstitute.dsde.workbench.leonardo.monitor.ClusterMonitorSupervisor
 import org.broadinstitute.dsde.workbench.leonardo.monitor.ClusterMonitorSupervisor._
 import org.broadinstitute.dsde.workbench.leonardo.service.{BucketHelper, LeonardoService, ProxyService, StatusService}
-import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
-import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 
 import scala.concurrent.ExecutionContext
 import scala.util.{Failure, Success}
@@ -71,8 +68,8 @@ object Boot extends App with LazyLogging {
       dbRef.database.close()
     }
 
-    val petGoogleDAO: (WorkbenchEmail, GoogleProject) => GoogleStorageDAO = (email, project) => {
-      new HttpGoogleStorageDAO(dataprocConfig.applicationName, Token(() => serviceAccountProvider.getAccessToken(email, project)), "google")
+    val petGoogleDAO: String => GoogleStorageDAO = token => {
+      new HttpGoogleStorageDAO(dataprocConfig.applicationName, Token(() => token), "google")
     }
 
     val (leoServiceAccountEmail, leoServiceAccountPemFile) = serviceAccountProvider.getLeoServiceAccountAndKey

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/auth/DefaultServiceAccountProvider.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/auth/DefaultServiceAccountProvider.scala
@@ -30,5 +30,7 @@ class DefaultServiceAccountProvider(config: Config) extends ServiceAccountProvid
     Future.successful(List.empty)
   }
 
-  override def getAccessToken(userEmail: WorkbenchEmail, googleProject: GoogleProject): String = ""
+  override def getAccessToken(userEmail: WorkbenchEmail, googleProject: GoogleProject)(implicit executionContext: ExecutionContext): Future[Option[String]] = {
+    Future.successful(None)
+  }
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/auth/ServiceAccountProviderHelper.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/auth/ServiceAccountProviderHelper.scala
@@ -83,5 +83,9 @@ class ServiceAccountProviderHelper(wrappedServiceAccountProvider: ServiceAccount
     }
   }
 
-  override def getAccessToken(userEmail: WorkbenchEmail, googleProject: GoogleProject): String = wrappedServiceAccountProvider.getAccessToken(userEmail, googleProject)
+  override def getAccessToken(userEmail: WorkbenchEmail, googleProject: GoogleProject)(implicit executionContext: ExecutionContext): Future[Option[String]] = {
+    safeCall {
+      wrappedServiceAccountProvider.getAccessToken(userEmail, googleProject)
+    }
+  }
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/auth/sam/PetClusterServiceAccountProvider.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/auth/sam/PetClusterServiceAccountProvider.scala
@@ -28,5 +28,7 @@ class PetClusterServiceAccountProvider(val config: Config) extends ServiceAccoun
     Future.successful(List.empty)
   }
 
-  override def getAccessToken(userEmail: WorkbenchEmail, googleProject: GoogleProject): String = samClient.getCachedPetAccessToken(userEmail, googleProject)
+  override def getAccessToken(userEmail: WorkbenchEmail, googleProject: GoogleProject)(implicit executionContext: ExecutionContext): Future[Option[String]] = {
+    Future(Option(samClient.getCachedPetAccessToken(userEmail, googleProject)))
+  }
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/auth/sam/PetNotebookServiceAccountProvider.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/auth/sam/PetNotebookServiceAccountProvider.scala
@@ -39,5 +39,7 @@ class PetNotebookServiceAccountProvider(val config: Config) extends ServiceAccou
     Future.successful(List.empty)
   }
 
-  override def getAccessToken(userEmail: WorkbenchEmail, googleProject: GoogleProject): String = samClient.getCachedPetAccessToken(userEmail, googleProject)
+  override def getAccessToken(userEmail: WorkbenchEmail, googleProject: GoogleProject)(implicit executionContext: ExecutionContext): Future[Option[String]] = {
+    Future(Option(samClient.getCachedPetAccessToken(userEmail, googleProject)))
+  }
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/ServiceAccountProvider.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/ServiceAccountProvider.scala
@@ -72,5 +72,5 @@ abstract class ServiceAccountProvider(config: Config) {
     */
   def listUsersStagingBucketReaders(userEmail: WorkbenchEmail)(implicit executionContext: ExecutionContext): Future[List[WorkbenchEmail]]
 
-  def getAccessToken(userEmail: WorkbenchEmail, googleProject: GoogleProject): String
+  def getAccessToken(userEmail: WorkbenchEmail, googleProject: GoogleProject)(implicit executionContext: ExecutionContext): Future[Option[String]]
 }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/TestLeoRoutes.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/TestLeoRoutes.scala
@@ -6,6 +6,7 @@ import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import com.typesafe.config.ConfigFactory
 import net.ceedubs.ficus.Ficus._
+import org.broadinstitute.dsde.workbench.google.GoogleStorageDAO
 import org.broadinstitute.dsde.workbench.google.mock.{MockGoogleDataprocDAO, MockGoogleIamDAO, MockGoogleStorageDAO}
 import org.broadinstitute.dsde.workbench.leonardo.auth.WhitelistAuthProvider
 import org.broadinstitute.dsde.workbench.leonardo.auth.sam.MockPetClusterServiceAccountProvider
@@ -18,6 +19,7 @@ import org.broadinstitute.dsde.workbench.model.google._
 import org.broadinstitute.dsde.workbench.model.{UserInfo, WorkbenchEmail, WorkbenchUserId}
 import org.scalatest.concurrent.ScalaFutures
 
+import scala.concurrent.Future
 import scala.concurrent.duration._
 
 /**
@@ -35,7 +37,7 @@ trait TestLeoRoutes { this: ScalatestRouteTest with ScalaFutures =>
   val mockGoogleStorageDAO = new MockGoogleStorageDAO
   val userScriptPath = GcsPath(GcsBucketName("bucket1"), GcsObjectName("script.tar.gz"))
   val extensionPath = GcsPath(GcsBucketName("bucket"), GcsObjectName("my_extension.tar.gz"))
-  val mockPetGoogleDAO:(WorkbenchEmail, GoogleProject) => MockGoogleStorageDAO = (email, project) => {
+  val mockPetGoogleDAO: String => GoogleStorageDAO = _ => {
     val petMock = new MockGoogleStorageDAO
     petMock.buckets += userScriptPath.bucketName -> Set((userScriptPath.objectName, new ByteArrayInputStream("foo".getBytes())))
     petMock.buckets += extensionPath.bucketName -> Set((extensionPath.objectName, new ByteArrayInputStream("foo".getBytes())))
@@ -54,7 +56,7 @@ trait TestLeoRoutes { this: ScalatestRouteTest with ScalaFutures =>
   // Route tests don't currently do cluster monitoring, so use NoopActor
   val clusterMonitorSupervisor = system.actorOf(NoopActor.props)
   val bucketHelper = new BucketHelper(dataprocConfig, mockGoogleDataprocDAO, mockGoogleStorageDAO, serviceAccountProvider)
-  val leonardoService = new LeonardoService(dataprocConfig, clusterFilesConfig, clusterResourcesConfig, clusterDefaultsConfig, proxyConfig, swaggerConfig, mockGoogleDataprocDAO, mockGoogleIamDAO, mockGoogleStorageDAO,mockPetGoogleDAO, DbSingleton.ref, clusterMonitorSupervisor, whitelistAuthProvider, serviceAccountProvider, whitelist, bucketHelper)
+  val leonardoService = new LeonardoService(dataprocConfig, clusterFilesConfig, clusterResourcesConfig, clusterDefaultsConfig, proxyConfig, swaggerConfig, mockGoogleDataprocDAO, mockGoogleIamDAO, mockGoogleStorageDAO, mockPetGoogleDAO, DbSingleton.ref, clusterMonitorSupervisor, whitelistAuthProvider, serviceAccountProvider, whitelist, bucketHelper)
   val proxyService = new MockProxyService(proxyConfig, mockGoogleDataprocDAO, DbSingleton.ref, whitelistAuthProvider)
   val statusService = new StatusService(mockGoogleDataprocDAO, mockSamDAO, DbSingleton.ref, dataprocConfig, pollInterval = 1.second)
   val defaultUserInfo = UserInfo(OAuth2BearerToken("accessToken"), WorkbenchUserId("user1"), WorkbenchEmail("user1@example.com"), 0)

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/auth/sam/MockPetClusterServiceAccountProvider.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/auth/sam/MockPetClusterServiceAccountProvider.scala
@@ -32,5 +32,7 @@ class MockPetClusterServiceAccountProvider(config: Config) extends ServiceAccoun
     Future(mockSwaggerSamClient.getUserProxyFromSam(userEmail))map(List(_))
   }
 
-  override def getAccessToken(userEmail: WorkbenchEmail, googleProject: GoogleProject): String = mockSwaggerSamClient.getCachedPetAccessToken(userEmail,googleProject)
+  override def getAccessToken(userEmail: WorkbenchEmail, googleProject: GoogleProject)(implicit executionContext: ExecutionContext): Future[Option[String]] = {
+    Future(Option(mockSwaggerSamClient.getCachedPetAccessToken(userEmail, googleProject)))
+  }
 }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/auth/sam/MockPetNotebookServiceAccountProvider.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/auth/sam/MockPetNotebookServiceAccountProvider.scala
@@ -33,5 +33,7 @@ class MockPetNotebookServiceAccountProvider(config: Config) extends ServiceAccou
     Future(mockSamClient.getUserProxyFromSam(userEmail))map(List(_))
   }
 
-  override def getAccessToken(userEmail: WorkbenchEmail, googleProject: GoogleProject): String = mockSamClient.getCachedPetAccessToken(userEmail, googleProject)
+  override def getAccessToken(userEmail: WorkbenchEmail, googleProject: GoogleProject)(implicit executionContext: ExecutionContext): Future[Option[String]] = {
+    Future(Option(mockSamClient.getCachedPetAccessToken(userEmail, googleProject)))
+  }
 }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/auth/sam/MockSwaggerSamClient.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/auth/sam/MockSwaggerSamClient.scala
@@ -44,4 +44,8 @@ class MockSwaggerSamClient extends SwaggerSamClient("fake/path", new FiniteDurat
   override def getPetServiceAccount(userEmail: WorkbenchEmail, googleProject: GoogleProject): WorkbenchEmail = {
     serviceAccount
   }
+
+  override def getCachedPetAccessToken(userEmail: WorkbenchEmail, googleProject: GoogleProject): String = {
+    "token"
+  }
 }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorSpec.scala
@@ -78,7 +78,7 @@ class ClusterMonitorSpec extends TestKit(ActorSystem("leonardotest")) with FlatS
     val cacheActor = system.actorOf(ClusterDnsCache.props(proxyConfig, DbSingleton.ref))
     val bucketHelper = new BucketHelper(dataprocConfig, gdDAO, storageDAO, serviceAccountProvider)
     val supervisorActor = system.actorOf(TestClusterSupervisorActor.props(dataprocConfig, gdDAO, iamDAO, storageDAO, DbSingleton.ref, cacheActor, testKit, authProvider))
-    val mockPetGoogleDAO:(WorkbenchEmail, GoogleProject) => MockGoogleStorageDAO = (email, project) => {
+    val mockPetGoogleDAO: String => GoogleStorageDAO = _ => {
       new MockGoogleStorageDAO
     }
     new LeonardoService(dataprocConfig, clusterFilesConfig, clusterResourcesConfig, clusterDefaultsConfig, proxyConfig, swaggerConfig, gdDAO, iamDAO, storageDAO, mockPetGoogleDAO, DbSingleton.ref, supervisorActor, whitelistAuthProvider, serviceAccountProvider, whitelist, bucketHelper)

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/AuthProviderSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/AuthProviderSpec.scala
@@ -25,10 +25,13 @@ import org.scalatest.mockito.MockitoSugar
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{BeforeAndAfterAll, FreeSpec, Matchers, OptionValues}
 import net.ceedubs.ficus.Ficus._
+import org.broadinstitute.dsde.workbench.google.GoogleStorageDAO
 import org.broadinstitute.dsde.workbench.leonardo.auth.sam.MockPetClusterServiceAccountProvider
 import org.broadinstitute.dsde.workbench.leonardo.model.NotebookClusterActions.GetClusterStatus
 import org.broadinstitute.dsde.workbench.leonardo.model.google.ClusterName
 import org.mockito.Mockito
+
+import scala.concurrent.Future
 
 class AuthProviderSpec extends FreeSpec with ScalatestRouteTest with Matchers with MockitoSugar with TestComponent with ScalaFutures with OptionValues with GcsPathUtils with TestProxy with BeforeAndAfterAll {
   val name1 = ClusterName("name1")
@@ -94,7 +97,7 @@ class AuthProviderSpec extends FreeSpec with ScalatestRouteTest with Matchers wi
   }
 
   def leoWithAuthProvider(authProvider: LeoAuthProvider): LeonardoService = {
-    val mockPetGoogleDAO:(WorkbenchEmail, GoogleProject) => MockGoogleStorageDAO = (email, project) => {
+    val mockPetGoogleDAO: String => GoogleStorageDAO = _ => {
       new MockGoogleStorageDAO
     }
     new LeonardoService(dataprocConfig, clusterFilesConfig, clusterResourcesConfig, clusterDefaultsConfig, proxyConfig, swaggerConfig, gdDAO, iamDAO, storageDAO,mockPetGoogleDAO, DbSingleton.ref, system.actorOf(NoopActor.props), authProvider, serviceAccountProvider, whitelist, bucketHelper)

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoServiceSpec.scala
@@ -6,6 +6,7 @@ import java.util.UUID
 import akka.actor.ActorSystem
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import akka.testkit.TestKit
+import org.broadinstitute.dsde.workbench.google.GoogleStorageDAO
 import org.broadinstitute.dsde.workbench.google.mock.{MockGoogleDataprocDAO, MockGoogleIamDAO, MockGoogleStorageDAO}
 import org.broadinstitute.dsde.workbench.leonardo.CommonTestData
 import org.broadinstitute.dsde.workbench.leonardo.auth.WhitelistAuthProvider
@@ -46,7 +47,7 @@ class LeonardoServiceSpec extends TestKit(ActorSystem("leonardotest")) with Flat
     authProvider = new WhitelistAuthProvider(whitelistAuthConfig, serviceAccountProvider)
 
     bucketHelper = new BucketHelper(dataprocConfig, gdDAO, storageDAO, serviceAccountProvider)
-    val mockPetGoogleDAO:(WorkbenchEmail, GoogleProject) => MockGoogleStorageDAO = (email, project) => {
+    val mockPetGoogleDAO: String => GoogleStorageDAO = _ => {
       new MockGoogleStorageDAO
     }
     leo = new LeonardoService(dataprocConfig, clusterFilesConfig, clusterResourcesConfig, clusterDefaultsConfig, proxyConfig, swaggerConfig, gdDAO, iamDAO, storageDAO, mockPetGoogleDAO, DbSingleton.ref, system.actorOf(NoopActor.props), authProvider, serviceAccountProvider, whitelist, bucketHelper)
@@ -242,7 +243,7 @@ class LeonardoServiceSpec extends TestKit(ActorSystem("leonardotest")) with Flat
   it should "delete a cluster" in isolatedDbTest {
     // need a specialized LeonardoService for this test, so we can spy on its authProvider
     val spyProvider: LeoAuthProvider = spy(authProvider)
-    val mockPetGoogleDAO:(WorkbenchEmail, GoogleProject) => MockGoogleStorageDAO = (email, project) => {
+    val mockPetGoogleDAO: String => GoogleStorageDAO = _ => {
       new MockGoogleStorageDAO
     }
     val leoForTest = new LeonardoService(dataprocConfig, clusterFilesConfig, clusterResourcesConfig, clusterDefaultsConfig, proxyConfig, swaggerConfig, gdDAO, iamDAO, storageDAO, mockPetGoogleDAO, DbSingleton.ref, system.actorOf(NoopActor.props), spyProvider, serviceAccountProvider, whitelist, bucketHelper)
@@ -491,7 +492,7 @@ class LeonardoServiceSpec extends TestKit(ActorSystem("leonardotest")) with Flat
       }
     }
 
-    val mockPetGoogleDAO:(WorkbenchEmail, GoogleProject) => MockGoogleStorageDAO = (email, project) => {
+    val mockPetGoogleDAO: String => GoogleStorageDAO = _ => {
       new MockGoogleStorageDAO
     }
     // make a new LeoService


### PR DESCRIPTION
Hey @vkumra-broad, I was doing some experimentation and I think this may address my comments in https://github.com/DataBiosphere/leonardo/pull/253. It allows `ServiceAccountProvider.getAccessToken()` to return a `Future[Option[String]]` and makes `DefaultServiceAccountProvider` work by simply skipping bucket validation. Please review and accept this into your branch if it makes sense. Thanks.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
