### PR TITLE
Increase selenium timeout for opening notebooks after resume

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/ClusterMonitoringSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/ClusterMonitoringSpec.scala
@@ -13,6 +13,7 @@ import org.broadinstitute.dsde.workbench.model.google.{EmailGcsEntity, GcsObject
 import org.broadinstitute.dsde.workbench.service.util.Tags
 import org.scalatest.{FreeSpec, ParallelTestExecution}
 
+import scala.concurrent.duration._
 import scala.util.Try
 
 class ClusterMonitoringSpec extends FreeSpec with LeonardoTestUtils with ParallelTestExecution with BillingFixtures {
@@ -130,7 +131,8 @@ class ClusterMonitoringSpec extends FreeSpec with LeonardoTestUtils with Paralle
 
             // TODO make tests rename notebooks?
             val notebookPath = new File("Untitled.ipynb")
-            withOpenNotebook(cluster, notebookPath) { notebookPage =>
+            // Use a longer timeout than default because opening notebooks after resume can be slow
+            withOpenNotebook(cluster, notebookPath, 5.minutes) { notebookPage =>
               // old output should still exist
               val firstCell = notebookPage.firstCell
               notebookPage.cellOutput(firstCell) shouldBe Some(printStr)
@@ -177,7 +179,8 @@ class ClusterMonitoringSpec extends FreeSpec with LeonardoTestUtils with Paralle
               startAndMonitor(cluster.googleProject, cluster.clusterName)
 
               // Verify the Hail import again in a new notebook
-              withNewNotebook(cluster) { notebookPage =>
+              // Use a longer timeout than default because opening notebooks after resume can be slow
+              withNewNotebook(cluster, timeout = 5.minutes) { notebookPage =>
                 notebookPage.executeCell("sum(range(1,10))") shouldBe Some("45")
 
                 // TODO: Hail verification is disabled here because Spark sometimes doesn't restart correctly

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
@@ -288,7 +288,7 @@ trait LeonardoTestUtils extends WebBrowserSpec with Matchers with Eventually wit
         status shouldBe ClusterStatus.Running
       }
 
-      logger.info("Checking if cluster is proxyable yet")
+      logger.info(s"Checking if cluster is proxyable yet")
       val getResult = Try(Leonardo.notebooks.getApi(googleProject, clusterName))
       getResult.isSuccess shouldBe true
       getResult.get should not include "ProxyException"
@@ -434,25 +434,25 @@ trait LeonardoTestUtils extends WebBrowserSpec with Matchers with Eventually wit
     }
   }
 
-  def withNotebookUpload[T](cluster: Cluster, file: File)(testCode: NotebookPage => T)(implicit webDriver: WebDriver, token: AuthToken): T = {
+  def withNotebookUpload[T](cluster: Cluster, file: File, timeout: FiniteDuration = 2.minutes)(testCode: NotebookPage => T)(implicit webDriver: WebDriver, token: AuthToken): T = {
     withFileUpload(cluster, file) { notebooksListPage =>
-      notebooksListPage.withOpenNotebook(file) { notebookPage =>
+      notebooksListPage.withOpenNotebook(file, timeout) { notebookPage =>
         testCode(notebookPage)
       }
     }
   }
 
-  def withNewNotebook[T](cluster: Cluster, kernel: Kernel = PySpark2)(testCode: NotebookPage => T)(implicit webDriver: WebDriver, token: AuthToken): T = {
+  def withNewNotebook[T](cluster: Cluster, kernel: Kernel = PySpark2, timeout: FiniteDuration = 2.minutes)(testCode: NotebookPage => T)(implicit webDriver: WebDriver, token: AuthToken): T = {
     withNotebooksListPage(cluster) { notebooksListPage =>
-      notebooksListPage.withNewNotebook(kernel) { notebookPage =>
+      notebooksListPage.withNewNotebook(kernel, timeout) { notebookPage =>
         testCode(notebookPage)
       }
     }
   }
 
-  def withOpenNotebook[T](cluster: Cluster, notebookPath: File)(testCode: NotebookPage => T)(implicit webDriver: WebDriver, token: AuthToken): T = {
+  def withOpenNotebook[T](cluster: Cluster, notebookPath: File, timeout: FiniteDuration = 2.minutes)(testCode: NotebookPage => T)(implicit webDriver: WebDriver, token: AuthToken): T = {
     withNotebooksListPage(cluster) { notebooksListPage =>
-      notebooksListPage.withOpenNotebook(notebookPath) { notebookPage =>
+      notebooksListPage.withOpenNotebook(notebookPath, timeout) { notebookPage =>
         testCode(notebookPage)
       }
     }

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/NotebookPage.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/NotebookPage.scala
@@ -20,9 +20,7 @@ class NotebookPage(override val url: String)(override implicit val authToken: Au
   extends JupyterPage with Eventually with LazyLogging {
 
   override def open(implicit webDriver: WebDriver): NotebookPage = {
-    val page: NotebookPage = super.open.asInstanceOf[NotebookPage]
-    awaitReadyKernel()
-    page
+    super.open.asInstanceOf[NotebookPage]
   }
 
   // selects all menus from the header bar
@@ -210,7 +208,7 @@ class NotebookPage(override val url: String)(override implicit val authToken: Au
     awaitReadyKernel(timeout)
   }
 
-  def awaitReadyKernel(timeout: FiniteDuration = 2.minutes): Unit = {
+  def awaitReadyKernel(timeout: FiniteDuration): Unit = {
     val time = Timeout(scaled(Span(timeout.toSeconds, Seconds)))
     val pollInterval = Interval(scaled(Span(5, Seconds)))
     eventually(time, pollInterval) {

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorActor.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorActor.scala
@@ -141,14 +141,14 @@ class ClusterMonitorActor(val cluster: Cluster,
       // Remove credentials from instance metadata.
       // Only happens if an notebook service account was used.
       _ <- if (clusterStatus == ClusterStatus.Creating) removeCredentialsFromMetadata else Future.successful(())
-      // Ensure the cluster is ready for proxying but updating the IP -> DNS cache
-      _ <- ensureClusterReadyForProxying(publicIp, clusterStatus)
       // create or update instances in the DB
       _ <- persistInstances(instances)
       // update DB after auth futures finish
       _ <- dbRef.inTransaction { dataAccess =>
         dataAccess.clusterQuery.setToRunning(cluster.id, publicIp)
       }
+      // Ensure the cluster is ready for proxying by updating the IP -> DNS cache
+      _ <- ensureClusterReadyForProxying(publicIp, clusterStatus)
       // Remove the Dataproc Worker IAM role for the cluster service account.
       // Only happens if the cluster was created with a service account other
       // than the compute engine default service account.


### PR DESCRIPTION

See https://github.com/DataBiosphere/leonardo/issues/571

This increases selenium timeouts for opening notebooks, since it is observed that page loads are slow after resuming a cluster (but they should not fail).

Plan is to see if this improves the fail rate for the pause/resume tests, then evaluate if we need to do further work.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
