### PR TITLE
Specify JupyterLab extension from single JS file 

### DIFF
--- a/automation/src/test/resources/bucket-tests/example_lab_extension.js
+++ b/automation/src/test/resources/bucket-tests/example_lab_extension.js
@@ -1,0 +1,8 @@
+module.exports = [{
+    id: 'example_lab_extension',
+    autoStart: true,
+    activate: function(app) {
+      console.log('JupyterLab extension example_lab_extension is activated!');
+      console.log(app.commands);
+    }
+}];

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/NotebookCustomizationSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/NotebookCustomizationSpec.scala
@@ -97,7 +97,7 @@ final class NotebookCustomizationSpec extends FreeSpec
       withProject { project => implicit token =>
         val exampleLabExtensionFile = ResourceFile("bucket-tests/example_lab_extension.js")
         withResourceFileInBucket(project, exampleLabExtensionFile, "text/plain") { exampleLabExtensionBucketPath =>
-          val clusterRequestWithLabExtension = ClusterRequest(Map(), Option(exampleLabExtensionBucketPath.toUri), None)
+          val clusterRequestWithLabExtension = ClusterRequest(userJupyterExtensionConfig = Some(UserJupyterExtensionConfig(labExtensions = Map("example_lab_extension" -> exampleLabExtensionBucketPath.toUri))))
           withNewCluster(project, request = clusterRequestWithLabExtension) { cluster =>
             withWebDriver { implicit driver =>
               withNewNotebook(cluster) { notebookPage =>

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/NotebookCustomizationSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/NotebookCustomizationSpec.scala
@@ -92,5 +92,21 @@ final class NotebookCustomizationSpec extends FreeSpec
         }
       }
     }
+
+    "should install user specified lab extensions from a js file" in {
+      withProject { project => implicit token =>
+        val exampleLabExtensionFile = ResourceFile("bucket-tests/example_lab_extension.js")
+        withResourceFileInBucket(project, exampleLabExtensionFile, "text/plain") { exampleLabExtensionBucketPath =>
+          val clusterRequestWithLabExtension = ClusterRequest(Map(), Option(exampleLabExtensionBucketPath.toUri), None)
+          withNewCluster(project, request = clusterRequestWithLabExtension) { cluster =>
+            withWebDriver { implicit driver =>
+              withNewNotebook(cluster) { notebookPage =>
+                notebookPage.executeCell("!jupyter labextension list").get should include("example_lab_extension")
+              }
+            }
+          }
+        }
+      }
+    }
   }
 }

--- a/docker/jupyter/Dockerfile
+++ b/docker/jupyter/Dockerfile
@@ -285,6 +285,7 @@ RUN apt-get update \
  && pip3 install python-datauri \
  && pip3 install jupyter_contrib_nbextensions \
  && pip3 install jupyter_nbextensions_configurator \
+ && pip3 install cookiecutter \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
 

--- a/docker/jupyter/scripts/extension/jupyter_install_lab_extension.sh
+++ b/docker/jupyter/scripts/extension/jupyter_install_lab_extension.sh
@@ -5,6 +5,15 @@ set -e
 
 if [ -n "$1" ]; then
   JUPYTER_EXTENSION=$1
-  jupyter labextension install $JUPYTER_EXTENSION
+  if [[ ${JUPYTER_EXTENSION} == *'.js' ]]; then
+    JUPYTER_EXTENSION_NAME=`basename ${JUPYTER_EXTENSION%%.*}`
+    cookiecutter --no-input https://github.com/jupyterlab/extension-cookiecutter-ts extension_name=${JUPYTER_EXTENSION_NAME}
+    cp ${JUPYTER_EXTENSION} ${JUPYTER_EXTENSION_NAME}/lib/plugin.js
+    cd ${JUPYTER_EXTENSION_NAME}
+    jlpm
+    jupyter labextension install . --no-build
+  else
+    jupyter labextension install $JUPYTER_EXTENSION
+  fi
 fi
 

