### PR TITLE
[EARLY] [IA-1226] Add toc to test data syncing notebooks

### DIFF
--- a/automation/src/test/resources/bucket-tests/gcsFile.ipynb
+++ b/automation/src/test/resources/bucket-tests/gcsFile.ipynb
@@ -44,6 +44,19 @@
       "nbconvert_exporter": "python",
       "pygments_lexer": "ipython3",
       "version": "3.7.3"
+    },
+    "toc": {
+      "base_numbering": 1,
+      "nav_menu": {},
+      "number_sections": true,
+      "sideBar": true,
+      "skip_h1_title": false,
+      "title_cell": "Table of Contents",
+      "title_sidebar": "Contents",
+      "toc_cell": false,
+      "toc_position": {},
+      "toc_section_display": true,
+      "toc_window_display": false
     }
   },
   "nbformat": 4,

--- a/automation/src/test/resources/bucket-tests/gcsFile2.ipynb
+++ b/automation/src/test/resources/bucket-tests/gcsFile2.ipynb
@@ -44,6 +44,19 @@
       "nbconvert_exporter": "python",
       "pygments_lexer": "ipython3",
       "version": "3.7.3"
+    },
+    "toc": {
+      "base_numbering": 1,
+      "nav_menu": {},
+      "number_sections": true,
+      "sideBar": true,
+      "skip_h1_title": false,
+      "title_cell": "Table of Contents",
+      "title_sidebar": "Contents",
+      "toc_cell": false,
+      "toc_position": {},
+      "toc_section_display": true,
+      "toc_window_display": false
     }
   },
   "nbformat": 4,

--- a/automation/src/test/resources/bucket-tests/gcsFile3.ipynb
+++ b/automation/src/test/resources/bucket-tests/gcsFile3.ipynb
@@ -44,6 +44,19 @@
       "nbconvert_exporter": "python",
       "pygments_lexer": "ipython3",
       "version": "3.7.3"
+    },
+    "toc": {
+      "base_numbering": 1,
+      "nav_menu": {},
+      "number_sections": true,
+      "sideBar": true,
+      "skip_h1_title": false,
+      "title_cell": "Table of Contents",
+      "title_sidebar": "Contents",
+      "toc_cell": false,
+      "toc_position": {},
+      "toc_section_display": true,
+      "toc_window_display": false
     }
   },
   "nbformat": 4,

--- a/automation/src/test/resources/bucket-tests/gcsFile4.ipynb
+++ b/automation/src/test/resources/bucket-tests/gcsFile4.ipynb
@@ -44,6 +44,19 @@
       "nbconvert_exporter": "python",
       "pygments_lexer": "ipython3",
       "version": "3.7.3"
+    },
+    "toc": {
+      "base_numbering": 1,
+      "nav_menu": {},
+      "number_sections": true,
+      "sideBar": true,
+      "skip_h1_title": false,
+      "title_cell": "Table of Contents",
+      "title_sidebar": "Contents",
+      "toc_cell": false,
+      "toc_position": {},
+      "toc_section_display": true,
+      "toc_window_display": false
     }
   },
   "nbformat": 4,


### PR DESCRIPTION
Not tested yet. I think the [file size assertions](https://github.com/DataBiosphere/leonardo/blob/develop/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookDataSyncingSpec.scala#L97) in `NotebookDataSyncingSpec` are subject to a race condition, because Jupyter UI adds `toc` metadata when notebooks are loaded. This PR makes it so the `toc` metadata is already in GCS, so hopefully there is no more race condition.

Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
