### PR TITLE
Set service account scopes on cluster resume

### DIFF
--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -45,6 +45,11 @@ object Dependencies {
       excludeApacheHttpClient,
       excludeGoogleJsr305,
       excludeJacksonCore),
+    "com.google.apis" % "google-api-services-sourcerepo" % s"v1-rev21-1.23.0" excludeAll (
+      excludeGuavaJdk5,
+      excludeApacheHttpClient,
+      excludeGoogleJsr305,
+      excludeJacksonCore),
     "com.google.api-client" % "google-api-client"   % "1.23.0" excludeAll (
       excludeGuavaJdk5,
       excludeApacheHttpClient,

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/ClusterMonitoringSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/ClusterMonitoringSpec.scala
@@ -32,7 +32,7 @@ class ClusterMonitoringSpec extends FreeSpec with LeonardoTestUtils with Paralle
           cluster.serviceAccountInfo.notebookServiceAccount shouldBe None
 
           withWebDriver { implicit driver =>
-            withNewNotebook(cluster) { notebookPage =>
+            withNewNotebook(cluster, PySpark2) { notebookPage =>
               // should not have notebook credentials because Leo is not configured to use a notebook service account
               verifyNoNotebookCredentials(notebookPage, PySpark2, petEmail)
             }

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/ClusterMonitoringSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/ClusterMonitoringSpec.scala
@@ -26,7 +26,7 @@ class ClusterMonitoringSpec extends FreeSpec with LeonardoTestUtils with Paralle
         val petEmail = getAndVerifyPet(project)
 
         // Create a cluster
-        withNewCluster(project, kernel = PySpark2, apiVersion = V2) { cluster =>
+        withNewCluster(project, apiVersion = V2) { cluster =>
           // cluster should have been created with the pet service account
           cluster.serviceAccountInfo.clusterServiceAccount shouldBe Some(petEmail)
           cluster.serviceAccountInfo.notebookServiceAccount shouldBe None
@@ -34,7 +34,7 @@ class ClusterMonitoringSpec extends FreeSpec with LeonardoTestUtils with Paralle
           withWebDriver { implicit driver =>
             withNewNotebook(cluster, PySpark2) { notebookPage =>
               // should not have notebook credentials because Leo is not configured to use a notebook service account
-              verifyNoNotebookCredentials(notebookPage, PySpark2, petEmail)
+              verifyClusterServiceAccount(notebookPage, PySpark2, petEmail)
             }
           }
         }
@@ -63,7 +63,7 @@ class ClusterMonitoringSpec extends FreeSpec with LeonardoTestUtils with Paralle
           withWebDriver { implicit driver =>
             withNewNotebook(cluster) { notebookPage =>
               // should have notebook credentials
-              verifyNotebookCredentials(notebookPage, petEmail)
+              verifyNotebookServiceAccount(notebookPage, PySpark2, petEmail)
             }
           }
         }
@@ -121,7 +121,7 @@ class ClusterMonitoringSpec extends FreeSpec with LeonardoTestUtils with Paralle
             withNewNotebook(cluster, kernel = Python3) { notebookPage =>
               notebookPage.executeCell(s"""print("$printStr")""") shouldBe Some(printStr)
               // Also verify the credentials on the cluster
-              verifyNoNotebookCredentials(notebookPage, Python3, petEmail)
+              verifyClusterServiceAccount(notebookPage, Python3, petEmail)
               notebookPage.saveAndCheckpoint()
             }
 
@@ -142,7 +142,7 @@ class ClusterMonitoringSpec extends FreeSpec with LeonardoTestUtils with Paralle
               notebookPage.executeCell("sum(range(1,10))") shouldBe Some("45")
               // The credentials should be correct after pause/resume
               // See https://github.com/DataBiosphere/leonardo/issues/495.
-              verifyNoNotebookCredentials(notebookPage, Python3, petEmail)
+              verifyClusterServiceAccount(notebookPage, Python3, petEmail)
             }
           }
         }

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
@@ -337,7 +337,7 @@ trait LeonardoTestUtils extends WebBrowserSpec with Matchers with Eventually wit
   def verifyGoogleAuth(notebookPage: NotebookPage, expectedEmail: Option[WorkbenchEmail], expectedScopes: Option[Seq[String]]): Unit = {
     notebookPage.executeCell("import google.auth") shouldBe None
     notebookPage.executeCell("credentials, project_id = google.auth.default()") shouldBe None
-    notebookPage.executeCell("print(credentials.service_account_email)") shouldBe expectedEmail.map(_.value).orElse(Some("None"))
+    notebookPage.executeCell("print(credentials.service_account_email)") shouldBe expectedEmail.map(_.value).orElse(Some("default"))
     val actualScopes = notebookPage.executeCell("print(credentials.scopes)")
     actualScopes shouldBe 'defined
     expectedScopes match {

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
@@ -8,7 +8,6 @@ import java.util.Base64
 import cats.data.OptionT
 import cats.implicits._
 import com.google.api.services.bigquery.BigqueryScopes
-import com.google.api.services.compute.ComputeScopes
 import com.google.api.services.oauth2.Oauth2Scopes
 import com.google.api.services.sourcerepo.v1.CloudSourceRepositoriesScopes
 import com.typesafe.scalalogging.LazyLogging
@@ -77,8 +76,7 @@ trait LeonardoTestUtils extends WebBrowserSpec with Matchers with Eventually wit
     Oauth2Scopes.USERINFO_EMAIL,
     Oauth2Scopes.USERINFO_PROFILE,
     BigqueryScopes.BIGQUERY,
-    CloudSourceRepositoriesScopes.SOURCE_READ_ONLY,
-    ComputeScopes.CLOUD_PLATFORM)
+    CloudSourceRepositoriesScopes.SOURCE_READ_ONLY)
 
   // TODO: show diffs as screenshot or other test output?
   def compareFilesExcludingIPs(left: File, right: File): Unit = {

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
@@ -8,6 +8,7 @@ import java.util.Base64
 import cats.data.OptionT
 import cats.implicits._
 import com.google.api.services.bigquery.BigqueryScopes
+import com.google.api.services.compute.ComputeScopes
 import com.google.api.services.oauth2.Oauth2Scopes
 import com.google.api.services.sourcerepo.v1.CloudSourceRepositoriesScopes
 import com.typesafe.scalalogging.LazyLogging
@@ -76,7 +77,8 @@ trait LeonardoTestUtils extends WebBrowserSpec with Matchers with Eventually wit
     Oauth2Scopes.USERINFO_EMAIL,
     Oauth2Scopes.USERINFO_PROFILE,
     BigqueryScopes.BIGQUERY,
-    CloudSourceRepositoriesScopes.SOURCE_READ_ONLY)
+    CloudSourceRepositoriesScopes.SOURCE_READ_ONLY,
+    ComputeScopes.CLOUD_PLATFORM)
 
   // TODO: show diffs as screenshot or other test output?
   def compareFilesExcludingIPs(left: File, right: File): Unit = {
@@ -332,50 +334,80 @@ trait LeonardoTestUtils extends WebBrowserSpec with Matchers with Eventually wit
     cluster
   }
 
