### PR TITLE
[692] Allow users to pick their Jupyter image at cluster creation time

### DIFF
--- a/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changelog.xml
+++ b/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changelog.xml
@@ -27,4 +27,5 @@
     <include file="changesets/20180625_autopause_threshold.xml" relativeToChangelogFile="true" />
     <include file="changesets/20180810_default_client_id.xml" relativeToChangelogFile="true" />
     <include file="changesets/20180919_stop_after_creation.xml" relativeToChangelogFile="true" />
+    <include file="changesets/20181126_cluster_image.xml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/20181126_cluster_image.xml
+++ b/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/20181126_cluster_image.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog logicalFilePath="leonardo" xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+    <changeSet logicalFilePath="leonardo" author="rtitle" id="cluster_image">
+        <createTable tableName="CLUSTER_IMAGE">
+            <column name="clusterId" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="tool" type="VARCHAR(254)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="dockerImage" type="VARCHAR(1024)">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+        <createIndex indexName="FK_CLUSTER_IMAGE_CLUSTER_ID" tableName="CLUSTER_IMAGE">
+            <column name="clusterId"/>
+        </createIndex>
+        <addForeignKeyConstraint baseColumnNames="clusterId" baseTableName="CLUSTER_IMAGE" constraintName="FK_CLUSTER_IMAGE_CLUSTER_ID" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="id" referencedTableName="CLUSTER"/>
+        <addUniqueConstraint columnNames="clusterId, tool" constraintName="IDX_CLUSTER_IMAGE_UNIQUE" tableName="CLUSTER_IMAGE"/>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/20181126_cluster_image.xml
+++ b/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/20181126_cluster_image.xml
@@ -11,6 +11,9 @@
             <column name="dockerImage" type="VARCHAR(1024)">
                 <constraints nullable="false"/>
             </column>
+            <column name="timestamp" type="TIMESTAMP(6)" defaultValueComputed="NOW(6)">
+                <constraints nullable="false"/>
+            </column>
         </createTable>
         <createIndex indexName="FK_CLUSTER_IMAGE_CLUSTER_ID" tableName="CLUSTER_IMAGE">
             <column name="clusterId"/>

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -870,7 +870,7 @@ definitions:
         description: The default Google Client ID.
       jupyterDockerImage:
         type: String
-        description: The Jupyter image to install. If not set, then a default Jupyter image will be installed.
+        description: The Jupyter docker image to install. May be Dockerhub or GCR. If not set, then a default Jupyter image will be installed.
 
   ClusterError:
     description: 'Errors encountered on cluster create'

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -868,6 +868,9 @@ definitions:
       defaultClientId:
         type: string
         description: The default Google Client ID.
+      jupyterDockerImage:
+        type: String
+        description: The Jupyter image to install. If not set, then a default Jupyter image will be installed.
 
   ClusterError:
     description: 'Errors encountered on cluster create'

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/AllComponents.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/AllComponents.scala
@@ -1,4 +1,9 @@
 package org.broadinstitute.dsde.workbench.leonardo.db
 
 // a trait combining all of the individual LeoComponent traits
