### PR TITLE
Leo creating too many pets

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/auth/DefaultServiceAccountProvider.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/auth/DefaultServiceAccountProvider.scala
@@ -2,7 +2,7 @@ package org.broadinstitute.dsde.workbench.leonardo.auth
 
 import com.typesafe.config.Config
 import org.broadinstitute.dsde.workbench.leonardo.model.ServiceAccountProvider
-import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
+import org.broadinstitute.dsde.workbench.model.{UserInfo, WorkbenchEmail}
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -12,12 +12,12 @@ import scala.concurrent.{ExecutionContext, Future}
   */
 class DefaultServiceAccountProvider(config: Config) extends ServiceAccountProvider(config) {
 
-  override def getClusterServiceAccount(userEmail: WorkbenchEmail, googleProject: GoogleProject)(implicit executionContext: ExecutionContext): Future[Option[WorkbenchEmail]] = {
+  override def getClusterServiceAccount(userInfo: UserInfo, googleProject: GoogleProject)(implicit executionContext: ExecutionContext): Future[Option[WorkbenchEmail]] = {
     // Create clusters with the Compute Engine default service account
     Future.successful(None)
   }
 
-  override def getNotebookServiceAccount(userEmail: WorkbenchEmail, googleProject: GoogleProject)(implicit executionContext: ExecutionContext): Future[Option[WorkbenchEmail]] = {
+  override def getNotebookServiceAccount(userInfo: UserInfo, googleProject: GoogleProject)(implicit executionContext: ExecutionContext): Future[Option[WorkbenchEmail]] = {
     // Don't localize any credentials to the notebook server
     Future.successful(None)
   }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/auth/LeoAuthProviderHelper.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/auth/LeoAuthProviderHelper.scala
@@ -7,7 +7,7 @@ import com.typesafe.scalalogging.LazyLogging
 import net.ceedubs.ficus.Ficus._
 import org.broadinstitute.dsde.workbench.leonardo.model._
 import org.broadinstitute.dsde.workbench.leonardo.model.google.ClusterName
-import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
+import org.broadinstitute.dsde.workbench.model.{UserInfo, WorkbenchEmail}
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.broadinstitute.dsde.workbench.util.FutureSupport
 
@@ -60,21 +60,21 @@ class LeoAuthProviderHelper(wrappedAuthProvider: LeoAuthProvider, authConfig: Co
     try { future.withTimeout(providerTimeout, "" /* errMsg, not used */).recoverWith(exceptionHandler) } catch exceptionHandler
   }
 
-  override def hasProjectPermission(userEmail: WorkbenchEmail, action: ProjectActions.ProjectAction, googleProject: GoogleProject)(implicit executionContext: ExecutionContext): Future[Boolean] = {
+  override def hasProjectPermission(userInfo: UserInfo, action: ProjectActions.ProjectAction, googleProject: GoogleProject)(implicit executionContext: ExecutionContext): Future[Boolean] = {
     safeCall {
-      wrappedAuthProvider.hasProjectPermission(userEmail, action, googleProject)
+      wrappedAuthProvider.hasProjectPermission(userInfo, action, googleProject)
     }
   }
 
-  override def canSeeAllClustersInProject(userEmail: WorkbenchEmail, googleProject: GoogleProject)(implicit executionContext: ExecutionContext): Future[Boolean] = {
+  override def hasNotebookClusterPermission(userInfo: UserInfo, action: NotebookClusterActions.NotebookClusterAction, googleProject: GoogleProject, clusterName: ClusterName)(implicit executionContext: ExecutionContext): Future[Boolean] = {
     safeCall {
-      wrappedAuthProvider.canSeeAllClustersInProject(userEmail, googleProject)
+      wrappedAuthProvider.hasNotebookClusterPermission(userInfo, action, googleProject, clusterName)
     }
   }
 
-  override def hasNotebookClusterPermission(userEmail: WorkbenchEmail, action: NotebookClusterActions.NotebookClusterAction, googleProject: GoogleProject, clusterName: ClusterName)(implicit executionContext: ExecutionContext): Future[Boolean] = {
+  override def filterClusters(userInfo: UserInfo, clusters: List[(GoogleProject, ClusterName)])(implicit executionContext: ExecutionContext): Future[List[(GoogleProject, ClusterName)]] = {
     safeCall {
-      wrappedAuthProvider.hasNotebookClusterPermission(userEmail, action, googleProject, clusterName)
+      wrappedAuthProvider.filterClusters(userInfo, clusters)
     }
   }
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/auth/ServiceAccountProviderHelper.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/auth/ServiceAccountProviderHelper.scala
@@ -6,7 +6,7 @@ import com.typesafe.config.Config
 import com.typesafe.scalalogging.LazyLogging
 import net.ceedubs.ficus.Ficus._
 import org.broadinstitute.dsde.workbench.leonardo.model.{LeoException, ServiceAccountProvider}
-import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
+import org.broadinstitute.dsde.workbench.model.{UserInfo, WorkbenchEmail}
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.broadinstitute.dsde.workbench.util.FutureSupport
 
@@ -59,15 +59,15 @@ class ServiceAccountProviderHelper(wrappedServiceAccountProvider: ServiceAccount
     try { future.withTimeout(providerTimeout, "" /* errMsg, not used */).recoverWith(exceptionHandler) } catch exceptionHandler
   }
 
-  override def getClusterServiceAccount(workbenchEmail: WorkbenchEmail, googleProject: GoogleProject)(implicit executionContext: ExecutionContext): Future[Option[WorkbenchEmail]] = {
+  override def getClusterServiceAccount(userInfo: UserInfo, googleProject: GoogleProject)(implicit executionContext: ExecutionContext): Future[Option[WorkbenchEmail]] = {
     safeCall {
-      wrappedServiceAccountProvider.getClusterServiceAccount(workbenchEmail, googleProject)
+      wrappedServiceAccountProvider.getClusterServiceAccount(userInfo, googleProject)
     }
   }
 
-  override def getNotebookServiceAccount(workbenchEmail: WorkbenchEmail, googleProject: GoogleProject)(implicit executionContext: ExecutionContext): Future[Option[WorkbenchEmail]] = {
+  override def getNotebookServiceAccount(userInfo: UserInfo, googleProject: GoogleProject)(implicit executionContext: ExecutionContext): Future[Option[WorkbenchEmail]] = {
     safeCall {
-      wrappedServiceAccountProvider.getNotebookServiceAccount(workbenchEmail, googleProject)
+      wrappedServiceAccountProvider.getNotebookServiceAccount(userInfo, googleProject)
     }
   }
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/auth/sam/PetClusterServiceAccountProvider.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/auth/sam/PetClusterServiceAccountProvider.scala
@@ -2,21 +2,21 @@ package org.broadinstitute.dsde.workbench.leonardo.auth.sam
 
 import com.typesafe.config.Config
 import org.broadinstitute.dsde.workbench.leonardo.model.ServiceAccountProvider
-import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
+import org.broadinstitute.dsde.workbench.model.{UserInfo, WorkbenchEmail}
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 
 import scala.concurrent.{ExecutionContext, Future}
 
 class PetClusterServiceAccountProvider(val config: Config) extends ServiceAccountProvider(config) with SamProvider {
 
-  override def getClusterServiceAccount(workbenchEmail: WorkbenchEmail, googleProject: GoogleProject)(implicit executionContext: ExecutionContext): Future[Option[WorkbenchEmail]] = {
-    // Ask Sam for a pet service account for the given (email, project)
+  override def getClusterServiceAccount(userInfo: UserInfo, googleProject: GoogleProject)(implicit executionContext: ExecutionContext): Future[Option[WorkbenchEmail]] = {
+    // Ask Sam for a pet service account for the given (user, project)
     Future {
-      Option(samClient.getPetServiceAccount(workbenchEmail, googleProject))
+      Option(samClient.getPetServiceAccount(userInfo, googleProject))
     }
   }
 
-  override def getNotebookServiceAccount(workbenchEmail: WorkbenchEmail, googleProject: GoogleProject)(implicit executionContext: ExecutionContext): Future[Option[WorkbenchEmail]] = {
+  override def getNotebookServiceAccount(userInfo: UserInfo, googleProject: GoogleProject)(implicit executionContext: ExecutionContext): Future[Option[WorkbenchEmail]] = {
     Future(None)
   }
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/auth/sam/PetNotebookServiceAccountProvider.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/auth/sam/PetNotebookServiceAccountProvider.scala
@@ -2,7 +2,7 @@ package org.broadinstitute.dsde.workbench.leonardo.auth.sam
 
 import com.typesafe.config.Config
 import org.broadinstitute.dsde.workbench.leonardo.model.ServiceAccountProvider
-import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
+import org.broadinstitute.dsde.workbench.model.{UserInfo, WorkbenchEmail}
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -19,15 +19,15 @@ import scala.concurrent.{ExecutionContext, Future}
   */
 class PetNotebookServiceAccountProvider(val config: Config) extends ServiceAccountProvider(config) with SamProvider {
 
-  override def getClusterServiceAccount(userEmail: WorkbenchEmail, googleProject: GoogleProject)(implicit executionContext: ExecutionContext): Future[Option[WorkbenchEmail]] = {
+  override def getClusterServiceAccount(userInfo: UserInfo, googleProject: GoogleProject)(implicit executionContext: ExecutionContext): Future[Option[WorkbenchEmail]] = {
     // Create cluster with the Google Compute Engine default service account
     Future(None)
   }
 
-  override def getNotebookServiceAccount(userEmail: WorkbenchEmail, googleProject: GoogleProject)(implicit executionContext: ExecutionContext): Future[Option[WorkbenchEmail]] = {
-    // Ask Sam for a pet service account for the given (email, project)
+  override def getNotebookServiceAccount(userInfo: UserInfo, googleProject: GoogleProject)(implicit executionContext: ExecutionContext): Future[Option[WorkbenchEmail]] = {
+    // Ask Sam for a pet service account for the given (user, project)
     Future {
-      Option(samClient.getPetServiceAccount(userEmail, googleProject))
+      Option(samClient.getPetServiceAccount(userInfo, googleProject))
     }
   }
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/auth/sam/SwaggerSamClient.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/auth/sam/SwaggerSamClient.scala
@@ -75,6 +75,7 @@ class SwaggerSamClient(samBasePath: String, cacheExpiryTime: FiniteDuration, cac
 
   //"Slow" lookup of pet's access token. The cache calls this when it needs to.
   private def getPetAccessTokenFromSam(userEmail: WorkbenchEmail, googleProject: GoogleProject): String = {
+    logger.info(s"Calling Sam getPetAccessTokenFromSam as user ${userEmail.value} and project ${googleProject.value}")
     val samAPI = samGoogleApi(getAccessTokenUsingPem(leoEmail, leoPem))
     val userPetServiceAccountKey = samAPI.getUserPetServiceAccountKey(googleProject.value, userEmail.value)
     getAccessTokenUsingJson(userPetServiceAccountKey)
@@ -109,27 +110,33 @@ class SwaggerSamClient(samBasePath: String, cacheExpiryTime: FiniteDuration, cac
 
 
   def createNotebookClusterResource(userEmail: WorkbenchEmail, googleProject: GoogleProject, clusterName: ClusterName) = {
+    logger.info(s"Calling Sam createNotebookClusterResource as user ${userEmail.value} and project ${googleProject.value} and clusterName ${clusterName.value}")
     resourcesApiAsPet(userEmail, googleProject).createResource(notebookClusterResourceTypeName, getClusterResourceId(googleProject, clusterName))
   }
 
   def deleteNotebookClusterResource(creatorEmail: WorkbenchEmail, googleProject: GoogleProject, clusterName: ClusterName) = {
+    logger.info(s"Calling Sam deleteNotebookClusterResource as user ${creatorEmail.value} and project ${googleProject.value} and clusterName ${clusterName.value}")
     resourcesApiAsPet(creatorEmail, googleProject).deleteResource(notebookClusterResourceTypeName, getClusterResourceId(googleProject, clusterName))
   }
 
   def hasActionOnBillingProjectResource(userEmail: WorkbenchEmail, googleProject: GoogleProject, action: String): Boolean = {
+    logger.info(s"Calling Sam hasActionOnBillingProjectResource as user ${userEmail.value} and project ${googleProject.value} and action ${action}")
     hasActionOnResource(billingProjectResourceTypeName, googleProject.value, userEmail, googleProject, action)
   }
 
   def hasActionOnNotebookClusterResource(userEmail: WorkbenchEmail, googleProject: GoogleProject, clusterName: ClusterName, action: String): Boolean = {
+    logger.info(s"Calling Sam hasActionOnNotebookClusterResource as user ${userEmail.value} and project ${googleProject.value} and action ${action}")
     hasActionOnResource(notebookClusterResourceTypeName, getClusterResourceId(googleProject, clusterName), userEmail, googleProject, action)
   }
 
   def getUserProxyFromSam(userEmail: WorkbenchEmail): WorkbenchEmail = {
+    logger.info(s"Calling Sam getUserProxyFromSam as user ${userEmail.value}")
     val samAPI = samGoogleApi(getAccessTokenUsingPem(leoEmail, leoPem))
     WorkbenchEmail(samAPI.getProxyGroup(userEmail.value))
   }
 
   def getPetServiceAccount(userEmail: WorkbenchEmail, googleProject: GoogleProject): WorkbenchEmail = {
+    logger.info(s"Calling Sam getPetServiceAccount as user ${userEmail.value} and project ${googleProject.value}")
     WorkbenchEmail(googleApiAsPet(userEmail, googleProject).getPetServiceAccount(googleProject.value))
   }
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeoAuthProvider.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeoAuthProvider.scala
@@ -4,11 +4,10 @@ import java.io.File
 
 import com.typesafe.config.Config
 import org.broadinstitute.dsde.workbench.leonardo.model.google.ClusterName
-import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
+import org.broadinstitute.dsde.workbench.model.{UserInfo, WorkbenchEmail}
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 
 import scala.concurrent.{ExecutionContext, Future}
-
 
 sealed trait LeoAuthAction extends Product with Serializable
 
@@ -25,45 +24,31 @@ object NotebookClusterActions {
   case object SyncDataToCluster extends NotebookClusterAction
   case object DeleteCluster extends NotebookClusterAction
   val allActions = Seq(GetClusterStatus, ConnectToCluster, SyncDataToCluster, DeleteCluster)
-
 }
 
 abstract class LeoAuthProvider(authConfig: Config, serviceAccountProvider: ServiceAccountProvider) {
 
   /**
-    * @param userEmail The user in question
+    * @param userInfo The user in question
     * @param action The project-level action (above) the user is requesting
     * @param googleProject The Google project to check in
     * @return If the given user has permissions in this project to perform the specified action.
     */
-  def hasProjectPermission(userEmail: WorkbenchEmail, action: ProjectActions.ProjectAction, googleProject: GoogleProject)(implicit executionContext: ExecutionContext): Future[Boolean]
-
-  /**
-    * When listing clusters, Leo will perform a GROUP BY on google projects and call this function once per google project.
-    * If you have an implementation such that users, even in some cases, can see all clusters in a google project, overriding
-    * this function may lead to significant performance improvements.
-    * For any projects where this function call returns Future.successful(false), Leo will then call hasNotebookClusterPermission
-    * for every cluster in that project, passing in action = GetClusterStatus.
-    *
-    * @param userEmail The user in question
-    * @param googleProject A Google project
-    * @return If the given user can see all clusters in this project
-    */
-  def canSeeAllClustersInProject(userEmail: WorkbenchEmail, googleProject: GoogleProject)(implicit executionContext: ExecutionContext): Future[Boolean] = {
-    Future.successful(false)
-  }
+  def hasProjectPermission(userInfo: UserInfo, action: ProjectActions.ProjectAction, googleProject: GoogleProject)(implicit executionContext: ExecutionContext): Future[Boolean]
 
   /**
     * Leo calls this method to verify if the user has permission to perform the given action on a specific notebook cluster.
     * It may call this method passing in a cluster that doesn't exist. Return Future.successful(false) if so.
     *
-    * @param userEmail      The user in question
+    * @param userInfo      The user in question
     * @param action        The cluster-level action (above) the user is requesting
     * @param googleProject The Google project the cluster was created in
     * @param clusterName   The user-provided name of the Dataproc cluster
     * @return If the userEmail has permission on this individual notebook cluster to perform this action
     */
-  def hasNotebookClusterPermission(userEmail: WorkbenchEmail, action: NotebookClusterActions.NotebookClusterAction, googleProject: GoogleProject, clusterName: ClusterName)(implicit executionContext: ExecutionContext): Future[Boolean]
+  def hasNotebookClusterPermission(userInfo: UserInfo, action: NotebookClusterActions.NotebookClusterAction, googleProject: GoogleProject, clusterName: ClusterName)(implicit executionContext: ExecutionContext): Future[Boolean]
+
+  def filterClusters(userInfo: UserInfo, clusters: List[(GoogleProject, ClusterName)])(implicit executionContext: ExecutionContext): Future[List[(GoogleProject, ClusterName)]]
 
   //Notifications that Leo has created/destroyed clusters. Allows the auth provider to register things.
 
@@ -86,7 +71,7 @@ abstract class LeoAuthProvider(authConfig: Config, serviceAccountProvider: Servi
     * Leo will wait, so be timely!
     *
     * @param userEmail     The email address of the user in question
-    * @param creatorEmail     The email address of the creator of the cluster
+    * @param creatorEmail  The email address of the creator of the cluster
     * @param googleProject The Google project the cluster was created in
     * @param clusterName   The user-provided name of the Dataproc cluster
     * @return A Future that will complete when the auth provider has finished doing its business.

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/ServiceAccountProvider.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/ServiceAccountProvider.scala
@@ -4,7 +4,7 @@ import java.io.File
 
 import com.typesafe.config.Config
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
-import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
+import org.broadinstitute.dsde.workbench.model.{UserInfo, WorkbenchEmail}
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -38,11 +38,11 @@ abstract class ServiceAccountProvider(config: Config) {
     * (https://cloud.google.com/compute/docs/access/service-accounts#compute_engine_default_service_account)
     * is used instead.
     *
-    * @param userEmail the user who is making the Leo request
+    * @param userInfo the user who is making the Leo request
     * @param googleProject the Google project the cluster is created in
     * @return service account email
     */
-  def getClusterServiceAccount(userEmail: WorkbenchEmail, googleProject: GoogleProject)(implicit executionContext: ExecutionContext): Future[Option[WorkbenchEmail]]
+  def getClusterServiceAccount(userInfo: UserInfo, googleProject: GoogleProject)(implicit executionContext: ExecutionContext): Future[Option[WorkbenchEmail]]
 
   /**
     * Optional. The service account email that will be localized into the user environment
@@ -52,11 +52,11 @@ abstract class ServiceAccountProvider(config: Config) {
     * If not present, application default credentials will return the service account in
     * instance metadata, i.e. the service account returned by [getClusterServiceAccount].
     *
-    * @param userEmail the user who is making the Leo request
+    * @param userInfo the user who is making the Leo request
     * @param googleProject the Google project the cluster is created in
     * @return service account email
     */
-  def getNotebookServiceAccount(userEmail: WorkbenchEmail, googleProject: GoogleProject)(implicit executionContext: ExecutionContext): Future[Option[WorkbenchEmail]]
+  def getNotebookServiceAccount(userInfo: UserInfo, googleProject: GoogleProject)(implicit executionContext: ExecutionContext): Future[Option[WorkbenchEmail]]
 
   /**
     *

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoService.scala
@@ -89,20 +89,20 @@ class LeonardoService(protected val dataprocConfig: DataprocConfig,
   // Register this instance with the cluster monitor supervisor so our cluster monitor can potentially delete and recreate clusters
   clusterMonitorSupervisor ! RegisterLeoService(this)
 
-  protected def checkProjectPermission(userEmail: WorkbenchEmail, action: ProjectAction, project: GoogleProject): Future[Unit] = {
-    authProvider.hasProjectPermission(userEmail, action, project) map {
-      case false => throw AuthorizationError(Option(userEmail))
+  protected def checkProjectPermission(userInfo: UserInfo, action: ProjectAction, project: GoogleProject): Future[Unit] = {
+    authProvider.hasProjectPermission(userInfo, action, project) map {
+      case false => throw AuthorizationError(Option(userInfo.userEmail))
       case true => ()
     }
   }
 
   //Throws 404 and pretends we don't even know there's a cluster there, by default.
   //If the cluster really exists and you're OK with the user knowing that, set throw401 = true.
-  protected def checkClusterPermission(user: UserInfo, action: NotebookClusterAction, cluster: Cluster, throw401: Boolean = false): Future[Unit] = {
-    authProvider.hasNotebookClusterPermission(user.userEmail, action, cluster.googleProject, cluster.clusterName) map {
+  protected def checkClusterPermission(userInfo: UserInfo, action: NotebookClusterAction, cluster: Cluster, throw401: Boolean = false): Future[Unit] = {
+    authProvider.hasNotebookClusterPermission(userInfo, action, cluster.googleProject, cluster.clusterName) map {
       case false =>
         if( throw401 )
-          throw AuthorizationError(Option(user.userEmail))
+          throw AuthorizationError(Option(userInfo.userEmail))
         else
           throw ClusterNotFoundException(cluster.googleProject, cluster.clusterName)
       case true => ()
@@ -111,11 +111,11 @@ class LeonardoService(protected val dataprocConfig: DataprocConfig,
 
   def createCluster(userInfo: UserInfo, googleProject: GoogleProject, clusterName: ClusterName, clusterRequest: ClusterRequest): Future[Cluster] = {
     for {
-      _ <- checkProjectPermission(userInfo.userEmail, CreateClusters, googleProject)
+      _ <- checkProjectPermission(userInfo, CreateClusters, googleProject)
 
       // Grab the service accounts from serviceAccountProvider for use later
-      clusterServiceAccountOpt <- serviceAccountProvider.getClusterServiceAccount(userInfo.userEmail, googleProject)
-      notebookServiceAccountOpt <- serviceAccountProvider.getNotebookServiceAccount(userInfo.userEmail, googleProject)
+      clusterServiceAccountOpt <- serviceAccountProvider.getClusterServiceAccount(userInfo, googleProject)
+      notebookServiceAccountOpt <- serviceAccountProvider.getNotebookServiceAccount(userInfo, googleProject)
       serviceAccountInfo = ServiceAccountInfo(clusterServiceAccountOpt, notebookServiceAccountOpt)
 
       cluster <- internalCreateCluster(userInfo.userEmail, serviceAccountInfo, googleProject, clusterName, clusterRequest)
@@ -207,31 +207,10 @@ class LeonardoService(protected val dataprocConfig: DataprocConfig,
     for {
       paramMap <- processListClustersParameters(params)
       clusterList <- dbRef.inTransaction { da => da.clusterQuery.listByLabels(paramMap._1, paramMap._2) }
-      //LeoAuthProviders can override canSeeAllClustersInProject if they have a speedy implementation, e.g. "you're a
-      //project owner so of course you do". In order to use it, we first group our list of clusters by project, and
-      //call canSeeAllClustersInProject once per project. If the answer is "no" for a given project, we check each
-      //cluster in that project individually.
-      clustersByProject = clusterList.groupBy(_.googleProject)
-      visibleClusters <- clustersByProject.toList.flatTraverse[Future, Cluster] { case (googleProject, clusters) =>
-        val clusterList = clusters.toList
-        authProvider.canSeeAllClustersInProject(userInfo.userEmail, googleProject).recover { case NonFatal(e) =>
-          logger.warn(s"The auth provider returned an exception calling canSeeAllClustersInProject for resource ${googleProject.value}. Filtering out this project from list results.", e)
-          false
-        } flatMap {
-          case true => Future.successful(clusterList)
-          case false => clusterList.traverseFilter { cluster =>
-            authProvider.hasNotebookClusterPermission(userInfo.userEmail, GetClusterStatus, cluster.googleProject, cluster.clusterName) map {
-              case false => None
-              case true => Some(cluster)
-            } recover { case NonFatal(e) =>
-              logger.warn(s"The auth provider returned an exception for resource ${cluster.projectNameString}. Filtering out from list results.", e)
-              None
-            }
-          }
-        }
-      }
+      visibleClusters <- authProvider.filterClusters(userInfo, clusterList.map(c => (c.googleProject, c.clusterName)).toList)
     } yield {
-      visibleClusters
+      val visibleClustersSet = visibleClusters.toSet
+      clusterList.filter(c => visibleClustersSet.contains((c.googleProject, c.clusterName)))
     }
   }
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/ProxyService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/ProxyService.scala
@@ -68,8 +68,8 @@ class ProxyService(proxyConfig: ProxyConfig,
    */
   private[leonardo] def authCheck(userInfo: UserInfo, googleProject: GoogleProject, clusterName: ClusterName, notebookAction: NotebookClusterAction): Future[Unit] = {
     for {
-      hasViewPermission <- authProvider.hasNotebookClusterPermission(userInfo.userEmail, GetClusterStatus, googleProject, clusterName)
-      hasRequiredPermission <- authProvider.hasNotebookClusterPermission(userInfo.userEmail, notebookAction, googleProject, clusterName)
+      hasViewPermission <- authProvider.hasNotebookClusterPermission(userInfo, GetClusterStatus, googleProject, clusterName)
+      hasRequiredPermission <- authProvider.hasNotebookClusterPermission(userInfo, notebookAction, googleProject, clusterName)
     } yield {
       if (!hasViewPermission) {
         throw ClusterNotFoundException(googleProject, clusterName)

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/CommonTestData.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/CommonTestData.scala
@@ -28,6 +28,7 @@ trait CommonTestData { this: ScalaFutures =>
   val userInfo = UserInfo(OAuth2BearerToken("accessToken"), WorkbenchUserId("user1"), userEmail, 0)
   val serviceAccountEmail = WorkbenchEmail("pet-1234567890@test-project.iam.gserviceaccount.com")
   val unauthorizedEmail = WorkbenchEmail("somecreep@example.com")
+  val unauthorizedUserInfo = UserInfo(OAuth2BearerToken("accessToken"), WorkbenchUserId("somecreep"), unauthorizedEmail, 0)
   val jupyterExtensionUri = GcsPath(GcsBucketName("extension_bucket"), GcsObjectName("extension_path"))
   val jupyterUserScriptUri = GcsPath(GcsBucketName("userscript_bucket"), GcsObjectName("userscript.sh"))
   val serviceAccountKey = ServiceAccountKey(ServiceAccountKeyId("123"), ServiceAccountPrivateKeyData("abcdefg"), Some(Instant.now), Some(Instant.now.plusSeconds(300)))
@@ -61,11 +62,11 @@ trait CommonTestData { this: ScalaFutures =>
 
 
   protected def clusterServiceAccount(googleProject: GoogleProject)(implicit executionContext: ExecutionContext): Option[WorkbenchEmail] = {
-    serviceAccountProvider.getClusterServiceAccount(userInfo.userEmail, googleProject).futureValue
+    serviceAccountProvider.getClusterServiceAccount(userInfo, googleProject).futureValue
   }
 
   protected def notebookServiceAccount(googleProject: GoogleProject)(implicit executionContext: ExecutionContext): Option[WorkbenchEmail] = {
-    serviceAccountProvider.getNotebookServiceAccount(userInfo.userEmail, googleProject).futureValue
+    serviceAccountProvider.getNotebookServiceAccount(userInfo, googleProject).futureValue
   }
 }
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/LeoRoutesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/LeoRoutesSpec.scala
@@ -50,8 +50,8 @@ class LeoRoutesSpec extends FlatSpec with Matchers with ScalatestRouteTest with 
     Get(s"/api/cluster/${googleProject.value}/${clusterName.value}") ~> leoRoutes.route ~> check {
       status shouldEqual StatusCodes.OK
       val responseCluster = responseAs[Cluster]
-      responseCluster.serviceAccountInfo.clusterServiceAccount shouldEqual serviceAccountProvider.getClusterServiceAccount(defaultUserInfo.userEmail, googleProject).futureValue
-      responseCluster.serviceAccountInfo.notebookServiceAccount shouldEqual serviceAccountProvider.getNotebookServiceAccount(defaultUserInfo.userEmail, googleProject).futureValue
+      responseCluster.serviceAccountInfo.clusterServiceAccount shouldEqual serviceAccountProvider.getClusterServiceAccount(defaultUserInfo, googleProject).futureValue
+      responseCluster.serviceAccountInfo.notebookServiceAccount shouldEqual serviceAccountProvider.getNotebookServiceAccount(defaultUserInfo, googleProject).futureValue
       responseCluster.jupyterExtensionUri shouldEqual Some(extensionPath)
     }
   }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/TestLeoRoutes.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/TestLeoRoutes.scala
@@ -57,10 +57,10 @@ trait TestLeoRoutes { this: ScalatestRouteTest with ScalaFutures =>
   }
 
   def clusterServiceAccount(googleProject: GoogleProject): Option[WorkbenchEmail] = {
-    serviceAccountProvider.getClusterServiceAccount(defaultUserInfo.userEmail, googleProject).futureValue
+    serviceAccountProvider.getClusterServiceAccount(defaultUserInfo, googleProject).futureValue
   }
 
   def notebookServiceAccount(googleProject: GoogleProject): Option[WorkbenchEmail] = {
-    serviceAccountProvider.getNotebookServiceAccount(defaultUserInfo.userEmail, googleProject).futureValue
+    serviceAccountProvider.getNotebookServiceAccount(defaultUserInfo, googleProject).futureValue
   }
 }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/auth/sam/MockPetClusterServiceAccountProvider.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/auth/sam/MockPetClusterServiceAccountProvider.scala
@@ -1,7 +1,6 @@
 package org.broadinstitute.dsde.workbench.leonardo.auth.sam
 
 import com.typesafe.config.Config
-import org.broadinstitute.dsde.workbench.leonardo.dao.MockSamDAO
 import org.broadinstitute.dsde.workbench.leonardo.model.ServiceAccountProvider
 import org.broadinstitute.dsde.workbench.model.{UserInfo, WorkbenchEmail}
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
@@ -15,12 +14,12 @@ class MockPetClusterServiceAccountProvider(config: Config) extends ServiceAccoun
   protected[leonardo] val mockSwaggerSamClient = new MockSwaggerSamClient
   private implicit val ec = scala.concurrent.ExecutionContext.global
 
-  override def getClusterServiceAccount(workbenchEmail: WorkbenchEmail, googleProject: GoogleProject)(implicit executionContext: ExecutionContext): Future[Option[WorkbenchEmail]] = {
+  override def getClusterServiceAccount(userInfo: UserInfo, googleProject: GoogleProject)(implicit executionContext: ExecutionContext): Future[Option[WorkbenchEmail]] = {
     // Pretend we're asking Sam for the pet
-    Future(Option(mockSwaggerSamClient.getPetServiceAccount(workbenchEmail, googleProject)))
+    Future(Option(mockSwaggerSamClient.getPetServiceAccount(userInfo, googleProject)))
   }
 
-  override def getNotebookServiceAccount(workbenchEmail: WorkbenchEmail, googleProject: GoogleProject)(implicit executionContext: ExecutionContext): Future[Option[WorkbenchEmail]] = {
+  override def getNotebookServiceAccount(userInfo: UserInfo, googleProject: GoogleProject)(implicit executionContext: ExecutionContext): Future[Option[WorkbenchEmail]] = {
     Future(None)
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/auth/sam/MockPetNotebookServiceAccountProvider.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/auth/sam/MockPetNotebookServiceAccountProvider.scala
@@ -1,7 +1,6 @@
 package org.broadinstitute.dsde.workbench.leonardo.auth.sam
 
 import com.typesafe.config.Config
-import org.broadinstitute.dsde.workbench.leonardo.dao.MockSamDAO
 import org.broadinstitute.dsde.workbench.leonardo.model.ServiceAccountProvider
 import org.broadinstitute.dsde.workbench.model.{UserInfo, WorkbenchEmail}
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
@@ -15,14 +14,14 @@ class MockPetNotebookServiceAccountProvider(config: Config) extends ServiceAccou
   private val mockSamClient = new MockSwaggerSamClient
   private implicit val ec = scala.concurrent.ExecutionContext.global
 
-  override def getClusterServiceAccount(workbenchEmail: WorkbenchEmail, googleProject: GoogleProject)(implicit executionContext: ExecutionContext): Future[Option[WorkbenchEmail]] = {
+  override def getClusterServiceAccount(userInfo: UserInfo, googleProject: GoogleProject)(implicit executionContext: ExecutionContext): Future[Option[WorkbenchEmail]] = {
     // Pretend we're using the compute engine default SA
     Future.successful(None)
   }
 
-  override def getNotebookServiceAccount(userEmail: WorkbenchEmail, googleProject: GoogleProject)(implicit executionContext: ExecutionContext): Future[Option[WorkbenchEmail]] = {
+  override def getNotebookServiceAccount(userInfo: UserInfo, googleProject: GoogleProject)(implicit executionContext: ExecutionContext): Future[Option[WorkbenchEmail]] = {
     // Pretend we're asking Sam for the pet
-    Future(Option(mockSamClient.getPetServiceAccount(userEmail, googleProject)))
+    Future(Option(mockSamClient.getPetServiceAccount(userInfo, googleProject)))
   }
 
   override def listUsersStagingBucketReaders(userEmail: WorkbenchEmail)(implicit executionContext: ExecutionContext): Future[List[WorkbenchEmail]] = {


### PR DESCRIPTION
Should fix https://github.com/DataBiosphere/leonardo/issues/263.

Improvements around Leo/Sam integration:
1. Use a token instead of a pet key where possible (per Doug: pets should only be used for offline access. I agree)
2. Use Sam `listResourcePolicies` for list clusters, instead of calling Sam one-by-one for each cluster.
3. Add some debug logging around Sam APIs

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
