### PR TITLE
mv gsutil delocalize to the background

### DIFF
--- a/jupyter-docker/test/jupyter_delocalize_test.py
+++ b/jupyter-docker/test/jupyter_delocalize_test.py
@@ -6,7 +6,6 @@ import tempfile
 import unittest
 from datetime import timedelta
 from nbformat.v4 import new_notebook
-import tornado
 from tornado.testing import AsyncTestCase, gen_test
 from unittest.mock import patch
 


### PR DESCRIPTION
This makes the UI a bit snappier on save, rename, delete.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
