### PR TITLE
Added missing Terra domains to Content-Security-Policy

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -110,7 +110,7 @@ autoFreeze {
 
 jupyterConfig {
   # https://*.npmjs.org and 'unsafe-eval' needed for jupyterlab
-  contentSecurityPolicy = "frame-ancestors 'self' http://localhost:3000 http://localhost:4200 https://localhost:443 https://bvdp-saturn-prod.appspot.com https://bvdp-saturn-dev.appspot.com https://app.terra.bio https://all-of-us-workbench-test.appspot.com https://all-of-us-rw-staging.appspot.com https://all-of-us-rw-stable.appspot.com https://stable.fake-research-aou.org https://workbench.researchallofus.org; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://apis.google.com ; style-src 'self' 'unsafe-inline'; connect-src 'self' wss://*.broadinstitute.org:* wss://notebooks.firecloud.org:* *.googleapis.com https://*.npmjs.org"
+  contentSecurityPolicy = "frame-ancestors 'self' http://localhost:3000 http://localhost:4200 https://localhost:443 https://bvdp-saturn-prod.appspot.com https://bvdp-saturn-staging.appspot.com https://bvdp-saturn-perf.appspot.com https://bvdp-saturn-alpha.appspot.com https://bvdp-saturn-dev.appspot.com https://app.terra.bio https://firecloud.terra.bio https://all-of-us-workbench-test.appspot.com https://all-of-us-rw-staging.appspot.com https://all-of-us-rw-stable.appspot.com https://stable.fake-research-aou.org https://workbench.researchallofus.org; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://apis.google.com ; style-src 'self' 'unsafe-inline'; connect-src 'self' wss://*.broadinstitute.org:* wss://notebooks.firecloud.org:* *.googleapis.com https://*.npmjs.org"
 }
 
 zombieClusterMonitor {


### PR DESCRIPTION
Added:
- https://bvdp-saturn-staging.appspot.com 
- https://bvdp-saturn-perf.appspot.com 
- https://bvdp-saturn-alpha.appspot.com 
- https://firecloud.terra.bio

This needs to be included in the May 1 release since that is when https://firecloud.terra.bio is going live.

Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
