### PR TITLE
[EARLY] Don't allow deleting a cluster in Creating status

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/ClusterConcurrencySpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/ClusterConcurrencySpec.scala
@@ -39,16 +39,6 @@ class ClusterConcurrencySpec extends FreeSpec with LeonardoTestUtils with Parall
       }
     }
 
-    // create -> no wait -> delete
-    "should delete a creating cluster" in {
-      withProject { project => implicit token =>
-        logger.info(s"${project.value}: should delete a creating cluster")
-
-        // delete while the cluster is still creating
-        withNewCluster(project, monitorCreate = false, monitorDelete = true, apiVersion = V2)(noop)
-      }
-    }
-
     // create -> wait -> delete -> no wait -> delete
     "should not be able to delete a deleting cluster" in {
       withProject { project => implicit token =>

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -274,6 +274,10 @@ paths:
           description: Cluster not found
           schema:
             $ref: '#/definitions/ErrorReport'
+        '409':
+          description: Cluster cannot be deleted
+          schema:
+            $ref: '#/definitions/ErrorReport'
         '500':
           description: Internal Error
           schema:

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/google/GoogleModel.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/google/GoogleModel.scala
@@ -67,8 +67,8 @@ object ClusterStatus extends Enum[ClusterStatus] {
   // A user might need to connect to this notebook in the future. Keep it warm in the DNS cache.
   val activeStatuses: Set[ClusterStatus] = Set(Unknown, Creating, Running, Updating, Stopping, Stopped, Starting)
 
-  // Can a user delete this cluster? Contains everything except Deleting, Deleted.
-  val deletableStatuses: Set[ClusterStatus] = Set(Unknown, Creating, Running, Updating, Error, Stopping, Stopped, Starting)
+  // Can a user delete this cluster? Contains everything except Deleting, Deleted, Creating.
+  val deletableStatuses: Set[ClusterStatus] = Set(Unknown, Running, Updating, Error, Stopping, Stopped, Starting)
 
   // Non-terminal statuses. Requires cluster monitoring via ClusterMonitorActor.
   val monitoredStatuses: Set[ClusterStatus] = Set(Unknown, Creating, Updating, Deleting, Stopping, Starting)


### PR DESCRIPTION
This came up when Saturn tried to delete clusters seconds after they were created. This exposed a race condition in Leo code where the cluster deletion can step on async cluster creation. It's probably safer to just disallow delete when the cluster is in Creating status. FireCloud UI already enforces this, and Saturn will be doing similar. This PR enforces it at the API level.

I haven't ran automation tests yet, the changes are just a guess.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've documented my API changes in Swagger

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
