### PR TITLE
jupyter-docker: update R to v3.4

### DIFF
--- a/jupyter-docker/Dockerfile
+++ b/jupyter-docker/Dockerfile
@@ -10,9 +10,16 @@ USER root
 
 ENV DEBIAN_FRONTEND noninteractive
 ENV DEBIAN_REPO http://cdn-fastly.deb.debian.org
+ENV CRAN_REPO http://cran.mtu.edu
 
-RUN echo "deb $DEBIAN_REPO/debian jessie main\ndeb $DEBIAN_REPO/debian-security jessie/updates main\ndeb $DEBIAN_REPO/debian jessie-backports main" > /etc/apt/sources.list \
- && apt-get update && apt-get -yq dist-upgrade \
+RUN echo "deb $DEBIAN_REPO/debian jessie main"                   > /etc/apt/sources.list \
+ && echo "deb $DEBIAN_REPO/debian-security jessie/updates main" >> /etc/apt/sources.list \
+ && echo "deb $DEBIAN_REPO/debian jessie-backports main"        >> /etc/apt/sources.list \
+ && echo "deb $CRAN_REPO/bin/linux/debian jessie-cran34/"       >> /etc/apt/sources.list \
+ && apt-key adv --keyserver keys.gnupg.net \
+    --recv-key 'E19F5F87128899B192B1A2C2AD5F960A256A04AF' \
+ && apt-get update \
+ && apt-get -yq dist-upgrade \
  && apt-get install -yq --no-install-recommends \
     nano \
     wget \
@@ -165,16 +172,17 @@ RUN apt-get install -yq --no-install-recommends python3 \
 # R Kernel
 #######################
 
-RUN apt-get update && apt-get -t jessie-backports install -y --no-install-recommends \
-    r-base=3.3.3-1~bpo8+1 r-base-dev=3.3.3-1~bpo8+1 \
+RUN apt-get -t jessie-cran34 install -y --no-install-recommends \
+    r-base \
+    r-base-dev \
+    r-recommended \
+ && apt-get install -y --no-install-recommends \
     fonts-dejavu \
     tzdata \
     gfortran \
     gcc \
     libcurl4-openssl-dev \
-    libssl-dev \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+    libssl-dev
 
 RUN R -e 'install.packages(c( \
     "repr",  \


### PR DESCRIPTION
This change updates the default jupyter docker file to use R 3.4 by using the debian installation instructions [here](https://cran.r-project.org/bin/linux/debian/).

Additionally, I have removed a routine that clears /var/lib/apt/lists/*. Because docker image layers are segmented by RUN commands, the clearing doesn't save any storage, it just marks the files as unavailable in the top-most layer. For this optimization to work, we would need clear out the cache after every use of `apt-get update && apt-get install ...`

In all cases:
- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
