### PR TITLE
Cluster init without R kernel was failing due to this missing directory

### DIFF
--- a/docker/jupyter/scripts/kernel/kernelspec.sh
+++ b/docker/jupyter/scripts/kernel/kernelspec.sh
@@ -3,9 +3,12 @@
 TMP_KERNELSPEC_DIR=$1
 KERNELSPEC_HOME=$2
 
-# Create directories for PySpark kernels
-# Python kernel directories are somehow already created at this point.
+# TODO: only run this script for the kernels we're actually installing
+
+# Create kernel directories for those which do not already exist
+mkdir ${KERNELSPEC_HOME}/python{2,3}
 mkdir ${KERNELSPEC_HOME}/pyspark{2,3}
+mkdir ${KERNELSPEC_HOME}/ir
 
 # Replace the contents of the Python kernel scripts
 sed -e 's/${PY_VERSION}/2/g' -e 's|${JUPYTER_HOME}|'${JUPYTER_HOME}'|g' ${TMP_KERNELSPEC_DIR}/python_kernelspec.tmpl > ${KERNELSPEC_HOME}/python2/kernel.json


### PR DESCRIPTION
Temp fix for Hackathon - need a Leo image with this.

Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
