### PR TITLE
Fix null check for unset googleClientId

### DIFF
--- a/src/main/resources/jupyter/google_sign_in.js
+++ b/src/main/resources/jupyter/google_sign_in.js
@@ -83,7 +83,7 @@ function set_cookie(token, expires_in) {
 function init() {
     startTimer();
     window.addEventListener('message', receive);
-    if (googleClientId == null) {
+    if (!googleClientId) {
         window.opener.postMessage({'type': 'bootstrap-auth.request'}, '*');
     }
 }


### PR DESCRIPTION
Likely this was a regression with the addition of "defaultClientId". If a default is unspecified, `googleClientId` is now set to `""`. `"" == null` fails, so we never request the client ID from the parent frame.