### PR TITLE
Document that Leo requires Java 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ $ cd leonardo
 ```
 
 ### Run Leonardo unit tests
+
+Leonardo requires Java 8 due to a dependency on Java's DNS SPI functionality. This feature is removed in Java 9 and above.
+
 Ensure docker is running. Spin up MySQL locally:
 ```
 $ ./docker/run-mysql.sh start leonardo  


### PR DESCRIPTION
I tried to build Leo on my dev machine, which has Java 11 installed, and couldn't. As of Java 9, the `Nameservice` stuff [has been removed](https://bugs.openjdk.java.net/browse/JDK-8134577). This is causing [some consternation within the Java community](https://bugs.openjdk.java.net/browse/JDK-8192780) -- Google is unhappy, for one -- but at the very least, we should document the requirement.