-  def verifyNotebookCredentials(notebookPage: NotebookPage, expectedEmail: WorkbenchEmail): Unit = {
-    // verify google-auth
+  def verifyGoogleAuth(notebookPage: NotebookPage, expectedEmail: Option[WorkbenchEmail], expectedScopes: Option[Seq[String]]): Unit = {
     notebookPage.executeCell("import google.auth") shouldBe None
     notebookPage.executeCell("credentials, project_id = google.auth.default()") shouldBe None
-    notebookPage.executeCell("print credentials._service_account_email") shouldBe Some(expectedEmail.value)
-
-    // verify FISS
-    notebookPage.executeCell("import firecloud.api as fapi") shouldBe None
-    notebookPage.executeCell("fiss_credentials, project = fapi.google.auth.default()") shouldBe None
-    notebookPage.executeCell("print fiss_credentials.service_account_email") shouldBe Some(expectedEmail.value)
-
-    // verify Spark
-    notebookPage.executeCell("hadoop_config = sc._jsc.hadoopConfiguration()") shouldBe None
-    notebookPage.executeCell("print hadoop_config.get('google.cloud.auth.service.account.enable')") shouldBe Some("true")
-    notebookPage.executeCell("print hadoop_config.get('google.cloud.auth.service.account.json.keyfile')") shouldBe Some("/etc/service-account-credentials.json")
-    val nbEmail = notebookPage.executeCell("! grep client_email /etc/service-account-credentials.json")
-    nbEmail shouldBe 'defined
-    nbEmail.get should include (expectedEmail.value)
+    notebookPage.executeCell("print(credentials.service_account_email)") shouldBe expectedEmail.map(_.value).orElse(Some("None"))
+    val actualScopes = notebookPage.executeCell("print(credentials.scopes)")
+    actualScopes shouldBe 'defined
+    expectedScopes match {
+      case Some(scopes) =>
+        scopes.foreach { scope =>
+          actualScopes.get should include (scope)
+        }
+      case None =>
+        actualScopes shouldBe Some("None")
+    }
   }
 
-  def verifyNoNotebookCredentials(notebookPage: NotebookPage): Unit = {
-    // verify google-authn
-    notebookPage.executeCell("import google.auth") shouldBe None
-    notebookPage.executeCell("credentials, project_id = google.auth.default()") shouldBe None
-    notebookPage.executeCell("print(credentials.service_account_email)") shouldBe Some("None")
-    notebookPage.executeCell("print(credentials.scopes)") shouldBe Some("None")
-    // verify FISS
+  def verifyFiss(notebookPage: NotebookPage, expectedEmail: Option[WorkbenchEmail], expectedScopes: Option[Seq[String]]): Unit = {
     notebookPage.executeCell("import firecloud.api as fapi") shouldBe None
     notebookPage.executeCell("fiss_credentials, project = fapi.google.auth.default()") shouldBe None
-    notebookPage.executeCell("print(fiss_credentials.service_account_email)") shouldBe Some("default")
-    notebookPage.executeCell("print(fiss_credentials.scopes)") shouldBe Some("None")
-    // verify Spark
-    if (kernel == PySpark2 || kernel == PySpark3) {
-      notebookPage.executeCell("hadoop_config = sc._jsc.hadoopConfiguration()") shouldBe None
-      notebookPage.executeCell("print(hadoop_config.get('google.cloud.auth.service.account.enable'))") shouldBe Some("None")
-      notebookPage.executeCell("print(hadoop_config.get('google.cloud.auth.service.account.json.keyfile'))") shouldBe Some("None")
+    notebookPage.executeCell("print(fiss_credentials.service_account_email)") shouldBe expectedEmail.map(_.value).orElse(Some("default"))
+    val actualScopes = notebookPage.executeCell("print(fiss_credentials.scopes)")
+    actualScopes shouldBe 'defined
+    expectedScopes match {
+      case Some(scopes) =>
+        scopes.foreach { scope =>
+          actualScopes.get should include (scope)
+        }
+      case None =>
+        actualScopes shouldBe Some("None")
     }
-     // verify metadata server
+  }
+
+  def verifySpark(notebookPage: NotebookPage, expectedEmail: Option[WorkbenchEmail]): Unit = {
+    // verify Spark
+    notebookPage.executeCell("hadoop_config = sc._jsc.hadoopConfiguration()") shouldBe None
+    val serviceAccountEnabled = notebookPage.executeCell("print(hadoop_config.get('google.cloud.auth.service.account.enable'))")
+    val keyFile = notebookPage.executeCell("print(hadoop_config.get('google.cloud.auth.service.account.json.keyfile'))")
+    expectedEmail match {
+      case Some(email) =>
+        serviceAccountEnabled shouldBe Some("true")
+        keyFile shouldBe Some("/etc/service-account-credentials.json")
+        val nbEmail = notebookPage.executeCell("! grep client_email /etc/service-account-credentials.json")
+        nbEmail shouldBe 'defined
+        nbEmail.get should include (email.value)
+      case None =>
+        serviceAccountEnabled shouldBe Some("None")
+        keyFile shouldBe Some("None")
+    }
+  }
+
+  def verifyMetadataServer(notebookPage: NotebookPage, expectedEmail: WorkbenchEmail, expectedScopes: Seq[String]): Unit = {
     val metadata = notebookPage.executeCell("""!curl "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/?recursive=true" -H "Metadata-Flavor: Google"""")
     metadata shouldBe 'defined
     metadata.get should include (expectedEmail.value)
     expectedScopes.foreach { scope =>
       metadata.get should include (scope)
-    }  
+    }
+  }
+
+  def verifyNotebookServiceAccount(notebookPage: NotebookPage, kernel: Kernel, expectedEmail: WorkbenchEmail): Unit = {
+    verifyGoogleAuth(notebookPage, Some(expectedEmail), Some(expectedServiceAccountScopes))
+    verifyFiss(notebookPage, Some(expectedEmail), Some(expectedServiceAccountScopes))
+    if (kernel == PySpark2 || kernel == PySpark3) {
+      verifySpark(notebookPage, Some(expectedEmail))
+    }
+  }
+
+  def verifyClusterServiceAccount(notebookPage: NotebookPage, kernel: Kernel, expectedEmail: WorkbenchEmail): Unit = {
+    verifyGoogleAuth(notebookPage, None, None)
+    verifyFiss(notebookPage, None, None)
+    if (kernel == PySpark2 || kernel == PySpark3) {
+      verifySpark(notebookPage, None)
+    }
+    verifyMetadataServer(notebookPage, expectedEmail, expectedServiceAccountScopes)
   }
 
   def getAndVerifyPet(project: GoogleProject)(implicit token: AuthToken): WorkbenchEmail = {

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -91,8 +91,7 @@ serviceAccounts {
 }
 
 autoFreeze {
-  #Change to true once auto freeze is ready for prod
-  enableAutoFreeze = false
+  enableAutoFreeze = true
   dateAccessedMonitorScheduler = 1 minute
   autoFreezeAfter = 30 minutes
   autoFreezeCheckScheduler = 1 minute

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/google/GoogleComputeDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/google/GoogleComputeDAO.scala
@@ -24,4 +24,6 @@ trait GoogleComputeDAO {
   def getComputeEngineDefaultServiceAccount(googleProject: GoogleProject): Future[Option[WorkbenchEmail]]
 
   def getProjectNumber(googleProject: GoogleProject): Future[Option[Long]]
+
+  def setServiceAccount(instanceKey: InstanceKey, serviceAccountEmail: WorkbenchEmail, serviceAccountScopes: Seq[String]): Future[Unit]
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/google/GoogleDataprocDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/google/GoogleDataprocDAO.scala
@@ -10,7 +10,14 @@ import org.broadinstitute.dsde.workbench.model.google._
 import scala.concurrent.Future
 
 trait GoogleDataprocDAO {
-  def createCluster(googleProject: GoogleProject, clusterName: ClusterName, machineConfig: MachineConfig, initScript: GcsPath, clusterServiceAccount: Option[WorkbenchEmail], credentialsFileName: Option[String], stagingBucket: GcsBucketName): Future[Operation]
+  def createCluster(googleProject: GoogleProject,
+                    clusterName: ClusterName,
+                    machineConfig: MachineConfig,
+                    initScript: GcsPath,
+                    clusterServiceAccount: Option[WorkbenchEmail],
+                    credentialsFileName: Option[String],
+                    stagingBucket: GcsBucketName,
+                    serviceAccountScopes: Seq[String]): Future[Operation]
 
   def deleteCluster(googleProject: GoogleProject, clusterName: ClusterName): Future[Unit]
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/google/HttpGoogleComputeDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/google/HttpGoogleComputeDAO.scala
@@ -156,7 +156,9 @@ class HttpGoogleComputeDAO(appName: String,
     }
   }
 
-  override def setServiceAccount(instanceKey: InstanceKey, serviceAccountEmail: WorkbenchEmail, serviceAccountScopes: Seq[String]): Future[Unit] = {
+  override def setServiceAccount(instanceKey: InstanceKey,
+                                 serviceAccountEmail: WorkbenchEmail,
+                                 serviceAccountScopes: Seq[String]): Future[Unit] = {
     val request = compute.instances().setServiceAccount(instanceKey.project.value, instanceKey.zone.value, instanceKey.name.value,
       new InstancesSetServiceAccountRequest().setEmail(serviceAccountEmail.value).setScopes(serviceAccountScopes.asJava))
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/google/HttpGoogleDataprocDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/google/HttpGoogleDataprocDAO.scala
@@ -10,12 +10,10 @@ import cats.data.OptionT
 import cats.implicits._
 import com.google.api.client.googleapis.json.GoogleJsonResponseException
 import com.google.api.client.http.HttpResponseException
-import com.google.api.services.bigquery.BigqueryScopes
 import com.google.api.services.compute.ComputeScopes
 import com.google.api.services.dataproc.Dataproc
 import com.google.api.services.dataproc.model.{Cluster => DataprocCluster, ClusterConfig => DataprocClusterConfig, ClusterStatus => DataprocClusterStatus, Operation => DataprocOperation, _}
-import com.google.api.services.oauth2.{Oauth2, Oauth2Scopes}
-import com.google.api.services.sourcerepo.v1.CloudSourceRepositoriesScopes
+import com.google.api.services.oauth2.Oauth2
 import org.broadinstitute.dsde.workbench.google.AbstractHttpGoogleDAO
 import org.broadinstitute.dsde.workbench.google.GoogleCredentialModes._
 import org.broadinstitute.dsde.workbench.leonardo.model.google.DataprocRole.{Master, SecondaryWorker, Worker}
@@ -44,10 +42,6 @@ class HttpGoogleDataprocDAO(appName: String,
 
   override val scopes: Seq[String] = Seq(ComputeScopes.CLOUD_PLATFORM)
 
-  private lazy val oauth2Scopes = List(Oauth2Scopes.USERINFO_EMAIL, Oauth2Scopes.USERINFO_PROFILE)
-  private lazy val bigqueryScopes = List(BigqueryScopes.BIGQUERY)
-  private lazy val cloudSourceRepositoryScopes = List(CloudSourceRepositoriesScopes.SOURCE_READ_ONLY)
-
   private lazy val dataproc = {
     new Dataproc.Builder(httpTransport, jsonFactory, googleCredential)
       .setApplicationName(appName).build()
@@ -64,10 +58,11 @@ class HttpGoogleDataprocDAO(appName: String,
                              initScript: GcsPath,
                              clusterServiceAccount: Option[WorkbenchEmail],
                              credentialsFileName: Option[String],
-                             stagingBucket: GcsBucketName): Future[Operation] = {
+                             stagingBucket: GcsBucketName,
+                             serviceAccountScopes: Seq[String]): Future[Operation] = {
     val cluster = new DataprocCluster()
       .setClusterName(clusterName.value)
-      .setConfig(getClusterConfig(machineConfig, initScript, clusterServiceAccount, credentialsFileName, stagingBucket))
+      .setConfig(getClusterConfig(machineConfig, initScript, clusterServiceAccount, credentialsFileName, stagingBucket, serviceAccountScopes))
 
     val request = dataproc.projects().regions().clusters().create(googleProject.value, defaultRegion, cluster)
 
@@ -212,7 +207,7 @@ class HttpGoogleDataprocDAO(appName: String,
       }
   }
 
-  private def getClusterConfig(machineConfig: MachineConfig, initScript: GcsPath, clusterServiceAccount: Option[WorkbenchEmail], credentialsFileName: Option[String], stagingBucket: GcsBucketName): DataprocClusterConfig = {
+  private def getClusterConfig(machineConfig: MachineConfig, initScript: GcsPath, clusterServiceAccount: Option[WorkbenchEmail], credentialsFileName: Option[String], stagingBucket: GcsBucketName, serviceAccountScopes: Seq[String]): DataprocClusterConfig = {
     // Create a GceClusterConfig, which has the common config settings for resources of Google Compute Engine cluster instances,
     // applicable to all instances in the cluster.
     // Set the network tag, network, and subnet. This allows the created GCE instances to be exposed by Leo's firewall rule.
@@ -233,7 +228,7 @@ class HttpGoogleDataprocDAO(appName: String,
     // Set the cluster service account, if present.
     // This is the service account passed to the create cluster API call.
     clusterServiceAccount.foreach { serviceAccountEmail =>
-      gceClusterConfig.setServiceAccount(serviceAccountEmail.value).setServiceAccountScopes((oauth2Scopes ++ bigqueryScopes ++ cloudSourceRepositoryScopes).asJava)
+      gceClusterConfig.setServiceAccount(serviceAccountEmail.value).setServiceAccountScopes(serviceAccountScopes.asJava)
     }
 
     // Create a NodeInitializationAction, which specifies the executable to run on a node.

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/google/HttpGoogleDataprocDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/google/HttpGoogleDataprocDAO.scala
@@ -207,7 +207,12 @@ class HttpGoogleDataprocDAO(appName: String,
       }
   }
 
-  private def getClusterConfig(machineConfig: MachineConfig, initScript: GcsPath, clusterServiceAccount: Option[WorkbenchEmail], credentialsFileName: Option[String], stagingBucket: GcsBucketName, serviceAccountScopes: Seq[String]): DataprocClusterConfig = {
+  private def getClusterConfig(machineConfig: MachineConfig,
+                               initScript: GcsPath,
+                               clusterServiceAccount: Option[WorkbenchEmail],
+                               credentialsFileName: Option[String],
+                               stagingBucket: GcsBucketName,
+                               serviceAccountScopes: Seq[String]): DataprocClusterConfig = {
     // Create a GceClusterConfig, which has the common config settings for resources of Google Compute Engine cluster instances,
     // applicable to all instances in the cluster.
     // Set the network tag, network, and subnet. This allows the created GCE instances to be exposed by Leo's firewall rule.

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoService.scala
@@ -10,7 +10,6 @@ import cats.implicits._
 import com.google.api.client.googleapis.json.GoogleJsonResponseException
 import com.google.api.client.http.HttpResponseException
 import com.google.api.services.bigquery.BigqueryScopes
-import com.google.api.services.compute.ComputeScopes
 import com.google.api.services.oauth2.Oauth2Scopes
 import com.google.api.services.sourcerepo.v1.CloudSourceRepositoriesScopes
 import com.typesafe.scalalogging.LazyLogging
@@ -117,9 +116,8 @@ class LeonardoService(protected val dataprocConfig: DataprocConfig,
   private val oauth2Scopes = List(Oauth2Scopes.USERINFO_EMAIL, Oauth2Scopes.USERINFO_PROFILE)
   private val bigqueryScopes = List(BigqueryScopes.BIGQUERY)
   private val cloudSourceRepositoryScopes = List(CloudSourceRepositoriesScopes.SOURCE_READ_ONLY)
-  private val cloudPlatformScopes = List(ComputeScopes.CLOUD_PLATFORM)
 
-  private[service] val serviceAccountScopes = oauth2Scopes ++ bigqueryScopes ++ cloudSourceRepositoryScopes ++ cloudPlatformScopes
+  private[service] val serviceAccountScopes = oauth2Scopes ++ bigqueryScopes ++ cloudSourceRepositoryScopes
 
   def isWhitelisted(userInfo: UserInfo): Future[Boolean] = {
     if( whitelist contains userInfo.userEmail.value.toLowerCase ) {

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/google/MockGoogleComputeDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/google/MockGoogleComputeDAO.scala
@@ -1,4 +1,5 @@
 package org.broadinstitute.dsde.workbench.leonardo.dao.google
+
 import org.broadinstitute.dsde.workbench.leonardo.model.google.InstanceStatus.{Running, Stopped}
 import org.broadinstitute.dsde.workbench.leonardo.model.google._
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
@@ -16,6 +17,7 @@ class MockGoogleComputeDAO extends GoogleComputeDAO {
   val instances: mutable.Map[InstanceKey, Instance] = new TrieMap()
   val firewallRules: mutable.Map[GoogleProject, FirewallRule] = new TrieMap()
   val instanceMetadata: mutable.Map[InstanceKey, Map[String, String]] = new TrieMap()
+  val instanceServiceAccounts: mutable.Map[InstanceKey, (WorkbenchEmail, Seq[String])] = new TrieMap()
 
   override def getInstance(instanceKey: InstanceKey): Future[Option[Instance]] = {
     Future.successful(instances.get(instanceKey))
@@ -36,16 +38,12 @@ class MockGoogleComputeDAO extends GoogleComputeDAO {
   }
 
   override def addInstanceMetadata(instanceKey: InstanceKey, metadata: Map[String, String]): Future[Unit] = {
-    instanceMetadata.get(instanceKey).foreach { existingMetadata =>
-      instanceMetadata += instanceKey -> (existingMetadata ++ metadata)
-    }
+    instanceMetadata += instanceKey -> metadata
     Future.successful(())
   }
 
   override def updateFirewallRule(googleProject: GoogleProject, firewallRule: FirewallRule): Future[Unit] = {
-    if (!firewallRules.contains(googleProject)) {
-      firewallRules += googleProject -> firewallRule
-    }
+    firewallRules += googleProject -> firewallRule
     Future.successful(())
   }
 
@@ -59,6 +57,7 @@ class MockGoogleComputeDAO extends GoogleComputeDAO {
   }
 
   override def setServiceAccount(instanceKey: InstanceKey, serviceAccountEmail: WorkbenchEmail, serviceAccountScopes: Seq[String]): Future[Unit] = {
+    instanceServiceAccounts += instanceKey -> (serviceAccountEmail, serviceAccountScopes)
     Future.successful(())
   }
 }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/google/MockGoogleComputeDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/google/MockGoogleComputeDAO.scala
@@ -57,4 +57,8 @@ class MockGoogleComputeDAO extends GoogleComputeDAO {
     val rng = new Random
     Future.successful(Some(rng.nextLong()))
   }
+
+  override def setServiceAccount(instanceKey: InstanceKey, serviceAccountEmail: WorkbenchEmail, serviceAccountScopes: Seq[String]): Future[Unit] = {
+    Future.successful(())
+  }
 }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/google/MockGoogleDataprocDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/google/MockGoogleDataprocDAO.scala
@@ -26,7 +26,7 @@ class MockGoogleDataprocDAO(ok: Boolean = true) extends GoogleDataprocDAO {
 
   private def googleID = UUID.randomUUID()
 
-  override def createCluster(googleProject: GoogleProject, clusterName: ClusterName, machineConfg: MachineConfig, initScript: GcsPath, clusterServiceAccount: Option[WorkbenchEmail], credentialsFileName: Option[String], stagingBucket: GcsBucketName): Future[Operation] = {
+  override def createCluster(googleProject: GoogleProject, clusterName: ClusterName, machineConfg: MachineConfig, initScript: GcsPath, clusterServiceAccount: Option[WorkbenchEmail], credentialsFileName: Option[String], stagingBucket: GcsBucketName, serviceAccountScopes: Seq[String]): Future[Operation] = {
     if (clusterName == badClusterName) {
       Future.failed(new Exception("bad cluster!"))
     } else {

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorSpec.scala
@@ -468,7 +468,7 @@ class ClusterMonitorSpec extends TestKit(ActorSystem("leonardotest")) with FlatS
 
     val newClusterId = UUID.randomUUID()
     when {
-      gdDAO.createCluster(mockitoEq(creatingCluster.googleProject), mockitoEq(creatingCluster.clusterName), any[MachineConfig], any[GcsPath], any[Option[WorkbenchEmail]], any[Option[String]], any[GcsBucketName])
+      gdDAO.createCluster(mockitoEq(creatingCluster.googleProject), mockitoEq(creatingCluster.clusterName), any[MachineConfig], any[GcsPath], any[Option[WorkbenchEmail]], any[Option[String]], any[GcsBucketName], any[Seq[String]])
     } thenReturn Future.successful {
       Operation(creatingCluster.dataprocInfo.operationName.get, newClusterId)
     }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoServiceSpec.scala
@@ -879,8 +879,9 @@ class LeonardoServiceSpec extends TestKit(ActorSystem("leonardotest")) with Flat
       masterInstance.key -> InstanceStatus.Stopped,
       workerInstance1.key -> InstanceStatus.Stopped,
       workerInstance2.key -> InstanceStatus.Stopped)
-     // metadata and service account should not be set (that happens at resume time)
-    computeDAO.instanceMetadata shouldBe 'empty
+    // metadata should be set on the master instance only
+    computeDAO.instanceMetadata shouldBe Map(masterInstance.key -> leo.masterInstanceStartupScript)
+    // service account should not be set (that happens at resume time)
     computeDAO.instanceServiceAccounts shouldBe 'empty
   }
 
@@ -926,8 +927,9 @@ class LeonardoServiceSpec extends TestKit(ActorSystem("leonardotest")) with Flat
       masterInstance.key -> InstanceStatus.Stopped,
       workerInstance1.key -> InstanceStatus.Stopped,
       workerInstance2.key -> InstanceStatus.Stopped)
-     // metadata and service account should not be set (that happens at resume time)
-    computeDAO.instanceMetadata shouldBe 'empty
+    // metadata should be set on the master instance only
+    computeDAO.instanceMetadata shouldBe Map(masterInstance.key -> leo.masterInstanceStartupScript)
+    // service account should not be set (that happens at resume time)
     computeDAO.instanceServiceAccounts shouldBe 'empty
   }
 
@@ -969,9 +971,9 @@ class LeonardoServiceSpec extends TestKit(ActorSystem("leonardotest")) with Flat
       masterInstance.key -> InstanceStatus.Running,
       workerInstance1.key -> InstanceStatus.Running,
       workerInstance2.key -> InstanceStatus.Running)
-     // metadata and service account should be set on the master instance only
-    computeDAO.instanceMetadata shouldBe Map(masterInstance.key -> leo.masterInstanceStartupScript)
-     // service account should be set on all instances
+    // metadata should not be set (that happens at stop time)
+    computeDAO.instanceMetadata shouldBe Map.empty
+    // service account should be set on all instances
     computeDAO.instanceServiceAccounts shouldBe
       Map(
         masterInstance.key -> (samClient.serviceAccount, leo.serviceAccountScopes),
@@ -1018,9 +1020,9 @@ class LeonardoServiceSpec extends TestKit(ActorSystem("leonardotest")) with Flat
       masterInstance.key -> InstanceStatus.Running,
       workerInstance1.key -> InstanceStatus.Running,
       workerInstance2.key -> InstanceStatus.Running)
-     // metadata and service account should be set on the master instance only
-    computeDAO.instanceMetadata shouldBe Map(masterInstance.key -> leo.masterInstanceStartupScript)
-     // service account should be set on all instances
+    // metadata should not be set (that happens at stop time)
+    computeDAO.instanceMetadata shouldBe Map.empty
+    // service account should be set on all instances
     computeDAO.instanceServiceAccounts shouldBe
       Map(
         masterInstance.key -> (samClient.serviceAccount, leo.serviceAccountScopes),


### PR DESCRIPTION
See https://github.com/DataBiosphere/leonardo/issues/495

When we create a cluster, we set a service account and scopes which go into VM metadata. For some reason, if the instance is stopped/started, the service account persists but the scopes do not. This causes errors when using libraries which require certain scopes (e.g. FISS, AoU client) after pause/resume.

This makes Leo re-set the service account and scopes on the VM at cluster resume time. I verified manually that this works, and also added automation tests. 

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
