### PR TITLE
Fix ggplot on python 2

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/NotebookPyKernelSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/NotebookPyKernelSpec.scala
@@ -120,5 +120,17 @@ class NotebookPyKernelSpec extends ClusterFixtureSpec {
         }
       }
     }
+
+    // https://github.com/DataBiosphere/leonardo/issues/797
+    Seq(Python2, Python3).foreach { kernel =>
+      s"should be able to import ggplot for ${kernel.toString}" in { clusterFixture =>
+        withWebDriver { implicit driver =>
+          withNewNotebook(clusterFixture.cluster, kernel) { notebookPage =>
+            notebookPage.executeCell("from ggplot import *").get should not include ("ImportError")
+            notebookPage.executeCell("ggplot") shouldBe Some("ggplot.ggplot.ggplot")
+          }
+        }
+      }
+    }
   }
 }

--- a/docker/jupyter/Dockerfile
+++ b/docker/jupyter/Dockerfile
@@ -165,6 +165,8 @@ RUN apt-get update \
  && pip install -U scikit-learn==0.20.0 \
  && pip install statsmodels==0.9.0 \
  && pip install ggplot==0.11.5 \
+ # fixed current ggplot issue where it imports Timestamp from pandas.lib (deprecated) instead of pandas
+ && sed -i 's/pandas.lib/pandas/g' /usr/local/lib/python2.7/site-packages/ggplot/stats/smoothers.py \
  && pip install bokeh==1.0.0  \
  && pip install pyfasta==0.5.2 \
  && pip install pdoc==0.3.2 \
@@ -274,6 +276,8 @@ RUN apt-get update \
  && pip3 install scikit-learn==0.20.0 \
  && pip3 install statsmodels==0.9.0 \
  && pip3 install ggplot==0.11.5 \
+ # fixed current ggplot issue where it imports Timestamp from pandas.lib (deprecated) instead of pandas
+ && sed -i 's/pandas.lib/pandas/g' /usr/local/lib/python3.6/site-packages/ggplot/stats/smoothers.py \
  && pip3 install bokeh==1.0.0 \
  && pip3 install pyfasta==0.5.2 \
  && pip3 install pdoc==0.3.2 \

--- a/docker/jupyter/Dockerfile
+++ b/docker/jupyter/Dockerfile
@@ -293,9 +293,6 @@ RUN apt-get update \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
 
-# fixed current ggplot issue where it imports Timestamp from pandas.lib (deprecated) instead of pandas
-RUN sed -i 's/pandas.lib/pandas/g' /usr/local/lib/python3.6/site-packages/ggplot/stats/smoothers.py
-
 # make pip install to a user directory, instead of a system directory which requires root.
 # this is useful so `pip install` commands can be run in the context of a notebook.
 ENV PIP_USER=true

--- a/docker/jupyter/Dockerfile
+++ b/docker/jupyter/Dockerfile
@@ -166,7 +166,7 @@ RUN apt-get update \
  && pip install statsmodels==0.9.0 \
  && pip install ggplot==0.11.5 \
  # fixed current ggplot issue where it imports Timestamp from pandas.lib (deprecated) instead of pandas
- && sed -i 's/pandas.lib/pandas/g' /usr/local/lib/python2.7/site-packages/ggplot/stats/smoothers.py \
+ && sed -i 's/pandas.lib/pandas/g' /usr/local/lib/python2.7/dist-packages/ggplot/stats/smoothers.py \
  && pip install bokeh==1.0.0  \
  && pip install pyfasta==0.5.2 \
  && pip install pdoc==0.3.2 \


### PR DESCRIPTION
See https://github.com/DataBiosphere/leonardo/issues/797. This bug report came from Yossi.

The ggplot fix essentially comes from here: https://stackoverflow.com/questions/50591982/importerror-cannot-import-name-timestamp

Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
