### PR TITLE
Jupyterlab Extension Install Fix

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
@@ -69,7 +69,6 @@ trait LeonardoTestUtils extends WebBrowserSpec with Matchers with Eventually wit
 
   val multiExtensionClusterRequest = UserJupyterExtensionConfig(
     nbExtensions = Map("map" -> "gmaps"),
-    serverExtensions = Map("jupyterlab" -> "jupyterlab"),
     combinedExtensions = Map("pizza" -> "pizzabutton")
   )
   val jupyterLabExtensionClusterRequest = UserJupyterExtensionConfig(

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookCustomizationSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookCustomizationSpec.scala
@@ -101,7 +101,6 @@ final class NotebookCustomizationSpec extends FreeSpec
             withNewNotebook(cluster) { notebookPage =>
               val query = """!jupyter labextension install @jupyterlab/toc"""
               val result = notebookPage.executeCell(query).get
-              println(result)
               result should not include("Permission denied")
             }
           }

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookCustomizationSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookCustomizationSpec.scala
@@ -94,6 +94,21 @@ final class NotebookCustomizationSpec extends FreeSpec
       }
     }
 
+    "should allow users to install extensions after cluster creation" in {
+      withProject { project => implicit token =>
+        withNewCluster(project) { cluster =>
+          withWebDriver { implicit driver =>
+            withNewNotebook(cluster) { notebookPage =>
+              val query = """!jupyter labextension install @jupyterlab/toc"""
+              val result = notebookPage.executeCell(query).get
+              println(result)
+              result should not include("Permission denied")
+            }
+          }
+        }
+      }
+    }
+
     "should install user specified lab extensions from a js file" in {
       withProject { project => implicit token =>
         val exampleLabExtensionFile = ResourceFile("bucket-tests/example_lab_extension.js")

--- a/src/main/resources/jupyter/init-actions.sh
+++ b/src/main/resources/jupyter/init-actions.sh
@@ -315,7 +315,7 @@ if [[ "${ROLE}" == 'Master' ]]; then
         gsutil cp ${JUPYTER_LAB_GOOGLE_PLUGIN_URI} /etc
         JUPYTER_LAB_GOOGLE_PLUGIN=`basename ${JUPYTER_LAB_GOOGLE_PLUGIN_URI}`
         docker cp /etc/${JUPYTER_LAB_GOOGLE_PLUGIN} ${JUPYTER_SERVER_NAME}:${JUPYTER_HOME}/${JUPYTER_LAB_GOOGLE_PLUGIN}
-        retry 3 docker exec -u root ${JUPYTER_SERVER_NAME} ${JUPYTER_SCRIPTS}/extension/jupyter_install_lab_extension.sh ${JUPYTER_HOME}/${JUPYTER_LAB_GOOGLE_PLUGIN}
+        retry 3 docker exec ${JUPYTER_SERVER_NAME} ${JUPYTER_SCRIPTS}/extension/jupyter_install_lab_extension.sh ${JUPYTER_HOME}/${JUPYTER_LAB_GOOGLE_PLUGIN}
       fi
 
       if [ ! -z ${JUPYTER_NOTEBOOK_CONFIG_URI} ] ; then

--- a/src/main/resources/jupyter/init-actions.sh
+++ b/src/main/resources/jupyter/init-actions.sh
@@ -265,6 +265,7 @@ if [[ "${ROLE}" == 'Master' ]]; then
       fi
       
       #Install lab extensions
+      #Note: lab extensions need to installed as jupyter user, not root
       if [ ! -z "${JUPYTER_LAB_EXTENSIONS}" ] ; then
         for ext in ${JUPYTER_LAB_EXTENSIONS}
         do
@@ -274,15 +275,15 @@ if [[ "${ROLE}" == 'Master' ]]; then
             gsutil cp -r $ext /etc
             JUPYTER_EXTENSION_ARCHIVE=`basename $ext`
             docker cp /etc/${JUPYTER_EXTENSION_ARCHIVE} ${JUPYTER_SERVER_NAME}:${JUPYTER_HOME}/${JUPYTER_EXTENSION_ARCHIVE}
-            retry 3 docker exec -u root ${JUPYTER_SERVER_NAME} ${JUPYTER_SCRIPTS}/extension/jupyter_install_lab_extension.sh ${JUPYTER_HOME}/${JUPYTER_EXTENSION_ARCHIVE}
+            retry 3 docker exec ${JUPYTER_SERVER_NAME} ${JUPYTER_SCRIPTS}/extension/jupyter_install_lab_extension.sh ${JUPYTER_HOME}/${JUPYTER_EXTENSION_ARCHIVE}
           elif [[ $ext == 'http://'* || $ext == 'https://'* ]]; then
             JUPYTER_EXTENSION_FILE=`basename $ext`
             curl $ext -o /etc/${JUPYTER_EXTENSION_FILE}
             docker cp /etc/${JUPYTER_EXTENSION_FILE} ${JUPYTER_SERVER_NAME}:${JUPYTER_HOME}/${JUPYTER_EXTENSION_FILE}
-            retry 3 docker exec -u root ${JUPYTER_SERVER_NAME} ${JUPYTER_SCRIPTS}/extension/jupyter_install_lab_extension.sh ${JUPYTER_HOME}/${JUPYTER_EXTENSION_FILE}
+            retry 3 docker exec ${JUPYTER_SERVER_NAME} ${JUPYTER_SCRIPTS}/extension/jupyter_install_lab_extension.sh ${JUPYTER_HOME}/${JUPYTER_EXTENSION_FILE}
 
           else
-            retry 3 docker exec -u root ${JUPYTER_SERVER_NAME} ${JUPYTER_SCRIPTS}/extension/jupyter_install_lab_extension.sh $ext
+            retry 3 docker exec ${JUPYTER_SERVER_NAME} ${JUPYTER_SCRIPTS}/extension/jupyter_install_lab_extension.sh $ext
           fi
         done
       fi


### PR DESCRIPTION
Users were unable to install jupyterlab extensions after cluster creation. The reason for this was that a previous PR changed the extensions to be installed as root, when they were originally installed as jupyteruser. This PR reverts this change. 

Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
