### PR TITLE
Date accessed should only be updated when cluster is ready

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -91,7 +91,7 @@ serviceAccounts {
 
 autoFreeze {
   #Change to true once auto freeze is ready for prod
-  enableAutoFreeze = false
+  enableAutoFreeze = true
   dateAccessedMonitorScheduler = 1 minute
   autoFreezeAfter = 30 minutes
   autoFreezeCheckScheduler = 1 minute

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -91,7 +91,7 @@ serviceAccounts {
 
 autoFreeze {
   #Change to true once auto freeze is ready for prod
-  enableAutoFreeze = true
+  enableAutoFreeze = false
   dateAccessedMonitorScheduler = 1 minute
   autoFreezeAfter = 30 minutes
   autoFreezeCheckScheduler = 1 minute

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/ProxyService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/ProxyService.scala
@@ -122,8 +122,6 @@ class ProxyService(proxyConfig: ProxyConfig,
 
   private def proxyInternal(userInfo: UserInfo, googleProject: GoogleProject, clusterName: ClusterName, request: HttpRequest): Future[HttpResponse] = {
     logger.debug(s"Received proxy request for user user $userInfo")
-    clusterDateAccessedActor ! UpdateDateAccessed(clusterName, googleProject, Instant.now())
-
     getTargetHost(googleProject, clusterName) flatMap {
       case ClusterReady(targetHost) =>
         // If this is a WebSocket request (e.g. wss://leo:8080/...) then akka-http injects a

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/ProxyService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/ProxyService.scala
@@ -143,7 +143,6 @@ class ProxyService(proxyConfig: ProxyConfig,
       case ClusterNotFound =>
         throw ClusterNotFoundException(googleProject, clusterName)
     }
-
   }
 
   private def handleHttpRequest(targetHost: Host, request: HttpRequest): Future[HttpResponse] = {

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/ProxyService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/ProxyService.scala
@@ -123,11 +123,13 @@ class ProxyService(proxyConfig: ProxyConfig,
   private def proxyInternal(userInfo: UserInfo, googleProject: GoogleProject, clusterName: ClusterName, request: HttpRequest): Future[HttpResponse] = {
     logger.debug(s"Received proxy request for user user $userInfo")
     clusterDateAccessedActor ! UpdateDateAccessed(clusterName, googleProject, Instant.now())
+
     getTargetHost(googleProject, clusterName) flatMap {
       case ClusterReady(targetHost) =>
         // If this is a WebSocket request (e.g. wss://leo:8080/...) then akka-http injects a
         // virtual UpgradeToWebSocket header which contains facilities to handle the WebSocket data.
         // The presence of this header distinguishes WebSocket from http requests.
+        clusterDateAccessedActor ! UpdateDateAccessed(clusterName, googleProject, Instant.now())
         val responseFuture = request.header[UpgradeToWebSocket] match {
           case Some(upgrade) => handleWebSocketRequest(targetHost, request, upgrade)
           case None => handleHttpRequest(targetHost, request)
@@ -143,6 +145,7 @@ class ProxyService(proxyConfig: ProxyConfig,
       case ClusterNotFound =>
         throw ClusterNotFoundException(googleProject, clusterName)
     }
+
   }
 
   private def handleHttpRequest(targetHost: Host, request: HttpRequest): Future[HttpResponse] = {


### PR DESCRIPTION

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
