### PR TITLE
Make data syncing notebooks consistent with what Jupyter saves

### DIFF
--- a/automation/src/test/resources/bucket-tests/gcsFile.ipynb
+++ b/automation/src/test/resources/bucket-tests/gcsFile.ipynb
@@ -1,64 +1,66 @@
 {
-  "cells": [
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "pycharm": {}
+   },
+   "outputs": [
     {
-      "cell_type": "code",
-      "execution_count": 1,
-      "metadata": {
-        "pycharm": {}
-      },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "test file\n"
-          ]
-        }
-      ],
-      "source": "print(\"test file\")"
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "pycharm": {}
-      },
-      "outputs": [],
-      "source": []
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "test file\n"
+     ]
     }
-  ],
-  "metadata": {
-    "kernelspec": {
-      "display_name": "Python 3",
-      "language": "python",
-      "name": "python3"
-    },
-    "language_info": {
-      "codemirror_mode": {
-        "name": "ipython",
-        "version": 3
-      },
-      "file_extension": ".py",
-      "mimetype": "text/x-python",
-      "name": "python",
-      "nbconvert_exporter": "python",
-      "pygments_lexer": "ipython3",
-      "version": "3.7.3"
-    },
-    "toc": {
-      "base_numbering": 1,
-      "nav_menu": {},
-      "number_sections": true,
-      "sideBar": true,
-      "skip_h1_title": false,
-      "title_cell": "Table of Contents",
-      "title_sidebar": "Contents",
-      "toc_cell": false,
-      "toc_position": {},
-      "toc_section_display": true,
-      "toc_window_display": false
-    }
+   ],
+   "source": [
+    "print(\"test file\")"
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 2
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "pycharm": {}
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.8"
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": true,
+   "sideBar": true,
+   "skip_h1_title": false,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": false,
+   "toc_position": {},
+   "toc_section_display": true,
+   "toc_window_display": false
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
 }

--- a/automation/src/test/resources/bucket-tests/gcsFile2.ipynb
+++ b/automation/src/test/resources/bucket-tests/gcsFile2.ipynb
@@ -1,64 +1,66 @@
 {
-  "cells": [
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "pycharm": {}
+   },
+   "outputs": [
     {
-      "cell_type": "code",
-      "execution_count": 1,
-      "metadata": {
-        "pycharm": {}
-      },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "test file\n"
-          ]
-        }
-      ],
-      "source": "print(\"test file\")"
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "pycharm": {}
-      },
-      "outputs": [],
-      "source": []
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "test file\n"
+     ]
     }
-  ],
-  "metadata": {
-    "kernelspec": {
-      "display_name": "Python 3",
-      "language": "python",
-      "name": "python3"
-    },
-    "language_info": {
-      "codemirror_mode": {
-        "name": "ipython",
-        "version": 3
-      },
-      "file_extension": ".py",
-      "mimetype": "text/x-python",
-      "name": "python",
-      "nbconvert_exporter": "python",
-      "pygments_lexer": "ipython3",
-      "version": "3.7.3"
-    },
-    "toc": {
-      "base_numbering": 1,
-      "nav_menu": {},
-      "number_sections": true,
-      "sideBar": true,
-      "skip_h1_title": false,
-      "title_cell": "Table of Contents",
-      "title_sidebar": "Contents",
-      "toc_cell": false,
-      "toc_position": {},
-      "toc_section_display": true,
-      "toc_window_display": false
-    }
+   ],
+   "source": [
+    "print(\"test file\")"
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 2
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "pycharm": {}
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.8"
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": true,
+   "sideBar": true,
+   "skip_h1_title": false,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": false,
+   "toc_position": {},
+   "toc_section_display": true,
+   "toc_window_display": false
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
 }

--- a/automation/src/test/resources/bucket-tests/gcsFile3.ipynb
+++ b/automation/src/test/resources/bucket-tests/gcsFile3.ipynb
@@ -1,64 +1,66 @@
 {
-  "cells": [
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "pycharm": {}
+   },
+   "outputs": [
     {
-      "cell_type": "code",
-      "execution_count": 1,
-      "metadata": {
-        "pycharm": {}
-      },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "test file\n"
-          ]
-        }
-      ],
-      "source": "print(\"test file\")"
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "pycharm": {}
-      },
-      "outputs": [],
-      "source": []
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "test file\n"
+     ]
     }
-  ],
-  "metadata": {
-    "kernelspec": {
-      "display_name": "Python 3",
-      "language": "python",
-      "name": "python3"
-    },
-    "language_info": {
-      "codemirror_mode": {
-        "name": "ipython",
-        "version": 3
-      },
-      "file_extension": ".py",
-      "mimetype": "text/x-python",
-      "name": "python",
-      "nbconvert_exporter": "python",
-      "pygments_lexer": "ipython3",
-      "version": "3.7.3"
-    },
-    "toc": {
-      "base_numbering": 1,
-      "nav_menu": {},
-      "number_sections": true,
-      "sideBar": true,
-      "skip_h1_title": false,
-      "title_cell": "Table of Contents",
-      "title_sidebar": "Contents",
-      "toc_cell": false,
-      "toc_position": {},
-      "toc_section_display": true,
-      "toc_window_display": false
-    }
+   ],
+   "source": [
+    "print(\"test file\")"
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 2
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "pycharm": {}
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.8"
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": true,
+   "sideBar": true,
+   "skip_h1_title": false,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": false,
+   "toc_position": {},
+   "toc_section_display": true,
+   "toc_window_display": false
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
 }

