### PR TITLE
Fix automation test failure

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookClusterMonitoringSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookClusterMonitoringSpec.scala
@@ -347,7 +347,7 @@ class NotebookClusterMonitoringSpec extends FreeSpec with NotebookTestUtils with
 
               val result = notebookPage.executeCell(query, timeout = 5.minutes).get
               result should include("BigQuery error in query operation")
-              result.replace("&#010;", " ") should include("Invalid credential")
+              result.replace(System.lineSeparator(), " ") should include("Invalid credential")
             }
           }
         }

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookClusterMonitoringSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookClusterMonitoringSpec.scala
@@ -346,7 +346,8 @@ class NotebookClusterMonitoringSpec extends FreeSpec with NotebookTestUtils with
               val query = """! bq query --disable_ssl_validation --format=json "SELECT COUNT(*) AS scullion_count FROM publicdata.samples.shakespeare WHERE word='scullion'" """
 
               val result = notebookPage.executeCell(query, timeout = 5.minutes).get
-              result should include("BigQuery error in query operation: Invalid credential")
+              result should include("BigQuery error in query operation")
+              result.replace("&#010;", " ") should include("Invalid credential")
             }
           }
         }


### PR DESCRIPTION
`"BigQuery error in query operation: Error processing job&#010;'gpalloc-qa-master-33az1ak:bqjob_r4eb47604ba9b74c6_0000016ac4894b1f_1': Invalid&#010;credential" did not include substring "BigQuery error in query operation: Invalid credential"`

Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
