### PR TITLE
[no JIRA][risk=no] Rename and refactor addClusterLabels

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeonardoModel.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeonardoModel.scala
@@ -43,7 +43,12 @@ final case class ClusterRequest(labels: LabelMap,
 case class UserJupyterExtensionConfig(nbExtensions: Map[String, String] = Map(),
                                       serverExtensions: Map[String, String] = Map(),
                                       combinedExtensions: Map[String, String] = Map(),
-                                      labExtensions: Map[String, String] = Map())
+                                      labExtensions: Map[String, String] = Map()) {
+
+  def asLabels: LabelMap = {
+    nbExtensions ++ serverExtensions ++ combinedExtensions ++ labExtensions
+  }
+}
 
 
 // A resource that is required by a cluster


### PR DESCRIPTION
Rename addClusterLabels to augmentClusterRequest because it does more than labels
- split out the labeling to a new addClusterLabels
- refactor augmentClusterRequest

As I was poking around the cluster creation code regarding extensions, I was confused by this method which appeared to do two things.  So I couldn't resist doing a little refactoring.  Feel free to close this PR if it is not welcome. 

Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
