### PR TITLE
LEO-214: Fix Downloaded Notebook Name

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
@@ -361,7 +361,7 @@ trait LeonardoTestUtils extends WebBrowserSpec with Matchers with Eventually wit
     }
 
     // sanity check the file downloaded correctly
-    val downloadFile = new File(downloadDir, "utf-8''"+uploadFile.getName)  // TODO https://github.com/DataBiosphere/leonardo/issues/214
+    val downloadFile = new File(downloadDir, uploadFile.getName)
     downloadFile.exists() shouldBe true
     downloadFile.isFile() shouldBe true
     math.abs(System.currentTimeMillis - downloadFile.lastModified()) shouldBe < (timeout.toMillis)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object Dependencies {
   val akkaV         = "2.5.3"
-  val akkaHttpV     = "10.0.9"
+  val akkaHttpV     = "10.1.0"
   val jacksonV      = "2.9.2"
   val googleV       = "1.22.0"
   val scalaLoggingV = "3.7.2"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,7 +1,7 @@
 import sbt._
 
 object Dependencies {
-  val akkaV         = "2.5.3"
+  val akkaV         = "2.5.11"
   val akkaHttpV     = "10.1.0"
   val jacksonV      = "2.9.2"
   val googleV       = "1.22.0"

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/ProxyService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/ProxyService.scala
@@ -26,7 +26,6 @@ import org.broadinstitute.dsde.workbench.model.UserInfo
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 
 import scala.collection.immutable
-import scala.collection.JavaConverters._
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/ProxyService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/ProxyService.scala
@@ -1,16 +1,14 @@
 package org.broadinstitute.dsde.workbench.leonardo.service
 
 import java.time.Instant
-import java.util
 import java.util.concurrent.TimeUnit
 
 import akka.actor.{ActorRef, ActorSystem}
-import akka.http.javadsl.model.headers.{ContentDisposition, ContentDispositionType}
+import akka.http.javadsl.model.headers.{ContentDisposition}
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.model.Uri.Host
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.headers.`Content-Disposition`
-import akka.http.scaladsl.model.headers.ContentDispositionTypes
 import akka.http.scaladsl.model.ws._
 import akka.pattern.ask
 import akka.stream.ActorMaterializer
@@ -32,7 +30,6 @@ import scala.collection.immutable
 import scala.collection.JavaConverters._
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
-import scala.util.matching.Regex
 
 case class ClusterNotReadyException(googleProject: GoogleProject, clusterName: ClusterName) extends LeoException(s"Cluster ${googleProject.value}/${clusterName.value} is not ready yet, chill out and try again later", StatusCodes.EnhanceYourCalm)
 case class ProxyException(googleProject: GoogleProject, clusterName: ClusterName) extends LeoException(s"Unable to proxy connection to Jupyter notebook on ${googleProject.value}/${clusterName.value}", StatusCodes.InternalServerError)

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/ProxyRoutesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/ProxyRoutesSpec.scala
@@ -2,7 +2,7 @@ package org.broadinstitute.dsde.workbench.leonardo.api
 
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
 import akka.http.scaladsl.model._
-import akka.http.scaladsl.model.headers._
+import akka.http.scaladsl.model.headers.{ContentDispositionTypes, `Content-Disposition`, _}
 import akka.http.scaladsl.model.ws.{TextMessage, WebSocketRequest}
 import akka.http.scaladsl.testkit.{RouteTestTimeout, ScalatestRouteTest}
 import akka.http.scaladsl.Http
@@ -137,6 +137,13 @@ class ProxyRoutesSpec extends FlatSpec with Matchers with BeforeAndAfterAll with
       .addHeader(RawHeader("foo", "bar"))
       .addHeader(RawHeader("baz", "biz")) ~> leoRoutes.route ~> check {
       responseAs[Data].headers should contain allElementsOf Map("foo" -> "bar", "baz" -> "biz")
+    }
+  }
+
+  it should "remove utf-8'' from content-disposition header filenames" in {
+    // The TestProxy adds the Content-Disposition header to the response, we can't do it from here
+    Get(s"/notebooks/$googleProject/$clusterName/content-disposition-test").addHeader(Cookie(tokenCookie)) ~> leoRoutes.route ~> check {
+      responseAs[HttpResponse].headers should contain (`Content-Disposition`(ContentDispositionTypes.attachment, Map("filename" -> "notebook.ipynb")))
     }
   }
 


### PR DESCRIPTION
- Updates akka and akk-http versions
- Adds a step in httpResponse processing to replace Content-Disposition header's filename param with correct one 

FIAB this branch is currently running on if you want to check it out:  fiab-ansingh-ruling-racer (35.192.122.4)


Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
