### PR TITLE
[Auto tests] Save welder.log file for debugging

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
@@ -87,7 +87,7 @@ trait LeonardoTestUtils extends WebBrowserSpec with Matchers with Eventually wit
       Try {
         val contentItem = Notebook.getContentItem(googleProject, clusterName, path, includeContent = true)
         val content = contentItem.content.getOrElse(throw new RuntimeException(s"Could not download ${path} for cluster ${googleProject.value}/${clusterName.string}"))
-        val downloadFile = new File(logDir, s"${googleProject.value}-${clusterName.string}-$suffix-${path}.log")
+        val downloadFile = new File(logDir, s"${googleProject.value}-${clusterName.string}-$suffix-${path}")
         val fos = new FileOutputStream(downloadFile)
         fos.write(content.getBytes(StandardCharsets.UTF_8))
         fos.close()

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
@@ -85,9 +85,9 @@ trait LeonardoTestUtils extends WebBrowserSpec with Matchers with Eventually wit
   def saveClusterLogFiles(googleProject: GoogleProject, clusterName: ClusterName, paths: List[String], suffix: String)(implicit token: AuthToken): Unit = {
     val fileResult = paths.traverse[Try, File] { path =>
       Try {
-        val jupyterLogOpt = Notebook.getContentItem(googleProject, clusterName, path, includeContent = true)
-        val content = jupyterLogOpt.content.getOrElse(throw new RuntimeException(s"Could not download ${path} for cluster ${googleProject.value}/${clusterName.string}"))
-        val downloadFile = new File(logDir, s"${googleProject.value}-${clusterName.string}-$suffix-jupyter.log")
+        val contentItem = Notebook.getContentItem(googleProject, clusterName, path, includeContent = true)
+        val content = contentItem.content.getOrElse(throw new RuntimeException(s"Could not download ${path} for cluster ${googleProject.value}/${clusterName.string}"))
+        val downloadFile = new File(logDir, s"${googleProject.value}-${clusterName.string}-$suffix-${path}.log")
         val fos = new FileOutputStream(downloadFile)
         fos.write(content.getBytes(StandardCharsets.UTF_8))
         fos.close()

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
@@ -82,15 +82,23 @@ trait LeonardoTestUtils extends WebBrowserSpec with Matchers with Eventually wit
   val google2StorageResource = GoogleStorageService.resource[IO](LeonardoConfig.GCS.pathToQAJson)
 
   // TODO: move this to NotebookTestUtils and chance cluster-specific functions to only call if necessary after implementing RStudio
-  def saveJupyterLogFile(clusterName: ClusterName, googleProject: GoogleProject, suffix: String)(implicit token: AuthToken): Try[File] = {
-    Try {
-      val jupyterLogOpt = Notebook.getContentItem(googleProject, clusterName, "jupyter.log", includeContent = true)
-      val content = jupyterLogOpt.content.getOrElse(throw new RuntimeException(s"Could not download jupyter.log for cluster ${googleProject.value}/${clusterName.string}"))
-      val downloadFile = new File(logDir, s"${googleProject.value}-${clusterName.string}-$suffix-jupyter.log")
-      val fos = new FileOutputStream(downloadFile)
-      fos.write(content.getBytes(StandardCharsets.UTF_8))
-      fos.close()
-      downloadFile
+  def saveClusterLogFiles(googleProject: GoogleProject, clusterName: ClusterName, paths: List[String], suffix: String)(implicit token: AuthToken): Unit = {
+    val fileResult = paths.traverse[Try, File] { path =>
+      Try {
+        val jupyterLogOpt = Notebook.getContentItem(googleProject, clusterName, path, includeContent = true)
+        val content = jupyterLogOpt.content.getOrElse(throw new RuntimeException(s"Could not download ${path} for cluster ${googleProject.value}/${clusterName.string}"))
+        val downloadFile = new File(logDir, s"${googleProject.value}-${clusterName.string}-$suffix-jupyter.log")
+        val fos = new FileOutputStream(downloadFile)
+        fos.write(content.getBytes(StandardCharsets.UTF_8))
+        fos.close()
+        downloadFile
+      }
+    }
+    fileResult match {
+      case Success(files) =>
+        logger.info(s"Saved files [${files.map(_.getName).mkString(", ")}] for cluster ${googleProject.value}/${clusterName.string}")
+      case Failure(e) =>
+        logger.warn(s"Could not save files for cluster ${googleProject.value}/${clusterName.string} . Not failing test.", e)
     }
   }
 
@@ -218,15 +226,10 @@ trait LeonardoTestUtils extends WebBrowserSpec with Matchers with Eventually wit
         logger.warn(s"Could not obtain Dataproc log files for cluster ${creatingCluster.projectNameString}")
     }
 
-    // If the cluster is running, grab the jupyter.log file for debugging.
+    // If the cluster is running, grab the jupyter.log and welder.log files for debugging.
     runningOrErroredCluster.foreach { cluster =>
       if (cluster.status == ClusterStatus.Running) {
-        saveJupyterLogFile(cluster.clusterName, cluster.googleProject, "create") match {
-          case Success(file) =>
-            logger.info(s"Saved jupyter.log file for cluster ${cluster.projectNameString} to ${file.getAbsolutePath}")
-          case Failure(e) =>
-            logger.warn(s"Could not save jupyter.log file for cluster ${cluster.projectNameString} . Not failing test.", e)
-        }
+        saveClusterLogFiles(cluster.googleProject, cluster.clusterName, List("jupyter.log", "welder.log"), "create")
       }
     }
 
@@ -239,12 +242,7 @@ trait LeonardoTestUtils extends WebBrowserSpec with Matchers with Eventually wit
   }
 
   def deleteCluster(googleProject: GoogleProject, clusterName: ClusterName, monitor: Boolean)(implicit token: AuthToken): Unit = {
-    saveJupyterLogFile(clusterName, googleProject, "delete") match {
-      case Success(file) =>
-        logger.info(s"Saved jupyter.log file for cluster ${googleProject.value}/${clusterName.string} to ${file.getAbsolutePath}")
-      case Failure(e) =>
-        logger.warn(s"Could not save jupyter.log file for cluster ${googleProject.value}/${clusterName.string} . Not failing test.", e)
-    }
+    saveClusterLogFiles(googleProject, clusterName, List("jupyter.log", "welder.log"), "delete")
     try {
       Leonardo.cluster.delete(googleProject, clusterName) shouldBe
         "The request has been accepted for processing, but the processing has not been completed."
@@ -336,13 +334,8 @@ trait LeonardoTestUtils extends WebBrowserSpec with Matchers with Eventually wit
       getResult.isSuccess shouldBe true
       getResult.get should not include "ProxyException"
 
-      // Grab the jupyter.log file for debugging.
-      saveJupyterLogFile(startingCluster.clusterName, startingCluster.googleProject, "start") match {
-        case Success(file) =>
-          logger.info(s"Saved jupyter.log file for cluster ${startingCluster.projectNameString} to ${file.getAbsolutePath}")
-        case Failure(e) =>
-          logger.warn(s"Could not save jupyter.log file for cluster ${startingCluster.projectNameString} . Not failing test.", e)
-      }
+      // Grab the jupyter.log and welder.log files for debugging.
+      saveClusterLogFiles(googleProject, clusterName, List("jupyter.log", "welder.log"), "start")
     }
   }
 

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookTestUtils.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookTestUtils.scala
@@ -20,6 +20,7 @@ import org.openqa.selenium.WebDriver
 import org.scalatest.Suite
 
 import scala.concurrent._
+import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 import scala.language.postfixOps
 import scala.util.{Failure, Success, Try}
@@ -91,7 +92,6 @@ trait NotebookTestUtils extends LeonardoTestUtils {
     }
   }
 
-  implicit val ec: ExecutionContextExecutor = ExecutionContext.global
   def withNewNotebook[T](cluster: Cluster, kernel: NotebookKernel = Python3, timeout: FiniteDuration = 2.minutes)(testCode: NotebookPage => T)(implicit webDriver: WebDriver, token: AuthToken): T = {
     withNotebooksListPage(cluster) { notebooksListPage =>
       val result: Future[T] = retryUntilSuccessOrTimeout(whenKernelNotReady, failureLogMessage = s"Cannot make new notebook")(30 seconds, 2 minutes) {() =>

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookTestUtils.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookTestUtils.scala
@@ -19,8 +19,6 @@ import org.broadinstitute.dsde.workbench.service.Sam
 import org.openqa.selenium.WebDriver
 import org.scalatest.Suite
 
-import scala.concurrent._
-import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 import scala.language.postfixOps
 import scala.util.{Failure, Success, Try}
@@ -94,12 +92,9 @@ trait NotebookTestUtils extends LeonardoTestUtils {
 
   def withNewNotebook[T](cluster: Cluster, kernel: NotebookKernel = Python3, timeout: FiniteDuration = 2.minutes)(testCode: NotebookPage => T)(implicit webDriver: WebDriver, token: AuthToken): T = {
     withNotebooksListPage(cluster) { notebooksListPage =>
-      val result: Future[T] = retryUntilSuccessOrTimeout(whenKernelNotReady, failureLogMessage = s"Cannot make new notebook")(30 seconds, 2 minutes) {() =>
-        Future(notebooksListPage.withNewNotebook(kernel, timeout) { notebookPage =>
-          testCode(notebookPage)
-        })
+      notebooksListPage.withNewNotebook(kernel, timeout) { notebookPage =>
+        testCode(notebookPage)
       }
-      Await.result(result, 10 minutes)
     }
   }
 


### PR DESCRIPTION
In trying to debug [this issue](https://broadworkbench.atlassian.net/browse/IA-1228), it would be helpful to save the welder.log file in the test for debugging.

Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
