### PR TITLE
[NOMERGE] Use python 3.7 on the worker nodes only

### DIFF
--- a/src/main/resources/jupyter/init-actions.sh
+++ b/src/main/resources/jupyter/init-actions.sh
@@ -317,5 +317,5 @@ export DEBIAN_FRONTEND=noninteractive
 echo "deb http://ftp.de.debian.org/debian testing main"      >> /etc/apt/sources.list
 retry 5 betterAptGet
 retry 5 apt-get -yq --force-yes install -t testing --no-install-recommends \
-    python3.6
-retry 5 update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.6 100
+    python3.7
+retry 5 update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.7 100


### PR DESCRIPTION
Experimental to see what happens. This will make the master node use the 3.6 image and the workers user 3.7. I suspect Spark/Hail won't work but it might be a temporary solution to fix cluster creation.

Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
