### PR TITLE
Update work mount location to match Jupyter home

### DIFF
--- a/docker/jupyter/custom/jupyter_localize_extension.py
+++ b/docker/jupyter/custom/jupyter_localize_extension.py
@@ -6,6 +6,7 @@ import tornado
 from tornado import gen
 from tornado.web import HTTPError
 from notebook.base.handlers import IPythonHandler
+
 from notebook.utils import url_path_join
 from datauri import DataURI
 
@@ -18,11 +19,13 @@ class LocalizeHandler(IPythonHandler):
     # expand user directories and make intermediate directories
     else:
       expanded = os.path.expanduser(pathstr)
+      # Treat relative URLs as relative to the notebooks directory root.
+      full = os.path.normpath(os.path.join(self.config.NotebookApp.notebook_dir, expanded))
       try:
-        os.makedirs(os.path.dirname(expanded))
+        os.makedirs(os.path.dirname(full))
       except OSError: #thrown if dirs already exist
         pass
-      return expanded
+      return full
 
   def _localize_gcs_uri(self, locout, source, dest):
     """Localizes an entry where either the source or destination is a gs: path.

--- a/docker/jupyter/custom/jupyter_localize_extension.py
+++ b/docker/jupyter/custom/jupyter_localize_extension.py
@@ -6,7 +6,6 @@ import tornado
 from tornado import gen
 from tornado.web import HTTPError
 from notebook.base.handlers import IPythonHandler
-
 from notebook.utils import url_path_join
 from datauri import DataURI
 
@@ -19,13 +18,11 @@ class LocalizeHandler(IPythonHandler):
     # expand user directories and make intermediate directories
     else:
       expanded = os.path.expanduser(pathstr)
-      # Treat relative URLs as relative to the notebooks directory root.
-      full = os.path.normpath(os.path.join(self.config.NotebookApp.notebook_dir, expanded))
       try:
-        os.makedirs(os.path.dirname(full))
+        os.makedirs(os.path.dirname(expanded))
       except OSError: #thrown if dirs already exist
         pass
-      return full
+      return expanded
 
   def _localize_gcs_uri(self, locout, source, dest):
     """Localizes an entry where either the source or destination is a gs: path.

--- a/src/main/resources/jupyter/init-actions.sh
+++ b/src/main/resources/jupyter/init-actions.sh
@@ -147,7 +147,7 @@ if [[ "${ROLE}" == 'Master' ]]; then
 
     mkdir /work
     mkdir /certs
-    chmod a+wx /work
+    chmod a+rwx /work
 
     # Add the certificates from the bucket to the VM. They are used by the docker-compose file
     gsutil cp ${SERVER_CRT} /certs

--- a/src/main/resources/jupyter/jupyter-docker-compose.yaml
+++ b/src/main/resources/jupyter/jupyter-docker-compose.yaml
@@ -30,5 +30,7 @@ services:
       WORKSPACE_NAMESPACE: "${GOOGLE_PROJECT}"
       CLUSTER_NAME: "${CLUSTER_NAME}"
       OWNER_EMAIL: "${OWNER_EMAIL}"
+      # Value must be the string "true" to enable.
+      WELDER_ENABLE: "${WELDER_ENABLE}"
     env_file:
       - /etc/google_application_credentials.env

--- a/src/main/resources/jupyter/jupyter-docker-compose.yaml
+++ b/src/main/resources/jupyter/jupyter-docker-compose.yaml
@@ -10,7 +10,7 @@ services:
     network_mode: host
     volumes:
       # shared with welder
-      - /work:/home/user/work
+      - /work:/home/jupyter-user/notebooks
       - /usr/lib/bigtop-utils:/usr/lib/bigtop-utils
       - /usr/lib/hadoop:/usr/lib/hadoop
       - /usr/lib/hadoop-hdfs:/usr/lib/hadoop-hdfs

--- a/src/main/resources/jupyter/jupyter_notebook_config.py
+++ b/src/main/resources/jupyter/jupyter_notebook_config.py
@@ -21,9 +21,9 @@ fragment = os.environ['GOOGLE_PROJECT'] + '/' + os.environ['CLUSTER_NAME']
 c.NotebookApp.base_url = '/notebooks/' + fragment + '/'
 
 # Using an alternate notebooks_dir allows for mounting of a shared volume here.
-# The default notebook root dir is /home/jupyter, which is also the home
+# The default notebook root dir is /home/jupyter-user, which is also the home
 # directory (which contains several other files on the image). We don't want
-# to mount there as it effectively deletes existing files.
+# to mount there as it effectively deletes existing files on the image.
 # See https://docs.google.com/document/d/1b8wIydzC4D7Sbb6h2zWe-jCvoNq-bbD02CT1cnKLbGk
 c.NotebookApp.notebook_dir = '/home/jupyter-user/notebooks'
 

--- a/src/main/resources/jupyter/jupyter_notebook_config.py
+++ b/src/main/resources/jupyter/jupyter_notebook_config.py
@@ -20,6 +20,13 @@ c.NotebookApp.terminado_settings={'shell_command': ['bash']}
 fragment = os.environ['GOOGLE_PROJECT'] + '/' + os.environ['CLUSTER_NAME']
 c.NotebookApp.base_url = '/notebooks/' + fragment + '/'
 
+# Using an alternate notebooks_dir allows for mounting of a shared volume here.
+# The default notebook root dir is /home/jupyter, which is also the home
+# directory (which contains several other files on the image). We don't want
+# to mount there as it effectively deletes existing files.
+# See https://docs.google.com/document/d/1b8wIydzC4D7Sbb6h2zWe-jCvoNq-bbD02CT1cnKLbGk
+c.NotebookApp.notebook_dir = '/home/jupyter-user/notebooks'
+
 # This is also specified in run-jupyter.sh
 c.NotebookApp.nbserver_extensions = {
     'jupyter_localize_extension': True

--- a/src/main/resources/jupyter/jupyter_notebook_config.py
+++ b/src/main/resources/jupyter/jupyter_notebook_config.py
@@ -25,7 +25,10 @@ c.NotebookApp.base_url = '/notebooks/' + fragment + '/'
 # directory (which contains several other files on the image). We don't want
 # to mount there as it effectively deletes existing files on the image.
 # See https://docs.google.com/document/d/1b8wIydzC4D7Sbb6h2zWe-jCvoNq-bbD02CT1cnKLbGk
-c.NotebookApp.notebook_dir = '/home/jupyter-user/notebooks'
+if os.environ['WELDER_ENABLE'] == 'true':
+  # Only enable this along with Welder, as this change is backwards incompatible
+  # for older localization users.
+  c.NotebookApp.notebook_dir = '/home/jupyter-user/notebooks'
 
 # This is also specified in run-jupyter.sh
 c.NotebookApp.nbserver_extensions = {


### PR DESCRIPTION
* Change the notebooks root and mount the welder volume there
* AFAICT /usr/home/work was never used.
* See https://docs.google.com/document/d/1b8wIydzC4D7Sbb6h2zWe-jCvoNq-bbD02CT1cnKLbGk for alternatives considered

- [x] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
