### PR TITLE
Reuse pet token for all GCS validations instead of re-fetching token each time

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoService.scala
@@ -563,7 +563,7 @@ class LeonardoService(protected val dataprocConfig: DataprocConfig,
         // See https://github.com/DataBiosphere/leonardo/issues/460
         // Note GoogleStorageDAO already retries 500 and other errors internally, so we just need to catch 401s here.
         // We might think about moving the retry-on-401 logic inside GoogleStorageDAO.
-        val gcsFuture: Future[Boolean] = retryUntilSuccessOrTimeout(whenGoogle401, s"GCS object validation failed for user [${userEmail.value}] and object [${gcsUri}]")(interval = 1 second, timeout = 3 seconds) { () =>
+        val gcsFuture: Future[Boolean] = retryUntilSuccessOrTimeout(whenGoogle401, s"GCS object validation failed for user [${userEmail.value}] and token [$userToken] and object [${gcsUri}]")(interval = 1 second, timeout = 3 seconds) { () =>
           petGoogleStorageDAO(userToken).objectExists(gcsPath.bucketName, gcsPath.objectName)
         }
         gcsFuture.map {

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoService.scala
@@ -578,7 +578,7 @@ class LeonardoService(protected val dataprocConfig: DataprocConfig,
   }
 
   private def whenGoogle401(t: Throwable): Boolean = t match {
-    case g: GoogleJsonResponseException if g.getStatusCode == StatusCodes.Unauthorized => true
+    case g: GoogleJsonResponseException if g.getStatusCode == StatusCodes.Unauthorized.intValue => true
     case _ => false
   }
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoService.scala
@@ -579,6 +579,9 @@ class LeonardoService(protected val dataprocConfig: DataprocConfig,
           case e: HttpResponseException if e.getStatusCode == StatusCodes.Forbidden.intValue =>
             logger.error(s"User ${userEmail.value} does not have access to ${gcsPath.bucketName} / ${gcsPath.objectName}")
             throw BucketObjectAccessException(userEmail, gcsPath)
+          case e if whenGoogle401(e) =>
+            logger.warn(s"Could not validate object [${gcsUri}] as user [${userEmail.value}]", e)
+            ()
         }
     }
   }


### PR DESCRIPTION
I'm still seeing a lot of test failures due to 401s from GCS. See: https://github.com/DataBiosphere/leonardo/issues/460

I noticed that we are potentially validating a lot of GCS objects (user scripts, extensions), and fetching a new token from Sam for each validation. I changed it to just fetch 1 token at the beginning and reuse it to validate each object. Maybe that will help flakiness.

Note this PR doesn't yet add retries, but that might be the next step if this doesn't fix it.

\<your comments for this PR go here\>

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
