### PR TITLE
Separate Python and Spark kernels

### DIFF
--- a/automation/src/test/resources/diff-tests/hail-tutorial.ipynb
+++ b/automation/src/test/resources/diff-tests/hail-tutorial.ipynb
@@ -1651,9 +1651,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "PySpark 2",
    "language": "python",
-   "name": "python2"
+   "name": "pyspark2"
   },
   "language_info": {
    "codemirror_mode": {

--- a/automation/src/test/resources/diff-tests/import-hail.ipynb
+++ b/automation/src/test/resources/diff-tests/import-hail.ipynb
@@ -34,9 +34,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "PySpark 2",
    "language": "python",
-   "name": "python2"
+   "name": "pyspark2"
   },
   "language_info": {
    "codemirror_mode": {

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
@@ -559,8 +559,8 @@ trait LeonardoTestUtils extends WebBrowserSpec with Matchers with Eventually wit
 
   def pipInstall(notebookPage: NotebookPage, kernel: Kernel, packageName: String): Unit = {
     val pip = kernel match {
-      case Python2 => "pip2"
-      case Python3 => "pip3"
+      case Python2 | PySpark2 => "pip2"
+      case Python3 | PySpark3 => "pip3"
       case _ => throw new IllegalArgumentException(s"Can't pip install in a ${kernel.string} kernel")
     }
 

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
@@ -325,7 +325,7 @@ trait LeonardoTestUtils extends WebBrowserSpec with Matchers with Eventually wit
     }
   }
 
-  def withNewNotebook[T](cluster: Cluster, kernel: Kernel = Python2)(testCode: NotebookPage => T)(implicit webDriver: WebDriver, token: AuthToken): T = {
+  def withNewNotebook[T](cluster: Cluster, kernel: Kernel = PySpark2)(testCode: NotebookPage => T)(implicit webDriver: WebDriver, token: AuthToken): T = {
     withNotebooksListPage(cluster) { notebooksListPage =>
       notebooksListPage.withNewNotebook(kernel) { notebookPage =>
         testCode(notebookPage)

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/NotebookInteractionSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/NotebookInteractionSpec.scala
@@ -236,7 +236,7 @@ class NotebookInteractionSpec extends FreeSpec with LeonardoTestUtils with Befor
         notebookPage.executeCell("1+1") shouldBe Some("2")
         notebookPage.executeCell(getPythonVersion) shouldBe Some("3.4.2")
         notebookPage.executeCell(getBxPython).get should include("Copyright (c)")
-        notebookPage.executeCell(sparkJob).get should include("Pi is roughly ")
+        //notebookPage.executeCell(sparkJob).get should include("Pi is roughly ")
       }
     }
 

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/NotebookInteractionSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/NotebookInteractionSpec.scala
@@ -212,6 +212,7 @@ class NotebookInteractionSpec extends FreeSpec with LeonardoTestUtils with Befor
         }
       }
     }
+    
     "should create a notebook with a working Python 3 kernel and import installed packages" in withWebDriver { implicit driver =>
       Orchestration.billing.addUserToBillingProject(billingProject.value, ronEmail, Orchestration.billing.BillingProjectRole.User)(hermioneAuthToken)
 
@@ -223,20 +224,21 @@ class NotebookInteractionSpec extends FreeSpec with LeonardoTestUtils with Befor
           """import bx.bitset
             |bx.bitset.sys.copyright""".stripMargin
         val sparkJob =
-          """import random
-            |NUM_SAMPLES=20
-            |def inside(p):
-            |    x, y = random.random(), random.random()
-            |    return x*x + y*y < 1
+          """try:
+            |    name = sc.appName
             |
-            |count = sc.parallelize(range(0, NUM_SAMPLES)) \
-            |             .filter(inside).count()
-            |print("Pi is roughly %f" % (4.0 * count / NUM_SAMPLES))""".stripMargin
+            |except NameError as err:
+            |    print(err)""".stripMargin
 
         notebookPage.executeCell("1+1") shouldBe Some("2")
         notebookPage.executeCell(getPythonVersion) shouldBe Some("3.4.2")
         notebookPage.executeCell(getBxPython).get should include("Copyright (c)")
-        notebookPage.executeCell(sparkJob).get should include("Pi is roughly ")
+
+        // As proof of not having Spark installed:
+        // We should get an error upon attempting to access the SparkContext object 'sc'
+        // since Python kernels do not include Spark.
+        val sparkErrorMessage = "name 'sc' is not defined"
+        notebookPage.executeCell(sparkJob).get shouldBe sparkErrorMessage
       }
     }
 
