### PR TITLE
Put the init/staging bucket label at the beginning of the bucket name

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoService.scala
@@ -238,8 +238,8 @@ class LeonardoService(protected val dataprocConfig: DataprocConfig,
                                            clusterName: ClusterName,
                                            clusterRequest: ClusterRequest)
                                           (implicit executionContext: ExecutionContext): Future[(Cluster, GcsBucketName, Option[ServiceAccountKey])] = {
-    val initBucketName = generateUniqueBucketName("LeoInit-"+clusterName.value)
-    val stagingBucketName = generateUniqueBucketName("LeoStaging-"+clusterName.value)
+    val initBucketName = generateUniqueBucketName("leoinit-"+clusterName.value)
+    val stagingBucketName = generateUniqueBucketName("leostaging-"+clusterName.value)
 
     val googleFuture = for {
       // Validate that the Jupyter extension URI and Jupyter user script URI are valid URIs and reference real GCS objects

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoService.scala
@@ -238,8 +238,8 @@ class LeonardoService(protected val dataprocConfig: DataprocConfig,
                                            clusterName: ClusterName,
                                            clusterRequest: ClusterRequest)
                                           (implicit executionContext: ExecutionContext): Future[(Cluster, GcsBucketName, Option[ServiceAccountKey])] = {
-    val initBucketName = generateUniqueBucketName("LeoInit"+clusterName.value)
-    val stagingBucketName = generateUniqueBucketName("LeoStaging"+clusterName.value)
+    val initBucketName = generateUniqueBucketName("LeoInit-"+clusterName.value)
+    val stagingBucketName = generateUniqueBucketName("LeoStaging-"+clusterName.value)
 
     val googleFuture = for {
       // Validate that the Jupyter extension URI and Jupyter user script URI are valid URIs and reference real GCS objects

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoService.scala
@@ -238,8 +238,8 @@ class LeonardoService(protected val dataprocConfig: DataprocConfig,
                                            clusterName: ClusterName,
                                            clusterRequest: ClusterRequest)
                                           (implicit executionContext: ExecutionContext): Future[(Cluster, GcsBucketName, Option[ServiceAccountKey])] = {
-    val initBucketName = generateUniqueBucketName(clusterName.value+"-init")
-    val stagingBucketName = generateUniqueBucketName(clusterName.value+"-staging")
+    val initBucketName = generateUniqueBucketName("LeoInit"+clusterName.value)
+    val stagingBucketName = generateUniqueBucketName("LeoStaging"+clusterName.value)
 
     val googleFuture = for {
       // Validate that the Jupyter extension URI and Jupyter user script URI are valid URIs and reference real GCS objects

--- a/src/test/resources/reference.conf
+++ b/src/test/resources/reference.conf
@@ -4,7 +4,7 @@
 // -e MYSQL_ROOT_PASSWORD=leonardo-test \
 // -e MYSQL_USER=leonardo-test \
 // -e MYSQL_PASSWORD=leonardo-test \
-// -e MYSQL_DATABASE=leotest \
+// -e MYSQL_DATABASE=leotestdb \
 // -d -p 3306:3306 mysql/mysql-server:5.6
 
 mysql {

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoServiceSpec.scala
@@ -90,7 +90,7 @@ class LeonardoServiceSpec extends TestKit(ActorSystem("leonardotest")) with Flat
     val initBucketOpt = storageDAO.buckets.keys.find(_.value.startsWith("leoinit-"+name1.value))
     initBucketOpt shouldBe 'defined
 
-    val stagingBucketOpt = storageDAO.buckets.keys.find(_.value.startsWith("leoinit-"+name1.value))
+    val stagingBucketOpt = storageDAO.buckets.keys.find(_.value.startsWith("leostaging-"+name1.value))
     stagingBucketOpt shouldBe 'defined
 
     // check the init files were added to the init bucket

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoServiceSpec.scala
@@ -485,8 +485,8 @@ class LeonardoServiceSpec extends TestKit(ActorSystem("leonardotest")) with Flat
     gdDAO.firewallRules(project).name.value shouldBe proxyConfig.firewallRuleName
 
     //staging bucket lives on!
-    storageDAO.buckets.keys.find(bucket => bucket.value.contains("-init")).size shouldBe 0
-    storageDAO.buckets.keys.find(bucket => bucket.value.contains("-staging")).size shouldBe 1
+    storageDAO.buckets.keys.find(bucket => bucket.value.contains("leoinit-")).size shouldBe 0
+    storageDAO.buckets.keys.find(bucket => bucket.value.contains("leostaging-")).size shouldBe 1
   }
 
   it should "tell you if you're whitelisted" in isolatedDbTest {

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoServiceSpec.scala
@@ -87,10 +87,10 @@ class LeonardoServiceSpec extends TestKit(ActorSystem("leonardotest")) with Flat
     gdDAO.firewallRules(project).name.value shouldBe proxyConfig.firewallRuleName
 
     // should have created init and staging buckets
-    val initBucketOpt = storageDAO.buckets.keys.find(_.value.startsWith(name1.value+"-init"))
+    val initBucketOpt = storageDAO.buckets.keys.find(_.value.startsWith("LeoInit-"+name1.value))
     initBucketOpt shouldBe 'defined
 
-    val stagingBucketOpt = storageDAO.buckets.keys.find(_.value.startsWith(name1.value+"-staging"))
+    val stagingBucketOpt = storageDAO.buckets.keys.find(_.value.startsWith("LeoStaging-"+name1.value))
     stagingBucketOpt shouldBe 'defined
 
     // check the init files were added to the init bucket

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoServiceSpec.scala
@@ -87,10 +87,10 @@ class LeonardoServiceSpec extends TestKit(ActorSystem("leonardotest")) with Flat
     gdDAO.firewallRules(project).name.value shouldBe proxyConfig.firewallRuleName
 
     // should have created init and staging buckets
-    val initBucketOpt = storageDAO.buckets.keys.find(_.value.startsWith("LeoInit-"+name1.value))
+    val initBucketOpt = storageDAO.buckets.keys.find(_.value.startsWith("leoinit-"+name1.value))
     initBucketOpt shouldBe 'defined
 
-    val stagingBucketOpt = storageDAO.buckets.keys.find(_.value.startsWith("LeoStaging-"+name1.value))
+    val stagingBucketOpt = storageDAO.buckets.keys.find(_.value.startsWith("leoinit-"+name1.value))
     stagingBucketOpt shouldBe 'defined
 
     // check the init files were added to the init bucket


### PR DESCRIPTION
Put the init and staging bucket prefixes at the beginning of the bucket name. I'm doing this because the UUID often cuts off `-staging` from the bucket name, which makes it harder to distinguish between a cluster's init and staging buckets.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've documented my API changes in Swagger

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
