### PR TITLE
[864] WORKSPACE_NAME environment variable is empty when workspace name has spaces

### DIFF
--- a/docker/jupyter/scripts/kernel/kernel_bootstrap.sh
+++ b/docker/jupyter/scripts/kernel/kernel_bootstrap.sh
@@ -13,7 +13,7 @@
 
 # The workspace name is simply the CWD of the running notebook.
 PWD="$(pwd)"
-export WORKSPACE_NAME="$(basename $PWD)"
+export WORKSPACE_NAME="$(basename "$PWD")"
 
 # Parse the .delocalize.json file (if it exists) in the workspace directory to obtain the workspace bucket.
 DELOCALIZE_FILE="$PWD/.delocalize.json"


### PR DESCRIPTION
See https://github.com/DataBiosphere/leonardo/issues/864

I validated this works manually on a Terra cluster. The suggested fix came from @mbookman.

Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