@@ -272,7 +274,7 @@ class NotebookInteractionSpec extends FreeSpec with LeonardoTestUtils with Befor
         // http://httr.r-lib.org//index.html
 
         // it may take a little while to install
-        val installTimeout = 2 minutes
+        val installTimeout = 2.minutes
 
         notebookPage.executeCell("""install.packages("httr")""", installTimeout).get should include ("Installing package into '/home/jupyter-user/.rpackages'")
 
@@ -312,6 +314,29 @@ class NotebookInteractionSpec extends FreeSpec with LeonardoTestUtils with Befor
         withNewNotebook(ronCluster, kernel) { notebookPage =>
           // verify that tensorflow is installed
           verifyTensorFlow(notebookPage, kernel)
+        }
+      }
+    }
+
+    val pySparkJob =
+      """import random
+        |NUM_SAMPLES=20
+        |def inside(p):
+        |    x, y = random.random(), random.random()
+        |    return x*x + y*y < 1
+        |
+        |count = sc.parallelize(range(0, NUM_SAMPLES)) \
+        |             .filter(inside).count()
+        |print("Pi is roughly %f" % (4.0 * count / NUM_SAMPLES))""".stripMargin
+
+    Seq(PySpark2, PySpark3).foreach { kernel =>
+      s"should be able to run a Spark job with a ${kernel.string} kernel" in withWebDriver { implicit driver =>
+        Orchestration.billing.addUserToBillingProject(billingProject.value, ronEmail, Orchestration.billing.BillingProjectRole.User)(hermioneAuthToken)
+
+        withNewNotebook(ronCluster, kernel) { notebookPage =>
+          val cellResult = notebookPage.executeCell(pySparkJob).get
+          cellResult should include("Pi is roughly ")
+          cellResult.toLowerCase should not include "error"
         }
       }
     }

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/NotebookInteractionSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/NotebookInteractionSpec.scala
@@ -236,7 +236,7 @@ class NotebookInteractionSpec extends FreeSpec with LeonardoTestUtils with Befor
         notebookPage.executeCell("1+1") shouldBe Some("2")
         notebookPage.executeCell(getPythonVersion) shouldBe Some("3.4.2")
         notebookPage.executeCell(getBxPython).get should include("Copyright (c)")
-        //notebookPage.executeCell(sparkJob).get should include("Pi is roughly ")
+        notebookPage.executeCell(sparkJob).get should include("Pi is roughly ")
       }
     }
 

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/NotebooksListPage.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/NotebooksListPage.scala
@@ -60,7 +60,7 @@ class NotebooksListPage(override val url: String)(override implicit val authToke
     result.get
   }
 
