### PR TITLE
Increase timeout to wait for jupyter kernel after resuming cluster in tests

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/ClusterMonitoringSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/ClusterMonitoringSpec.scala
@@ -132,7 +132,7 @@ class ClusterMonitoringSpec extends FreeSpec with LeonardoTestUtils with Paralle
             // TODO make tests rename notebooks?
             val notebookPath = new File("Untitled.ipynb")
             // Use a longer timeout than default because opening notebooks after resume can be slow
-            withOpenNotebook(cluster, notebookPath, 5.minutes) { notebookPage =>
+            withOpenNotebook(cluster, notebookPath, 10.minutes) { notebookPage =>
               // old output should still exist
               val firstCell = notebookPage.firstCell
               notebookPage.cellOutput(firstCell) shouldBe Some(printStr)
@@ -180,7 +180,7 @@ class ClusterMonitoringSpec extends FreeSpec with LeonardoTestUtils with Paralle
 
               // Verify the Hail import again in a new notebook
               // Use a longer timeout than default because opening notebooks after resume can be slow
-              withNewNotebook(cluster, timeout = 5.minutes) { notebookPage =>
+              withNewNotebook(cluster, timeout = 10.minutes) { notebookPage =>
                 notebookPage.executeCell("sum(range(1,10))") shouldBe Some("45")
 
                 // TODO: Hail verification is disabled here because Spark sometimes doesn't restart correctly

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/NotebookPage.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/NotebookPage.scala
@@ -215,10 +215,17 @@ class NotebookPage(override val url: String)(override implicit val authToken: Au
     val time = Timeout(scaled(Span(timeout.toSeconds, Seconds)))
     val pollInterval = Interval(scaled(Span(5, Seconds)))
     try {
+      val t0 = System.nanoTime()
+
       eventually(time, pollInterval) {
         val ready = (!cellsAreRunning && isKernelReady && kernelNotificationText == "none")
         ready shouldBe true
       }
+
+      val t1 = System.nanoTime()
+      val timediff = FiniteDuration(t1 - t0, NANOSECONDS)
+
+      logger.info(s"kernel was ready after ${timediff.toSeconds} seconds. Timeout was ${timeout.toSeconds}")
     } catch {
       case e: TestFailedDueToTimeoutException => throw KernelNotReadyException(time)
     }


### PR DESCRIPTION
\<your comments for this PR go here\>

Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
