### PR TITLE
Add local docker compose for Jupyter + Welder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .metals
 /project/boot/
 /project/plugins/project
+docker/local/etc-jupyter
 target/
 lib_managed/
 src_managed/

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /project/boot/
 /project/plugins/project
 docker/local/etc-jupyter
+docker/local/jupyter-ext
 target/
 lib_managed/
 src_managed/

--- a/docker/jupyter/custom/jupyter_delocalize.py
+++ b/docker/jupyter/custom/jupyter_delocalize.py
@@ -185,7 +185,7 @@ class WelderContentsManager(FileContentsManager):
       # not; strip for Welder.
       'localPath': path.lstrip('/')
     }))
-    if not resp.ok
+    if not resp.ok:
       try:
         msg = json.dumps(resp.json())
       except:

--- a/docker/jupyter/custom/jupyter_delocalize.py
+++ b/docker/jupyter/custom/jupyter_delocalize.py
@@ -185,7 +185,7 @@ class WelderContentsManager(FileContentsManager):
       # not; strip for Welder.
       'localPath': path.lstrip('/')
     }))
-    if resp.status_code != requests.codes.ok:
+    if not resp.ok
       try:
         msg = json.dumps(resp.json())
       except:

--- a/docker/local/cluster-site.conf
+++ b/docker/local/cluster-site.conf
@@ -1,0 +1,22 @@
+<VirtualHost *:80>
+
+    RewriteEngine on
+
+    # Welder
+
+    RewriteCond %{REQUEST_URI} /proxy/[^/]*/[^/]*/welder/.* [NC]
+    RewriteRule /proxy/[^/]*/[^/]*/welder/(.*) http://127.0.0.1:8080/$1 [P,L]
+
+    # Jupyter (legacy path)
+
+    RewriteCond %{HTTP:Upgrade} =websocket
+    RewriteCond %{REQUEST_URI} /notebooks/[^/]*/[^/]*/.* [NC]
+    RewriteRule .*     ws://127.0.0.1:8000%{REQUEST_URI}  [P,L]
+
+    RewriteCond %{HTTP:Upgrade} !=websocket
+    RewriteCond %{REQUEST_URI} /notebooks/[^/]*/[^/]*/.* [NC]
+    RewriteRule .*     http://127.0.0.1:8000%{REQUEST_URI}  [P,L]
+
+    ProxyPass / http://127.0.0.1:8000/ retry=10
+    ProxyPassReverse / http://127.0.0.1:8000/
+</VirtualHost>

--- a/docker/local/docker-compose.yml
+++ b/docker/local/docker-compose.yml
@@ -2,8 +2,6 @@ version: '2'
 services:
   welder:
     image: "us.gcr.io/broad-dsp-gcr-public/welder-server"
-    ports:
-      - 8080:8080
     network_mode: host
     environment:
       GOOGLE_APPLICATION_CREDENTIALS: /usr/adc.json
@@ -17,12 +15,11 @@ services:
   jupyter:
     image: "us.gcr.io/broad-dsp-gcr-public/leonardo-jupyter:prod"
     network_mode: host
-    ports:
-      - 8000:8000
     volumes:
       # shared with welder
       - welder-data:/home/jupyter-user/notebooks
       - ./etc-jupyter:/etc/jupyter
+      - ./jupyter-ext:/home/jupyter-user/.jupyter
       - ~/.config/gcloud/application_default_credentials.json:/usr/adc.json
     environment:
       GOOGLE_APPLICATION_CREDENTIALS: /usr/adc.json
@@ -31,5 +28,11 @@ services:
       CLUSTER_NAME: "test-cluster"
       OWNER_EMAIL: "foo@bar.com"
       WELDER_ENABLE: "true"
+  proxy:
+    image: "broadinstitute/openidc-proxy:2.3.1_2"
+    network_mode: host
+    volumes:
+      - ./cluster-site.conf:/etc/apache2/sites-enabled/site.conf
+    restart: always
 volumes:
   welder-data:

--- a/docker/local/docker-compose.yml
+++ b/docker/local/docker-compose.yml
@@ -1,0 +1,35 @@
+version: '2'
+services:
+  welder:
+    image: "us.gcr.io/broad-dsp-gcr-public/welder-server"
+    ports:
+      - 8080:8080
+    network_mode: host
+    environment:
+      GOOGLE_APPLICATION_CREDENTIALS: /usr/adc.json
+      GOOGLE_PROJECT: "test-project"
+      WORKSPACE_NAMESPACE: "test-project"
+      CLUSTER_NAME: "test-cluster"
+      OWNER_EMAIL: "foo@bar.com"
+    volumes:
+      - welder-data:/work
+      - ~/.config/gcloud/application_default_credentials.json:/usr/adc.json
+  jupyter:
+    image: "us.gcr.io/broad-dsp-gcr-public/leonardo-jupyter:prod"
+    network_mode: host
+    ports:
+      - 8000:8000
+    volumes:
+      # shared with welder
+      - welder-data:/home/jupyter-user/notebooks
+      - ./etc-jupyter:/etc/jupyter
+      - ~/.config/gcloud/application_default_credentials.json:/usr/adc.json
+    environment:
+      GOOGLE_APPLICATION_CREDENTIALS: /usr/adc.json
+      GOOGLE_PROJECT: "test-project"
+      WORKSPACE_NAMESPACE: "test-project"
+      CLUSTER_NAME: "test-cluster"
+      OWNER_EMAIL: "foo@bar.com"
+      WELDER_ENABLE: "true"
+volumes:
+  welder-data:

--- a/docker/local/run.sh
+++ b/docker/local/run.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+(cd $(git rev-parse --show-toplevel)/docker/local && mkdir -p etc-jupyter/custom)
+
+# Substitute templated vars in the notebook config.
+pushd $(git rev-parse --show-toplevel) > /dev/null
+readonly etc_dir=docker/local/etc-jupyter
+readonly nb_config="${etc_dir}/jupyter_notebook_config.py"
+cp src/main/resources/jupyter/jupyter_notebook_config.py "${nb_config}"
+sed -i 's/$(contentSecurityPolicy)/""/' "${nb_config}"
+
+cp docker/jupyter/custom/*.py "${etc_dir}/custom/"
+
+chmod -R a+rwx ${etc_dir}
+popd > /dev/null
+
+docker-compose up
+

--- a/docker/local/run.sh
+++ b/docker/local/run.sh
@@ -11,7 +11,13 @@ sed -i 's/$(contentSecurityPolicy)/""/' "${nb_config}"
 
 cp docker/jupyter/custom/*.py "${etc_dir}/custom/"
 
+# TODO: This doesn't actually activate the extension.
+readonly ext_dir=docker/local/jupyter-ext
+mkdir -p "${ext_dir}/custom"
+cp src/main/resources/jupyter/safe-mode.js "${ext_dir}/custom/"
+
 chmod -R a+rwx ${etc_dir}
+chmod -R a+rwx ${ext_dir}
 popd > /dev/null
 
 docker-compose up

--- a/src/main/resources/jupyter/jupyter_notebook_config.py
+++ b/src/main/resources/jupyter/jupyter_notebook_config.py
@@ -34,7 +34,10 @@ if os.environ['WELDER_ENABLE'] == 'true':
 c.NotebookApp.nbserver_extensions = {
     'jupyter_localize_extension': True
 }
-c.NotebookApp.contents_manager_class = 'jupyter_delocalize.DelocalizingContentsManager'
+mgr_class = 'DelocalizingContentsManager'
+if os.environ['WELDER_ENABLE'] == 'true':
+  mgr_class = 'WelderContentsManager'
+c.NotebookApp.contents_manager_class = 'jupyter_delocalize.' + mg_class
 
 # Unset Content-Security-Policy so Jupyter can be rendered in an iframe
 # See https://jupyter-notebook.readthedocs.io/en/latest/public_server.html?highlight=server#embedding-the-notebook-in-another-website

--- a/src/main/resources/jupyter/jupyter_notebook_config.py
+++ b/src/main/resources/jupyter/jupyter_notebook_config.py
@@ -7,7 +7,9 @@ import errno
 import stat
 
 c = get_config()
-c.NotebookApp.ip = 'localhost'
+# Needed to access Jupyter from an alternate host. Untested in GCP - may need
+# to make this conditional.
+c.NotebookApp.ip = '0.0.0.0'
 c.NotebookApp.port = 8000
 c.NotebookApp.open_browser = False
 

--- a/src/main/resources/jupyter/jupyter_notebook_config.py
+++ b/src/main/resources/jupyter/jupyter_notebook_config.py
@@ -39,7 +39,7 @@ c.NotebookApp.nbserver_extensions = {
 mgr_class = 'DelocalizingContentsManager'
 if os.environ['WELDER_ENABLE'] == 'true':
   mgr_class = 'WelderContentsManager'
-c.NotebookApp.contents_manager_class = 'jupyter_delocalize.' + mg_class
+c.NotebookApp.contents_manager_class = 'jupyter_delocalize.' + mgr_class
 
 # Unset Content-Security-Policy so Jupyter can be rendered in an iframe
 # See https://jupyter-notebook.readthedocs.io/en/latest/public_server.html?highlight=server#embedding-the-notebook-in-another-website


### PR DESCRIPTION
Proof-of-concept local development setup for Jupyter + Welder.

Usage:

```
# One-time setup
gcloud auth application-default login
chmod a+r ~/.config/gcloud/application_default_credentials.json # Not ideal, should find a better workaround

# Local welder changes
welder$ sbt server/docker:publishLocal

docker/local/run.sh

# Make changes to Jupyter extension.
docker/local/run.sh
```

Limitations:
- Does not simulate the proxy; this could be added via an nginx docker service
- Does not run the Leo init-actions script
- Does not currently allow hot reload of Welder or Jupyter extensions
- Currently uses the "latest" Welder label to pickup local builds, would be better to use an explicit local tag.
- Need to expand ACLs on ADC JSON file (can probably find another workaround for this).
- Having some issues with Kernels locally - possible a websocket issue