--- a/docker/jupyter/scripts/extension/jupyter_install_lab_extension.sh
+++ b/docker/jupyter/scripts/extension/jupyter_install_lab_extension.sh
@@ -14,6 +14,14 @@ if [ -n "$1" ]; then
     cd ${JUPYTER_EXTENSION_NAME}
     jlpm
     jupyter labextension install .
+  elif [[ ${JUPYTER_EXTENSION} == *'.ts' ]]; then
+    # same as above but in typescript, see https://github.com/jupyterlab/extension-cookiecutter-ts
+    JUPYTER_EXTENSION_NAME=`basename ${JUPYTER_EXTENSION%%.*}`
+    cookiecutter --no-input https://github.com/jupyterlab/extension-cookiecutter-ts extension_name=${JUPYTER_EXTENSION_NAME}
+    cp -f ${JUPYTER_EXTENSION} ${JUPYTER_EXTENSION_NAME}/src/index.ts
+    cd ${JUPYTER_EXTENSION_NAME}
+    jlpm
+    jupyter labextension install .
   else
     jupyter labextension install $JUPYTER_EXTENSION
   fi

--- a/docker/jupyter/scripts/extension/jupyter_install_lab_extension.sh
+++ b/docker/jupyter/scripts/extension/jupyter_install_lab_extension.sh
@@ -6,12 +6,14 @@ set -e
 if [ -n "$1" ]; then
   JUPYTER_EXTENSION=$1
   if [[ ${JUPYTER_EXTENSION} == *'.js' ]]; then
+    # use jupyterlab extension template to create an extension using the specified JS file
+    # see https://github.com/jupyterlab/extension-cookiecutter-js
     JUPYTER_EXTENSION_NAME=`basename ${JUPYTER_EXTENSION%%.*}`
-    cookiecutter --no-input https://github.com/jupyterlab/extension-cookiecutter-ts extension_name=${JUPYTER_EXTENSION_NAME}
-    cp ${JUPYTER_EXTENSION} ${JUPYTER_EXTENSION_NAME}/lib/plugin.js
+    cookiecutter --no-input https://github.com/jupyterlab/extension-cookiecutter-js extension_name=${JUPYTER_EXTENSION_NAME}
+    cp -f ${JUPYTER_EXTENSION} ${JUPYTER_EXTENSION_NAME}/lib/plugin.js
     cd ${JUPYTER_EXTENSION_NAME}
     jlpm
-    jupyter labextension install . --no-build
+    jupyter labextension install .
   else
     jupyter labextension install $JUPYTER_EXTENSION
   fi

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -975,7 +975,7 @@ definitions:
       labExtensions:
         type: object
         description: |
-          Optional, map of extension name and lab extension. The extension should be a verified jupyterlab extension that is uploaded to npm (list of public extensions here: https://github.com/search?utf8=%E2%9C%93&q=topic%3Ajupyterlab-extension&type=Repositories), a gzipped tarball made using 'npm pack', a folder structured by 'jlpm build', or a URL to either of the latter.
+          Optional, map of extension name and lab extension. The extension should be a verified jupyterlab extension that is uploaded to npm (list of public extensions here: https://github.com/search?utf8=%E2%9C%93&q=topic%3Ajupyterlab-extension&type=Repositories), a gzipped tarball made using 'npm pack', a folder structured by 'jlpm build', a JS file to be inserted into an JL extension template (see https://github.com/jupyterlab/extension-cookiecutter-js), or a URL to one of the last three options.
 
   SubsystemStatus:
     description: status of a subsystem Leonardo depends on


### PR DESCRIPTION
Terra provides their extension by hosting a JS file. This ticket supports this by inserting a provided JS file into a generic JupyterLab extension template (https://github.com/jupyterlab/extension-cookiecutter-js). 

This was manually tested by creating a cluster with a test JS file placed in a Google bucket and specifying the bucket in the userJupyterExtensionConfig. Since the logic is the same for extensions specified through a URL, this test should be sufficient. 

Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
