### PR TITLE
[risk=no][IA-1026]Defer the execution of Welder until after its container is created

### DIFF
--- a/docker/jupyter/Dockerfile
+++ b/docker/jupyter/Dockerfile
@@ -392,4 +392,9 @@ USER $USER
 WORKDIR $HOME
 
 EXPOSE $JUPYTER_PORT
+
+# Note: this entrypoint is provided for running Jupyter independently of Leonardo.
+# When Leonardo deploys this image onto a cluster, the entrypoint is overwritten to enable
+# additional setup inside the container before execution.  Jupyter execution occurs when the
+# init-actions.sh script uses 'docker exec' to call run-jupyter.sh.
 ENTRYPOINT ["/usr/local/bin/jupyter", "notebook"]

--- a/src/main/resources/jupyter/init-actions.sh
+++ b/src/main/resources/jupyter/init-actions.sh
@@ -162,7 +162,7 @@ if [[ "${ROLE}" == 'Master' ]]; then
     touch /hadoop_gcs_connector_metadata_cache
     touch auth_openidc.conf
 
-    # TODO make this configurable. https://broadworkbench.atlassian.net/browse/IA-1037
+    # TODO make this configurable. https://broadworkbench.atlassian.net/browse/IA-1033
     # do not enable welder yet.  Remove flag when welder is complete.
     WELDER_ENABLED=false
 

--- a/src/main/resources/jupyter/init-actions.sh
+++ b/src/main/resources/jupyter/init-actions.sh
@@ -162,6 +162,7 @@ if [[ "${ROLE}" == 'Master' ]]; then
     touch /hadoop_gcs_connector_metadata_cache
     touch auth_openidc.conf
 
+    # TODO make this configurable. https://broadworkbench.atlassian.net/browse/IA-1037
     # do not enable welder yet.  Remove flag when welder is complete.
     WELDER_ENABLED=false
 

--- a/src/main/resources/jupyter/init-actions.sh
+++ b/src/main/resources/jupyter/init-actions.sh
@@ -218,6 +218,13 @@ if [[ "${ROLE}" == 'Master' ]]; then
     retry 5 docker-compose "${COMPOSE_FILES[@]}" pull
     retry 5 docker-compose "${COMPOSE_FILES[@]}" up -d
 
+    # if Welder is installed, start the service.
+    # See https://broadworkbench.atlassian.net/browse/IA-1026
+    if [ ! -z ${WELDER_DOCKER_IMAGE} ] && [ "${WELDER_ENABLED}" == "true" ] ; then
+      log 'Starting Welder file synchronization service...'
+      retry 3 docker exec -u daemon -d ${WELDER_SERVER_NAME} /opt/docker/bin/server start
+    fi
+
     # Jupyter-specific setup, only do if Jupyter is installed
     if [ ! -z ${JUPYTER_DOCKER_IMAGE} ] ; then
       log 'Installing Jupydocker kernelspecs...'

--- a/src/main/resources/jupyter/welder-docker-compose.yaml
+++ b/src/main/resources/jupyter/welder-docker-compose.yaml
@@ -3,6 +3,11 @@ services:
   welder:
     container_name: "${WELDER_SERVER_NAME}"
     image: "${WELDER_DOCKER_IMAGE}"
