### PR TITLE
Added wss://notebooks.firecloud.org:* to CSP

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -100,5 +100,5 @@ autoFreeze {
 
 jupyterConfig {
   # https://*.npmjs.org and 'unsafe-eval' needed for jupyterlab
-  contentSecurityPolicy = "frame-ancestors 'self' http://localhost:3000 https://bvdp-saturn-prod.appspot.com https://bvdp-saturn-dev.appspot.com https://localhost:443; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://apis.google.com ; style-src 'self' 'unsafe-inline'; connect-src 'self' wss://*.broadinstitute.org:* *.googleapis.com https://*.npmjs.org"
+  contentSecurityPolicy = "frame-ancestors 'self' http://localhost:3000 https://bvdp-saturn-prod.appspot.com https://bvdp-saturn-dev.appspot.com https://localhost:443; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://apis.google.com ; style-src 'self' 'unsafe-inline'; connect-src 'self' wss://*.broadinstitute.org:* wss://notebooks.firecloud.org:* *.googleapis.com https://*.npmjs.org"
 }


### PR DESCRIPTION
The CSP `connect-src` currently contains `wss://*.broadinstitute.org:*` which works for non-prod, but the prod domain is `notebooks.firecloud.org`. This adds `wss://notebooks.firecloud.org:*` to CSP.

The failure mode was the Jupyter UI loaded, but the kernel (websocket) failed to start. Looking in the browser console, the error was:

> kernel.js:461 Refused to connect to 'wss://notebooks.firecloud.org/notebooks/broad-firecloud-dsde/rt-long-running-test/api/kernels/8f09d2ef-d81c-4411-9314-fc3f37b39eab/channels?session_id=5dcf44675e01460c9dfa5807c14d577a' because it violates the following Content Security Policy directive: "connect-src 'self' wss://*.broadinstitute.org:* *.googleapis.com https://*.npmjs.org".

which pointed to the issue.

I manually made the config fix on prod and verified that the kernel starts up. This only affected clusters created between 5pm and 7:30pm EST, so hopefully nobody hit it (and if they did, recreating their cluster should resolve the issue).

Unsure how tests could have caught this since prod uses a "special" domain. 


Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
