### PR TITLE
Add support for obtaining a GCR service account from vault

### DIFF
--- a/docker/build.sh
+++ b/docker/build.sh
@@ -169,7 +169,6 @@ function make_jar()
 
 function docker_cmd()
 {
-    echo "running docker_cmd with $DOCKER_CMD"
     if [ $DOCKER_CMD = "build" ] || [ $DOCKER_CMD = "push" ]; then
         echo "building $IMAGE docker image..."
         if [ "$ENV" != "dev" ] && [ "$ENV" != "alpha" ] && [ "$ENV" != "staging" ] && [ "$ENV" != "perf" ]; then

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -45,6 +45,7 @@ GIT_BRANCH="${BRANCH:-$(git rev-parse --abbrev-ref HEAD)}"
 DOCKER_REGISTRY="dockerhub"  # Must be either "dockerhub" or "gcr"
 DOCKER_CMD=""
 ENV=${ENV:-""}  # if env is not set, push an image with branch name
+SERVICE_ACCOUNT_KEY_FILE=""  # default to no service account
 
 MAKE_JAR=false
 RUN_DOCKER=false

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -20,7 +20,10 @@ HELP_TEXT="$(cat <<EOF
    -p | --project: set the project used at either dockerhub or with gcr
            container registries.
    -n | --notebook-repo: (default: --project) the repo to push the notebooks
-           image. Can be a dockerhub or GCR repo. 
+           image. Can be a dockerhub or GCR repo.
+   -k | --service-account-key-file: (optional) path to a service account key json
+           file. If set, the script will call "gcloud auth activate-service-account".
+           Otherwise, the script will not authenticate with gcloud.
    -h | --help: print help text.
 
  Examples:
@@ -80,6 +83,11 @@ while [ "$1" != "" ]; do
             echo "notebook-repo == $1"
             NOTEBOOK_REPO=$1
             ;;
+        -k | --service-account-key-file)
+            shift
+            echo "service-account-key-file == $1"
+            SERVICE_ACCOUNT_KEY_FILE=$1
+            ;;
         -h | --help)
             PRINT_HELP=true
             ;;
@@ -123,6 +131,12 @@ fi
 
 TESTS_IMAGE=$IMAGE-tests
 
+# Run gcloud auth if a service account key file was specified.
+if [[ -n $SERVICE_ACCOUNT_KEY_FILE ]]; then
+  TMP_DIR=$(mktemp -d tmp-XXXXXX)
+  export CLOUDSDK_CONFIG=$(pwd)/${TMP_DIR}
+  gcloud auth activate-service-account --key-file="${SERVICE_ACCOUNT_KEY_FILE}"
+fi
 
 function make_jar()
 {
@@ -155,6 +169,7 @@ function make_jar()
 
 function docker_cmd()
 {
+    echo "running docker_cmd with $DOCKER_CMD"
     if [ $DOCKER_CMD = "build" ] || [ $DOCKER_CMD = "push" ]; then
         echo "building $IMAGE docker image..."
         if [ "$ENV" != "dev" ] && [ "$ENV" != "alpha" ] && [ "$ENV" != "staging" ] && [ "$ENV" != "perf" ]; then
@@ -189,6 +204,15 @@ function docker_cmd()
     fi
 }
 
+function cleanup()
+{
+    echo "cleaning up..."
+    if [[ -n $SERVICE_ACCOUNT_KEY_FILE ]]; then
+      gcloud auth revoke
+      rm -rf ${CLOUDSDK_CONFIG}
+    fi
+}
+
 if $MAKE_JAR; then
   make_jar
 fi
@@ -196,3 +220,5 @@ fi
 if $RUN_DOCKER; then
   docker_cmd
 fi
+
+cleanup

--- a/jenkins/jenkins_build.sh
+++ b/jenkins/jenkins_build.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -eux
+
+if [ "$skip_docker_build" = false ]; then
+  GCR_SVCACCT_VAULT="secret/dsde/dsp-techops/common/dspci-wb-gcr-service-account.json"
+  GCR_REPO_PROJ="broad-dsp-gcr-public"
+
+  docker run --rm  -v /etc/vault-token-dsde:/root/.vault-token:ro \
+       broadinstitute/dsde-toolbox:latest vault read --format=json ${GCR_SVCACCT_VAULT} \
+       | jq .data > dspci-wb-gcr-service-account.json
+
+  ./docker/build.sh jar -d push -n "us.gcr.io/broad-dsp-gcr-public" \
+      -k "dspci-wb-gcr-service-account.json"
+
+  # clean up
+  rm -f dspci-wb-gcr-service-account.json
+else
+  GIT_SHA=$(git rev-parse origin/${BRANCH})
+  echo GIT_SHA=$GIT_SHA > env.properties
+fi
+


### PR DESCRIPTION
Made the following changes to the Leo build script:

1. Added `--service-account-key-file` option to `build.sh` which if set, will cause the script to call `gcloud auth activate-service-account`. This is needed for pushing to our public [GCR repo](http://us.gcr.io/broad-dsp-gcr-public).
2. Added `jenkins_build.sh` with the DSP-specific logic: vault token/paths, service accounts, repos, etc. The idea is to make [leonardo-build](https://fc-jenkins.dsp-techops.broadinstitute.org/job/leonardo-build/) just call this script directly.

The scripts work locally & in [Jenkins](https://fc-jenkins.dsp-techops.broadinstitute.org/job/leonardo-build/2208/console). Plan for rollout:

1. Merge this PR; it should not have any effect initially. Make sure dev deploy+tests pass.
2. Update Jenkins leonardo-build job to call `jenkins_build.sh`. Run a build to make sure it works. This should push the first `dev`-tagged image to GCR.
3. Rerun automation tests against the fc-develop [PR](https://github.com/broadinstitute/firecloud-develop/pull/1068) which actually makes Leo use the GCR dev image. Tests should pass.
4. Merge https://github.com/broadinstitute/firecloud-develop/pull/1068; confirm dev deploy+tests pass.
5. Profit!

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
