### PR TITLE
Change ZombieClusterMonitor to mark clusters Deleted instead of Error

### DIFF
--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ZombieClusterMonitorSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ZombieClusterMonitorSpec.scala
@@ -51,7 +51,8 @@ class ZombieClusterMonitorSpec extends TestKit(ActorSystem("leonardotest")) with
         val c2 = dbFutureValue { _.clusterQuery.getClusterById(savedTestCluster2.id) }.get
 
         List(c1, c2).foreach { c =>
-          c.status shouldBe ClusterStatus.Error
+          c.status shouldBe ClusterStatus.Deleted
+          c.auditInfo.destroyedDate shouldBe 'defined
           c.errors.size shouldBe 1
           c.errors.head.errorCode shouldBe -1
           c.errors.head.errorMessage should include ("An underlying resource was removed in Google")
@@ -82,7 +83,8 @@ class ZombieClusterMonitorSpec extends TestKit(ActorSystem("leonardotest")) with
         val c2 = dbFutureValue { _.clusterQuery.getClusterById(savedTestCluster2.id) }.get
 
         List(c1, c2).foreach { c =>
-          c.status shouldBe ClusterStatus.Error
+          c.status shouldBe ClusterStatus.Deleted
+          c.auditInfo.destroyedDate shouldBe 'defined
           c.errors.size shouldBe 1
           c.errors.head.errorCode shouldBe -1
           c.errors.head.errorMessage should include ("An underlying resource was removed in Google")
@@ -120,7 +122,8 @@ class ZombieClusterMonitorSpec extends TestKit(ActorSystem("leonardotest")) with
         val c1 = dbFutureValue { _.clusterQuery.getClusterById(savedTestCluster1.id) }.get
         val c2 = dbFutureValue { _.clusterQuery.getClusterById(savedTestCluster2.id) }.get
 
-        c2.status shouldBe ClusterStatus.Error
+        c2.status shouldBe ClusterStatus.Deleted
+        c2.auditInfo.destroyedDate shouldBe 'defined
         c2.errors.size shouldBe 1
         c2.errors.head.errorCode shouldBe -1
         c2.errors.head.errorMessage should include ("An underlying resource was removed in Google")
@@ -156,12 +159,14 @@ class ZombieClusterMonitorSpec extends TestKit(ActorSystem("leonardotest")) with
         val c1 = dbFutureValue { _.clusterQuery.getClusterById(savedTestCluster1.id) }.get
         val c2 = dbFutureValue { _.clusterQuery.getClusterById(savedTestCluster2.id) }.get
 
-        c1.status shouldBe ClusterStatus.Error
+        c1.status shouldBe ClusterStatus.Deleted
+        c1.auditInfo.destroyedDate shouldBe 'defined
         c1.errors.size shouldBe 1
         c1.errors.head.errorCode shouldBe -1
         c1.errors.head.errorMessage should include ("An underlying resource was removed in Google")
 
-        c2.status shouldBe ClusterStatus.Error
+        c2.status shouldBe ClusterStatus.Deleted
+        c2.auditInfo.destroyedDate shouldBe 'defined
         c2.errors.size shouldBe 1
         c2.errors.head.errorCode shouldBe -1
         c2.errors.head.errorMessage should include ("An underlying resource was removed in Google")
@@ -247,7 +252,8 @@ class ZombieClusterMonitorSpec extends TestKit(ActorSystem("leonardotest")) with
         c2.status shouldBe ClusterStatus.Running
         c2.errors shouldBe 'empty
 
-        c3.status shouldBe ClusterStatus.Error
+        c3.status shouldBe ClusterStatus.Deleted
+        c3.auditInfo.destroyedDate shouldBe 'defined
         c3.errors.size shouldBe 1
         c3.errors.head.errorCode shouldBe -1
         c3.errors.head.errorMessage should include ("An underlying resource was removed in Google")


### PR DESCRIPTION
This came from a conversation with @bradtaylor, @tmm211, and @sharmatime.

Leo has functionality to detect clusters that are active in Leo (meaning running or paused) but do not exist in Google. We call these "zombie" clusters. Our current behavior when we detect a zombie cluster is to set it to `Error` status and persist a specific error message.

However now that I'm thinking about it this situation is not really an error. It might be better to just set the clusters to `Deleted` in Leo to reconcile the state between Google <--> Leo.

This came up because we've run a cleanup script in the past to delete Google clusters that were mistakenly autogenerated by Terra. Now users are seeing error messages for old deleted clusters. See JIRA: https://broadworkbench.atlassian.net/browse/SUP-20. As part of this change I'd also like to run a DB migration to delete old clusters in this zombie state.

Let me know what you think.

Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
