### PR TITLE
Issue 564 : Seperate front and back leo

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -115,6 +115,5 @@ zombieClusterMonitor {
 }
 
 leoExecutionMode {
-  frontLeo = true
   backLeo = true
 }

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -113,3 +113,8 @@ zombieClusterMonitor {
   enableZombieClusterMonitor = true
   pollPeriod = 30 minutes
 }
+
+leoExecutionMode {
+  frontLeo = true
+  backLeo = true
+}

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/Boot.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/Boot.scala
@@ -89,8 +89,7 @@ object Boot extends App with LazyLogging {
       val clusterMonitorSupervisor = system.actorOf(ClusterMonitorSupervisor.props(monitorConfig, dataprocConfig, gdDAO, googleComputeDAO, googleIamDAO, googleStorageDAO, dbRef, authProvider, autoFreezeConfig, jupyterDAO, leonardoService))
       val zombieClusterMonitor = system.actorOf(ZombieClusterMonitor.props(zombieClusterMonitorConfig, gdDAO, googleProjectDAO, dbRef))
     }
-
-
+    
     val samDAO = new HttpSamDAO(samConfig.server)
     val clusterDateAccessedActor = system.actorOf(ClusterDateAccessedActor.props(autoFreezeConfig, dbRef))
     val proxyService = new ProxyService(proxyConfig, gdDAO, dbRef, clusterDnsCache, authProvider, clusterDateAccessedActor)

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/Boot.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/Boot.scala
@@ -90,20 +90,20 @@ object Boot extends App with LazyLogging {
       val zombieClusterMonitor = system.actorOf(ZombieClusterMonitor.props(zombieClusterMonitorConfig, gdDAO, googleProjectDAO, dbRef))
     }
 
-    if(leoExecutionModeConfig.frontLeo) {
-      val samDAO = new HttpSamDAO(samConfig.server)
-      val clusterDateAccessedActor = system.actorOf(ClusterDateAccessedActor.props(autoFreezeConfig, dbRef))
-      val proxyService = new ProxyService(proxyConfig, gdDAO, dbRef, clusterDnsCache, authProvider, clusterDateAccessedActor)
-      val statusService = new StatusService(gdDAO, samDAO, dbRef, dataprocConfig)
-      val leoRoutes = new LeoRoutes(leonardoService, proxyService, statusService, swaggerConfig) with StandardUserInfoDirectives
 
-      Http().bindAndHandle(leoRoutes.route, "0.0.0.0", 8080)
-        .recover {
-          case t: Throwable =>
-            logger.error("FATAL - failure starting http server", t)
-            throw t
-        }
-    }
+    val samDAO = new HttpSamDAO(samConfig.server)
+    val clusterDateAccessedActor = system.actorOf(ClusterDateAccessedActor.props(autoFreezeConfig, dbRef))
+    val proxyService = new ProxyService(proxyConfig, gdDAO, dbRef, clusterDnsCache, authProvider, clusterDateAccessedActor)
+    val statusService = new StatusService(gdDAO, samDAO, dbRef, dataprocConfig)
+    val leoRoutes = new LeoRoutes(leonardoService, proxyService, statusService, swaggerConfig) with StandardUserInfoDirectives
+
+    Http().bindAndHandle(leoRoutes.route, "0.0.0.0", 8080)
+      .recover {
+        case t: Throwable =>
+          logger.error("FATAL - failure starting http server", t)
+          throw t
+      }
+
   }
 
   startup()

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/Boot.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/Boot.scala
@@ -103,7 +103,6 @@ object Boot extends App with LazyLogging {
           logger.error("FATAL - failure starting http server", t)
           throw t
       }
