### PR TITLE
Test fix: load library in a different cell

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/NotebookRKernelSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/NotebookRKernelSpec.scala
@@ -19,10 +19,10 @@ class NotebookRKernelSpec extends ClusterFixtureSpec {
 
           // Make sure unicode characters display correctly
           notebookPage.executeCell("""install.packages("skimr")""")
+          notebookPage.executeCell("library(skimr)")
 
           val output = notebookPage.executeCell(
-            """library(skimr)
-              |data(iris)
+            """data(iris)
               |skim(iris)""".stripMargin)
 
           output shouldBe 'defined


### PR DESCRIPTION
For some reason this test started failing:

https://fc-jenkins.dsp-techops.broadinstitute.org/job/leonardo-fiab-test-runner/10438/testReport/org.broadinstitute.dsde.workbench.leonardo/NotebookRKernelSpec/Leonardo_notebooks_should_use_UTF_8_encoding/

https://fc-jenkins.dsp-techops.broadinstitute.org/job/leonardo-fiab-test-runner/10438/artifact/failure_screenshots/NotebookRKernelSpec_14-11-15-596.png

I suspect it's grabbing the wrong cell output. Seeing if this fixes it.

Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
