### PR TITLE
Don't continually monitor zombie clusters

### DIFF
--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorSpec.scala
@@ -56,6 +56,9 @@ class ClusterMonitorSpec extends TestKit(ActorSystem("leonardotest")) with FlatS
   val startingCluster = makeCluster(4).copy(serviceAccountInfo = ServiceAccountInfo(clusterServiceAccount(project), notebookServiceAccount(project)),
                                             status = ClusterStatus.Starting)
 
+  val errorCluster = makeCluster(5).copy(
+    serviceAccountInfo = ServiceAccountInfo(clusterServiceAccount(project), notebookServiceAccount(project)),
+    status = ClusterStatus.Error)
 
   val clusterInstances = Map(Master -> Set(masterInstance.key),
                              Worker -> Set(workerInstance1.key, workerInstance2.key))
@@ -964,6 +967,40 @@ class ClusterMonitorSpec extends TestKit(ActorSystem("leonardotest")) with FlatS
       verify(storageDAO, never()).deleteBucket(any[GcsBucketName], any[Boolean])
       verify(iamDAO, if (clusterServiceAccount(creatingCluster.googleProject).isDefined) times(1) else never()).removeIamRolesForUser(any[GoogleProject], any[WorkbenchEmail], mockitoEq(Set("roles/dataproc.worker")))
       verify(iamDAO, never()).removeServiceAccountKey(any[GoogleProject], any[WorkbenchEmail], any[ServiceAccountKeyId])
+    }
+  }
+
+  // Pre:
+  // - cluster exists in the DB with status Error
+  // - dataproc DAO throws exception
+  // Post:
+  // - cluster is not updated in the DB
+  // - monitor actor shuts down
+  // - dataproc DAO should not have been called
+  it should "stop monitoring a cluster in Error status" in isolatedDbTest {
+    val savedErrorCluster = errorCluster.save()
+    savedErrorCluster shouldEqual errorCluster
+
+    val gdDAO = mock[GoogleDataprocDAO]
+    when {
+      gdDAO.getClusterStatus(mockitoEq(creatingCluster.googleProject), mockitoEq(creatingCluster.clusterName))
+    } thenReturn Future.failed(new Exception)
+
+    val computeDAO = mock[GoogleComputeDAO]
+    val storageDAO = mock[GoogleStorageDAO]
+    val iamDAO = mock[GoogleIamDAO]
+    val authProvider = mock[LeoAuthProvider]
+
+    withClusterSupervisor(gdDAO, computeDAO, iamDAO, storageDAO, authProvider, mockJupyterDAO, false) { actor =>
+      actor ! ClusterCreated(savedErrorCluster, stopAfterCreate = true)
+
+      expectMsgClass(1 second, classOf[Terminated])
+
+      val dbCluster = dbFutureValue { _.clusterQuery.getActiveClusterByName(errorCluster.googleProject, errorCluster.clusterName) }
+      dbCluster shouldBe 'defined
+      dbCluster.get shouldEqual errorCluster
+
+      verify(gdDAO, never()).getClusterStatus(any[GoogleProject], any[ClusterName])
     }
   }
 }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorSpec.scala
@@ -982,10 +982,6 @@ class ClusterMonitorSpec extends TestKit(ActorSystem("leonardotest")) with FlatS
     savedErrorCluster shouldEqual errorCluster
 
     val gdDAO = mock[GoogleDataprocDAO]
-    when {
-      gdDAO.getClusterStatus(mockitoEq(creatingCluster.googleProject), mockitoEq(creatingCluster.clusterName))
-    } thenReturn Future.failed(new Exception)
-
     val computeDAO = mock[GoogleComputeDAO]
     val storageDAO = mock[GoogleStorageDAO]
     val iamDAO = mock[GoogleIamDAO]


### PR DESCRIPTION
Problem: if a "zombie" cluster starts getting monitored (for example at Leo startup) the `ClusterMonitorActor` goes into an infinite error loop. It logs errors like this:

```
Caused by: com.google.api.client.googleapis.json.GoogleJsonResponseException: 403 Forbidden
{
  "code" : 403,
  "errors" : [ {
    "domain" : "usageLimits",
    "message" : "Cloud Dataproc API has not been used in project 713110123530 before or it is disabled. Enable it by visiting https://console.developers.google.com/apis/api/dataproc.googleapis.com/overview?project=713110123530 then retry. If you enabled this API recently, wait a few minutes for the action to propagate to our systems and retry.",
    "reason" : "accessNotConfigured",
    "extendedHelp" : "https://console.developers.google.com"
  } ],
  "message" : "Cloud Dataproc API has not been used in project 713110123530 before or it is disabled. Enable it by visiting https://console.developers.google.com/apis/api/dataproc.googleapis.com/overview?project=713110123530 then retry. If you enabled this API recently, wait a few minutes for the action to propagate to our systems and retry.",
  "status" : "PERMISSION_DENIED"
}
	at com.google.api.client.googleapis.json.GoogleJsonResponseException.from(GoogleJsonResponseException.java:146)
	at com.google.api.client.googleapis.services.json.AbstractGoogleJsonClientRequest.newExceptionOnError(AbstractGoogleJsonClientRequest.java:113)
	at com.google.api.client.googleapis.services.json.AbstractGoogleJsonClientRequest.newExceptionOnError(AbstractGoogleJsonClientRequest.java:40)
	at com.google.api.client.googleapis.services.AbstractGoogleClientRequest$1.interceptResponse(AbstractGoogleClientRequest.java:321)
	at com.google.api.client.http.HttpRequest.execute(HttpRequest.java:1065)
	at com.google.api.client.googleapis.services.AbstractGoogleClientRequest.executeUnparsed(AbstractGoogleClientRequest.java:419)
	at com.google.api.client.googleapis.services.AbstractGoogleClientRequest.executeUnparsed(AbstractGoogleClientRequest.java:352)
	at org.broadinstitute.dsde.workbench.google.GoogleUtilities.$anonfun$executeGoogleCall$1(GoogleUtilities.scala:70)
	at scala.util.Try$.apply(Try.scala:209)
	at org.broadinstitute.dsde.workbench.google.GoogleUtilities.executeGoogleCall(GoogleUtilities.scala:70)
	at org.broadinstitute.dsde.workbench.google.GoogleUtilities.executeGoogleCall$(GoogleUtilities.scala:67)
	at org.broadinstitute.dsde.workbench.google.AbstractHttpGoogleDAO.executeGoogleCall(AbstractHttpGoogleDAO.scala:14)
	at org.broadinstitute.dsde.workbench.google.GoogleUtilities.executeGoogleRequest(GoogleUtilities.scala:51)
	at org.broadinstitute.dsde.workbench.google.GoogleUtilities.executeGoogleRequest$(GoogleUtilities.scala:50)
	at org.broadinstitute.dsde.workbench.google.AbstractHttpGoogleDAO.executeGoogleRequest(AbstractHttpGoogleDAO.scala:14)
	at org.broadinstitute.dsde.workbench.leonardo.dao.google.HttpGoogleDataprocDAO.$anonfun$getCluster$1(HttpGoogleDataprocDAO.scala:344)
```

The loop is not broken _even after_ the zombie cluster is detected and errored by `ZombieClusterMonitor`.

Solution: Have `ClusterMonitorActor` **abort** monitoring of clusters whose DB status have been updated to a terminal state.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
