### PR TITLE
[IA-1255] Update jackson version due to SourceClear-reported vulnerabilities

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ import sbt._
 object Dependencies {
   val akkaV         = "2.5.22"
   val akkaHttpV     = "10.1.8"
-  val jacksonV      = "2.9.8"
+  val jacksonV      = "2.9.9.2"
   val googleV       = "1.23.0"
   val scalaLoggingV = "3.9.0"
   val scalaTestV    = "3.0.5"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,8 @@ import sbt._
 object Dependencies {
   val akkaV         = "2.5.22"
   val akkaHttpV     = "10.1.8"
-  val jacksonV      = "2.9.9.2"
+  val jacksonV      = "2.9.9"
+  val jacksonDatabindV = "2.9.9.2"  // jackson-databind has a security patch on the 2.9.9 branch
   val googleV       = "1.23.0"
   val scalaLoggingV = "3.9.0"
   val scalaTestV    = "3.0.5"
@@ -43,7 +44,7 @@ object Dependencies {
   val excludeReactiveStream     = ExclusionRule(organization = "org.reactivestreams", name = "reactive-streams")
 
   val jacksonAnnotations: ModuleID = "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonV
-  val jacksonDatabind: ModuleID =    "com.fasterxml.jackson.core" % "jackson-databind"    % jacksonV excludeAll(excludeJacksonAnnotation)
+  val jacksonDatabind: ModuleID =    "com.fasterxml.jackson.core" % "jackson-databind"    % jacksonDatabindV excludeAll(excludeJacksonAnnotation)
   val jacksonCore: ModuleID =        "com.fasterxml.jackson.core" % "jackson-core"        % jacksonV
 
   val logbackClassic: ModuleID = "ch.qos.logback"             %  "logback-classic" % "1.2.3"


### PR DESCRIPTION
JIRA:
https://broadworkbench.atlassian.net/browse/IA-1255

SourceClear:
https://broadinstitute-dsp.sourceclear.io/workspaces/jppForw/issues/vulnerabilities/7039251/18759591
https://broadinstitute-dsp.sourceclear.io/workspaces/jppForw/issues/vulnerabilities/7039251/18759592

Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
