### PR TITLE
Automation tests: add jitter to project claim

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/ClusterFixtureSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/ClusterFixtureSpec.scala
@@ -6,8 +6,9 @@ import org.broadinstitute.dsde.workbench.fixture._
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.broadinstitute.dsde.workbench.service.Orchestration
 import org.broadinstitute.dsde.workbench.service.test.RandomUtil
+import org.broadinstitute.dsde.workbench.util.addJitter
 import org.scalatest.{BeforeAndAfterAll, Outcome, fixture}
-
+import scala.concurrent.duration._
 import scala.util.{Failure, Success, Try}
 
 
@@ -42,6 +43,10 @@ abstract class ClusterFixtureSpec extends fixture.FreeSpec with BeforeAndAfterAl
     */
   def claimBillingProject(): Unit = {
     Try {
+      val jitter = addJitter(5 seconds, 1 minute)
+      logger.info(s"Sleeping ${jitter.toSeconds} seconds before claiming a billing project")
+      Thread sleep jitter.toMillis
+
       claimedBillingProject = claimGPAllocProject(hermioneCreds)
       billingProject = GoogleProject(claimedBillingProject.projectName)
       logger.info(s"Billing project claimed: ${claimedBillingProject.projectName}")

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
@@ -22,7 +22,7 @@ import org.broadinstitute.dsde.workbench.leonardo.Leonardo.ApiVersion.{V1, V2}
 import org.broadinstitute.dsde.workbench.leonardo.StringValueClass.LabelMap
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
 import org.broadinstitute.dsde.workbench.model.google._
-import org.broadinstitute.dsde.workbench.util.{LocalFileUtil, Retry}
+import org.broadinstitute.dsde.workbench.util._
 import org.openqa.selenium.WebDriver
 import org.scalactic.source.Position
 import org.scalatest.{Matchers, Suite}
@@ -406,6 +406,9 @@ trait LeonardoTestUtils extends WebBrowserSpec with Matchers with Eventually wit
   // testCode is curried so the token can be made implicit:
   // https://stackoverflow.com/questions/14072061/function-literal-with-multiple-implicit-arguments
   def withProject(testCode: GoogleProject => UserAuthToken => Any): Unit = {
+    val jitter = addJitter(5 seconds, 1 minute)
+    logger.info(s"Sleeping ${jitter.toSeconds} seconds before claiming a billing project")
+    Thread sleep jitter.toMillis
     withCleanBillingProject(hermioneCreds) { projectName =>
       val project = GoogleProject(projectName)
       Orchestration.billing.addUserToBillingProject(projectName, ronEmail, Orchestration.billing.BillingProjectRole.User)(hermioneAuthToken)


### PR DESCRIPTION
I'm hoping this will help address the intermittent failures in https://broadworkbench.atlassian.net/browse/WB-82. 

Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
