### PR TITLE
Update work mount location to match Jupyter home

### DIFF
--- a/src/main/resources/jupyter/jupyter-docker-compose.yaml
+++ b/src/main/resources/jupyter/jupyter-docker-compose.yaml
@@ -10,7 +10,7 @@ services:
     network_mode: host
     volumes:
       # shared with welder
-      - /work:/home/user/work
+      - /work:/home/jupyter-user
       - /usr/lib/bigtop-utils:/usr/lib/bigtop-utils
       - /usr/lib/hadoop:/usr/lib/hadoop
       - /usr/lib/hadoop-hdfs:/usr/lib/hadoop-hdfs


### PR DESCRIPTION
`/user/home/work` was never used AFAICT. Updating to match the local jupyter-home where notebooks are stored by default.

Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
