### PR TITLE
Use commontestdata and refactor testLeoRoutes

### DIFF
--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/ProxyRoutesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/ProxyRoutesSpec.scala
@@ -163,10 +163,10 @@ class ProxyRoutesSpec extends FlatSpec with BeforeAndAfterAll with BeforeAndAfte
     //  - `upgradeResponse` is a Future[WebSocketUpgradeResponse] that completes or fails when the connection succeeds or fails.
     //  - `result` is a Future[String] with the stream completion from the incoming sink.
     val (upgradeResponse, result) =
-    outgoing
-      .viaMat(webSocketFlow)(Keep.right)
-      .toMat(incoming)(Keep.both)
-      .run()
+      outgoing
+        .viaMat(webSocketFlow)(Keep.right)
+        .toMat(incoming)(Keep.both)
+        .run()
 
     // The connection future should have returned the HTTP 101 status code
     upgradeResponse.futureValue.response.status shouldBe StatusCodes.SwitchingProtocols

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/ProxyRoutesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/ProxyRoutesSpec.scala
@@ -1,18 +1,17 @@
 package org.broadinstitute.dsde.workbench.leonardo.api
 
+import akka.http.scaladsl.Http
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
+import akka.http.scaladsl.model.HttpMethods._
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.headers.{ContentDispositionTypes, `Content-Disposition`, _}
 import akka.http.scaladsl.model.ws.{TextMessage, WebSocketRequest}
 import akka.http.scaladsl.testkit.{RouteTestTimeout, ScalatestRouteTest}
-import akka.http.scaladsl.Http
-import akka.http.scaladsl.model.HttpMethods._
 import akka.stream.scaladsl.{Keep, Sink, Source}
 import org.broadinstitute.dsde.workbench.leonardo.db.TestComponent
-import org.broadinstitute.dsde.workbench.leonardo.GcsPathUtils
 import org.broadinstitute.dsde.workbench.leonardo.service.TestProxy
 import org.broadinstitute.dsde.workbench.leonardo.service.TestProxy.Data
-import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
+import org.broadinstitute.dsde.workbench.leonardo.{CommonTestData, GcsPathUtils}
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.time.{Seconds, Span}
 import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, FlatSpec}
@@ -23,7 +22,7 @@ import scala.concurrent.duration._
 /**
   * Created by rtitle on 8/10/17.
   */