-  def withNewNotebook[T](kernel: Kernel = Python2)(testCode: NotebookPage => T): T = {
+  def withNewNotebook[T](kernel: Kernel = PySpark2)(testCode: NotebookPage => T): T = {
     switchToNewTab {
       click on (await enabled(newButton, 30))
       click on (await enabled cssSelector(kernel.cssSelectorString))

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/NotebooksListPage.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/NotebooksListPage.scala
@@ -23,6 +23,16 @@ case object Python3 extends Kernel {
   def cssSelectorString: String = "[title='Create a new notebook with Python 3']"
 }
 
+case object PySpark2 extends Kernel {
+  def string: String = "PySpark 2"
+  def cssSelectorString: String = "[title='Create a new notebook with PySpark 2']"
+}
+
+case object PySpark3 extends Kernel {
+  def string: String = "PySpark 3"
+  def cssSelectorString: String = "[title='Create a new notebook with PySpark 3']"
+}
+
 case object RKernel extends Kernel {
   def string: String = "R"
   def cssSelectorString: String = "[title='Create a new notebook with R']"

--- a/jupyter-docker/Dockerfile
+++ b/jupyter-docker/Dockerfile
@@ -216,6 +216,7 @@ RUN R -e 'install.packages(c( \
 
 ADD kernelspec.sh $JUPYTER_HOME/
 ADD python_kernelspec.tmpl $JUPYTER_HOME/
+ADD pyspark_kernelspec.tmpl $JUPYTER_HOME/
 ADD spark_install_hail.sh $HAIL_HOME/
 ADD jupyter_notebook_config.py $JUPYTER_HOME/
 ADD jupyter_localize_extension.py $JUPYTER_HOME/custom/

--- a/jupyter-docker/Dockerfile
+++ b/jupyter-docker/Dockerfile
@@ -72,7 +72,7 @@ ENV HAILJAR hail-0.1-$HAILHASH-Spark-$SPARK_VER.jar
 ENV HAILPYTHON hail-0.1-$HAILHASH.zip
 ENV HAILZIP Hail-0.1-$HAILHASH-Spark-$SPARK_VER.zip
 ENV HAIL_HOME /etc/hail
-ENV KERNELSPEC_HOME /usr/local/share/jupyter/kernals
+ENV KERNELSPEC_HOME /usr/local/share/jupyter/kernels
 
 # Note Spark and Hadoop are mounted from the outside Dataproc VM.
 # Make empty conf dirs for the update-alternatives commands.

--- a/jupyter-docker/kernelspec.sh
+++ b/jupyter-docker/kernelspec.sh
@@ -3,8 +3,12 @@
 TMP_KERNELSPEC_DIR=$1
 KERNELSPEC_HOME=$2
 
-# replace the contents of the kernel scripts
+# replace the contents of the Python kernel scripts
 sed 's/${PY_VERSION}/2/g' ${TMP_KERNELSPEC_DIR}/python_kernelspec.tmpl > ${KERNELSPEC_HOME}/python2/kernel.json
 sed 's/${PY_VERSION}/3/g' ${TMP_KERNELSPEC_DIR}/python_kernelspec.tmpl > ${KERNELSPEC_HOME}/python3/kernel.json
+
+# replace the contents of the PySpark kernel scripts
+sed 's/${PY_SPARK_VERSION}/2/g' ${TMP_KERNELSPEC_DIR}/pyspark_kernelspec.tmpl > ${KERNELSPEC_HOME}/pyspark2/kernel.json
+sed 's/${PY_SPARK_VERSION}/3/g' ${TMP_KERNELSPEC_DIR}/pyspark_kernelspec.tmpl > ${KERNELSPEC_HOME}/pyspark3/kernel.json
 
 

--- a/jupyter-docker/kernelspec.sh
+++ b/jupyter-docker/kernelspec.sh
@@ -8,7 +8,7 @@ sed 's/${PY_VERSION}/2/g' ${TMP_KERNELSPEC_DIR}/python_kernelspec.tmpl > ${KERNE
 sed 's/${PY_VERSION}/3/g' ${TMP_KERNELSPEC_DIR}/python_kernelspec.tmpl > ${KERNELSPEC_HOME}/python3/kernel.json
 
 # replace the contents of the PySpark kernel scripts
-sed 's/${PY_SPARK_VERSION}/2/g' ${TMP_KERNELSPEC_DIR}/pyspark_kernelspec.tmpl > ${KERNELSPEC_HOME}/pyspark2/kernel.json
-sed 's/${PY_SPARK_VERSION}/3/g' ${TMP_KERNELSPEC_DIR}/pyspark_kernelspec.tmpl > ${KERNELSPEC_HOME}/pyspark3/kernel.json
+sed 's/${PY_VERSION}/2/g' ${TMP_KERNELSPEC_DIR}/pyspark_kernelspec.tmpl > ${KERNELSPEC_HOME}/pyspark2/kernel.json
+sed 's/${PY_VERSION}/3/g' ${TMP_KERNELSPEC_DIR}/pyspark_kernelspec.tmpl > ${KERNELSPEC_HOME}/pyspark3/kernel.json
 
 

--- a/jupyter-docker/pyspark_kernelspec.tmpl
+++ b/jupyter-docker/pyspark_kernelspec.tmpl
@@ -1,6 +1,6 @@
 {
  "language": "python",
- "display_name": "PySpark ${PY_SPARK_VERSION}",
+ "display_name": "PySpark ${PY_VERSION}",
  "argv": [
   "python${PY_VERSION}",
   "-m",

--- a/jupyter-docker/pyspark_kernelspec.tmpl
+++ b/jupyter-docker/pyspark_kernelspec.tmpl
@@ -9,7 +9,8 @@
   "{connection_file}"
  ],
  "env": {
-   "PYSPARK_PYTHON": "python${PY_SPARK_VERSION}",
-   "PYSPARK_SUBMIT_ARGS": "--master yarn-client pyspark-shell"
+  "PYSPARK_PYTHON": "python${PY_VERSION}",
+  "PYTHONSTARTUP": "/usr/lib/spark/python/pyspark/shell.py",
+  "PYSPARK_SUBMIT_ARGS": "--master yarn-client pyspark-shell"
  }
 }

--- a/jupyter-docker/pyspark_kernelspec.tmpl
+++ b/jupyter-docker/pyspark_kernelspec.tmpl
@@ -1,0 +1,15 @@
+{
+ "language": "python",
+ "display_name": "PySpark ${PY_SPARK_VERSION}",
+ "argv": [
+  "python${PY_VERSION}",
+  "-m",
+  "ipykernel_launcher",
+  "-f",
+  "{connection_file}"
+ ],
+ "env": {
+   "PYSPARK_PYTHON": "python${PY_SPARK_VERSION}",
+   "PYSPARK_SUBMIT_ARGS": "--master yarn-client pyspark-shell"
+ }
+}

--- a/jupyter-docker/python_kernelspec.tmpl
+++ b/jupyter-docker/python_kernelspec.tmpl
@@ -9,8 +9,6 @@
   "{connection_file}"
  ],
  "env": {
-   "PYSPARK_PYTHON": "python${PY_VERSION}",
    "PYTHONSTARTUP": "/usr/lib/spark/python/pyspark/shell.py",
-   "PYSPARK_SUBMIT_ARGS": "--master yarn-client pyspark-shell"
  }
 }

--- a/jupyter-docker/python_kernelspec.tmpl
+++ b/jupyter-docker/python_kernelspec.tmpl
@@ -7,8 +7,5 @@
   "ipykernel_launcher",
   "-f",
   "{connection_file}"
- ],
- "env": {
-   "PYTHONSTARTUP": "/usr/lib/spark/python/pyspark/shell.py",
- }
+ ]
 }

