### PR TITLE
Expand scope of cluster PATCH endpoint

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
@@ -444,6 +444,16 @@ trait LeonardoTestUtils extends WebBrowserSpec with Matchers with Eventually wit
     }
   }
 
+  def withRestartCluster[T](cluster: Cluster)(testCode: Cluster => T)(implicit token: AuthToken): T = {
+    stopAndMonitor(cluster.googleProject, cluster.clusterName)
+    val resolvedCluster = Leonardo.cluster.get(cluster.googleProject, cluster.clusterName)
+    resolvedCluster.status shouldBe ClusterStatus.Stopped
+    val testResult = Try {
+      testCode(resolvedCluster)
+    }
+    startAndMonitor(cluster.googleProject, cluster.clusterName)
+    testResult.get
+  }
 
   def withNewGoogleBucket[T](googleProject: GoogleProject, bucketName: GcsBucketName = generateUniqueBucketName("leo-auto"))(testCode: GcsBucketName => T): T = {
     implicit val patienceConfig: PatienceConfig = storagePatience

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookClusterMonitoringSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookClusterMonitoringSpec.scala
@@ -190,10 +190,9 @@ class NotebookClusterMonitoringSpec extends FreeSpec with NotebookTestUtils with
           // Note this requires a cluster restart. A future enhancement may be for Leo to handle this internally.
           withRestartCluster(cluster) { cluster =>
             Leonardo.cluster.update(project, cluster.clusterName, ClusterRequest(machineConfig = Option(newMachineConfig.copy(masterMachineType = Some("n1-standard-4")))))
-            eventually(timeout(Span(60, Seconds)), interval(Span(5, Seconds))) {
-              val status = Leonardo.cluster.get(project, cluster.clusterName).status
-              status shouldBe ClusterStatus.Updating
-            }
+            // cluster status should still be Stopped
+            val status = Leonardo.cluster.get(project, cluster.clusterName).status
+            status shouldBe ClusterStatus.Stopped
           }
 
           eventually(timeout(Span(300, Seconds)), interval(Span(30, Seconds))) {

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookClusterMonitoringSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookClusterMonitoringSpec.scala
@@ -163,7 +163,7 @@ class NotebookClusterMonitoringSpec extends FreeSpec with NotebookTestUtils with
           }
 
           val timeToAddWorker = time {
-            eventually(timeout(Span(300, Seconds)), interval(Span(30, Seconds))) {
+            eventually(timeout(Span(420, Seconds)), interval(Span(30, Seconds))) {
               val clusterResponse = Leonardo.cluster.get(project, cluster.clusterName)
               clusterResponse.machineConfig.numberOfWorkers shouldBe newMachineConfig.numberOfWorkers
               clusterResponse.machineConfig.masterMachineType shouldBe initialMachineConfig.masterMachineType
@@ -184,7 +184,7 @@ class NotebookClusterMonitoringSpec extends FreeSpec with NotebookTestUtils with
           }
 
           val timeToRemoveWorker = time {
-            eventually(timeout(Span(300, Seconds)), interval(Span(30, Seconds))) {
+            eventually(timeout(Span(420, Seconds)), interval(Span(30, Seconds))) {
               val clusterResponse = Leonardo.cluster.get(project, cluster.clusterName)
               clusterResponse.machineConfig.numberOfWorkers shouldBe twoWorkersConfig.numberOfWorkers
               clusterResponse.machineConfig.masterMachineType shouldBe initialMachineConfig.masterMachineType

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookClusterMonitoringSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookClusterMonitoringSpec.scala
@@ -181,7 +181,7 @@ class NotebookClusterMonitoringSpec extends FreeSpec with NotebookTestUtils with
           eventually(timeout(Span(300, Seconds)), interval(Span(30, Seconds))) {
             val clusterResponse = Leonardo.cluster.get(project, cluster.clusterName)
             clusterResponse.machineConfig.numberOfWorkers shouldBe Some(2)
-            clusterResponse.machineConfig.masterMachineType shouldBe newMachineConfig.masterMachineType
+            clusterResponse.machineConfig.masterMachineType shouldBe initialMachineConfig.masterMachineType
             clusterResponse.machineConfig.masterDiskSize shouldBe newMachineConfig.masterDiskSize
             clusterResponse.status shouldBe ClusterStatus.Running
           }

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookCustomizationSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookCustomizationSpec.scala
@@ -10,6 +10,7 @@ import org.broadinstitute.dsde.workbench.service.Sam
 import org.broadinstitute.dsde.workbench.service.util.Tags
 import org.scalatest.{FreeSpec, ParallelTestExecution}
 
+import scala.concurrent.duration._
 import scala.language.postfixOps
 
 final class NotebookCustomizationSpec extends FreeSpec
@@ -100,7 +101,7 @@ final class NotebookCustomizationSpec extends FreeSpec
           withWebDriver { implicit driver =>
             withNewNotebook(cluster) { notebookPage =>
               val query = """!jupyter labextension install @jupyterlab/toc"""
-              val result = notebookPage.executeCell(query).get
+              val result = notebookPage.executeCell(query, timeout = 5.minutes).get
               result should not include("Permission denied")
             }
           }

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -1112,7 +1112,7 @@ definitions:
       masterDiskSize:
         type: integer
         description: |
-          Optional, the size in megabytes of the disk on the master node. Minimum size is 10GB. If unspecified, default size is 100GB.
+          Optional, the size in gigabytes of the disk on the master node. Minimum size is 10GB. If unspecified, default size is 100GB.
       workerMachineType:
         type: string
         description: |
@@ -1122,7 +1122,7 @@ definitions:
       workerDiskSize:
         type: integer
         description: |
-          Optional, the size in megabytes of the disk on the master node. Minimum size is 10GB. If unspecified, default size is 100GB.
+          Optional, the size in gigabytes of the disk on the master node. Minimum size is 10GB. If unspecified, default size is 100GB.
           Ignored if numberOfWorkers is 0.
       numberOfWorkerLocalSSDs:
         type: integer
@@ -1213,3 +1213,13 @@ definitions:
         description: |
           Optional, the number of preemptible workers. If unspecified, the default number is 0. Ignored if numberOfWorkers is 0.
           For more information, see https://cloud.google.com/compute/docs/instances/preemptible
+      masterMachineType:
+        type: string
+        description: |
+          Optional, the machine type determines the number of CPUs and memory for the master node. For example "n1-standard-16"
+          or "n1-highmem-64". To decide which is right for you, see https://cloud.google.com/compute/docs/machine-types
+      masterDiskSize:
+        type: integer
+        description: |
+          Optional, the size in gigabytes of the disk on the master node. Minimum size is 10GB. Note: disk size cannot be
+          decreased in an update request, only increased.

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/google/GoogleComputeDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/google/GoogleComputeDAO.scala
@@ -24,4 +24,8 @@ trait GoogleComputeDAO {
   def getComputeEngineDefaultServiceAccount(googleProject: GoogleProject): Future[Option[WorkbenchEmail]]
 
   def getProjectNumber(googleProject: GoogleProject): Future[Option[Long]]
+
+  def setMachineType(instanceKey: InstanceKey, newMachineType: MachineType): Future[Unit]
+
+  def resizeDisk(instanceKey: InstanceKey, newSize: Int): Future[Unit]
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/google/GoogleComputeDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/google/GoogleComputeDAO.scala
@@ -27,5 +27,5 @@ trait GoogleComputeDAO {
 
   def setMachineType(instanceKey: InstanceKey, newMachineType: MachineType): Future[Unit]
 
-  def resizeDisk(instanceKey: InstanceKey, newSize: Int): Future[Unit]
+  def resizeDisk(instanceKey: InstanceKey, newSizeGb: Int): Future[Unit]
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/google/HttpGoogleComputeDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/google/HttpGoogleComputeDAO.scala
@@ -172,7 +172,7 @@ class HttpGoogleComputeDAO(appName: String,
 
   override def setMachineType(instanceKey: InstanceKey, newMachineType: MachineType): Future[Unit] = {
     val request = compute.instances().setMachineType(instanceKey.project.value, instanceKey.zone.value, instanceKey.name.value,
-      new InstancesSetMachineTypeRequest().setMachineType(newMachineType.value))
+      new InstancesSetMachineTypeRequest().setMachineType(buildMachineTypeUri(instanceKey, newMachineType.value)))
 
     retryWhen500orGoogleError(() => executeGoogleRequest(request)).void.handleGoogleException(instanceKey)
   }
@@ -182,6 +182,11 @@ class HttpGoogleComputeDAO(appName: String,
       new DisksResizeRequest().setSizeGb(newSizeGb.toLong))
 
     retryWhen500orGoogleError(() => executeGoogleRequest(request)).void.handleGoogleException(instanceKey)
+  }
+
+  private def buildMachineTypeUri(instanceKey: InstanceKey, machineType: String): String = {
+    // TODO handle other inputs?
+    s"zones/${instanceKey.zone.value}/machineTypes/$machineType"
   }
 
   private implicit class GoogleExceptionSupport[A](future: Future[A]) {

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/google/HttpGoogleComputeDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/google/HttpGoogleComputeDAO.scala
@@ -185,7 +185,6 @@ class HttpGoogleComputeDAO(appName: String,
   }
 
   private def buildMachineTypeUri(instanceKey: InstanceKey, machineType: String): String = {
-    // TODO handle other inputs?
     s"zones/${instanceKey.zone.value}/machineTypes/$machineType"
   }
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/google/HttpGoogleComputeDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/google/HttpGoogleComputeDAO.scala
@@ -177,9 +177,9 @@ class HttpGoogleComputeDAO(appName: String,
     retryWhen500orGoogleError(() => executeGoogleRequest(request)).void.handleGoogleException(instanceKey)
   }
 
-  override def resizeDisk(instanceKey: InstanceKey, newSize: Int): Future[Unit] = {
+  override def resizeDisk(instanceKey: InstanceKey, newSizeGb: Int): Future[Unit] = {
     val request = compute.disks().resize(instanceKey.project.value, instanceKey.zone.value, instanceKey.name.value,
-      new DisksResizeRequest().setSizeGb(newSize.toLong))
+      new DisksResizeRequest().setSizeGb(newSizeGb.toLong))
 
     retryWhen500orGoogleError(() => executeGoogleRequest(request)).void.handleGoogleException(instanceKey)
   }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponent.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponent.scala
@@ -346,7 +346,7 @@ trait ClusterComponent extends LeoComponent {
       findByIdQuery(id).map(_.masterMachineType).update(newMachineType.value)
     }
 
-    def udpateMasterDiskSize(id: Long, newSizeGb: Int): DBIO[Int] = {
+    def updateMasterDiskSize(id: Long, newSizeGb: Int): DBIO[Int] = {
       findByIdQuery(id).map(_.masterDiskSize).update(newSizeGb)
     }
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponent.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponent.scala
@@ -342,12 +342,12 @@ trait ClusterComponent extends LeoComponent {
       findByIdQuery(id).map(_.numberOfPreemptibleWorkers).update(numberOfPreemptibleWorkers)
     }
 
-    def updateMasterMachineType(id: Long, masterMachineType: MachineType): DBIO[Int] = {
-      findByIdQuery(id).map(_.masterMachineType).update(masterMachineType.value)
+    def updateMasterMachineType(id: Long, newMachineType: MachineType): DBIO[Int] = {
+      findByIdQuery(id).map(_.masterMachineType).update(newMachineType.value)
     }
 
-    def udpateMasterDiskSize(id: Long, newDiskSize: Int): DBIO[Int] = {
-      findByIdQuery(id).map(_.masterDiskSize).update(newDiskSize)
+    def udpateMasterDiskSize(id: Long, newSizeGb: Int): DBIO[Int] = {
+      findByIdQuery(id).map(_.masterDiskSize).update(newSizeGb)
     }
 
     def setToRunning(id: Long, hostIp: IP): DBIO[Int] = {

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponent.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponent.scala
@@ -342,6 +342,14 @@ trait ClusterComponent extends LeoComponent {
       findByIdQuery(id).map(_.numberOfPreemptibleWorkers).update(numberOfPreemptibleWorkers)
     }
 
+    def updateMasterMachineType(id: Long, masterMachineType: MachineType): DBIO[Int] = {
+      findByIdQuery(id).map(_.masterMachineType).update(masterMachineType.value)
+    }
+
+    def udpateMasterDiskSize(id: Long, newDiskSize: Int): DBIO[Int] = {
+      findByIdQuery(id).map(_.masterDiskSize).update(newDiskSize)
+    }
+
     def setToRunning(id: Long, hostIp: IP): DBIO[Int] = {
       updateClusterStatusAndHostIp(id, ClusterStatus.Running, Some(hostIp))
     }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/google/GoogleModel.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/google/GoogleModel.scala
@@ -78,7 +78,7 @@ object ClusterStatus extends Enum[ClusterStatus] {
   val startableStatuses: Set[ClusterStatus] = Set(Stopped, Stopping)
 
   // Can a user update (i.e. resize) this cluster?
-  val updatableStatuses: Set[ClusterStatus] = Set(Running)
+  val updatableStatuses: Set[ClusterStatus] = Set(Running, Stopped)
 
   implicit class EnrichedClusterStatus(status: ClusterStatus) {
     def isActive: Boolean = activeStatuses contains status

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoService.scala
@@ -490,7 +490,7 @@ class LeonardoService(protected val dataprocConfig: DataprocConfig,
               Future.successful(())
           }
         }.flatMap { _ =>
-          dbRef.inTransaction { _.clusterQuery.udpateMasterDiskSize(existingCluster.id, updatedMasterDiskSize) }
+          dbRef.inTransaction { _.clusterQuery.updateMasterDiskSize(existingCluster.id, updatedMasterDiskSize) }
         }.as(true)
 
       case Some(_) =>

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoService.scala
@@ -365,12 +365,12 @@ class LeonardoService(protected val dataprocConfig: DataprocConfig,
   }
 
   def internalUpdateCluster(existingCluster: Cluster, clusterRequest: ClusterRequest) = {
-    if (existingCluster.status.isUpdatable) {
-      implicit val booleanSumMonoidInstance = new Monoid[Boolean] {
-        def empty = false
-        def combine(a: Boolean, b: Boolean) = a || b
-      }
+    implicit val booleanSumMonoidInstance = new Monoid[Boolean] {
+      def empty = false
+      def combine(a: Boolean, b: Boolean) = a || b
+    }
 
+    if (existingCluster.status.isUpdatable) {
       for {
         autopauseChanged <- maybeUpdateAutopauseThreshold(existingCluster.id, clusterRequest.autopause, clusterRequest.autopauseThreshold).as(false).attempt
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoService.scala
@@ -361,6 +361,7 @@ class LeonardoService(protected val dataprocConfig: DataprocConfig,
 
   def internalUpdateCluster(existingCluster: Cluster, clusterRequest: ClusterRequest) = {
     if (existingCluster.status.isUpdatable) {
+      // TODO accumulate errors instead of fail-fast
       for {
         _ <- maybeUpdateAutopauseThreshold(existingCluster.id, clusterRequest.autopause, clusterRequest.autopauseThreshold)
 
@@ -444,6 +445,8 @@ class LeonardoService(protected val dataprocConfig: DataprocConfig,
       getUpdatedValueIfChanged(existingCluster.machineConfig.masterMachineType, machineConfig.masterMachineType)
     }
 
+    // TODO clsuter needs to be stop/started
+
     updatedMasterMachineTypeOpt match {
       case Some(updatedMasterMachineType) =>
         logger.info(s"New machine config present. Changing machine type to ${updatedMasterMachineType} for cluster ${existingCluster.projectNameString}...")
@@ -477,7 +480,7 @@ class LeonardoService(protected val dataprocConfig: DataprocConfig,
 
     updatedMasterDiskSizeOpt match {
       case Some(updatedMasterDiskSize) if diskSizeIncreased(updatedMasterDiskSize) =>
-        logger.info(s"New machine config present. Changing master disk size to $updatedMasterDiskSize} GB for cluster ${existingCluster.projectNameString}...")
+        logger.info(s"New machine config present. Changing master disk size to $updatedMasterDiskSize GB for cluster ${existingCluster.projectNameString}...")
 
         Future.traverse(existingCluster.instances) { instance =>
           instance.dataprocRole match {

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoService.scala
@@ -5,7 +5,7 @@ import java.time.Instant
 
 import akka.actor.ActorSystem
 import akka.http.scaladsl.model.StatusCodes
-import cats.data.OptionT
+import cats.data.{Ior, OptionT}
 import cats.implicits._
 import com.google.api.client.googleapis.json.GoogleJsonResponseException
 import com.google.api.client.http.HttpResponseException
@@ -59,6 +59,9 @@ case class ClusterCannotBeStartedException(googleProject: GoogleProject, cluster
 
 case class ClusterCannotBeUpdatedException(cluster: Cluster)
   extends LeoException(s"Cluster ${cluster.projectNameString} cannot be updated in ${cluster.status} status", StatusCodes.Conflict)
+
+case class ClusterDiskSizeCannotBeDecreasedException(cluster: Cluster)
+  extends LeoException(s"Cluster ${cluster.projectNameString}'s master disk size cannot be decreased", StatusCodes.PreconditionFailed)
 
 case class InitializationFileException(googleProject: GoogleProject, clusterName: ClusterName, errorMessage: String)
   extends LeoException(s"Unable to process initialization files for ${googleProject.value}/${clusterName.value}. Returned message: $errorMessage", StatusCodes.Conflict)
@@ -363,14 +366,28 @@ class LeonardoService(protected val dataprocConfig: DataprocConfig,
 
         clusterResized <- maybeResizeCluster(existingCluster, clusterRequest.machineConfig)
 
+        masterMachineTypeChanged <- maybeChangeMasterMachineType(existingCluster, clusterRequest.machineConfig)
+
+        masterDiskSizeChanged <- maybeChangeMasterDiskSize(existingCluster, clusterRequest.machineConfig)
+
         // Set the cluster status to Updating only if the cluster was resized
-        _ <- if(clusterResized) { dbRef.inTransaction { _.clusterQuery.updateClusterStatus(existingCluster.id, ClusterStatus.Updating) } } else Future.successful(0)
+        _ <- if (clusterResized || masterMachineTypeChanged || masterDiskSizeChanged) {
+          dbRef.inTransaction { _.clusterQuery.updateClusterStatus(existingCluster.id, ClusterStatus.Updating) }
+        } else Future.successful(0)
 
         updatedCluster <- internalGetActiveClusterDetails(existingCluster.googleProject, existingCluster.clusterName)
       } yield {
         updatedCluster
       }
     } else Future.failed(ClusterCannotBeUpdatedException(existingCluster))
+  }
+
+  private def getUpdatedValue[A](existing: Option[A], updated: Option[A]): Option[A] = {
+    if (updated.isDefined && updated != existing) {
+      updated
+    } else {
+      None
+    }
   }
 
   def maybeUpdateAutopauseThreshold(clusterId: Long, autopause: Option[Boolean], autopauseThreshold: Option[Int]): Future[Int] = {
@@ -380,40 +397,105 @@ class LeonardoService(protected val dataprocConfig: DataprocConfig,
     }
   }
 
+
   //returns true if cluster was resized, otherwise returns false
   def maybeResizeCluster(existingCluster: Cluster, machineConfigOpt: Option[MachineConfig]): Future[Boolean] = {
-    machineConfigOpt match {
-      case Some(machineConfig) =>
+    val updatedNumWorkersAndPreemptiblesOpt = machineConfigOpt.flatMap { machineConfig =>
+      Ior.fromOptions(
+        getUpdatedValue(existingCluster.machineConfig.numberOfWorkers, machineConfig.numberOfWorkers),
+        getUpdatedValue(existingCluster.machineConfig.numberOfPreemptibleWorkers, machineConfig.numberOfPreemptibleWorkers))
+    }
 
-        (machineConfig.numberOfWorkers, machineConfig.numberOfPreemptibleWorkers) match {
-          case (Some(_), _) | (_, Some(_))
-            if (existingCluster.machineConfig.numberOfWorkers != machineConfig.numberOfWorkers) || (existingCluster.machineConfig.numberOfPreemptibleWorkers != machineConfig.numberOfPreemptibleWorkers) => {
+    updatedNumWorkersAndPreemptiblesOpt match {
+      case Some(updatedNumWorkersAndPreemptibles) =>
+        logger.info(s"New machine config present. Resizing cluster '${existingCluster.clusterName}' " +
+          s"in Google project '${existingCluster.googleProject}'...")
 
-            logger.info(s"New machine config present. Resizing cluster '${existingCluster.clusterName}' " +
-              s"in Google project '${existingCluster.googleProject}'...")
+        for {
+          // Add Dataproc Worker role to the cluster service account, if present.
+          // This is needed to be able to spin up Dataproc clusters.
+          // If the Google Compute default service account is being used, this is not necessary.
+          _ <- addDataprocWorkerRoleToServiceAccount(existingCluster.googleProject, existingCluster.serviceAccountInfo.clusterServiceAccount)
 
-            for {
-              // Add Dataproc Worker role to the cluster service account, if present.
-              // This is needed to be able to spin up Dataproc clusters.
-              // If the Google Compute default service account is being used, this is not necessary.
-              _ <- addDataprocWorkerRoleToServiceAccount(existingCluster.googleProject, existingCluster.serviceAccountInfo.clusterServiceAccount)
-              _ <- gdDAO.resizeCluster(existingCluster.googleProject, existingCluster.clusterName, machineConfig.numberOfWorkers, machineConfig.numberOfPreemptibleWorkers) recoverWith {
-                case gjre: GoogleJsonResponseException =>
-                  //typically we will revoke this role in the monitor after everything is complete, but if Google fails to resize the cluster we need to revoke it manually here
-                  removeDataprocWorkerRoleFromServiceAccount(existingCluster.googleProject, existingCluster.serviceAccountInfo.clusterServiceAccount)
-                  throw InvalidDataprocMachineConfigException(gjre.getMessage)
-              }
-              _ <- machineConfig.numberOfWorkers.map { numWorkers =>
-                dbRef.inTransaction { _.clusterQuery.updateNumberOfWorkers(existingCluster.id, numWorkers) }
-              } getOrElse Future.successful(0)
-              _ <- machineConfig.numberOfPreemptibleWorkers.map { numWorkers =>
-                dbRef.inTransaction { _.clusterQuery.updateNumberOfPreemptibleWorkers(existingCluster.id, Option(numWorkers)) }
-              } getOrElse Future.successful(0)
-            } yield { true }
+          // Resize the clsuter
+          _ <- gdDAO.resizeCluster(existingCluster.googleProject, existingCluster.clusterName, updatedNumWorkersAndPreemptibles.left, updatedNumWorkersAndPreemptibles.right) recoverWith {
+            case gjre: GoogleJsonResponseException =>
+              //typically we will revoke this role in the monitor after everything is complete, but if Google fails to resize the cluster we need to revoke it manually here
+              removeDataprocWorkerRoleFromServiceAccount(existingCluster.googleProject, existingCluster.serviceAccountInfo.clusterServiceAccount)
+              throw InvalidDataprocMachineConfigException(gjre.getMessage)
           }
-          case _ => Future.successful(false) //no-op because machineConfig values didn't change
-        }
-      case None => Future.successful(false) //no-op because no machineConfig specified
+
+          // Update the DB
+          _ <- dbRef.inTransaction { dataAccess =>
+            updatedNumWorkersAndPreemptibles.fold(
+              a => dataAccess.clusterQuery.updateNumberOfWorkers(existingCluster.id, a),
+              a => dataAccess.clusterQuery.updateNumberOfPreemptibleWorkers(existingCluster.id, Option(a)),
+              (a, b) => dataAccess.clusterQuery.updateNumberOfWorkers(existingCluster.id, a)
+                .flatMap(_ =>  dataAccess.clusterQuery.updateNumberOfPreemptibleWorkers(existingCluster.id, Option(b)))
+            )
+          }
+        } yield true
+
+      case None => Future.successful(false)
+    }
+  }
+
+  def maybeChangeMasterMachineType(existingCluster: Cluster, machineConfigOpt: Option[MachineConfig]): Future[Boolean] = {
+    val updatedMasterMachineTypeOpt = machineConfigOpt.flatMap { machineConfig =>
+      getUpdatedValue(existingCluster.machineConfig.masterMachineType, machineConfig.masterMachineType)
+    }
+
+    updatedMasterMachineTypeOpt match {
+      case Some(updatedMasterMachineType) =>
+        logger.info(s"New machine config present. Changing machine type to ${updatedMasterMachineType} for cluster " +
+          s"'${existingCluster.clusterName}' in Google project '${existingCluster.googleProject}'...")
+
+        Future.traverse(existingCluster.instances) { instance =>
+          instance.dataprocRole match {
+            case Some(Master) =>
+              googleComputeDAO.setMachineType(instance.key, MachineType(updatedMasterMachineType))
+            case _ =>
+              // don't update worker instances
+              Future.successful(())
+          }
+        }.flatMap { _ =>
+          dbRef.inTransaction { _.clusterQuery.updateMasterMachineType(existingCluster.id, MachineType(updatedMasterMachineType)) }
+        }.as(true)
+
+      case None =>
+        Future.successful(false)
+    }
+  }
+
+  def maybeChangeMasterDiskSize(existingCluster: Cluster, machineConfigOpt: Option[MachineConfig]): Future[Boolean] = {
+    val updatedMasterDiskSizeOpt = machineConfigOpt.flatMap { machineConfig =>
+      getUpdatedValue(existingCluster.machineConfig.masterDiskSize, machineConfig.masterDiskSize)
+    }
+
+    val diskSizeIncreased = (newSize: Int) => existingCluster.machineConfig.masterDiskSize.exists(_ < newSize)
+
+    updatedMasterDiskSizeOpt match {
+      case Some(updatedMasterDiskSize) if diskSizeIncreased(updatedMasterDiskSize) =>
+        logger.info(s"New machine config present. Changing master disk size to $updatedMasterDiskSize} GB for cluster " +
+          s"'${existingCluster.clusterName}' in Google project '${existingCluster.googleProject}'...")
+
+        Future.traverse(existingCluster.instances) { instance =>
+          instance.dataprocRole match {
+            case Some(Master) =>
+              googleComputeDAO.resizeDisk(instance.key, updatedMasterDiskSize)
+            case _ =>
+              // don't update worker instances
+              Future.successful(())
+          }
+        }.flatMap { _ =>
+          dbRef.inTransaction { _.clusterQuery.udpateMasterDiskSize(existingCluster.id, updatedMasterDiskSize) }
+        }.as(true)
+
+      case Some(_) =>
+        Future.failed(ClusterDiskSizeCannotBeDecreasedException(existingCluster))
+
+      case None =>
+        Future.successful(false)
     }
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/google/MockGoogleComputeDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/google/MockGoogleComputeDAO.scala
@@ -57,4 +57,12 @@ class MockGoogleComputeDAO extends GoogleComputeDAO {
     val rng = new Random
     Future.successful(Some(rng.nextLong()))
   }
+
+  override def setMachineType(instanceKey: InstanceKey, newMachineType: MachineType): Future[Unit] = {
+    Future.successful(())
+  }
+
+  def resizeDisk(instanceKey: InstanceKey, newSizeGb: Int): Future[Unit] = {
+    Future.successful(())
+  }
 }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponentSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponentSpec.scala
@@ -221,4 +221,30 @@ class ClusterComponentSpec extends TestComponent with FlatSpecLike with CommonTe
     dbFutureValue { _.clusterQuery.getActiveClusterForDnsCache(savedCluster1.googleProject, savedCluster1.clusterName) } shouldEqual
       Some(savedCluster1).map(stripFieldsForListCluster andThen (_.copy(labels = Map.empty)))
   }
+
+  it should "update master machine type" in isolatedDbTest {
+    val savedCluster1 = makeCluster(1)
+      .copy(machineConfig =
+        MachineConfig(Some(3), Some("test-master-machine-type"), Some(500), Some("test-worker-machine-type"), Some(200), Some(2), Some(1)))
+      .save()
+
+    val newMachineType = MachineType("this-is-a-new-machine-type")
+    dbFutureValue { _.clusterQuery.updateMasterMachineType(savedCluster1.id, newMachineType) }
+
+    dbFutureValue { _.clusterQuery.getClusterById(savedCluster1.id).map(_.map(_.machineConfig.masterMachineType)) } shouldBe
+      Option(newMachineType).map(_.value)
+  }
+
+  it should "update master disk size" in isolatedDbTest {
+    val savedCluster1 = makeCluster(1)
+      .copy(machineConfig =
+        MachineConfig(Some(3), Some("test-master-machine-type"), Some(500), Some("test-worker-machine-type"), Some(200), Some(2), Some(1)))
+      .save()
+
+    val newDiskSize = 1000
+    dbFutureValue { _.clusterQuery.updateMasterMachineType(savedCluster1.id, newDiskSize) }
+
+    dbFutureValue { _.clusterQuery.getClusterById(savedCluster1.id).map(_.map(_.machineConfig.masterDiskSize)) } shouldBe
+      Option(newDiskSize)
+  }
 }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponentSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponentSpec.scala
@@ -242,7 +242,7 @@ class ClusterComponentSpec extends TestComponent with FlatSpecLike with CommonTe
       .save()
 
     val newDiskSize = 1000
-    dbFutureValue { _.clusterQuery.updateMasterMachineType(savedCluster1.id, newDiskSize) }
+    dbFutureValue { _.clusterQuery.updateMasterDiskSize(savedCluster1.id, newDiskSize) }
 
     dbFutureValue { _.clusterQuery.getClusterById(savedCluster1.id).map(_.map(_.machineConfig.masterDiskSize)) } shouldBe
       Option(newDiskSize)

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponentSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponentSpec.scala
@@ -231,8 +231,8 @@ class ClusterComponentSpec extends TestComponent with FlatSpecLike with CommonTe
     val newMachineType = MachineType("this-is-a-new-machine-type")
     dbFutureValue { _.clusterQuery.updateMasterMachineType(savedCluster1.id, newMachineType) }
 
-    dbFutureValue { _.clusterQuery.getClusterById(savedCluster1.id).map(_.map(_.machineConfig.masterMachineType)) } shouldBe
-      Option(newMachineType).map(_.value)
+    dbFutureValue { _.clusterQuery.getClusterById(savedCluster1.id) }.flatMap(_.machineConfig.masterMachineType) shouldBe
+      Option(newMachineType.value)
   }
 
   it should "update master disk size" in isolatedDbTest {
@@ -244,7 +244,7 @@ class ClusterComponentSpec extends TestComponent with FlatSpecLike with CommonTe
     val newDiskSize = 1000
     dbFutureValue { _.clusterQuery.updateMasterDiskSize(savedCluster1.id, newDiskSize) }
 
-    dbFutureValue { _.clusterQuery.getClusterById(savedCluster1.id).map(_.map(_.machineConfig.masterDiskSize)) } shouldBe
+    dbFutureValue { _.clusterQuery.getClusterById(savedCluster1.id) }.flatMap(_.machineConfig.masterDiskSize) shouldBe
       Option(newDiskSize)
   }
 }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoServiceSpec.scala
@@ -1027,10 +1027,10 @@ class LeonardoServiceSpec extends TestKit(ActorSystem("leonardotest")) with Flat
 
     leo.updateCluster(userInfo, project, name1, testClusterRequest.copy(autopause = Some(true), autopauseThreshold = Some(7))).futureValue
 
-    //check that status of cluster is Updating
+    //check that status of cluster is still Running
     dbFutureValue { _.clusterQuery.getClusterStatus(clusterCreateResponse.id) } shouldBe Some(ClusterStatus.Running)
 
-    //check that the machine config has been updated
+    //check that the autopause threshold has been updated
     dbFutureValue { _.clusterQuery.getClusterById(clusterCreateResponse.id) }.get.autopauseThreshold shouldBe 7
   }
 
@@ -1045,8 +1045,8 @@ class LeonardoServiceSpec extends TestKit(ActorSystem("leonardotest")) with Flat
     val newMachineType = "n1-micro-1"
     leo.updateCluster(userInfo, project, name1, testClusterRequest.copy(machineConfig = Some(MachineConfig(masterMachineType = Some(newMachineType))))).futureValue
 
-    //check that status of cluster is Updating
-    dbFutureValue { _.clusterQuery.getClusterStatus(clusterCreateResponse.id) } shouldBe Some(ClusterStatus.Updating)
+    //check that status of cluster is still Stopped
+    dbFutureValue { _.clusterQuery.getClusterStatus(clusterCreateResponse.id) } shouldBe Some(ClusterStatus.Stopped)
 
     //check that the machine config has been updated
     dbFutureValue { _.clusterQuery.getClusterById(clusterCreateResponse.id) }.get.machineConfig.masterMachineType shouldBe Some(newMachineType)
@@ -1080,8 +1080,8 @@ class LeonardoServiceSpec extends TestKit(ActorSystem("leonardotest")) with Flat
     val newDiskSize = 1000
     leo.updateCluster(userInfo, project, name1, testClusterRequest.copy(machineConfig = Some(MachineConfig(masterDiskSize = Some(newDiskSize))))).futureValue
 
-    //check that status of cluster is Updating
-    dbFutureValue { _.clusterQuery.getClusterStatus(clusterCreateResponse.id) } shouldBe Some(ClusterStatus.Updating)
+    //check that status of cluster is still Running
+    dbFutureValue { _.clusterQuery.getClusterStatus(clusterCreateResponse.id) } shouldBe Some(ClusterStatus.Running)
 
     //check that the machine config has been updated
     dbFutureValue { _.clusterQuery.getClusterById(clusterCreateResponse.id) }.get.machineConfig.masterDiskSize shouldBe Some(newDiskSize)

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoServiceSpec.scala
@@ -20,6 +20,7 @@ import org.broadinstitute.dsde.workbench.leonardo.dao.google.MockGoogleComputeDA
 import org.broadinstitute.dsde.workbench.leonardo.db.{DbSingleton, LeoComponent, TestComponent}
 import org.broadinstitute.dsde.workbench.leonardo.model.MachineConfigOps.{NegativeIntegerArgumentInClusterRequestException, OneWorkerSpecifiedInClusterRequestException}
 import org.broadinstitute.dsde.workbench.leonardo.model._
+import org.broadinstitute.dsde.workbench.leonardo.model.google.ClusterStatus.Stopped
 import org.broadinstitute.dsde.workbench.leonardo.model.google._
 import org.broadinstitute.dsde.workbench.leonardo.util.BucketHelper
 import org.broadinstitute.dsde.workbench.model._
@@ -1038,8 +1039,8 @@ class LeonardoServiceSpec extends TestKit(ActorSystem("leonardotest")) with Flat
     val clusterCreateResponse =
       leo.processClusterCreationRequest(userInfo, project, name1, testClusterRequest).futureValue
 
-    // set the cluster to Running
-    dbFutureValue { _.clusterQuery.setToRunning(clusterCreateResponse.id, IP("1.2.3.4")) }
+    // set the cluster to Stopped
+    dbFutureValue { _.clusterQuery.updateClusterStatus(clusterCreateResponse.id, Stopped) }
 
     val newMachineType = "n1-micro-1"
     leo.updateCluster(userInfo, project, name1, testClusterRequest.copy(machineConfig = Some(MachineConfig(masterMachineType = Some(newMachineType))))).futureValue
@@ -1049,6 +1050,23 @@ class LeonardoServiceSpec extends TestKit(ActorSystem("leonardotest")) with Flat
 
     //check that the machine config has been updated
     dbFutureValue { _.clusterQuery.getClusterById(clusterCreateResponse.id) }.get.machineConfig.masterMachineType shouldBe Some(newMachineType)
+  }
+
+  it should "not allow changing the master machine type for a cluster in RUNNING state" in isolatedDbTest {
+    // create the cluster
+    val clusterCreateResponse =
+      leo.processClusterCreationRequest(userInfo, project, name1, testClusterRequest).futureValue
+
+    // set the cluster to Running
+    dbFutureValue { _.clusterQuery.setToRunning(clusterCreateResponse.id, IP("1.2.3.4")) }
+
+    val newMachineType = "n1-micro-1"
+    val failure = leo.updateCluster(userInfo, project, name1, testClusterRequest.copy(machineConfig = Some(MachineConfig(masterMachineType = Some(newMachineType))))).failed.futureValue
+
+    //check that status of cluster is still Running
+    dbFutureValue { _.clusterQuery.getClusterStatus(clusterCreateResponse.id) } shouldBe Some(ClusterStatus.Running)
+
+    failure shouldBe a [ClusterMachineTypeCannotBeChangedException]
   }
 
   it should "update the master disk size for a cluster" in isolatedDbTest {


### PR DESCRIPTION
See ticket: https://github.com/databiosphere/leonardo/issues/842

Before, our PATCH endpoint supported the following:
- add/removing worker nodes of the same type to a cluster
- changing autopause settings

Now, it does the following:
- add/removing worker nodes of the same type to a cluster
- changing autopause settings
- changing the master machine type (e.g. CPU and memory)
- increasing the master disk size

Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
