### PR TITLE
User Interface: create cluster modal and form

### DIFF
--- a/ui/src/components/CreateClusterForm.js
+++ b/ui/src/components/CreateClusterForm.js
@@ -205,7 +205,7 @@ class UnstyledCreateClusterForm extends React.Component {
       {/* Configure worker node number and type. */}
           <Typography
             className={classes.formInfo}
-            color="primary"
+            color="inherit"
           >
             Cluster worker configuration:
           </Typography>

--- a/ui/src/components/CreateClusterForm.js
+++ b/ui/src/components/CreateClusterForm.js
@@ -26,7 +26,10 @@ const clusterRegex = /^[a-z][a-z0-9-]{0,25}[a-z0-9]$/;
 const validMachineTypes = [
   "n1-standard-2",
   "n1-standard-4",
-  "n1-standard-8"];
+  "n1-standard-8",
+  "n1-standard-16",
+  "n1-highmem-8",
+  "n1-highmem-16"];
 
 const validDiskSizes = [200, 500, 1000];
 
@@ -188,6 +191,9 @@ class UnstyledCreateClusterForm extends React.Component {
               <MenuItem value={"n1-standard-2"}>2 cores, 7.5 GB</MenuItem>
               <MenuItem value={"n1-standard-4"}>4 cores, 15 GB</MenuItem>
               <MenuItem value={"n1-standard-8"}>8 cores, 30 GB</MenuItem>
+              <MenuItem value={"n1-highmem-8"}>8 cores, 52 GB</MenuItem>
+              <MenuItem value={"n1-standard-16"}>16 cores, 60 GB</MenuItem>
+              <MenuItem value={"n1-highmem-16"}>16 cores, 104 GB</MenuItem>
             </Select>
           </FormControl>
           <FormControl className={classes.mediumFormControl}>

--- a/ui/src/components/CreateClusterForm.js
+++ b/ui/src/components/CreateClusterForm.js
@@ -1,0 +1,288 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { withStyles } from 'material-ui/styles';
+import { InputLabel } from 'material-ui/Input';
+import TextField from 'material-ui/TextField';
+import Typography from 'material-ui/Typography';
+import { MenuItem } from 'material-ui/Menu';
+import { FormControl } from 'material-ui/Form';
+import Select from 'material-ui/Select';
+import Button from 'material-ui/Button';
+import { CircularProgress } from 'material-ui/Progress';
+
+import { createApiUrl } from '../net'
+
+
+const DEFAULT_MASTER_MACHINE_TYPE = "n1-standard-4";
+const DEFAULT_WORKER_MACHINE_TYPE = "n1-standard-2";
+const DEFAULT_WORKER_DISK_SIZE = 200;
+
+// Regex for GCP Project names.
+const projectRegex = /^[a-z][a-z0-9_-]{0,50}[a-z0-9]$/;
+
+// Regex for cluster names.
+const clusterRegex = /^[a-z][a-z0-9-]{0,25}[a-z0-9]$/;
+
+const validMachineTypes = [
+  "n1-standard-2",
+  "n1-standard-4",
+  "n1-standard-8"];
+
+const validDiskSizes = [200, 500, 1000];
+
+/**
+ * Spinner that only shows when there's a request in progress.
+ * @props requestInProgress bool indicates request status.
+ */
+class HiddenSpinner extends React.Component {
+  render() {
+    if (this.props.requestInProgress) {
+      return (
+        <span>
+          <CircularProgress color="secondary" />
+        </span>);
+    } else {
+      return <span/>
+    }
+  }
+}
+
+
+/**
+ * Render a form used to configure and launch a new cluster.
+ * @props closeFormOnSuccess function callback to modal to close the
+ *        form and refresh clusters from the API.
+ * @props closeFormOnFailure function callback to modal to close the
+ *        form and display the error.
+ * @props googleAuthToken string auth token from oauth login.
+ */
+class UnstyledCreateClusterForm extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      clusterName: "",
+      googleProject: "",
+      machineType: DEFAULT_MASTER_MACHINE_TYPE,
+      workerMachineType: DEFAULT_WORKER_MACHINE_TYPE,
+      diskSize: 200,
+      createRequestValid: false,
+      requestInProgress: false,
+      numberOfWorkers: 0,
+    };
+  }
+
+  postStateChangeValidationCallback = () => {
+    if (projectRegex.test(this.state.googleProject)
+        && clusterRegex.test(this.state.clusterName)
+        && validMachineTypes.includes(this.state.machineType)
+        && validDiskSizes.includes(this.state.diskSize)) {
+      this.setState({createRequestValid: true});
+    } else {
+      this.setState({createRequestValid: false});
+    }
+  }
+
+  createClusterRequest = (event) => {
+    // Sets state to disable submission & and show loading spinner.
+    this.setState({
+      createRequestValid: false,
+      requestInProgress: true,
+    });
+
+    var createRequest = {
+      labels: {},
+      machineConfig: {
+        // Worker config.
+        numberOfWorkers: this.state.numberOfWorkers,
+        workerMachineType: this.state.workerMachineType,
+        numberOfPreemptibleWorkers: 0,
+        workerDiskSize: DEFAULT_WORKER_DISK_SIZE,
+        // Master config
+        masterDiskSize: this.state.diskSize,
+        masterMachineType: this.state.machineType
+
+      }
+    };
+    // Use fetch to send a put request, and register success/fail callbacks.
+    fetch(
+      createApiUrl(this.state.googleProject, this.state.clusterName),
+      {
+        body: JSON.stringify(createRequest),
+        method: "PUT",
+        headers: {
+          "Authorization": "Bearer " + this.props.googleAuthToken,
+          "content-type": "application/json"
+        },
+        credentials: "include"
+      })
+      // Check for responses indicating failure. If a reason was given, try
+      // parsing that reason and giving it to the user via the thrown error.
+      .then((response) => {
+        if (response.status < 200 || response.status >= 300) {
+          console.log(response);
+          if (response.headers.get("content-type").includes("application/json")) {
+            throw new Error(response.json().reason);
+          } else {
+            throw new Error("Create failed with status " + response.status.toString());
+          }
+        }
+        return response;
+      })
+      .then((response) => response.json())
+      // On success, close the form. Callback will also refresh the cluster list.
+      .then((responseJson) => this.props.closeFormOnSuccess())
+      // Handle errors.
+      .catch((error) => {
+        this.props.closeFormOnFailure(error.toString());
+      });
+  }
+
+  handleChange = name => event => {
+    this.setState(
+      {[name]: event.target.value},
+      this.postStateChangeValidationCallback);
+  };
+
+  render() {
+    const { classes } = this.props;
+    return (
+      <form noValidate autoComplete="off">
+      {/* Google cloud project entry */}
+        <div>
+          <FormControl className={classes.wideFormControl}>
+            <TextField
+              id="googleProject"
+              label="Google Project"
+              value={this.state.googleProject}
+              onChange={this.handleChange("googleProject")}
+              margin="normal"
+            />
+          </FormControl>
+        </div>
+      {/* Cluster name. */}
+        <div>
+          <FormControl className={classes.wideFormControl}>
+            <TextField
+              id="clusterName"
+              label="Cluster Name"
+              value={this.state.clusterName}
+              onChange={this.handleChange("clusterName")}
+              margin="normal"
+            />
+          </FormControl>
+        </div>
+        <div style={{marginTop: 25}}>
+      {/* Configure master node type and storage. */}
+          <Typography
+            className={classes.formInfo}
+            color="inherit"
+          >
+            Master node configuration:
+          </Typography>
+          <FormControl className={classes.formControl}>
+            <InputLabel htmlFor="name-machine-type">Machine type</InputLabel>
+            <Select
+              label="Machine Type"
+              value={this.state.machineType}
+              onChange={this.handleChange("machineType")}>
+              <MenuItem value={"n1-standard-2"}>2 cores, 7.5 GB</MenuItem>
+              <MenuItem value={"n1-standard-4"}>4 cores, 15 GB</MenuItem>
+              <MenuItem value={"n1-standard-8"}>8 cores, 30 GB</MenuItem>
+            </Select>
+          </FormControl>
+          <FormControl className={classes.mediumFormControl}>
+            <InputLabel htmlFor="disk-size">Disk Size</InputLabel>
+            <Select
+              label="Disk Size"
+              value={this.state.diskSize}
+              onChange={this.handleChange("diskSize")}>
+              <MenuItem value={200}>200 GB</MenuItem>
+              <MenuItem value={1000}>1000 GB</MenuItem>
+            </Select>
+          </FormControl>
+        </div>
+        <div style={{marginTop: 25}}>
+      {/* Configure worker node number and type. */}
+          <Typography
+            className={classes.formInfo}
+            color="primary"
+          >
+            Cluster worker configuration:
+          </Typography>
+          <FormControl className={classes.narrowFormControl}>
+            <InputLabel htmlFor="number-of-workers">Workers</InputLabel>
+            <Select
+              label="Workers"
+              value={this.state.numberOfWorkers}
+              onChange={this.handleChange("numberOfWorkers")}
+            >
+              <MenuItem value={0}>0</MenuItem>
+              <MenuItem value={2}>2</MenuItem>
+              <MenuItem value={4}>4</MenuItem>
+              <MenuItem value={8}>8</MenuItem>
+            </Select>
+          </FormControl>
+          <FormControl
+            className={classes.formControl}
+            disabled={this.state.numberOfWorkers < 1}
+          >
+            <InputLabel htmlFor="worker-machine-type">Worker machine type</InputLabel>
+            <Select
+              label="Worker type"
+              value={this.state.workerMachineType}
+              onChange={this.handleChange("workerMachineType")}
+            >
+              <MenuItem value={"n1-standard-2"}>2 cores, 7.5 GB</MenuItem>
+              <MenuItem value={"n1-standard-4"}>4 cores, 15 GB</MenuItem>
+              <MenuItem value={"n1-standard-8"}>8 cores, 30 GB</MenuItem>
+            </Select>
+          </FormControl>
+        </div>
+        <div style={{marginTop: 25}}>
+      {/* Create the cluster. */}
+        <Button
+          disabled={!this.state.createRequestValid}
+          variant="raised"
+          color="primary"
+          onClick={this.createClusterRequest}
+        >
+          create
+        </Button>
+        <HiddenSpinner
+          requestInProgress={this.state.requestInProgress} />
+        </div>
+      </form>
+    );
+  }
+}
+
+UnstyledCreateClusterForm.propTypes = {
+  classes: PropTypes.object.isRequired,
+};
+
+
+const formSyles = theme => ({
+  wideFormControl: {
+    margin: theme.spacing.unit,
+    minWidth: 250,
+  },
+  formControl: {
+    margin: theme.spacing.unit,
+    minWidth: 180,
+  },
+  mediumFormControl: {
+    margin: theme.spacing.unit,
+    minWidth: 100,
+  },
+  narrowFormControl: {
+    margin: theme.spacing.unit,
+    minWidth: 40,
+  },
+  formInfo: {
+    fontSize: 18,
+    marginTop: 20,
+    marginBottom: 10,
+  }
+});
+
+export default withStyles(formSyles)(UnstyledCreateClusterForm);

