### PR TITLE
[NOT YET] Add explicit pulls of the docker images before calling docker-compose

### DIFF
--- a/src/main/resources/jupyter/init-actions.sh
+++ b/src/main/resources/jupyter/init-actions.sh
@@ -126,6 +126,14 @@ if [[ "${ROLE}" == 'Master' ]]; then
       gcloud docker --authorize-only
     fi
 
+    log 'Pulling the $JUPYTER_DOCKER_IMAGE image'
+
+    docker pull ${JUPYTER_DOCKER_IMAGE}
+
+    log 'Pulling the $PROXY_DOCKER_IMAGE image'
+
+    docker pull ${PROXY_DOCKER_IMAGE}
+
     log 'Starting up the Jupydocker...'
 
     # Run docker-compose. This mounts Hadoop, Spark, and other resources inside the docker container.


### PR DESCRIPTION
Seeing if this reduces flakiness pulling images from GCR.

Opening PR to get some test runs, not looking to merge yet.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
