### PR TITLE
Don't delete Creating clusters in the ClusterMonitorActor

### DIFF
--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorSpec.scala
@@ -42,7 +42,7 @@ class ClusterMonitorSpec extends TestKit(ActorSystem("leonardotest")) with FlatS
                                             dataprocInfo = makeDataprocInfo(1).copy(hostIp = None),
                                             status = ClusterStatus.Creating,
                                             userJupyterExtensionConfig = Some(userExtConfig),
-                                            stopAfterCreation = true)
+                                            stopAfterCreation = false)
 
   val deletingCluster = makeCluster(2).copy(serviceAccountInfo = ServiceAccountInfo(clusterServiceAccount(project), notebookServiceAccount(project)),
                                             status = ClusterStatus.Deleting,
@@ -911,8 +911,8 @@ class ClusterMonitorSpec extends TestKit(ActorSystem("leonardotest")) with FlatS
   // - instances are populated in the DB
   // - monitor actor shuts down
   it should "stop a cluster after creation" in isolatedDbTest {
-    val savedCreatingCluster = creatingCluster.save()
-    creatingCluster shouldEqual savedCreatingCluster
+    val stopAfterCreationCluster = creatingCluster.copy(stopAfterCreation = true)
+    stopAfterCreationCluster.save() shouldEqual stopAfterCreationCluster
 
     val gdDAO = mock[GoogleDataprocDAO]
     when {


### PR DESCRIPTION
Fixes a race condition introduced by https://github.com/DataBiosphere/leonardo/pull/689.

1. Cluster is created via API. Record is inserted to the database with status Creating. Cluster is not created in Google yet.
2. ClusterMonitorSupervisor detects Creating cluster and starts monitoring it.
3. ClusterMonitorActor tries to delete cluster because it doesn't exist in Google yet.
4. Async cluster creation kicks in and finally creates cluster in Google.
5. End result is a cluster existing in Google with status `Deleted` in the Leo DB
6. Tests fail with messages like:
```
{"statusCode":404,"source":"leonardo","causes":[],"exceptionClass":"org.broadinstitute.dsde.workbench.leonardo.service.ClusterNotFoundException","stackTrace":[],"message":"Cluster gpalloc-qa-master-1ngr1ls/automation-test-ajdtpeuiz not found"}.
```

This didn't used to happen because the supervisor was not notified until async cluster creation had finished.

Snippet from test logs:
```
root@764e190e7ceb:/log# grep extktwwjdq leonardo.log 
[INFO] [16:30:09.676] [leonardo-akka.actor.default-dispatcher-31] o.b.d.w.l.service.LeonardoService - Attempting to notify the AuthProvider for creation of cluster 'user-jupyter-extktwwjdq' on Google project 'gpalloc-qa-master-2djle1k'...
[INFO] [16:30:11.062] [leonardo-akka.actor.default-dispatcher-31] o.b.d.w.l.service.LeonardoService - Successfully notified the AuthProvider for creation of cluster 'user-jupyter-extktwwjdq' on Google project 'gpalloc-qa-master-2djle1k'.
[INFO] [16:30:11.081] [leonardo-akka.actor.default-dispatcher-31] o.b.d.w.l.service.LeonardoService - Inserted an initial record into the DB for cluster 'user-jupyter-extktwwjdq' on Google project 'gpalloc-qa-master-2djle1k'.
[INFO] [16:30:11.082] [leonardo-akka.actor.default-dispatcher-31] o.b.d.w.l.service.LeonardoService - Attempting to asynchronously create cluster 'user-jupyter-extktwwjdq' on Google project 'gpalloc-qa-master-2djle1k'...
[INFO] [16:30:11.082] [leonardo-akka.actor.default-dispatcher-31] o.b.d.w.l.service.LeonardoService - Submitting to Google the request to create cluster 'user-jupyter-extktwwjdq' on Google project 'gpalloc-qa-master-2djle1k'...
[INFO] [16:30:11.563] [leonardo-akka.actor.default-dispatcher-30] o.b.d.w.l.m.ClusterMonitorSupervisor - Monitoring cluster gpalloc-qa-master-2djle1k/user-jupyter-extktwwjdq for initialization.
[INFO] [16:30:14.545] [leonardo-akka.actor.default-dispatcher-52] o.b.d.w.l.m.ClusterMonitorActor - Cluster gpalloc-qa-master-2djle1k/user-jupyter-extktwwjdq has been deleted.
[WARN] [16:30:14.551] [leonardo-akka.actor.default-dispatcher-52] o.b.d.w.l.m.ClusterMonitorActor - Could not lookup bucket for cluster gpalloc-qa-master-2djle1k/user-jupyter-extktwwjdq: cluster not in db
[INFO] [16:30:16.989] [leonardo-akka.actor.default-dispatcher-4] o.b.d.w.l.service.LeonardoService - Successfully submitted to Google the request to create cluster 'user-jupyter-extktwwjdq' on Google project 'gpalloc-qa-master-2djle1k', and updated the database record accordingly. Will monitor the cluster creation process...

```

Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
