### PR TITLE
Pip install as user by default

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/ClusterMonitoringSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/ClusterMonitoringSpec.scala
@@ -169,7 +169,7 @@ class ClusterMonitoringSpec extends FreeSpec with LeonardoTestUtils with Paralle
             val firstCell = notebookPage.firstCell
             notebookPage.cellOutput(firstCell) shouldBe Some(printStr)
             // execute a new cell to make sure the notebook kernel still works
-            notebookPage.runAllCells(60)
+            notebookPage.runAllCells()
             notebookPage.executeCell("sum(range(1,10))") shouldBe Some("45")
           }
         }

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
@@ -556,4 +556,27 @@ trait LeonardoTestUtils extends WebBrowserSpec with Matchers with Eventually wit
     val timediff = FiniteDuration(t1 - t0, NANOSECONDS)
     TimeResult(result, timediff)
   }
+
+  def pipInstall(notebookPage: NotebookPage, kernel: Kernel, packageName: String): Unit = {
+    val pip = kernel match {
+      case Python2 => "pip2"
+      case Python3 => "pip3"
+      case _ => throw new IllegalArgumentException(s"Can't pip install in a ${kernel.string} kernel")
+    }
+
+    val installOutput = notebookPage.executeCell(s"!$pip install $packageName")
+    installOutput shouldBe 'defined
+    installOutput.get should include (s"Collecting $packageName")
+    installOutput.get should include ("Installing collected packages:")
+    installOutput.get should include ("Successfully installed")
+    installOutput.get should not include ("Exception:")
+  }
+
+  // https://github.com/aymericdamien/TensorFlow-Examples/blob/master/notebooks/1_Introduction/helloworld.ipynb
+  def verifyTensorFlow(notebookPage: NotebookPage): Unit = {
+    notebookPage.executeCell("import tensorflow as tf") shouldBe None
+    notebookPage.executeCell("hello = tf.constant('Hello, TensorFlow!')") shouldBe None
+    notebookPage.executeCell("sess = tf.Session()") shouldBe None
+    notebookPage.executeCell("print(sess.run(hello))") shouldBe Some("Hello, TensorFlow!")
+  }
 }

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
@@ -573,10 +573,15 @@ trait LeonardoTestUtils extends WebBrowserSpec with Matchers with Eventually wit
   }
 
   // https://github.com/aymericdamien/TensorFlow-Examples/blob/master/notebooks/1_Introduction/helloworld.ipynb
-  def verifyTensorFlow(notebookPage: NotebookPage): Unit = {
+  def verifyTensorFlow(notebookPage: NotebookPage, kernel: Kernel): Unit = {
     notebookPage.executeCell("import tensorflow as tf") shouldBe None
     notebookPage.executeCell("hello = tf.constant('Hello, TensorFlow!')") shouldBe None
     notebookPage.executeCell("sess = tf.Session()") shouldBe None
-    notebookPage.executeCell("print(sess.run(hello))") shouldBe Some("Hello, TensorFlow!")
+    val helloOutput = notebookPage.executeCell("print(sess.run(hello))")
+    kernel match {
+      case Python2 => helloOutput shouldBe Some("Hello, TensorFlow!")
+      case Python3 => helloOutput shouldBe Some("b'Hello, TensorFlow!'")
+      case other => fail(s"Unexpected kernel: $other")
+    }
   }
 }

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
@@ -573,10 +573,10 @@ trait LeonardoTestUtils extends WebBrowserSpec with Matchers with Eventually wit
   }
 
   // https://github.com/aymericdamien/TensorFlow-Examples/blob/master/notebooks/1_Introduction/helloworld.ipynb
-  def verifyTensorFlow(notebookPage: NotebookPage): Unit = {
-    notebookPage.executeCell("import tensorflow as tf") shouldBe None
-    notebookPage.executeCell("hello = tf.constant('Hello, TensorFlow!')") shouldBe None
-    notebookPage.executeCell("sess = tf.Session()") shouldBe None
-    notebookPage.executeCell("print(sess.run(hello))") shouldBe Some("Hello, TensorFlow!")
+  def verifyTensorFlow(notebookPage: NotebookPage, startCellNumber: Option[Int] = None): Unit = {
+    notebookPage.executeCell("import tensorflow as tf", cellNumberOpt = startCellNumber) shouldBe None
+    notebookPage.executeCell("hello = tf.constant('Hello, TensorFlow!')", cellNumberOpt = startCellNumber.map(_ + 1)) shouldBe None
+    notebookPage.executeCell("sess = tf.Session()", cellNumberOpt = startCellNumber.map(_ + 2)) shouldBe None
+    notebookPage.executeCell("print(sess.run(hello))", cellNumberOpt = startCellNumber.map(_ + 3)) shouldBe Some("Hello, TensorFlow!")
   }
 }

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
@@ -504,7 +504,7 @@ trait LeonardoTestUtils extends WebBrowserSpec with Matchers with Eventually wit
     uploadFile.exists() shouldBe true
 
     withNotebookUpload(cluster, uploadFile) { notebook =>
-      notebook.runAllCells(timeout.toSeconds)
+      notebook.runAllCells(timeout)
       notebook.download()
     }
 
