### PR TITLE
UI: fix bug; null jupyterUserScriptUri fails to create cluster.

### DIFF
--- a/ui/src/components/CreateClusterForm.js
+++ b/ui/src/components/CreateClusterForm.js
@@ -108,7 +108,6 @@ class UnstyledCreateClusterForm extends React.Component {
     var createRequest = {
       labels: {},
       stopAfterCreation: false,
-      jupyterUserScriptUri: this.state.jupyterUserScriptUri,
       machineConfig: {
         // Worker config.
         numberOfWorkers: this.state.numberOfWorkers,
@@ -118,9 +117,14 @@ class UnstyledCreateClusterForm extends React.Component {
         // Master config
         masterDiskSize: this.state.diskSize,
         masterMachineType: this.state.machineType
-
       }
     };
+    // User script is only attached if the value is not nullish.
+    var userScriptUri = this.state.jupyterUserScriptUri.trim()
+    if (userScriptUri) {
+      createRequest["jupyterUserScriptUri"] = userScriptUri;
+    }
+
     // Use fetch to send a put request, and register success/fail callbacks.
     fetch(
       createApiUrl(this.state.googleProject, this.state.clusterName),


### PR DESCRIPTION
TLDR: see title. Because the config system passes empty values as an empty string, cluster creation fails using the new default startup script value derived from the config if that value is set to blank (or if a user overrides the value with a blank.

In all cases:
- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