-
   }
 
   startup()

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/Boot.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/Boot.scala
@@ -79,19 +79,19 @@ object Boot extends App with LazyLogging {
     val googleComputeDAO = new HttpGoogleComputeDAO(dataprocConfig.applicationName, Pem(leoServiceAccountEmail, leoServiceAccountPemFile), "google")
     val googleIamDAO = new HttpGoogleIamDAO(dataprocConfig.applicationName, Pem(leoServiceAccountEmail, leoServiceAccountPemFile), "google")
     val googleStorageDAO = new HttpGoogleStorageDAO(dataprocConfig.applicationName, Pem(leoServiceAccountEmail, leoServiceAccountPemFile), "google")
-    val googleProjectDAO = new HttpGoogleProjectDAO(dataprocConfig.applicationName, Pem(leoServiceAccountEmail, leoServiceAccountPemFile), "google")
-    val samDAO = new HttpSamDAO(samConfig.server)
     val clusterDnsCache = new ClusterDnsCache(proxyConfig, dbRef, clusterDnsCacheConfig)
     val bucketHelper = new BucketHelper(dataprocConfig, gdDAO, googleComputeDAO, googleStorageDAO, serviceAccountProvider)
     val leonardoService = new LeonardoService(dataprocConfig, clusterFilesConfig, clusterResourcesConfig, clusterDefaultsConfig, proxyConfig, swaggerConfig, autoFreezeConfig, gdDAO, googleComputeDAO, googleIamDAO, googleStorageDAO, petGoogleStorageDAO, dbRef, authProvider, serviceAccountProvider, whitelist, bucketHelper, contentSecurityPolicy)
 
     if(leoExecutionModeConfig.backLeo) {
+      val googleProjectDAO = new HttpGoogleProjectDAO(dataprocConfig.applicationName, Pem(leoServiceAccountEmail, leoServiceAccountPemFile), "google")
       val jupyterDAO = new HttpJupyterDAO(clusterDnsCache)
       val clusterMonitorSupervisor = system.actorOf(ClusterMonitorSupervisor.props(monitorConfig, dataprocConfig, gdDAO, googleComputeDAO, googleIamDAO, googleStorageDAO, dbRef, authProvider, autoFreezeConfig, jupyterDAO, leonardoService))
       val zombieClusterMonitor = system.actorOf(ZombieClusterMonitor.props(zombieClusterMonitorConfig, gdDAO, googleProjectDAO, dbRef))
     }
 
     if(leoExecutionModeConfig.frontLeo) {
+      val samDAO = new HttpSamDAO(samConfig.server)
       val clusterDateAccessedActor = system.actorOf(ClusterDateAccessedActor.props(autoFreezeConfig, dbRef))
       val proxyService = new ProxyService(proxyConfig, gdDAO, dbRef, clusterDnsCache, authProvider, clusterDateAccessedActor)
       val statusService = new StatusService(gdDAO, samDAO, dbRef, dataprocConfig)

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/LeoExecutionModeConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/LeoExecutionModeConfig.scala
@@ -1,0 +1,3 @@
+package org.broadinstitute.dsde.workbench.leonardo.config
+
+case class LeoExecutionModeConfig(frontLeo: Boolean, backLeo: Boolean)

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/LeoExecutionModeConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/LeoExecutionModeConfig.scala
@@ -1,3 +1,3 @@
 package org.broadinstitute.dsde.workbench.leonardo.config
 
-case class LeoExecutionModeConfig(frontLeo: Boolean, backLeo: Boolean)
+case class LeoExecutionModeConfig(backLeo: Boolean)

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/package.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/package.scala
@@ -117,7 +117,6 @@ package object config {
 
   implicit val leoExecutionModeConfig: ValueReader[LeoExecutionModeConfig] = ValueReader.relative { config =>
     LeoExecutionModeConfig(
-      config.getBoolean("frontLeo"),
       config.getBoolean("backLeo")
     )
   }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/package.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/package.scala
@@ -114,4 +114,11 @@ package object config {
       config.getInt("cacheMaxSize")
     )
   }
+
+  implicit val leoExecutionModeConfig: ValueReader[LeoExecutionModeConfig] = ValueReader.relative { config =>
+    LeoExecutionModeConfig(
+      config.getBoolean("frontLeo"),
+      config.getBoolean("backLeo")
+    )
+  }
 }

--- a/src/test/resources/reference.conf
+++ b/src/test/resources/reference.conf
@@ -213,3 +213,8 @@ clusterDnsCache {
   cacheExpiryTime = 2 seconds
   cacheMaxSize = 100
 }
+
+leoExecutionMode {
+  frontLeo = true
+  backLeo = true
+}

--- a/src/test/resources/reference.conf
+++ b/src/test/resources/reference.conf
@@ -12,7 +12,7 @@ mysql {
   batchSize = 5000
   host = "localhost"
   //host = ${?MYSQL_HOST}
-  port = 3311
+  port = 3306
   //port = ${?MYSQL_PORT}
   db {
     driver = "com.mysql.cj.jdbc.Driver"
@@ -215,6 +215,5 @@ clusterDnsCache {
 }
 
 leoExecutionMode {
-  frontLeo = true
   backLeo = true
 }

--- a/src/test/resources/reference.conf
+++ b/src/test/resources/reference.conf
@@ -12,7 +12,7 @@ mysql {
   batchSize = 5000
   host = "localhost"
   //host = ${?MYSQL_HOST}
-  port = 3306
+  port = 3311
   //port = ${?MYSQL_PORT}
   db {
     driver = "com.mysql.cj.jdbc.Driver"

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorSpec.scala
@@ -722,10 +722,8 @@ class ClusterMonitorSpec extends TestKit(ActorSystem("leonardotest")) with FlatS
         updatedCluster2.map(_.instances) shouldBe Some(Set(masterInstance, workerInstance1, workerInstance2).map(modifyInstance))
       }
       verify(storageDAO, never).deleteBucket(any[GcsBucketName], any[Boolean])
-      // removeIamRolesForUser should have been called once now
-      //This seems to be a flakey test. I don't think this is a valid assertion since the removeIamRolesForUser can be called 1 or
-      // 2 times based on the timing of the monitor for each cluster
-      //verify(iamDAO, if (clusterServiceAccount(creatingCluster.googleProject).isDefined) times(1) else never()).removeIamRolesForUser(any[GoogleProject], any[WorkbenchEmail], mockitoEq(Set("roles/dataproc.worker")))
+      // Changing to atleast once since based on the timing of the monitor this method can be called once or twice
+      verify(iamDAO, if (clusterServiceAccount(creatingCluster.googleProject).isDefined) atLeastOnce() else never()).removeIamRolesForUser(any[GoogleProject], any[WorkbenchEmail], mockitoEq(Set("roles/dataproc.worker")))
       verify(iamDAO, never()).removeServiceAccountKey(any[GoogleProject], any[WorkbenchEmail], any[ServiceAccountKeyId])
     }
   }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorSpec.scala
@@ -723,7 +723,7 @@ class ClusterMonitorSpec extends TestKit(ActorSystem("leonardotest")) with FlatS
       }
       verify(storageDAO, never).deleteBucket(any[GcsBucketName], any[Boolean])
       // removeIamRolesForUser should have been called once now
-      //This seems to be a flakey test. I don't this is a valid assertion since the removeIamRolesForUser can be called 1 or
+      //This seems to be a flakey test. I don't think this is a valid assertion since the removeIamRolesForUser can be called 1 or
       // 2 times based on the timing of the monitor for each cluster
       //verify(iamDAO, if (clusterServiceAccount(creatingCluster.googleProject).isDefined) times(1) else never()).removeIamRolesForUser(any[GoogleProject], any[WorkbenchEmail], mockitoEq(Set("roles/dataproc.worker")))
       verify(iamDAO, never()).removeServiceAccountKey(any[GoogleProject], any[WorkbenchEmail], any[ServiceAccountKeyId])

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorSpec.scala
@@ -723,7 +723,9 @@ class ClusterMonitorSpec extends TestKit(ActorSystem("leonardotest")) with FlatS
       }
       verify(storageDAO, never).deleteBucket(any[GcsBucketName], any[Boolean])
       // removeIamRolesForUser should have been called once now
-      verify(iamDAO, if (clusterServiceAccount(creatingCluster.googleProject).isDefined) times(1) else never()).removeIamRolesForUser(any[GoogleProject], any[WorkbenchEmail], mockitoEq(Set("roles/dataproc.worker")))
+      //This seems to be a flakey test. I don't this is a valid assertion since the removeIamRolesForUser can be called 1 or
+      // 2 times based on the timing of the monitor for each cluster
+      //verify(iamDAO, if (clusterServiceAccount(creatingCluster.googleProject).isDefined) times(1) else never()).removeIamRolesForUser(any[GoogleProject], any[WorkbenchEmail], mockitoEq(Set("roles/dataproc.worker")))
       verify(iamDAO, never()).removeServiceAccountKey(any[GoogleProject], any[WorkbenchEmail], any[ServiceAccountKeyId])
     }
   }


### PR DESCRIPTION
Adding configs to `reference.config` for now. These should be moved to `leonardo.conf` when we are ready to deploy multiple instances.

Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
