### PR TITLE
Dev build fix for R 

### DIFF
--- a/docker/jupyter/Dockerfile
+++ b/docker/jupyter/Dockerfile
@@ -301,9 +301,12 @@ ENV PIP_USER=true
 
 RUN apt-get update && apt-get install -y --no-install-recommends apt-utils \
  && apt-get update && apt-get -t stretch-cran35 install -y --no-install-recommends \
-    r-base \
-    r-base-dev \
-    r-recommended \
+    r-base-core=3.5.2-1 \
+    r-base=3.5.2-1 \
+    r-base-dev=3.5.2-1 \
+    r-recommended=3.5.2-1 \
+    r-cran-mgcv \
+    r-cran-codetools \
  && apt-get install -t stretch-backports -y --no-install-recommends \
     fonts-dejavu \
     tzdata \


### PR DESCRIPTION
A new version of R (3.5.3) was released on the 11th and our dev builds were failing because of it. This pegs the R version to 3.5.2.


Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
