### PR TITLE
Auto-delete clusters after a configurable number of days of inactivity [completely untested]

### DIFF
--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -44,6 +44,7 @@
         <appender-ref ref="SYSLOG"/>
         <appender-ref ref="Sentry" />
     </logger>
+    
 
     <logger name="akka" level="info" additivity="false">
         <appender-ref ref="file"/>

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -45,6 +45,33 @@
         <appender-ref ref="Sentry" />
     </logger>
 
+    <logger name="org.broadinstitute.dsde.workbench.google.HttpGoogleIamDAO" level="debug" additivity="false">
+        <appender-ref ref="file"/>
+        <appender-ref ref="console"/>
+        <appender-ref ref="SYSLOG"/>
+        <appender-ref ref="Sentry" />
+    </logger>
+
+    <logger name="org.broadinstitute.dsde.workbench.google.HttpGoogleComputeDAO" level="debug" additivity="false">
+        <appender-ref ref="file"/>
+        <appender-ref ref="console"/>
+        <appender-ref ref="SYSLOG"/>
+        <appender-ref ref="Sentry" />
+    </logger>
+
+    <logger name="org.broadinstitute.dsde.workbench.leonardo.dao.google.HttpGoogleDataprocDAO" level="debug" additivity="false">
+        <appender-ref ref="file"/>
+        <appender-ref ref="console"/>
+        <appender-ref ref="SYSLOG"/>
+        <appender-ref ref="Sentry" />
+    </logger>
+
+    <logger name="org.broadinstitute.dsde.workbench.leonardo.dao.google.HttpGoogleStorageDAO" level="debug" additivity="false">
+        <appender-ref ref="file"/>
+        <appender-ref ref="console"/>
+        <appender-ref ref="SYSLOG"/>
+        <appender-ref ref="Sentry" />
+    </logger>
 
     <logger name="akka" level="info" additivity="false">
         <appender-ref ref="file"/>

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -44,7 +44,7 @@
         <appender-ref ref="SYSLOG"/>
         <appender-ref ref="Sentry" />
     </logger>
-    
+
 
     <logger name="akka" level="info" additivity="false">
         <appender-ref ref="file"/>

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -45,34 +45,6 @@
         <appender-ref ref="Sentry" />
     </logger>
 
-    <logger name="org.broadinstitute.dsde.workbench.google.HttpGoogleIamDAO" level="debug" additivity="false">
-        <appender-ref ref="file"/>
-        <appender-ref ref="console"/>
-        <appender-ref ref="SYSLOG"/>
-        <appender-ref ref="Sentry" />
-    </logger>
-
-    <logger name="org.broadinstitute.dsde.workbench.google.HttpGoogleComputeDAO" level="debug" additivity="false">
-        <appender-ref ref="file"/>
-        <appender-ref ref="console"/>
-        <appender-ref ref="SYSLOG"/>
-        <appender-ref ref="Sentry" />
-    </logger>
-
-    <logger name="org.broadinstitute.dsde.workbench.leonardo.dao.google.HttpGoogleDataprocDAO" level="debug" additivity="false">
-        <appender-ref ref="file"/>
-        <appender-ref ref="console"/>
-        <appender-ref ref="SYSLOG"/>
-        <appender-ref ref="Sentry" />
-    </logger>
-
-    <logger name="org.broadinstitute.dsde.workbench.leonardo.dao.google.HttpGoogleStorageDAO" level="debug" additivity="false">
-        <appender-ref ref="file"/>
-        <appender-ref ref="console"/>
-        <appender-ref ref="SYSLOG"/>
-        <appender-ref ref="Sentry" />
-    </logger>
-
     <logger name="akka" level="info" additivity="false">
         <appender-ref ref="file"/>
         <appender-ref ref="console"/>

--- a/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changelog.xml
+++ b/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changelog.xml
@@ -29,5 +29,5 @@
     <include file="changesets/20180919_stop_after_creation.xml" relativeToChangelogFile="true" />
     <include file="changesets/20181114_scopes.xml" relativeToChangelogFile="true" />
     <include file="changesets/20181126_cluster_image.xml" relativeToChangelogFile="true" />
-    <!--<include file="changesets/20190403_cluster_auto_delete_threshold.xml" relativeToChangelogFile="true" />-->
+    <include file="changesets/20190403_cluster_auto_delete_threshold.xml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changelog.xml
+++ b/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changelog.xml
@@ -29,4 +29,5 @@
     <include file="changesets/20180919_stop_after_creation.xml" relativeToChangelogFile="true" />
     <include file="changesets/20181114_scopes.xml" relativeToChangelogFile="true" />
     <include file="changesets/20181126_cluster_image.xml" relativeToChangelogFile="true" />
+    <!--<include file="changesets/20190403_cluster_auto_delete_threshold.xml" relativeToChangelogFile="true" />-->
 </databaseChangeLog>

--- a/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/20190403_cluster_auto_delete_threshold.xml
+++ b/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/20190403_cluster_auto_delete_threshold.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog logicalFilePath="leonardo" xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+    <changeSet logicalFilePath="leonardo" author="mbemis" id="autodelete-threshold-1">
+        <addColumn tableName="CLUSTER">
+            <column name="autoDeleteThreshold" type="INT">
+                <constraints nullable="true" />
+            </column>
+        </addColumn>
+    </changeSet>
+
+    <changeSet logicalFilePath="leonardo" author="mbemis" id="autodelete-threshold-2">
+        <sql>UPDATE CLUSTER SET autoDeleteThreshold = 0 WHERE autoDeleteThreshold IS NULL</sql>
+    </changeSet>
+
+    <changeSet logicalFilePath="leonardo" author="mbemis" id="autodelete-threshold-3">
+        <addNotNullConstraint columnDataType="INT"
+                              columnName="autoDeleteThreshold"
+                              tableName="CLUSTER"/>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -101,18 +101,20 @@ serviceAccounts {
   }
 }
 
