### PR TITLE
#625: Make Dataproc init script timeout configurable

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -3,6 +3,7 @@
 dataproc {
   applicationName = "firecloud:leonardo"
   dataprocDockerImage = "gcr.io/broad-dsde-prod/leonardo-notebooks:prod"
+  defaultExecutionTimeout = "1800s"
   jupyterServerName = "jupyter-server"
   firewallRuleName = "leonardo-notebooks-rule"
   networkTag = "leonardo"

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -3,7 +3,7 @@
 dataproc {
   applicationName = "firecloud:leonardo"
   dataprocDockerImage = "gcr.io/broad-dsde-prod/leonardo-notebooks:prod"
-  defaultExecutionTimeout = "1800s"
+  defaultExecutionTimeout = 30 minutes
   jupyterServerName = "jupyter-server"
   firewallRuleName = "leonardo-notebooks-rule"
   networkTag = "leonardo"

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/Boot.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/Boot.scala
@@ -77,7 +77,7 @@ object Boot extends App with LazyLogging {
     }
 
     val (leoServiceAccountEmail, leoServiceAccountPemFile) = serviceAccountProvider.getLeoServiceAccountAndKey
-    val gdDAO = new HttpGoogleDataprocDAO(dataprocConfig.applicationName, Pem(leoServiceAccountEmail, leoServiceAccountPemFile), "google", NetworkTag(dataprocConfig.networkTag), dataprocConfig.vpcNetwork.map(VPCNetworkName), dataprocConfig.vpcSubnet.map(VPCSubnetName), dataprocConfig.dataprocDefaultRegion)
+    val gdDAO = new HttpGoogleDataprocDAO(dataprocConfig.applicationName, Pem(leoServiceAccountEmail, leoServiceAccountPemFile), "google", NetworkTag(dataprocConfig.networkTag), dataprocConfig.vpcNetwork.map(VPCNetworkName), dataprocConfig.vpcSubnet.map(VPCSubnetName), dataprocConfig.dataprocDefaultRegion, dataprocConfig.defaultExecutionTimeout)
     val googleComputeDAO = new HttpGoogleComputeDAO(dataprocConfig.applicationName, Pem(leoServiceAccountEmail, leoServiceAccountPemFile), "google")
     val googleIamDAO = new HttpGoogleIamDAO(dataprocConfig.applicationName, Pem(leoServiceAccountEmail, leoServiceAccountPemFile), "google")
     val googleStorageDAO = new HttpGoogleStorageDAO(dataprocConfig.applicationName, Pem(leoServiceAccountEmail, leoServiceAccountPemFile), "google")

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/DataprocConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/DataprocConfig.scala
@@ -2,13 +2,15 @@ package org.broadinstitute.dsde.workbench.leonardo.config
 
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 
+import scala.concurrent.duration.FiniteDuration
+
 case class DataprocConfig(
                            applicationName: String,
                            dataprocDefaultRegion: String,
                            leoGoogleProject: GoogleProject,
                            dataprocDockerImage: String,
                            clusterUrlBase: String,
-                           defaultExecutionTimeout: String,
+                           defaultExecutionTimeout: FiniteDuration,
                            jupyterServerName: String,
                            firewallRuleName: String,
                            networkTag: String,

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/DataprocConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/DataprocConfig.scala
@@ -8,6 +8,7 @@ case class DataprocConfig(
                            leoGoogleProject: GoogleProject,
                            dataprocDockerImage: String,
                            clusterUrlBase: String,
+                           defaultExecutionTimeout: String,
                            jupyterServerName: String,
                            firewallRuleName: String,
                            networkTag: String,

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/package.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/package.scala
@@ -23,7 +23,7 @@ package object config {
       GoogleProject(config.getString("leoGoogleProject")),
       config.getString("dataprocDockerImage"),
       config.getString("clusterUrlBase"),
-      config.getString("defaultExecutionTimeout"),
+      toScalaDuration(config.getDuration("defaultExecutionTimeout")),
       config.getString("jupyterServerName"),
       config.getString("firewallRuleName"),
       config.getString("networkTag"),

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/package.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/package.scala
@@ -23,6 +23,7 @@ package object config {
       GoogleProject(config.getString("leoGoogleProject")),
       config.getString("dataprocDockerImage"),
       config.getString("clusterUrlBase"),
+      config.getString("defaultExecutionTimeout"),
       config.getString("jupyterServerName"),
       config.getString("firewallRuleName"),
       config.getString("networkTag"),

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/google/HttpGoogleDataprocDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/google/HttpGoogleDataprocDAO.scala
@@ -27,6 +27,7 @@ import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GcsPath, G
 import org.broadinstitute.dsde.workbench.model.{UserInfo, WorkbenchEmail, WorkbenchException, WorkbenchUserId}
 
 import scala.collection.JavaConverters._
+import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Try
 
@@ -37,7 +38,7 @@ class HttpGoogleDataprocDAO(appName: String,
                             vpcNetwork: Option[VPCNetworkName],
                             vpcSubnet: Option[VPCSubnetName],
                             defaultRegion: String,
-                            defaultExecutionTimeout: String)
+                            defaultExecutionTimeout: FiniteDuration)
                            (implicit override val system: ActorSystem, override val executionContext: ExecutionContext)
   extends AbstractHttpGoogleDAO(appName, googleCredentialMode, workbenchMetricBaseName) with GoogleDataprocDAO {
 
@@ -239,7 +240,7 @@ class HttpGoogleDataprocDAO(appName: String,
 
     // Create a NodeInitializationAction, which specifies the executable to run on a node.
     // This executable is our init-actions.sh, which will stand up our jupyter server and proxy.
-    val initActions = Seq(new NodeInitializationAction().setExecutableFile(initScript.toUri).setExecutionTimeout(defaultExecutionTimeout))
+    val initActions = Seq(new NodeInitializationAction().setExecutableFile(initScript.toUri).setExecutionTimeout(s"${defaultExecutionTimeout.toSeconds}s"))
 
     // Create a config for the master node, if properties are not specified in request, use defaults
     val masterConfig = new InstanceGroupConfig()

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/google/HttpGoogleDataprocDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/google/HttpGoogleDataprocDAO.scala
@@ -36,7 +36,8 @@ class HttpGoogleDataprocDAO(appName: String,
                             networkTag: NetworkTag,
                             vpcNetwork: Option[VPCNetworkName],
                             vpcSubnet: Option[VPCSubnetName],
-                            defaultRegion: String)
+                            defaultRegion: String,
+                            defaultExecutionTimeout: String)
                            (implicit override val system: ActorSystem, override val executionContext: ExecutionContext)
   extends AbstractHttpGoogleDAO(appName, googleCredentialMode, workbenchMetricBaseName) with GoogleDataprocDAO {
 
@@ -238,7 +239,7 @@ class HttpGoogleDataprocDAO(appName: String,
 
     // Create a NodeInitializationAction, which specifies the executable to run on a node.
     // This executable is our init-actions.sh, which will stand up our jupyter server and proxy.
-    val initActions = Seq(new NodeInitializationAction().setExecutableFile(initScript.toUri))
+    val initActions = Seq(new NodeInitializationAction().setExecutableFile(initScript.toUri).setExecutionTimeout(defaultExecutionTimeout))
 
     // Create a config for the master node, if properties are not specified in request, use defaults
     val masterConfig = new InstanceGroupConfig()

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/google/HttpGoogleDataprocDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/google/HttpGoogleDataprocDAO.scala
@@ -2,7 +2,6 @@ package org.broadinstitute.dsde.workbench.leonardo.dao.google
 
 import java.time.Instant
 import java.util.UUID
-import java.util.concurrent.TimeUnit
 
 import akka.actor.ActorSystem
 import akka.http.scaladsl.model.StatusCodes

--- a/src/test/resources/reference.conf
+++ b/src/test/resources/reference.conf
@@ -35,7 +35,7 @@ dataproc {
   leoGoogleProject = "test-bucket"
   dataprocDockerImage = "testrepo/test"
   clusterUrlBase = "http://leonardo/"
-  defaultExecutionTimeout = "1800s"
+  defaultExecutionTimeout = 30 minutes
   jupyterServerName = "test-server"
   createClusterAsPetServiceAccount = false
   firewallRuleName = "test-rule"

--- a/src/test/resources/reference.conf
+++ b/src/test/resources/reference.conf
@@ -35,6 +35,7 @@ dataproc {
   leoGoogleProject = "test-bucket"
   dataprocDockerImage = "testrepo/test"
   clusterUrlBase = "http://leonardo/"
+  defaultExecutionTimeout = "1800s"
   jupyterServerName = "test-server"
   createClusterAsPetServiceAccount = false
   firewallRuleName = "test-rule"


### PR DESCRIPTION
will go in after https://github.com/broadinstitute/firecloud-develop/pull/1393 and tests will fail until then

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've documented my API changes in Swagger

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [x] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
