### PR TITLE
Issue 272: CORS headers are double-set for proxied Jupyter rest API

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/CorsSupport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/CorsSupport.scala
@@ -26,11 +26,15 @@ trait CorsSupport {
       case Some(origin) => `Access-Control-Allow-Origin`(origin.value)
       case None => `Access-Control-Allow-Origin`.*
     } flatMap { allowOrigin =>
-      respondWithHeaders(
-        allowOrigin,
-        `Access-Control-Allow-Credentials`(true),
-        `Access-Control-Allow-Headers`("Authorization", "Content-Type", "Accept", "Origin"),
-        `Access-Control-Max-Age`(1728000))
+      mapResponseHeaders { headers =>
+        // Filter out the Access-Control-Allow-Origin set by Jupyter so we don't have duplicate headers
+        // (causes issues on some browsers). See https://github.com/DataBiosphere/leonardo/issues/272
+        headers.filter(_.isNot(`Access-Control-Allow-Origin`.lowercaseName)) ++
+          Seq(allowOrigin,
+            `Access-Control-Allow-Credentials`(true),
+            `Access-Control-Allow-Headers`("Authorization", "Content-Type", "Accept", "Origin"),
+            `Access-Control-Max-Age`(1728000))
+      }
     }
   }
 


### PR DESCRIPTION
Issue: https://github.com/DataBiosphere/leonardo/issues/272

Summary: Jupyter sets `Access-Control-Allow-Origin: *`, but the Leo proxy overrides it in some cases (when the origin is a different domain than Leo). Previously this was causing 2 `Access-Control-Allow-Origin` headers (with different values) which were causing browser exceptions in some cases.

Changed the proxy routes to do a replace instead of append, and added a unit test to reproduce the issue. 

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
