### PR TITLE
[no ticket, no security risk] Remove problematic control characters from filename

### DIFF
--- a/automation/hotswap.sh
+++ b/automation/hotswap.sh
@@ -11,7 +11,7 @@ fi
 
 FIAB=$1
 
-FULL_LEO_JAR=$(sbt assembly | tail -3 | head -2 | grep -o '/Users[^ ]*')
+FULL_LEO_JAR=$(sbt -Dsbt.log.noformat=true assembly | tail -3 | head -2 | grep -o '/Users[^ ]*')
 SHORT_LEO_JAR=$(echo ${FULL_LEO_JAR} | grep -oP 'leonardo-assembly[^ ]*')
 
 gcloud compute scp ${FULL_LEO_JAR} ${FIAB}:/tmp --zone=us-central1-a --project broad-dsde-dev


### PR DESCRIPTION
`sbt assembly` control characters can result in bad filenames like `/Users/thibault/src/leonardo/target/scala-2.12/leonardo-assembly-0.1-f2ee3a3f-SNAPSHOT.jar\033[0m`, causing this script to fail.

Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
