### PR TITLE
Bugfix: disabling auto-pause does not work

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponent.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponent.scala
@@ -6,6 +6,7 @@ import java.util.UUID
 
 import cats.data.Chain
 import cats.implicits._
+import org.broadinstitute.dsde.workbench.leonardo._
 import org.broadinstitute.dsde.workbench.leonardo.model.Cluster.LabelMap
 import org.broadinstitute.dsde.workbench.leonardo.model._
 import org.broadinstitute.dsde.workbench.leonardo.model.google._
@@ -277,7 +278,9 @@ trait ClusterComponent extends LeoComponent {
       val tsdiff = SimpleFunction.ternary[String, Timestamp, Timestamp, Int]("TIMESTAMPDIFF")
       val minute = SimpleLiteral[String]("MINUTE")
 
-      fullClusterQuery.filter { record => tsdiff(minute, record._1.dateAccessed, now) >= record._1.autopauseThreshold}
+      fullClusterQuery
+        .filter { _._1.autopauseThreshold =!= autoPauseOffValue }
+        .filter { record => tsdiff(minute, record._1.dateAccessed, now) >= record._1.autopauseThreshold}
         .filter(_._1.status inSetBind ClusterStatus.stoppableStatuses.map(_.toString))
         .result map { recs => unmarshalFullCluster(recs)}
     }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/package.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/package.scala
@@ -4,4 +4,5 @@ import org.broadinstitute.dsde.workbench.model.ErrorReportSource
 
 package object leonardo {
   implicit val errorReportSource = ErrorReportSource("leonardo")
+  final val autoPauseOffValue = 0
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoService.scala
@@ -12,6 +12,7 @@ import com.google.api.client.googleapis.json.GoogleJsonResponseException
 import com.google.api.client.http.HttpResponseException
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.workbench.google.{GoogleIamDAO, GoogleStorageDAO}
+import org.broadinstitute.dsde.workbench.leonardo._
 import org.broadinstitute.dsde.workbench.leonardo.config.{AutoFreezeConfig, ClusterDefaultsConfig, ClusterFilesConfig, ClusterResourcesConfig, DataprocConfig, ProxyConfig, SwaggerConfig}
 import org.broadinstitute.dsde.workbench.leonardo.dao.google.{GoogleComputeDAO, GoogleDataprocDAO}
 import org.broadinstitute.dsde.workbench.leonardo.db.{DataAccess, DbReference}
@@ -724,16 +725,14 @@ class LeonardoService(protected val dataprocConfig: DataprocConfig,
   }
 
   private def calculateAutopauseThreshold(autopause: Option[Boolean], autopauseThreshold: Option[Int]): Int = {
-    val AutoPauseOffValue = 0
-
     autopause match {
       case None =>
         autoFreezeConfig.autoFreezeAfter.toMinutes.toInt
       case Some(false) =>
-        AutoPauseOffValue
+        autoPauseOffValue
       case _ =>
         if (autopauseThreshold.isEmpty) autoFreezeConfig.autoFreezeAfter.toMinutes.toInt
-        else Math.max(AutoPauseOffValue, autopauseThreshold.get)
+        else Math.max(autoPauseOffValue, autopauseThreshold.get)
     }
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponentSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponentSpec.scala
@@ -179,7 +179,7 @@ class ClusterComponentSpec extends TestComponent with FlatSpecLike with CommonTe
     val autopauseDisabledCluster = makeCluster(4).copy(
       auditInfo = auditInfo.copy(dateAccessed = Instant.now().minus(100, ChronoUnit.DAYS)),
       status = ClusterStatus.Running,
-      autopauseThreshold = 0)
+      autopauseThreshold = 0).save()
 
     val autoFreezeList = dbFutureValue { _.clusterQuery.getClustersReadyToAutoFreeze() }
     autoFreezeList should contain (runningCluster1)

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponentSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponentSpec.scala
@@ -176,11 +176,17 @@ class ClusterComponentSpec extends TestComponent with FlatSpecLike with CommonTe
 
     val stoppedCluster = makeCluster(3).copy(status = ClusterStatus.Stopped).save()
 
+    val autopauseDisabledCluster = makeCluster(4).copy(
+      auditInfo = auditInfo.copy(dateAccessed = Instant.now().minus(100, ChronoUnit.DAYS)),
+      status = ClusterStatus.Running,
+      autopauseThreshold = 0)
+
     val autoFreezeList = dbFutureValue { _.clusterQuery.getClustersReadyToAutoFreeze() }
     autoFreezeList should contain (runningCluster1)
     //cluster2 is already stopped
     autoFreezeList should not contain stoppedCluster
     autoFreezeList should not contain runningCluster2
+    autoFreezeList should not contain autopauseDisabledCluster
   }
 
   it should "list by labels and project" in isolatedDbTest {


### PR DESCRIPTION
I stumbled upon this when explaining to Adelaide how to use the PATCH endpoint to disable auto-pause. To disable autopause, we set a "special" value of 0 in the database. However we weren't actually honoring this value in the DB query -- so instead we were autopausing the cluster _immediately_. This hopefully fixes it.

Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
