### PR TITLE
Fix test "should be able to install mlr"

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/NotebookRKernelSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/NotebookRKernelSpec.scala
@@ -95,7 +95,7 @@ class NotebookRKernelSpec extends ClusterFixtureSpec {
           installOutput.get should not include ("Installation failed")
 
           // Make sure it was installed correctly; if not, this will return an error
-          notebookPage.executeCell("library(mlr)") shouldBe Some("Loading required package: ParamHelpers")
+          notebookPage.executeCell("library(mlr)").get should include ("Loading required package: ParamHelpers")
           notebookPage.executeCell(""""mlr" %in% installed.packages()""") shouldBe Some("TRUE")
         }
       }


### PR DESCRIPTION
Comparing with `include` instead `shouldBe` in `NotebookRKernelSpec` test `should be able to install mlr`.

actual cell output: 
`Loading required package: ParamHelpers
Warning message:
“replacing previous import ‘BBmisc::isFALSE’ by ‘backports::isFALSE’ when loading ‘ParamHelpers’”") `
 
expect cell output:
`Loading required package: ParamHelpers`

Stacktrace:
```
[info] - should be able to install mlr *** FAILED *** (2 minutes, 15 seconds)
[info]   Some("Loading required package: ParamHelpers
[info]   Warning message:
[info]   “replacing previous import ‘BBmisc::isFALSE’ by ‘backports::isFALSE’ when loading ‘ParamHelpers’”") was not equal to Some("Loading required package: ParamHelpers") (NotebookRKernelSpec.scala:98)
[info]   org.scalatest.exceptions.TestFailedException
```

https://fc-jenkins.dsp-techops.broadinstitute.org/job/swatomation-pipeline/7244/
https://fc-jenkins.dsp-techops.broadinstitute.org/job/swatomation-pipeline/7245/


Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
