### PR TITLE
Use third-person language in REMOTE_DELETED modal

### DIFF
--- a/src/main/resources/jupyter/edit-mode.js
+++ b/src/main/resources/jupyter/edit-mode.js
@@ -51,7 +51,7 @@ define(() => {
     const lockConflictTitle = "File is in use"
     const syncIssueTitle = "File versions out of sync"
     const syncIssueBody = "Your version of this file does not match the version in the workspace. What would you like to do?"
-    const syncIssueNotFoundBody = "This file was either deleted or never was stored with us."
+    const syncIssueNotFoundBody = "This file was either deleted from or was never saved to the workspace."
 
     //URLS for leo deployment
     const leoUrl = '' //we are choosing to use a relative path here


### PR DESCRIPTION

Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've documented my API changes in Swagger

In all cases:

- [x] Get a thumbsworth of review and PO signoff if necessary
- [x] Verify all tests go green
- [x] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
