### PR TITLE
set editor metadata field when autosaving notebook to bucket

### DIFF
--- a/docker/jupyter/custom/jupyter_delocalize.py
+++ b/docker/jupyter/custom/jupyter_delocalize.py
@@ -125,7 +125,7 @@ class DelocalizingContentsManager(FileContentsManager):
       return ret
 
     self._log_and_call_file_cmd_async(
-        ['cp', os_path, self._remote_path(meta, os_path)])
+        ['-h', os.path.expandvars('x-goog-meta-editor: $OWNER_EMAIL'), 'cp', os_path, self._remote_path(meta, os_path)])
     return ret
 
   def rename_file(self, old_path, new_path):


### PR DESCRIPTION
\<your comments for this PR go here\>

Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
