### PR TITLE
Use different sbt baseimage for Dockerfile-tests

### DIFF
--- a/automation/Dockerfile-tests
+++ b/automation/Dockerfile-tests
@@ -1,6 +1,4 @@
-FROM hseeberger/scala-sbt:8u212_1.2.8_2.12.8
-
-RUN mkdir /app
+FROM bigtruedata/sbt
 
 COPY src /app/src
 COPY test.sh /app

--- a/automation/Dockerfile-tests
+++ b/automation/Dockerfile-tests
@@ -1,4 +1,4 @@
-FROM hseeberger/scala-sbt
+FROM hseeberger/scala-sbt:8u212_1.2.8_2.12.8
 
 RUN mkdir /app
 

--- a/docker/jupyter/Dockerfile
+++ b/docker/jupyter/Dockerfile
@@ -271,6 +271,7 @@ RUN apt-get update \
  && python3 -mpip install matplotlib==3.0.0 \
  && pip3 install pandas==0.23.4 \
  && pip3 install seaborn==0.9.0 \
+ && pip3 install notebook==5.7.8 \
  && pip3 install jupyter==1.0.0 \
  && pip3 install jupyterlab==0.35.4 \
  && pip3 install python-lzo==1.12 \


### PR DESCRIPTION
Leo builds are failing to build the `Dockerfile-tests` image with:

```
Step 1/8 : FROM hseeberger/scala-sbt
manifest for hseeberger/scala-sbt:latest not found
```
See: https://fc-jenkins.dsp-techops.broadinstitute.org/job/leonardo-build/4812/

This also happens locally if I `docker pull hseeberger/scala-sbt`. Apparently as of today this image no longer has a `latest` tag. See: https://github.com/hseeberger/scala-sbt/issues/76.

I just switched to `bigtruedata/sbt` which is what Rawls and Sam tests use as a base:
https://github.com/broadinstitute/sam/blob/develop/automation/Dockerfile-tests#L1
https://github.com/broadinstitute/rawls/blob/develop/automation/Dockerfile-tests#L1

It seems to work :)

Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
