### PR TITLE
290: Add retries to SwaggerSamClient

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/auth/sam/PetClusterServiceAccountProvider.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/auth/sam/PetClusterServiceAccountProvider.scala
@@ -5,14 +5,14 @@ import org.broadinstitute.dsde.workbench.leonardo.model.ServiceAccountProvider
 import org.broadinstitute.dsde.workbench.model.{UserInfo, WorkbenchEmail}
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent._
 
 class PetClusterServiceAccountProvider(val config: Config) extends ServiceAccountProvider(config) with SamProvider {
 
   override def getClusterServiceAccount(userInfo: UserInfo, googleProject: GoogleProject)(implicit executionContext: ExecutionContext): Future[Option[WorkbenchEmail]] = {
     // Ask Sam for a pet service account for the given (user, project)
     Future {
-      Option(samClient.getPetServiceAccount(userInfo, googleProject))
+      Option(blocking(samClient.getPetServiceAccount(userInfo, googleProject)))
     }
   }
 
@@ -21,7 +21,7 @@ class PetClusterServiceAccountProvider(val config: Config) extends ServiceAccoun
   }
 
   override def listGroupsStagingBucketReaders(userEmail: WorkbenchEmail)(implicit executionContext: ExecutionContext): Future[List[WorkbenchEmail]] = {
-    Future(samClient.getUserProxyFromSam(userEmail)).map(List(_))
+    Future(blocking(samClient.getUserProxyFromSam(userEmail))).map(List(_))
   }
 
   override def listUsersStagingBucketReaders(userEmail: WorkbenchEmail)(implicit executionContext: ExecutionContext): Future[List[WorkbenchEmail]] = {
@@ -29,6 +29,6 @@ class PetClusterServiceAccountProvider(val config: Config) extends ServiceAccoun
   }
 
   override def getAccessToken(userEmail: WorkbenchEmail, googleProject: GoogleProject)(implicit executionContext: ExecutionContext): Future[Option[String]] = {
-    Future(Option(samClient.getCachedPetAccessToken(userEmail, googleProject)))
+    Future(Option(blocking(samClient.getCachedPetAccessToken(userEmail, googleProject))))
   }
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/auth/sam/PetNotebookServiceAccountProvider.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/auth/sam/PetNotebookServiceAccountProvider.scala
@@ -5,7 +5,7 @@ import org.broadinstitute.dsde.workbench.leonardo.model.ServiceAccountProvider
 import org.broadinstitute.dsde.workbench.model.{UserInfo, WorkbenchEmail}
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent._
 
 /**
   * Created by rtitle on 12/5/17.
@@ -27,7 +27,7 @@ class PetNotebookServiceAccountProvider(val config: Config) extends ServiceAccou
   override def getNotebookServiceAccount(userInfo: UserInfo, googleProject: GoogleProject)(implicit executionContext: ExecutionContext): Future[Option[WorkbenchEmail]] = {
     // Ask Sam for a pet service account for the given (user, project)
     Future {
-      Option(samClient.getPetServiceAccount(userInfo, googleProject))
+      Option(blocking(samClient.getPetServiceAccount(userInfo, googleProject)))
     }
   }
 
@@ -40,6 +40,6 @@ class PetNotebookServiceAccountProvider(val config: Config) extends ServiceAccou
   }
 
   override def getAccessToken(userEmail: WorkbenchEmail, googleProject: GoogleProject)(implicit executionContext: ExecutionContext): Future[Option[String]] = {
-    Future(Option(samClient.getCachedPetAccessToken(userEmail, googleProject)))
+    Future(Option(blocking(samClient.getCachedPetAccessToken(userEmail, googleProject))))
   }
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/auth/sam/SamProvider.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/auth/sam/SamProvider.scala
@@ -2,16 +2,19 @@ package org.broadinstitute.dsde.workbench.leonardo.auth.sam
 
 import java.io.File
 
+import akka.actor.ActorSystem
 import com.typesafe.config.Config
+import com.typesafe.scalalogging.LazyLogging
 import net.ceedubs.ficus.Ficus._
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
+import org.broadinstitute.dsde.workbench.util.Retry
 
 import scala.concurrent.duration._
 
 /**
   * Common trait for Leo providers which need a SwaggerSamClient.
   */
-trait SamProvider {
+trait SamProvider extends Retry with LazyLogging {
   val config: Config
 
   protected def getLeoServiceAccountAndKey: (WorkbenchEmail, File)
@@ -21,4 +24,5 @@ trait SamProvider {
   protected lazy val cacheMaxSize = config.getAs[Int]("petTokenCacheMaxSize").getOrElse(1000)
   protected lazy val (leoEmail, leoPemFile) = getLeoServiceAccountAndKey
   protected lazy val samClient = new SwaggerSamClient(samServer, cacheExpiryTime, cacheMaxSize, leoEmail, leoPemFile)
+  override val system = ActorSystem("leonardo-sam-provider")
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/auth/sam/SwaggerSamClient.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/auth/sam/SwaggerSamClient.scala
@@ -65,6 +65,10 @@ class SwaggerSamClient(samBasePath: String, cacheExpiryTime: FiniteDuration, cac
     petTokenCache.get(UserEmailAndProject(userEmail, googleProject))
   }
 
+  def invalidatePetAccessToken(userEmail: WorkbenchEmail, googleProject: GoogleProject): Unit = {
+    petTokenCache.invalidate(UserEmailAndProject(userEmail, googleProject))
+  }
+
   private[leonardo] val petTokenCache = CacheBuilder.newBuilder()
     .expireAfterWrite(cacheExpiryTime.toMinutes, TimeUnit.MINUTES)
     .maximumSize(cacheMaxSize)

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/auth/sam/MockSwaggerSamClient.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/auth/sam/MockSwaggerSamClient.scala
@@ -2,6 +2,7 @@ package org.broadinstitute.dsde.workbench.leonardo.auth.sam
 
 import java.io.File
 
+import io.swagger.client.ApiException
 import org.broadinstitute.dsde.workbench.leonardo.model.google.ClusterName
 import org.broadinstitute.dsde.workbench.model.{UserInfo, WorkbenchEmail}
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
@@ -19,10 +20,12 @@ class MockSwaggerSamClient extends SwaggerSamClient("fake/path", new FiniteDurat
   val userProxy = "PROXY_1234567890@dev.test.firecloud.org"
   val serviceAccount = WorkbenchEmail("pet-1234567890@test-project.iam.gserviceaccount.com")
 
+  @throws[ApiException]
   override def createNotebookClusterResource(userEmail: WorkbenchEmail, googleProject: GoogleProject, clusterName: ClusterName) = {
     notebookClusters += (googleProject, clusterName, userEmail) -> Set("status", "connect", "sync", "delete", "read_policies")
   }
 
+  @throws[ApiException]
   override def deleteNotebookClusterResource(userEmail: WorkbenchEmail, googleProject: GoogleProject, clusterName: ClusterName) = {
     notebookClusters.remove((googleProject, clusterName, userEmail))
   }


### PR DESCRIPTION
See https://github.com/DataBiosphere/leonardo/issues/290

Added invalidate-cache-and-retry logic to Sam `notifyClusterCreated` and `notifyClusterDeleted`. I only updated those methods because only they use the pet; all other Sam calls are done with the user's token or the Leo service account.

I also started a bit conservative: I am only retrying 401s and 50xs from Sam, and only retrying twice.

I am going to run a bunch of UI tests against this PR to see if it helps the intermittent failures.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
