### PR TITLE
Minimal cluster query for clearing kernelFoundBusyDate

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponent.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponent.scala
@@ -362,7 +362,7 @@ trait ClusterComponent extends LeoComponent {
     }
 
     def clearKernelFoundBusyDateByProjectAndName(googleProject: GoogleProject, clusterName: ClusterName): DBIO[Int] = {
-      clusterQuery.getActiveClusterByName(googleProject, clusterName) flatMap {
+      clusterQuery.getActiveClusterByNameMinimal(googleProject, clusterName) flatMap {
         case Some(c) => clusterQuery.clearKernelFoundBusyDate(c.id)
         case None => DBIO.successful(0)
       }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponent.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponent.scala
@@ -347,7 +347,7 @@ trait ClusterComponent extends LeoComponent {
     }
 
     def updateDateAccessedByProjectAndName(googleProject: GoogleProject, clusterName: ClusterName, dateAccessed: Instant): DBIO[Int] = {
-      clusterQuery.getActiveClusterByName(googleProject, clusterName) flatMap {
+      clusterQuery.getActiveClusterByNameMinimal(googleProject, clusterName) flatMap {
         case Some(c) => clusterQuery.updateDateAccessed(c.id, dateAccessed)
         case None => DBIO.successful(0)
       }


### PR DESCRIPTION
Small PR to use a minimal cluster query to avoid unnecessary left joins. 

Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
