### PR TITLE
User Interface: cluster cards manage state refresh on their own.

### DIFF
--- a/ui/src/components/ClusterCard.js
+++ b/ui/src/components/ClusterCard.js
@@ -11,6 +11,24 @@ import DeleteDialog from './DeleteDialog'
 import StatusIcon from './StatusIcon'
 
 
+// The following statuses indicate that the status
+// of the cluster is likely to change in the near
+// future.
+const statusInFlux = [
+  "Creating",
+  "Starting",
+  "Stopping",
+  "Updating",
+  "Deleting",
+]
+
+const unknownStatus = "Unknown";
+
+
+const statusCheckInterval = 30000;  // 30 seconds.
+const maxStatusChecks = 30; // 30 checks, or, 15 minutes.
+
+
 const styles = {
   card: {
     minWidth: 300,
@@ -36,7 +54,7 @@ const styles = {
 
 /**
  * @props errorHandler function callback displays a string as a dismissable error.
- * @props googleToken string access token provided by oauth login.
+ * @props googleAuthToken string access token provided by oauth login.
  * @props oauthClientId string oauth client used for app auth.
  * @props clusterModel object contains a cluster model returned by Leonardo's API.
  */
@@ -46,22 +64,73 @@ class ClusterCard extends React.Component {
     super(props);
     this.state = {
       clusterStatus: this.props.clusterModel.status,
+      statusFetches: 0
     };
-  }
-
-  setClusterStatusRunning = () => {
-    this.setState({ clusterStatus: "Running" });
-  }
-
-  setClusterStatusError = () => {
-    this.setState({ clusterStatus: "Error" });
   }
 
   setClusterStatusDeleting = () => {
     this.setState({ clusterStatus: "Deleting" });
   }
 
+  /**
+   * Refresh cluster status if there have been fewer than `maxStatusChecks` prior refreshes.
+   */
+  tryRefreshingClusterStatus = () => {
+    // Exit early if too many checks have been done. Set status to unknown.
+    if (this.state.statusFetches > maxStatusChecks) {
+      this.setState({clusterStatus: unknownStatus});
+      return
+    }
+    // Path to fetch cluster json.
+    var getPath = '/api/cluster/' + this.props.clusterModel.googleProject + '/' + this.props.clusterModel.clusterName;
+    // Begin the GET request and register callbacks.
+    return fetch(
+      getPath,
+      {
+        method: "GET",
+        headers: {
+          "Authorization": "Bearer " + this.props.googleAuthToken
+        },
+        credentials: "include"
+      }
+    )
+    // Validate response content type is application/json.
+    .then((response) => {
+      if (response.headers.get("content-type").indexOf("application/json") <= -1) {
+        console.log("List cluster response not of type 'application/json'")
+        console.log(response);
+        this.setState({clusterStatus: unknownStatus, statusFetches: 0});
+      }
+      return response
+    })
+    // Validate response status and throw if not in 200s.
+    .then((response) => {
+      if (response.status < 200 || response.status >= 300) {
+        console.log(response);
+        this.setState({clusterStatus: unknownStatus, statusFetches: 0});
+      }
+      return response;
+    })
+    // Get response json object.
+    .then((response) => response.json())
+    // Update the status only if the status is new, otherwise increment the counter.
+    .then((responseJson) => {
+      if (responseJson.status !== this.state.clusterStatus) {
+        this.setState({clusterStatus: responseJson.status, statusFetches: 0});
+      } else {
+        this.setState({statusFetches: this.state.statusFetches + 1});
+      }
+    })
+    // Handle any errors.
+    .catch((error) => this.props.errorHandler(error.toString()));
+  }
+
   render() {
+    if (statusInFlux.indexOf(this.state.clusterStatus) >= 0) {
+      setTimeout(this.tryRefreshingClusterStatus, statusCheckInterval);
+    }
+
+    // Grab variables used for rendering.
     var classes = this.props.classes;
     var model = this.props.clusterModel;
     var machineCfg = model.machineConfig;

--- a/ui/src/components/ConfigLoader.js
+++ b/ui/src/components/ConfigLoader.js
@@ -16,7 +16,7 @@ class ConfigLoader extends React.Component {
   /**
    * Load configuration from static assets.
    */
-  loadConfig() {
+  loadConfig = () => {
     fetch("/config.json")
       .then((response) => {
         if (response.status < 200 || response.status >= 300) {
@@ -36,10 +36,13 @@ class ConfigLoader extends React.Component {
       });
   }
 
+  componentWillMount() {
+    this.loadConfig()
+  }
+
   render() {
     // Load the config before showing sign-in modal.
     if (this.state.configLoading) {
-      this.loadConfig()
       return <div>Loading configuration</div>
     }
     return (<GoogleSignInWrapper errorHandler={this.props.errorHandler} />)

--- a/ui/src/components/CreateClusterForm.js
+++ b/ui/src/components/CreateClusterForm.js
@@ -18,7 +18,7 @@ const DEFAULT_WORKER_MACHINE_TYPE = "n1-standard-2";
 const DEFAULT_WORKER_DISK_SIZE = 200;
 
 // Regex for GCP Project names.
-const projectRegex = /^[a-z][a-z0-9_-]{0,50}[a-z0-9]$/;
+const projectRegex = /^[a-z][a-z0-9_:.-]{0,50}[a-z0-9]$/;
 
 // Regex for cluster names.
 const clusterRegex = /^[a-z][a-z0-9-]{0,25}[a-z0-9]$/;

--- a/ui/src/components/ListStateContainer.js
+++ b/ui/src/components/ListStateContainer.js
@@ -49,7 +49,7 @@ class ListStateContainer extends React.Component {
     var listUri = "/api/clusters?includeDeleted=false";
     if (this.state.perUserFilter) {
       var creatorFilter = encodeURIComponent("creator=" + this.props.googleProfile.email);
-      listUri = listUri + "&" + "_labels=" + creatorFilter;
+      listUri = listUri + "&_labels=" + creatorFilter;
     }
     // Begin the GET request and register callbacks.
     return fetch(


### PR DESCRIPTION
Prior to this change, cluster cards would need to be refreshed manually with the refresh button in the UI. This change ensures that clusters whose state is in flux (deleting, creating, starting, stopping, etc...) will hit the Leonardo API periodically to check for a new state.

This change also adds the behavior that running clusters will re-check their state every 5 minutes to make sure that their state hasn't changed (for example, due to auto-suspend).


In all cases:
- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
