### PR TITLE
Correctly handle null stagingBucket in the Cluster response

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/Leonardo.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/Leonardo.scala
@@ -77,7 +77,7 @@ object Leonardo extends RestClient with LazyLogging {
         labels,
         jupyterExtensionUri map (parseGcsPath(_).right.get),
         jupyterUserScriptUri map (parseGcsPath(_).right.get),
-        Some(GcsBucketName(stagingBucket)),
+        Option(stagingBucket).map(GcsBucketName),
         errors,
         Instant.parse(dateAccessed),
         defaultClientId


### PR DESCRIPTION
I think this test failed because of this issue: https://fc-jenkins.dsp-techops.broadinstitute.org/job/leonardo-fiab-test-runner/4154/

Basically `stagingBucket` was being returned as `null` in `getCluster` calls (which is possible when using the V2 createCluster API). The code was then wrapping the `null` in a `Some`, giving us: Some(GcsBucketName(null))`. This caused failures around [here](https://github.com/DataBiosphere/leonardo/blob/develop/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala#L125-L130) because the code just checks if the option is defined.

I changed the JSON deserialization code to use `Option(..)` instead of `Some(..)` which should correctly handle nulls.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
