### PR TITLE
Upgrade jackson to 2.9.8 to address CVE reports

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ import sbt._
 object Dependencies {
   val akkaV         = "2.5.13"
   val akkaHttpV     = "10.1.1"
-  val jacksonV      = "2.9.5"
+  val jacksonV      = "2.9.8"
   val googleV       = "1.23.0"
   val scalaLoggingV = "3.9.0"
   val scalaTestV    = "3.0.5"


### PR DESCRIPTION
Addresses some vulnerabilities in `jackson-databind` detected by SourceClear. For example: https://broadinstitute-dsp.sourceclear.io/workspaces/jppForw/issues/vulnerabilities/5952483/11678214

This is similar to this PR: https://github.com/broadinstitute/firecloud-orchestration/pull/707


Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
