### PR TITLE
Save jupyter.log to Jenkins after create and start cluster

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoModelCopy.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoModelCopy.scala
@@ -69,7 +69,9 @@ case class Cluster(clusterName: ClusterName,
                    errors:List[ClusterError],
                    dateAccessed: Instant,
                    defaultClientId: Option[String],
-                   stopAfterCreation: Boolean)
+                   stopAfterCreation: Boolean) {
+  def projectNameString: String = s"${googleProject.value}/${clusterName.string}"
+}
 
 case class ClusterRequest(labels: LabelMap = Map(),
                           jupyterExtensionUri: Option[String] = None,


### PR DESCRIPTION
Haven't run tests yet. This will hopefully help us debug cluster errors after start (and confirm a theory I have that a sqlite database is getting corrupted..).


Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
