### PR TITLE
Explicitly set VPC net/subnet on cluster creation

### DIFF
--- a/docker/run-mysql.sh
+++ b/docker/run-mysql.sh
@@ -13,6 +13,7 @@ start() {
     echo "starting up mysql container..."
     docker run --name $CONTAINER \
                -e MYSQL_ROOT_PASSWORD=leonardo-test \
+               -e 'MYSQL_ROOT_HOST=%' \
                -e MYSQL_USER=leonardo-test \
                -e MYSQL_PASSWORD=leonardo-test \
                -e MYSQL_DATABASE=leotestdb \

--- a/leonardo-example.conf
+++ b/leonardo-example.conf
@@ -45,6 +45,15 @@ mysql {
 proxy {
   # Should match the jupyter wildcard cert specified in command above
   jupyterDomain = "JUPYTER_DOMAIN_NAME"
+  # This tag is used to associate the cluster's master with Leonardo's firewall rule.
+  networkTag = "leonardo"
+  # The VPC network that the firewall rule is applied to. Most instances of leo should use
+  # 'default' since it is the VPC allocated in all newly configured GCP projects.
+  firewallVPCNetwork = "default"
+  # The subnet on which the cluster is launched. Like the VPC, it should usually be 'default'.
+  # If the subnet in a shared VPC, this field can accept a partial URI (ex.
+  # "projects/[projectId]/regions/us-east1/sub0") in addition to the short-name form "sub0".
+  firewallVPCSubnet = "default"
 }
 
 # Keys and certificate authorities for cluster

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -47,6 +47,7 @@ proxy {
   proxyServerName = "jupyter-proxy-server"
   firewallRuleName = "leonardo-notebooks-rule"
   firewallVPCNetwork = "default"
+  firewallVPCSubnet = "default"
   networkTag = "leonardo"
   jupyterPort = 443
   jupyterProtocol = "tcp"

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/Boot.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/Boot.scala
@@ -15,7 +15,7 @@ import org.broadinstitute.dsde.workbench.leonardo.dao.HttpSamDAO
 import org.broadinstitute.dsde.workbench.leonardo.dao.google.{HttpGoogleComputeDAO, HttpGoogleDataprocDAO}
 import org.broadinstitute.dsde.workbench.leonardo.db.DbReference
 import org.broadinstitute.dsde.workbench.leonardo.dns.ClusterDnsCache
-import org.broadinstitute.dsde.workbench.leonardo.model.google.{ClusterStatus, NetworkTag}
+import org.broadinstitute.dsde.workbench.leonardo.model.google.{ClusterStatus, NetworkTag, VPCNetworkName, VPCSubnetName}
 import org.broadinstitute.dsde.workbench.leonardo.monitor.ClusterMonitorSupervisor
 import org.broadinstitute.dsde.workbench.leonardo.monitor.ClusterMonitorSupervisor._
 import org.broadinstitute.dsde.workbench.leonardo.service.{LeonardoService, ProxyService, StatusService}
@@ -74,7 +74,7 @@ object Boot extends App with LazyLogging {
     }
 
     val (leoServiceAccountEmail, leoServiceAccountPemFile) = serviceAccountProvider.getLeoServiceAccountAndKey
-    val gdDAO = new HttpGoogleDataprocDAO(dataprocConfig.applicationName, Pem(leoServiceAccountEmail, leoServiceAccountPemFile), "google", NetworkTag(proxyConfig.networkTag), dataprocConfig.dataprocDefaultRegion)
+    val gdDAO = new HttpGoogleDataprocDAO(dataprocConfig.applicationName, Pem(leoServiceAccountEmail, leoServiceAccountPemFile), "google", NetworkTag(proxyConfig.networkTag), VPCSubnetName(proxyConfig.firewallVPCSubnet), dataprocConfig.dataprocDefaultRegion)
     val googleComputeDAO = new HttpGoogleComputeDAO(dataprocConfig.applicationName, Pem(leoServiceAccountEmail, leoServiceAccountPemFile), "google")
     val googleIamDAO = new HttpGoogleIamDAO(dataprocConfig.applicationName, Pem(leoServiceAccountEmail, leoServiceAccountPemFile), "google")
     val googleStorageDAO = new HttpGoogleStorageDAO(dataprocConfig.applicationName, Pem(leoServiceAccountEmail, leoServiceAccountPemFile), "google")

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/ProxyConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/ProxyConfig.scala
@@ -8,6 +8,7 @@ case class ProxyConfig(
                         proxyServerName: String,
                         firewallRuleName: String,
                         firewallVPCNetwork: String,
+                        firewallVPCSubnet: String,
                         networkTag: String,
                         jupyterPort: Int,
                         jupyterProtocol: String,

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/package.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/package.scala
@@ -69,6 +69,7 @@ package object config {
       config.getString("proxyServerName"),
       config.getString("firewallRuleName"),
       config.getString("firewallVPCNetwork"),
+      config.getString("firewallVPCSubnet"),
       config.getString("networkTag"),
       config.getInt("jupyterPort"),
       config.getString("jupyterProtocol"),

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/google/HttpGoogleDataprocDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/google/HttpGoogleDataprocDAO.scala
@@ -32,6 +32,7 @@ class HttpGoogleDataprocDAO(appName: String,
                             googleCredentialMode: GoogleCredentialMode,
                             override val workbenchMetricBaseName: String,
                             defaultNetworkTag: NetworkTag,
+                            defaultVPCSubnet: VPCSubnetName,
                             defaultRegion: String)
                            (implicit override val system: ActorSystem, override val executionContext: ExecutionContext)
   extends AbstractHttpGoogleDAO(appName, googleCredentialMode, workbenchMetricBaseName) with GoogleDataprocDAO {
@@ -189,8 +190,10 @@ class HttpGoogleDataprocDAO(appName: String,
   private def getClusterConfig(machineConfig: MachineConfig, initScript: GcsPath, clusterServiceAccount: Option[WorkbenchEmail], credentialsFileName: Option[String], stagingBucket: GcsBucketName): DataprocClusterConfig = {
     // Create a GceClusterConfig, which has the common config settings for resources of Google Compute Engine cluster instances,
     // applicable to all instances in the cluster.
-    // Set the network tag, which is needed by the firewall rule that allows leo to talk to the cluster
-    val gceClusterConfig = new GceClusterConfig().setTags(List(defaultNetworkTag.value).asJava)
+    // Set the network tag, network, and subnet. This allows the creaed GCE instances to be exposed by Leo's firewall rule.
+    val gceClusterConfig = new GceClusterConfig()
+      .setTags(List(defaultNetworkTag.value).asJava)
+      .setSubnetworkUri(defaultVPCSubnet.value)
 
     // Set the cluster service account, if present.
     // This is the service account passed to the create cluster API call.

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/google/GoogleModel.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/google/GoogleModel.scala
@@ -93,9 +93,10 @@ case class IP(value: String) extends ValueObject
 case class NetworkTag(value: String) extends ValueObject
 case class FirewallRuleName(value: String) extends ValueObject
 case class FirewallRulePort(value: String) extends ValueObject
-case class FirewallRuleNetwork(value: String) extends ValueObject
 case class FirewallRuleProtocol(value: String) extends ValueObject
-case class FirewallRule(name: FirewallRuleName, protocol: FirewallRuleProtocol, ports: List[FirewallRulePort], network: FirewallRuleNetwork, targetTags: List[NetworkTag])
+case class VPCNetworkName(value: String) extends ValueObject
+case class VPCSubnetName(value: String) extends ValueObject
+case class FirewallRule(name: FirewallRuleName, protocol: FirewallRuleProtocol, ports: List[FirewallRulePort], network: VPCNetworkName, targetTags: List[NetworkTag])
 
 // Instance status
 // See: https://cloud.google.com/compute/docs/instances/checking-instance-status
@@ -162,7 +163,7 @@ object GoogleJsonSupport extends SprayJsonSupport with DefaultJsonProtocol {
   implicit val FirewallRuleNameFormat = ValueObjectFormat(FirewallRuleName)
   implicit val FirewallRulePortFormat = ValueObjectFormat(FirewallRulePort)
   implicit val FirewallRuleProtocolFormat = ValueObjectFormat(FirewallRuleProtocol)
-  implicit val FirewallRuleNetworkFormat = ValueObjectFormat(FirewallRuleNetwork)
+  implicit val VPCNetworkNameFormat = ValueObjectFormat(VPCNetworkName)
   implicit val FirewallRuleFormat = jsonFormat5(FirewallRule)
 
   implicit val InstanceNameFormat = ValueObjectFormat(InstanceName)

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoService.scala
@@ -91,7 +91,7 @@ class LeonardoService(protected val dataprocConfig: DataprocConfig,
     name = FirewallRuleName(proxyConfig.firewallRuleName),
     protocol = FirewallRuleProtocol(proxyConfig.jupyterProtocol),
     ports = List(FirewallRulePort(proxyConfig.jupyterPort.toString)),
-    network = FirewallRuleNetwork(proxyConfig.firewallVPCNetwork),
+    network = VPCNetworkName(proxyConfig.firewallVPCNetwork),
     targetTags = List(NetworkTag(proxyConfig.networkTag)))
 
   // Startup script to install on the cluster master node. This is needed to support pause/resume clusters.


### PR DESCRIPTION
This PR resolves [issue 359](https://github.com/DataBiosphere/leonardo/issues/359) (working with non-default VPCs) and  [issue 360](https://github.com/DataBiosphere/leonardo/issues/360) (working with non-auto-subnet VPCs).

Specifically:
  * Added subnet config to ProxyConfig
  * Documented additional ProxyConfig fields leonardo-example.conf
  * Added subnet config to HttpGoogleDataprocDAO
  * Fixed an issue in run-mysql.sh where in some difficult-to-reproduce instances, the root user credentials were rejected due to a non-matching host


I, the developer opening this PR, do solemnly pinky swear to:
- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