+    # Override entrypoint with a placeholder to keep the container running indefinitely.
+    # The cluster init script will start welder via docker exec,
+    # when Application Default Credentials are available.
+    # See https://broadworkbench.atlassian.net/browse/IA-1026
+    entrypoint: "tail -f /dev/null"
     network_mode: host
     restart: always
     environment:

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -10,8 +10,8 @@ dataproc {
   firewallRuleName = "leonardo-notebooks-rule"
   networkTag = "leonardo"
   defaultScopes = ["https://www.googleapis.com/auth/userinfo.email", "https://www.googleapis.com/auth/userinfo.profile", "https://www.googleapis.com/auth/bigquery", "https://www.googleapis.com/auth/source.read_only"]
-  # TODO: temp 2019-05-29
-  welderDockerImage = "us.gcr.io/broad-dsp-gcr-public/welder-server:5c3d6bb"
+  # TODO: temp 2019-06-07
+  welderDockerImage = "us.gcr.io/broad-dsp-gcr-public/welder-server:0b28747"
   # Unset to use project-level defaults. Note a VPC/subnet with the literal name "default" may not exist.
   #vpcNetwork = "default"
   #vpcSubnet = "default"

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoService.scala
@@ -129,7 +129,7 @@ class LeonardoService(protected val dataprocConfig: DataprocConfig,
     // so we need to fall back running `jupyter notebook` directly. See https://github.com/DataBiosphere/leonardo/issues/481.
     val jupyterStart = s"docker exec -d ${dataprocConfig.jupyterServerName} /bin/bash -c '/etc/jupyter/scripts/run-jupyter.sh || /usr/local/bin/jupyter notebook'"
 
-    // TODO make this flag configurable. https://broadworkbench.atlassian.net/browse/IA-1037
+    // TODO make this flag configurable. https://broadworkbench.atlassian.net/browse/IA-1033
     val enableWelder = false
     val servicesStart = if (enableWelder) {
       val welderStart = s"docker exec -u daemon -d ${dataprocConfig.welderServerName} /opt/docker/bin/server start"

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoService.scala
@@ -120,12 +120,13 @@ class LeonardoService(protected val dataprocConfig: DataprocConfig,
     network = dataprocConfig.vpcNetwork.map(VPCNetworkName),
     targetTags = List(NetworkTag(dataprocConfig.networkTag)))
 
-  // Startup script to install on the cluster master node. This allows Jupyter to start back up after
-  // a cluster is resumed.
+  // Startup scripts to install on the cluster master node.
+  // This allows Jupyter and Welder to start back up after a cluster is resumed.
   //
   // The || clause is included because older clusters may not have the run-jupyter.sh script installed,
   // so we need to fall back running `jupyter notebook` directly. See https://github.com/DataBiosphere/leonardo/issues/481.
   private lazy val masterInstanceStartupScript: immutable.Map[String, String] = {
+ //TODO
     immutable.Map("startup-script" -> s"docker exec -d ${dataprocConfig.jupyterServerName} /bin/bash -c '/etc/jupyter/scripts/run-jupyter.sh || /usr/local/bin/jupyter notebook'")
   }
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoService.scala
@@ -122,12 +122,22 @@ class LeonardoService(protected val dataprocConfig: DataprocConfig,
 
   // Startup scripts to install on the cluster master node.
   // This allows Jupyter and Welder to start back up after a cluster is resumed.
-  //
-  // The || clause is included because older clusters may not have the run-jupyter.sh script installed,
-  // so we need to fall back running `jupyter notebook` directly. See https://github.com/DataBiosphere/leonardo/issues/481.
   private lazy val masterInstanceStartupScript: immutable.Map[String, String] = {
- //TODO
-    immutable.Map("startup-script" -> s"docker exec -d ${dataprocConfig.jupyterServerName} /bin/bash -c '/etc/jupyter/scripts/run-jupyter.sh || /usr/local/bin/jupyter notebook'")
+    val googleKey = "startup-script"  // required; see https://cloud.google.com/compute/docs/startupscript
+
+    // The || clause is included because older clusters may not have the run-jupyter.sh script installed,
+    // so we need to fall back running `jupyter notebook` directly. See https://github.com/DataBiosphere/leonardo/issues/481.
+    val jupyterStart = s"docker exec -d ${dataprocConfig.jupyterServerName} /bin/bash -c '/etc/jupyter/scripts/run-jupyter.sh || /usr/local/bin/jupyter notebook'"
+
+    // TODO make this flag configurable
+    val enableWelder = false
+    val servicesStart = if (enableWelder) {
+      val welderStart = s"docker exec -u daemon -d ${dataprocConfig.welderServerName} /opt/docker/bin/server start"
+      s"($jupyterStart) && $welderStart"
+    }
+    else jupyterStart
+
+    immutable.Map(googleKey -> servicesStart)
   }
 
   protected def checkProjectPermission(userInfo: UserInfo, action: ProjectAction, project: GoogleProject): Future[Unit] = {

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoService.scala
@@ -129,7 +129,7 @@ class LeonardoService(protected val dataprocConfig: DataprocConfig,
     // so we need to fall back running `jupyter notebook` directly. See https://github.com/DataBiosphere/leonardo/issues/481.
     val jupyterStart = s"docker exec -d ${dataprocConfig.jupyterServerName} /bin/bash -c '/etc/jupyter/scripts/run-jupyter.sh || /usr/local/bin/jupyter notebook'"
 
-    // TODO make this flag configurable
+    // TODO make this flag configurable. https://broadworkbench.atlassian.net/browse/IA-1037
     val enableWelder = false
     val servicesStart = if (enableWelder) {
       val welderStart = s"docker exec -u daemon -d ${dataprocConfig.welderServerName} /opt/docker/bin/server start"


### PR DESCRIPTION
It’s not clear why, but running Welder as an Entrypoint in its docker container does not allow it to find the [Application Default Credentials](https://cloud.google.com/docs/authentication/production) available on the host.

Welder does find the ADC if it is run inside the already-running container, so we defer execution in this way.  Interestingly, Jupyter already does this, for unrelated reasons.  Perhaps that is what enables Jupyter to use ADC as well.

Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