--- a/ui/src/components/CreateClusterModalButton.js
+++ b/ui/src/components/CreateClusterModalButton.js
@@ -1,0 +1,106 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import Icon from 'material-ui/Icon';
+import IconButton from 'material-ui/IconButton';
+import Modal from 'material-ui/Modal';
+import { withStyles } from 'material-ui/styles';
+import Typography from 'material-ui/Typography';
+import Tooltip from 'material-ui/Tooltip';
+
+import CreateClusterForm from './CreateClusterForm'
+
+const styles = theme => ({
+  paper: {
+    position: 'absolute',
+    width: theme.spacing.unit * 70,
+    backgroundColor: theme.palette.background.paper,
+    boxShadow: theme.shadows[5],
+    padding: theme.spacing.unit * 4,
+  },
+  button: {
+    fontSize: 38,
+    '&:hover': {textShadow: "-1.5px 1.5px #B2BCC1"}
+  }
+});
+
+const modalPosition = {
+    top: "50%",
+    left: "50%",
+    transform: "translate(-50%, -50%)",
+};
+
+
+/**
+ * Button that opens a modal for cluster creation.
+ * @props googleAuthToken string auth token from oauth login.
+ * @props cardsRefreshHandler function callback to refresh cluster list state.
+ * @props errorHandler function callback to display errors text.
+ */
+class CreateClusterModalButton extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      open: false,
+    };
+  }
+
+  handleClickOpen = () => {
+    this.setState({ open: true });
+  }
+
+  handleClose = () => {
+    this.setState({ open: false });
+  }
+
+  closeFormOnSuccess = () => {
+    this.handleClose();
+    this.props.cardsRefreshHandler();
+  }
+
+  closeFormOnFailure = (failReason) => {
+    this.handleClose();
+    this.props.errorHandler(failReason);
+  }
+
+  render() {
+    return (
+      <div style={{paddingLeft:24, paddingBottom:32}}>
+        <IconButton onClick={this.handleClickOpen}>
+          <Tooltip
+          id="tooltip-right"
+          placement="right"
+          title="Create a notebook server"
+          >
+            <Icon color="secondary" className={this.props.classes.button}>
+              add_circle
+            </Icon>
+          </Tooltip>
+        </IconButton>
+        <Modal
+          aria-labelledby="simple-modal-title"
+          aria-describedby="simple-modal-description"
+          open={this.state.open}
+          onClose={this.handleClose}
+        >
+          <div style={modalPosition} className={this.props.classes.paper}>
+            <Typography variant="title" id="modal-title">
+              Create a cluster:
+            </Typography>
+            <CreateClusterForm
+              googleAuthToken={this.props.googleAuthToken}
+              closeFormOnSuccess={this.closeFormOnSuccess}
+              closeFormOnFailure={this.closeFormOnFailure} />
+        </div>
+      </Modal>
+      </div>
+    );
+  }
+}
+
+CreateClusterModalButton.propTypes = {
+  classes: PropTypes.object.isRequired,
+};
+
+
+export default withStyles(styles)(CreateClusterModalButton);;