@@ -573,10 +573,10 @@ trait LeonardoTestUtils extends WebBrowserSpec with Matchers with Eventually wit
   }
 
   // https://github.com/aymericdamien/TensorFlow-Examples/blob/master/notebooks/1_Introduction/helloworld.ipynb
-  def verifyTensorFlow(notebookPage: NotebookPage, startCellNumber: Option[Int] = None): Unit = {
-    notebookPage.executeCell("import tensorflow as tf", cellNumberOpt = startCellNumber) shouldBe None
-    notebookPage.executeCell("hello = tf.constant('Hello, TensorFlow!')", cellNumberOpt = startCellNumber.map(_ + 1)) shouldBe None
-    notebookPage.executeCell("sess = tf.Session()", cellNumberOpt = startCellNumber.map(_ + 2)) shouldBe None
-    notebookPage.executeCell("print(sess.run(hello))", cellNumberOpt = startCellNumber.map(_ + 3)) shouldBe Some("Hello, TensorFlow!")
+  def verifyTensorFlow(notebookPage: NotebookPage): Unit = {
+    notebookPage.executeCell("import tensorflow as tf") shouldBe None
+    notebookPage.executeCell("hello = tf.constant('Hello, TensorFlow!')") shouldBe None
+    notebookPage.executeCell("sess = tf.Session()") shouldBe None
+    notebookPage.executeCell("print(sess.run(hello))") shouldBe Some("Hello, TensorFlow!")
   }
 }

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/NotebookInteractionSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/NotebookInteractionSpec.scala
@@ -308,10 +308,11 @@ class NotebookInteractionSpec extends FreeSpec with LeonardoTestUtils with Befor
 
           // need to restart the kernel for the install to take effect
           notebookPage.restartKernel()
+
+          // re-run all cells so the cell numbers are consistent (otherwise they start over at 1 after a kernel restart)
           notebookPage.runAllCells()
 
           // verify that tensorflow is installed
-          // note cell numbers start at 1 after the kernel is restarted
           verifyTensorFlow(notebookPage, kernel)
         }
       }

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/NotebookInteractionSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/NotebookInteractionSpec.scala
@@ -308,10 +308,11 @@ class NotebookInteractionSpec extends FreeSpec with LeonardoTestUtils with Befor
 
           // need to restart the kernel for the install to take effect
           notebookPage.restartKernel()
+          notebookPage.runAllCells()
 
           // verify that tensorflow is installed
           // note cell numbers start at 1 after the kernel is restarted
-          verifyTensorFlow(notebookPage, Some(1))
+          verifyTensorFlow(notebookPage)
         }
       }
     }

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/NotebookInteractionSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/NotebookInteractionSpec.scala
@@ -299,5 +299,20 @@ class NotebookInteractionSpec extends FreeSpec with LeonardoTestUtils with Befor
         }
       }
     }
+
+    Seq(Python2, Python3).foreach { kernel =>
+      s"should be able to pip install packages using ${kernel.string}" in withWebDriver { implicit driver =>
+        withNewNotebook(ronCluster, kernel) { notebookPage =>
+          // install tensorflow
+          pipInstall(notebookPage, kernel, "tensorflow")
+
+          // need to restart the kernel for the install to take effect
+          notebookPage.restartKernel()
+
+          // verify that tensorflow is installed
+          verifyTensorFlow(notebookPage)
+        }
+      }
+    }
   }
 }

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/NotebookInteractionSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/NotebookInteractionSpec.scala
@@ -312,7 +312,7 @@ class NotebookInteractionSpec extends FreeSpec with LeonardoTestUtils with Befor
 
           // verify that tensorflow is installed
           // note cell numbers start at 1 after the kernel is restarted
-          verifyTensorFlow(notebookPage)
+          verifyTensorFlow(notebookPage, kernel)
         }
       }
     }

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/NotebookInteractionSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/NotebookInteractionSpec.scala
@@ -310,7 +310,8 @@ class NotebookInteractionSpec extends FreeSpec with LeonardoTestUtils with Befor
           notebookPage.restartKernel()
 
           // verify that tensorflow is installed
