### PR TITLE
Fix for cookie age unit bug

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/Boot.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/Boot.scala
@@ -18,7 +18,8 @@ import org.broadinstitute.dsde.workbench.leonardo.dns.ClusterDnsCache
 import org.broadinstitute.dsde.workbench.leonardo.model.google.{ClusterStatus, NetworkTag}
 import org.broadinstitute.dsde.workbench.leonardo.monitor.ClusterMonitorSupervisor
 import org.broadinstitute.dsde.workbench.leonardo.monitor.ClusterMonitorSupervisor._
-import org.broadinstitute.dsde.workbench.leonardo.service.{BucketHelper, LeonardoService, ProxyService, StatusService}
+import org.broadinstitute.dsde.workbench.leonardo.service.{LeonardoService, ProxyService, StatusService}
+import org.broadinstitute.dsde.workbench.leonardo.util.BucketHelper
 
 import scala.concurrent.ExecutionContext
 import scala.util.{Failure, Success}

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/LeoRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/LeoRoutes.scala
@@ -17,7 +17,7 @@ import org.broadinstitute.dsde.workbench.leonardo.model.{ClusterRequest, LeoExce
 import org.broadinstitute.dsde.workbench.leonardo.model.google.ClusterName
 import org.broadinstitute.dsde.workbench.leonardo.model.LeonardoJsonSupport._
 import org.broadinstitute.dsde.workbench.leonardo.service.{LeonardoService, ProxyService, StatusService}
-import org.broadinstitute.dsde.workbench.leonardo.util.RouteHelper
+import org.broadinstitute.dsde.workbench.leonardo.util.CookieHelper
 import org.broadinstitute.dsde.workbench.model.ErrorReportJsonSupport._
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.broadinstitute.dsde.workbench.model.{ErrorReport, WorkbenchException, WorkbenchExceptionWithErrorReport}
@@ -26,9 +26,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 abstract class LeoRoutes(val leonardoService: LeonardoService, val proxyService: ProxyService, val statusService: StatusService, val swaggerConfig: SwaggerConfig)
                         (implicit val system: ActorSystem, val materializer: Materializer, val executionContext: ExecutionContext)
-  extends LazyLogging with RouteHelper with ProxyRoutes with SwaggerRoutes with StatusRoutes with UserInfoDirectives {
-
-  private val tokenCookieName = "LeoToken"
+  extends LazyLogging with CookieHelper with ProxyRoutes with SwaggerRoutes with StatusRoutes with UserInfoDirectives {
 
   def unauthedRoutes: Route =
     path("ping") {

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/LeoRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/LeoRoutes.scala
@@ -17,13 +17,18 @@ import org.broadinstitute.dsde.workbench.leonardo.model.{ClusterRequest, LeoExce
 import org.broadinstitute.dsde.workbench.leonardo.model.google.ClusterName
 import org.broadinstitute.dsde.workbench.leonardo.model.LeonardoJsonSupport._
 import org.broadinstitute.dsde.workbench.leonardo.service.{LeonardoService, ProxyService, StatusService}
+import org.broadinstitute.dsde.workbench.leonardo.util.RouteHelper
 import org.broadinstitute.dsde.workbench.model.ErrorReportJsonSupport._
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.broadinstitute.dsde.workbench.model.{ErrorReport, WorkbenchException, WorkbenchExceptionWithErrorReport}
 
 import scala.concurrent.{ExecutionContext, Future}
 
-abstract class LeoRoutes(val leonardoService: LeonardoService, val proxyService: ProxyService, val statusService: StatusService, val swaggerConfig: SwaggerConfig)(implicit val system: ActorSystem, val materializer: Materializer, val executionContext: ExecutionContext) extends LazyLogging with ProxyRoutes with SwaggerRoutes with StatusRoutes with UserInfoDirectives {
+abstract class LeoRoutes(val leonardoService: LeonardoService, val proxyService: ProxyService, val statusService: StatusService, val swaggerConfig: SwaggerConfig)
+                        (implicit val system: ActorSystem, val materializer: Materializer, val executionContext: ExecutionContext)
+  extends LazyLogging with RouteHelper with ProxyRoutes with SwaggerRoutes with StatusRoutes with UserInfoDirectives {
+
+  private val tokenCookieName = "LeoToken"
 
   def unauthedRoutes: Route =
     path("ping") {
@@ -38,7 +43,7 @@ abstract class LeoRoutes(val leonardoService: LeonardoService, val proxyService:
 
   def leoRoutes: Route =
     requireUserInfo { userInfo =>
-      setTokenCookie(userInfo) {
+      setTokenCookie(userInfo, tokenCookieName) {
         path("isWhitelisted") {
           get {
             complete {

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/ProxyRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/ProxyRoutes.scala
@@ -12,16 +12,14 @@ import akka.http.scaladsl.model.headers._
 import akka.http.scaladsl.server.RouteResult.Complete
 import akka.http.scaladsl.server.directives.{DebuggingDirectives, LogEntry, LoggingMagnet}
 import org.broadinstitute.dsde.workbench.leonardo.model.NotebookClusterActions.ConnectToCluster
-import org.broadinstitute.dsde.workbench.leonardo.util.RouteHelper
+import org.broadinstitute.dsde.workbench.leonardo.util.CookieHelper
 import org.broadinstitute.dsde.workbench.model.UserInfo
 
 import scala.concurrent.ExecutionContext
 
-trait ProxyRoutes extends UserInfoDirectives with CorsSupport with RouteHelper { self: LazyLogging =>
+trait ProxyRoutes extends UserInfoDirectives with CorsSupport with CookieHelper { self: LazyLogging =>
   val proxyService: ProxyService
   implicit val executionContext: ExecutionContext
-
-  private val tokenCookieName = "LeoToken"
 
   protected val proxyRoutes: Route =
     pathPrefix("notebooks") {

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/ProxyRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/ProxyRoutes.scala
@@ -143,7 +143,7 @@ trait ProxyRoutes extends UserInfoDirectives with CorsSupport { self: LazyLoggin
       value = userInfo.accessToken.token,
       secure = true,  // cookie is only sent for SSL requests
       domain = None,  // Do not specify domain, making it default to Leo's domain
-      maxAge = Option(userInfo.tokenExpiresIn / 1000),  // coookie expiry is tied to the token expiry
+      maxAge = Option(userInfo.tokenExpiresIn),  // coookie expiry is tied to the token expiry
       path = Some("/")  // needed so it works for AJAX requests
     )
   }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoService.scala
@@ -20,6 +20,7 @@ import org.broadinstitute.dsde.workbench.leonardo.model._
 import org.broadinstitute.dsde.workbench.leonardo.model.google.DataprocRole.{Master, SecondaryWorker, Worker}
 import org.broadinstitute.dsde.workbench.leonardo.model.google._
 import org.broadinstitute.dsde.workbench.leonardo.monitor.ClusterMonitorSupervisor._
+import org.broadinstitute.dsde.workbench.leonardo.util.BucketHelper
 import org.broadinstitute.dsde.workbench.model.google._
 import org.broadinstitute.dsde.workbench.model.{UserInfo, WorkbenchEmail}
 import slick.dbio.DBIO

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/ProxyService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/ProxyService.scala
@@ -67,7 +67,7 @@ class ProxyService(proxyConfig: ProxyConfig,
     googleTokenCache.get(token).map {
       case (userInfo, expireTime) =>
         if (expireTime.isAfter(Instant.now))
-          userInfo.copy(tokenExpiresIn = expireTime.toEpochMilli - Instant.now.toEpochMilli)
+          userInfo.copy(tokenExpiresIn = expireTime.getEpochSecond - Instant.now.getEpochSecond)
         else
           throw AccessTokenExpiredException()
     }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/BucketHelper.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/BucketHelper.scala
@@ -1,4 +1,4 @@
-package org.broadinstitute.dsde.workbench.leonardo.service
+package org.broadinstitute.dsde.workbench.leonardo.util
 
 import cats.data.OptionT
 import cats.implicits._
@@ -6,12 +6,11 @@ import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.workbench.google.GoogleStorageDAO
 import org.broadinstitute.dsde.workbench.leonardo.config.DataprocConfig
 import org.broadinstitute.dsde.workbench.leonardo.dao.google.{GoogleComputeDAO, GoogleDataprocDAO}
-import org.broadinstitute.dsde.workbench.leonardo.model.google.ClusterName
 import org.broadinstitute.dsde.workbench.leonardo.model.{ServiceAccountInfo, ServiceAccountProvider}
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
 import org.broadinstitute.dsde.workbench.model.google.GcsEntityTypes.{Group, User}
 import org.broadinstitute.dsde.workbench.model.google.GcsRoles.{GcsRole, Owner, Reader}
-import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GcsEntity, GoogleProject, generateUniqueBucketName}
+import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GcsEntity, GoogleProject}
 
 import scala.concurrent.{ExecutionContext, Future}
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/CookieHelper.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/CookieHelper.scala
@@ -5,7 +5,9 @@ import akka.http.scaladsl.server.Directive0
 import akka.http.scaladsl.server.Directives.setCookie
 import org.broadinstitute.dsde.workbench.model.UserInfo
 
-trait RouteHelper {
+trait CookieHelper {
+  protected val tokenCookieName = "LeoToken"
+
   /**
     * Sets a token cookie in the HTTP response.
     */

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/RouteHelper.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/RouteHelper.scala
@@ -1,0 +1,26 @@
+package org.broadinstitute.dsde.workbench.leonardo.util
+
+import akka.http.scaladsl.model.headers.HttpCookie
+import akka.http.scaladsl.server.Directive0
+import akka.http.scaladsl.server.Directives.setCookie
+import org.broadinstitute.dsde.workbench.model.UserInfo
+
+trait RouteHelper {
+  /**
+    * Sets a token cookie in the HTTP response.
+    */
+  def setTokenCookie(userInfo: UserInfo, cookieName: String): Directive0 = {
+    setCookie(buildCookie(userInfo, cookieName))
+  }
+
+  def buildCookie(userInfo: UserInfo, cookieName: String): HttpCookie = {
+    HttpCookie(
+      name = cookieName,
+      value = userInfo.accessToken.token,
+      secure = true,  // cookie is only sent for SSL requests
+      domain = None,  // Do not specify domain, making it default to Leo's domain
+      maxAge = Option(userInfo.tokenExpiresIn),  // coookie expiry is tied to the token expiry
+      path = Some("/")  // needed so it works for AJAX requests
+    )
+  }
+}

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/TestLeoRoutes.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/TestLeoRoutes.scala
@@ -15,7 +15,8 @@ import org.broadinstitute.dsde.workbench.leonardo.dao.MockSamDAO
 import org.broadinstitute.dsde.workbench.leonardo.dao.google.MockGoogleComputeDAO
 import org.broadinstitute.dsde.workbench.leonardo.db.DbSingleton
 import org.broadinstitute.dsde.workbench.leonardo.monitor.NoopActor
-import org.broadinstitute.dsde.workbench.leonardo.service.{BucketHelper, LeonardoService, MockProxyService, StatusService}
+import org.broadinstitute.dsde.workbench.leonardo.service.{LeonardoService, MockProxyService, StatusService}
+import org.broadinstitute.dsde.workbench.leonardo.util.BucketHelper
 import org.broadinstitute.dsde.workbench.model.google._
 import org.broadinstitute.dsde.workbench.model.{UserInfo, WorkbenchEmail, WorkbenchUserId}
 import org.scalatest.Matchers

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/TestLeoRoutes.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/TestLeoRoutes.scala
@@ -85,7 +85,7 @@ trait TestLeoRoutes { this: ScalatestRouteTest with ScalaFutures with Matchers =
 
   private[api] def validateCookie(setCookie: Option[`Set-Cookie`],
                              expectedCookie: HttpCookiePair = tokenCookie,
-                             age: Long = tokenAge / 1000): Unit = {
+                             age: Long = tokenAge): Unit = {
     def roundUpToNearestTen(d: Long) = Math.ceil(d / 10.0) * 10
 
     setCookie shouldBe 'defined

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorSpec.scala
@@ -18,7 +18,8 @@ import org.broadinstitute.dsde.workbench.leonardo.model.google.DataprocRole.{Mas
 import org.broadinstitute.dsde.workbench.leonardo.model.google.InstanceStatus
 import org.broadinstitute.dsde.workbench.leonardo.model.google._
 import org.broadinstitute.dsde.workbench.leonardo.monitor.ClusterMonitorSupervisor.{ClusterCreated, ClusterDeleted}
-import org.broadinstitute.dsde.workbench.leonardo.service.{BucketHelper, LeonardoService}
+import org.broadinstitute.dsde.workbench.leonardo.service.LeonardoService
+import org.broadinstitute.dsde.workbench.leonardo.util.BucketHelper
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
 import org.broadinstitute.dsde.workbench.model.google.GcsRoles.GcsRole
 import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GcsEntity, GcsObjectName, GcsPath, GoogleProject, ServiceAccountKeyId}

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/AuthProviderSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/AuthProviderSpec.scala
@@ -28,6 +28,7 @@ import org.broadinstitute.dsde.workbench.google.GoogleStorageDAO
 import org.broadinstitute.dsde.workbench.leonardo.auth.sam.MockPetClusterServiceAccountProvider
 import org.broadinstitute.dsde.workbench.leonardo.dao.google.MockGoogleComputeDAO
 import org.broadinstitute.dsde.workbench.leonardo.model.google.ClusterName
+import org.broadinstitute.dsde.workbench.leonardo.util.BucketHelper
 import org.mockito.Mockito
 
 import scala.concurrent.Future

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoServiceSpec.scala
@@ -18,6 +18,7 @@ import org.broadinstitute.dsde.workbench.leonardo.model.MachineConfigOps.{Negati
 import org.broadinstitute.dsde.workbench.leonardo.model._
 import org.broadinstitute.dsde.workbench.leonardo.model.google._
 import org.broadinstitute.dsde.workbench.leonardo.monitor.NoopActor
+import org.broadinstitute.dsde.workbench.leonardo.util.BucketHelper
 import org.broadinstitute.dsde.workbench.model._
 import org.broadinstitute.dsde.workbench.model.google._
 import org.mockito.ArgumentMatchers.{any, eq => mockitoEq}


### PR DESCRIPTION
- Fixes a bug where cookie expiration time was erroneously converted into milliseconds while being cached in `ProxyService`.

- Factors out helper methods that are now being utilized by multiple `Routes`.