### PR TITLE
[NOT YET] Fix broken docker build due to R dependencies

### DIFF
--- a/docker/jupyter/Dockerfile
+++ b/docker/jupyter/Dockerfile
@@ -309,8 +309,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends apt-utils \
     tzdata \
     gfortran \
     gcc \
-    libcurl4 \
-    libcurl4-openssl-dev \
+#    libcurl4 \
+#    libcurl4-openssl-dev \
     libssl-dev \
     libxml2-dev \
  && apt-get clean \


### PR DESCRIPTION
I believe installing `libcurl4` is causing R packages to be removed. Here's a recent build where it happened: 

https://fc-jenkins.dsp-techops.broadinstitute.org/job/leonardo-build/3875/consoleFull
```
The following packages will be REMOVED:
  libcurl3 r-base r-base-core r-base-dev r-cran-class r-cran-kernsmooth
  r-cran-mass r-cran-nnet r-cran-rpart r-cran-spatial r-recommended
```

Here's an older build where it didn't happen:

https://fc-jenkins.dsp-techops.broadinstitute.org/job/leonardo-build/3846/consoleFull
```
The following packages will be REMOVED:
  libcurl3
```

This issue also seems similar: https://askubuntu.com/questions/1118202/installing-libcurl4-removes-r-packages

Q: do we really need `libcurl4`? The docker build seems to succeed when I remove it. Not sure if it breaks anything else. I'm interested in how our test results look against this PR with libcurl4 removed.

Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
