### PR TITLE
Change SparkR to 2.2.3

### DIFF
--- a/docker/jupyter/Dockerfile
+++ b/docker/jupyter/Dockerfile
@@ -335,7 +335,7 @@ RUN R -e 'install.packages(c( \
  && R -e 'devtools::install_github("IRkernel/IRkernel")' \
  && R -e 'IRkernel::installspec(user=FALSE)' \
  && chown -R $USER:users /home/jupyter-user/.local  \
- && R -e 'devtools::install_github("apache/spark@v2.2.0", subdir="R/pkg")' \
+ && R -e 'devtools::install_github("apache/spark@v2.2.3", subdir="R/pkg")' \
  && mkdir -p /home/jupyter-user/.rpackages \
  && echo "R_LIBS=/home/jupyter-user/.rpackages" > /home/jupyter-user/.Renviron \
  && chown -R $USER:users /home/jupyter-user/.rpackages


### PR DESCRIPTION
A test was failing (https://fc-jenkins.dsp-techops.broadinstitute.org/job/leonardo-fiab-test-runner/10136/testReport/), and we suspect it might have to do with the discrepancy in versions between Spark and SparkR. This updates the SparkR version to 2.2.3 to match the Spark version to see if tests will pass. 

Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