--- a/ui/src/components/ListStateContainer.js
+++ b/ui/src/components/ListStateContainer.js
@@ -2,7 +2,7 @@ import React from 'react';
 import CssBaseline from 'material-ui/CssBaseline';
 
 import ClusterCardList from './ClusterCardList';
-//import CreateClusterModalButton from './CreateClusterModalButton';
+import CreateClusterModalButton from './CreateClusterModalButton';
 import LeonardoAppBar from './LeonardoAppBar';
 
 
@@ -132,13 +132,11 @@ class ListStateContainer extends React.Component {
             clusterModels={this.state.clusters}
           />
         </div>
-
-
-        <div>
-             CreateClusterModalButton placeholder
-        </div>
-
-
+        <CreateClusterModalButton
+          googleAuthToken={this.props.googleAuthToken}
+          cardsRefreshHandler={this.state.clusterListRefreshCallback}
+          errorHandler={this.props.errorHandler}
+        />
       </div>
     );
   }


### PR DESCRIPTION
Add a cluster-create button that launches a modal. The modal runs simple name validation and builds the request. Additionally, the modal will briefly show a progress spinner while waiting for the API to return a successful response. On success the modal notifies the application state container to refresh the entire list.

See a screenshot of the modal [here](https://docs.google.com/document/d/16sEFuGvr4omhDiB1iVxc1ogeYkb1zIUL-6txKew8oJ4)


- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
