### PR TITLE
GAWB-3902: Update workbench-service-test version

### DIFF
--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -9,7 +9,7 @@ object Dependencies {
 
   val workbenchModelV   = "0.12-a19203d"
   val workbenchGoogleV  = "0.16-f2a0020"
-  val serviceTestV = "0.13-dc0998e"
+  val serviceTestV = "0.15-6344f5d"
 
   val excludeWorkbenchModel  = ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = "workbench-model_" + scalaV)
   val excludeWorkbenchGoogle = ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = "workbench-google_" + scalaV)


### PR DESCRIPTION
This bumps the workbench-service-test version to include [this change](https://github.com/broadinstitute/workbench-libs/commit/6344f5d25ddc62a02daf50fd9c7e2db0147cc69e), which was from [this ticket](https://broadinstitute.atlassian.net/browse/GAWB-3902).
This version is being bumped in rawls, orch, fc-ui, sam, and leo


Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
