### PR TITLE
Remove 10s createCluster check

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
@@ -57,7 +57,6 @@ trait LeonardoTestUtils extends WebBrowserSpec with Matchers with Eventually wit
   val localizePatience = PatienceConfig(timeout = scaled(Span(1, Minutes)), interval = scaled(Span(1, Seconds)))
   val saPatience = PatienceConfig(timeout = scaled(Span(1, Minutes)), interval = scaled(Span(1, Seconds)))
   val storagePatience = PatienceConfig(timeout = scaled(Span(1, Minutes)), interval = scaled(Span(1, Seconds)))
-  val tenSeconds = FiniteDuration(10, SECONDS)
   val startPatience = PatienceConfig(timeout = scaled(Span(5, Minutes)), interval = scaled(Span(1, Seconds)))
   val getAfterCreatePatience = PatienceConfig(timeout = scaled(Span(30, Seconds)), interval = scaled(Span(2, Seconds)))
 
@@ -145,9 +144,6 @@ trait LeonardoTestUtils extends WebBrowserSpec with Matchers with Eventually wit
     val clusterTimeResult = time(Leonardo.cluster.create(googleProject, clusterName, clusterRequest, apiVersion))
     logger.info(s"Time it took to get cluster create response with " +
       s"API version $apiVersion: ${clusterTimeResult.duration}")
-    if (apiVersion == V2) {
-      clusterTimeResult.duration should be < tenSeconds
-    }
 
     // We will verify the create cluster response.
     // We don't want to check bucket for v2 (async) cluster creation API


### PR DESCRIPTION
See https://docs.google.com/document/d/1qrqI4V18YuKTaX1zsJ6YugKg7lwD0W9jmZPn-jF88RQ/edit?ts=5b87f266

This check is failing pretty often in auto-tests. I think auto-tests isn't really the right place to be checking this anyway. We should be measuring performance in other ways like instrumentation on production machines. There is a lot of slowness on a "clean" fiab which doesn't necessarily reflect reality. 

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
