### PR TITLE
Experimental: obtain apt-key in init-actions.sh to work around interm…

### DIFF
--- a/src/main/resources/jupyter/init-actions.sh
+++ b/src/main/resources/jupyter/init-actions.sh
@@ -96,6 +96,11 @@ if [[ "${ROLE}" == 'Master' ]]; then
 
     log 'Installing prerequisites...'
 
+    # Obtain the latest valid apt-key.gpg key file from https://packages.cloud.google.com to work
+    # around intermittent apt authentication errors. See:
+    # https://cloud.google.com/compute/docs/troubleshooting/known-issues
+    retry 5 curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
+
     # install Docker
     # https://docs.docker.com/install/linux/docker-ce/debian/
     export DOCKER_CE_VERSION="18.03.0~ce-0~debian"

--- a/src/main/resources/jupyter/init-actions.sh
+++ b/src/main/resources/jupyter/init-actions.sh
@@ -100,6 +100,7 @@ if [[ "${ROLE}" == 'Master' ]]; then
     # around intermittent apt authentication errors. See:
     # https://cloud.google.com/compute/docs/troubleshooting/known-issues
     retry 5 curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
+    retry 5 apt-key update
 
     # install Docker
     # https://docs.docker.com/install/linux/docker-ce/debian/


### PR DESCRIPTION
…ittent apt authentication failures

See comment in: https://broadinstitute.atlassian.net/browse/GAWB-3868

\<your comments for this PR go here\>

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
