### PR TITLE
Example config update to set akka-http parsing max-content-length parameter

### DIFF
--- a/leonardo-example.conf
+++ b/leonardo-example.conf
@@ -76,10 +76,12 @@ clusterFiles {
 
 akka {
   loglevel = INFO
+
   http {
     server.idle-timeout = 1 hour
     client.idle-timeout = 1 hour
     server.request-timeout = 60 seconds
+    parsing.max-content-length = 64m
   }
 
   #Add your ssl config info below


### PR DESCRIPTION
I've unsuccessfully to tried to come up with a test example to auto-verify the handling of large files and decided to leave it at updating the documentation only.