### PR TITLE
Synchronous jupyter_localize_extension

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/Leonardo.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/Leonardo.scala
@@ -150,8 +150,8 @@ object Leonardo extends RestClient with LazyLogging {
     def contentsPath(googleProject: GoogleProject, clusterName: ClusterName, contentPath: String): String =
       s"${notebooksPath(googleProject, clusterName)}/api/contents/$contentPath"
 
-    def localizePath(googleProject: GoogleProject, clusterName: ClusterName, sync: Boolean = false): String =
-      s"${notebooksPath(googleProject, clusterName)}/api/localize${if (sync) "?sync=true" else ""}"
+    def localizePath(googleProject: GoogleProject, clusterName: ClusterName, async: Boolean = false): String =
+      s"${notebooksPath(googleProject, clusterName)}/api/localize${if (async) "?async=true" else ""}"
 
     def get(googleProject: GoogleProject, clusterName: ClusterName)(implicit token: AuthToken, webDriver: WebDriver): NotebooksListPage = {
       val path = notebooksPath(googleProject, clusterName)
@@ -165,8 +165,8 @@ object Leonardo extends RestClient with LazyLogging {
       parseResponse(getRequest(url + path))
     }
 
-    def localize(googleProject: GoogleProject, clusterName: ClusterName, locMap: Map[String, String], sync: Boolean = false)(implicit token: AuthToken): String = {
-      val path = localizePath(googleProject, clusterName, sync)
+    def localize(googleProject: GoogleProject, clusterName: ClusterName, locMap: Map[String, String], async: Boolean = false)(implicit token: AuthToken): String = {
+      val path = localizePath(googleProject, clusterName, async)
       logger.info(s"Localize notebook files: POST /$path")
       val cookie = Cookie(HttpCookiePair("LeoToken", token.value))
       postRequest(url + path, locMap, httpHeaders = List(cookie))

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/Leonardo.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/Leonardo.scala
@@ -150,8 +150,8 @@ object Leonardo extends RestClient with LazyLogging {
     def contentsPath(googleProject: GoogleProject, clusterName: ClusterName, contentPath: String): String =
       s"${notebooksPath(googleProject, clusterName)}/api/contents/$contentPath"
 
-    def localizePath(googleProject: GoogleProject, clusterName: ClusterName): String =
-      s"${notebooksPath(googleProject, clusterName)}/api/localize"
+    def localizePath(googleProject: GoogleProject, clusterName: ClusterName, sync: Boolean = false): String =
+      s"${notebooksPath(googleProject, clusterName)}/api/localize${if (sync) "?sync=true" else ""}"
 
     def get(googleProject: GoogleProject, clusterName: ClusterName)(implicit token: AuthToken, webDriver: WebDriver): NotebooksListPage = {
       val path = notebooksPath(googleProject, clusterName)
@@ -165,8 +165,8 @@ object Leonardo extends RestClient with LazyLogging {
       parseResponse(getRequest(url + path))
     }
 
-    def localize(googleProject: GoogleProject, clusterName: ClusterName, locMap: Map[String, String])(implicit token: AuthToken): String = {
-      val path = localizePath(googleProject, clusterName)
+    def localize(googleProject: GoogleProject, clusterName: ClusterName, locMap: Map[String, String], sync: Boolean = false)(implicit token: AuthToken): String = {
+      val path = localizePath(googleProject, clusterName, sync)
       logger.info(s"Localize notebook files: POST /$path")
       val cookie = Cookie(HttpCookiePair("LeoToken", token.value))
       postRequest(url + path, locMap, httpHeaders = List(cookie))

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
@@ -15,7 +15,7 @@ import org.broadinstitute.dsde.workbench.service.test.WebBrowserSpec
 import org.broadinstitute.dsde.workbench.leonardo.ClusterStatus.ClusterStatus
 import org.broadinstitute.dsde.workbench.leonardo.StringValueClass.LabelMap
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
-import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GcsObjectName, GcsPath, GoogleProject, ServiceAccountName, generateUniqueBucketName}
+import org.broadinstitute.dsde.workbench.model.google._
 import org.broadinstitute.dsde.workbench.util.LocalFileUtil
 import org.openqa.selenium.WebDriver
 import org.scalactic.source.Position
@@ -381,6 +381,64 @@ trait LeonardoTestUtils extends WebBrowserSpec with Matchers with Eventually wit
     testResult.get
   }
 
+  def withLocalizeDelocalizeFiles[T](cluster: Cluster, localizeFileName: String, localizeFileContents: String, delocalizeFileName: String, delocalizeFileContents: String)(testCode: (Map[String, String], GcsBucketName) => T)(implicit webDriver: WebDriver, token: AuthToken): T = {
+    implicit val patienceConfig: PatienceConfig = storagePatience
+
+    withNewGoogleBucket(cluster.googleProject) { bucketName =>
+      // give the user's pet owner access to the bucket
+      val petServiceAccount = Sam.user.petServiceAccountEmail(cluster.googleProject.value)
+      googleStorageDAO.setBucketAccessControl(bucketName, GcsEntity(petServiceAccount, GcsEntityTypes.User), GcsRoles.Owner).futureValue
+
+      // create a bucket object to localize
+      val bucketObjectToLocalize = GcsObjectName(localizeFileName)
+      withNewBucketObject(bucketName, bucketObjectToLocalize, localizeFileContents, "text/plain") { objectName =>
+        // give the user's pet read access to the object
+        googleStorageDAO.setObjectAccessControl(bucketName, objectName, GcsEntity(petServiceAccount, GcsEntityTypes.User), GcsRoles.Owner).futureValue
+
+        // create a notebook file to delocalize
+        withNewNotebook(cluster) { notebookPage =>
+          notebookPage.executeCell(s"""! echo -n "$delocalizeFileContents" > $delocalizeFileName""")
+
+          val localizeRequest = Map(
+            localizeFileName -> GcsPath(bucketName, bucketObjectToLocalize).toUri,
+            GcsPath(bucketName, GcsObjectName(delocalizeFileName)).toUri -> delocalizeFileName
+          )
+
+          val testResult = Try(testCode(localizeRequest, bucketName))
+
+          // clean up files on the cluster
+          // no need to clean up the bucket objects; that will happen as part of `withNewBucketObject`
+          notebookPage.executeCell(s"""! rm -f $localizeFileName""")
+          notebookPage.executeCell(s"""! rm -f $delocalizeFileName""")
+
+          testResult.get
+        }
+      }
+    }
+  }
+
+  def verifyLocalizeDelocalize(cluster: Cluster, localizeFileName: String, localizeFileContents: String, delocalizeBucketPath: GcsPath, delocalizeBucketContents: String)(implicit token: AuthToken): Unit = {
+    implicit val patienceConfig: PatienceConfig = storagePatience
+
+    // check localization.log for existence
+    val localizationLog = Leonardo.notebooks.getContentItem(cluster.googleProject, cluster.clusterName, "localization.log", includeContent = true)
+    localizationLog.content shouldBe defined
+
+    // Save localization.log to test output to aid in debugging
+    val downloadFile = new File(logDir, s"${cluster.googleProject.value}-${cluster.clusterName.string}-localization.log")
+    val fos = new FileOutputStream(downloadFile)
+    fos.write(localizationLog.content.get.getBytes)
+    fos.close()
+    logger.info(s"Saved localization log for cluster ${cluster.googleProject.value}/${cluster.clusterName.string} to ${downloadFile.getAbsolutePath}")
+
+    // the localized file should exist on the notebook VM
+    val item = Leonardo.notebooks.getContentItem(cluster.googleProject, cluster.clusterName, localizeFileName, includeContent = true)
+    item.content shouldBe Some(localizeFileContents)
+
+    // the delocalized file should exist in the Google bucket
+    val data = googleStorageDAO.getObject(delocalizeBucketPath.bucketName, delocalizeBucketPath.objectName).futureValue
+    data.map(_.toString) shouldBe Some(delocalizeBucketContents)
+  }
 
   def verifyHailImport(notebookPage: NotebookPage, vcfPath: GcsPath, clusterName: ClusterName): Unit = {
     val hailTimeout = 5 minutes

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
@@ -419,7 +419,7 @@ trait LeonardoTestUtils extends WebBrowserSpec with Matchers with Eventually wit
     }
   }
 
-  def verifyLocalizeDelocalize(cluster: Cluster, localizeFileName: String, localizeFileContents: String, delocalizeBucketPath: GcsPath, delocalizeBucketContents: String)(implicit token: AuthToken): Unit = {
+  def verifyLocalizeDelocalize(cluster: Cluster, localizedFileName: String, localizedFileContents: String, delocalizedBucketPath: GcsPath, delocalizedBucketContents: String)(implicit token: AuthToken): Unit = {
     implicit val patienceConfig: PatienceConfig = storagePatience
 
     // check localization.log for existence
@@ -434,12 +434,12 @@ trait LeonardoTestUtils extends WebBrowserSpec with Matchers with Eventually wit
     logger.info(s"Saved localization log for cluster ${cluster.googleProject.value}/${cluster.clusterName.string} to ${downloadFile.getAbsolutePath}")
 
     // the localized file should exist on the notebook VM
-    val item = Leonardo.notebooks.getContentItem(cluster.googleProject, cluster.clusterName, localizeFileName, includeContent = true)
-    item.content shouldBe Some(localizeFileContents)
+    val item = Leonardo.notebooks.getContentItem(cluster.googleProject, cluster.clusterName, localizedFileName, includeContent = true)
+    item.content shouldBe Some(localizedFileContents)
 
     // the delocalized file should exist in the Google bucket
-    val data = googleStorageDAO.getObject(delocalizeBucketPath.bucketName, delocalizeBucketPath.objectName).futureValue
-    data.map(_.toString) shouldBe Some(delocalizeBucketContents)
+    val data = googleStorageDAO.getObject(delocalizedBucketPath.bucketName, delocalizedBucketPath.objectName).futureValue
+    data.map(_.toString) shouldBe Some(delocalizedBucketContents)
   }
 
   def verifyHailImport(notebookPage: NotebookPage, vcfPath: GcsPath, clusterName: ClusterName): Unit = {

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/NotebookInteractionSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/NotebookInteractionSpec.scala
@@ -94,7 +94,7 @@ class NotebookInteractionSpec extends FreeSpec with LeonardoTestUtils with Befor
 
       withLocalizeDelocalizeFiles(ronCluster, localizeFileName, localizeFileContents, delocalizeFileName, delocalizeFileContents) { (localizeRequest, bucketName) =>
         // call localize; this should return 200
-        Leonardo.notebooks.localize(ronCluster.googleProject, ronCluster.clusterName, localizeRequest, sync = false)
+        Leonardo.notebooks.localize(ronCluster.googleProject, ronCluster.clusterName, localizeRequest, async = true)
 
         // check that the files are eventually at their destinations
         implicit val patienceConfig: PatienceConfig = localizePatience
@@ -104,7 +104,7 @@ class NotebookInteractionSpec extends FreeSpec with LeonardoTestUtils with Befor
 
         // call localize again with bad data. This should still return 200 since we're in async mode.
         val badLocalize = Map("file.out" -> "gs://nobuckethere")
-        Leonardo.notebooks.localize(ronCluster.googleProject, ronCluster.clusterName, badLocalize, sync = false)
+        Leonardo.notebooks.localize(ronCluster.googleProject, ronCluster.clusterName, badLocalize, async = true)
 
         // it should not have localized this file
         val thrown = the [RestException] thrownBy {
@@ -123,7 +123,7 @@ class NotebookInteractionSpec extends FreeSpec with LeonardoTestUtils with Befor
 
       withLocalizeDelocalizeFiles(ronCluster, localizeFileName, localizeFileContents, delocalizeFileName, delocalizeFileContents) { (localizeRequest, bucketName) =>
         // call localize; this should return 200
-        Leonardo.notebooks.localize(ronCluster.googleProject, ronCluster.clusterName, localizeRequest, sync = true)
+        Leonardo.notebooks.localize(ronCluster.googleProject, ronCluster.clusterName, localizeRequest, async = false)
 
         // check that the files are immediately at their destinations
         verifyLocalizeDelocalize(ronCluster, localizeFileName, localizeFileContents, GcsPath(bucketName, GcsObjectName(delocalizeFileName)), delocalizeFileContents)
@@ -131,7 +131,7 @@ class NotebookInteractionSpec extends FreeSpec with LeonardoTestUtils with Befor
         // call localize again with bad data. This should still return 500 since we're in sync mode.
         val badLocalize = Map("file.out" -> "gs://nobuckethere")
         val thrown = the [RestException] thrownBy {
-          Leonardo.notebooks.localize(ronCluster.googleProject, ronCluster.clusterName, badLocalize, sync = true)
+          Leonardo.notebooks.localize(ronCluster.googleProject, ronCluster.clusterName, badLocalize, async = false)
         }
         // why doesn't `RestException` have a status code field?
         thrown.message should include ("500 : Internal Server Error")

--- a/jupyter-docker/jupyter_localize_extension.py
+++ b/jupyter-docker/jupyter_localize_extension.py
@@ -59,7 +59,8 @@ class LocalizeHandler(IPythonHandler):
 
     else:
       #run localize synchronous to the HTTP request
-      ok = self.localize(pathdict)
+      #run_sync() doesn't take arguments, so we must wrap the call in a lambda.
+      ok = tornado.ioloop.IOLoop().run_sync(lambda: self.localize(pathdict))
 
       #complete the request only after localize completes
       if not ok:

--- a/jupyter-docker/jupyter_localize_extension.py
+++ b/jupyter-docker/jupyter_localize_extension.py
@@ -23,7 +23,7 @@ class LocalizeHandler(IPythonHandler):
   @gen.coroutine
   def localize(self, pathdict):
     """Treats the given dict as a string/string map and sends it to gsutil."""
-    ok = True
+    all_success = True
     #This gets dropped inside the user's notebook working directory
     with open("localization.log", 'a', buffering=1) as locout:
       for key in pathdict:
@@ -32,8 +32,8 @@ class LocalizeHandler(IPythonHandler):
         locout.write(' '.join(cmd) + '\n')
         code = subprocess.call(cmd, stderr=locout)
         if code is not 0:
-          ok = False
-    return ok
+          all_success = False
+    return all_success
 
   def post(self):
     try:
@@ -60,10 +60,10 @@ class LocalizeHandler(IPythonHandler):
     else:
       #run localize synchronous to the HTTP request
       #run_sync() doesn't take arguments, so we must wrap the call in a lambda.
-      ok = tornado.ioloop.IOLoop().run_sync(lambda: self.localize(pathdict))
+      success = tornado.ioloop.IOLoop().run_sync(lambda: self.localize(pathdict))
 
       #complete the request only after localize completes
-      if not ok:
+      if not success:
         raise HTTPError(500, "Error occurred during localization. See localization.log for details.")
       else:
         self.set_status(200)

--- a/jupyter-docker/jupyter_localize_extension.py
+++ b/jupyter-docker/jupyter_localize_extension.py
@@ -47,9 +47,9 @@ class LocalizeHandler(IPythonHandler):
     if not all(map(lambda v: type(v) is unicode, pathdict.values())):
       raise HTTPError(400, "Body must be JSON object of type string/string")
 
-    synchronous = self.get_query_argument('sync', False)
+    async = self.get_query_argument('async', False)
 
-    if not synchronous:
+    if async:
       #complete the request HERE, without waiting for the localize to run
       self.set_status(200)
       self.finish()

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -337,9 +337,8 @@ paths:
         Sends a command to a Jupyter notebook server to localize files between the server and GCS.
         Output, including any errors, will appear in `localization.log` in the working directory of the Jupyter notebook server.
 
-        By default this operation will happen asynchronously and this API will always return a 200 status.
-        However, if the `sync` parameter is specfied then the localization will happen synchronous to the request, and the API will
-        return 500 if an error occurred during the copy.
+        By default this operation will happen synchronously and the response status will reflect any errors encountered in the copy.
+        However, if the `async` parameter is specfied then the localization will happen asynchronously to the request, and the API will always return 200.
       operationId: proxyLocalize
       tags:
         - notebooks
@@ -355,10 +354,10 @@ paths:
           required: true
           type: string
         - in: query
-          name: sync
+          name: async
           description: |
-            If true, the copy will happen synchronous to the request and the API response will reflect any errors encountered during the copy.
-            If false, the copy will happen asynchronous to the request and the API will always return 200.
+            If true, the copy will happen asynchronously to the request and the API will always return 200.
+            If false (the default), the copy will happen synchronously and the response will reflect any errors encountered during the copy.
           required: false
           type: boolean
           default: false

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -335,7 +335,11 @@ paths:
       summary: Localize files to/from a Jupyter notebook server
       description: |
         Sends a command to a Jupyter notebook server to localize files between the server and GCS.
-        This operation will happen asynchronously; output, including any errors, will appear in `localization.log` in the working directory of the Jupyter notebook server.
+        Output, including any errors, will appear in `localization.log` in the working directory of the Jupyter notebook server.
+
+        By default this operation will happen asynchronously and this API will always return a 200 status.
+        However, if the `sync` parameter is specfied then the localization will happen synchronous to the request, and the API will
+        return 500 if an error occurred during the copy.
       operationId: proxyLocalize
       tags:
         - notebooks
@@ -350,6 +354,14 @@ paths:
           description: clusterName
           required: true
           type: string
+        - in: query
+          name: sync
+          description: |
+            If true, the copy will happen synchronous to the request and the API response will reflect any errors encountered during the copy.
+            If false, the copy will happen asynchronous to the request and the API will always return 200.
+          required: false
+          type: boolean
+          default: false
         - in: body
           description: |
             JSON object. Keys represent destinations, values represent sources.


### PR DESCRIPTION
This includes:

- https://github.com/DataBiosphere/leonardo/issues/293: update jupyter_localize_extension.py to use arrays like jupyter_delocalyze.py
- https://github.com/DataBiosphere/leonardo/issues/306: Allow jupyter_localize_extension to run in synchronous mode

cc @zarsky-broad @calbach @dionloy 

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
