### PR TITLE
Make the websocket flicker go away

### DIFF
--- a/jupyter-docker/Dockerfile
+++ b/jupyter-docker/Dockerfile
@@ -214,6 +214,12 @@ RUN chown -R $USER:users $JUPYTER_HOME \
  && chmod +x $HAIL_HOME/spark_install_hail.sh \
  && chmod +x $JUPYTER_HOME/kernelspec.sh
 
+# This is a hacky way to get the ui to stop flickering as a result of kernel switches, restarts and reconnects from within a notebook
+# This edits the already built main.min.js file to prevent the notebook from scheduling a reconnect when a websocket is in a closing state
+# As a result, the websocket is allowed to reconnect on its own and doesn't get stuck in an infinite reconnection loop.
+# It should be removed at the first opportunity :(
+RUN sed -i "s/this._schedule_reconnect();//" ./usr/local/lib/python2.7/dist-packages/notebook/static/notebook/js/main.min.js
+
 USER $USER
 WORKDIR $HOME
 


### PR DESCRIPTION
I've built this on a Fiab - fiab-ansingh-liked-ewe (35.193.223.133)

This fixes flicker for Switch Kernel, Restart and Reconnect.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
