### PR TITLE
Recursively copy jupyterlab extension

### DIFF
--- a/src/main/resources/jupyter/init-actions.sh
+++ b/src/main/resources/jupyter/init-actions.sh
@@ -255,7 +255,7 @@ if [[ "${ROLE}" == 'Master' ]]; then
         log 'Installing JupyterLab extension [$ext]...'
         pwd
         if [[ $ext == 'gs://'* ]]; then
-          gsutil cp $ext /etc
+          gsutil cp -r $ext /etc
           JUPYTER_EXTENSION_ARCHIVE=`basename $ext`
           docker cp /etc/${JUPYTER_EXTENSION_ARCHIVE} ${JUPYTER_SERVER_NAME}:${JUPYTER_HOME}/${JUPYTER_EXTENSION_ARCHIVE}
           retry 3 docker exec ${JUPYTER_SERVER_NAME} ${JUPYTER_SCRIPTS}/extension/jupyter_install_lab_extension.sh ${JUPYTER_HOME}/${JUPYTER_EXTENSION_ARCHIVE}

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -975,7 +975,7 @@ definitions:
       labExtensions:
         type: object
         description: |
-          Optional, map of extension name and lab extension. The extension should be a verified jupyterlab extension that is uploaded to npm (list of public extensions here: https://github.com/search?utf8=%E2%9C%93&q=topic%3Ajupyterlab-extension&type=Repositories), a gzipped tarball made using 'npm pack', or a URL to a gzipped tarball made using 'npm pack'.
+          Optional, map of extension name and lab extension. The extension should be a verified jupyterlab extension that is uploaded to npm (list of public extensions here: https://github.com/search?utf8=%E2%9C%93&q=topic%3Ajupyterlab-extension&type=Repositories), a gzipped tarball made using 'npm pack', a folder structured by 'jlpm build', or a URL to either of the latter.
 
   SubsystemStatus:
     description: status of a subsystem Leonardo depends on


### PR DESCRIPTION
Allows a user to specify a folder containing a jupyterlab extension, rather than only being able to specify gzipped tarballs. This was requested by All of Us. 

Was manually tested using the TOC jupyterlab extension

Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
