### PR TITLE
Increase akka patience in ClusterMonitorSpec

### DIFF
--- a/src/test/resources/reference.conf
+++ b/src/test/resources/reference.conf
@@ -91,6 +91,12 @@ swagger {
   realm = "broad-dsde-test"
 }
 
+monitor {
+  pollPeriod = 1 second
+  maxRetries = -1  # means retry forever
+  recreateCluster = true
+}
+
 auth {
   providerClass = "org.broadinstitute.dsde.workbench.leonardo.auth.SamAuthProvider"
   providerConfig = {

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorSpec.scala
@@ -9,10 +9,10 @@ import akka.testkit.TestKit
 import io.grpc.Status.Code
 import org.broadinstitute.dsde.workbench.google.mock.MockGoogleStorageDAO
 import org.broadinstitute.dsde.workbench.google.{GoogleIamDAO, GoogleStorageDAO}
-
 import org.broadinstitute.dsde.workbench.leonardo.dao.JupyterDAO
 import org.broadinstitute.dsde.workbench.leonardo.dao.google.{GoogleComputeDAO, GoogleDataprocDAO}
 import org.broadinstitute.dsde.workbench.leonardo.ClusterEnrichments.clusterEq
+import org.broadinstitute.dsde.workbench.leonardo.config.MonitorConfig
 import org.broadinstitute.dsde.workbench.leonardo.{CommonTestData, GcsPathUtils}
 import org.broadinstitute.dsde.workbench.leonardo.db.{DbSingleton, TestComponent}
 import org.broadinstitute.dsde.workbench.leonardo.dns.ClusterDnsCache
@@ -105,7 +105,7 @@ class ClusterMonitorSpec extends TestKit(ActorSystem("leonardotest")) with FlatS
     val mockPetGoogleStorageDAO: String => GoogleStorageDAO = _ => {
       new MockGoogleStorageDAO
     }
-    val supervisorActor = system.actorOf(TestClusterSupervisorActor.props(dataprocConfig, gdDAO, computeDAO, iamDAO, storageDAO, DbSingleton.ref, cacheActor, testKit, authProvider, autoFreezeConfig, jupyterDAO))
+    val supervisorActor = system.actorOf(TestClusterSupervisorActor.props(monitorConfig, dataprocConfig, gdDAO, computeDAO, iamDAO, storageDAO, DbSingleton.ref, cacheActor, testKit, authProvider, autoFreezeConfig, jupyterDAO))
     new LeonardoService(dataprocConfig, clusterFilesConfig, clusterResourcesConfig, clusterDefaultsConfig, proxyConfig, swaggerConfig, autoFreezeConfig, gdDAO, computeDAO, iamDAO, storageDAO, mockPetGoogleStorageDAO, DbSingleton.ref, supervisorActor, whitelistAuthProvider, serviceAccountProvider, whitelist, bucketHelper, contentSecurityPolicy)
     supervisorActor
   }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/TestClusterSupervisorActor.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/TestClusterSupervisorActor.scala
@@ -21,7 +21,23 @@ object TearDown
 /**
   * Extends ClusterMonitorSupervisor so the akka TestKit can watch the child ClusterMonitorActors.
   */
-class TestClusterSupervisorActor(dataprocConfig: DataprocConfig, gdDAO: GoogleDataprocDAO, googleComputeDAO: GoogleComputeDAO, googleIamDAO: GoogleIamDAO, googleStorageDAO: GoogleStorageDAO, dbRef: DbReference, clusterDnsCache: ActorRef, testKit: TestKit, authProvider: LeoAuthProvider, autoFreezeConfig: AutoFreezeConfig, jupyterProxyDAO: JupyterDAO) extends ClusterMonitorSupervisor(MonitorConfig(100 millis), dataprocConfig, gdDAO, googleComputeDAO, googleIamDAO, googleStorageDAO, dbRef, clusterDnsCache, authProvider, autoFreezeConfig, jupyterProxyDAO) {
+class TestClusterSupervisorActor(dataprocConfig: DataprocConfig,
+                                 gdDAO: GoogleDataprocDAO,
+                                 googleComputeDAO: GoogleComputeDAO,
+                                 googleIamDAO: GoogleIamDAO,
+                                 googleStorageDAO: GoogleStorageDAO,
+                                 dbRef: DbReference,
+                                 clusterDnsCache: ActorRef,
+                                 testKit: TestKit,
+                                 authProvider: LeoAuthProvider,
+                                 autoFreezeConfig: AutoFreezeConfig,
+                                 jupyterProxyDAO: JupyterDAO)
+  extends ClusterMonitorSupervisor(
+    MonitorConfig(1 second),
+    dataprocConfig, gdDAO, googleComputeDAO, googleIamDAO,
+    googleStorageDAO, dbRef, clusterDnsCache, authProvider,
+    autoFreezeConfig, jupyterProxyDAO) {
+
   // Keep track of spawned child actors so we can shut them down when this actor is stopped
   var childActors: Seq[ActorRef] = Seq.empty
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/TestClusterSupervisorActor.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/TestClusterSupervisorActor.scala
@@ -12,8 +12,8 @@ import org.broadinstitute.dsde.workbench.leonardo.model.{Cluster, LeoAuthProvide
 import scala.concurrent.duration._
 
 object TestClusterSupervisorActor {
-  def props(dataprocConfig: DataprocConfig, gdDAO: GoogleDataprocDAO, googleComputeDAO: GoogleComputeDAO, googleIamDAO: GoogleIamDAO, googleStorageDAO: GoogleStorageDAO, dbRef: DbReference, clusterDnsCache: ActorRef, testKit: TestKit, authProvider: LeoAuthProvider, autoFreezeConfig: AutoFreezeConfig, jupyterProxyDAO: JupyterDAO): Props =
-    Props(new TestClusterSupervisorActor(dataprocConfig, gdDAO, googleComputeDAO, googleIamDAO, googleStorageDAO, dbRef, clusterDnsCache, testKit, authProvider, autoFreezeConfig, jupyterProxyDAO))
+  def props(monitorConfig: MonitorConfig, dataprocConfig: DataprocConfig, gdDAO: GoogleDataprocDAO, googleComputeDAO: GoogleComputeDAO, googleIamDAO: GoogleIamDAO, googleStorageDAO: GoogleStorageDAO, dbRef: DbReference, clusterDnsCache: ActorRef, testKit: TestKit, authProvider: LeoAuthProvider, autoFreezeConfig: AutoFreezeConfig, jupyterProxyDAO: JupyterDAO): Props =
+    Props(new TestClusterSupervisorActor(monitorConfig, dataprocConfig, gdDAO, googleComputeDAO, googleIamDAO, googleStorageDAO, dbRef, clusterDnsCache, testKit, authProvider, autoFreezeConfig, jupyterProxyDAO))
 }
 
 object TearDown
@@ -21,7 +21,8 @@ object TearDown
 /**
   * Extends ClusterMonitorSupervisor so the akka TestKit can watch the child ClusterMonitorActors.
   */
-class TestClusterSupervisorActor(dataprocConfig: DataprocConfig,
+class TestClusterSupervisorActor(monitorConfig: MonitorConfig,
+                                 dataprocConfig: DataprocConfig,
                                  gdDAO: GoogleDataprocDAO,
                                  googleComputeDAO: GoogleComputeDAO,
                                  googleIamDAO: GoogleIamDAO,
@@ -33,10 +34,9 @@ class TestClusterSupervisorActor(dataprocConfig: DataprocConfig,
                                  autoFreezeConfig: AutoFreezeConfig,
                                  jupyterProxyDAO: JupyterDAO)
   extends ClusterMonitorSupervisor(
-    MonitorConfig(1 second),
-    dataprocConfig, gdDAO, googleComputeDAO, googleIamDAO,
-    googleStorageDAO, dbRef, clusterDnsCache, authProvider,
-    autoFreezeConfig, jupyterProxyDAO) {
+    monitorConfig, dataprocConfig, gdDAO, googleComputeDAO,
+    googleIamDAO, googleStorageDAO, dbRef, clusterDnsCache,
+    authProvider, autoFreezeConfig, jupyterProxyDAO) {
 
   // Keep track of spawned child actors so we can shut them down when this actor is stopped
   var childActors: Seq[ActorRef] = Seq.empty


### PR DESCRIPTION
Hopefully addresses a common unit test flake:

```
java.lang.AssertionError: assertion failed: timeout (1 second) during expectMsgClass waiting for class akka.actor.Terminated
    at scala.Predef$.assert(Predef.scala:219)
    at akka.testkit.TestKitBase.expectMsgClass_internal(TestKit.scala:509)
    at akka.testkit.TestKitBase.expectMsgClass(TestKit.scala:505)
    at akka.testkit.TestKitBase.expectMsgClass$(TestKit.scala:505)
    at akka.testkit.TestKit.expectMsgClass(TestKit.scala:896)
    at org.broadinstitute.dsde.workbench.leonardo.monitor.ClusterMonitorSpec.$anonfun$new$3(ClusterMonitorSpec.scala:174)
    at org.broadinstitute.dsde.workbench.leonardo.monitor.ClusterMonitorSpec.$anonfun$withClusterSupervisor$1(ClusterMonitorSpec.scala:113)
```

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
