### PR TITLE
List clusters by project

### DIFF
--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -119,6 +119,57 @@ paths:
             - email
             - profile
 
+  '/api/clusters/{googleProject}':
+    get:
+      summary: List all active clusters within the given Google project
+      description: List all active clusters within the given Google project, optionally filtering on a set of labels
+      operationId: listClustersByProject
+      tags:
+      - cluster
+      parameters:
+      - in: path
+        name: googleProject
+        description: googleProject
+        required: true
+        type: string
+      - in: query
+        name: _labels
+        description: |
+          Optional label key-value pairs to filter results by. Example: Querying by key1=val1,key2=val2
+          returns all clusters that contain the key1/val1 and key2/val2 labels (possibly among other labels).
+
+          Note: this string format is a workaround because Swagger doesn't support free-form
+          query string parameters. The recommended way to use this endpoint is to specify the
+          labels as top-level query string parameters. For instance: GET /api/clusters?key1=val1&key2=val2.
+        required: false
+        type: string
+      - in: query
+        name: includeDeleted
+        description: Optional filter that includes any clusters with a Deleted status.
+        required: false
+        type: boolean
+        default: false
+      responses:
+        '200':
+          description: List of clusters
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Cluster'
+        '400':
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/ErrorReport'
+        '500':
+          description: Internal Error
+          schema:
+            $ref: '#/definitions/ErrorReport'
+      security:
+      - googleoauth:
+        - openid
+        - email
+        - profile
+
   '/api/cluster/v2/{googleProject}/{clusterName}':
     put:
       summary: Creates a new Dataproc cluster in the given project with the given name.

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/LeoRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/LeoRoutes.scala
@@ -113,11 +113,24 @@ abstract class LeoRoutes(val leonardoService: LeonardoService, val proxyService:
             }
           }
         } ~
-        path("clusters") {
+        pathPrefix("clusters") {
           parameterMap { params =>
-            complete {
-              leonardoService.listClusters(userInfo, params).map { clusters =>
-                StatusCodes.OK -> clusters
+            path(Segment) { googleProject =>
+              get {
+                complete {
+                  leonardoService.listClustersByGoogleProject(userInfo, GoogleProject(googleProject), params).map { clusters =>
+                    StatusCodes.OK -> clusters
+                  }
+                }
+              }
+            } ~
+            pathEndOrSingleSlash {
+              get {
+                complete {
+                  leonardoService.listClusters(userInfo, params).map { clusters =>
+                    StatusCodes.OK -> clusters
+                  }
+                }
               }
             }
           }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoServiceSpec.scala
@@ -787,6 +787,23 @@ class LeonardoServiceSpec extends TestKit(ActorSystem("leonardotest")) with Flat
     }
   }
 
+  it should "list clusters belonging to a project" in isolatedDbTest {
+    // create a couple of clusters
+    val clusterName1 = ClusterName(s"cluster-${UUID.randomUUID.toString}")
+    val cluster1 = leo.createCluster(userInfo, project, clusterName1, testClusterRequest).futureValue
+
+    val clusterName2 = ClusterName(s"cluster-${UUID.randomUUID.toString}")
+    val newProject = GoogleProject("new-project")
+    val cluster2 = leo.createCluster(userInfo, newProject, clusterName2, testClusterRequest.copy(labels = Map("a" -> "b", "foo" -> "bar"))).futureValue
+
+    leo.listClustersByGoogleProject(userInfo, project, Map.empty).futureValue.toSet shouldBe Set(cluster1)
+    leo.listClustersByGoogleProject(userInfo, newProject, Map.empty).futureValue.toSet shouldBe Set(cluster2)
+    leo.listClustersByGoogleProject(userInfo, project, Map("foo" -> "bar")).futureValue.toSet shouldBe Set(cluster1)
+    leo.listClustersByGoogleProject(userInfo, newProject, Map("foo" -> "bar")).futureValue.toSet shouldBe Set(cluster2)
+    leo.listClustersByGoogleProject(userInfo, project, Map("k" -> "v")).futureValue.toSet shouldBe Set.empty
+    leo.listClustersByGoogleProject(userInfo, newProject, Map("k" -> "v")).futureValue.toSet shouldBe Set.empty
+  }
+
   it should "delete the init bucket if cluster creation fails" in isolatedDbTest {
     // create the cluster
     val clusterCreateResponse = leo.createCluster(userInfo, project, gdDAO.badClusterName, testClusterRequest).failed.futureValue


### PR DESCRIPTION
Adds a new Leo endpoint to list clusters belonging to a given Google project.

This is to address a performance issue: when the UI calls `listClusters` it is filtering clusters to the current google project, but internally Leo is selecting ALL non-deleted clusters from the DB and testing each one against Sam. With this new endpoint, Leo includes a `WHERE googleProject = ?` in the DB query, drastically reducing the number of records we need to process.

UI PR to use this endpoint is here: TBD

Tests pass, I'd like to do manual testing on a fiab next.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
