### PR TITLE
Include git in Leo docker image

### DIFF
--- a/jupyter-docker/Dockerfile
+++ b/jupyter-docker/Dockerfile
@@ -22,6 +22,8 @@ RUN echo "deb $DEBIAN_REPO/debian jessie main\ndeb $DEBIAN_REPO/debian-security 
     build-essential \
     lsb-release \
     procps \
+    # to support userScript pip installs via git
+    git \
 
  # google-cloud-sdk separately because it need lsb-release and other prereqs installed above
  && export CLOUD_SDK_REPO="cloud-sdk-$(lsb_release -c -s)" \


### PR DESCRIPTION
Offering this as one possible solution. I'm currently attempting to install git in my user script instead which would also be an acceptable solution, but without success (#265 to try and help me debug that one). The value here is that it would enable using the following form to pip install custom packages:

```
pip install --upgrade  --user "git+https://github.com/calbach/pyclient.git@ch/config-json#egg=aou_workbench_client&subdirectory=py"
```

This fails if you don't have git installed. For AoU, it would be convenient to use this technique for testing unreleased changes to the Python client library.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
