### PR TITLE
Improve cluster cleanup-on-error logic

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,7 +11,7 @@ object Dependencies {
 
   val workbenchUtilV    = "0.2-d97f551"
   val workbenchModelV   = "0.10-6800f3a"
-  val workbenchGoogleV  = "0.15-2fc79a3"
+  val workbenchGoogleV  = "0.16-16e3aab"
   val workbenchMetricsV = "0.3-d97f551"
 
   val samV =  "1.0-5cdffb4"

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/BucketHelper.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/BucketHelper.scala
@@ -27,8 +27,7 @@ class BucketHelper(dataprocConfig: DataprocConfig,
   /**
     * Creates the dataproc init bucket and sets the necessary ACLs.
     */
-  def createInitBucket(googleProject: GoogleProject, clusterName: ClusterName, serviceAccountInfo: ServiceAccountInfo): Future[GcsBucketName] = {
-    val bucketName = generateUniqueBucketName(clusterName.value+"-init")
+  def createInitBucket(googleProject: GoogleProject, bucketName: GcsBucketName, serviceAccountInfo: ServiceAccountInfo): Future[GcsBucketName] = {
     for {
       // The init bucket is created in Leo's project, not the cluster's project.
       _ <- googleStorageDAO.createBucket(dataprocConfig.leoGoogleProject, bucketName)
@@ -45,8 +44,7 @@ class BucketHelper(dataprocConfig: DataprocConfig,
   /**
     * Creates the dataproc staging bucket and sets the necessary ACLs.
     */
-  def createStagingBucket(userEmail: WorkbenchEmail, googleProject: GoogleProject, clusterName: ClusterName, serviceAccountInfo: ServiceAccountInfo): Future[GcsBucketName] = {
-    val bucketName = generateUniqueBucketName(clusterName.value+"-staging")
+  def createStagingBucket(userEmail: WorkbenchEmail, googleProject: GoogleProject, bucketName: GcsBucketName, serviceAccountInfo: ServiceAccountInfo): Future[GcsBucketName] = {
     for {
       // The staging bucket is created in the cluster's project.
       _ <- googleStorageDAO.createBucket(googleProject, bucketName)

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoService.scala
@@ -286,10 +286,10 @@ class LeonardoService(protected val dataprocConfig: DataprocConfig,
       }
     } yield (cluster, initBucket, serviceAccountKeyOpt)
 
-    // Clean up Google resources on errors and return the original error
-    // Don't wait for this future.
-    googleFuture.andThen {
-      case Failure(t) => cleanUpGoogleResourcesOnError(t, googleProject, clusterName, initBucketName, serviceAccountInfo)
+    // If anything fails, we need to clean up Google resources that might have been created
+    googleFuture.andThen { case Failure(t) =>
+      // Don't wait for this future
+      cleanUpGoogleResourcesOnError(t, googleProject, clusterName, initBucketName, serviceAccountInfo)
     }
   }
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoService.scala
@@ -28,7 +28,7 @@ import scala.collection.Map
 import scala.concurrent.{ExecutionContext, Future}
 import scala.io.Source
 import scala.util.control.NonFatal
-import scala.util.{Failure, Success}
+import scala.util.Failure
 
 case class AuthorizationError(email: Option[WorkbenchEmail] = None)
   extends LeoException(s"${email.map(e => s"'${e.value}'").getOrElse("Your account")} is unauthorized", StatusCodes.Unauthorized)
@@ -146,13 +146,14 @@ class LeonardoService(protected val dataprocConfig: DataprocConfig,
           clusterMonitorSupervisor ! ClusterCreated(savedCluster)
           savedCluster
         }
-        clusterFuture.onComplete {
-          case Failure(_) =>
-            //make a dummy cluster with the details
-            val clusterToDelete = Cluster.createDummyForDeletion(clusterRequest, userEmail, clusterName, googleProject, serviceAccountInfo)
-            internalDeleteCluster(userEmail, clusterToDelete) //don't wait for it
-          case Success(_) => //no-op
+
+        // If cluster creation failed, createGoogleCluster removes resources in Google.
+        // We also need to notify our auth provider that the cluster has been deleted.
+        clusterFuture.andThen { case Failure(e) =>
+          // Don't wait for this future
+          authProvider.notifyClusterDeleted(userEmail, userEmail, googleProject, clusterName)
         }
+
         clusterFuture
     }
   }
@@ -253,7 +254,10 @@ class LeonardoService(protected val dataprocConfig: DataprocConfig,
                                            clusterName: ClusterName,
                                            clusterRequest: ClusterRequest)
                                           (implicit executionContext: ExecutionContext): Future[(Cluster, GcsBucketName, Option[ServiceAccountKey])] = {
-    for {
+    val initBucketName = generateUniqueBucketName(clusterName.value+"-init")
+    val stagingBucketName = generateUniqueBucketName(clusterName.value+"-staging")
+
+    val googleFuture = for {
       // Validate that the Jupyter extension URI and Jupyter user script URI are valid URIs and reference real GCS objects
       _ <- validateBucketObjectUri(googleProject, clusterRequest.jupyterExtensionUri)
       _ <- validateBucketObjectUri(googleProject, clusterRequest.jupyterUserScriptUri)
@@ -269,24 +273,52 @@ class LeonardoService(protected val dataprocConfig: DataprocConfig,
       _ <- addDataprocWorkerRoleToServiceAccount(googleProject, serviceAccountInfo.clusterServiceAccount)
       // Create the bucket in leo's google project and populate with initialization files.
       // ACLs are granted so the cluster service account can access the bucket at initialization time.
-      initBucket <- bucketHelper.createInitBucket(googleProject, clusterName, serviceAccountInfo)
+      initBucket <- bucketHelper.createInitBucket(googleProject, initBucketName, serviceAccountInfo)
       _ <- initializeBucketObjects(userEmail, googleProject, clusterName, initBucket, clusterRequest, serviceAccountKeyOpt)
       // Create the cluster staging bucket. ACLs are granted so the user/pet can access it.
-      stagingBucket <- bucketHelper.createStagingBucket(userEmail, googleProject, clusterName, serviceAccountInfo)
+      stagingBucket <- bucketHelper.createStagingBucket(userEmail, googleProject, stagingBucketName, serviceAccountInfo)
       // Create the cluster
       machineConfig = MachineConfigOps.create(clusterRequest.machineConfig, clusterDefaultsConfig)
       initScript = GcsPath(initBucket, GcsObjectName(clusterResourcesConfig.initActionsScript.value))
       credentialsFileName = serviceAccountInfo.notebookServiceAccount.map(_ => s"/etc/${ClusterInitValues.serviceAccountCredentialsFilename}")
       cluster <- gdDAO.createCluster(googleProject, clusterName, machineConfig, initScript, serviceAccountInfo.clusterServiceAccount, credentialsFileName, stagingBucket).map { operation =>
         Cluster.create(clusterRequest, userEmail, clusterName, googleProject, operation, serviceAccountInfo, machineConfig, dataprocConfig.clusterUrlBase, stagingBucket)
-      } andThen { case Failure(_) =>
-        // If cluster creation fails, delete the init bucket asynchronously and return the original error.
-        // Don't delete the staging bucket so the user can see error logs.
-        googleStorageDAO.deleteBucket(initBucket, recurse = true)
       }
-    } yield {
-      (cluster, initBucket, serviceAccountKeyOpt)
+    } yield (cluster, initBucket, serviceAccountKeyOpt)
+
+    // Clean up Google resources on errors and return the original error
+    // Don't wait for this future.
+    googleFuture.andThen {
+      case Failure(t) => cleanUpGoogleResourcesOnError(t, googleProject, clusterName, initBucketName, serviceAccountInfo)
     }
+  }
+
+  private[service] def cleanUpGoogleResourcesOnError(throwable: Throwable, googleProject: GoogleProject, clusterName: ClusterName, initBucketName: GcsBucketName, serviceAccountInfo: ServiceAccountInfo): Future[Unit] = {
+    logger.error(s"Cluster creation failed in Google for ${googleProject.value} / ${clusterName.value}. Cleaning up resources in Google...")
+
+    // Clean up resources in Google
+
+    val deleteInitBucketFuture = googleStorageDAO.deleteBucket(initBucketName, recurse = true) map { _ =>
+      logger.info(s"Successfully deleted init bucket ${initBucketName.value} for  ${googleProject.value} / ${clusterName.value}")
+    } recover { case e =>
+      logger.error(s"Failed to delete init bucket ${initBucketName.value} for  ${googleProject.value} / ${clusterName.value}", e)
+    }
+
+    // Don't delete the staging bucket so the user can see error logs.
+
+    val deleteClusterFuture = gdDAO.deleteCluster(googleProject, clusterName) map { _ =>
+      logger.info(s"Successfully deleted cluster ${googleProject.value} / ${clusterName.value}")
+    } recover { case e =>
+      logger.error(s"Failed to delete cluster ${googleProject.value} / ${clusterName.value}", e)
+    }
+
+    val deleteServiceAccountKeyFuture =  removeServiceAccountKey(googleProject, clusterName, serviceAccountInfo.notebookServiceAccount) map { _ =>
+      logger.info(s"Successfully deleted service account key for ${serviceAccountInfo.notebookServiceAccount}")
+    } recover { case e =>
+      logger.error(s"Failed to delete service account key for ${serviceAccountInfo.notebookServiceAccount}", e)
+    }
+
+    Future.sequence(Seq(deleteInitBucketFuture, deleteClusterFuture, deleteServiceAccountKeyFuture)).void
   }
 
   private[service] def generateServiceAccountKey(googleProject: GoogleProject, serviceAccountOpt: Option[WorkbenchEmail]): Future[Option[ServiceAccountKey]] = {

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/AuthProviderSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/AuthProviderSpec.scala
@@ -230,10 +230,9 @@ class AuthProviderSpec extends FreeSpec with ScalatestRouteTest with Matchers wi
       // check that the cluster does not exist
       gdDAO.clusters should not contain key (name1)
 
+      // creation and deletion notifications should have been fired
       verify(spyProvider).notifyClusterCreated(userEmail, project, name1)
-
-      // the auth provider is only notified after deletion is complete
-      verify(spyProvider, never).notifyClusterDeleted(userEmail, userEmail, project, name1)
+      verify(spyProvider).notifyClusterDeleted(userEmail, userEmail, project, name1)
     }
 
     "should use optimized canSeeAllClustersInProject in listClusters where appropriate" in isolatedDbTest {

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoServiceSpec.scala
@@ -296,7 +296,8 @@ class LeonardoServiceSpec extends TestKit(ActorSystem("leonardotest")) with Flat
 
   it should "initialize bucket with correct files" in isolatedDbTest {
     // create the bucket and add files
-    val bucket = bucketHelper.createInitBucket(project, name1, ServiceAccountInfo(None, Some(serviceAccountEmail))).futureValue
+    val bucketName = generateUniqueBucketName(name1.value+"-init")
+    val bucket = bucketHelper.createInitBucket(project, bucketName, ServiceAccountInfo(None, Some(serviceAccountEmail))).futureValue
     leo.initializeBucketObjects(userInfo.userEmail, project, name1, bucket, testClusterRequest, Some(serviceAccountKey)).futureValue
 
     // our bucket should now exist


### PR DESCRIPTION
I think our cleanup-on-error was causing https://github.com/DataBiosphere/leonardo/issues/262, which has been observed several times by the AoU team. I made some effort to clean up our cleanup. See comments below.

Automation tests passed against this branch: https://fc-jenkins.dsp-techops.broadinstitute.org/job/swatomation-pipeline/3306/. I was looking into the possibility of recreating the "stuck in Creating" issue in an automation test. However it's a little tricky because a) it's hard to simulate errors in cluster PUT requests and b) the issue is due to a race condition between actors which is hard to reproduce reliably.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
