### PR TITLE
GAWB-3947: update serviceTest version to get bugfixes [risk: low]

### DIFF
--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -9,7 +9,7 @@ object Dependencies {
 
   val workbenchModelV   = "0.12-a19203d"
   val workbenchGoogleV  = "0.16-f2a0020"
-  val serviceTestV = "0.12-7b3f0d6"
+  val serviceTestV = "0.13-dc0998e"
 
   val excludeWorkbenchModel  = ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = "workbench-model_" + scalaV)
   val excludeWorkbenchGoogle = ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = "workbench-google_" + scalaV)


### PR DESCRIPTION
Ticket: GAWB-3947

update serviceTest version in automation, to pick up this bugfix from workbench-libs:

> bugfix: BillingFixtures.claimGPAllocProject now uses the proper OAuth scopes in the case where GPAlloc did not return a project and therefore the calling test needs to create one on the fly.

---


Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've documented my API changes in Swagger

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [x] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
