### PR TITLE
Experimental: allow opening Jupyter in an iframe

### DIFF
--- a/jupyter-docker/jupyter_notebook_config.py
+++ b/jupyter-docker/jupyter_notebook_config.py
@@ -23,3 +23,11 @@ c.NotebookApp.nbserver_extensions = {
     'jupyter_localize_extension': True,
 }
 c.NotebookApp.contents_manager_class = 'jupyter_delocalize.DelocalizingContentsManager'
+
+# Unset Content-Security-Policy so Jupyter can be rendered in an iframe
+# See https://jupyter-notebook.readthedocs.io/en/latest/public_server.html?highlight=server#embedding-the-notebook-in-another-website
+c.NotebookApp.tornado_settings = {
+    'headers': {
+        'Content-Security-Policy': ""
+    }
+}

--- a/jupyter-docker/jupyter_notebook_config.py
+++ b/jupyter-docker/jupyter_notebook_config.py
@@ -28,6 +28,6 @@ c.NotebookApp.contents_manager_class = 'jupyter_delocalize.DelocalizingContentsM
 # See https://jupyter-notebook.readthedocs.io/en/latest/public_server.html?highlight=server#embedding-the-notebook-in-another-website
 c.NotebookApp.tornado_settings = {
     'headers': {
-        'Content-Security-Policy': ""
+        'Content-Security-Policy': ''
     }
 }

--- a/src/main/resources/jupyter/custom.js
+++ b/src/main/resources/jupyter/custom.js
@@ -3,3 +3,11 @@ define([
 ], function(events) {
     require(['custom/google_sign_in'])
 });
+
+// Put the notebook in single tab mode
+// See https://jupyter-notebook.readthedocs.io/en/latest/public_server.html?highlight=server#embedding-the-notebook-in-another-website
+define([
+    'base/js/namespace'
+], function(Jupyter) {
+    Jupyter._target = '_self';
+});

--- a/src/main/resources/jupyter/custom.js
+++ b/src/main/resources/jupyter/custom.js
@@ -3,11 +3,3 @@ define([
 ], function(events) {
     require(['custom/google_sign_in'])
 });
-
-// Put the notebook in single tab mode
-// See https://jupyter-notebook.readthedocs.io/en/latest/public_server.html?highlight=server#embedding-the-notebook-in-another-website
-define([
-    'base/js/namespace'
-], function(Jupyter) {
-    Jupyter._target = '_self';
-});


### PR DESCRIPTION
Request from @zarsky-broad to allow loading the Jupyter notebook in an iframe.

See: https://jupyter-notebook.readthedocs.io/en/latest/public_server.html?highlight=server#embedding-the-notebook-in-another-website

Note: I haven't tested this myself yet. One thing I'm curious about is whether single-tab mode is undesirable when NOT running in an iframe (e.g. the AoU case). If so, we might want to make this configurable.

Also: this might screw up the tests

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
