### PR TITLE
More efficient database unmarshaling

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,8 +8,9 @@ object Dependencies {
   val scalaLoggingV = "3.9.0"
   val scalaTestV    = "3.0.5"
   val slickV        = "3.2.3"
+  val catsV         = "1.3.1"
 
-  val workbenchUtilV    = "0.3-0e9d080"
+  val workbenchUtilV    = "0.5-6942040"
   val workbenchModelV   = "0.11-2bddd5b"
   val workbenchGoogleV  = "0.16-4fe117d"
   val workbenchMetricsV = "0.3-c5b80d2"
@@ -48,7 +49,7 @@ object Dependencies {
   val scalaLogging: ModuleID =   "com.typesafe.scala-logging" %% "scala-logging"   % scalaLoggingV
   val swaggerUi: ModuleID =      "org.webjars"                %  "swagger-ui"      % "2.2.5"
   val ficus: ModuleID =          "com.iheart"                 %% "ficus"           % "1.4.3"
-  val cats: ModuleID =           "org.typelevel"              %% "cats"            % "0.9.0"
+  val cats: ModuleID =           "org.typelevel"              %% "cats-core"       % catsV
   val httpClient: ModuleID =     "org.apache.httpcomponents"  % "httpclient"       % "4.5.5"  // upgrading a transitive dependency to avoid security warnings
   val enumeratum: ModuleID =     "com.beachape"               %% "enumeratum"      % "1.5.13"
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -12,7 +12,7 @@ object Dependencies {
 
   val workbenchUtilV    = "0.5-6942040"
   val workbenchModelV   = "0.11-2bddd5b"
-  val workbenchGoogleV  = "0.16-4fe117d"
+  val workbenchGoogleV  = "0.18-6942040"
   val workbenchMetricsV = "0.3-c5b80d2"
 
   val samV =  "1.0-5cdffb4"

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/google/HttpGoogleDataprocDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/google/HttpGoogleDataprocDAO.scala
@@ -97,7 +97,7 @@ class HttpGoogleDataprocDAO(appName: String,
   override def getClusterStatus(googleProject: GoogleProject, clusterName: ClusterName): Future[ClusterStatus] = {
     val transformed = for {
       cluster <- OptionT(getCluster(googleProject, clusterName))
-      status <- OptionT.pure[Future, ClusterStatus](
+      status <- OptionT.pure[Future](
         Try(ClusterStatus.withNameInsensitive(cluster.getStatus.getState)).toOption.getOrElse(ClusterStatus.Unknown))
     } yield status
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dns/ClusterDnsCache.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dns/ClusterDnsCache.scala
@@ -60,7 +60,7 @@ class ClusterDnsCache(proxyConfig: ProxyConfig, dbRef: DbReference, dnsCacheConf
         def load(key: DnsCacheKey) = {
           logger.debug(s"DNS Cache miss for ${key.clusterName} / ${key.clusterName}...loading from DB...")
           dbRef
-            .inTransaction { _.clusterQuery.getActiveClusterByName(key.googleProject, key.clusterName) }
+            .inTransaction { _.clusterQuery.getActiveClusterForDnsCache(key.googleProject, key.clusterName) }
             .map {
               case Some(cluster) => getHostStatusAndUpdateHostToIpIfHostReady(cluster)
               case None => HostNotFound

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ZombieClusterMonitor.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ZombieClusterMonitor.scala
@@ -86,8 +86,8 @@ class ZombieClusterMonitor(config: ZombieClusterConfig, gdDAO: GoogleDataprocDAO
 
   private def isProjectActiveInGoogle(googleProject: GoogleProject): Future[Boolean] = {
     // Check the project and its billing info
-    (googleProjectDAO.isProjectActive(googleProject.value) |@| googleProjectDAO.isBillingActive(googleProject.value))
-      .map(_ && _)
+    (googleProjectDAO.isProjectActive(googleProject.value), googleProjectDAO.isBillingActive(googleProject.value))
+      .mapN(_ && _)
       .recover { case e =>
         logger.warn(s"Unable to check status of project ${googleProject.value} for zombie cluster detection", e)
         true

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoService.scala
@@ -728,7 +728,7 @@ class LeonardoService(protected val dataprocConfig: DataprocConfig,
       // Validate the user script URI
       _ <- clusterRequest.jupyterUserScriptUri match {
         case Some(userScriptUri) => OptionT.liftF[Future, Unit](validateBucketObjectUri(userEmail, petToken, userScriptUri.toUri))
-        case None => OptionT.pure[Future, Unit](())
+        case None => OptionT.pure[Future](())
       }
 
       // Validate the extension URIs
@@ -736,7 +736,7 @@ class LeonardoService(protected val dataprocConfig: DataprocConfig,
         case Some(config) =>
           val extensionsToValidate = (config.nbExtensions.values ++ config.serverExtensions.values ++ config.combinedExtensions.values).filter(_.startsWith("gs://"))
           OptionT.liftF(Future.traverse(extensionsToValidate)(x => validateBucketObjectUri(userEmail, petToken, x)))
-        case None => OptionT.pure[Future, Unit](())
+        case None => OptionT.pure[Future](())
       }
     } yield ()
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/ClusterEnrichments.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/ClusterEnrichments.scala
@@ -52,7 +52,7 @@ object ClusterEnrichments {
     fcs1 == fcs2
   }
 
-  def stripFieldsForListCluster(cluster: Cluster): Cluster = {
+  def stripFieldsForListCluster: Cluster => Cluster = { cluster =>
     cluster.copy(
       instances = Set.empty,
       clusterImages = Set.empty,

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponentSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponentSpec.scala
@@ -209,4 +209,16 @@ class ClusterComponentSpec extends TestComponent with FlatSpecLike with CommonTe
     dbFutureValue { _.clusterQuery.listByLabels(Map("a" -> "b"), true, Some(project)) }.toSet shouldEqual Set(savedCluster3).map(stripFieldsForListCluster)
     dbFutureValue { _.clusterQuery.listByLabels(Map("a" -> "b"), true, Some(project2)) }.toSet shouldEqual Set.empty[Cluster]
   }
+
+  it should "get for dns cache" in isolatedDbTest {
+    val savedCluster1 = makeCluster(1)
+      .copy(
+        labels = Map("bam" -> "yes", "vcf" -> "no", "foo" -> "bar"),
+        instances = Set(masterInstance, workerInstance1, workerInstance2))
+      .save(Some(serviceAccountKey.id))
+
+    // Result should not include labels or instances
+    dbFutureValue { _.clusterQuery.getActiveClusterForDnsCache(savedCluster1.googleProject, savedCluster1.clusterName) } shouldEqual
+      Some(savedCluster1).map(stripFieldsForListCluster andThen (_.copy(labels = Map.empty)))
+  }
 }


### PR DESCRIPTION
I'm on-call and saw several Leo high CPU alerts on 2/12. I looked at some thread dumps and saw multiple threads here:
```
"leonardo-akka.actor.default-dispatcher-50705" #319469 prio=5 os_prio=0 tid=0x00007f4a5c04f800 nid=0x6b1d runnable [0x00007f49f6640000]
   java.lang.Thread.State: RUNNABLE
	at scala.collection.mutable.ListBuffer.$plus$eq(ListBuffer.scala:177)
	at scala.collection.mutable.ListBuffer.$plus$eq(ListBuffer.scala:44)
	at scala.collection.generic.Growable.loop$1(Growable.scala:53)
	at scala.collection.generic.Growable.$plus$plus$eq(Growable.scala:58)
	at scala.collection.generic.Growable.$plus$plus$eq$(Growable.scala:50)
	at scala.collection.mutable.ListBuffer.$plus$plus$eq(ListBuffer.scala:186)
	at scala.collection.immutable.List.$colon$colon$colon(List.scala:128)
	at cats.kernel.instances.ListMonoid.combine(list.scala:81)
	at cats.kernel.instances.ListMonoid.combine(list.scala:79)
	at cats.kernel.instances.TupleInstances$$anon$83.combine(TupleAlgebra.scala:245)
	at cats.kernel.instances.TupleInstances$$anon$83.combine(TupleAlgebra.scala:244)
	at cats.kernel.SemigroupFunctions.maybeCombine(Semigroup.scala:56)
	at cats.kernel.instances.MapMonoid.$anonfun$combine$1(map.scala:33)
	at cats.kernel.instances.MapMonoid$$Lambda$1580/442904133.apply(Unknown Source)
	at scala.collection.TraversableOnce.$anonfun$foldLeft$1(TraversableOnce.scala:157)
	at scala.collection.TraversableOnce.$anonfun$foldLeft$1$adapted(TraversableOnce.scala:157)
	at scala.collection.TraversableOnce$$Lambda$68/1374026904.apply(Unknown Source)
	at scala.collection.immutable.Map$Map1.foreach(Map.scala:125)
	at scala.collection.TraversableOnce.foldLeft(TraversableOnce.scala:157)
	at scala.collection.TraversableOnce.foldLeft$(TraversableOnce.scala:155)
	at scala.collection.AbstractTraversable.foldLeft(Traversable.scala:104)
	at cats.kernel.instances.MapMonoid.combine(map.scala:32)
	at cats.kernel.instances.MapMonoid.combine(map.scala:26)
	at cats.Foldable.$anonfun$foldMap$1(Foldable.scala:172)
	at cats.Foldable$$Lambda$1578/1338520970.apply(Unknown Source)
	at scala.collection.LinearSeqOptimized.foldLeft(LinearSeqOptimized.scala:122)
	at scala.collection.LinearSeqOptimized.foldLeft$(LinearSeqOptimized.scala:118)
	at scala.collection.immutable.List.foldLeft(List.scala:86)
	at cats.instances.ListInstances$$anon$1.foldLeft(list.scala:52)
	at cats.instances.ListInstances$$anon$1.foldLeft(list.scala:12)
	at cats.Foldable.foldMap(Foldable.scala:172)
	at cats.Foldable.foldMap$(Foldable.scala:26)
	at cats.instances.ListInstances$$anon$1.foldMap(list.scala:12)
	at cats.Foldable$Ops.foldMap(Foldable.scala:26)
	at cats.Foldable$Ops.foldMap$(Foldable.scala:26)
	at cats.Foldable$ToFoldableOps$$anon$3.foldMap(Foldable.scala:26)
	at org.broadinstitute.dsde.workbench.leonardo.db.ClusterComponent$clusterQuery$.unmarshalFullCluster(ClusterComponent.scala:421)
	at org.broadinstitute.dsde.workbench.leonardo.db.ClusterComponent$clusterQuery$.$anonfun$getActiveClusterByName$4(ClusterComponent.scala:182)
	at org.broadinstitute.dsde.workbench.leonardo.db.ClusterComponent$clusterQuery$$$Lambda$1768/1485543541.apply(Unknown Source)
	at slick.dbio.DBIOAction.$anonfun$map$1(DBIOAction.scala:43)
	at slick.dbio.DBIOAction$$Lambda$1370/1175847072.apply(Unknown Source)
	at slick.basic.BasicBackend$DatabaseDef.$anonfun$runInContextInline$1(BasicBackend.scala:171)
	at slick.basic.BasicBackend$DatabaseDef$$Lambda$1374/582919910.apply(Unknown Source)
	at scala.concurrent.Future.$anonfun$flatMap$1(Future.scala:303)
	at scala.concurrent.Future$$Lambda$610/1720451111.apply(Unknown Source)
	at scala.concurrent.impl.Promise.$anonfun$transformWith$1(Promise.scala:37)
	at scala.concurrent.impl.Promise$$Lambda$607/1165895922.apply(Unknown Source)
	at scala.concurrent.impl.CallbackRunnable.run(Promise.scala:60)
	at akka.dispatch.BatchingExecutor$AbstractBatch.processBatch(BatchingExecutor.scala:55)
	at akka.dispatch.BatchingExecutor$BlockableBatch.$anonfun$run$1(BatchingExecutor.scala:91)
	at akka.dispatch.BatchingExecutor$BlockableBatch$$Lambda$604/387462873.apply$mcV$sp(Unknown Source)
	at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:12)
	at scala.concurrent.BlockContext$.withBlockContext(BlockContext.scala:81)
	at akka.dispatch.BatchingExecutor$BlockableBatch.run(BatchingExecutor.scala:91)
	at akka.dispatch.TaskInvocation.run(AbstractDispatcher.scala:40)
	at akka.dispatch.ForkJoinExecutorConfigurator$AkkaForkJoinTask.exec(ForkJoinExecutorConfigurator.scala:44)
	at akka.dispatch.forkjoin.ForkJoinTask.doExec(ForkJoinTask.java:260)
	at akka.dispatch.forkjoin.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1339)
	at akka.dispatch.forkjoin.ForkJoinPool.runWorker(ForkJoinPool.java:1979)
	at akka.dispatch.forkjoin.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:107)
```

A couple things stand out:
1. The code is unmarshaling a DB response in `ClusterComponent.getActiveClusterByName`. This method is called in 2 places:
   - `LeonardoService` methods (create, get, update, delete)
   - `ClusterDnsCache` when it [repopulates](https://github.com/DataBiosphere/leonardo/blob/develop/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dns/ClusterDnsCache.scala#L63) the cache (I suspect in practice it's mostly coming from here).
2. It's stuck in `ListMonoid`. Scala lists are notoriously inefficient for everything except prepending.

So I made the following changes:
1. `ClusterDnsCache` no longer calls the expensive `getActiveClusterByName` because it doesn't need all the extra join information. I added a new method `getActiveClusterForDnsCache` which doesn't do any joins.
2. I switched from `List` to `Chain` where we are using the list monoid (note to do this I had to upgrade cats). Chain is supposedly much more efficient, though I haven't verified it. See:
   - https://typelevel.org/cats/datatypes/chain.html
   - https://typelevel.org/blog/2018/09/04/chain-replacing-the-list-monoid.html
   - https://github.com/typelevel/cats/issues/2429

Unit tests pass, will verify automation tests.

Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
