### PR TITLE
Add the creator's email to the jupyter environment

### DIFF
--- a/src/main/resources/jupyter/cluster-docker-compose.yaml
+++ b/src/main/resources/jupyter/cluster-docker-compose.yaml
@@ -42,5 +42,6 @@ services:
     environment:
       GOOGLE_PROJECT: "${GOOGLE_PROJECT}"
       CLUSTER_NAME: "${CLUSTER_NAME}"
+      OWNER_EMAIL: "${OWNER_EMAIL}"
     env_file:
       - /etc/google_application_credentials.env

--- a/src/main/resources/jupyter/init-actions.sh
+++ b/src/main/resources/jupyter/init-actions.sh
@@ -43,6 +43,7 @@ if [[ "${ROLE}" == 'Master' ]]; then
     # The following values are populated by Leo when a cluster is created.
     export CLUSTER_NAME=$(clusterName)
     export GOOGLE_PROJECT=$(googleProject)
+    export OWNER_EMAIL=$(userEmailLoginHint)
     export JUPYTER_SERVER_NAME=$(jupyterServerName)
     export PROXY_SERVER_NAME=$(proxyServerName)
     export JUPYTER_DOCKER_IMAGE=$(jupyterDockerImage)


### PR DESCRIPTION
We are setting up a system where a user's root directory can sync with GCS. We can automate parts of the setup inside the Jupiter-docker if the user's email is visible in the docker environment. This change simply takes advantage of a substitution variable that was already present.

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
