### PR TITLE
Persist stopAfterCreation flag (#579)

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/ClusterConcurrencySpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/ClusterConcurrencySpec.scala
@@ -107,7 +107,7 @@ class ClusterConcurrencySpec extends FreeSpec with LeonardoTestUtils with Parall
       withProject { project => implicit token =>
         val request = defaultClusterRequest.copy(stopAfterCreation = Some(true))
         withNewCluster(project, request = request) { cluster =>
-          // no-op; just verify the cluster is stopped
+          cluster.stopAfterCreation shouldBe true
         }
       }
     }
@@ -118,6 +118,7 @@ class ClusterConcurrencySpec extends FreeSpec with LeonardoTestUtils with Parall
         val request = defaultClusterRequest.copy(defaultClientId = Some("this is a client ID"))
         withNewCluster(project, request = request) { cluster =>
           cluster.defaultClientId shouldBe Some("this is a client ID")
+          cluster.stopAfterCreation shouldBe false
         }
       }
 

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/Leonardo.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/Leonardo.scala
@@ -60,7 +60,8 @@ object Leonardo extends RestClient with LazyLogging {
                                     stagingBucket: String,
                                     errors: List[ClusterError],
                                     dateAccessed: String,
-                                    defaultClientId: Option[String]) {
+                                    defaultClientId: Option[String],
+                                    stopAfterCreation: Option[Boolean]) {
 
       def toCluster = Cluster(clusterName,
         googleId,
@@ -80,7 +81,8 @@ object Leonardo extends RestClient with LazyLogging {
         Option(stagingBucket).map(GcsBucketName),
         errors,
         Instant.parse(dateAccessed),
-        defaultClientId
+        defaultClientId,
+        stopAfterCreation.getOrElse(false)
       )
     }
 

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoModelCopy.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoModelCopy.scala
@@ -68,8 +68,8 @@ case class Cluster(clusterName: ClusterName,
                    stagingBucket:Option[GcsBucketName],
                    errors:List[ClusterError],
                    dateAccessed: Instant,
-                   defaultClientId: Option[String]
-                  )
+                   defaultClientId: Option[String],
+                   stopAfterCreation: Boolean)
 
 case class ClusterRequest(labels: LabelMap = Map(),
                           jupyterExtensionUri: Option[String] = None,

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
@@ -119,6 +119,9 @@ trait LeonardoTestUtils extends WebBrowserSpec with Matchers with Eventually wit
 
     cluster.googleProject shouldBe expectedProject
     cluster.clusterName shouldBe expectedName
+    
+    val expectedStopAfterCreation = clusterRequest.stopAfterCreation.getOrElse(false)
+    cluster.stopAfterCreation shouldBe expectedStopAfterCreation
 
     labelCheck(cluster.labels, expectedName, expectedProject, cluster.creator, clusterRequest)
 

--- a/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changelog.xml
+++ b/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changelog.xml
@@ -26,4 +26,5 @@
     <include file="changesets/20180607_master_disk_size.xml" relativeToChangelogFile="true" />
     <include file="changesets/20180625_autopause_threshold.xml" relativeToChangelogFile="true" />
     <include file="changesets/20180810_default_client_id.xml" relativeToChangelogFile="true" />
+    <include file="changesets/20180919_stop_after_creation.xml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/20180919_stop_after_creation.xml
+++ b/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/20180919_stop_after_creation.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog logicalFilePath="leonardo" xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+    <changeSet logicalFilePath="leonardo" author="kyuksel" id="stop_after_creation">
+        <addColumn tableName="CLUSTER">
+            <column name="stopAfterCreation" type="boolean">
+                <constraints nullable="false" />
+            </column>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/CommonTestData.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/CommonTestData.scala
@@ -98,7 +98,8 @@ trait CommonTestData{ this: ScalaFutures =>
       instances = Set.empty,
       userJupyterExtensionConfig = None,
       autopauseThreshold = 30,
-      defaultClientId = Some("defaultClientId")
+      defaultClientId = Some("defaultClientId"),
+      stopAfterCreation = false
     )
   }
 
@@ -118,9 +119,10 @@ trait CommonTestData{ this: ScalaFutures =>
     instances = Set.empty,
     userJupyterExtensionConfig = None,
     autopauseThreshold = if (autopause) autopauseThreshold else 0,
-    defaultClientId = None)
+    defaultClientId = None,
+    stopAfterCreation = false)
 
