### PR TITLE
Terminal timeout after 2 mins

### DIFF
--- a/src/main/resources/jupyter/google_sign_in.js
+++ b/src/main/resources/jupyter/google_sign_in.js
@@ -59,7 +59,7 @@ function startTimer() {
             }
         }
 
-        // refresh token every 2 minutes
+        // refresh token every 3 minutes
         console.log('Starting token refresh timer');
         setInterval(doAuth, 180000);
     });

--- a/src/main/resources/jupyter/google_sign_in.js
+++ b/src/main/resources/jupyter/google_sign_in.js
@@ -61,7 +61,7 @@ function startTimer() {
 
         // refresh token every 2 minutes
         console.log('Starting token refresh timer');
-        setInterval(doAuth, 120000);
+        setInterval(doAuth, 180000);
     });
 
 


### PR DESCRIPTION
If left alone for more than two minutes, the terminal of a jupyter notebook would become unresponsive with a message about the websocket being closed/closing in the developer's tools' console. This PR fixes this problem by increasing the timeout of the auth token refresh from two to three minutes. I'm not entirely sure why this works, but I'm suspecting that there's an overlap of timeouts that is causing the websocket to close at two minutes, and changing one of the timeouts to three minutes fixed the problem. 

Testing: I tested to make sure that the terminal timeout issue was resolved by leaving a terminal window of a jupyter notebook open and using a timer to make sure that it didn't become unresponsive before the cluster autopaused. I made sure that the access token was still being refreshed by leaving a notebook open for more than an hour, and ensuring it was still usable after. 

Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
