### PR TITLE
Peg the statsmodels dependency for compatibility

### DIFF
--- a/jupyter-docker/Dockerfile
+++ b/jupyter-docker/Dockerfile
@@ -129,6 +129,7 @@ RUN apt-get install -yq --no-install-recommends \
  && pip install google-cloud \
  && pip install --ignore-installed firecloud==0.16.7 \
  && pip install -U scikit-learn \
+ && pip install statsmodels==0.8.0 \
  && pip install ggplot \
  && pip install bokeh \
  && pip install pyfasta \
@@ -158,6 +159,7 @@ RUN apt-get install -yq --no-install-recommends python3 \
  && pip3 install google-cloud \
  && pip3 install --ignore-installed firecloud==0.16.7 \
  && pip3 install -U scikit-learn \
+ && pip3 install statsmodels==0.8.0 \
  && pip3 install ggplot \
  && pip3 install bokeh \
  && pip3 install pyfasta \


### PR DESCRIPTION
Looks like `ggplot` pulls the latest version of `statsmodels`, which recently changed from 0.8.0 to 0.9.0 and broke things. This pegs `statsmodels` to 0.8.0 to resolve the issue.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
