### PR TITLE
Fix locale so unicode characters actually display

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/NotebookInteractionSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/NotebookInteractionSpec.scala
@@ -291,7 +291,10 @@ class NotebookInteractionSpec extends FreeSpec with LeonardoTestUtils with Befor
         // it may take a little while to install
         val installTimeout = 2.minutes
 
-        notebookPage.executeCell("""install.packages("httr")""", installTimeout).get should include ("Installing package into '/home/jupyter-user/.rpackages'")
+        val output = notebookPage.executeCell("""install.packages("httr")""", installTimeout)
+        output shouldBe 'defined
+        output.get should include ("Installing package into")
+        output.get should include ("/home/jupyter-user/.rpackages")
 
         val httpGetTest =
           """library(httr)

--- a/jupyter-docker/Dockerfile
+++ b/jupyter-docker/Dockerfile
@@ -32,6 +32,12 @@ RUN echo "deb $DEBIAN_REPO/debian jessie main"                   > /etc/apt/sour
     procps \
     # to support userScript pip installs via git
     git \
+    locales \
+
+ # Uncomment en_US.UTF-8 for inclusion in generation
+ && sed -i 's/^# *\(en_US.UTF-8\)/\1/' /etc/locale.gen \
+ # Generate locale
+ && locale-gen \
 
  # google-cloud-sdk separately because it need lsb-release and other prereqs installed above
  && export CLOUD_SDK_REPO="cloud-sdk-$(lsb_release -c -s)" \
@@ -40,6 +46,8 @@ RUN echo "deb $DEBIAN_REPO/debian jessie main"                   > /etc/apt/sour
  && apt-get update \
  && apt-get install -yq --no-install-recommends \
     google-cloud-sdk
+
+ENV LC_ALL en_US.UTF-8
 
 #######################
 # Java
@@ -177,8 +185,6 @@ ENV PIP_USER=true
 #######################
 # R Kernel
 #######################
-
-ENV LC_ALL en_US.UTF-8
 
 RUN apt-get update \
  && apt-get -t jessie-cran34 install -y --no-install-recommends \


### PR DESCRIPTION
I had previously set  `LC_ALL` to  `en_US.UTF-8` but it didn't actually work because that locale wasn't installed. :( Updated the Dockerfile to actually install the locale and updated the test to verify that the characters get displayed instead of just checking the EV.

Context: this is needed for Nurses Health, who is using mlr/skimr in notebooks and would like these funky histograms to display.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
