### PR TITLE
User Interface: new options and other fixes

### DIFF
--- a/ui/.env
+++ b/ui/.env
@@ -8,3 +8,15 @@ REACT_APP_FILTER_TO_CURRENT_USER='true'
 
 # OAuth 2.0 client ID used for auth.
 #REACT_APP_OAUTH_CLIENT_ID='---client-id---'
+
+# Provide a default project for users (this will be populated
+# in the cluster creation form).
+REACT_APP_DEFAULT_PROJECT=""
+
+# Set to the string "true" in order to prevent user-entry of a
+# project. This should be used with the default project setting.
+REACT_APP_DISABLE_PROJECT_ENTRY='false'
+
+# A 'gs://' path to a cluster init script. If present, this will be provided
+# as the argument to jupyterUserScriptUri on cluster creation
+REACT_APP_STARTUP_SCRIPT_URI=""

--- a/ui/public/index.html
+++ b/ui/public/index.html
@@ -20,7 +20,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
+    <title>Leonardo</title>
   </head>
   <body>
     <noscript>

--- a/ui/public/manifest.json
+++ b/ui/public/manifest.json
@@ -1,6 +1,6 @@
 {
-  "short_name": "React App",
-  "name": "Create React App Sample",
+  "short_name": "Leonardo",
+  "name": "Leonardo Notebook Cluster Manager",
   "icons": [
     {
       "src": "favicon.ico",

--- a/ui/src/components/ClusterCardList.js
+++ b/ui/src/components/ClusterCardList.js
@@ -19,7 +19,8 @@ class ClusterCardList extends React.Component {
     var models = this.props.clusterModels;
     for (var i = 0; i < models.length; i++) {
       var model = models[i];
-      var clusterKey = model.googleProject + "/" + model.clusterName;
+      // Any difference in status should trigger card re-render.
+      var clusterKey = model.googleProject + "/" + model.clusterName + "/" + model.status;
       clusterCards.push(
         <ClusterCard
           oauthClientId={this.props.oauthClientId}

--- a/ui/src/components/CreateClusterForm.js
+++ b/ui/src/components/CreateClusterForm.js
@@ -62,11 +62,22 @@ class HiddenSpinner extends React.Component {
 class UnstyledCreateClusterForm extends React.Component {
   constructor(props) {
     super(props);
+    // Initialize project with default value (if applicable).
+    var project = "";
+    var projectEntryDisabled = false
+    if (process.env.REACT_APP_DEFAULT_PROJECT) {
+      project = process.env.REACT_APP_DEFAULT_PROJECT;
+    }
+    if (process.env.REACT_APP_DISABLE_PROJECT_ENTRY == 'true') {
+      projectEntryDisabled = true;
+    }
+
     this.state = {
       clusterName: "",
-      googleProject: "",
+      googleProject: project,
       machineType: DEFAULT_MASTER_MACHINE_TYPE,
       workerMachineType: DEFAULT_WORKER_MACHINE_TYPE,
+      projectEntryDisabled: projectEntryDisabled,
       diskSize: 200,
       createRequestValid: false,
       requestInProgress: false,
@@ -94,6 +105,7 @@ class UnstyledCreateClusterForm extends React.Component {
 
     var createRequest = {
       labels: {},
+      stopAfterCreation: false,
       machineConfig: {
         // Worker config.
         numberOfWorkers: this.state.numberOfWorkers,
@@ -106,6 +118,9 @@ class UnstyledCreateClusterForm extends React.Component {
 
       }
     };
+    if (process.env.REACT_APP_STARTUP_SCRIPT_URI) {
+      createRequest["jupyterUserScriptUri"] = process.env.REACT_APP_STARTUP_SCRIPT_URI;
+    }
     // Use fetch to send a put request, and register success/fail callbacks.
     fetch(
       createApiUrl(this.state.googleProject, this.state.clusterName),
@@ -159,6 +174,7 @@ class UnstyledCreateClusterForm extends React.Component {
               value={this.state.googleProject}
               onChange={this.handleChange("googleProject")}
               margin="normal"
+              disabled={this.state.projectEntryDisabled}
             />
           </FormControl>
         </div>

--- a/ui/src/components/ListStateContainer.js
+++ b/ui/src/components/ListStateContainer.js
@@ -49,12 +49,11 @@ class ListStateContainer extends React.Component {
    */
   refreshListFromApi = () => {
     // Construct the request URI.
-    var listUri = "/api/clusters?";
+    var listUri = "/api/clusters?includeDeleted=false";
     if (this.state.perUserFilter) {
       var creatorFilter = encodeURIComponent("creator=" + this.props.googleProfile.email);
-      listUri = listUri + creatorFilter + "&";
+      listUri = listUri + "&" + "_labels=" + creatorFilter;
     }
-    listUri = listUri + "includeDeleted=false";
     // Begin the GET request and register callbacks.
     return fetch(
       listUri,


### PR DESCRIPTION
This PR includes a few UI fixes and config features.

 * Bugfix: creator filter should have used '_labels' url field.
 * Feature: pre-populate the project field via the config.
 * Feature: lock the project field via the config.
 * Other fix: make page title display `Leonardo` instead of `React App`.

In all cases:
- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
