### PR TITLE
Null check window.opener before using it

### DIFF
--- a/src/main/resources/jupyter/google_sign_in.js
+++ b/src/main/resources/jupyter/google_sign_in.js
@@ -83,7 +83,7 @@ function set_cookie(token, expires_in) {
 function init() {
     startTimer();
     window.addEventListener('message', receive);
-    if (!googleClientId) {
+    if (!googleClientId && window.opener) {
         window.opener.postMessage({'type': 'bootstrap-auth.request'}, '*');
     }
 }


### PR DESCRIPTION
I noticed this in a lot of test console logs:

```
[2018-11-05T17:14:34+0000] [SEVERE] https://leonardo-fiab.dsde-qa.broadinstitute.org:30443/notebooks/gpalloc-qa-master-hgfhhlk/automation-test-al1imp9nz/custom/google_sign_in.js?v=20181105171319 86:22 Uncaught TypeError: Cannot read property 'postMessage' of null
```

It was probably introduced as a result of [this PR](https://github.com/DataBiosphere/leonardo/pull/644). There is no `window.opener` in tests so it was trying to use a null reference.

Complete speculation, but I was wondering if the uncaught error was causing other issues in the Jupyter JS code, perhaps leading to the "kernel not ready" test failures in https://broadinstitute.atlassian.net/browse/GAWB-3882.

Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