-  // TODO look into parameterized tests so both provider impls can both be tested
+  // TODO look into parameterized tests so both provider impls can be tested
   // Also remove code duplication with LeonardoServiceSpec, TestLeoRoutes, and CommonTestData
   val serviceAccountProvider = new MockPetClusterServiceAccountProvider(serviceAccountsConfig)
   val whitelistAuthProvider = new WhitelistAuthProvider(whitelistAuthConfig, serviceAccountProvider)

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponentSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponentSpec.scala
@@ -18,7 +18,8 @@ class ClusterComponentSpec extends TestComponent with FlatSpecLike with CommonTe
     lazy val err1 = ClusterError("some failure", 10, Instant.now().truncatedTo(ChronoUnit.SECONDS))
     lazy val cluster1UUID = UUID.randomUUID()
     val cluster1 = makeCluster(1).copy(dataprocInfo = makeDataprocInfo(1).copy(googleId = Some(cluster1UUID)),
-                                      instances = Set(masterInstance, workerInstance1, workerInstance2))
+                                      instances = Set(masterInstance, workerInstance1, workerInstance2),
+                                      stopAfterCreation = true)
 
     val cluster1WithErr = makeCluster(1).copy(dataprocInfo = makeDataprocInfo(1).copy(googleId = Some(cluster1UUID)),
                                        errors = List(err1),
@@ -52,7 +53,7 @@ class ClusterComponentSpec extends TestComponent with FlatSpecLike with CommonTe
     dbFutureValue { _.clusterQuery.getActiveClusterByName(cluster3.googleProject, cluster3.clusterName) } shouldEqual Some(savedCluster3)
 
     dbFutureValue { _.clusterErrorQuery.save(savedCluster1.id, err1) }
-    val cluster1WithErrAssignedId = cluster1WithErr.copy(id = savedCluster1.id)
+    val cluster1WithErrAssignedId = cluster1WithErr.copy(id = savedCluster1.id, stopAfterCreation = true)
 
     dbFutureValue { _.clusterQuery.getClusterById(savedCluster1.id) } shouldEqual Some(cluster1WithErrAssignedId)
     dbFutureValue { _.clusterQuery.getClusterById(savedCluster2.id) } shouldEqual Some(savedCluster2)

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeonardoModelSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeonardoModelSpec.scala
@@ -21,7 +21,8 @@ class LeonardoModelSpec extends TestComponent with FlatSpecLike with Matchers wi
   val cluster = makeCluster(1).copy(dataprocInfo = makeDataprocInfo(1).copy(googleId = Option(fromString("4ba97751-026a-4555-961b-89ae6ce78df4"))),
                                     auditInfo = auditInfo.copy(createdDate = exampleTime,
                                                                dateAccessed = exampleTime),
-                                    jupyterExtensionUri = Some(jupyterExtensionUri))
+                                    jupyterExtensionUri = Some(jupyterExtensionUri),
+                                    stopAfterCreation = true)
 
 
   it should "serialize/deserialize to/from JSON" in isolatedDbTest {
@@ -55,7 +56,7 @@ class LeonardoModelSpec extends TestComponent with FlatSpecLike with Matchers wi
         |  "dateAccessed": "2018-08-07T10:12:35Z",
         |  "autopauseThreshold": 30,
         |  "defaultClientId": "defaultClientId",
-        |  "stopAfterCreation": false
+        |  "stopAfterCreation": true
         |}
       """.stripMargin.parseJson
 
@@ -94,8 +95,8 @@ class LeonardoModelSpec extends TestComponent with FlatSpecLike with Matchers wi
       """.stripMargin.parseJson
 
     val testJson = cluster.toJson(ClusterFormat)
-
     testJson should equal (expectedJson)
+    
     val returnedCluster = testJson.convertTo[Cluster]
     returnedCluster shouldBe cluster
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeonardoModelSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeonardoModelSpec.scala
@@ -54,7 +54,8 @@ class LeonardoModelSpec extends TestComponent with FlatSpecLike with Matchers wi
         |  "instances": [],
         |  "dateAccessed": "2018-08-07T10:12:35Z",
         |  "autopauseThreshold": 30,
-        |  "defaultClientId": "defaultClientId"
+        |  "defaultClientId": "defaultClientId",
+        |  "stopAfterCreation": false
         |}
       """.stripMargin.parseJson
 
@@ -87,7 +88,8 @@ class LeonardoModelSpec extends TestComponent with FlatSpecLike with Matchers wi
         |  "errors": [],
         |  "instances": [],
         |  "dateAccessed": "2018-08-07T10:12:35Z",
-        |  "autopauseThreshold": 0
+        |  "autopauseThreshold": 0,
+        |  "stopAfterCreation": false
         |}
       """.stripMargin.parseJson
 


### PR DESCRIPTION
In the API request `stopAfterCreation` flag is optional. Other than when it's specified as `Option(true)`, I mapped it to `false` (and not `Option(false)`) in the model and in the database for simplicity downstream, assuming that we don't need to distinguish between `stopAfterCreation` being `Option(false)` vs. `None`.