### PR TITLE
Do the pip install verification in a new notebook

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/NotebookInteractionSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/NotebookInteractionSpec.scala
@@ -302,17 +302,15 @@ class NotebookInteractionSpec extends FreeSpec with LeonardoTestUtils with Befor
 
     Seq(Python2, Python3).foreach { kernel =>
       s"should be able to pip install packages using ${kernel.string}" in withWebDriver { implicit driver =>
-        withNotebooksListPage(ronCluster) { notebooksListPage =>
+        withNewNotebook(ronCluster, kernel) { notebookPage =>
           // install tensorflow
-          notebooksListPage.withNewNotebook(kernel) { notebookPage =>
-            pipInstall(notebookPage, kernel, "tensorflow")
-          }
+          pipInstall(notebookPage, kernel, "tensorflow")
+        }
 
-          // need to restart the kernel for the install to take effect
-          notebooksListPage.withNewNotebook(kernel) { notebookPage =>
-            // verify that tensorflow is installed
-            verifyTensorFlow(notebookPage, kernel)
-          }
+        // need to restart the kernel for the install to take effect
+        withNewNotebook(ronCluster, kernel) { notebookPage =>
+          // verify that tensorflow is installed
+          verifyTensorFlow(notebookPage, kernel)
         }
       }
     }

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/NotebookInteractionSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/NotebookInteractionSpec.scala
@@ -305,13 +305,10 @@ class NotebookInteractionSpec extends FreeSpec with LeonardoTestUtils with Befor
         withNewNotebook(ronCluster, kernel) { notebookPage =>
           // install tensorflow
           pipInstall(notebookPage, kernel, "tensorflow")
+        }
 
-          // need to restart the kernel for the install to take effect
-          notebookPage.restartKernel()
-
-          // re-run all cells so the cell numbers are consistent (otherwise they start over at 1 after a kernel restart)
-          notebookPage.runAllCells()
-
+        // need to restart the kernel for the install to take effect
+        withNewNotebook(ronCluster, kernel) { notebookPage =>
           // verify that tensorflow is installed
           verifyTensorFlow(notebookPage, kernel)
         }

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/NotebookInteractionSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/NotebookInteractionSpec.scala
@@ -302,15 +302,17 @@ class NotebookInteractionSpec extends FreeSpec with LeonardoTestUtils with Befor
 
     Seq(Python2, Python3).foreach { kernel =>
       s"should be able to pip install packages using ${kernel.string}" in withWebDriver { implicit driver =>
-        withNewNotebook(ronCluster, kernel) { notebookPage =>
+        withNotebooksListPage(ronCluster) { notebooksListPage =>
           // install tensorflow
-          pipInstall(notebookPage, kernel, "tensorflow")
-        }
+          notebooksListPage.withNewNotebook(kernel) { notebookPage =>
+            pipInstall(notebookPage, kernel, "tensorflow")
+          }
 
-        // need to restart the kernel for the install to take effect
-        withNewNotebook(ronCluster, kernel) { notebookPage =>
-          // verify that tensorflow is installed
-          verifyTensorFlow(notebookPage, kernel)
+          // need to restart the kernel for the install to take effect
+          notebooksListPage.withNewNotebook(kernel) { notebookPage =>
+            // verify that tensorflow is installed
+            verifyTensorFlow(notebookPage, kernel)
+          }
         }
       }
     }

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/NotebookInteractionSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/NotebookInteractionSpec.scala
@@ -305,6 +305,7 @@ class NotebookInteractionSpec extends FreeSpec with LeonardoTestUtils with Befor
         withNewNotebook(ronCluster, kernel) { notebookPage =>
           // install tensorflow
           pipInstall(notebookPage, kernel, "tensorflow")
+          notebookPage.saveAndCheckpoint()
         }
 
         // need to restart the kernel for the install to take effect


### PR DESCRIPTION
I'm hoping this fixes the test flakes:
```
Leonardo notebooks should be able to pip install packages using Python 2
Leonardo notebooks should be able to pip install packages using Python 3
```
The flakiness seems related to restarting the kernel using Selenium. Creating a brand new notebook should be more reliable, and still exercise this feature. 

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
