### PR TITLE
Don't caps-lock Playground Mode

### DIFF
--- a/src/main/resources/jupyter/edit-mode.js
+++ b/src/main/resources/jupyter/edit-mode.js
@@ -367,7 +367,7 @@ define(() => {
             toolTipText = "<p>You have locked this file for editing and your changes are being automatically saved to the workspace.</p>"
             bannerStyling = "notification_widget " + baseStyling;
         } else {
-            bannerText = "PLAYGROUND MODE (Edits not saved)"
+            bannerText = "Playground Mode (Edits not saved)"
             toolTipText = "<p>Playground mode allows you to explore, change, and run the code, but your changes will not be saved to the workspace.</p>"
             bannerStyling = "btn-warning " + baseStyling
         }


### PR DESCRIPTION
This makes it consistent with edit mode.

Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
