### PR TITLE
Use http mirror because of broken cert

### DIFF
--- a/jupyter-docker/Dockerfile
+++ b/jupyter-docker/Dockerfile
@@ -232,7 +232,7 @@ RUN R -e 'install.packages(c( \
     "reshape2",  \
     "bigrquery",  \
     "tidyverse"), \
-    repos="https://cran.mtu.edu")' \
+    repos="http://cran.mtu.edu")' \
  && R -e 'devtools::install_github("IRkernel/IRkernel")' \
  && R -e 'IRkernel::installspec(user=FALSE)' \
  && chown -R $USER:users /home/jupyter-user/.local  \


### PR DESCRIPTION
http might be faster anyway

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
