### PR TITLE
Bug fix for cluster creation API v2 

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/Leonardo.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/Leonardo.scala
@@ -130,11 +130,6 @@ object Leonardo extends RestClient with LazyLogging {
     def get(googleProject: GoogleProject, clusterName: ClusterName)(implicit token: AuthToken): Cluster = {
       val path = clusterPath(googleProject, clusterName)
 
-      // TODO Find and fix the root-cause of why we get successive 404's without this sleep, and remove the sleep
-      val sleepTime = 4000
-      logger.info(s"Sleeping for ${sleepTime/1000} seconds before GET'ing /$path...")
-      Thread sleep sleepTime
-
       val cluster = handleClusterResponse(parseResponse(getRequest(url + path)))
       logger.info(s"Get cluster: GET /$path. Response: $cluster")
 

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
@@ -146,7 +146,9 @@ trait LeonardoTestUtils extends WebBrowserSpec with Matchers with Eventually wit
     val clusterTimeResult = time(Leonardo.cluster.create(googleProject, clusterName, clusterRequest, apiVersion))
     logger.info(s"Time it took to get cluster create response with " +
       s"API version $apiVersion: ${clusterTimeResult.duration}")
-    clusterTimeResult.duration should be < tenSeconds
+    if (apiVersion == V2) {
+      clusterTimeResult.duration should be < tenSeconds
+    }
 
     // We will verify the create cluster response.
     // We don't want to check bucket for v2 (async) cluster creation API

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
@@ -144,9 +144,9 @@ trait LeonardoTestUtils extends WebBrowserSpec with Matchers with Eventually wit
     Thread sleep Random.nextInt(30000)
 
     val clusterTimeResult = time(Leonardo.cluster.create(googleProject, clusterName, clusterRequest, apiVersion))
-    logger.info("Time to get cluster create response:" + clusterTimeResult.duration)
-    // TODO Uncomment out the following when the response time is indeed less than 10 seconds
-    // clusterTimeResult.duration should be < tenSeconds
+    logger.info(s"Time it took to get cluster create response with " +
+      s"API version $apiVersion: ${clusterTimeResult.duration}")
+    clusterTimeResult.duration should be < tenSeconds
 
     // We will verify the create cluster response.
     // We don't want to check bucket for v2 (async) cluster creation API


### PR DESCRIPTION
- Ensures that Sam is notified about cluster creation before returning a response, preventing 404s from GET cluster requests made immediate after PUT cluster responses.
- Adds more logging around cluster creation steps.