### PR TITLE
CORS support for X-App-Id header

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/CorsSupport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/CorsSupport.scala
@@ -32,7 +32,7 @@ trait CorsSupport {
         headers.filter(_.isNot(`Access-Control-Allow-Origin`.lowercaseName)) ++
           Seq(allowOrigin,
             `Access-Control-Allow-Credentials`(true),
-            `Access-Control-Allow-Headers`("Authorization", "Content-Type", "Accept", "Origin"),
+            `Access-Control-Allow-Headers`("Authorization", "Content-Type", "Accept", "Origin", "X-App-Id"),
             `Access-Control-Max-Age`(1728000))
       }
     }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/ProxyRoutesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/ProxyRoutesSpec.scala
@@ -269,7 +269,7 @@ class ProxyRoutesSpec extends FlatSpec with BeforeAndAfterAll with BeforeAndAfte
     headers.count(_.is(`Access-Control-Allow-Origin`.lowercaseName)) shouldBe 1
     header[`Access-Control-Allow-Origin`] shouldBe origin.map(`Access-Control-Allow-Origin`(_)).orElse(Some(`Access-Control-Allow-Origin`.*))
     header[`Access-Control-Allow-Credentials`] shouldBe Some(`Access-Control-Allow-Credentials`(true))
-    header[`Access-Control-Allow-Headers`] shouldBe Some(`Access-Control-Allow-Headers`("Authorization", "Content-Type", "Accept", "Origin"))
+    header[`Access-Control-Allow-Headers`] shouldBe Some(`Access-Control-Allow-Headers`("Authorization", "Content-Type", "Accept", "Origin", "X-App-Id"))
     header[`Access-Control-Max-Age`] shouldBe Some(`Access-Control-Max-Age`(1728000))
     header[`Access-Control-Allow-Methods`] shouldBe (
       if (optionsRequest) Some(`Access-Control-Allow-Methods`(OPTIONS, POST, PUT, GET, DELETE, HEAD, PATCH))


### PR DESCRIPTION
As discussed elsewhere in tech docs. This simply allows the X-App-Id in via ajax; I will be making separate PRs to actually send that header from the UI.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've documented my API changes in Swagger

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
