### PR TITLE
Change jupyter to listen on localhost instead of *

### DIFF
--- a/src/main/resources/jupyter/jupyter_notebook_config.py
+++ b/src/main/resources/jupyter/jupyter_notebook_config.py
@@ -7,7 +7,7 @@ import errno
 import stat
 
 c = get_config()
-c.NotebookApp.ip = '*'
+c.NotebookApp.ip = 'localhost'
 c.NotebookApp.port = 8000
 c.NotebookApp.open_browser = False
 


### PR DESCRIPTION
Something changed and Leo started returning 502s for all requests to the notebooks proxy. This is causing all automation tests to fail since 9/28 8:40pm: https://fc-jenkins.dsp-techops.broadinstitute.org/job/leonardo-fiab-test-runner/

The root cause is this error in jupyter.log:
```
Traceback (most recent call last):
  File "/usr/local/bin/jupyter-notebook", line 11, in <module>
    sys.exit(main())
  File "/usr/local/lib/python2.7/dist-packages/jupyter_core/application.py", line 266, in launch_instance
    return super(JupyterApp, cls).launch_instance(argv=argv, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/traitlets/config/application.py", line 657, in launch_instance
    app.initialize(argv)
  File "<decorator-gen-7>", line 2, in initialize
  File "/usr/local/lib/python2.7/dist-packages/traitlets/config/application.py", line 87, in catch_config_error
    return method(app, *args, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/notebook/notebookapp.py", line 1629, in initialize
    self.init_webapp()
  File "/usr/local/lib/python2.7/dist-packages/notebook/notebookapp.py", line 1379, in init_webapp
    self.jinja_environment_options,
  File "/usr/local/lib/python2.7/dist-packages/notebook/notebookapp.py", line 158, in __init__
    default_url, settings_overrides, jinja_env_options)
  File "/usr/local/lib/python2.7/dist-packages/notebook/notebookapp.py", line 251, in init_settings
    allow_remote_access=jupyter_app.allow_remote_access,
  File "/usr/local/lib/python2.7/dist-packages/traitlets/traitlets.py", line 556, in __get__
    return self.get(obj, cls)
  File "/usr/local/lib/python2.7/dist-packages/traitlets/traitlets.py", line 535, in get
    value = self._validate(obj, dynamic_default())
  File "/usr/local/lib/python2.7/dist-packages/notebook/notebookapp.py", line 872, in _default_allow_remote
    for info in socket.getaddrinfo(self.ip, self.port, 0, socket.SOCK_STREAM):
socket.gaierror: [Errno -2] Name or service not known
```

Googling, it looks like it couldn't resolve '*' as a host name. Changing to `localhost` resolves the issue. This is safe because Jupyter is only accessed by the apache proxy running on the same VM, and the docker [networks use 'host' mode](https://github.com/DataBiosphere/leonardo/blob/develop/src/main/resources/jupyter/cluster-docker-compose.yaml#L25).

I am not sure what caused this to start last night -- possibly some docker dependency changed upstream.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
