### PR TITLE
Upgrade java to u191, the old one doesn't exist anymore

### DIFF
--- a/jupyter-docker/Dockerfile
+++ b/jupyter-docker/Dockerfile
@@ -55,9 +55,9 @@ ENV LC_ALL en_US.UTF-8
 # Java
 #######################
 
-ENV JAVA_VER jdk1.8.0_181
-ENV JAVA_TGZ jdk-8u181-linux-x64.tar.gz
-ENV JAVA_URL http://download.oracle.com/otn-pub/java/jdk/8u181-b13/96a7b8442fe848ef90c96a2fad6ed6d1/$JAVA_TGZ
+ENV JAVA_VER jdk1.8.0_191
+ENV JAVA_TGZ jdk-8u191-linux-x64.tar.gz
+ENV JAVA_URL http://download.oracle.com/otn-pub/java/jdk/8u191-b12/2787e4a523244c269598db4e85c51e0c/$JAVA_TGZ
 ENV JAVA_HOME /usr/lib/jdk/$JAVA_VER
 
 RUN wget --header "Cookie: oraclelicense=accept-securebackup-cookie" $JAVA_URL \


### PR DESCRIPTION
This is causing some build failures, so we should get this out sooner rather than later. I think this is included in @akarukappadath's dockerfire branch.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
