### PR TITLE
#596: Return 401 only when it's an authentication error

### DIFF
--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -253,6 +253,8 @@ paths:
           description: Bad Request
           schema:
             $ref: '#/definitions/ErrorReport'
+        '403':
+            description: User does not have permission to perform action on cluster
         '409':
           description: Conflict
           schema:
@@ -288,6 +290,8 @@ paths:
           description: Cluster found, here are the details
           schema:
             $ref: '#/definitions/Cluster'
+        '403':
+          description: User does not have permission to perform action on cluster
         '404':
           description: Cluster not found
           schema:
@@ -321,6 +325,8 @@ paths:
       responses:
         '202':
           description: Cluster deletion request accepted
+        '403':
+          description: User does not have permission to perform action on cluster
         '404':
           description: Cluster not found
           schema:
@@ -353,6 +359,8 @@ paths:
       responses:
         '202':
           description: Cluster stop request accepted
+        '403':
+          description: User does not have permission to perform action on cluster
         '404':
           description: Cluster not found
           schema:
@@ -388,6 +396,8 @@ paths:
       responses:
         '202':
           description: Cluster start request accepted
+        '403':
+          description: User does not have permission to perform action on cluster
         '404':
           description: Cluster not found
           schema:

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -424,7 +424,7 @@ paths:
       responses:
         '200':
           description: Proxy connection successful
-        '401':
+        '403':
           description: Proxy connection unauthorized
           schema:
             $ref: '#/definitions/ErrorReport'
@@ -502,7 +502,7 @@ paths:
           description: Proxy connection successful
         '400':
           description: "Bad request. Your POST body is probably malformed: it should be a string/string JSON object."
-        '401':
+        '403':
           description: Proxy connection unauthorized
           schema:
             $ref: '#/definitions/ErrorReport'

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/ProxyRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/ProxyRoutes.scala
@@ -6,7 +6,7 @@ import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.{Directive0, Directive1, Route}
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.workbench.leonardo.model.google.ClusterName
-import org.broadinstitute.dsde.workbench.leonardo.service.{AuthorizationError, ProxyService}
+import org.broadinstitute.dsde.workbench.leonardo.service.{AuthenticationError, AuthorizationError, ProxyService}
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import akka.http.scaladsl.model.headers._
 import akka.http.scaladsl.server.RouteResult.Complete
@@ -93,7 +93,7 @@ trait ProxyRoutes extends UserInfoDirectives with CorsSupport with CookieHelper 
         case Some(cookie) => provide(cookie.value)
 
         // Not found in cookie or Authorization header, fail
-        case None => failWith(AuthorizationError())
+        case None => failWith(AuthenticationError())
       }
     }
   }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/google/HttpGoogleDataprocDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/google/HttpGoogleDataprocDAO.scala
@@ -20,7 +20,7 @@ import org.broadinstitute.dsde.workbench.google.AbstractHttpGoogleDAO
 import org.broadinstitute.dsde.workbench.google.GoogleCredentialModes._
 import org.broadinstitute.dsde.workbench.leonardo.model.google.DataprocRole.{Master, SecondaryWorker, Worker}
 import org.broadinstitute.dsde.workbench.leonardo.model.google._
-import org.broadinstitute.dsde.workbench.leonardo.service.{AuthorizationError, BucketObjectAccessException, DataprocDisabledException}
+import org.broadinstitute.dsde.workbench.leonardo.service.{AuthenticationError, AuthorizationError, BucketObjectAccessException, DataprocDisabledException}
 import org.broadinstitute.dsde.workbench.metrics.GoogleInstrumentedService
 import org.broadinstitute.dsde.workbench.metrics.GoogleInstrumentedService.GoogleInstrumentedService
 import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GcsPath, GoogleProject}
@@ -208,7 +208,7 @@ class HttpGoogleDataprocDAO(appName: String,
           throw new WorkbenchException(msg, e)
         // Google throws IllegalArgumentException when passed an invalid token. Handle this case and rethrow a 401.
         case e: IllegalArgumentException =>
-          throw AuthorizationError()
+          throw AuthenticationError()
       }
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/LeoRoutesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/LeoRoutesSpec.scala
@@ -44,9 +44,9 @@ class LeoRoutesSpec extends FlatSpec with ScalatestRouteTest with CommonTestData
     }
   }
 
-  it should "401 if you're not on the whitelist" in isolatedDbTest {
+  it should "403 if you're not on the whitelist" in isolatedDbTest {
     Get(s"/api/isWhitelisted") ~> invalidUserLeoRoutes.route ~> check {
-      status shouldEqual StatusCodes.Unauthorized
+      status shouldEqual StatusCodes.Forbidden
     }
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/AuthProviderSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/AuthProviderSpec.scala
@@ -107,7 +107,7 @@ class AuthProviderSpec extends FreeSpec with ScalatestRouteTest with Matchers wi
       //can't make a cluster
       val clusterCreateException = leo.createCluster(userInfo, project, cluster1Name, testClusterRequest).failed.futureValue
       clusterCreateException shouldBe a [AuthorizationError]
-      clusterCreateException.asInstanceOf[AuthorizationError].statusCode shouldBe StatusCodes.Unauthorized
+      clusterCreateException.asInstanceOf[AuthorizationError].statusCode shouldBe StatusCodes.Forbidden
 
       //can't get details on an existing cluster
       //poke a cluster into the database so we actually have something to look for


### PR DESCRIPTION
~Did my best to go through and sort things out throughout the entire service. If you're reviewing this early, just know that I am going to do another pass on this but I think I got them all.~

Note that we also need to communicate this change to comms because this does result in some minor response code changes.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've documented my API changes in Swagger

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [x] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
