### PR TITLE
Make stopAfterCreation truly optional in the create cluster request

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/ClusterConcurrencySpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/ClusterConcurrencySpec.scala
@@ -154,7 +154,7 @@ class ClusterConcurrencySpec extends FreeSpec with LeonardoTestUtils with Parall
     // set the "stop after creation" flag
     "should stop a cluster after creation" in withWebDriver { implicit driver =>
       withProject { project => implicit token =>
-        val request = defaultClusterRequest.copy(stopAfterCreation = true)
+        val request = defaultClusterRequest.copy(stopAfterCreation = Some(true))
         withNewCluster(project, request = request) { cluster =>
           // no-op; just verify the cluster is stopped
         }

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoModelCopy.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoModelCopy.scala
@@ -73,7 +73,7 @@ case class ClusterRequest(labels: LabelMap = Map(),
                           jupyterExtensionUri: Option[String] = None,
                           jupyterUserScriptUri: Option[String] = None,
                           machineConfig: Option[MachineConfig] = None,
-                          stopAfterCreation: Boolean = false)
+                          stopAfterCreation: Option[Boolean] = None)
 
 case class ClusterError(errorMessage: String,
                         errorCode: Int,

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
@@ -136,7 +136,7 @@ trait LeonardoTestUtils extends WebBrowserSpec with Matchers with Eventually wit
     if (monitor) {
       // wait for "Running", "Stopped", or error (fail fast)
       implicit val patienceConfig: PatienceConfig = clusterPatience
-      val expectedStatuses = if (clusterRequest.stopAfterCreation) {
+      val expectedStatuses = if (clusterRequest.stopAfterCreation.getOrElse(false)) {
         Seq(ClusterStatus.Stopped, ClusterStatus.Error)
       } else {
         Seq(ClusterStatus.Running, ClusterStatus.Error)
@@ -280,7 +280,7 @@ trait LeonardoTestUtils extends WebBrowserSpec with Matchers with Eventually wit
   def createNewCluster(googleProject: GoogleProject, name: ClusterName = randomClusterName, request: ClusterRequest = defaultClusterRequest, monitor: Boolean = true)(implicit token: AuthToken): Cluster = {
     val cluster = createCluster(googleProject, name, request, monitor)
     if (monitor) {
-      cluster.status shouldBe (if (request.stopAfterCreation) ClusterStatus.Stopped else ClusterStatus.Running)
+      cluster.status shouldBe (if (request.stopAfterCreation.getOrElse(false)) ClusterStatus.Stopped else ClusterStatus.Running)
     } else {
       cluster.status shouldBe ClusterStatus.Creating
     }

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -685,6 +685,7 @@ definitions:
           a cluster in Stopped state. Otherwise, the end result will be a cluster in Running state.
           Defaults to false.
         type: boolean
+        default: false
 
   ClusterError:
     description: 'Errors encountered on cluster create'

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeonardoModel.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeonardoModel.scala
@@ -26,7 +26,7 @@ case class ClusterRequest(labels: LabelMap = Map(),
                           jupyterExtensionUri: Option[GcsPath] = None,
                           jupyterUserScriptUri: Option[GcsPath] = None,
                           machineConfig: Option[MachineConfig] = None,
-                          stopAfterCreation: Boolean = false)
+                          stopAfterCreation: Option[Boolean] = None)
 
 // A resource that is required by a cluster
 case class ClusterResource(value: String) extends ValueObject

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoService.scala
@@ -164,7 +164,7 @@ class LeonardoService(protected val dataprocConfig: DataprocConfig,
           savedCluster <- dbRef.inTransaction(_.clusterQuery.save(cluster, GcsPath(initBucket, GcsObjectName("")), serviceAccountKeyOpt.map(_.id)))
         } yield {
           // Notify the cluster monitor that the cluster has been created
-          clusterMonitorSupervisor ! ClusterCreated(savedCluster, clusterRequest.stopAfterCreation)
+          clusterMonitorSupervisor ! ClusterCreated(savedCluster, clusterRequest.stopAfterCreation.getOrElse(false))
           savedCluster
         }
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/LeoRoutesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/LeoRoutesSpec.scala
@@ -240,6 +240,26 @@ class LeoRoutesSpec extends FlatSpec with ScalatestRouteTest with TestLeoRoutes 
     }
   }
 
+  it should "create a cluster with stopAfterCreation specified" in {
+    val stopAfterCreation = ClusterRequest(Map.empty, Some(extensionPath), Some(userScriptPath), stopAfterCreation = Some(true))
+
+    Put(s"/api/cluster/${googleProject.value}/${clusterName.value}", stopAfterCreation.toJson) ~>
+      timedLeoRoutes.route ~> check {
+      status shouldEqual StatusCodes.OK
+
+      validateCookie { header[`Set-Cookie`] }
+    }
+
+    val noStopAfterCreation = ClusterRequest(Map.empty, Some(extensionPath), Some(userScriptPath), stopAfterCreation = Some(false))
+
+    Put(s"/api/cluster/${googleProject.value}/${clusterName.value}", noStopAfterCreation.toJson) ~>
+      timedLeoRoutes.route ~> check {
+      status shouldEqual StatusCodes.OK
+
+      validateCookie { header[`Set-Cookie`] }
+    }
+  }
+
   private def serviceAccountLabels: Map[String, String] = {
     (
       clusterServiceAccount(googleProject).map { sa => Map("clusterServiceAccount" -> sa.value) } getOrElse Map.empty

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/LeoRoutesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/LeoRoutesSpec.scala
@@ -240,23 +240,16 @@ class LeoRoutesSpec extends FlatSpec with ScalatestRouteTest with TestLeoRoutes 
     }
   }
 
-  it should "create a cluster with stopAfterCreation specified" in {
-    val stopAfterCreation = ClusterRequest(Map.empty, Some(extensionPath), Some(userScriptPath), stopAfterCreation = Some(true))
+  Seq(true, false).foreach { stopAfterCreation =>
+    it should s"create a cluster with stopAfterCreation = $stopAfterCreation" in isolatedDbTest {
+      val request = ClusterRequest(Map.empty, Some(extensionPath), Some(userScriptPath), stopAfterCreation = Some(stopAfterCreation))
 
-    Put(s"/api/cluster/${googleProject.value}/${clusterName.value}", stopAfterCreation.toJson) ~>
-      timedLeoRoutes.route ~> check {
-      status shouldEqual StatusCodes.OK
+      Put(s"/api/cluster/${googleProject.value}/${clusterName.value}", request.toJson) ~>
+        timedLeoRoutes.route ~> check {
+        status shouldEqual StatusCodes.OK
 
-      validateCookie { header[`Set-Cookie`] }
-    }
-
-    val noStopAfterCreation = ClusterRequest(Map.empty, Some(extensionPath), Some(userScriptPath), stopAfterCreation = Some(false))
-
-    Put(s"/api/cluster/${googleProject.value}/${clusterName.value}", noStopAfterCreation.toJson) ~>
-      timedLeoRoutes.route ~> check {
-      status shouldEqual StatusCodes.OK
-
-      validateCookie { header[`Set-Cookie`] }
+        validateCookie { header[`Set-Cookie`] }
+      }
     }
   }
 


### PR DESCRIPTION
This was a mistake on my part. In https://github.com/DataBiosphere/leonardo/pull/349 I added the `stopAfterCreation` boolean parameter to `ClusterRequest` thinking it was optional, but I misunderstood how spray-json works and accidentally made it required. This means clients that don't set this parameter (e.g. FireCloud and AoU) currently can't create clusters in Leo-dev. This fixes it. I'd like to merge this quickly to fix dev.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
