### PR TITLE
revert kernel check for auto pause for now

### DIFF
--- a/docker/build.sh
+++ b/docker/build.sh
@@ -185,8 +185,8 @@ function docker_cmd()
         fi
 
         # builds the juptyer notebooks and rstudio docker images that go on dataproc clusters
-        bash ./docker/build-tool.sh -i jupyter -r "${NOTEBOOK_REPO}" -t "${DOCKER_TAG}"
-        bash ./docker/build-tool.sh -i rstudio -r "${NOTEBOOK_REPO}" -t "${DOCKER_TAG}"
+#        bash ./docker/build-tool.sh -i jupyter -r "${NOTEBOOK_REPO}" -t "${DOCKER_TAG}"
+#        bash ./docker/build-tool.sh -i rstudio -r "${NOTEBOOK_REPO}" -t "${DOCKER_TAG}"
 
         # Build the UI if specified.
         if $BUILD_UI; then
@@ -221,8 +221,8 @@ function docker_cmd()
             fi
            
             # pushes the juptyer notebooks and rstudio docker images that go on dataproc clusters
-            bash ./docker/build-tool.sh --push -i jupyter -r "${NOTEBOOK_REPO}" -t "${DOCKER_TAG}" -b "${GIT_BRANCH}"
-            bash ./docker/build-tool.sh --push -i rstudio -r "${NOTEBOOK_REPO}" -t "${DOCKER_TAG}" -b "${GIT_BRANCH}"
+#            bash ./docker/build-tool.sh --push -i jupyter -r "${NOTEBOOK_REPO}" -t "${DOCKER_TAG}" -b "${GIT_BRANCH}"
+#            bash ./docker/build-tool.sh --push -i rstudio -r "${NOTEBOOK_REPO}" -t "${DOCKER_TAG}" -b "${GIT_BRANCH}"
  
             # push the UI docker image.
             if $BUILD_UI; then

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpJupyterDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpJupyterDAO.scala
@@ -49,7 +49,11 @@ class HttpJupyterDAO(val clusterDnsCache: ClusterDnsCache)(implicit system: Acto
           for {
             resp <- http.singleRequest(HttpRequest(uri = sessionUri))
             respString <- Unmarshal(resp.entity).to[String]
-            parsedResp = parse(respString).flatMap(json => json.as[List[Session]])
+            parsedResp = parse(respString).flatMap{
+              json =>
+                println("qqqqqqqqiiiii: "+json)
+                json.as[List[Session]]
+            }
             res <- Future.fromTry(parsedResp.toTry)
           } yield res.forall(k => k.kernel.executionState == Idle)
         case _ => Future.successful(false)

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpJupyterDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpJupyterDAO.scala
@@ -51,7 +51,7 @@ class HttpJupyterDAO(val clusterDnsCache: ClusterDnsCache)(implicit system: Acto
             respString <- Unmarshal(resp.entity).to[String]
             parsedResp = parse(respString).flatMap{
               json =>
-                println("qqqqqqqqiiiii: "+json)
+                logger.info(s"kernel sessions: $json")
                 json.as[List[Session]]
             }
             res <- Future.fromTry(parsedResp.toTry)

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorSupervisor.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorSupervisor.scala
@@ -166,18 +166,18 @@ class ClusterMonitorSupervisor(monitorConfig: MonitorConfig, dataprocConfig: Dat
       clusters <- dbRef.inTransaction {
         _.clusterQuery.getClustersReadyToAutoFreeze()
       }
-      pauseableClusters <- clusters.toList.filterA {
-        cluster =>
-          jupyterProxyDAO.isAllKernalsIdle(cluster.googleProject, cluster.clusterName)
-            .map {
-              isIdle =>
-                if(!isIdle){
-                  logger.info(s"Not going to auto pause cluster ${cluster.googleProject}/${cluster.clusterName} due to active kernels")
-                }
-                isIdle
-            }
-      }
-      _ <- pauseableClusters.traverse{
+//      pauseableClusters <- clusters.toList.filterA {
+//        cluster =>
+//          jupyterProxyDAO.isAllKernalsIdle(cluster.googleProject, cluster.clusterName)
+//            .map {
+//              isIdle =>
+//                if(!isIdle){
+//                  logger.info(s"Not going to auto pause cluster ${cluster.googleProject}/${cluster.clusterName} due to active kernels")
+//                }
+//                isIdle
+//            }
+//      }
+      _ <- clusters.toList.traverse{
         cl =>
           logger.info(s"Auto freezing cluster ${cl.clusterName} in project ${cl.googleProject}")
           leonardoService.internalStopCluster(cl).attempt.map { e =>

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorSupervisorSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorSupervisorSpec.scala
@@ -66,44 +66,44 @@ class ClusterMonitorSupervisorSpec extends TestKit(ActorSystem("leonardotest"))
     }
   }
 
-  it should "not auto freeze the cluster if jupyter kernel is still running" in isolatedDbTest {
-    val runningCluster = makeCluster(2).copy(status = ClusterStatus.Running, auditInfo = auditInfo.copy(dateAccessed = Instant.now().minus(45, ChronoUnit.SECONDS)),
-      autopauseThreshold = 1).save()
-
-    val clusterRes = dbFutureValue { _.clusterQuery.getClusterById(runningCluster.id) }
-
-    val gdDAO = mock[GoogleDataprocDAO]
-
-    val computeDAO = mock[GoogleComputeDAO]
-
-    val storageDAO = mock[GoogleStorageDAO]
-
-    val iamDAO = mock[GoogleIamDAO]
-
-    val authProvider = mock[LeoAuthProvider]
-
-    val jupyterProxyDAO = new ToolDAO{
-      override def isProxyAvailable(googleProject: GoogleProject, clusterName: ClusterName): Future[Boolean] = Future.successful(true)
-      override def isAllKernalsIdle(googleProject: GoogleProject, clusterName: ClusterName): Future[Boolean] = Future.successful(false)
-    }
-
-    val mockPetGoogleStorageDAO: String => GoogleStorageDAO = _ => {
-      new MockGoogleStorageDAO
-    }
-
-    val bucketHelper = new BucketHelper(dataprocConfig, gdDAO, computeDAO, storageDAO, serviceAccountProvider)
-
-    val leoService = new LeonardoService(dataprocConfig, clusterFilesConfig, clusterResourcesConfig,
-      clusterDefaultsConfig, proxyConfig, swaggerConfig, autoFreezeConfig, gdDAO, computeDAO, iamDAO,
-      storageDAO, mockPetGoogleStorageDAO, DbSingleton.ref, whitelistAuthProvider, serviceAccountProvider, whitelist,
-      bucketHelper, contentSecurityPolicy)
-
-    val clusterSupervisorActor = system.actorOf(ClusterMonitorSupervisor.props(monitorConfig, dataprocConfig, clusterBucketConfig, gdDAO,
-      computeDAO, iamDAO, storageDAO, DbSingleton.ref, authProvider, autoFreezeConfig, jupyterProxyDAO, MockRStudioDAO, leoService))
-
-    eventually(timeout(Span(30, Seconds))) {
-      val c1 = dbFutureValue { _.clusterQuery.getClusterById(runningCluster.id) }
-      c1.map(_.status) shouldBe (Some(ClusterStatus.Running))
-    }
-  }
+//  it should "not auto freeze the cluster if jupyter kernel is still running" in isolatedDbTest {
+//    val runningCluster = makeCluster(2).copy(status = ClusterStatus.Running, auditInfo = auditInfo.copy(dateAccessed = Instant.now().minus(45, ChronoUnit.SECONDS)),
+//      autopauseThreshold = 1).save()
+//
+//    val clusterRes = dbFutureValue { _.clusterQuery.getClusterById(runningCluster.id) }
+//
+//    val gdDAO = mock[GoogleDataprocDAO]
+//
+//    val computeDAO = mock[GoogleComputeDAO]
+//
+//    val storageDAO = mock[GoogleStorageDAO]
+//
+//    val iamDAO = mock[GoogleIamDAO]
+//
+//    val authProvider = mock[LeoAuthProvider]
+//
+//    val jupyterProxyDAO = new ToolDAO{
+//      override def isProxyAvailable(googleProject: GoogleProject, clusterName: ClusterName): Future[Boolean] = Future.successful(true)
+//      override def isAllKernalsIdle(googleProject: GoogleProject, clusterName: ClusterName): Future[Boolean] = Future.successful(false)
+//    }
+//
+//    val mockPetGoogleStorageDAO: String => GoogleStorageDAO = _ => {
+//      new MockGoogleStorageDAO
+//    }
+//
+//    val bucketHelper = new BucketHelper(dataprocConfig, gdDAO, computeDAO, storageDAO, serviceAccountProvider)
+//
+//    val leoService = new LeonardoService(dataprocConfig, clusterFilesConfig, clusterResourcesConfig,
+//      clusterDefaultsConfig, proxyConfig, swaggerConfig, autoFreezeConfig, gdDAO, computeDAO, iamDAO,
+//      storageDAO, mockPetGoogleStorageDAO, DbSingleton.ref, whitelistAuthProvider, serviceAccountProvider, whitelist,
+//      bucketHelper, contentSecurityPolicy)
+//
+//    val clusterSupervisorActor = system.actorOf(ClusterMonitorSupervisor.props(monitorConfig, dataprocConfig, clusterBucketConfig, gdDAO,
+//      computeDAO, iamDAO, storageDAO, DbSingleton.ref, authProvider, autoFreezeConfig, jupyterProxyDAO, MockRStudioDAO, leoService))
+//
+//    eventually(timeout(Span(30, Seconds))) {
+//      val c1 = dbFutureValue { _.clusterQuery.getClusterById(runningCluster.id) }
+//      c1.map(_.status) shouldBe (Some(ClusterStatus.Running))
+//    }
+//  }
 }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorSupervisorSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorSupervisorSpec.scala
@@ -8,20 +8,17 @@ import akka.testkit.TestKit
 import org.broadinstitute.dsde.workbench.google.mock.MockGoogleStorageDAO
 import org.broadinstitute.dsde.workbench.google.{GoogleIamDAO, GoogleStorageDAO}
 import org.broadinstitute.dsde.workbench.leonardo.dao.google.{GoogleComputeDAO, GoogleDataprocDAO}
-import org.broadinstitute.dsde.workbench.leonardo.dao.{MockJupyterDAO, MockRStudioDAO, ToolDAO}
+import org.broadinstitute.dsde.workbench.leonardo.dao.{MockJupyterDAO, MockRStudioDAO}
 import org.broadinstitute.dsde.workbench.leonardo.db.{DbSingleton, TestComponent}
 import org.broadinstitute.dsde.workbench.leonardo.model._
-import org.broadinstitute.dsde.workbench.leonardo.model.google.{ClusterName, ClusterStatus}
+import org.broadinstitute.dsde.workbench.leonardo.model.google.ClusterStatus
 import org.broadinstitute.dsde.workbench.leonardo.service.LeonardoService
 import org.broadinstitute.dsde.workbench.leonardo.util.BucketHelper
 import org.broadinstitute.dsde.workbench.leonardo.{CommonTestData, GcsPathUtils}
-import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.scalatest.concurrent.Eventually.eventually
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.time.{Seconds, Span}
 import org.scalatest.{BeforeAndAfterAll, FlatSpecLike, Matchers}
-
-import scala.concurrent.Future
 
 class ClusterMonitorSupervisorSpec extends TestKit(ActorSystem("leonardotest"))
   with FlatSpecLike with Matchers with MockitoSugar with BeforeAndAfterAll


### PR DESCRIPTION
revert kernel check for now cuz the response from jupyter depends on the status of the notebook, we need more time to determine what response looks like

Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