-class ProxyRoutesSpec extends FlatSpec with BeforeAndAfterAll with BeforeAndAfter with ScalatestRouteTest with ScalaFutures with TestLeoRoutes with TestProxy with TestComponent with GcsPathUtils {
+class ProxyRoutesSpec extends FlatSpec with BeforeAndAfterAll with BeforeAndAfter with ScalatestRouteTest with ScalaFutures with CommonTestData with TestLeoRoutes with TestProxy with TestComponent with GcsPathUtils {
   implicit val patience = PatienceConfig(timeout = scaled(Span(30, Seconds)))
   implicit val routeTimeout = RouteTestTimeout(10 seconds)
 
@@ -31,8 +30,8 @@ class ProxyRoutesSpec extends FlatSpec with BeforeAndAfterAll with BeforeAndAfte
   val googleProject = "dsp-leo-test"
   val unauthorizedTokenCookie = HttpCookiePair("LeoToken", "unauthorized")
   val expiredTokenCookie = HttpCookiePair("LeoToken", "expired")
-  val serviceAccountEmail = WorkbenchEmail("pet-1234567890@test-project.iam.gserviceaccount.com")
-  val userEmail = WorkbenchEmail("user1@example.com")
+  //  val serviceAccountEmail = WorkbenchEmail("pet-1234567890@test-project.iam.gserviceaccount.com")
+  //  val userEmail = WorkbenchEmail("user1@example.com")
 
   val routeTest = this
 
@@ -142,7 +141,7 @@ class ProxyRoutesSpec extends FlatSpec with BeforeAndAfterAll with BeforeAndAfte
   it should "remove utf-8'' from content-disposition header filenames" in {
     // The TestProxy adds the Content-Disposition header to the response, we can't do it from here
     Get(s"/notebooks/$googleProject/$clusterName/content-disposition-test").addHeader(Cookie(tokenCookie)) ~> leoRoutes.route ~> check {
-      responseAs[HttpResponse].headers should contain (`Content-Disposition`(ContentDispositionTypes.attachment, Map("filename" -> "notebook.ipynb")))
+      responseAs[HttpResponse].headers should contain(`Content-Disposition`(ContentDispositionTypes.attachment, Map("filename" -> "notebook.ipynb")))
     }
   }
 
@@ -166,10 +165,10 @@ class ProxyRoutesSpec extends FlatSpec with BeforeAndAfterAll with BeforeAndAfte
     //  - `upgradeResponse` is a Future[WebSocketUpgradeResponse] that completes or fails when the connection succeeds or fails.
     //  - `result` is a Future[String] with the stream completion from the incoming sink.
     val (upgradeResponse, result) =
-      outgoing
-        .viaMat(webSocketFlow)(Keep.right)
-        .toMat(incoming)(Keep.both)
-        .run()
+    outgoing
+      .viaMat(webSocketFlow)(Keep.right)
+      .toMat(incoming)(Keep.both)
+      .run()
 
     // The connection future should have returned the HTTP 101 status code
     upgradeResponse.futureValue.response.status shouldBe StatusCodes.SwitchingProtocols
@@ -184,7 +183,7 @@ class ProxyRoutesSpec extends FlatSpec with BeforeAndAfterAll with BeforeAndAfte
     // login request with Authorization header should succeed and return a Set-Cookie header
     Get(s"/notebooks/$googleProject/$clusterName/setCookie")
       .addHeader(Authorization(OAuth2BearerToken(tokenCookie.value)))
-      .addHeader(Origin("http://example.com"))  ~> leoRoutes.route ~> check {
+      .addHeader(Origin("http://example.com")) ~> leoRoutes.route ~> check {
       validateCookie(setCookie = header[`Set-Cookie`], age = 3600)
 
       validateCors(origin = Some("http://example.com"))
@@ -197,7 +196,7 @@ class ProxyRoutesSpec extends FlatSpec with BeforeAndAfterAll with BeforeAndAfte
   it should "handle preflight OPTIONS requests" in {
     Options(s"/notebooks/$googleProject/$clusterName/setCookie")
       .addHeader(Authorization(OAuth2BearerToken(tokenCookie.value)))
-      .addHeader(Origin("http://example.com"))  ~> leoRoutes.route ~> check {
+      .addHeader(Origin("http://example.com")) ~> leoRoutes.route ~> check {
       handled shouldBe true
       status shouldEqual StatusCodes.NoContent
       header[`Set-Cookie`] shouldBe None
@@ -207,7 +206,7 @@ class ProxyRoutesSpec extends FlatSpec with BeforeAndAfterAll with BeforeAndAfte
 
   it should "401 when not given an Authorization header" in {
     Get(s"/notebooks/$googleProject/$clusterName/setCookie")
-      .addHeader(Origin("http://example.com"))  ~> leoRoutes.route ~> check {
+      .addHeader(Origin("http://example.com")) ~> leoRoutes.route ~> check {
       handled shouldBe true
       status shouldEqual StatusCodes.Unauthorized
     }
@@ -216,7 +215,7 @@ class ProxyRoutesSpec extends FlatSpec with BeforeAndAfterAll with BeforeAndAfte
   it should "404 when using a non-white-listed user" in {
     Get(s"/notebooks/$googleProject/$clusterName/setCookie")
       .addHeader(Authorization(OAuth2BearerToken(unauthorizedTokenCookie.value)))
-      .addHeader(Origin("http://example.com"))  ~> leoRoutes.route ~> check {
+      .addHeader(Origin("http://example.com")) ~> leoRoutes.route ~> check {
       status shouldEqual StatusCodes.NotFound
     }
   }
@@ -224,7 +223,7 @@ class ProxyRoutesSpec extends FlatSpec with BeforeAndAfterAll with BeforeAndAfte
   it should "401 when using an expired token" in {
     Get(s"/notebooks/$googleProject/$clusterName")
       .addHeader(Authorization(OAuth2BearerToken(expiredTokenCookie.value)))
-      .addHeader(Origin("http://example.com"))  ~> leoRoutes.route ~> check {
+      .addHeader(Origin("http://example.com")) ~> leoRoutes.route ~> check {
       status shouldEqual StatusCodes.Unauthorized
     }
   }
@@ -269,7 +268,7 @@ class ProxyRoutesSpec extends FlatSpec with BeforeAndAfterAll with BeforeAndAfte
 
   private def validateCors(origin: Option[String] = None, optionsRequest: Boolean = false): Unit = {
     // Issue 272: CORS headers should not be double set
-    headers.filter(_.is(`Access-Control-Allow-Origin`.lowercaseName)).size shouldBe 1
+    headers.count(_.is(`Access-Control-Allow-Origin`.lowercaseName)) shouldBe 1
     header[`Access-Control-Allow-Origin`] shouldBe origin.map(`Access-Control-Allow-Origin`(_)).orElse(Some(`Access-Control-Allow-Origin`.*))
     header[`Access-Control-Allow-Credentials`] shouldBe Some(`Access-Control-Allow-Credentials`(true))
     header[`Access-Control-Allow-Headers`] shouldBe Some(`Access-Control-Allow-Headers`("Authorization", "Content-Type", "Accept", "Origin"))
@@ -277,7 +276,7 @@ class ProxyRoutesSpec extends FlatSpec with BeforeAndAfterAll with BeforeAndAfte
     header[`Access-Control-Allow-Methods`] shouldBe (
       if (optionsRequest) Some(`Access-Control-Allow-Methods`(OPTIONS, POST, PUT, GET, DELETE, HEAD, PATCH))
       else None
-    )
+      )
   }
 }
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/ProxyRoutesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/ProxyRoutesSpec.scala
@@ -30,8 +30,6 @@ class ProxyRoutesSpec extends FlatSpec with BeforeAndAfterAll with BeforeAndAfte
   val googleProject = "dsp-leo-test"
   val unauthorizedTokenCookie = HttpCookiePair("LeoToken", "unauthorized")
   val expiredTokenCookie = HttpCookiePair("LeoToken", "expired")
-  //  val serviceAccountEmail = WorkbenchEmail("pet-1234567890@test-project.iam.gserviceaccount.com")
-  //  val userEmail = WorkbenchEmail("user1@example.com")
 
   val routeTest = this
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/StatusRoutesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/StatusRoutesSpec.scala
@@ -1,25 +1,26 @@
 package org.broadinstitute.dsde.workbench.leonardo.api
 
+import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.testkit.ScalatestRouteTest
-import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
 import org.broadinstitute.dsde.workbench.google.mock.MockGoogleDataprocDAO
+import org.broadinstitute.dsde.workbench.leonardo.CommonTestData
 import org.broadinstitute.dsde.workbench.leonardo.dao.MockSamDAO
 import org.broadinstitute.dsde.workbench.leonardo.db.{DbSingleton, TestComponent}
 import org.broadinstitute.dsde.workbench.leonardo.service.StatusService
 import org.broadinstitute.dsde.workbench.model.UserInfo
-import org.broadinstitute.dsde.workbench.util.health.{HealthMonitor, StatusCheckResponse}
-import org.broadinstitute.dsde.workbench.util.health.Subsystems._
 import org.broadinstitute.dsde.workbench.util.health.StatusJsonSupport._
-import org.scalatest.{FlatSpec, Matchers}
+import org.broadinstitute.dsde.workbench.util.health.Subsystems._
+import org.broadinstitute.dsde.workbench.util.health.{HealthMonitor, StatusCheckResponse}
 import org.scalatest.concurrent.Eventually.eventually
+import org.scalatest.{FlatSpec, Matchers}
 
 import scala.concurrent.duration._
 
 /**
   * Created by rtitle on 10/26/17.
   */
-class StatusRoutesSpec extends FlatSpec with Matchers with ScalatestRouteTest with TestLeoRoutes with TestComponent {
+class StatusRoutesSpec extends FlatSpec with Matchers with ScalatestRouteTest with CommonTestData with TestLeoRoutes with TestComponent {
   override implicit val patienceConfig = PatienceConfig(timeout = 1.second)
 
   "GET /status" should "give 200 for ok" in {

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/TestLeoRoutes.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/TestLeoRoutes.scala
@@ -44,14 +44,6 @@ trait TestLeoRoutes { this: ScalatestRouteTest with Matchers with CommonTestData
     override val userInfo: UserInfo = timedUserInfo
   }
 
-//  def clusterServiceAccount(googleProject: GoogleProject): Option[WorkbenchEmail] = {
-//    serviceAccountProvider.getClusterServiceAccount(defaultUserInfo, googleProject).futureValue
-//  }
-//
-//  def notebookServiceAccount(googleProject: GoogleProject): Option[WorkbenchEmail] = {
-//    serviceAccountProvider.getNotebookServiceAccount(defaultUserInfo, googleProject).futureValue
-//  }
-
   private[api] def validateCookie(setCookie: Option[`Set-Cookie`],
                              expectedCookie: HttpCookiePair = tokenCookie,
                              age: Long = tokenAge): Unit = {

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/TestLeoRoutes.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/TestLeoRoutes.scala
@@ -2,72 +2,40 @@ package org.broadinstitute.dsde.workbench.leonardo.api
 
 import java.io.ByteArrayInputStream
 
-import akka.http.scaladsl.model.headers.{HttpCookiePair, OAuth2BearerToken, `Set-Cookie`}
+import akka.http.scaladsl.model.headers.{HttpCookiePair, `Set-Cookie`}
 import akka.http.scaladsl.testkit.ScalatestRouteTest
-import com.typesafe.config.ConfigFactory
-import net.ceedubs.ficus.Ficus._
 import org.broadinstitute.dsde.workbench.google.GoogleStorageDAO
-import org.broadinstitute.dsde.workbench.google.mock.{MockGoogleDataprocDAO, MockGoogleIamDAO, MockGoogleStorageDAO}
-import org.broadinstitute.dsde.workbench.leonardo.auth.WhitelistAuthProvider
-import org.broadinstitute.dsde.workbench.leonardo.auth.sam.MockPetClusterServiceAccountProvider
-import org.broadinstitute.dsde.workbench.leonardo.config.{ClusterDefaultsConfig, ClusterFilesConfig, ClusterResourcesConfig, DataprocConfig, ProxyConfig, SwaggerConfig}
-import org.broadinstitute.dsde.workbench.leonardo.dao.MockSamDAO
-import org.broadinstitute.dsde.workbench.leonardo.dao.google.MockGoogleComputeDAO
+import org.broadinstitute.dsde.workbench.google.mock.{MockGoogleIamDAO, MockGoogleStorageDAO}
+import org.broadinstitute.dsde.workbench.leonardo.CommonTestData
 import org.broadinstitute.dsde.workbench.leonardo.db.DbSingleton
 import org.broadinstitute.dsde.workbench.leonardo.monitor.NoopActor
 import org.broadinstitute.dsde.workbench.leonardo.service.{LeonardoService, MockProxyService, StatusService}
 import org.broadinstitute.dsde.workbench.leonardo.util.BucketHelper
-import org.broadinstitute.dsde.workbench.model.google._
-import org.broadinstitute.dsde.workbench.model.{UserInfo, WorkbenchEmail, WorkbenchUserId}
+import org.broadinstitute.dsde.workbench.model.UserInfo
 import org.scalatest.Matchers
-import org.scalatest.concurrent.ScalaFutures
 
 import scala.concurrent.duration._
 
 /**
   * Created by rtitle on 8/15/17.
   */
-trait TestLeoRoutes { this: ScalatestRouteTest with ScalaFutures with Matchers =>
-  val config = ConfigFactory.parseResources("reference.conf").withFallback(ConfigFactory.load())
-  val whitelist = config.as[Set[String]]("auth.whitelistProviderConfig.whitelist").map(_.toLowerCase)
-  val dataprocConfig = config.as[DataprocConfig]("dataproc")
-  val proxyConfig = config.as[ProxyConfig]("proxy")
-  val clusterFilesConfig = config.as[ClusterFilesConfig]("clusterFiles")
-  val clusterResourcesConfig = config.as[ClusterResourcesConfig]("clusterResources")
-  val swaggerConfig = config.as[SwaggerConfig]("swagger")
+trait TestLeoRoutes { this: ScalatestRouteTest with Matchers with CommonTestData =>
+
   val mockGoogleIamDAO = new MockGoogleIamDAO
   val mockGoogleStorageDAO = new MockGoogleStorageDAO
-  val userScriptPath = GcsPath(GcsBucketName("bucket1"), GcsObjectName("script.tar.gz"))
-  val extensionPath = GcsPath(GcsBucketName("bucket"), GcsObjectName("my_extension.tar.gz"))
+  mockGoogleStorageDAO.buckets += jupyterExtensionUri.bucketName -> Set((jupyterExtensionUri.objectName, new ByteArrayInputStream("foo".getBytes())))
   val mockPetGoogleStorageDAO: String => GoogleStorageDAO = _ => {
     val petMock = new MockGoogleStorageDAO
-    petMock.buckets += userScriptPath.bucketName -> Set((userScriptPath.objectName, new ByteArrayInputStream("foo".getBytes())))
-    petMock.buckets += extensionPath.bucketName -> Set((extensionPath.objectName, new ByteArrayInputStream("foo".getBytes())))
+    petMock.buckets += jupyterUserScriptUri.bucketName -> Set((jupyterUserScriptUri.objectName, new ByteArrayInputStream("foo".getBytes())))
+    petMock.buckets += jupyterExtensionUri.bucketName -> Set((jupyterExtensionUri.objectName, new ByteArrayInputStream("foo".getBytes())))
     petMock
   }
-  val mockSamDAO = new MockSamDAO
-  val clusterDefaultsConfig = config.as[ClusterDefaultsConfig]("clusterDefaults")
-  val mockGoogleDataprocDAO = new MockGoogleDataprocDAO
-  val mockGoogleComputeDAO = new MockGoogleComputeDAO
-  mockGoogleStorageDAO.buckets += extensionPath.bucketName -> Set((extensionPath.objectName, new ByteArrayInputStream("foo".getBytes())))
-
-  // TODO look into parameterized tests so both provider impls can both be tested
-  //val serviceAccountProvider = new MockPetServiceAccountProvider(config.getConfig("serviceAccounts.config"))
-  val serviceAccountProvider = new MockPetClusterServiceAccountProvider(config.getConfig("serviceAccounts.config"))
-
-  val whitelistAuthProvider = new WhitelistAuthProvider(config.getConfig("auth.whitelistProviderConfig"), serviceAccountProvider)
-
   // Route tests don't currently do cluster monitoring, so use NoopActor
   val clusterMonitorSupervisor = system.actorOf(NoopActor.props)
   val bucketHelper = new BucketHelper(dataprocConfig, mockGoogleDataprocDAO, mockGoogleComputeDAO, mockGoogleStorageDAO, serviceAccountProvider)
   val leonardoService = new LeonardoService(dataprocConfig, clusterFilesConfig, clusterResourcesConfig, clusterDefaultsConfig, proxyConfig, swaggerConfig, mockGoogleDataprocDAO, mockGoogleComputeDAO, mockGoogleIamDAO, mockGoogleStorageDAO, mockPetGoogleStorageDAO, DbSingleton.ref, clusterMonitorSupervisor, whitelistAuthProvider, serviceAccountProvider, whitelist, bucketHelper)
   val proxyService = new MockProxyService(proxyConfig, mockGoogleDataprocDAO, DbSingleton.ref, whitelistAuthProvider)
   val statusService = new StatusService(mockGoogleDataprocDAO, mockSamDAO, DbSingleton.ref, dataprocConfig, pollInterval = 1.second)
-  val defaultUserInfo = UserInfo(OAuth2BearerToken("accessToken"), WorkbenchUserId("user1"), WorkbenchEmail("user1@example.com"), 0)
-  val tokenAge = 500000
-  val tokenName = "LeoToken"
-  val tokenValue = "accessToken"
-  val tokenCookie = HttpCookiePair(tokenName, tokenValue)
   val timedUserInfo = defaultUserInfo.copy(tokenExpiresIn = tokenAge)
   val leoRoutes = new LeoRoutes(leonardoService, proxyService, statusService, swaggerConfig) with MockUserInfoDirectives {
     override val userInfo: UserInfo = defaultUserInfo
@@ -76,13 +44,13 @@ trait TestLeoRoutes { this: ScalatestRouteTest with ScalaFutures with Matchers =
     override val userInfo: UserInfo = timedUserInfo
   }
 
-  def clusterServiceAccount(googleProject: GoogleProject): Option[WorkbenchEmail] = {
-    serviceAccountProvider.getClusterServiceAccount(defaultUserInfo, googleProject).futureValue
-  }
-
-  def notebookServiceAccount(googleProject: GoogleProject): Option[WorkbenchEmail] = {
-    serviceAccountProvider.getNotebookServiceAccount(defaultUserInfo, googleProject).futureValue
-  }
+//  def clusterServiceAccount(googleProject: GoogleProject): Option[WorkbenchEmail] = {
+//    serviceAccountProvider.getClusterServiceAccount(defaultUserInfo, googleProject).futureValue
+//  }
+//
+//  def notebookServiceAccount(googleProject: GoogleProject): Option[WorkbenchEmail] = {
+//    serviceAccountProvider.getNotebookServiceAccount(defaultUserInfo, googleProject).futureValue
+//  }
 
   private[api] def validateCookie(setCookie: Option[`Set-Cookie`],
                              expectedCookie: HttpCookiePair = tokenCookie,

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/AuthProviderSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/AuthProviderSpec.scala
@@ -3,69 +3,35 @@ package org.broadinstitute.dsde.workbench.leonardo.service
 import java.time.Instant
 import java.util.UUID
 
-import akka.http.scaladsl.model.{HttpRequest, StatusCodes, Uri}
 import akka.http.scaladsl.model.HttpMethods._
-import akka.http.scaladsl.model.headers.{HttpCookiePair, OAuth2BearerToken}
+import akka.http.scaladsl.model.{HttpRequest, StatusCodes, Uri}
 import akka.http.scaladsl.testkit.ScalatestRouteTest
-import com.typesafe.config.ConfigFactory
-import org.broadinstitute.dsde.workbench.google.mock.{MockGoogleDataprocDAO, MockGoogleIamDAO, MockGoogleStorageDAO}
-import org.broadinstitute.dsde.workbench.leonardo.GcsPathUtils
+import org.broadinstitute.dsde.workbench.google.GoogleStorageDAO
+import org.broadinstitute.dsde.workbench.google.mock.{MockGoogleIamDAO, MockGoogleStorageDAO}
 import org.broadinstitute.dsde.workbench.leonardo.auth.MockLeoAuthProvider
-import org.broadinstitute.dsde.workbench.leonardo.config.{ClusterDefaultsConfig, ClusterFilesConfig, ClusterResourcesConfig, DataprocConfig, ProxyConfig, SwaggerConfig}
-import org.broadinstitute.dsde.workbench.leonardo.dao.MockSamDAO
 import org.broadinstitute.dsde.workbench.leonardo.db.{DbSingleton, TestComponent}
 import org.broadinstitute.dsde.workbench.leonardo.model._
-import org.broadinstitute.dsde.workbench.leonardo.model.google._
+import org.broadinstitute.dsde.workbench.leonardo.model.google.{ClusterName, _}
 import org.broadinstitute.dsde.workbench.leonardo.monitor.NoopActor
-import org.broadinstitute.dsde.workbench.model.{UserInfo, WorkbenchEmail, WorkbenchUserId}
-import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GoogleProject}
-import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar
-import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{BeforeAndAfterAll, FreeSpec, Matchers, OptionValues}
-import net.ceedubs.ficus.Ficus._
-import org.broadinstitute.dsde.workbench.google.GoogleStorageDAO
-import org.broadinstitute.dsde.workbench.leonardo.auth.sam.MockPetClusterServiceAccountProvider
-import org.broadinstitute.dsde.workbench.leonardo.dao.google.MockGoogleComputeDAO
-import org.broadinstitute.dsde.workbench.leonardo.model.google.ClusterName
 import org.broadinstitute.dsde.workbench.leonardo.util.BucketHelper
+import org.broadinstitute.dsde.workbench.leonardo.{CommonTestData, GcsPathUtils}
+import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GoogleProject}
 import org.mockito.Mockito
+import org.mockito.Mockito._
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.mockito.MockitoSugar
+import org.scalatest.{BeforeAndAfterAll, FreeSpec, Matchers, OptionValues}
 
-import scala.concurrent.Future
+class AuthProviderSpec extends FreeSpec with ScalatestRouteTest with Matchers with MockitoSugar with TestComponent with ScalaFutures with OptionValues with GcsPathUtils with TestProxy with BeforeAndAfterAll with CommonTestData{
 
-class AuthProviderSpec extends FreeSpec with ScalatestRouteTest with Matchers with MockitoSugar with TestComponent with ScalaFutures with OptionValues with GcsPathUtils with TestProxy with BeforeAndAfterAll {
-  val name1 = ClusterName("name1")
-  val project = GoogleProject("dsp-leo-test")
-  val userInfo = UserInfo(OAuth2BearerToken("accessToken"), WorkbenchUserId("user1"), WorkbenchEmail("user1@example.com"), 0)
-  val userEmail = WorkbenchEmail("user1@example.com")
-  val serviceAccountEmail = WorkbenchEmail("pet-1234567890@test-project.iam.gserviceaccount.com")
   val clusterName = name1.value
   val googleProject = project.value
-
-  val config = ConfigFactory.parseResources("reference.conf").withFallback(ConfigFactory.load())
-  val whitelist = config.as[Set[String]]("auth.whitelistProviderConfig.whitelist").map(_.toLowerCase)
-  val dataprocConfig = config.as[DataprocConfig]("dataproc")
-  val proxyConfig = config.as[ProxyConfig]("proxy")
-  val clusterFilesConfig = config.as[ClusterFilesConfig]("clusterFiles")
-  val clusterResourcesConfig = config.as[ClusterResourcesConfig]("clusterResources")
-  val swaggerConfig = config.as[SwaggerConfig]("swagger")
-  val mockGoogleIamDAO = new MockGoogleIamDAO
-  val mockSamDAO = new MockSamDAO
-  val clusterDefaultsConfig = config.as[ClusterDefaultsConfig]("clusterDefaults")
-  val clusterUrlBase = dataprocConfig.clusterUrlBase
-
-  val routeTest = this
-
-  private val testClusterRequest = ClusterRequest(Map("bam" -> "yes", "vcf" -> "no", "foo" -> "bar"), None)
-  private val serviceAccountProvider = new MockPetClusterServiceAccountProvider(config.getConfig("serviceAccounts.config"))
-  private val alwaysYesProvider = new MockLeoAuthProvider(config.getConfig("auth.alwaysYesProviderConfig"), serviceAccountProvider)
-  private val alwaysNoProvider = new MockLeoAuthProvider(config.getConfig("auth.alwaysNoProviderConfig"), serviceAccountProvider)
 
   val c1 = Cluster(
     clusterName = name1,
     googleId = UUID.randomUUID(),
     googleProject = project,
-    serviceAccountInfo = ServiceAccountInfo(None, Some(serviceAccountEmail)),
+    serviceAccountInfo = serviceAccountInfo,
     machineConfig = MachineConfig(Some(0),Some(""), Some(500)),
     clusterUrl = Cluster.getClusterUrl(project, name1, clusterUrlBase),
     operationName = OperationName("op1"),
@@ -77,20 +43,21 @@ class AuthProviderSpec extends FreeSpec with ScalatestRouteTest with Matchers wi
     labels = Map("bam" -> "yes", "vcf" -> "no"),
     jupyterExtensionUri = None,
     jupyterUserScriptUri = None,
-    stagingBucket = Some(GcsBucketName("testStagingBucket1")), 
+    stagingBucket = Some(GcsBucketName("testStagingBucket1")),
     List.empty,
     Set.empty,
     None,
     Instant.now()
   )
 
-  val gdDAO = new MockGoogleDataprocDAO
-  val computeDAO = new MockGoogleComputeDAO
-  val iamDAO = new MockGoogleIamDAO
-  val storageDAO = new MockGoogleStorageDAO
-  val samDAO = new MockSamDAO
-  val tokenCookie = HttpCookiePair("LeoToken", "me")
-  val bucketHelper = new BucketHelper(dataprocConfig, gdDAO, computeDAO, storageDAO, serviceAccountProvider)
+  val routeTest = this
+
+  private val alwaysYesProvider = new MockLeoAuthProvider(config.getConfig("auth.alwaysYesProviderConfig"), serviceAccountProvider)
+  private val alwaysNoProvider = new MockLeoAuthProvider(config.getConfig("auth.alwaysNoProviderConfig"), serviceAccountProvider)
+
+  val mockGoogleIamDAO = new MockGoogleIamDAO
+  val mockGoogleStorageDAO = new MockGoogleStorageDAO
+  val bucketHelper = new BucketHelper(dataprocConfig, mockGoogleDataprocDAO, mockGoogleComputeDAO, mockGoogleStorageDAO, serviceAccountProvider)
 
   override def beforeAll(): Unit = {
     super.beforeAll()
@@ -106,11 +73,11 @@ class AuthProviderSpec extends FreeSpec with ScalatestRouteTest with Matchers wi
     val mockPetGoogleStorageDAO: String => GoogleStorageDAO = _ => {
       new MockGoogleStorageDAO
     }
-    new LeonardoService(dataprocConfig, clusterFilesConfig, clusterResourcesConfig, clusterDefaultsConfig, proxyConfig, swaggerConfig, gdDAO, computeDAO, iamDAO, storageDAO ,mockPetGoogleStorageDAO, DbSingleton.ref, system.actorOf(NoopActor.props), authProvider, serviceAccountProvider, whitelist, bucketHelper)
+    new LeonardoService(dataprocConfig, clusterFilesConfig, clusterResourcesConfig, clusterDefaultsConfig, proxyConfig, swaggerConfig, mockGoogleDataprocDAO, mockGoogleComputeDAO , mockGoogleIamDAO, mockGoogleStorageDAO ,mockPetGoogleStorageDAO, DbSingleton.ref, system.actorOf(NoopActor.props), authProvider, serviceAccountProvider, whitelist, bucketHelper)
   }
 
   def proxyWithAuthProvider(authProvider: LeoAuthProvider): ProxyService = {
-    new MockProxyService(proxyConfig, gdDAO, DbSingleton.ref, authProvider)
+    new MockProxyService(proxyConfig, mockGoogleDataprocDAO, DbSingleton.ref, authProvider)
   }
 
   "Leo with an AuthProvider" - {
@@ -240,7 +207,7 @@ class AuthProviderSpec extends FreeSpec with ScalatestRouteTest with Matchers wi
       clusterLookup shouldBe 'empty
 
       // check that the cluster does not exist
-      gdDAO.clusters should not contain key (name1)
+      mockGoogleDataprocDAO.clusters should not contain key (name1)
 
       // creation and deletion notifications should have been fired
       verify(spyProvider).notifyClusterCreated(userEmail, project, name1)


### PR DESCRIPTION
Refactored CommonTestData and TestLeoRoutes, moved the common code to CommonTestData.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
