### PR TITLE
Exponentially retry 409s from GoogleIamDAO policy changes, to support…

### DIFF
--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoServiceSpec.scala
@@ -9,6 +9,7 @@ import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import akka.testkit.TestKit
 import com.google.api.client.googleapis.testing.json.GoogleJsonResponseExceptionFactoryTesting
 import com.google.api.client.testing.json.MockJsonFactory
+import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.workbench.google.GoogleStorageDAO
 import org.broadinstitute.dsde.workbench.google.mock.{MockGoogleDataprocDAO, MockGoogleIamDAO, MockGoogleStorageDAO}
 import org.broadinstitute.dsde.workbench.leonardo.CommonTestData
@@ -25,11 +26,13 @@ import org.broadinstitute.dsde.workbench.leonardo.monitor.NoopActor
 import org.broadinstitute.dsde.workbench.leonardo.util.BucketHelper
 import org.broadinstitute.dsde.workbench.model._
 import org.broadinstitute.dsde.workbench.model.google._
+import org.broadinstitute.dsde.workbench.util.Retry
 import org.mockito.ArgumentMatchers.{any, eq => mockitoEq}
 import org.mockito.Mockito.{never, verify, _}
 import org.scalatest._
 import org.scalatest.concurrent.Eventually.eventually
 import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.time.{Minutes, Span}
 import spray.json._
 
 import scala.concurrent.duration._
@@ -37,7 +40,7 @@ import scala.concurrent.{Await, ExecutionContext, Future}
 
 class LeonardoServiceSpec extends TestKit(ActorSystem("leonardotest")) with FlatSpecLike with Matchers
   with BeforeAndAfter with BeforeAndAfterAll with TestComponent with ScalaFutures
-  with OptionValues with CommonTestData with LeoComponent {
+  with OptionValues with CommonTestData with LeoComponent with Retry with LazyLogging {
 
   private var gdDAO: MockGoogleDataprocDAO = _
   private var computeDAO: MockGoogleComputeDAO = _
@@ -975,8 +978,9 @@ class LeonardoServiceSpec extends TestKit(ActorSystem("leonardotest")) with Flat
       new MockGoogleStorageDAO
     }
 
-    //we meed to use a special version of the MockGoogleDataprocDAO to simulate an error during the call to resizeCluster
-    leo = new LeonardoService(dataprocConfig, clusterFilesConfig, clusterResourcesConfig, clusterDefaultsConfig, proxyConfig, swaggerConfig, autoFreezeConfig, mockGoogleDataprocDAO, computeDAO, new ErroredMockGoogleIamDAO, storageDAO, mockPetGoogleDAO, DbSingleton.ref, authProvider, serviceAccountProvider, whitelist, bucketHelper, contentSecurityPolicy)
+    //we meed to use a special version of the MockGoogleIamDAO to simulate an error when adding IAM roles
+    val iamDAO = new ErroredMockGoogleIamDAO
+    leo = new LeonardoService(dataprocConfig, clusterFilesConfig, clusterResourcesConfig, clusterDefaultsConfig, proxyConfig, swaggerConfig, autoFreezeConfig, mockGoogleDataprocDAO, computeDAO, iamDAO, storageDAO, mockPetGoogleDAO, DbSingleton.ref, authProvider, serviceAccountProvider, whitelist, bucketHelper, contentSecurityPolicy)
 
     // create the cluster
     val clusterCreateResponse =
@@ -985,6 +989,30 @@ class LeonardoServiceSpec extends TestKit(ActorSystem("leonardotest")) with Flat
     eventually {
       dbFutureValue { _.clusterQuery.getClusterStatus(clusterCreateResponse.id) } shouldBe Some(ClusterStatus.Error)
     }
+
+    // IAM call should not have been retried
+    iamDAO.invocationCount shouldBe 1
+  }
+
+  it should "retry 409 errors when adding dataproc worker role" in isolatedDbTest {
+    val mockPetGoogleDAO: String => GoogleStorageDAO = _ => {
+      new MockGoogleStorageDAO
+    }
+
+    //we meed to use a special version of the MockGoogleIamDAO to simulate a conflict when adding IAM roles
+    val iamDAO = new ErroredMockGoogleIamDAO(409)
+    leo = new LeonardoService(dataprocConfig, clusterFilesConfig, clusterResourcesConfig, clusterDefaultsConfig, proxyConfig, swaggerConfig, autoFreezeConfig, mockGoogleDataprocDAO, computeDAO, iamDAO, storageDAO, mockPetGoogleDAO, DbSingleton.ref, authProvider, serviceAccountProvider, whitelist, bucketHelper, contentSecurityPolicy)
+
+    // create the cluster
+    val clusterCreateResponse =
+      leo.processClusterCreationRequest(userInfo, project, name1, testClusterRequest).futureValue
+
+    eventually(timeout(Span(5, Minutes))) {
+      dbFutureValue { _.clusterQuery.getClusterStatus(clusterCreateResponse.id) } shouldBe Some(ClusterStatus.Error)
+    }
+
+    // IAM call should have been retried exponentially
+    iamDAO.invocationCount shouldBe exponentialBackOffIntervals.size + 1
   }
 
   it should "update the autopause threshold for a cluster" in isolatedDbTest {
@@ -1158,10 +1186,12 @@ class LeonardoServiceSpec extends TestKit(ActorSystem("leonardotest")) with Flat
     }
   }
 
-  private class ErroredMockGoogleIamDAO extends MockGoogleIamDAO {
+  private class ErroredMockGoogleIamDAO(statusCode: Int = 400) extends MockGoogleIamDAO {
+    var invocationCount = 0
     override def addIamRolesForUser(iamProject: GoogleProject, email: WorkbenchEmail, rolesToAdd: Set[String]): Future[Unit] = {
+      invocationCount += 1
       val jsonFactory = new MockJsonFactory
-      val testException = GoogleJsonResponseExceptionFactoryTesting.newMock(jsonFactory, 400, "oh no i have failed")
+      val testException = GoogleJsonResponseExceptionFactoryTesting.newMock(jsonFactory, statusCode, "oh no i have failed")
 
       Future.failed(testException)
     }


### PR DESCRIPTION
… concurrent cluster creations in the same project

This came up in workshop testing. In an upcoming workshop, attendees will be creating clusters in the same project. This is different than previous workshops, where attendees typically used dedicated or free-trial projects. We saw a significant number of clusters fail with:
```
Asynchronous creation of cluster 'aj-ashg-aq3uoeyjvl' on Google project 'aj-test-nhs-saturn-1-15-2019-c' failed due to 'com.google.api.client.googleapis.json.GoogleJsonResponseException: 409 Conflict
{
  "code" : 409,
  "errors" : [ {
    "domain" : "global",
    "message" : "There were concurrent policy changes. Please retry the whole read-modify-write with exponential backoff.",
    "reason" : "aborted"
  } ],
  "message" : "There were concurrent policy changes. Please retry the whole read-modify-write with exponential backoff.",
  "status" : "ABORTED"
```

This PR adds exponential retries to `GoogleIamDAO.addIamRolesForUser`/`removeIamRolesForUser`, as suggested by the error message.

Note: all these calls are asynchronous to the request, so should not impact request latency/timeouts. I decided to add this in Leo as opposed to workbench-libs, as I didn't want to inadvertently affect other callers of these APIs.


\<your comments for this PR go here\>

Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