-autoFreeze {
-  enableAutoFreeze = true
+clusterLifecycle {
   dateAccessedMonitorScheduler = 1 minute
-  autoFreezeAfter = 30 minutes
-  autoFreezeCheckScheduler = 1 minute
-}
 
-autoDelete {
-  enableAutoDelete = true
-  dateAccessedMonitorScheduler = 1 minute
-  autoDeleteAfter = 30 days
-  autoDeleteCheckScheduler = 12 hours
+  autoFreeze {
+    enableAutoFreeze = true
+    autoFreezeAfter = 30 minutes
+    autoFreezeCheckScheduler = 1 minute
+  }
+
+  autoDelete {
+    enableAutoDelete = true
+    autoDeleteAfter = 30 days
+    autoDeleteCheckScheduler = 12 hours
+  }
 }
 
 jupyterConfig {

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -108,6 +108,13 @@ autoFreeze {
   autoFreezeCheckScheduler = 1 minute
 }
 
+autoDelete {
+  enableAutoDelete = true
+  dateAccessedMonitorScheduler = 1 minute
+  autoDeleteAfter = 30 days
+  autoDeleteCheckScheduler = 12 hours
+}
+
 jupyterConfig {
   # https://*.npmjs.org and 'unsafe-eval' needed for jupyterlab
   contentSecurityPolicy = "frame-ancestors 'self' http://localhost:3000 http://localhost:4200 https://localhost:443 https://bvdp-saturn-prod.appspot.com https://bvdp-saturn-dev.appspot.com https://app.terra.bio https://all-of-us-workbench-test.appspot.com https://all-of-us-rw-staging.appspot.com https://all-of-us-rw-stable.appspot.com https://stable.fake-research-aou.org https://workbench.researchallofus.org; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://apis.google.com ; style-src 'self' 'unsafe-inline'; connect-src 'self' wss://*.broadinstitute.org:* wss://notebooks.firecloud.org:* *.googleapis.com https://*.npmjs.org"

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -1063,6 +1063,12 @@ definitions:
       autopauseThreshold:
         type: integer
         description: The number of minutes of idle time to elapse before the cluster is autopaused. If autopause is set to false, this value is disregarded. A value of 0 is equivalent to autopause being turned off. If autopause is enabled and this is unset, a system default threshold will be used.
+      autoDelete:
+        type: boolean
+        description: Whether auto-delete feature is enabled for this specific cluster. If unset, auto-delete will be enabled and a system default threshold will be used.
+      autoDeleteThreshold:
+        type: integer
+        description: The number of days of idle time to elapse before the cluster is automatically deleted. If autoDelete is set to false, this value is disregarded. A value of 0 is equivalent to autoDelete being turned off. If autoDelete is enabled and this is unset, a system default threshold will be used.
       defaultClientId:
         type: string
         description: The default Google Client ID.

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/Boot.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/Boot.scala
@@ -10,7 +10,7 @@ import org.broadinstitute.dsde.workbench.google.GoogleCredentialModes.{Pem, Toke
 import org.broadinstitute.dsde.workbench.google.{GoogleStorageDAO, HttpGoogleIamDAO, HttpGoogleProjectDAO, HttpGoogleStorageDAO}
 import org.broadinstitute.dsde.workbench.leonardo.api.{LeoRoutes, StandardUserInfoDirectives}
 import org.broadinstitute.dsde.workbench.leonardo.auth.{LeoAuthProviderHelper, ServiceAccountProviderHelper}
-import org.broadinstitute.dsde.workbench.leonardo.config.{AutoFreezeConfig, ClusterDefaultsConfig, ClusterDnsCacheConfig, ClusterFilesConfig, ClusterResourcesConfig, DataprocConfig, LeoExecutionModeConfig, MonitorConfig, ProxyConfig, SamConfig, SwaggerConfig, ZombieClusterConfig, ClusterBucketConfig}
+import org.broadinstitute.dsde.workbench.leonardo.config.{AutoDeleteConfig, AutoFreezeConfig, ClusterBucketConfig, ClusterDefaultsConfig, ClusterDnsCacheConfig, ClusterFilesConfig, ClusterResourcesConfig, DataprocConfig, LeoExecutionModeConfig, MonitorConfig, ProxyConfig, SamConfig, SwaggerConfig, ZombieClusterConfig}
 import org.broadinstitute.dsde.workbench.leonardo.dao.{HttpJupyterDAO, HttpRStudioDAO, HttpSamDAO}
 import org.broadinstitute.dsde.workbench.leonardo.dao.google.{HttpGoogleComputeDAO, HttpGoogleDataprocDAO}
 import org.broadinstitute.dsde.workbench.leonardo.db.DbReference
@@ -47,6 +47,7 @@ object Boot extends App with LazyLogging {
     val monitorConfig = config.as[MonitorConfig]("monitor")
     val samConfig = config.as[SamConfig]("sam")
     val autoFreezeConfig = config.as[AutoFreezeConfig]("autoFreeze")
+    val autoDeleteConfig = config.as[AutoDeleteConfig]("autoDelete")
     val contentSecurityPolicy = config.as[Option[String]]("jupyterConfig.contentSecurityPolicy").getOrElse("default-src: 'self'")
     val zombieClusterMonitorConfig = config.as[ZombieClusterConfig]("zombieClusterMonitor")
     val clusterDnsCacheConfig = config.as[ClusterDnsCacheConfig]("clusterDnsCache")
@@ -82,7 +83,7 @@ object Boot extends App with LazyLogging {
     val googleStorageDAO = new HttpGoogleStorageDAO(dataprocConfig.applicationName, Pem(leoServiceAccountEmail, leoServiceAccountPemFile), "google")
     val clusterDnsCache = new ClusterDnsCache(proxyConfig, dbRef, clusterDnsCacheConfig)
     val bucketHelper = new BucketHelper(dataprocConfig, gdDAO, googleComputeDAO, googleStorageDAO, serviceAccountProvider)
-    val leonardoService = new LeonardoService(dataprocConfig, clusterFilesConfig, clusterResourcesConfig, clusterDefaultsConfig, proxyConfig, swaggerConfig, autoFreezeConfig, gdDAO, googleComputeDAO, googleIamDAO, googleStorageDAO, petGoogleStorageDAO, dbRef, authProvider, serviceAccountProvider, whitelist, bucketHelper, contentSecurityPolicy)
+    val leonardoService = new LeonardoService(dataprocConfig, clusterFilesConfig, clusterResourcesConfig, clusterDefaultsConfig, proxyConfig, swaggerConfig, autoFreezeConfig, autoDeleteConfig, gdDAO, googleComputeDAO, googleIamDAO, googleStorageDAO, petGoogleStorageDAO, dbRef, authProvider, serviceAccountProvider, whitelist, bucketHelper, contentSecurityPolicy)
 
     if(leoExecutionModeConfig.backLeo) {
       val googleProjectDAO = new HttpGoogleProjectDAO(dataprocConfig.applicationName, Pem(leoServiceAccountEmail, leoServiceAccountPemFile), "google")

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/AutoDeleteConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/AutoDeleteConfig.scala
@@ -4,7 +4,6 @@ import scala.concurrent.duration.FiniteDuration
 
 case class AutoDeleteConfig (
                               enableAutoDelete: Boolean,
-                              dateAccessedMonitorScheduler: FiniteDuration,
                               autoDeleteAfter: FiniteDuration,
                               autoDeleteCheckScheduler: FiniteDuration
                             )

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/AutoDeleteConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/AutoDeleteConfig.scala
@@ -1,0 +1,10 @@
+package org.broadinstitute.dsde.workbench.leonardo.config
+
+import scala.concurrent.duration.FiniteDuration
+
+case class AutoDeleteConfig (
+                              enableAutoDelete: Boolean,
+                              dateAccessedMonitorScheduler: FiniteDuration,
+                              autoDeleteAfter: FiniteDuration,
+                              autoDeleteCheckScheduler: FiniteDuration
+                            )

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/AutoFreezeConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/AutoFreezeConfig.scala
@@ -4,7 +4,6 @@ import scala.concurrent.duration.FiniteDuration
 
 case class AutoFreezeConfig (
                               enableAutoFreeze: Boolean,
-                              dateAccessedMonitorScheduler: FiniteDuration,
                               autoFreezeAfter: FiniteDuration,
                               autoFreezeCheckScheduler: FiniteDuration
                             )

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/ClusterLifecycleConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/ClusterLifecycleConfig.scala
@@ -1,0 +1,9 @@
+package org.broadinstitute.dsde.workbench.leonardo.config
+
+import scala.concurrent.duration.FiniteDuration
+
+case class ClusterLifecycleConfig (
+                              dateAccessedMonitorScheduler: FiniteDuration,
+                              autoFreezeConfig: AutoFreezeConfig,
+                              autoDeleteConfig: AutoDeleteConfig
+                            )

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/package.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/package.scala
@@ -97,11 +97,9 @@ package object config {
     SamConfig(config.getString("server"))
   }
 
-
   implicit val autoFreezeConfigReader: ValueReader[AutoFreezeConfig] = ValueReader.relative { config =>
     AutoFreezeConfig(
       config.getBoolean("enableAutoFreeze"),
-      toScalaDuration(config.getDuration("dateAccessedMonitorScheduler")),
       toScalaDuration(config.getDuration("autoFreezeAfter")),
       toScalaDuration(config.getDuration("autoFreezeCheckScheduler"))
     )
@@ -110,9 +108,16 @@ package object config {
   implicit val autoDeleteConfigReader: ValueReader[AutoDeleteConfig] = ValueReader.relative { config =>
     AutoDeleteConfig(
       config.getBoolean("enableAutoDelete"),
-      toScalaDuration(config.getDuration("dateAccessedMonitorScheduler")),
       toScalaDuration(config.getDuration("autoDeleteAfter")),
       toScalaDuration(config.getDuration("autoDeleteCheckScheduler"))
+    )
+  }
+
+  implicit val clusterLifecycleConfigReader: ValueReader[ClusterLifecycleConfig] = ValueReader.relative { config =>
+    ClusterLifecycleConfig(
+      toScalaDuration(config.getDuration("dateAccessedMonitorScheduler")),
+      config.as[AutoFreezeConfig]("clusterLifecycle.autoFreeze"),
+      config.as[AutoDeleteConfig]("clusterLifecycle.autoDelete")
     )
   }
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/package.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/package.scala
@@ -97,12 +97,22 @@ package object config {
     SamConfig(config.getString("server"))
   }
 
+
   implicit val autoFreezeConfigReader: ValueReader[AutoFreezeConfig] = ValueReader.relative { config =>
     AutoFreezeConfig(
       config.getBoolean("enableAutoFreeze"),
       toScalaDuration(config.getDuration("dateAccessedMonitorScheduler")),
       toScalaDuration(config.getDuration("autoFreezeAfter")),
       toScalaDuration(config.getDuration("autoFreezeCheckScheduler"))
+    )
+  }
+
+  implicit val autoDeleteConfigReader: ValueReader[AutoDeleteConfig] = ValueReader.relative { config =>
+    AutoDeleteConfig(
+      config.getBoolean("enableAutoDelete"),
+      toScalaDuration(config.getDuration("dateAccessedMonitorScheduler")),
+      toScalaDuration(config.getDuration("autoDeleteAfter")),
+      toScalaDuration(config.getDuration("autoDeleteCheckScheduler"))
     )
   }
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeonardoModel.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeonardoModel.scala
@@ -32,6 +32,8 @@ case class ClusterRequest(labels: Option[LabelMap] = Option(Map.empty),
                           userJupyterExtensionConfig: Option[UserJupyterExtensionConfig] = None,
                           autopause: Option[Boolean] = None,
                           autopauseThreshold: Option[Int] = None,
+                          autoDelete: Option[Boolean] = None,
+                          autoDeleteThreshold: Option[Int] = None,
                           defaultClientId: Option[String] = None,
                           jupyterDockerImage: Option[String] = None,
                           rstudioDockerImage: Option[String] = None,
@@ -93,6 +95,7 @@ case class Cluster(id: Long = 0, // DB AutoInc
                    instances: Set[Instance],
                    userJupyterExtensionConfig: Option[UserJupyterExtensionConfig],
                    autopauseThreshold: Int,
+                   autoDeleteThreshold: Int,
                    defaultClientId: Option[String],
                    stopAfterCreation: Boolean,
                    clusterImages: Set[ClusterImage],
@@ -111,6 +114,7 @@ object Cluster {
              machineConfig: MachineConfig,
              clusterUrlBase: String,
              autopauseThreshold: Int,
+             autoDeleteThreshold: Int,
              clusterScopes: Set[String],
              operation: Option[Operation] = None,
              stagingBucket: Option[GcsBucketName] = None,
@@ -131,6 +135,7 @@ object Cluster {
       instances = Set.empty,
       userJupyterExtensionConfig = clusterRequest.userJupyterExtensionConfig,
       autopauseThreshold = autopauseThreshold,
+      autoDeleteThreshold = autoDeleteThreshold,
       defaultClientId = clusterRequest.defaultClientId,
       stopAfterCreation = clusterRequest.stopAfterCreation.getOrElse(false),
       clusterImages = clusterImages,
@@ -312,7 +317,7 @@ object LeonardoJsonSupport extends SprayJsonSupport with DefaultJsonProtocol {
 
   implicit val UserClusterExtensionConfigFormat = jsonFormat4(UserJupyterExtensionConfig.apply)
 
-  implicit val ClusterRequestFormat = jsonFormat12(ClusterRequest)
+  implicit val ClusterRequestFormat = jsonFormat14(ClusterRequest)
 
   implicit val ClusterResourceFormat = ValueObjectFormat(ClusterResource)
 
@@ -354,6 +359,7 @@ object LeonardoJsonSupport extends SprayJsonSupport with DefaultJsonProtocol {
             fields.getOrElse("instances", JsNull).convertTo[Set[Instance]],
             fields.getOrElse("userJupyterExtensionConfig", JsNull).convertTo[Option[UserJupyterExtensionConfig]],
             fields.getOrElse("autopauseThreshold", JsNull).convertTo[Int],
+            fields.getOrElse("autoDeleteThreshold", JsNull).convertTo[Int],
             fields.getOrElse("defaultClientId", JsNull).convertTo[Option[String]],
             fields.getOrElse("stopAfterCreation", JsNull).convertTo[Boolean],
             fields.getOrElse("clusterImages", JsNull).convertTo[Set[ClusterImage]],

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterDateAccessedActor.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterDateAccessedActor.scala
@@ -3,19 +3,19 @@ package org.broadinstitute.dsde.workbench.leonardo.monitor
 import java.time.Instant
 
 import akka.actor.{Actor, Props}
-
 import org.broadinstitute.dsde.workbench.leonardo.db.DbReference
 import org.broadinstitute.dsde.workbench.leonardo.model.google.ClusterName
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import com.typesafe.scalalogging.LazyLogging
-import org.broadinstitute.dsde.workbench.leonardo.config.AutoFreezeConfig
+import org.broadinstitute.dsde.workbench.leonardo.config.{AutoFreezeConfig, ClusterLifecycleConfig}
 import org.broadinstitute.dsde.workbench.leonardo.monitor.ClusterDateAccessedActor.{Flush, UpdateDateAccessed}
+
 import scala.concurrent.duration._
 
 object ClusterDateAccessedActor {
 
-  def props(autoFreezeConfig: AutoFreezeConfig, dbReference: DbReference): Props =
-    Props(new ClusterDateAccessedActor(autoFreezeConfig, dbReference))
+  def props(clusterLifecycleConfig: ClusterLifecycleConfig, dbReference: DbReference): Props =
+    Props(new ClusterDateAccessedActor(clusterLifecycleConfig, dbReference))
 
   sealed trait ClusterAccessDateMessage
 
@@ -25,7 +25,7 @@ object ClusterDateAccessedActor {
 
 }
 
-class ClusterDateAccessedActor(autoFreezeConfig: AutoFreezeConfig, dbRef: DbReference) extends Actor with LazyLogging {
+class ClusterDateAccessedActor(clusterLifecycleConfig: ClusterLifecycleConfig, dbRef: DbReference) extends Actor with LazyLogging {
 
   var dateAccessedMap: Map[(ClusterName, GoogleProject), Instant] = Map.empty
 
@@ -33,7 +33,7 @@ class ClusterDateAccessedActor(autoFreezeConfig: AutoFreezeConfig, dbRef: DbRefe
 
   override def preStart(): Unit = {
     super.preStart()
-    system.scheduler.schedule(autoFreezeConfig.dateAccessedMonitorScheduler, autoFreezeConfig.dateAccessedMonitorScheduler, self, Flush)
+    system.scheduler.schedule(clusterLifecycleConfig.dateAccessedMonitorScheduler, clusterLifecycleConfig.dateAccessedMonitorScheduler, self, Flush)
   }
 
   override def receive: Receive = {

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoService.scala
@@ -257,12 +257,12 @@ class LeonardoService(protected val dataprocConfig: DataprocConfig,
     val machineConfig = MachineConfigOps.create(clusterRequest.machineConfig, clusterDefaultsConfig)
     val autopauseThreshold = calculateAutopauseThreshold(
       clusterRequest.autopause, clusterRequest.autopauseThreshold)
-    val autoDelete = calculateAutoDeleteThreshold(
+    val autoDeleteThreshold = calculateAutoDeleteThreshold(
       clusterRequest.autoDelete, clusterRequest.autoDeleteThreshold)
     val clusterScopes = clusterRequest.scopes.getOrElse(dataprocConfig.defaultScopes)
     val initialClusterToSave = Cluster.create(
       augmentedClusterRequest, userEmail, clusterName, googleProject,
-      serviceAccountInfo, machineConfig, dataprocConfig.clusterUrlBase, autopauseThreshold, autoDelete, clusterScopes,
+      serviceAccountInfo, machineConfig, dataprocConfig.clusterUrlBase, autopauseThreshold, autoDeleteThreshold, clusterScopes,
       clusterImages = clusterImages)
 
     // Validate that the Jupyter extension URIs and Jupyter user script URI are valid URIs and reference real GCS objects

--- a/src/test/resources/reference.conf
+++ b/src/test/resources/reference.conf
@@ -195,12 +195,20 @@ akka.ssl-config {
   }
 }
 
-autoFreeze {
-  #Change to true once auto freeze is ready for prod
-  enableAutoFreeze = true
-  dateAccessedMonitorScheduler = 1 second
-  autoFreezeAfter = 15 minutes
-  autoFreezeCheckScheduler = 10 second
+clusterLifecycle {
+  dateAccessedMonitorScheduler = 1 minute
+
+  autoFreeze {
+    enableAutoFreeze = true
+    autoFreezeAfter = 30 minutes
+    autoFreezeCheckScheduler = 1 minute
+  }
+
+  autoDelete {
+    enableAutoDelete = true
+    autoDeleteAfter = 30 days
+    autoDeleteCheckScheduler = 12 hours
+  }
 }
 
 jupyterConfig {

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/CommonTestData.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/CommonTestData.scala
@@ -9,7 +9,7 @@ import net.ceedubs.ficus.Ficus._
 import org.broadinstitute.dsde.workbench.google.mock.MockGoogleDataprocDAO
 import org.broadinstitute.dsde.workbench.leonardo.auth.WhitelistAuthProvider
 import org.broadinstitute.dsde.workbench.leonardo.auth.sam.MockPetClusterServiceAccountProvider
-import org.broadinstitute.dsde.workbench.leonardo.config.{AutoFreezeConfig, ClusterBucketConfig, ClusterDefaultsConfig, ClusterDnsCacheConfig, ClusterFilesConfig, ClusterResourcesConfig, DataprocConfig, MonitorConfig, ProxyConfig, SwaggerConfig, ZombieClusterConfig}
+import org.broadinstitute.dsde.workbench.leonardo.config.{AutoDeleteConfig, AutoFreezeConfig, ClusterBucketConfig, ClusterDefaultsConfig, ClusterDnsCacheConfig, ClusterFilesConfig, ClusterResourcesConfig, DataprocConfig, MonitorConfig, ProxyConfig, SwaggerConfig, ZombieClusterConfig}
 import org.broadinstitute.dsde.workbench.leonardo.dao.google.MockGoogleComputeDAO
 import org.broadinstitute.dsde.workbench.leonardo.dao.{MockJupyterDAO, MockRStudioDAO, MockSamDAO}
 import org.broadinstitute.dsde.workbench.leonardo.db.TestComponent
@@ -43,6 +43,8 @@ trait CommonTestData{ this: ScalaFutures =>
   val initBucketPath = GcsBucketName("bucket-path")
   val autopause = true
   val autopauseThreshold = 30
+  val autoDelete = true
+  val autoDeleteThreshold = 30
   val defaultScopes = Set("https://www.googleapis.com/auth/userinfo.email", "https://www.googleapis.com/auth/userinfo.profile", "https://www.googleapis.com/auth/bigquery", "https://www.googleapis.com/auth/source.read_only")
 
   val config = ConfigFactory.parseResources("reference.conf").withFallback(ConfigFactory.load())
@@ -55,6 +57,7 @@ trait CommonTestData{ this: ScalaFutures =>
   val proxyConfig = config.as[ProxyConfig]("proxy")
   val swaggerConfig = config.as[SwaggerConfig]("swagger")
   val autoFreezeConfig = config.as[AutoFreezeConfig]("autoFreeze")
+  val autoDeleteConfig = config.as[AutoDeleteConfig]("autoDelete")
   val zombieClusterConfig = config.as[ZombieClusterConfig]("zombieClusterMonitor")
   val dnsCacheConfig = config.as[ClusterDnsCacheConfig]("clusterDnsCache")
   val clusterUrlBase = dataprocConfig.clusterUrlBase
@@ -65,8 +68,8 @@ trait CommonTestData{ this: ScalaFutures =>
   val mockJupyterDAO = new MockJupyterDAO
   val mockRStudioDAO = new MockRStudioDAO
   val singleNodeDefaultMachineConfig = MachineConfig(Some(clusterDefaultsConfig.numberOfWorkers), Some(clusterDefaultsConfig.masterMachineType), Some(clusterDefaultsConfig.masterDiskSize))
-  val testClusterRequest = ClusterRequest(Some(Map("bam" -> "yes", "vcf" -> "no", "foo" -> "bar")), None, None, None, None, Some(UserJupyterExtensionConfig(Map("abc" -> "def"), Map("pqr" -> "pqr"), Map("xyz" -> "xyz"))), Some(true), Some(30), Some("ThisIsADefaultClientID"))
-  val testClusterRequestWithExtensionAndScript = ClusterRequest(Some(Map("bam" -> "yes", "vcf" -> "no", "foo" -> "bar")), Some(jupyterExtensionUri), Some(jupyterUserScriptUri), None, None, Some(UserJupyterExtensionConfig(Map("abc" -> "def"), Map("pqr" -> "pqr"), Map("xyz" -> "xyz"))), Some(true), Some(30), Some("ThisIsADefaultClientID"))
+  val testClusterRequest = ClusterRequest(Some(Map("bam" -> "yes", "vcf" -> "no", "foo" -> "bar")), None, None, None, None, Some(UserJupyterExtensionConfig(Map("abc" -> "def"), Map("pqr" -> "pqr"), Map("xyz" -> "xyz"))), Some(true), Some(30), Some(true), Some(30), Some("ThisIsADefaultClientID"))
+  val testClusterRequestWithExtensionAndScript = ClusterRequest(Some(Map("bam" -> "yes", "vcf" -> "no", "foo" -> "bar")), Some(jupyterExtensionUri), Some(jupyterUserScriptUri), None, None, Some(UserJupyterExtensionConfig(Map("abc" -> "def"), Map("pqr" -> "pqr"), Map("xyz" -> "xyz"))), Some(true), Some(30), Some(true), Some(30), Some("ThisIsADefaultClientID"))
 
   val mockSamDAO = new MockSamDAO
   val mockGoogleDataprocDAO = new MockGoogleDataprocDAO
@@ -108,6 +111,7 @@ trait CommonTestData{ this: ScalaFutures =>
       instances = Set.empty,
       userJupyterExtensionConfig = None,
       autopauseThreshold = 30,
+      autoDeleteThreshold = 30,
       defaultClientId = Some("defaultClientId"),
       stopAfterCreation = false,
       clusterImages = Set(jupyterImage),
@@ -131,6 +135,7 @@ trait CommonTestData{ this: ScalaFutures =>
     instances = Set.empty,
     userJupyterExtensionConfig = None,
     autopauseThreshold = if (autopause) autopauseThreshold else 0,
+    autoDeleteThreshold = if (autoDelete) autoDeleteThreshold else 0,
     defaultClientId = None,
     stopAfterCreation = false,
     clusterImages = Set(jupyterImage, rstudioImage),

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/CommonTestData.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/CommonTestData.scala
@@ -9,7 +9,7 @@ import net.ceedubs.ficus.Ficus._
 import org.broadinstitute.dsde.workbench.google.mock.MockGoogleDataprocDAO
 import org.broadinstitute.dsde.workbench.leonardo.auth.WhitelistAuthProvider
 import org.broadinstitute.dsde.workbench.leonardo.auth.sam.MockPetClusterServiceAccountProvider
-import org.broadinstitute.dsde.workbench.leonardo.config.{AutoDeleteConfig, AutoFreezeConfig, ClusterBucketConfig, ClusterDefaultsConfig, ClusterDnsCacheConfig, ClusterFilesConfig, ClusterResourcesConfig, DataprocConfig, MonitorConfig, ProxyConfig, SwaggerConfig, ZombieClusterConfig}
+import org.broadinstitute.dsde.workbench.leonardo.config.{AutoDeleteConfig, AutoFreezeConfig, ClusterBucketConfig, ClusterDefaultsConfig, ClusterDnsCacheConfig, ClusterFilesConfig, ClusterLifecycleConfig, ClusterResourcesConfig, DataprocConfig, MonitorConfig, ProxyConfig, SwaggerConfig, ZombieClusterConfig}
 import org.broadinstitute.dsde.workbench.leonardo.dao.google.MockGoogleComputeDAO
 import org.broadinstitute.dsde.workbench.leonardo.dao.{MockJupyterDAO, MockRStudioDAO, MockSamDAO}
 import org.broadinstitute.dsde.workbench.leonardo.db.TestComponent
@@ -56,8 +56,9 @@ trait CommonTestData{ this: ScalaFutures =>
   val clusterDefaultsConfig = config.as[ClusterDefaultsConfig]("clusterDefaults")
   val proxyConfig = config.as[ProxyConfig]("proxy")
   val swaggerConfig = config.as[SwaggerConfig]("swagger")
-  val autoFreezeConfig = config.as[AutoFreezeConfig]("autoFreeze")
-  val autoDeleteConfig = config.as[AutoDeleteConfig]("autoDelete")
+  val clusterLifecycleConfig = config.as[ClusterLifecycleConfig]("clusterLifecycle")
+  val autoFreezeConfig = clusterLifecycleConfig.autoFreezeConfig
+  val autoDeleteConfig = clusterLifecycleConfig.autoDeleteConfig
   val zombieClusterConfig = config.as[ZombieClusterConfig]("zombieClusterMonitor")
   val dnsCacheConfig = config.as[ClusterDnsCacheConfig]("clusterDnsCache")
   val clusterUrlBase = dataprocConfig.clusterUrlBase

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/TestLeoRoutes.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/TestLeoRoutes.scala
@@ -34,7 +34,7 @@ trait TestLeoRoutes { this: ScalatestRouteTest with Matchers with CommonTestData
   // Route tests don't currently do cluster monitoring, so use NoopActor
   val clusterMonitorSupervisor = system.actorOf(NoopActor.props)
   val bucketHelper = new BucketHelper(dataprocConfig, mockGoogleDataprocDAO, mockGoogleComputeDAO, mockGoogleStorageDAO, serviceAccountProvider)
-  val leonardoService = new LeonardoService(dataprocConfig, clusterFilesConfig, clusterResourcesConfig, clusterDefaultsConfig, proxyConfig, swaggerConfig, autoFreezeConfig, mockGoogleDataprocDAO, mockGoogleComputeDAO, mockGoogleIamDAO, mockGoogleStorageDAO, mockPetGoogleStorageDAO, DbSingleton.ref, whitelistAuthProvider, serviceAccountProvider, whitelist, bucketHelper, contentSecurityPolicy)
+  val leonardoService = new LeonardoService(dataprocConfig, clusterFilesConfig, clusterResourcesConfig, clusterDefaultsConfig, proxyConfig, swaggerConfig, autoFreezeConfig, autoDeleteConfig, mockGoogleDataprocDAO, mockGoogleComputeDAO, mockGoogleIamDAO, mockGoogleStorageDAO, mockPetGoogleStorageDAO, DbSingleton.ref, whitelistAuthProvider, serviceAccountProvider, whitelist, bucketHelper, contentSecurityPolicy)
   val clusterDnsCache = new ClusterDnsCache(proxyConfig, DbSingleton.ref, dnsCacheConfig)
   val proxyService = new MockProxyService(proxyConfig, mockGoogleDataprocDAO, DbSingleton.ref, whitelistAuthProvider, clusterDnsCache)
   val statusService = new StatusService(mockGoogleDataprocDAO, mockSamDAO, DbSingleton.ref, dataprocConfig, pollInterval = 1.second)

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterDateAccessedSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterDateAccessedSpec.scala
@@ -33,7 +33,7 @@ class ClusterDateAccessedSpec extends TestKit(ActorSystem("leonardotest")) with
     savedTestCluster1 shouldEqual testCluster1
 
     val currentTime = Instant.now()
-    val dateAccessedActor = system.actorOf(ClusterDateAccessedActor.props(autoFreezeConfig, DbSingleton.ref))
+    val dateAccessedActor = system.actorOf(ClusterDateAccessedActor.props(clusterLifecycleConfig, DbSingleton.ref))
     dateAccessedActor ! UpdateDateAccessed(testCluster1.clusterName, testCluster1.googleProject, currentTime)
     eventually(timeout(Span(5, Seconds))) {
       val c1 = dbFutureValue { _.clusterQuery.getClusterById(savedTestCluster1.id) }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorSpec.scala
@@ -112,7 +112,7 @@ class ClusterMonitorSpec extends TestKit(ActorSystem("leonardotest")) with FlatS
     val bucketHelper = new BucketHelper(dataprocConfig, gdDAO, computeDAO, storageDAO, serviceAccountProvider)
     val mockPetGoogleStorageDAO: String => GoogleStorageDAO = _ => new MockGoogleStorageDAO
     val leoService = new LeonardoService(dataprocConfig, clusterFilesConfig, clusterResourcesConfig, clusterDefaultsConfig, proxyConfig, swaggerConfig, autoFreezeConfig, autoDeleteConfig, gdDAO, computeDAO, iamDAO, storageDAO, mockPetGoogleStorageDAO, DbSingleton.ref, whitelistAuthProvider, serviceAccountProvider, whitelist, bucketHelper, contentSecurityPolicy)
-    val supervisorActor = system.actorOf(TestClusterSupervisorActor.props(monitorConfig, dataprocConfig, clusterBucketConfig, gdDAO, computeDAO, iamDAO, storageDAO, DbSingleton.ref, testKit, authProvider, autoFreezeConfig, jupyterDAO, rstudioDAO, leoService))
+    val supervisorActor = system.actorOf(TestClusterSupervisorActor.props(monitorConfig, dataprocConfig, clusterBucketConfig, gdDAO, computeDAO, iamDAO, storageDAO, DbSingleton.ref, testKit, authProvider, clusterLifecycleConfig, jupyterDAO, rstudioDAO, leoService))
 
     supervisorActor
   }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorSpec.scala
@@ -111,7 +111,7 @@ class ClusterMonitorSpec extends TestKit(ActorSystem("leonardotest")) with FlatS
   def createClusterSupervisor(gdDAO: GoogleDataprocDAO, computeDAO: GoogleComputeDAO, iamDAO: GoogleIamDAO, storageDAO: GoogleStorageDAO, authProvider: LeoAuthProvider, jupyterDAO: ToolDAO, rstudioDAO: ToolDAO): ActorRef = {
     val bucketHelper = new BucketHelper(dataprocConfig, gdDAO, computeDAO, storageDAO, serviceAccountProvider)
     val mockPetGoogleStorageDAO: String => GoogleStorageDAO = _ => new MockGoogleStorageDAO
-    val leoService = new LeonardoService(dataprocConfig, clusterFilesConfig, clusterResourcesConfig, clusterDefaultsConfig, proxyConfig, swaggerConfig, autoFreezeConfig, gdDAO, computeDAO, iamDAO, storageDAO, mockPetGoogleStorageDAO, DbSingleton.ref, whitelistAuthProvider, serviceAccountProvider, whitelist, bucketHelper, contentSecurityPolicy)
+    val leoService = new LeonardoService(dataprocConfig, clusterFilesConfig, clusterResourcesConfig, clusterDefaultsConfig, proxyConfig, swaggerConfig, autoFreezeConfig, autoDeleteConfig, gdDAO, computeDAO, iamDAO, storageDAO, mockPetGoogleStorageDAO, DbSingleton.ref, whitelistAuthProvider, serviceAccountProvider, whitelist, bucketHelper, contentSecurityPolicy)
     val supervisorActor = system.actorOf(TestClusterSupervisorActor.props(monitorConfig, dataprocConfig, clusterBucketConfig, gdDAO, computeDAO, iamDAO, storageDAO, DbSingleton.ref, testKit, authProvider, autoFreezeConfig, jupyterDAO, rstudioDAO, leoService))
 
     supervisorActor

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterSupervisorSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterSupervisorSpec.scala
@@ -59,7 +59,7 @@ class ClusterSupervisorSpec extends TestKit(ActorSystem("leonardotest"))
     savedRunningCluster shouldEqual runningCluster
 
     val leoService = new LeonardoService(dataprocConfig, clusterFilesConfig, clusterResourcesConfig,
-      clusterDefaultsConfig, proxyConfig, swaggerConfig, autoFreezeConfig, gdDAO, computeDAO, iamDAO,
+      clusterDefaultsConfig, proxyConfig, swaggerConfig, autoFreezeConfig, autoDeleteConfig, gdDAO, computeDAO, iamDAO,
       storageDAO, mockPetGoogleStorageDAO, DbSingleton.ref, whitelistAuthProvider, serviceAccountProvider, whitelist,
       bucketHelper, contentSecurityPolicy)
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterSupervisorSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterSupervisorSpec.scala
@@ -64,7 +64,7 @@ class ClusterSupervisorSpec extends TestKit(ActorSystem("leonardotest"))
       bucketHelper, contentSecurityPolicy)
 
     val clusterSupervisorActor = system.actorOf(ClusterMonitorSupervisor.props(monitorConfig, dataprocConfig, clusterBucketConfig, gdDAO,
-      computeDAO, iamDAO, storageDAO, DbSingleton.ref, authProvider, autoFreezeConfig, jupyterProxyDAO, rstudioProxyDAO, leoService))
+      computeDAO, iamDAO, storageDAO, DbSingleton.ref, authProvider, clusterLifecycleConfig, jupyterProxyDAO, rstudioProxyDAO, leoService))
 
     eventually(timeout(Span(30, Seconds))) {
       val c1 = dbFutureValue { _.clusterQuery.getClusterById(savedRunningCluster.id) }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/TestClusterSupervisorActor.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/TestClusterSupervisorActor.scala
@@ -3,7 +3,7 @@ package org.broadinstitute.dsde.workbench.leonardo.monitor
 import akka.actor.{ActorRef, Props}
 import akka.testkit.TestKit
 import org.broadinstitute.dsde.workbench.google.{GoogleIamDAO, GoogleStorageDAO}
-import org.broadinstitute.dsde.workbench.leonardo.config.{AutoFreezeConfig, ClusterBucketConfig, DataprocConfig, MonitorConfig}
+import org.broadinstitute.dsde.workbench.leonardo.config.{AutoFreezeConfig, ClusterBucketConfig, ClusterLifecycleConfig, DataprocConfig, MonitorConfig}
 import org.broadinstitute.dsde.workbench.leonardo.dao.ToolDAO
 import org.broadinstitute.dsde.workbench.leonardo.dao.google.{GoogleComputeDAO, GoogleDataprocDAO}
 import org.broadinstitute.dsde.workbench.leonardo.db.DbReference
@@ -21,13 +21,13 @@ object TestClusterSupervisorActor {
             dbRef: DbReference,
             testKit: TestKit,
             authProvider: LeoAuthProvider,
-            autoFreezeConfig: AutoFreezeConfig,
+            clusterLifecycleConfig: ClusterLifecycleConfig,
             jupyterProxyDAO: ToolDAO,
             rstudioProxyDAO: ToolDAO,
             leonardoService: LeonardoService): Props =
     Props(new TestClusterSupervisorActor(
       monitorConfig, dataprocConfig, clusterBucketConfig, gdDAO, googleComputeDAO, googleIamDAO, googleStorageDAO,
-      dbRef, testKit, authProvider, autoFreezeConfig, jupyterProxyDAO, rstudioProxyDAO, leonardoService))
+      dbRef, testKit, authProvider, clusterLifecycleConfig, jupyterProxyDAO, rstudioProxyDAO, leonardoService))
 }
 
 object TearDown
@@ -45,14 +45,14 @@ class TestClusterSupervisorActor(monitorConfig: MonitorConfig,
                                  dbRef: DbReference,
                                  testKit: TestKit,
                                  authProvider: LeoAuthProvider,
-                                 autoFreezeConfig: AutoFreezeConfig,
+                                 clusterLifecycleConfig: ClusterLifecycleConfig,
                                  jupyterProxyDAO: ToolDAO,
                                  rstudioProxyDAO: ToolDAO,
                                  leonardoService: LeonardoService)
   extends ClusterMonitorSupervisor(
     monitorConfig, dataprocConfig, clusterBucketConfig, gdDAO, googleComputeDAO,
     googleIamDAO, googleStorageDAO, dbRef,
-    authProvider, autoFreezeConfig, jupyterProxyDAO, rstudioProxyDAO, leonardoService) {
+    authProvider, clusterLifecycleConfig, jupyterProxyDAO, rstudioProxyDAO, leonardoService) {
 
   // Keep track of spawned child actors so we can shut them down when this actor is stopped
   var childActors: Seq[ActorRef] = Seq.empty

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/AuthProviderSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/AuthProviderSpec.scala
@@ -55,7 +55,7 @@ class AuthProviderSpec extends FreeSpec with ScalatestRouteTest with Matchers wi
     val mockPetGoogleStorageDAO: String => GoogleStorageDAO = _ => {
       new MockGoogleStorageDAO
     }
-    new LeonardoService(dataprocConfig, clusterFilesConfig, clusterResourcesConfig, clusterDefaultsConfig, proxyConfig, swaggerConfig, autoFreezeConfig, mockGoogleDataprocDAO, mockGoogleComputeDAO , mockGoogleIamDAO, mockGoogleStorageDAO ,mockPetGoogleStorageDAO, DbSingleton.ref, authProvider, serviceAccountProvider, whitelist, bucketHelper, contentSecurityPolicy)
+    new LeonardoService(dataprocConfig, clusterFilesConfig, clusterResourcesConfig, clusterDefaultsConfig, proxyConfig, swaggerConfig, autoFreezeConfig, autoDeleteConfig, mockGoogleDataprocDAO, mockGoogleComputeDAO , mockGoogleIamDAO, mockGoogleStorageDAO ,mockPetGoogleStorageDAO, DbSingleton.ref, authProvider, serviceAccountProvider, whitelist, bucketHelper, contentSecurityPolicy)
   }
 
   def proxyWithAuthProvider(authProvider: LeoAuthProvider): ProxyService = {

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoServiceSpec.scala
@@ -67,7 +67,7 @@ class LeonardoServiceSpec extends TestKit(ActorSystem("leonardotest")) with Flat
     val mockPetGoogleDAO: String => GoogleStorageDAO = _ => {
       new MockGoogleStorageDAO
     }
-    leo = new LeonardoService(dataprocConfig, clusterFilesConfig, clusterResourcesConfig, clusterDefaultsConfig, proxyConfig, swaggerConfig, autoFreezeConfig, gdDAO, computeDAO, iamDAO, storageDAO, mockPetGoogleDAO, DbSingleton.ref, authProvider, serviceAccountProvider, whitelist, bucketHelper, contentSecurityPolicy)
+    leo = new LeonardoService(dataprocConfig, clusterFilesConfig, clusterResourcesConfig, clusterDefaultsConfig, proxyConfig, swaggerConfig, autoFreezeConfig, autoDeleteConfig, gdDAO, computeDAO, iamDAO, storageDAO, mockPetGoogleDAO, DbSingleton.ref, authProvider, serviceAccountProvider, whitelist, bucketHelper, contentSecurityPolicy)
   }
 
   override def afterAll(): Unit = {
@@ -359,7 +359,7 @@ class LeonardoServiceSpec extends TestKit(ActorSystem("leonardotest")) with Flat
     val mockPetGoogleStorageDAO: String => GoogleStorageDAO = _ => {
       new MockGoogleStorageDAO
     }
-    val leoForTest = new LeonardoService(dataprocConfig, clusterFilesConfig, clusterResourcesConfig, clusterDefaultsConfig, proxyConfig, swaggerConfig, autoFreezeConfig, gdDAO, computeDAO, iamDAO, storageDAO, mockPetGoogleStorageDAO, DbSingleton.ref, spyProvider, serviceAccountProvider, whitelist, bucketHelper, contentSecurityPolicy)
+    val leoForTest = new LeonardoService(dataprocConfig, clusterFilesConfig, clusterResourcesConfig, clusterDefaultsConfig, proxyConfig, swaggerConfig, autoFreezeConfig, autoDeleteConfig, gdDAO, computeDAO, iamDAO, storageDAO, mockPetGoogleStorageDAO, DbSingleton.ref, spyProvider, serviceAccountProvider, whitelist, bucketHelper, contentSecurityPolicy)
 
     forallClusterCreationMethods(Seq((leoForTest.createCluster _).tupled, (leoForTest.processClusterCreationRequest _).tupled))(Seq(name1, name2)) {
       (creationMethod, clusterName) =>
@@ -958,7 +958,7 @@ class LeonardoServiceSpec extends TestKit(ActorSystem("leonardotest")) with Flat
     }
 
     //we meed to use a special version of the MockGoogleDataprocDAO to simulate an error during the call to resizeCluster
-    leo = new LeonardoService(dataprocConfig, clusterFilesConfig, clusterResourcesConfig, clusterDefaultsConfig, proxyConfig, swaggerConfig, autoFreezeConfig, new ErroredMockGoogleDataprocDAO, computeDAO, iamDAO, storageDAO, mockPetGoogleDAO, DbSingleton.ref, authProvider, serviceAccountProvider, whitelist, bucketHelper, contentSecurityPolicy)
+    leo = new LeonardoService(dataprocConfig, clusterFilesConfig, clusterResourcesConfig, clusterDefaultsConfig, proxyConfig, swaggerConfig, autoFreezeConfig, autoDeleteConfig, new ErroredMockGoogleDataprocDAO, computeDAO, iamDAO, storageDAO, mockPetGoogleDAO, DbSingleton.ref, authProvider, serviceAccountProvider, whitelist, bucketHelper, contentSecurityPolicy)
 
     // create the cluster
     val clusterCreateResponse =
@@ -985,7 +985,7 @@ class LeonardoServiceSpec extends TestKit(ActorSystem("leonardotest")) with Flat
 
     //we meed to use a special version of the MockGoogleIamDAO to simulate an error when adding IAM roles
     val iamDAO = new ErroredMockGoogleIamDAO
-    leo = new LeonardoService(dataprocConfig, clusterFilesConfig, clusterResourcesConfig, clusterDefaultsConfig, proxyConfig, swaggerConfig, autoFreezeConfig, mockGoogleDataprocDAO, computeDAO, iamDAO, storageDAO, mockPetGoogleDAO, DbSingleton.ref, authProvider, serviceAccountProvider, whitelist, bucketHelper, contentSecurityPolicy)
+    leo = new LeonardoService(dataprocConfig, clusterFilesConfig, clusterResourcesConfig, clusterDefaultsConfig, proxyConfig, swaggerConfig, autoFreezeConfig, autoDeleteConfig, mockGoogleDataprocDAO, computeDAO, iamDAO, storageDAO, mockPetGoogleDAO, DbSingleton.ref, authProvider, serviceAccountProvider, whitelist, bucketHelper, contentSecurityPolicy)
 
     // create the cluster
     val clusterCreateResponse =
@@ -1006,7 +1006,7 @@ class LeonardoServiceSpec extends TestKit(ActorSystem("leonardotest")) with Flat
 
     //we meed to use a special version of the MockGoogleIamDAO to simulate a conflict when adding IAM roles
     val iamDAO = new ErroredMockGoogleIamDAO(409)
-    leo = new LeonardoService(dataprocConfig, clusterFilesConfig, clusterResourcesConfig, clusterDefaultsConfig, proxyConfig, swaggerConfig, autoFreezeConfig, mockGoogleDataprocDAO, computeDAO, iamDAO, storageDAO, mockPetGoogleDAO, DbSingleton.ref, authProvider, serviceAccountProvider, whitelist, bucketHelper, contentSecurityPolicy)
+    leo = new LeonardoService(dataprocConfig, clusterFilesConfig, clusterResourcesConfig, clusterDefaultsConfig, proxyConfig, swaggerConfig, autoFreezeConfig, autoDeleteConfig, mockGoogleDataprocDAO, computeDAO, iamDAO, storageDAO, mockPetGoogleDAO, DbSingleton.ref, authProvider, serviceAccountProvider, whitelist, bucketHelper, contentSecurityPolicy)
 
     // create the cluster
     val clusterCreateResponse =


### PR DESCRIPTION
Prerequisites:
* We do not enforce this on existing clusters. Only newly clusters will be considered for auto-deletion. See Liquibase migration.
* Completely configurable via API. The default is 30 days of inactivity. I plan to expose this up through the UI.

TODO: 
* PATCH endpoint supports modifying this
* Test it

Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