-trait AllComponents extends ClusterComponent with LabelComponent with ClusterErrorComponent with InstanceComponent with ExtensionComponent
+trait AllComponents extends ClusterComponent
+  with LabelComponent
+  with ClusterErrorComponent
+  with InstanceComponent
+  with ExtensionComponent
+  with ClusterImageComponent

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponent.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponent.scala
@@ -45,7 +45,7 @@ case class ServiceAccountInfoRecord(clusterServiceAccount: Option[String],
                                     serviceAccountKeyId: Option[String])
 
 trait ClusterComponent extends LeoComponent {
-  this: LabelComponent with ClusterErrorComponent with InstanceComponent with ExtensionComponent =>
+  this: LabelComponent with ClusterErrorComponent with InstanceComponent with ExtensionComponent with ClusterImageComponent =>
 
   import profile.api._
 
@@ -92,8 +92,8 @@ trait ClusterComponent extends LeoComponent {
       (clusterServiceAccount, notebookServiceAccount, serviceAccountKeyId), stagingBucket, dateAccessed, autopauseThreshold, defaultClientId, stopAfterCreation
     ).shaped <> ({
       case (id, clusterName, googleId, googleProject, operationName, status, hostIp, creator,
-            createdDate, destroyedDate, jupyterExtensionUri, jupyterUserScriptUri, initBucket, machineConfig,
-            serviceAccountInfo, stagingBucket, dateAccessed, autopauseThreshold, defaultClientId, stopAfterCreation) =>
+      createdDate, destroyedDate, jupyterExtensionUri, jupyterUserScriptUri, initBucket, machineConfig,
+      serviceAccountInfo, stagingBucket, dateAccessed, autopauseThreshold, defaultClientId, stopAfterCreation) =>
         ClusterRecord(
           id, clusterName, googleId, googleProject, operationName, status, hostIp, creator,
           createdDate, destroyedDate, jupyterExtensionUri, jupyterUserScriptUri, initBucket,
@@ -113,7 +113,7 @@ trait ClusterComponent extends LeoComponent {
   }
 
   object clusterQuery extends TableQuery(new ClusterTable(_)) {
-    def save(cluster: Cluster, 
+    def save(cluster: Cluster,
              initBucket: Option[GcsPath] = None,
              serviceAccountKeyId: Option[ServiceAccountKeyId] = None): DBIO[Cluster] = {
       for {
@@ -121,6 +121,7 @@ trait ClusterComponent extends LeoComponent {
         _ <- labelQuery.saveAllForCluster(clusterId, cluster.labels)
         _ <- instanceQuery.saveAllForCluster(clusterId, cluster.instances.toSeq)
         _ <- extensionQuery.saveAllForCluster(clusterId, cluster.userJupyterExtensionConfig)
+        _ <- clusterImageQuery.saveAllForCluster(clusterId, cluster.clusterImages.toSeq)
       } yield cluster.copy(id = clusterId)
     }
 
@@ -134,18 +135,18 @@ trait ClusterComponent extends LeoComponent {
     // note: list* methods don't query the INSTANCE table
 
     def list(): DBIO[Seq[Cluster]] = {
-      clusterQueryWithLabels.result.map(unmarshalClustersWithLabels)
+      minimalClusterQuery.result.map(unmarshalMinimalCluster)
     }
 
     def listActive(): DBIO[Seq[Cluster]] = {
-      clusterQueryWithLabels.filter { _._1.status inSetBind ClusterStatus.activeStatuses.map(_.toString) }.result map { recs =>
-        unmarshalClustersWithLabels(recs)
+      minimalClusterQuery.filter { _._1.status inSetBind ClusterStatus.activeStatuses.map(_.toString) }.result map { recs =>
+        unmarshalMinimalCluster(recs)
       }
     }
 
     def listMonitored(): DBIO[Seq[Cluster]] = {
-      clusterQueryWithLabels.filter { _._1.status inSetBind ClusterStatus.monitoredStatuses.map(_.toString) }.result map { recs =>
-        unmarshalClustersWithLabels(recs)
+      minimalClusterQuery.filter { _._1.status inSetBind ClusterStatus.monitoredStatuses.map(_.toString) }.result map { recs =>
+        unmarshalMinimalCluster(recs)
       }
     }
 
@@ -160,28 +161,28 @@ trait ClusterComponent extends LeoComponent {
     // find* and get* methods do query the INSTANCE table
 
     def getActiveClusterByName(project: GoogleProject, name: ClusterName): DBIO[Option[Cluster]] = {
-      clusterQueryWithInstancesAndErrorsAndLabels
+      fullClusterQuery
         .filter { _._1.googleProject === project.value }
         .filter { _._1.clusterName === name.value }
         .filter { _._1.destroyedDate === Timestamp.from(dummyDate) }
         .result map { recs =>
-          unmarshalClustersWithInstancesAndLabels(recs).headOption
-        }
+        unmarshalFullCluster(recs).headOption
+      }
     }
 
     def getDeletingClusterByName(project: GoogleProject, name: ClusterName): DBIO[Option[Cluster]] = {
-      clusterQueryWithInstancesAndErrorsAndLabels
+      fullClusterQuery
         .filter { _._1.googleProject === project.value }
         .filter { _._1.clusterName === name.value }
         .filter { _._1.status === ClusterStatus.Deleting.toString }
         .result map { recs =>
-          unmarshalClustersWithInstancesAndLabels(recs).headOption
-        }
+        unmarshalFullCluster(recs).headOption
+      }
     }
 
     def getClusterById(id: Long): DBIO[Option[Cluster]] = {
-      clusterQueryWithInstancesAndErrorsAndLabels.filter { _._1.id === id }.result map { recs =>
-        unmarshalClustersWithInstancesAndLabels(recs).headOption
+      fullClusterQuery.filter { _._1.id === id }.result map { recs =>
+        unmarshalFullCluster(recs).headOption
       }
     }
 
@@ -204,8 +205,8 @@ trait ClusterComponent extends LeoComponent {
     private[leonardo] def getClusterByUniqueKey(googleProject: GoogleProject,
                                                 clusterName: ClusterName,
                                                 destroyedDateOpt: Option[Instant]): DBIO[Option[Cluster]] = {
-      clusterQueryWithInstancesAndErrorsAndLabelsByUniqueKey(googleProject, clusterName, destroyedDateOpt)
-        .map { recs => unmarshalClustersWithInstancesAndLabels(recs).headOption }
+      fullClusterQueryByUniqueKey(googleProject, clusterName, destroyedDateOpt)
+        .map { recs => unmarshalFullCluster(recs).headOption }
     }
 
     def getInitBucket(project: GoogleProject, name: ClusterName): DBIO[Option[GcsPath]] = {
@@ -215,7 +216,7 @@ trait ClusterComponent extends LeoComponent {
         .map(_.initBucket)
         .result
         .map { recs => recs.headOption.flatten.flatMap(head => parseGcsPath(head).toOption)
-      }
+        }
     }
 
     def getServiceAccountKeyId(project: GoogleProject, name: ClusterName): DBIO[Option[ServiceAccountKeyId]] = {
@@ -238,9 +239,9 @@ trait ClusterComponent extends LeoComponent {
       val tsdiff = SimpleFunction.ternary[String, Timestamp, Timestamp, Int]("TIMESTAMPDIFF")
       val minute = SimpleLiteral[String]("MINUTE")
 
-      clusterQueryWithInstancesAndErrorsAndLabels.filter { record => tsdiff(minute, record._1.dateAccessed, now) >= record._1.autopauseThreshold}
+      fullClusterQuery.filter { record => tsdiff(minute, record._1.dateAccessed, now) >= record._1.autopauseThreshold}
         .filter(_._1.status inSetBind ClusterStatus.stoppableStatuses.map(_.toString))
-        .result map { recs => unmarshalClustersWithInstancesAndLabels(recs)}
+        .result map { recs => unmarshalFullCluster(recs)}
     }
 
     def markPendingDeletion(id: Long): DBIO[Int] = {
@@ -312,7 +313,7 @@ trait ClusterComponent extends LeoComponent {
     }
 
     def listByLabels(labelMap: LabelMap, includeDeleted: Boolean, googleProjectOpt: Option[GoogleProject] = None): DBIO[Seq[Cluster]] = {
-      val clusterStatusQuery = if (includeDeleted) clusterQueryWithLabels else clusterQueryWithLabels.filterNot { _._1.status === "Deleted" }
+      val clusterStatusQuery = if (includeDeleted) minimalClusterQuery else minimalClusterQuery.filterNot { _._1.status === "Deleted" }
       val clusterStatusQueryByProject = googleProjectOpt match {
         case Some(googleProject) => clusterStatusQuery.filter { _._1.googleProject === googleProject.value }
         case None => clusterStatusQuery
@@ -344,7 +345,7 @@ trait ClusterComponent extends LeoComponent {
             .length === labelMap.size
         }
       }
-      query.result.map(unmarshalClustersWithLabels)
+      query.result.map(unmarshalMinimalCluster)
     }
 
     /* WARNING: The init bucket and SA key ID is secret to Leo, which means we don't unmarshal it.
@@ -389,9 +390,9 @@ trait ClusterComponent extends LeoComponent {
       )
     }
 
-    private def unmarshalClustersWithLabels(clusterLabels: Seq[(ClusterRecord, Option[LabelRecord], Option[ExtensionRecord])]): Seq[Cluster] = {
+    private def unmarshalMinimalCluster(clusterRecords: Seq[(ClusterRecord, Option[LabelRecord], Option[ExtensionRecord])]): Seq[Cluster] = {
       // Call foldMap to aggregate a Seq[(ClusterRecord, LabelRecord)] returned by the query to a Map[ClusterRecord, Map[labelKey, labelValue]].
-      val clusterLabelMap: Map[ClusterRecord, (Map[String, List[String]], List[ExtensionRecord])] = clusterLabels.toList.foldMap { case (clusterRecord, labelRecordOpt, extensionOpt) =>
+      val clusterLabelMap: Map[ClusterRecord, (Map[String, List[String]], List[ExtensionRecord])] = clusterRecords.toList.foldMap { case (clusterRecord, labelRecordOpt, extensionOpt) =>
         val labelMap = labelRecordOpt.map(labelRecordOpt => labelRecordOpt.key -> List(labelRecordOpt.value)).toMap
         val extList =  extensionOpt.toList
         Map(clusterRecord -> (labelMap, extList))
@@ -399,28 +400,28 @@ trait ClusterComponent extends LeoComponent {
 
       // Unmarshal each (ClusterRecord, Map[labelKey, labelValue]) to a Cluster object
       clusterLabelMap.map { case (clusterRec, (labelMap, extList)) =>
-        unmarshalCluster(clusterRec, Seq.empty, List.empty, labelMap.mapValues(_.toSet.head), extList)
+        unmarshalCluster(clusterRec, Seq.empty, List.empty, labelMap.mapValues(_.toSet.head), extList, List.empty)
       }.toSeq
     }
 
-    private def unmarshalClustersWithInstancesAndLabels(clusterInstanceLabels: Seq[(ClusterRecord, Option[InstanceRecord], Option[ClusterErrorRecord], Option[LabelRecord], Option[ExtensionRecord])]): Seq[Cluster] = {
+    private def unmarshalFullCluster(clusterRecords: Seq[(ClusterRecord, Option[InstanceRecord], Option[ClusterErrorRecord], Option[LabelRecord], Option[ExtensionRecord], Option[ClusterImageRecord])]): Seq[Cluster] = {
       // Call foldMap to aggregate a flat sequence of (cluster, instance, label) triples returned by the query
       // to a grouped (cluster -> (instances, labels)) structure.
-      val clusterInstanceLabelMap: Map[ClusterRecord, (List[InstanceRecord], List[ClusterErrorRecord], Map[String, List[String]], List[ExtensionRecord])] = clusterInstanceLabels.toList.foldMap { case (clusterRecord, instanceRecordOpt, errorRecordOpt, labelRecordOpt, extensionOpt) =>
+      val clusterRecordMap: Map[ClusterRecord, (List[InstanceRecord], List[ClusterErrorRecord], Map[String, List[String]], List[ExtensionRecord], List[ClusterImageRecord])] = clusterRecords.toList.foldMap { case (clusterRecord, instanceRecordOpt, errorRecordOpt, labelRecordOpt, extensionOpt, clusterImageOpt) =>
         val instanceList = instanceRecordOpt.toList
         val labelMap = labelRecordOpt.map(labelRecordOpt => labelRecordOpt.key -> List(labelRecordOpt.value)).toMap
         val errorList = errorRecordOpt.toList
-        val extList =  extensionOpt.toList
-        Map(clusterRecord -> (instanceList, errorList, labelMap, extList))
-
+        val extList = extensionOpt.toList
+        val clusterImageList = clusterImageOpt.toList
+        Map(clusterRecord -> (instanceList, errorList, labelMap, extList, clusterImageList))
       }
 
-      clusterInstanceLabelMap.map { case (clusterRecord, (instanceRecords, errorRecords, labels, extensions)) =>
-        unmarshalCluster(clusterRecord, instanceRecords.toSet.toSeq, errorRecords.groupBy(_.timestamp).map(_._2.head).toList, labels.mapValues(_.toSet.head), extensions)
+      clusterRecordMap.map { case (clusterRecord, (instanceRecords, errorRecords, labels, extensions, clusterImages)) =>
+        unmarshalCluster(clusterRecord, instanceRecords.toSet.toSeq, errorRecords.groupBy(_.timestamp).map(_._2.head).toList, labels.mapValues(_.toSet.head), extensions, clusterImages.toSet.toList)
       }.toSeq
     }
 
-    private def unmarshalCluster(clusterRecord: ClusterRecord, instanceRecords: Seq[InstanceRecord], errors: List[ClusterErrorRecord], labels: LabelMap, userJupyterExtensionConfig: List[ExtensionRecord]): Cluster = {
+    private def unmarshalCluster(clusterRecord: ClusterRecord, instanceRecords: Seq[InstanceRecord], errors: List[ClusterErrorRecord], labels: LabelMap, userJupyterExtensionConfig: List[ExtensionRecord], clusterImageRecords: List[ClusterImageRecord]): Cluster = {
       val name = ClusterName(clusterRecord.clusterName)
       val project = GoogleProject(clusterRecord.googleProject)
       val machineConfig = MachineConfig(
@@ -463,31 +464,49 @@ trait ClusterComponent extends LeoComponent {
         ClusterComponent.this.extensionQuery.unmarshallExtensions(userJupyterExtensionConfig),
         clusterRecord.autopauseThreshold,
         clusterRecord.defaultClientId,
-        clusterRecord.stopAfterCreation
+        clusterRecord.stopAfterCreation,
+        clusterImageRecords map ClusterComponent.this.clusterImageQuery.unmarshalClusterImage toSet
       )
     }
   }
 
-  // select * from cluster c left join label l on c.id = l.clusterId
-  val clusterQueryWithLabels: Query[(ClusterTable, Rep[Option[LabelTable]], Rep[Option[ExtensionTable]]), (ClusterRecord, Option[LabelRecord], Option[ExtensionRecord]), Seq] = {
+  // just clusters and labels: no instances, extensions, etc.
+  //   select * from cluster c
+  //   left join label l on c.id = l.clusterId
+  val minimalClusterQuery: Query[(ClusterTable, Rep[Option[LabelTable]], Rep[Option[ExtensionTable]]), (ClusterRecord, Option[LabelRecord], Option[ExtensionRecord]), Seq] = {
     for {
-      ((cluster, label), extension) <- clusterQuery joinLeft labelQuery on (_.id === _.clusterId) joinLeft extensionQuery on (_._1.id === _.clusterId)
+      ((cluster, label), extension) <-
+        clusterQuery joinLeft
+          labelQuery on (_.id === _.clusterId) joinLeft
+          extensionQuery on (_._1.id === _.clusterId)
     } yield (cluster, label, extension)
   }
 
-  // select * from cluster c left join instance i on c.id = i.clusterId left join cluster_error ce ce.clusterId = c.id left join label l on c.id = l.clusterId
-  val  clusterQueryWithInstancesAndErrorsAndLabels: Query[(ClusterTable, Rep[Option[InstanceTable]], Rep[Option[ClusterErrorTable]], Rep[Option[LabelTable]], Rep[Option[ExtensionTable]]), (ClusterRecord, Option[InstanceRecord], Option[ClusterErrorRecord], Option[LabelRecord], Option[ExtensionRecord]), Seq] = {
+  // cluster and all associated data: labels, instances, errors, extensions, images.
+  //   select * from cluster c
+  //   left join instance i on c.id = i.clusterId
+  //   left join cluster_error ce ce.clusterId = c.id
+  //   left join label l on c.id = l.clusterId
+  //   left join cluster_extension ext on c.id = ext.clusterId
+  //   left join cluster_image ci on c.id = ci.clusterId
+  val fullClusterQuery: Query[(ClusterTable, Rep[Option[InstanceTable]], Rep[Option[ClusterErrorTable]], Rep[Option[LabelTable]], Rep[Option[ExtensionTable]], Rep[Option[ClusterImageTable]]), (ClusterRecord, Option[InstanceRecord], Option[ClusterErrorRecord], Option[LabelRecord], Option[ExtensionRecord], Option[ClusterImageRecord]), Seq] = {
     for {
-      ((((cluster, instance), error), label), extension) <- clusterQuery joinLeft instanceQuery on (_.id === _.clusterId) joinLeft clusterErrorQuery on (_._1.id === _.clusterId) joinLeft labelQuery on (_._1._1.id === _.clusterId) joinLeft extensionQuery on (_._1._1._1.id === _.clusterId)
-    } yield (cluster, instance, error, label, extension)
+      (((((cluster, instance), error), label), extension), image) <-
+        clusterQuery joinLeft
+          instanceQuery on (_.id === _.clusterId) joinLeft
+          clusterErrorQuery on (_._1.id === _.clusterId) joinLeft
+          labelQuery on (_._1._1.id === _.clusterId) joinLeft
+          extensionQuery on (_._1._1._1.id === _.clusterId) joinLeft
+          clusterImageQuery on (_._1._1._1._1.id === _.clusterId)
+    } yield (cluster, instance, error, label, extension, image)
   }
 
-  private def clusterQueryWithInstancesAndErrorsAndLabelsByUniqueKey(googleProject: GoogleProject,
-                                                                     clusterName: ClusterName,
-                                                                     destroyedDateOpt: Option[Instant]) = {
+  private def fullClusterQueryByUniqueKey(googleProject: GoogleProject,
+                                          clusterName: ClusterName,
+                                          destroyedDateOpt: Option[Instant]) = {
     val destroyedDate = destroyedDateOpt.getOrElse(dummyDate)
 
-    clusterQueryWithInstancesAndErrorsAndLabels
+    fullClusterQuery
       .filter { _._1.googleProject === googleProject.value }
       .filter { _._1.clusterName === clusterName.value }
       .filter { _._1.destroyedDate === Timestamp.from(destroyedDate) }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterImageComponent.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterImageComponent.scala
@@ -1,0 +1,64 @@
+package org.broadinstitute.dsde.workbench.leonardo.db
+
+import org.broadinstitute.dsde.workbench.leonardo.model.{ClusterImage, ClusterTool}
+
+case class ClusterImageRecord(clusterId: Long, tool: String, dockerImage: String)
+
+trait ClusterImageComponent extends LeoComponent {
+  this: ClusterComponent =>
+
+  import profile.api._
+
+  class ClusterImageTable(tag: Tag) extends Table[ClusterImageRecord](tag, "CLUSTER_IMAGE") {
+    def clusterId = column[Long]("clusterId")
+
+    def tool = column[String]("tool", O.Length(254))
+
+    def dockerImage = column[String]("dockerImage", O.Length(1024))
+
+    def cluster = foreignKey("FK_CLUSTER_ID", clusterId, clusterQuery)(_.id)
+
+    def uniqueKey = index("IDX_CLUSTER_IMAGE_UNIQUE", (clusterId, tool), unique = true)
+
+    def * = (clusterId, tool, dockerImage) <> (ClusterImageRecord.tupled, ClusterImageRecord.unapply)
+  }
+
+  object clusterImageQuery extends TableQuery(new ClusterImageTable(_)) {
+
+    def save(clusterId: Long, clusterImage: ClusterImage): DBIO[Int] = {
+      clusterImageQuery += marshallClusterImage(clusterId, clusterImage)
+    }
+
+    def saveAllForCluster(clusterId: Long, clusterImages: Seq[ClusterImage]): DBIO[Option[Int]] = {
+      clusterImageQuery ++= clusterImages.map { c =>
+        marshallClusterImage(clusterId, c)
+      }
+    }
+
+    def get(clusterId: Long, tool: ClusterTool): DBIO[Option[ClusterImage]] = {
+      clusterImageQuery
+        .filter { _.clusterId === clusterId }
+        .filter { _.tool === tool.toString }
+        .result
+        .headOption
+        .map(_.map(unmarshalClusterImage))
+    }
+
+    def getAllForCluster(clusterId: Long): DBIO[Seq[ClusterImage]] = {
+      clusterImageQuery
+        .filter { _.clusterId === clusterId }
+        .result
+        .map(_.map(unmarshalClusterImage))
+    }
+
+    def marshallClusterImage(clusterId: Long, clusterImage: ClusterImage): ClusterImageRecord = {
+      ClusterImageRecord(clusterId, clusterImage.tool.toString, clusterImage.dockerImage)
+    }
+
+    def unmarshalClusterImage(clusterImageRecord: ClusterImageRecord): ClusterImage = {
+      ClusterImage(ClusterTool.withName(clusterImageRecord.tool), clusterImageRecord.dockerImage)
+    }
+
+  }
+
+}

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/DbReference.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/DbReference.scala
@@ -73,7 +73,12 @@ class DataAccess(val profile: JdbcProfile)(implicit val executionContext: Execut
 
     // important to keep the right order for referential integrity !
     // if table X has a Foreign Key to table Y, delete table X first
-    TableQuery[LabelTable].delete andThen TableQuery[ClusterErrorTable].delete andThen TableQuery[InstanceTable].delete andThen TableQuery[ExtensionTable].delete andThen TableQuery[ClusterTable].delete
+    TableQuery[LabelTable].delete andThen
+      TableQuery[ClusterErrorTable].delete andThen
+      TableQuery[InstanceTable].delete andThen
+      TableQuery[ExtensionTable].delete andThen
+      TableQuery[ClusterImageTable].delete andThen
+      TableQuery[ClusterTable].delete
   }
 
   def sqlDBStatus() = {

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeonardoModel.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeonardoModel.scala
@@ -69,7 +69,8 @@ object ClusterTool extends Enum[ClusterTool] {
   case object RStudio extends ClusterTool
 }
 case class ClusterImage(tool: ClusterTool,
-                        dockerImage: String)
+                        dockerImage: String,
+                        timestamp: Instant)
 
 // The cluster itself
 // Also the API response for "list clusters" and "get active cluster"
@@ -304,7 +305,7 @@ object LeonardoJsonSupport extends SprayJsonSupport with DefaultJsonProtocol {
 
   implicit val ClusterToolFormat = EnumEntryFormat(ClusterTool.withName)
 
-  implicit val ClusterImageFormat = jsonFormat2(ClusterImage.apply)
+  implicit val ClusterImageFormat = jsonFormat3(ClusterImage.apply)
 
 
   implicit object ClusterFormat extends RootJsonFormat[Cluster] {

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorSupervisor.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorSupervisor.scala
@@ -8,6 +8,7 @@ import org.broadinstitute.dsde.workbench.leonardo.config.{AutoFreezeConfig, Data
 import org.broadinstitute.dsde.workbench.leonardo.dao.JupyterDAO
 import org.broadinstitute.dsde.workbench.leonardo.dao.google.{GoogleComputeDAO, GoogleDataprocDAO}
 import org.broadinstitute.dsde.workbench.leonardo.db.DbReference
+import org.broadinstitute.dsde.workbench.leonardo.model.ClusterTool.Jupyter
 import org.broadinstitute.dsde.workbench.leonardo.model.{Cluster, ClusterRequest, LeoAuthProvider}
 import org.broadinstitute.dsde.workbench.leonardo.monitor.ClusterMonitorSupervisor._
 import org.broadinstitute.dsde.workbench.leonardo.service.LeonardoService
@@ -81,7 +82,8 @@ class ClusterMonitorSupervisor(monitorConfig: MonitorConfig, dataprocConfig: Dat
           cluster.userJupyterExtensionConfig,
           if (cluster.autopauseThreshold == 0) Some(false) else Some(true),
           Some(cluster.autopauseThreshold),
-          cluster.defaultClientId)
+          cluster.defaultClientId,
+          cluster.clusterImages.find(_.tool == Jupyter).map(_.dockerImage))
         leoService.internalCreateCluster(cluster.auditInfo.creator, cluster.serviceAccountInfo, cluster.googleProject, cluster.clusterName, clusterRequest).failed.foreach { e =>
           logger.error(s"Error occurred recreating cluster ${cluster.projectNameString}", e)
         }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoService.scala
@@ -929,7 +929,8 @@ class LeonardoService(protected val dataprocConfig: DataprocConfig,
   }
 
   private[service] def processClusterImages(clusterRequest: ClusterRequest): Set[ClusterImage] = {
-    // TODO validate image?
+    // Default to the configured default image if not specified in the request
+    // TODO should we validate the image somehow?
     val jupyterImage = clusterRequest.jupyterDockerImage.getOrElse(dataprocConfig.dataprocDockerImage)
 
     Set(ClusterImage(Jupyter, jupyterImage))

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoService.scala
@@ -15,6 +15,7 @@ import org.broadinstitute.dsde.workbench.leonardo.config.{AutoFreezeConfig, Clus
 import org.broadinstitute.dsde.workbench.leonardo.dao.google.{GoogleComputeDAO, GoogleDataprocDAO}
 import org.broadinstitute.dsde.workbench.leonardo.db.{DataAccess, DbReference}
 import org.broadinstitute.dsde.workbench.leonardo.model.Cluster.LabelMap
+import org.broadinstitute.dsde.workbench.leonardo.model.ClusterTool.Jupyter
 import org.broadinstitute.dsde.workbench.leonardo.model.LeonardoJsonSupport._
 import org.broadinstitute.dsde.workbench.leonardo.model.NotebookClusterActions._
 import org.broadinstitute.dsde.workbench.leonardo.model.ProjectActions._
@@ -184,6 +185,7 @@ class LeonardoService(protected val dataprocConfig: DataprocConfig,
       case Some(existingCluster) => throw ClusterAlreadyExistsException(googleProject, clusterName, existingCluster.status)
       case None =>
         val augmentedClusterRequest = addClusterLabels(serviceAccountInfo, googleProject, clusterName, userEmail, clusterRequest)
+        val clusterImages = processClusterImages(clusterRequest)
         val clusterFuture = for {
           // Notify the auth provider that the cluster has been created
           _ <- authProvider.notifyClusterCreated(userEmail, googleProject, clusterName)
@@ -192,7 +194,7 @@ class LeonardoService(protected val dataprocConfig: DataprocConfig,
           _ <- validateClusterRequestBucketObjectUri(userEmail, googleProject, augmentedClusterRequest)
 
           // Create the cluster in Google
-          (cluster, initBucket, serviceAccountKeyOpt) <- createGoogleCluster(userEmail, serviceAccountInfo, googleProject, clusterName, augmentedClusterRequest)
+          (cluster, initBucket, serviceAccountKeyOpt) <- createGoogleCluster(userEmail, serviceAccountInfo, googleProject, clusterName, augmentedClusterRequest, clusterImages)
 
           // Save the cluster in the database
           savedCluster <- dbRef.inTransaction(_.clusterQuery.save(cluster, Option(GcsPath(initBucket, GcsObjectName(""))), serviceAccountKeyOpt.map(_.id)))
@@ -257,12 +259,14 @@ class LeonardoService(protected val dataprocConfig: DataprocConfig,
 
     val augmentedClusterRequest = addClusterLabels(
       serviceAccountInfo, googleProject, clusterName, userEmail, clusterRequest)
+    val clusterImages = processClusterImages(clusterRequest)
     val machineConfig = MachineConfigOps.create(clusterRequest.machineConfig, clusterDefaultsConfig)
     val autopauseThreshold = calculateAutopauseThreshold(
       clusterRequest.autopause, clusterRequest.autopauseThreshold)
     val initialClusterToSave = Cluster.create(
       augmentedClusterRequest, userEmail, clusterName, googleProject,
-      serviceAccountInfo, machineConfig, dataprocConfig.clusterUrlBase, autopauseThreshold)
+      serviceAccountInfo, machineConfig, dataprocConfig.clusterUrlBase, autopauseThreshold,
+      clusterImages = clusterImages)
 
     // Validate that the Jupyter extension URIs and Jupyter user script URI are valid URIs and reference real GCS objects
     // and if so, save the cluster creation request parameters in DB
@@ -554,7 +558,7 @@ class LeonardoService(protected val dataprocConfig: DataprocConfig,
                                            cluster: Cluster,
                                            clusterRequest: ClusterRequest)
                                           (implicit executionContext: ExecutionContext): Future[(Cluster, GcsBucketName, Option[ServiceAccountKey])] = {
-    createGoogleCluster(userEmail, cluster.serviceAccountInfo, cluster.googleProject, cluster.clusterName, clusterRequest)
+    createGoogleCluster(userEmail, cluster.serviceAccountInfo, cluster.googleProject, cluster.clusterName, clusterRequest, cluster.clusterImages)
   }
 
   /* Creates a cluster in the given google project:
@@ -566,7 +570,8 @@ class LeonardoService(protected val dataprocConfig: DataprocConfig,
                                            serviceAccountInfo: ServiceAccountInfo,
                                            googleProject: GoogleProject,
                                            clusterName: ClusterName,
-                                           clusterRequest: ClusterRequest)
+                                           clusterRequest: ClusterRequest,
+                                           clusterImages: Set[ClusterImage])
                                           (implicit executionContext: ExecutionContext): Future[(Cluster, GcsBucketName, Option[ServiceAccountKey])] = {
     val initBucketName = generateUniqueBucketName("leoinit-"+clusterName.value)
     val stagingBucketName = generateUniqueBucketName("leostaging-"+clusterName.value)
@@ -588,7 +593,7 @@ class LeonardoService(protected val dataprocConfig: DataprocConfig,
       // Create the bucket in leo's google project and populate with initialization files.
       // ACLs are granted so the cluster service account can access the bucket at initialization time.
       initBucket <- bucketHelper.createInitBucket(googleProject, initBucketName, serviceAccountInfo)
-      _ <- initializeBucketObjects(userEmail, googleProject, clusterName, initBucket, clusterRequest, serviceAccountKeyOpt, contentSecurityPolicy)
+      _ <- initializeBucketObjects(userEmail, googleProject, clusterName, initBucket, clusterRequest, serviceAccountKeyOpt, contentSecurityPolicy, clusterImages)
 
       // Create the cluster staging bucket. ACLs are granted so the user/pet can access it.
       stagingBucket <- bucketHelper.createStagingBucket(userEmail, googleProject, stagingBucketName, serviceAccountInfo)
@@ -601,7 +606,7 @@ class LeonardoService(protected val dataprocConfig: DataprocConfig,
       operation <- gdDAO.createCluster(googleProject, clusterName, machineConfig, initScript,
         serviceAccountInfo.clusterServiceAccount, credentialsFileName, stagingBucket)
       cluster = Cluster.create(clusterRequest, userEmail, clusterName, googleProject, serviceAccountInfo,
-        machineConfig, dataprocConfig.clusterUrlBase, autopauseThreshold, Option(operation), Option(stagingBucket))
+        machineConfig, dataprocConfig.clusterUrlBase, autopauseThreshold, Option(operation), Option(stagingBucket), clusterImages)
     } yield (cluster, initBucket, serviceAccountKeyOpt)
 
     // If anything fails, we need to clean up Google resources that might have been created
@@ -773,11 +778,18 @@ class LeonardoService(protected val dataprocConfig: DataprocConfig,
   }
 
   /* Process the templated cluster init script and put all initialization files in the init bucket */
-  private[service] def initializeBucketObjects(userEmail: WorkbenchEmail, googleProject: GoogleProject, clusterName: ClusterName, initBucketName: GcsBucketName, clusterRequest: ClusterRequest, serviceAccountKey: Option[ServiceAccountKey], contentSecurityPolicy: String): Future[Unit] = {
+  private[service] def initializeBucketObjects(userEmail: WorkbenchEmail,
+                                               googleProject: GoogleProject,
+                                               clusterName: ClusterName,
+                                               initBucketName: GcsBucketName,
+                                               clusterRequest: ClusterRequest,
+                                               serviceAccountKey: Option[ServiceAccountKey],
+                                               contentSecurityPolicy: String,
+                                               clusterImages: Set[ClusterImage]): Future[Unit] = {
 
     // Build a mapping of (name, value) pairs with which to apply templating logic to resources
     val clusterInit = ClusterInitValues(googleProject, clusterName, initBucketName, clusterRequest, dataprocConfig,
-      clusterFilesConfig, clusterResourcesConfig, proxyConfig, serviceAccountKey, userEmail, contentSecurityPolicy)
+      clusterFilesConfig, clusterResourcesConfig, proxyConfig, serviceAccountKey, userEmail, contentSecurityPolicy, clusterImages)
     val replacements: Map[String, String] = clusterInit.toMap
 
     // Raw files to upload to the bucket, no additional processing needed.
@@ -914,5 +926,12 @@ class LeonardoService(protected val dataprocConfig: DataprocConfig,
     else clusterRequest
       .copy(labels = Option(allLabels))
       .copy(userJupyterExtensionConfig = updatedUserJupyterExtensionConfig)
+  }
+
+  private[service] def processClusterImages(clusterRequest: ClusterRequest): Set[ClusterImage] = {
+    // TODO validate image?
+    val jupyterImage = clusterRequest.jupyterDockerImage.getOrElse(dataprocConfig.dataprocDockerImage)
+
+    Set(ClusterImage(Jupyter, jupyterImage))
   }
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoService.scala
@@ -933,6 +933,6 @@ class LeonardoService(protected val dataprocConfig: DataprocConfig,
     // TODO should we validate the image somehow?
     val jupyterImage = clusterRequest.jupyterDockerImage.getOrElse(dataprocConfig.dataprocDockerImage)
 
-    Set(ClusterImage(Jupyter, jupyterImage))
+    Set(ClusterImage(Jupyter, jupyterImage, Instant.now))
   }
 }

--- a/src/test/resources/jupyter/test-init-actions.sh
+++ b/src/test/resources/jupyter/test-init-actions.sh
@@ -3,6 +3,7 @@
 $(clusterName)
 $(googleProject)
 $(jupyterDockerImage)
+$(proxyDockerImage)
 $(jupyterUserScriptUri)
 $(jupyterServiceAccountCredentials)
 $(jupyterServerExtensions)

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/ClusterEnrichments.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/ClusterEnrichments.scala
@@ -53,6 +53,10 @@ object ClusterEnrichments {
   }
 
   def stripFieldsForListCluster(cluster: Cluster): Cluster = {
-    cluster.copy(instances = Set.empty, clusterImages = Set.empty, errors = List.empty)
+    cluster.copy(
+      instances = Set.empty,
+      clusterImages = Set.empty,
+      errors = List.empty,
+      userJupyterExtensionConfig = None)
   }
 }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/ClusterEnrichments.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/ClusterEnrichments.scala
@@ -51,4 +51,8 @@ object ClusterEnrichments {
 
     fcs1 == fcs2
   }
+
+  def stripFieldsForListCluster(cluster: Cluster): Cluster = {
+    cluster.copy(instances = Set.empty, clusterImages = Set.empty, errors = List.empty)
+  }
 }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/CommonTestData.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/CommonTestData.scala
@@ -13,6 +13,7 @@ import org.broadinstitute.dsde.workbench.leonardo.config.{AutoFreezeConfig, Clus
 import org.broadinstitute.dsde.workbench.leonardo.dao.google.MockGoogleComputeDAO
 import org.broadinstitute.dsde.workbench.leonardo.dao.{MockJupyterDAO, MockSamDAO}
 import org.broadinstitute.dsde.workbench.leonardo.db.TestComponent
+import org.broadinstitute.dsde.workbench.leonardo.model.ClusterTool.{Jupyter, RStudio}
 import org.broadinstitute.dsde.workbench.leonardo.model._
 import org.broadinstitute.dsde.workbench.leonardo.model.google._
 import org.broadinstitute.dsde.workbench.model.google.{GoogleProject, ServiceAccountKey, ServiceAccountKeyId, ServiceAccountPrivateKeyData, _}
@@ -79,6 +80,9 @@ trait CommonTestData{ this: ScalaFutures =>
   val serviceAccountInfo = new ServiceAccountInfo(clusterServiceAccount, notebookServiceAccount)
 
   val auditInfo = AuditInfo(userEmail, Instant.now(), None, Instant.now())
+  val jupyterImage = ClusterImage(Jupyter, "jupyter/jupyter-base:latest")
+  val rstudioImage = ClusterImage(RStudio, "rocker/tidyverse:latest")
+
   def makeDataprocInfo(index: Int): DataprocInfo = {
     DataprocInfo(Option(UUID.randomUUID()), Option(OperationName("operationName" + index.toString)), Option(GcsBucketName("stagingBucketName" + index.toString)), Some(IP("numbers.and.dots")))
   }
@@ -102,7 +106,8 @@ trait CommonTestData{ this: ScalaFutures =>
       userJupyterExtensionConfig = None,
       autopauseThreshold = 30,
       defaultClientId = Some("defaultClientId"),
-      stopAfterCreation = false
+      stopAfterCreation = false,
+      clusterImages = Set(jupyterImage)
     )
   }
 
@@ -123,7 +128,9 @@ trait CommonTestData{ this: ScalaFutures =>
     userJupyterExtensionConfig = None,
     autopauseThreshold = if (autopause) autopauseThreshold else 0,
     defaultClientId = None,
-    stopAfterCreation = false)
+    stopAfterCreation = false,
+    clusterImages = Set(jupyterImage)
+  )
 
   // TODO look into parameterized tests so both provider impls can be tested
   // Also remove code duplication with LeonardoServiceSpec, TestLeoRoutes, and CommonTestData

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/CommonTestData.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/CommonTestData.scala
@@ -80,8 +80,8 @@ trait CommonTestData{ this: ScalaFutures =>
   val serviceAccountInfo = new ServiceAccountInfo(clusterServiceAccount, notebookServiceAccount)
 
   val auditInfo = AuditInfo(userEmail, Instant.now(), None, Instant.now())
-  val jupyterImage = ClusterImage(Jupyter, "jupyter/jupyter-base:latest")
-  val rstudioImage = ClusterImage(RStudio, "rocker/tidyverse:latest")
+  val jupyterImage = ClusterImage(Jupyter, "jupyter/jupyter-base:latest", Instant.now)
+  val rstudioImage = ClusterImage(RStudio, "rocker/tidyverse:latest", Instant.now)
 
   def makeDataprocInfo(index: Int): DataprocInfo = {
     DataprocInfo(Option(UUID.randomUUID()), Option(OperationName("operationName" + index.toString)), Option(GcsBucketName("stagingBucketName" + index.toString)), Some(IP("numbers.and.dots")))

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponentSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponentSpec.scala
@@ -7,9 +7,9 @@ import java.util.UUID
 
 import org.broadinstitute.dsde.workbench.leonardo.ClusterEnrichments.{clusterEq, clusterSeqEq, clusterSetEq}
 import org.broadinstitute.dsde.workbench.leonardo.{CommonTestData, GcsPathUtils}
+import org.broadinstitute.dsde.workbench.leonardo.ClusterEnrichments.stripFieldsForListCluster
 import org.broadinstitute.dsde.workbench.leonardo.model._
 import org.broadinstitute.dsde.workbench.leonardo.model.google._
-import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.scalatest.FlatSpecLike
 
 class ClusterComponentSpec extends TestComponent with FlatSpecLike with CommonTestData with GcsPathUtils {
@@ -46,7 +46,7 @@ class ClusterComponentSpec extends TestComponent with FlatSpecLike with CommonTe
 
     // instances are returned by list* methods
     val expectedClusters123 = Seq(savedCluster1, savedCluster2, savedCluster3).map(_.copy(instances = Set.empty))
-    dbFutureValue { _.clusterQuery.list() } should contain theSameElementsAs expectedClusters123
+    dbFutureValue { _.clusterQuery.list() } should contain theSameElementsAs expectedClusters123.map(stripFieldsForListCluster)
 
     // instances are returned by get* methods
     dbFutureValue { _.clusterQuery.getActiveClusterByName(cluster1.googleProject, cluster1.clusterName) } shouldEqual Some(savedCluster1)
@@ -72,7 +72,7 @@ class ClusterComponentSpec extends TestComponent with FlatSpecLike with CommonTe
     dbFailure { _.clusterQuery.save(cluster4, Option(gcsPath("gs://bucket3")), Some(serviceAccountKey.id)) } shouldBe a[SQLException]
 
     dbFutureValue { _.clusterQuery.markPendingDeletion(savedCluster1.id) } shouldEqual 1
-    dbFutureValue { _.clusterQuery.listActive() } should contain theSameElementsAs Seq(cluster2, cluster3)
+    dbFutureValue { _.clusterQuery.listActive() } should contain theSameElementsAs Seq(cluster2, cluster3).map(stripFieldsForListCluster)
 
     val cluster1status = dbFutureValue { _.clusterQuery.getClusterById(savedCluster1.id) }.get
     cluster1status.status shouldEqual ClusterStatus.Deleting
@@ -81,7 +81,7 @@ class ClusterComponentSpec extends TestComponent with FlatSpecLike with CommonTe
     cluster1status.instances shouldBe cluster1.instances
 
     dbFutureValue { _.clusterQuery.markPendingDeletion(savedCluster2.id) } shouldEqual 1
-    dbFutureValue { _.clusterQuery.listActive() } shouldEqual Seq(cluster3)
+    dbFutureValue { _.clusterQuery.listActive() } shouldEqual Seq(cluster3).map(stripFieldsForListCluster)
     val cluster2status = dbFutureValue { _.clusterQuery.getClusterById(savedCluster2.id) }.get
     cluster2status.status shouldEqual ClusterStatus.Deleting
     cluster2status.auditInfo.destroyedDate shouldBe None
@@ -104,20 +104,20 @@ class ClusterComponentSpec extends TestComponent with FlatSpecLike with CommonTe
     val savedCluster3 = makeCluster(3).copy(status = ClusterStatus.Deleted,
                                        labels = Map("a" -> "b", "bam" -> "yes")).save()
 
-    dbFutureValue { _.clusterQuery.listByLabels(Map.empty, false) }.toSet shouldEqual Set(savedCluster1, savedCluster2)
-    dbFutureValue { _.clusterQuery.listByLabels(Map("bam" -> "yes"), false) }.toSet shouldEqual Set(savedCluster1)
+    dbFutureValue { _.clusterQuery.listByLabels(Map.empty, false) }.toSet shouldEqual Set(savedCluster1, savedCluster2).map(stripFieldsForListCluster)
+    dbFutureValue { _.clusterQuery.listByLabels(Map("bam" -> "yes"), false) }.toSet shouldEqual Set(savedCluster1).map(stripFieldsForListCluster)
     dbFutureValue { _.clusterQuery.listByLabels(Map("bam" -> "no"), false) }.toSet shouldEqual Set.empty[Cluster]
-    dbFutureValue { _.clusterQuery.listByLabels(Map("bam" -> "yes", "vcf" -> "no"), false) }.toSet shouldEqual Set(savedCluster1)
-    dbFutureValue { _.clusterQuery.listByLabels(Map("foo" -> "bar", "vcf" -> "no"), false) }.toSet shouldEqual Set(savedCluster1)
-    dbFutureValue { _.clusterQuery.listByLabels(Map("bam" -> "yes", "vcf" -> "no", "foo" -> "bar"), false) }.toSet shouldEqual Set(savedCluster1)
+    dbFutureValue { _.clusterQuery.listByLabels(Map("bam" -> "yes", "vcf" -> "no"), false) }.toSet shouldEqual Set(savedCluster1).map(stripFieldsForListCluster)
+    dbFutureValue { _.clusterQuery.listByLabels(Map("foo" -> "bar", "vcf" -> "no"), false) }.toSet shouldEqual Set(savedCluster1).map(stripFieldsForListCluster)
+    dbFutureValue { _.clusterQuery.listByLabels(Map("bam" -> "yes", "vcf" -> "no", "foo" -> "bar"), false) }.toSet shouldEqual Set(savedCluster1).map(stripFieldsForListCluster)
     dbFutureValue { _.clusterQuery.listByLabels(Map("a" -> "b"), false) }.toSet shouldEqual Set.empty[Cluster]
     dbFutureValue { _.clusterQuery.listByLabels(Map("bam" -> "yes", "a" -> "b"), false) }.toSet shouldEqual Set.empty[Cluster]
     dbFutureValue { _.clusterQuery.listByLabels(Map("bam" -> "yes", "a" -> "c"), false) }.toSet shouldEqual Set.empty[Cluster]
-    dbFutureValue { _.clusterQuery.listByLabels(Map("bam" -> "yes", "vcf" -> "no"), true) }.toSet shouldEqual Set(savedCluster1)
-    dbFutureValue { _.clusterQuery.listByLabels(Map("foo" -> "bar", "vcf" -> "no"), true) }.toSet shouldEqual Set(savedCluster1)
-    dbFutureValue { _.clusterQuery.listByLabels(Map("bam" -> "yes", "vcf" -> "no", "foo" -> "bar"), true) }.toSet shouldEqual Set(savedCluster1)
-    dbFutureValue { _.clusterQuery.listByLabels(Map("a" -> "b"), true) }.toSet shouldEqual Set(savedCluster3)
-    dbFutureValue { _.clusterQuery.listByLabels(Map("bam" -> "yes", "a" -> "b"), true) }.toSet shouldEqual Set(savedCluster3)
+    dbFutureValue { _.clusterQuery.listByLabels(Map("bam" -> "yes", "vcf" -> "no"), true) }.toSet shouldEqual Set(savedCluster1).map(stripFieldsForListCluster)
+    dbFutureValue { _.clusterQuery.listByLabels(Map("foo" -> "bar", "vcf" -> "no"), true) }.toSet shouldEqual Set(savedCluster1).map(stripFieldsForListCluster)
+    dbFutureValue { _.clusterQuery.listByLabels(Map("bam" -> "yes", "vcf" -> "no", "foo" -> "bar"), true) }.toSet shouldEqual Set(savedCluster1).map(stripFieldsForListCluster)
+    dbFutureValue { _.clusterQuery.listByLabels(Map("a" -> "b"), true) }.toSet shouldEqual Set(savedCluster3).map(stripFieldsForListCluster)
+    dbFutureValue { _.clusterQuery.listByLabels(Map("bam" -> "yes", "a" -> "b"), true) }.toSet shouldEqual Set(savedCluster3).map(stripFieldsForListCluster)
     dbFutureValue { _.clusterQuery.listByLabels(Map("bam" -> "yes", "a" -> "c"), true) }.toSet shouldEqual Set.empty[Cluster]
     dbFutureValue { _.clusterQuery.listByLabels(Map("bogus" -> "value"), true) }.toSet shouldEqual Set.empty[Cluster]
   }
@@ -201,12 +201,12 @@ class ClusterComponentSpec extends TestComponent with FlatSpecLike with CommonTe
         labels = Map("a" -> "b", "bam" -> "yes"))
       .save()
 
-    dbFutureValue { _.clusterQuery.listByLabels(Map.empty, false, Some(project)) }.toSet shouldEqual Set(savedCluster1)
-    dbFutureValue { _.clusterQuery.listByLabels(Map.empty, true, Some(project)) }.toSet shouldEqual Set(savedCluster1, savedCluster3)
-    dbFutureValue { _.clusterQuery.listByLabels(Map.empty, false, Some(project2)) }.toSet shouldEqual Set(savedCluster2)
-    dbFutureValue { _.clusterQuery.listByLabels(Map("bam" -> "yes"), true, Some(project)) }.toSet shouldEqual Set(savedCluster1, savedCluster3)
-    dbFutureValue { _.clusterQuery.listByLabels(Map("bam" -> "yes"), false, Some(project2)) }.toSet shouldEqual Set(savedCluster2)
-    dbFutureValue { _.clusterQuery.listByLabels(Map("a" -> "b"), true, Some(project)) }.toSet shouldEqual Set(savedCluster3)
+    dbFutureValue { _.clusterQuery.listByLabels(Map.empty, false, Some(project)) }.toSet shouldEqual Set(savedCluster1).map(stripFieldsForListCluster)
+    dbFutureValue { _.clusterQuery.listByLabels(Map.empty, true, Some(project)) }.toSet shouldEqual Set(savedCluster1, savedCluster3).map(stripFieldsForListCluster)
+    dbFutureValue { _.clusterQuery.listByLabels(Map.empty, false, Some(project2)) }.toSet shouldEqual Set(savedCluster2).map(stripFieldsForListCluster)
+    dbFutureValue { _.clusterQuery.listByLabels(Map("bam" -> "yes"), true, Some(project)) }.toSet shouldEqual Set(savedCluster1, savedCluster3).map(stripFieldsForListCluster)
+    dbFutureValue { _.clusterQuery.listByLabels(Map("bam" -> "yes"), false, Some(project2)) }.toSet shouldEqual Set(savedCluster2).map(stripFieldsForListCluster)
+    dbFutureValue { _.clusterQuery.listByLabels(Map("a" -> "b"), true, Some(project)) }.toSet shouldEqual Set(savedCluster3).map(stripFieldsForListCluster)
     dbFutureValue { _.clusterQuery.listByLabels(Map("a" -> "b"), true, Some(project2)) }.toSet shouldEqual Set.empty[Cluster]
   }
 }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterImageComponentSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterImageComponentSpec.scala
@@ -1,0 +1,26 @@
+package org.broadinstitute.dsde.workbench.leonardo.db
+
+import org.broadinstitute.dsde.workbench.leonardo.CommonTestData
+import org.broadinstitute.dsde.workbench.leonardo.model.ClusterTool.{Jupyter, RStudio}
+import org.scalatest.FlatSpecLike
+
+class ClusterImageComponentSpec extends TestComponent with FlatSpecLike with CommonTestData {
+
+  "ClusterImageComponent" should "save and get" in isolatedDbTest {
+    val cluster = makeCluster(1).save()
+
+    dbFutureValue { _.clusterImageQuery.get(cluster.id, Jupyter) } shouldBe Some(jupyterImage)
+    dbFutureValue { _.clusterImageQuery.save(cluster.id, rstudioImage) }
+    dbFutureValue { _.clusterImageQuery.get(cluster.id, RStudio) } shouldBe Some(rstudioImage)
+  }
+
+  it should "save and get all for cluster" in isolatedDbTest {
+    val cluster = makeCluster(1).save()
+
+    dbFutureValue { _.clusterImageQuery.getAllForCluster(cluster.id) }.toSet shouldBe Set(jupyterImage)
+    dbFutureValue { _.clusterImageQuery.saveAllForCluster(cluster.id, Seq(rstudioImage)) }
+    dbFutureValue { _.clusterImageQuery.getAllForCluster(cluster.id) }.toSet shouldBe Set(jupyterImage, rstudioImage)
+    dbFutureValue { _.clusterImageQuery.getAllForCluster(-1) }.toSet shouldBe Set.empty
+  }
+
+}

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterImageComponentSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterImageComponentSpec.scala
@@ -10,7 +10,9 @@ class ClusterImageComponentSpec extends TestComponent with FlatSpecLike with Com
     val cluster = makeCluster(1).save()
 
     dbFutureValue { _.clusterImageQuery.get(cluster.id, Jupyter) } shouldBe Some(jupyterImage)
+    dbFutureValue { _.clusterImageQuery.get(cluster.id, RStudio) } shouldBe None
     dbFutureValue { _.clusterImageQuery.save(cluster.id, rstudioImage) }
+    dbFutureValue { _.clusterImageQuery.get(cluster.id, Jupyter) } shouldBe Some(jupyterImage)
     dbFutureValue { _.clusterImageQuery.get(cluster.id, RStudio) } shouldBe Some(rstudioImage)
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeonardoModelSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeonardoModelSpec.scala
@@ -6,8 +6,6 @@ import java.util.UUID._
 import org.broadinstitute.dsde.workbench.leonardo.{CommonTestData}
 import org.broadinstitute.dsde.workbench.leonardo.db.{TestComponent}
 import org.broadinstitute.dsde.workbench.leonardo.model.LeonardoJsonSupport._
-import org.broadinstitute.dsde.workbench.leonardo.model.google._
-import org.broadinstitute.dsde.workbench.model.google.GcsBucketName
 import org.scalatest.{FlatSpecLike, Matchers}
 import org.scalatest.concurrent.ScalaFutures
 
@@ -56,7 +54,12 @@ class LeonardoModelSpec extends TestComponent with FlatSpecLike with Matchers wi
         |  "dateAccessed": "2018-08-07T10:12:35Z",
         |  "autopauseThreshold": 30,
         |  "defaultClientId": "defaultClientId",
-        |  "stopAfterCreation": true
+        |  "stopAfterCreation": true,
+        |  "clusterImages": [
+        |    { "tool":"Jupyter",
+        |      "dockerImage":"jupyter/jupyter-base:latest"
+        |      }
+        |    ]
         |}
       """.stripMargin.parseJson
 
@@ -90,7 +93,8 @@ class LeonardoModelSpec extends TestComponent with FlatSpecLike with Matchers wi
         |  "instances": [],
         |  "dateAccessed": "2018-08-07T10:12:35Z",
         |  "autopauseThreshold": 0,
-        |  "stopAfterCreation": false
+        |  "stopAfterCreation": false,
+        |  "clusterImages": []
         |}
       """.stripMargin.parseJson
 
@@ -118,12 +122,12 @@ class LeonardoModelSpec extends TestComponent with FlatSpecLike with Matchers wi
 
   it should "create a map of ClusterInitValues object" in isolatedDbTest {
 
-    val clusterInit = ClusterInitValues(project, name1, initBucketPath, testClusterRequestWithExtensionAndScript, dataprocConfig, clusterFilesConfig, clusterResourcesConfig, proxyConfig, Some(serviceAccountKey), userInfo.userEmail, contentSecurityPolicy)
+    val clusterInit = ClusterInitValues(project, name1, initBucketPath, testClusterRequestWithExtensionAndScript, dataprocConfig, clusterFilesConfig, clusterResourcesConfig, proxyConfig, Some(serviceAccountKey), userInfo.userEmail, contentSecurityPolicy, Set(jupyterImage))
     val clusterInitMap = clusterInit.toMap
 
     clusterInitMap("googleProject") shouldBe project.value
     clusterInitMap("clusterName") shouldBe name1.value
-    clusterInitMap("jupyterDockerImage") shouldBe dataprocConfig.dataprocDockerImage
+    clusterInitMap("jupyterDockerImage") shouldBe jupyterImage.dockerImage
     clusterInitMap("proxyDockerImage") shouldBe proxyConfig.jupyterProxyDockerImage
     clusterInitMap("defaultClientId") shouldBe testClusterRequestWithExtensionAndScript.defaultClientId.getOrElse("")
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeonardoModelSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeonardoModelSpec.scala
@@ -16,11 +16,15 @@ class LeonardoModelSpec extends TestComponent with FlatSpecLike with Matchers wi
 
   val exampleTime = Instant.parse("2018-08-07T10:12:35Z")
 
-  val cluster = makeCluster(1).copy(dataprocInfo = makeDataprocInfo(1).copy(googleId = Option(fromString("4ba97751-026a-4555-961b-89ae6ce78df4"))),
-                                    auditInfo = auditInfo.copy(createdDate = exampleTime,
-                                                               dateAccessed = exampleTime),
-                                    jupyterExtensionUri = Some(jupyterExtensionUri),
-                                    stopAfterCreation = true)
+  val cluster = makeCluster(1).copy(
+    dataprocInfo = makeDataprocInfo(1).copy(
+      googleId = Option(fromString("4ba97751-026a-4555-961b-89ae6ce78df4"))),
+    auditInfo = auditInfo.copy(createdDate = exampleTime,
+      dateAccessed = exampleTime),
+    jupyterExtensionUri = Some(jupyterExtensionUri),
+    stopAfterCreation = true,
+    clusterImages = Set(jupyterImage.copy(timestamp = exampleTime))
+  )
 
 
   it should "serialize/deserialize to/from JSON" in isolatedDbTest {
@@ -56,8 +60,9 @@ class LeonardoModelSpec extends TestComponent with FlatSpecLike with Matchers wi
         |  "defaultClientId": "defaultClientId",
         |  "stopAfterCreation": true,
         |  "clusterImages": [
-        |    { "tool":"Jupyter",
-        |      "dockerImage":"jupyter/jupyter-base:latest"
+        |    { "tool": "Jupyter",
+        |      "dockerImage": "jupyter/jupyter-base:latest",
+        |      "timestamp": "2018-08-07T10:12:35Z"
         |      }
         |    ]
         |}

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/AuthProviderSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/AuthProviderSpec.scala
@@ -14,7 +14,7 @@ import org.broadinstitute.dsde.workbench.leonardo.model._
 import org.broadinstitute.dsde.workbench.leonardo.model.google.{ClusterName, _}
 import org.broadinstitute.dsde.workbench.leonardo.monitor.NoopActor
 import org.broadinstitute.dsde.workbench.leonardo.util.BucketHelper
-import org.broadinstitute.dsde.workbench.leonardo.ClusterEnrichments.{clusterEq, clusterSetEq}
+import org.broadinstitute.dsde.workbench.leonardo.ClusterEnrichments.{clusterEq, clusterSetEq, stripFieldsForListCluster}
 import org.broadinstitute.dsde.workbench.leonardo.dns.ClusterDnsCache
 import org.broadinstitute.dsde.workbench.leonardo.{CommonTestData, GcsPathUtils}
 import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GoogleProject}
@@ -78,7 +78,7 @@ class AuthProviderSpec extends FreeSpec with ScalatestRouteTest with Matchers wi
 
       // list
       val listResponse = leo.listClusters(userInfo, Map()).futureValue
-      listResponse shouldBe Seq(cluster1)
+      listResponse shouldBe Seq(cluster1).map(stripFieldsForListCluster)
 
       //connect
       val proxyRequest = HttpRequest(GET, Uri(s"/notebooks/$googleProject/$clusterName"))
@@ -155,7 +155,7 @@ class AuthProviderSpec extends FreeSpec with ScalatestRouteTest with Matchers wi
 
       // list should work for this user
       //list all clusters should be fine, but empty
-      leo.listClusters(userInfo, Map()).futureValue.toSet shouldEqual Set(cluster1)
+      leo.listClusters(userInfo, Map()).futureValue.toSet shouldEqual Set(cluster1).map(stripFieldsForListCluster)
 
       //connect should 401
       val httpRequest = HttpRequest(GET, Uri(s"/notebooks/$googleProject/$clusterName"))

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoServiceSpec.scala
@@ -12,6 +12,7 @@ import com.google.api.client.testing.json.MockJsonFactory
 import org.broadinstitute.dsde.workbench.google.GoogleStorageDAO
 import org.broadinstitute.dsde.workbench.google.mock.{MockGoogleDataprocDAO, MockGoogleIamDAO, MockGoogleStorageDAO}
 import org.broadinstitute.dsde.workbench.leonardo.CommonTestData
+import org.broadinstitute.dsde.workbench.leonardo.ClusterEnrichments.stripFieldsForListCluster
 import org.broadinstitute.dsde.workbench.leonardo.auth.WhitelistAuthProvider
 import org.broadinstitute.dsde.workbench.leonardo.auth.sam.{MockPetClusterServiceAccountProvider, MockSwaggerSamClient}
 import org.broadinstitute.dsde.workbench.leonardo.dao.google.MockGoogleComputeDAO
@@ -429,7 +430,7 @@ class LeonardoServiceSpec extends TestKit(ActorSystem("leonardotest")) with Flat
 
     // populate some instances for the cluster
     dbFutureValue { _.instanceQuery.saveAllForCluster(
-      getClusterId(clusterCreateResponse), Seq(masterInstance, workerInstance1, workerInstance2)) }
+        getClusterId(clusterCreateResponse), Seq(masterInstance, workerInstance1, workerInstance2)) }
 
     // change cluster status to Running so that it can be deleted
     dbFutureValue { _.clusterQuery.setToRunning(clusterCreateResponse.id, IP("numbers.and.dots")) }
@@ -465,7 +466,7 @@ class LeonardoServiceSpec extends TestKit(ActorSystem("leonardotest")) with Flat
 
     // populate some instances for the cluster
     dbFutureValue { _.instanceQuery.saveAllForCluster(
-      getClusterId(clusterCreateResponseV2), Seq(masterInstanceV2, workerInstance1V2, workerInstance2V2)) }
+        getClusterId(clusterCreateResponseV2), Seq(masterInstanceV2, workerInstance1V2, workerInstance2V2)) }
 
     // change cluster status to Running so that it can be deleted
     dbFutureValue { _.clusterQuery.setToRunning(clusterCreateResponseV2.id, IP("numbers.and.dots")) }
@@ -620,8 +621,6 @@ class LeonardoServiceSpec extends TestKit(ActorSystem("leonardotest")) with Flat
   }
 
   it should "list all clusters" in isolatedDbTest {
-    import org.broadinstitute.dsde.workbench.leonardo.ClusterEnrichments.stripFieldsForListCluster
-
     // create a couple of clusters
     val clusterName1 = ClusterName(s"cluster-${UUID.randomUUID.toString}")
     val cluster1 = leo.createCluster(userInfo, project, clusterName1, testClusterRequest).futureValue
@@ -646,8 +645,6 @@ class LeonardoServiceSpec extends TestKit(ActorSystem("leonardotest")) with Flat
   }
 
   it should "list all clusters created via v2 API" in isolatedDbTest {
-    import org.broadinstitute.dsde.workbench.leonardo.ClusterEnrichments.stripFieldsForListCluster
-
     // create a couple of clusters
     val clusterName1 = ClusterName(s"cluster-${UUID.randomUUID.toString}")
     leo.processClusterCreationRequest(userInfo, project, clusterName1, testClusterRequest).futureValue
@@ -668,8 +665,6 @@ class LeonardoServiceSpec extends TestKit(ActorSystem("leonardotest")) with Flat
   }
 
   it should "list all active clusters" in isolatedDbTest {
-    import org.broadinstitute.dsde.workbench.leonardo.ClusterEnrichments.stripFieldsForListCluster
-
     // create a couple of clusters
     val cluster1 = leo.createCluster(userInfo, project, name1, testClusterRequest).futureValue
 
@@ -691,8 +686,6 @@ class LeonardoServiceSpec extends TestKit(ActorSystem("leonardotest")) with Flat
   }
 
   it should "list all active clusters created via v2 API" in isolatedDbTest {
-    import org.broadinstitute.dsde.workbench.leonardo.ClusterEnrichments.stripFieldsForListCluster
-
     var cluster1, cluster2, cluster3: Cluster = null.asInstanceOf[Cluster]
 
     // create a couple of clusters
@@ -725,8 +718,6 @@ class LeonardoServiceSpec extends TestKit(ActorSystem("leonardotest")) with Flat
   }
 
   it should "list clusters with labels" in isolatedDbTest {
-    import org.broadinstitute.dsde.workbench.leonardo.ClusterEnrichments.stripFieldsForListCluster
-
     // create a couple of clusters
     val clusterName1 = ClusterName(s"cluster-${UUID.randomUUID.toString}")
     val cluster1 = leo.createCluster(userInfo, project, clusterName1, testClusterRequest).futureValue
@@ -745,8 +736,6 @@ class LeonardoServiceSpec extends TestKit(ActorSystem("leonardotest")) with Flat
   }
 
   it should "list clusters with labels created via v2 API" in isolatedDbTest {
-    import org.broadinstitute.dsde.workbench.leonardo.ClusterEnrichments.stripFieldsForListCluster
-
     // create a couple of clusters
     val clusterName1 = ClusterName(s"cluster-${UUID.randomUUID.toString}")
     leo.processClusterCreationRequest(userInfo, project, clusterName1, testClusterRequest).futureValue
@@ -783,8 +772,6 @@ class LeonardoServiceSpec extends TestKit(ActorSystem("leonardotest")) with Flat
   }
 
   it should "list clusters with swagger-style labels" in isolatedDbTest {
-    import org.broadinstitute.dsde.workbench.leonardo.ClusterEnrichments.stripFieldsForListCluster
-
     // create a couple of clusters
     val clusterName1 = ClusterName(s"cluster-${UUID.randomUUID.toString}")
     val cluster1 = leo.createCluster(userInfo, project, clusterName1, testClusterRequest).futureValue
@@ -806,8 +793,6 @@ class LeonardoServiceSpec extends TestKit(ActorSystem("leonardotest")) with Flat
   }
 
   it should "list clusters with swagger-style labels, created using v2 API" in isolatedDbTest {
-    import org.broadinstitute.dsde.workbench.leonardo.ClusterEnrichments.stripFieldsForListCluster
-
     // create a couple of clusters
     val clusterName1 = ClusterName(s"cluster-${UUID.randomUUID.toString}")
     leo.processClusterCreationRequest(userInfo, project, clusterName1, testClusterRequest).futureValue
@@ -835,8 +820,6 @@ class LeonardoServiceSpec extends TestKit(ActorSystem("leonardotest")) with Flat
   }
 
   it should "list clusters belonging to a project" in isolatedDbTest {
-    import org.broadinstitute.dsde.workbench.leonardo.ClusterEnrichments.stripFieldsForListCluster
-
     // create a couple of clusters
     val cluster1 = leo.createCluster(userInfo, project, name1, testClusterRequest).futureValue
     val cluster2 = leo.createCluster(userInfo, project2, name2, testClusterRequest.copy(labels = Some(Map("a" -> "b", "foo" -> "bar")))).futureValue
@@ -1060,7 +1043,7 @@ class LeonardoServiceSpec extends TestKit(ActorSystem("leonardotest")) with Flat
 
     // populate some instances for the cluster
     dbFutureValue { _.instanceQuery.saveAllForCluster(
-      getClusterId(clusterCreateResponse), Seq(masterInstance, workerInstance1, workerInstance2)) }
+        getClusterId(clusterCreateResponse), Seq(masterInstance, workerInstance1, workerInstance2)) }
 
     // set the cluster to Running
     dbFutureValue { _.clusterQuery.setToRunning(clusterCreateResponse.id, IP("1.2.3.4")) }


### PR DESCRIPTION
See https://github.com/DataBiosphere/leonardo/issues/692

Originally this was part of my RStudio branch but I decided to lift it into its own PR since it will be useful with the docker image upgrades as well. This change does the following:
- Adds a new optional `jupyterDockerImage` field to the `ClusterRequest` json
- If set, installs the specified Jupyter image on the cluster
- If unset, installs the latest "prod" image on the cluster (same behavior as today)
- Adds a new `CLUSTER_IMAGE` table which tracks the images installed on a cluster

Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
