### PR TITLE
[IA-1228] Dismiss 'notebook changed' modal

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookPage.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookPage.scala
@@ -341,6 +341,16 @@ class NotebookPage(override val url: String)(override implicit val authToken: Au
     click on getSelectorFrom(lockPlaygroundButton)
   }
 
+  /**
+    * In some situations Jupyter UI will display a "Notebook changed" modal if it detects
+    * the Jupyter last save date is out of sync with the filesystem last_modified timestamp.
+    *
+    * It's unclear why it sporadically happens in tests. It's not reproducible manually. This
+    * is a big hammer approach to dismiss the modal when it comes up. It resolves the issue,
+    * but we risk hiding a potentially legitimate bug.
+    *
+    * See https://broadworkbench.atlassian.net/browse/IA-1228
+    */
   def dismissNotebookChanged(): Unit = {
     if (find(modalNotebookChanged).exists(_.text == "Notebook changed")) {
       click on confirmNotebookSaveButton

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookTestUtils.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookTestUtils.scala
@@ -84,6 +84,7 @@ trait NotebookTestUtils extends LeonardoTestUtils {
 
   def withNotebookUpload[T](cluster: Cluster, file: File, timeout: FiniteDuration = 2.minutes)(testCode: NotebookPage => T)(implicit webDriver: WebDriver, token: AuthToken): T = {
     withFileUpload(cluster, file) { notebooksListPage =>
+      logger.info(s"Opening notebook ${file.getAbsolutePath} notebook on cluster ${cluster.googleProject.value} / ${cluster.clusterName.string}...")
       notebooksListPage.withOpenNotebook(file, timeout) { notebookPage =>
         testCode(notebookPage)
       }
@@ -92,6 +93,7 @@ trait NotebookTestUtils extends LeonardoTestUtils {
 
   def withNewNotebook[T](cluster: Cluster, kernel: NotebookKernel = Python3, timeout: FiniteDuration = 2.minutes)(testCode: NotebookPage => T)(implicit webDriver: WebDriver, token: AuthToken): T = {
     withNotebooksListPage(cluster) { notebooksListPage =>
+      logger.info(s"Creating new ${kernel.string} notebook on cluster ${cluster.googleProject.value} / ${cluster.clusterName.string}...")
       notebooksListPage.withNewNotebook(kernel, timeout) { notebookPage =>
         testCode(notebookPage)
       }
@@ -100,6 +102,7 @@ trait NotebookTestUtils extends LeonardoTestUtils {
 
   def withOpenNotebook[T](cluster: Cluster, notebookPath: File, timeout: FiniteDuration = 2.minutes)(testCode: NotebookPage => T)(implicit webDriver: WebDriver, token: AuthToken): T = {
     withNotebooksListPage(cluster) { notebooksListPage =>
+      logger.info(s"Opening notebook ${notebookPath.getAbsolutePath} notebook on cluster ${cluster.googleProject.value} / ${cluster.clusterName.string}...")
       notebooksListPage.withOpenNotebook(notebookPath, timeout) { notebookPage =>
         testCode(notebookPage)
       }


### PR DESCRIPTION
Note: I don't love this solution. I'm trying to address this intermittent issue in automation tests:

![image](https://user-images.githubusercontent.com/5368863/62262432-a266b200-b3e6-11e9-9ef1-eec76c51f834.png)

It's happening because the filesystem last_modified timestamp is sometimes a few seconds _after_ the notebook creation timestamp. Jupyter displays this modal if there is a diff of more than 500ms.

I am not sure why the timestamps are different. I can't seem to reproduce it when manually going through the same steps as the tests. It could be a clock sync issue -- or it could be the docker shared volume is messing with file mtimes somehow. Not sure.

This PR makes the tests resilient to this situation by dismissing the modal. If this were a true product issue I'd be hesitant to fixing the tests like this -- but given it's not reproducible (and we've had no user complaints) I'm ok with this change.

I did verify manually that the new selenium logic does the right thing.


Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
