### PR TITLE
Check that all specified cluster tools are ready before setting cluster to Running from Starting

### DIFF
--- a/automation/gce-deploy/leonardo.conf
+++ b/automation/gce-deploy/leonardo.conf
@@ -13,7 +13,7 @@ dataproc {
   leoGoogleProject = "TEMPLATE_VAR_PROJECT"    # the name of the google project to use during cluster startup
                                                # *this is not the project the cluster will be created in.
   dataprocDockerImage = "gcr.io/TEMPLATE_VAR_DOCKER_PROJECT/leonardo-notebooks:TEMPLATE_VAR_DOCKER_TAG"
-  clusterUrlBase = "https://TEMPLATE_VAR_DOMAIN/notebooks/" # the base url to access your cluster
+  clusterUrlBase = "https://TEMPLATE_VAR_DOMAIN/proxy/" # the base url to access your cluster
   jupyterServerName = "jupyter-server"
 }
 

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/ClusterMonitoringSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/ClusterMonitoringSpec.scala
@@ -281,6 +281,11 @@ class ClusterMonitoringSpec extends FreeSpec with LeonardoTestUtils with Paralle
       }
     }
 
+    "should install RStudio" taggedAs Tags.SmokeTest in {
+      withProject { project => implicit token =>
+      withNewCluster(project, request = ClusterRequest)}
+    }
+
     "should install JupyterLab" taggedAs Tags.SmokeTest in {
       withProject { project => implicit token =>
         withNewCluster(project, request = ClusterRequest()) { cluster =>

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/ClusterMonitoringSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/ClusterMonitoringSpec.scala
@@ -283,7 +283,14 @@ class ClusterMonitoringSpec extends FreeSpec with LeonardoTestUtils with Paralle
 
     "should install RStudio" taggedAs Tags.SmokeTest in {
       withProject { project => implicit token =>
-      withNewCluster(project, request = ClusterRequest)}
+        withNewCluster(project, request = ClusterRequest(rstudioDockerImage = Some("us.gcr.io/broad-dsp-gcr-public/leonardo-rstudio:860d5862f3f5"))) { cluster =>
+          withWebDriver {implicit driver =>
+            val getResult = Try(Leonardo.rstudio.getApi(project, cluster.clusterName))
+            getResult.isSuccess shouldBe true
+            getResult.get should not include "ProxyException"
+          }
+        }
+      }
     }
 
     "should install JupyterLab" taggedAs Tags.SmokeTest in {

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/Leonardo.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/Leonardo.scala
@@ -251,6 +251,17 @@ object Leonardo extends RestClient with LazyLogging {
     // TODO: add JupyterLab selenium test logic
   }
 
+  object rstudio {
+    def rstudioPath(googleProject: GoogleProject, clusterName: ClusterName): String =
+      s"proxy/${googleProject.value}/${clusterName.string}/rstudio"
+
+    def getApi(googleProject: GoogleProject, clusterName: ClusterName)(implicit token: AuthToken): String = {
+      val path = rstudioPath(googleProject, clusterName)
+      logger.info(s"Get rstudio: GET /$path")
+      parseResponse(getRequest(url + path))
+    }
+  }
+
   object dummyClient {
     import akka.http.scaladsl.Http
     import akka.http.scaladsl.model._

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoModelCopy.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoModelCopy.scala
@@ -50,6 +50,7 @@ object ServiceAccountInfo {
   )
 }
 
+
 case class Cluster(clusterName: ClusterName,
                    googleId: UUID,
                    googleProject: GoogleProject,
@@ -81,6 +82,8 @@ case class ClusterRequest(labels: LabelMap = Map(),
                           stopAfterCreation: Option[Boolean] = None,
                           userJupyterExtensionConfig: Option[UserJupyterExtensionConfig] = None,
                           defaultClientId: Option[String] = None,
+                          jupyterDockerImage: Option[String] = None,
+                          rstudioDockerImage: Option[String] = None,
                           scopes: Option[Set[String]] = None)
 
 case class UserJupyterExtensionConfig(nbExtensions: Map[String, String] = Map(),
@@ -141,3 +144,4 @@ object ClusterStatus extends Enumeration {
     values.find(_.toString.equalsIgnoreCase(str)).getOrElse(throw new IllegalArgumentException(s"Unknown cluster status: $str"))
   }
 }
+

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/Boot.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/Boot.scala
@@ -11,7 +11,7 @@ import org.broadinstitute.dsde.workbench.google.{GoogleStorageDAO, HttpGoogleIam
 import org.broadinstitute.dsde.workbench.leonardo.api.{LeoRoutes, StandardUserInfoDirectives}
 import org.broadinstitute.dsde.workbench.leonardo.auth.{LeoAuthProviderHelper, ServiceAccountProviderHelper}
 import org.broadinstitute.dsde.workbench.leonardo.config.{AutoFreezeConfig, ClusterDefaultsConfig, ClusterDnsCacheConfig, ClusterFilesConfig, ClusterResourcesConfig, DataprocConfig, LeoExecutionModeConfig, MonitorConfig, ProxyConfig, SamConfig, SwaggerConfig, ZombieClusterConfig}
-import org.broadinstitute.dsde.workbench.leonardo.dao.{HttpJupyterDAO, HttpSamDAO}
+import org.broadinstitute.dsde.workbench.leonardo.dao.{HttpJupyterDAO, HttpRStudioDAO, HttpSamDAO}
 import org.broadinstitute.dsde.workbench.leonardo.dao.google.{HttpGoogleComputeDAO, HttpGoogleDataprocDAO}
 import org.broadinstitute.dsde.workbench.leonardo.db.DbReference
 import org.broadinstitute.dsde.workbench.leonardo.dns.ClusterDnsCache
@@ -86,7 +86,8 @@ object Boot extends App with LazyLogging {
     if(leoExecutionModeConfig.backLeo) {
       val googleProjectDAO = new HttpGoogleProjectDAO(dataprocConfig.applicationName, Pem(leoServiceAccountEmail, leoServiceAccountPemFile), "google")
       val jupyterDAO = new HttpJupyterDAO(clusterDnsCache)
-      val clusterMonitorSupervisor = system.actorOf(ClusterMonitorSupervisor.props(monitorConfig, dataprocConfig, gdDAO, googleComputeDAO, googleIamDAO, googleStorageDAO, dbRef, authProvider, autoFreezeConfig, jupyterDAO, leonardoService))
+      val rstudioDAO = new HttpRStudioDAO(clusterDnsCache)
+      val clusterMonitorSupervisor = system.actorOf(ClusterMonitorSupervisor.props(monitorConfig, dataprocConfig, gdDAO, googleComputeDAO, googleIamDAO, googleStorageDAO, dbRef, authProvider, autoFreezeConfig, jupyterDAO, rstudioDAO, leonardoService))
       val zombieClusterMonitor = system.actorOf(ZombieClusterMonitor.props(zombieClusterMonitorConfig, gdDAO, googleProjectDAO, dbRef))
     }
     

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpRStudioDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpRStudioDAO.scala
@@ -1,13 +1,12 @@
 package org.broadinstitute.dsde.workbench.leonardo.dao
 
-import org.broadinstitute.dsde.workbench.leonardo.dns.ClusterDnsCache._
-import akka.actor.{ActorRef, ActorSystem}
+import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.model._
-import akka.pattern.ask
 import akka.stream.ActorMaterializer
 import akka.util.Timeout
 import com.typesafe.scalalogging.LazyLogging
+import org.broadinstitute.dsde.workbench.leonardo.dns.ClusterDnsCache._
 import org.broadinstitute.dsde.workbench.leonardo.dns.{ClusterDnsCache, DnsCacheKey}
 import org.broadinstitute.dsde.workbench.leonardo.model.google.ClusterName
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
@@ -15,14 +14,14 @@ import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
 
-class HttpJupyterDAO(val clusterDnsCache: ClusterDnsCache)(implicit system: ActorSystem, materializer: ActorMaterializer, executionContext: ExecutionContext) extends ToolDAO with LazyLogging {
+class HttpRStudioDAO(val clusterDnsCache: ClusterDnsCache)(implicit system: ActorSystem, materializer: ActorMaterializer, executionContext: ExecutionContext) extends ToolDAO with LazyLogging {
 
   val http = Http(system)
 
   override def isProxyAvailable(googleProject: GoogleProject, clusterName: ClusterName): Future[Boolean] = {
     getTargetHost(googleProject, clusterName) flatMap {
       case HostReady(targetHost) =>
-        val statusUri = Uri(s"https://${targetHost.toString}/notebooks/$googleProject/$clusterName/api/status")
+        val statusUri = Uri(s"https://${targetHost.toString}/proxy/$googleProject/$clusterName/rstudio")
         http.singleRequest(HttpRequest(uri = statusUri)) map { response =>
           response.status.isSuccess
         }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/ToolDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/ToolDAO.scala
@@ -4,6 +4,6 @@ import org.broadinstitute.dsde.workbench.leonardo.model.google.ClusterName
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import scala.concurrent.Future
 
-trait JupyterDAO {
+trait ToolDAO {
   def isProxyAvailable(googleProject: GoogleProject, clusterName: ClusterName): Future[Boolean]
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponent.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponent.scala
@@ -146,18 +146,11 @@ trait ClusterComponent extends LeoComponent {
       }
     }
 
-//    def listMonitoredClusterOnly(): DBIO[Seq[Cluster]] = {
-//      clusterQuery.filter{_.status inSetBind ClusterStatus.monitoredStatuses.map(_.toString) }.result map { recs =>
-//        recs.map(rec => unmarshalCluster(rec, Seq.empty, List.empty, Map.empty, List.empty, List.empty, List.empty))
-//      }
-//    }
-
     def listMonitoredClusterOnly(): DBIO[Seq[Cluster]] = {
-      clusterImagesQuery.filter{_._1.status inSetBind ClusterStatus.monitoredStatuses.map(_.toString) }.result map { recs =>
-        unmarshalImageCluster(recs)
+      clusterQuery.filter{_.status inSetBind ClusterStatus.monitoredStatuses.map(_.toString) }.result map { recs =>
+        recs.map(rec => unmarshalCluster(rec, Seq.empty, List.empty, Map.empty, List.empty, List.empty, List.empty))
       }
     }
-
 
     def listMonitored(): DBIO[Seq[Cluster]] = {
       clusterLabelQuery.filter { _._1.status inSetBind ClusterStatus.monitoredStatuses.map(_.toString) }.result map { recs =>
@@ -438,19 +431,6 @@ trait ClusterComponent extends LeoComponent {
       }.toSeq
     }
 
-    private def unmarshalImageCluster(clusterImages: Seq[(ClusterRecord, Option[ClusterImageRecord])]): Seq[Cluster] = {
-      // Same logic as above
-      val clusterImageMap: Map[ClusterRecord, Chain[ClusterImageRecord]] = clusterImages.toList.foldMap { case (clusterRecord, imageRecordOpt) =>
-        val clusterImages = imageRecordOpt.map(Chain(_)).getOrElse(Chain.empty)
-        Map(clusterRecord -> clusterImages)
-      }
-
-      // Unmarshal each (ClusterRecord, Chain[ImageRecord]) to a Cluster object
-      clusterImageMap.map { case (clusterRec, clusterImages) =>
-        unmarshalCluster(clusterRec, Seq.empty, List.empty, Map.empty, List.empty, clusterImages.toList, List.empty)
-      }.toSeq
-    }
-
     private def unmarshalFullCluster(clusterRecords: Seq[(ClusterRecord, Option[InstanceRecord], Option[ClusterErrorRecord], Option[LabelRecord], Option[ExtensionRecord], Option[ClusterImageRecord], Option[ScopeRecord])]): Seq[Cluster] = {
       // Call foldMap to aggregate a flat sequence of (cluster, instance, label) triples returned by the query
       // to a grouped (cluster -> (instances, labels)) structure.
@@ -528,12 +508,6 @@ trait ClusterComponent extends LeoComponent {
     for {
       (cluster, label) <- clusterQuery joinLeft labelQuery on (_.id === _.clusterId)
     } yield (cluster, label)
-  }
-
-  val clusterImagesQuery: Query[(ClusterTable, Rep[Option[ClusterImageTable]]), (ClusterRecord, Option[ClusterImageRecord]), Seq] = {
-    for {
-      (cluster, image) <- clusterQuery joinLeft clusterImageQuery on (_.id === _.clusterId)
-    } yield (cluster, image)
   }
 
   // cluster and all associated data: labels, instances, errors, extensions, images.

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorActor.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorActor.scala
@@ -259,7 +259,8 @@ class ClusterMonitorActor(val cluster: Cluster,
 
   private def checkCluster: Future[ClusterMonitorMessage] = {
     getDbClusterStatus.flatMap {
-      case status if status.isMonitored => checkClusterInGoogle(status)
+      case status if status.isMonitored =>
+        checkClusterInGoogle(status)
       case status =>
         logger.info(s"Stopping monitoring of cluster ${cluster.projectNameString} in status ${status}")
         Future.successful(ShutdownActor(RemoveFromList(cluster)))
@@ -291,6 +292,7 @@ class ClusterMonitorActor(val cluster: Cluster,
         case Running if leoClusterStatus == Starting && runningInstanceCount == googleInstances.size =>
           getMasterIp.flatMap {
             case Some(ip) =>
+              println(s"XYX here: ${cluster.clusterImages}")
               // Update the Host IP in the database so DNS cache can be properly populated with the first cache miss
               // Otherwise, when a cluster is resumed and transitions from Starting to Running, we get stuck
               // in that state - at least with the way HttpJupyterDAO.isProxyAvailable works
@@ -324,6 +326,7 @@ class ClusterMonitorActor(val cluster: Cluster,
   }
 
   private def isProxyAvailable(clusterTool: ClusterTool): Future[Boolean] = {
+    printf("calling with tool: %s", clusterTool)
     val toolDAO : ToolDAO = clusterTool match {
       case ClusterTool.Jupyter => jupyterProxyDAO
       case _ => rstudioProxyDAO // there are only two tools and it is impossible to create a cluster with no tools

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorActor.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorActor.scala
@@ -292,7 +292,6 @@ class ClusterMonitorActor(val cluster: Cluster,
         case Running if leoClusterStatus == Starting && runningInstanceCount == googleInstances.size =>
           getMasterIp.flatMap {
             case Some(ip) =>
-              println(s"XYX here: ${cluster.clusterImages}")
               // Update the Host IP in the database so DNS cache can be properly populated with the first cache miss
               // Otherwise, when a cluster is resumed and transitions from Starting to Running, we get stuck
               // in that state - at least with the way HttpJupyterDAO.isProxyAvailable works
@@ -326,7 +325,6 @@ class ClusterMonitorActor(val cluster: Cluster,
   }
 
   private def isProxyAvailable(clusterTool: ClusterTool): Future[Boolean] = {
-    printf("calling with tool: %s", clusterTool)
     val toolDAO : ToolDAO = clusterTool match {
       case ClusterTool.Jupyter => jupyterProxyDAO
       case _ => rstudioProxyDAO // there are only two tools and it is impossible to create a cluster with no tools

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorActor.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorActor.scala
@@ -300,10 +300,7 @@ class ClusterMonitorActor(val cluster: Cluster,
                     NotReadyCluster(ClusterStatus.Running, googleInstances)
                   else
                     ReadyCluster(ip, googleInstances)
-                }    //cluster.clusterImages.map(image => isProxyAvailable(image.tool)) contains false)
-//                  Future.successful(NotReadyCluster(ClusterStatus.Running, googleInstances))
-//                else
-//                  Future.successful(ReadyCluster(ip, googleInstances))
+                }
               }
             case None => Future.successful(NotReadyCluster(ClusterStatus.Running, googleInstances))
           }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorSupervisor.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorSupervisor.scala
@@ -5,7 +5,7 @@ import akka.actor.{Actor, ActorRef, OneForOneStrategy, Props, Timers}
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.workbench.google.{GoogleIamDAO, GoogleStorageDAO}
 import org.broadinstitute.dsde.workbench.leonardo.config.{AutoFreezeConfig, DataprocConfig, MonitorConfig}
-import org.broadinstitute.dsde.workbench.leonardo.dao.JupyterDAO
+import org.broadinstitute.dsde.workbench.leonardo.dao.ToolDAO
 import org.broadinstitute.dsde.workbench.leonardo.dao.google.{GoogleComputeDAO, GoogleDataprocDAO}
 import org.broadinstitute.dsde.workbench.leonardo.db.DbReference
 import org.broadinstitute.dsde.workbench.leonardo.model.ClusterTool.Jupyter
@@ -19,8 +19,8 @@ import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success}
 
 object ClusterMonitorSupervisor {
-  def props(monitorConfig: MonitorConfig, dataprocConfig: DataprocConfig, gdDAO: GoogleDataprocDAO, googleComputeDAO: GoogleComputeDAO, googleIamDAO: GoogleIamDAO, googleStorageDAO: GoogleStorageDAO, dbRef: DbReference, authProvider: LeoAuthProvider, autoFreezeConfig: AutoFreezeConfig, jupyterProxyDAO: JupyterDAO, leonardoService: LeonardoService): Props =
-    Props(new ClusterMonitorSupervisor(monitorConfig, dataprocConfig, gdDAO, googleComputeDAO, googleIamDAO, googleStorageDAO, dbRef, authProvider, autoFreezeConfig, jupyterProxyDAO, leonardoService))
+  def props(monitorConfig: MonitorConfig, dataprocConfig: DataprocConfig, gdDAO: GoogleDataprocDAO, googleComputeDAO: GoogleComputeDAO, googleIamDAO: GoogleIamDAO, googleStorageDAO: GoogleStorageDAO, dbRef: DbReference, authProvider: LeoAuthProvider, autoFreezeConfig: AutoFreezeConfig, jupyterProxyDAO: ToolDAO, rstudioProxyDAO: ToolDAO, leonardoService: LeonardoService): Props =
+    Props(new ClusterMonitorSupervisor(monitorConfig, dataprocConfig, gdDAO, googleComputeDAO, googleIamDAO, googleStorageDAO, dbRef, authProvider, autoFreezeConfig, jupyterProxyDAO, rstudioProxyDAO, leonardoService))
 
   sealed trait ClusterSupervisorMessage
 
@@ -49,7 +49,7 @@ object ClusterMonitorSupervisor {
   private case object CheckForClusters extends ClusterSupervisorMessage
 }
 
-class ClusterMonitorSupervisor(monitorConfig: MonitorConfig, dataprocConfig: DataprocConfig, gdDAO: GoogleDataprocDAO, googleComputeDAO: GoogleComputeDAO, googleIamDAO: GoogleIamDAO, googleStorageDAO: GoogleStorageDAO, dbRef: DbReference, authProvider: LeoAuthProvider, autoFreezeConfig: AutoFreezeConfig, jupyterProxyDAO: JupyterDAO, leonardoService: LeonardoService)
+class ClusterMonitorSupervisor(monitorConfig: MonitorConfig, dataprocConfig: DataprocConfig, gdDAO: GoogleDataprocDAO, googleComputeDAO: GoogleComputeDAO, googleIamDAO: GoogleIamDAO, googleStorageDAO: GoogleStorageDAO, dbRef: DbReference, authProvider: LeoAuthProvider, autoFreezeConfig: AutoFreezeConfig, jupyterProxyDAO: ToolDAO, rstudioProxyDAO: ToolDAO, leonardoService: LeonardoService)
   extends Actor with Timers with LazyLogging {
   import context.dispatcher
 
@@ -149,7 +149,7 @@ class ClusterMonitorSupervisor(monitorConfig: MonitorConfig, dataprocConfig: Dat
   }
 
   def createChildActor(cluster: Cluster): ActorRef = {
-    context.actorOf(ClusterMonitorActor.props(cluster, monitorConfig, dataprocConfig, gdDAO, googleComputeDAO, googleIamDAO, googleStorageDAO, dbRef, authProvider, jupyterProxyDAO))
+    context.actorOf(ClusterMonitorActor.props(cluster, monitorConfig, dataprocConfig, gdDAO, googleComputeDAO, googleIamDAO, googleStorageDAO, dbRef, authProvider, jupyterProxyDAO, rstudioProxyDAO))
   }
 
   def startClusterMonitorActor(cluster: Cluster, watchMessageOpt: Option[ClusterSupervisorMessage] = None): Unit = {

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorSupervisor.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorSupervisor.scala
@@ -149,7 +149,6 @@ class ClusterMonitorSupervisor(monitorConfig: MonitorConfig, dataprocConfig: Dat
   }
 
   def createChildActor(cluster: Cluster): ActorRef = {
-    println(s"childActor: ${cluster.clusterImages}")
     context.actorOf(ClusterMonitorActor.props(cluster, monitorConfig, dataprocConfig, gdDAO, googleComputeDAO, googleIamDAO, googleStorageDAO, dbRef, authProvider, jupyterProxyDAO, rstudioProxyDAO))
   }
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorSupervisor.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorSupervisor.scala
@@ -149,6 +149,7 @@ class ClusterMonitorSupervisor(monitorConfig: MonitorConfig, dataprocConfig: Dat
   }
 
   def createChildActor(cluster: Cluster): ActorRef = {
+    println(s"childActor: ${cluster.clusterImages}")
     context.actorOf(ClusterMonitorActor.props(cluster, monitorConfig, dataprocConfig, gdDAO, googleComputeDAO, googleIamDAO, googleStorageDAO, dbRef, authProvider, jupyterProxyDAO, rstudioProxyDAO))
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/CommonTestData.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/CommonTestData.scala
@@ -11,7 +11,7 @@ import org.broadinstitute.dsde.workbench.leonardo.auth.WhitelistAuthProvider
 import org.broadinstitute.dsde.workbench.leonardo.auth.sam.MockPetClusterServiceAccountProvider
 import org.broadinstitute.dsde.workbench.leonardo.config.{AutoFreezeConfig, ClusterDefaultsConfig, ClusterDnsCacheConfig, ClusterFilesConfig, ClusterResourcesConfig, DataprocConfig, MonitorConfig, ProxyConfig, SwaggerConfig, ZombieClusterConfig}
 import org.broadinstitute.dsde.workbench.leonardo.dao.google.MockGoogleComputeDAO
-import org.broadinstitute.dsde.workbench.leonardo.dao.{MockJupyterDAO, MockSamDAO}
+import org.broadinstitute.dsde.workbench.leonardo.dao.{MockJupyterDAO, MockRStudioDAO, MockSamDAO}
 import org.broadinstitute.dsde.workbench.leonardo.db.TestComponent
 import org.broadinstitute.dsde.workbench.leonardo.model.ClusterTool.{Jupyter, RStudio}
 import org.broadinstitute.dsde.workbench.leonardo.model._
@@ -62,6 +62,7 @@ trait CommonTestData{ this: ScalaFutures =>
   val monitorConfig = config.as[MonitorConfig]("monitor")
   val contentSecurityPolicy = config.as[Option[String]]("jupyterConfig.contentSecurityPolicy").getOrElse("default-src: 'self'")
   val mockJupyterDAO = new MockJupyterDAO
+  val mockRStudioDAO = new MockRStudioDAO
   val singleNodeDefaultMachineConfig = MachineConfig(Some(clusterDefaultsConfig.numberOfWorkers), Some(clusterDefaultsConfig.masterMachineType), Some(clusterDefaultsConfig.masterDiskSize))
   val testClusterRequest = ClusterRequest(Some(Map("bam" -> "yes", "vcf" -> "no", "foo" -> "bar")), None, None, None, None, Some(UserJupyterExtensionConfig(Map("abc" -> "def"), Map("pqr" -> "pqr"), Map("xyz" -> "xyz"))), Some(true), Some(30), Some("ThisIsADefaultClientID"))
   val testClusterRequestWithExtensionAndScript = ClusterRequest(Some(Map("bam" -> "yes", "vcf" -> "no", "foo" -> "bar")), Some(jupyterExtensionUri), Some(jupyterUserScriptUri), None, None, Some(UserJupyterExtensionConfig(Map("abc" -> "def"), Map("pqr" -> "pqr"), Map("xyz" -> "xyz"))), Some(true), Some(30), Some("ThisIsADefaultClientID"))

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/MockJupyterDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/MockJupyterDAO.scala
@@ -4,7 +4,7 @@ import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 
 import scala.concurrent.Future
 
-class MockJupyterDAO extends JupyterDAO{
+class MockJupyterDAO extends ToolDAO{
 
   override def isProxyAvailable(googleProject: GoogleProject, clusterName: ClusterName): Future[Boolean] = Future.successful(true)
 }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/MockRStudioDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/MockRStudioDAO.scala
@@ -1,0 +1,11 @@
+package org.broadinstitute.dsde.workbench.leonardo.dao
+
+import org.broadinstitute.dsde.workbench.leonardo.model.google.ClusterName
+import org.broadinstitute.dsde.workbench.model.google.GoogleProject
+
+import scala.concurrent.Future
+
+class MockRStudioDAO extends ToolDAO{
+
+  override def isProxyAvailable(googleProject: GoogleProject, clusterName: ClusterName): Future[Boolean] = Future.successful(true)
+}

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorSpec.scala
@@ -8,7 +8,7 @@ import akka.testkit.TestKit
 import io.grpc.Status.Code
 import org.broadinstitute.dsde.workbench.google.mock.MockGoogleStorageDAO
 import org.broadinstitute.dsde.workbench.google.{GoogleIamDAO, GoogleStorageDAO}
-import org.broadinstitute.dsde.workbench.leonardo.dao.JupyterDAO
+import org.broadinstitute.dsde.workbench.leonardo.dao.ToolDAO
 import org.broadinstitute.dsde.workbench.leonardo.dao.google.{GoogleComputeDAO, GoogleDataprocDAO}
 import org.broadinstitute.dsde.workbench.leonardo.ClusterEnrichments.clusterEq
 import org.broadinstitute.dsde.workbench.leonardo.{CommonTestData, GcsPathUtils}
@@ -101,7 +101,7 @@ class ClusterMonitorSpec extends TestKit(ActorSystem("leonardotest")) with FlatS
     super.afterAll()
   }
 
-  def createClusterSupervisor(gdDAO: GoogleDataprocDAO, computeDAO: GoogleComputeDAO, iamDAO: GoogleIamDAO, storageDAO: GoogleStorageDAO, authProvider: LeoAuthProvider, jupyterDAO: JupyterDAO): ActorRef = {
+  def createClusterSupervisor(gdDAO: GoogleDataprocDAO, computeDAO: GoogleComputeDAO, iamDAO: GoogleIamDAO, storageDAO: GoogleStorageDAO, authProvider: LeoAuthProvider, jupyterDAO: ToolDAO): ActorRef = {
     val bucketHelper = new BucketHelper(dataprocConfig, gdDAO, computeDAO, storageDAO, serviceAccountProvider)
     val mockPetGoogleStorageDAO: String => GoogleStorageDAO = _ => new MockGoogleStorageDAO
     val leoService = new LeonardoService(dataprocConfig, clusterFilesConfig, clusterResourcesConfig, clusterDefaultsConfig, proxyConfig, swaggerConfig, autoFreezeConfig, gdDAO, computeDAO, iamDAO, storageDAO, mockPetGoogleStorageDAO, DbSingleton.ref, whitelistAuthProvider, serviceAccountProvider, whitelist, bucketHelper, contentSecurityPolicy)
@@ -110,7 +110,7 @@ class ClusterMonitorSpec extends TestKit(ActorSystem("leonardotest")) with FlatS
     supervisorActor
   }
 
-  def withClusterSupervisor[T](gdDAO: GoogleDataprocDAO, computeDAO: GoogleComputeDAO, iamDAO: GoogleIamDAO, storageDAO: GoogleStorageDAO, authProvider: LeoAuthProvider, jupyterDAO: JupyterDAO = mockJupyterDAO, runningChild: Boolean = true)(testCode: ActorRef => T): T = {
+  def withClusterSupervisor[T](gdDAO: GoogleDataprocDAO, computeDAO: GoogleComputeDAO, iamDAO: GoogleIamDAO, storageDAO: GoogleStorageDAO, authProvider: LeoAuthProvider, jupyterDAO: ToolDAO = mockJupyterDAO, runningChild: Boolean = true)(testCode: ActorRef => T): T = {
     val supervisor = createClusterSupervisor(gdDAO, computeDAO, iamDAO, storageDAO, authProvider, jupyterDAO)
     val testResult = Try(testCode(supervisor))
     testKit watch supervisor
@@ -827,7 +827,7 @@ class ClusterMonitorSpec extends TestKit(ActorSystem("leonardotest")) with FlatS
     } thenReturn Future.successful(())
     val authProvider = mock[LeoAuthProvider]
 
-    val jupyterDAO = mock[JupyterDAO]
+    val jupyterDAO = mock[ToolDAO]
     when {
       jupyterDAO.isProxyAvailable(any[GoogleProject], any[ClusterName])
     } thenReturn Future.successful(true)
@@ -896,7 +896,7 @@ class ClusterMonitorSpec extends TestKit(ActorSystem("leonardotest")) with FlatS
     val authProvider = mock[LeoAuthProvider]
 
 
-    val jupyterDAO = mock[JupyterDAO]
+    val jupyterDAO = mock[ToolDAO]
     when {
       jupyterDAO.isProxyAvailable(mockitoEq(startingCluster.googleProject), mockitoEq(startingCluster.clusterName))
     } thenReturn Future.successful(false)

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterSupervisorSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterSupervisorSpec.scala
@@ -7,7 +7,7 @@ import akka.actor.ActorSystem
 import akka.testkit.TestKit
 import org.broadinstitute.dsde.workbench.google.mock.MockGoogleStorageDAO
 import org.broadinstitute.dsde.workbench.google.{GoogleIamDAO, GoogleStorageDAO}
-import org.broadinstitute.dsde.workbench.leonardo.dao.MockJupyterDAO
+import org.broadinstitute.dsde.workbench.leonardo.dao.{MockJupyterDAO, MockRStudioDAO}
 import org.broadinstitute.dsde.workbench.leonardo.dao.google.{GoogleComputeDAO, GoogleDataprocDAO}
 import org.broadinstitute.dsde.workbench.leonardo.{CommonTestData, GcsPathUtils}
 import org.broadinstitute.dsde.workbench.leonardo.db.{DbSingleton, TestComponent}
@@ -47,6 +47,8 @@ class ClusterSupervisorSpec extends TestKit(ActorSystem("leonardotest"))
 
     val jupyterProxyDAO = new MockJupyterDAO
 
+    val rstudioProxyDAO = new MockRStudioDAO
+
     val mockPetGoogleStorageDAO: String => GoogleStorageDAO = _ => {
       new MockGoogleStorageDAO
     }
@@ -62,7 +64,7 @@ class ClusterSupervisorSpec extends TestKit(ActorSystem("leonardotest"))
       bucketHelper, contentSecurityPolicy)
 
     val clusterSupervisorActor = system.actorOf(ClusterMonitorSupervisor.props(monitorConfig, dataprocConfig, gdDAO,
-      computeDAO, iamDAO, storageDAO, DbSingleton.ref, authProvider, autoFreezeConfig, jupyterProxyDAO, leoService))
+      computeDAO, iamDAO, storageDAO, DbSingleton.ref, authProvider, autoFreezeConfig, jupyterProxyDAO, rstudioProxyDAO, leoService))
 
     eventually(timeout(Span(30, Seconds))) {
       val c1 = dbFutureValue { _.clusterQuery.getClusterById(savedRunningCluster.id) }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/TestClusterSupervisorActor.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/TestClusterSupervisorActor.scala
@@ -22,10 +22,11 @@ object TestClusterSupervisorActor {
             authProvider: LeoAuthProvider,
             autoFreezeConfig: AutoFreezeConfig,
             jupyterProxyDAO: ToolDAO,
+            rstudioProxyDAO: ToolDAO,
             leonardoService: LeonardoService): Props =
     Props(new TestClusterSupervisorActor(
       monitorConfig, dataprocConfig, gdDAO, googleComputeDAO, googleIamDAO, googleStorageDAO,
-      dbRef, testKit, authProvider, autoFreezeConfig, jupyterProxyDAO, leonardoService))
+      dbRef, testKit, authProvider, autoFreezeConfig, jupyterProxyDAO, rstudioProxyDAO, leonardoService))
 }
 
 object TearDown
@@ -44,11 +45,12 @@ class TestClusterSupervisorActor(monitorConfig: MonitorConfig,
                                  authProvider: LeoAuthProvider,
                                  autoFreezeConfig: AutoFreezeConfig,
                                  jupyterProxyDAO: ToolDAO,
+                                 rstudioProxyDAO: ToolDAO,
                                  leonardoService: LeonardoService)
   extends ClusterMonitorSupervisor(
     monitorConfig, dataprocConfig, gdDAO, googleComputeDAO,
     googleIamDAO, googleStorageDAO, dbRef,
-    authProvider, autoFreezeConfig, jupyterProxyDAO, leonardoService) {
+    authProvider, autoFreezeConfig, jupyterProxyDAO, rstudioProxyDAO, leonardoService) {
 
   // Keep track of spawned child actors so we can shut them down when this actor is stopped
   var childActors: Seq[ActorRef] = Seq.empty

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/TestClusterSupervisorActor.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/TestClusterSupervisorActor.scala
@@ -4,7 +4,7 @@ import akka.actor.{ActorRef, Props}
 import akka.testkit.TestKit
 import org.broadinstitute.dsde.workbench.google.{GoogleIamDAO, GoogleStorageDAO}
 import org.broadinstitute.dsde.workbench.leonardo.config.{AutoFreezeConfig, DataprocConfig, MonitorConfig}
-import org.broadinstitute.dsde.workbench.leonardo.dao.JupyterDAO
+import org.broadinstitute.dsde.workbench.leonardo.dao.ToolDAO
 import org.broadinstitute.dsde.workbench.leonardo.dao.google.{GoogleComputeDAO, GoogleDataprocDAO}
 import org.broadinstitute.dsde.workbench.leonardo.db.DbReference
 import org.broadinstitute.dsde.workbench.leonardo.model.{Cluster, LeoAuthProvider}
@@ -21,7 +21,7 @@ object TestClusterSupervisorActor {
             testKit: TestKit,
             authProvider: LeoAuthProvider,
             autoFreezeConfig: AutoFreezeConfig,
-            jupyterProxyDAO: JupyterDAO,
+            jupyterProxyDAO: ToolDAO,
             leonardoService: LeonardoService): Props =
     Props(new TestClusterSupervisorActor(
       monitorConfig, dataprocConfig, gdDAO, googleComputeDAO, googleIamDAO, googleStorageDAO,
@@ -43,7 +43,7 @@ class TestClusterSupervisorActor(monitorConfig: MonitorConfig,
                                  testKit: TestKit,
                                  authProvider: LeoAuthProvider,
                                  autoFreezeConfig: AutoFreezeConfig,
-                                 jupyterProxyDAO: JupyterDAO,
+                                 jupyterProxyDAO: ToolDAO,
                                  leonardoService: LeonardoService)
   extends ClusterMonitorSupervisor(
     monitorConfig, dataprocConfig, gdDAO, googleComputeDAO,


### PR DESCRIPTION
When a cluster transitions from Starting to Running, we originally checked to see if the Jupyter proxy was up and ready. This PR goes through the cluster's clusterImages and checks the proxy of each tool before setting the cluster status to Running. 

Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