--- a/src/main/resources/jupyter/init-actions.sh
+++ b/src/main/resources/jupyter/init-actions.sh
@@ -131,6 +131,9 @@ if [[ "${ROLE}" == 'Master' ]]; then
 
     log 'Installing Jupydocker kernelspecs...'
 
+    # Create directories for PySpark kernels (Python kernel directories are somehow already created at this point)
+    docker exec -u root -d ${JUPYTER_SERVER_NAME} mkdir ${KERNELSPEC_HOME}/pyspark{2,3}
+
     # Change Python and PySpark 2 and 3 kernel specs to allow each to have its own spark
     docker exec -u root -d ${JUPYTER_SERVER_NAME} ${JUPYTER_HOME}/kernelspec.sh ${JUPYTER_HOME} ${KERNELSPEC_HOME}
 

--- a/src/main/resources/jupyter/init-actions.sh
+++ b/src/main/resources/jupyter/init-actions.sh
@@ -131,7 +131,7 @@ if [[ "${ROLE}" == 'Master' ]]; then
 
     log 'Installing Jupydocker kernelspecs...'
 
-    # Change python 2 and 3 kernel specs to allow each to have its own spark
+    # Change Python and PySpark 2 and 3 kernel specs to allow each to have its own spark
     docker exec -u root -d ${JUPYTER_SERVER_NAME} ${JUPYTER_HOME}/kernelspec.sh ${JUPYTER_HOME} ${KERNELSPEC_HOME}
 
     log 'Installing Hail additions to Jupydocker spark.conf...'


### PR DESCRIPTION
The `Python` kernels no longer comes with Spark installed, which cuts more than 10 seconds from the kernel start-up time.

The newly added `PySpark` kernels have the former `Python` kernels' functionality.

All four kernels are displayed on the notebook UI by default.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
