### PR TITLE
Fix Swagger validation errors

### DIFF
--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -389,7 +389,7 @@ paths:
           required: true
           schema:
             type: object
-            description:
+            description: ''
             example:
               "~/file.txt" : "gs://somebucket/file.txt"
               "~/directory" : "gs://somebucket/*"
@@ -589,9 +589,7 @@ definitions:
         type: string
         description: Google's operation ID for the cluster
       status:
-        type: string
-        enum: *CLUSTERSTATUS
-        description: The current state of the cluster
+        $ref: "#/definitions/ClusterStatus"
       hostIp:
         type: string
         description: The IP address of the cluster master node
@@ -646,9 +644,7 @@ definitions:
         type: string
         description: Google's unique id for this instance
       status:
-        type: string
-        enum: *INSTANCESTATUS
-        description: The current state of the instance
+        $ref: "#/definitions/InstanceStatus"
       ip:
         type: string
         description: The public IP address of the instance, if any


### PR DESCRIPTION
When syncing to AoU, we noticed these validation errors. We're using this gradle plugin to perform the validation: https://github.com/int128/gradle-swagger-generator-plugin/blob/26c71f3ab4ea7002a7f786f550e3dab502f58466/src/main/groovy/org/hidetake/gradle/swagger/generator/ValidateSwagger.groovy

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