--- a/automation/src/test/resources/bucket-tests/gcsFile4.ipynb
+++ b/automation/src/test/resources/bucket-tests/gcsFile4.ipynb
@@ -1,64 +1,66 @@
 {
-  "cells": [
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "pycharm": {}
+   },
+   "outputs": [
     {
-      "cell_type": "code",
-      "execution_count": 1,
-      "metadata": {
-        "pycharm": {}
-      },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "test file\n"
-          ]
-        }
-      ],
-      "source": "print(\"test file\")"
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "pycharm": {}
-      },
-      "outputs": [],
-      "source": []
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "test file\n"
+     ]
     }
-  ],
-  "metadata": {
-    "kernelspec": {
-      "display_name": "Python 3",
-      "language": "python",
-      "name": "python3"
-    },
-    "language_info": {
-      "codemirror_mode": {
-        "name": "ipython",
-        "version": 3
-      },
-      "file_extension": ".py",
-      "mimetype": "text/x-python",
-      "name": "python",
-      "nbconvert_exporter": "python",
-      "pygments_lexer": "ipython3",
-      "version": "3.7.3"
-    },
-    "toc": {
-      "base_numbering": 1,
-      "nav_menu": {},
-      "number_sections": true,
-      "sideBar": true,
-      "skip_h1_title": false,
-      "title_cell": "Table of Contents",
-      "title_sidebar": "Contents",
-      "toc_cell": false,
-      "toc_position": {},
-      "toc_section_display": true,
-      "toc_window_display": false
-    }
+   ],
+   "source": [
+    "print(\"test file\")"
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 2
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "pycharm": {}
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.8"
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": true,
+   "sideBar": true,
+   "skip_h1_title": false,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": false,
+   "toc_position": {},
+   "toc_section_display": true,
+   "toc_window_display": false
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
 }


### PR DESCRIPTION
Still seeing some intermittent test failures:
```
[info] - open notebook in playground mode should work *** FAILED *** (17 seconds, 786 milliseconds)
[info]   1333 was not equal to 1164 (NotebookDataSyncingSpec.scala:97)
[info]   org.scalatest.exceptions.TestFailedException:
[info]   at org.scalatest.MatchersHelper$.indicateFailure(MatchersHelper.scala:346)
[info]   at org.scalatest.Matchers$AnyShouldWrapper.shouldBe(Matchers.scala:6864)
[info]   at org.broadinstitute.dsde.workbench.leonardo.notebooks.NotebookDataSyncingSpec.$anonfun$new$14(NotebookDataSyncingSpec.scala:97)
[info]   at org.broadinstitute.dsde.workbench.leonardo.notebooks.NotebookTestUtils.$anonfun$withOpenNotebook$2(NotebookTestUtils.scala:114)
[info]   at org.broadinstitute.dsde.workbench.leonardo.notebooks.NotebooksListPage.$anonfun$withOpenNotebook$1(NotebooksListPage.scala:64)
[info]   at scala.util.Try$.apply(Try.scala:213)
[info]   at org.broadinstitute.dsde.workbench.leonardo.notebooks.NotebooksListPage.withOpenNotebook(NotebooksListPage.scala:64)
[info]   at org.broadinstitute.dsde.workbench.leonardo.notebooks.NotebookTestUtils.$anonfun$withOpenNotebook$1(NotebookTestUtils.scala:113)
[info]   at org.broadinstitute.dsde.workbench.leonardo.notebooks.NotebookTestUtils.withNotebooksListPage(NotebookTestUtils.scala:76)
[info]   at org.broadinstitute.dsde.workbench.leonardo.notebooks.NotebookTestUtils.withNotebooksListPage$(NotebookTestUtils.scala:74)
[info]   at org.broadinstitute.dsde.workbench.leonardo.notebooks.NotebookDataSyncingSpec.withNotebooksListPage(NotebookDataSyncingSpec.scala:23)
[info]   at org.broadinstitute.dsde.workbench.leonardo.notebooks.NotebookTestUtils.withOpenNotebook(NotebookTestUtils.scala:111)
[info]   at org.broadinstitute.dsde.workbench.leonardo.notebooks.NotebookTestUtils.withOpenNotebook$(NotebookTestUtils.scala:110)
[info]   at org.broadinstitute.dsde.workbench.leonardo.notebooks.NotebookDataSyncingSpec.withOpenNotebook(NotebookDataSyncingSpec.scala:23)
[info]   at org.broadinstitute.dsde.workbench.leonardo.notebooks.NotebookDataSyncingSpec.$anonfun$new$13(NotebookDataSyncingSpec.scala:87)
```

For `NotebookDataSyncingSpec` I think there are still slight discrepancies between the notebook contents in the bucket and what Jupyter transforms it to (when it autosaves). Hoping this fixes it.

Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