-          verifyTensorFlow(notebookPage)
+          // note cell numbers start at 1 after the kernel is restarted
+          verifyTensorFlow(notebookPage, Some(1))
         }
       }
     }

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/NotebookPage.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/NotebookPage.scala
@@ -58,8 +58,14 @@ class NotebookPage(override val url: String)(override implicit val authToken: Au
   // Kernel -> Shutdown
   lazy val shutdownKernelSelection: Query = cssSelector("[id='shutdown_kernel']")
 
+  // Kernel -> Restart
+  lazy val restartKernelSelection: Query = cssSelector("[id='restart_kernel']")
+
   // Jupyter asks: Are you sure you want to shutdown the kernel?
   lazy val shutdownKernelConfirmationSelection: Query = cssSelector("[class='btn btn-default btn-sm btn-danger']")
+
+  // Jupyter asks: Are you sure you want to restart the kernel?
+  lazy val restartKernelConfirmationSelection: Query = cssSelector("[class='btn btn-default btn-sm btn-danger']")
 
   // selects the numbered left-side cell prompts
   lazy val prompts: Query = cssSelector("[class='prompt input_prompt']")
@@ -84,6 +90,11 @@ class NotebookPage(override val url: String)(override implicit val authToken: Au
   // can we see that the kernel connection has terminated?
   def isKernelShutdown: Boolean = {
     find(kernelNotification).exists { e => e.text == "No kernel" }
+  }
+
+  // is the kernel ready?
+  def isKernelReady: Boolean = {
+    find(kernelNotification).exists { e => e.text == "Kernel ready" }
   }
 
   def runAllCells(timeoutSeconds: Long): Unit = {
@@ -158,5 +169,12 @@ class NotebookPage(override val url: String)(override implicit val authToken: Au
     click on (await enabled shutdownKernelSelection)
     click on (await enabled shutdownKernelConfirmationSelection)
     await condition isKernelShutdown
+  }
+
+  def restartKernel(): Unit = {
+    click on kernelMenu
+    click on (await enabled restartKernelSelection)
+    click on (await enabled restartKernelConfirmationSelection)
+    await condition isKernelReady
   }
 }

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/NotebookPage.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/NotebookPage.scala
@@ -97,10 +97,10 @@ class NotebookPage(override val url: String)(override implicit val authToken: Au
     find(kernelNotification).exists { e => e.text == "Kernel ready" }
   }
 
-  def runAllCells(timeoutSeconds: Long): Unit = {
+  def runAllCells(timeout: FiniteDuration = 60 seconds): Unit = {
     click on cellMenu
     click on (await enabled runAllCellsSelection)
-    await condition (!cellsAreRunning, timeoutSeconds)
+    await condition (!cellsAreRunning, timeout.toSeconds)
   }
 
   def download(): Unit = {

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/NotebookPage.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/NotebookPage.scala
@@ -135,10 +135,10 @@ class NotebookPage(override val url: String)(override implicit val authToken: Au
     outputs.asScala.headOption.map(_.getText)
   }
   
-  def executeCell(code: String, timeout: FiniteDuration = 1 minute, cellNumberOpt: Option[Int] = None): Option[String] = {
+  def executeCell(code: String, timeout: FiniteDuration = 1 minute): Option[String] = {
     await enabled cells
     val cell = lastCell
-    val cellNumber = cellNumberOpt.getOrElse(numCellsOnPage)
+    val cellNumber = numCellsOnPage
     click on cell
     val jsEscapedCode = StringEscapeUtils.escapeEcmaScript(code)
     executeScript(s"""arguments[0].CodeMirror.setValue("$jsEscapedCode");""", cell)

--- a/jupyter-docker/Dockerfile
+++ b/jupyter-docker/Dockerfile
@@ -167,6 +167,9 @@ RUN apt-get install -yq --no-install-recommends python3 \
  && pip3 install fastinterval \
  && pip3 install matplotlib-venn
 
+# make pip install to a user directory, instead of a system directory which requires root.
+# this is useful so `pip install` commands can be run in the context of a notebook.
+ENV PIP_USER=true
 
 #######################
 # R Kernel

--- a/src/main/resources/jupyter/init-actions.sh
+++ b/src/main/resources/jupyter/init-actions.sh
@@ -179,7 +179,7 @@ if [[ "${ROLE}" == 'Master' ]]; then
       JUPYTER_USER_SCRIPT=`basename ${JUPYTER_USER_SCRIPT_URI}`
       docker cp /etc/${JUPYTER_USER_SCRIPT} ${JUPYTER_SERVER_NAME}:${JUPYTER_HOME}/${JUPYTER_USER_SCRIPT}
       docker exec -u root -d ${JUPYTER_SERVER_NAME} chmod +x ${JUPYTER_HOME}/${JUPYTER_USER_SCRIPT}
-      docker exec -u root -d ${JUPYTER_SERVER_NAME} ${JUPYTER_HOME}/${JUPYTER_USER_SCRIPT}
+      docker exec -u root -d -e PIP_USER=false ${JUPYTER_SERVER_NAME} ${JUPYTER_HOME}/${JUPYTER_USER_SCRIPT}
     fi
 
     log 'Starting Jupyter Notebook...'


### PR DESCRIPTION
https://github.com/DataBiosphere/leonardo/issues/322

A few users have reported this. In a notebook, `pip install tensorflow` throws a permission error because the install directory is owned by root. `pip install tensorflow --user` works, but it's easy to forget to do that. This configures pip to install as user by default. 

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
