### PR TITLE
SamAuthProvider no longer checks tokenExpiresIn of userInfo when comparing cache keys

### DIFF
--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/auth/sam/SamAuthProviderSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/auth/sam/SamAuthProviderSpec.scala
@@ -152,6 +152,24 @@ class SamAuthProviderSpec extends TestKit(ActorSystem("leonardotest")) with Free
     samAuthProvider.hasNotebookClusterPermission(userInfo, SyncDataToCluster, project, name1).futureValue shouldBe true
   }
 
+  "should consider userInfo objects with different tokenExpiresIn values as the same" in isolatedDbTest {
+    val samAuthProvider = getSamAuthProvider
+
+    // cache should be empty
+    samAuthProvider.notebookAuthCache.size shouldBe 0
+
+    // populate backing samClient
+    samAuthProvider.samClient.notebookClusters += (project, name1, userInfo.userEmail) -> Set("sync")
+
+    // call provider method
+    samAuthProvider.hasNotebookClusterPermission(userInfo, SyncDataToCluster, project, name1).futureValue shouldBe true
+
+    samAuthProvider.hasNotebookClusterPermission(userInfo.copy(tokenExpiresIn = userInfo.tokenExpiresIn + 10), SyncDataToCluster, project, name1).futureValue shouldBe true
+
+    samAuthProvider.notebookAuthCache.size shouldBe 1
+
+  }
+
   "filterClusters should return clusters that were created by the user or whose project is owned by the user" in isolatedDbTest {
     val samAuthProvider = getSamAuthProvider
 


### PR DESCRIPTION
\<your comments for this PR go here\>

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
