### PR TITLE
User script to hide spark kernels

### DIFF
--- a/jupyter-docker/user-scripts/uninstall_spark_kernels.sh
+++ b/jupyter-docker/user-scripts/uninstall_spark_kernels.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+jupyter kernelspec uninstall -f pyspark2
+jupyter kernelspec uninstall -f pyspark3


### PR DESCRIPTION
In response to @calbach's request on #346, we are adding a user script that can be specified at cluster creation time in order to hide the Spark kernels (PySpark 2 and 3) so it looks like

![image](https://user-images.githubusercontent.com/5438223/39718826-6bb9f602-5205-11e8-9abc-c594093cd5c4.png)

**Note:** As with other user scripts, the GCS object containing the script needs to be readable by the user's pet service account. More information on whether it's necessary to manually grant read permission to the bucket and if so, how to do it, can be found [here](https://software.broadinstitute.org/firecloud/blog?id=11342).
