### PR TITLE
[IA-846] Record NR metrics in ClusterMonitorActor

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -16,7 +16,7 @@ object Dependencies {
   val workbenchGoogleV  = "0.19-084fa1b"
   val workbenchGoogle2V = "0.2-2149dba"
   val workbenchMetricsV = "0.3-c5b80d2"
-  val workbenchNewRelicV = "0.2-24dabc8"
+  val workbenchNewRelicV = "0.2-38aa1bc-SNAP" // TODO: update to non-SNAP once https://github.com/broadinstitute/workbench-libs/pull/269 is merged
 
   val samV =  "1.0-5cdffb4"
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorActor.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorActor.scala
@@ -511,7 +511,7 @@ class ClusterMonitorActor(val cluster: Cluster,
   private def recordMetrics(origStatus: ClusterStatus, finalStatus: ClusterStatus): IO[Unit] = {
     for {
       endTime <- IO(System.currentTimeMillis)
-      name = s"ClusterMonitor/${origStatus}_to_${finalStatus}"
+      name = s"ClusterMonitor/${origStatus}->${finalStatus}"
       duration = (endTime - startTime).millis
       _ <- Metrics.newRelic.incrementCounterIO(name)
       _ <- Metrics.newRelic.recordResponseTimeIO(name, duration)

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorActor.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorActor.scala
@@ -510,10 +510,12 @@ class ClusterMonitorActor(val cluster: Cluster,
   private def recordMetrics(origStatus: ClusterStatus, finalStatus: ClusterStatus): IO[Unit] = {
     for {
       endTime <- IO(System.currentTimeMillis)
-      name = s"ClusterMonitor/${origStatus}->${finalStatus}"
+      baseName = s"ClusterMonitor/${origStatus}->${finalStatus}"
+      counterName = s"${baseName}/count"
+      timerName = s"${baseName}/timer"
       duration = (endTime - startTime).millis
-      _ <- Metrics.newRelic.incrementCounterIO(name)
-      _ <- Metrics.newRelic.recordResponseTimeIO(name, duration)
+      _ <- Metrics.newRelic.incrementCounterIO(counterName)
+      _ <- Metrics.newRelic.recordResponseTimeIO(timerName, duration)
     } yield ()
   }
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorActor.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorActor.scala
@@ -15,6 +15,7 @@ import com.typesafe.scalalogging.LazyLogging
 import io.grpc.Status.Code
 import org.broadinstitute.dsde.workbench.google.{GoogleIamDAO, GoogleStorageDAO}
 import org.broadinstitute.dsde.workbench.google2.{GcsBlobName, GetMetadataResponse, GoogleStorageService}
+import org.broadinstitute.dsde.workbench.leonardo.Metrics
 import org.broadinstitute.dsde.workbench.leonardo.config.{ClusterBucketConfig, DataprocConfig, MonitorConfig}
 import org.broadinstitute.dsde.workbench.leonardo.dao.google.{GoogleComputeDAO, GoogleDataprocDAO}
 import org.broadinstitute.dsde.workbench.leonardo.db.DbReference
@@ -73,7 +74,8 @@ class ClusterMonitorActor(val cluster: Cluster,
                           val google2StorageDAO: GoogleStorageService[IO],
                           val dbRef: DbReference,
                           val authProvider: LeoAuthProvider,
-                          proxyDao: Map[ClusterTool, Function0[Future[Boolean]]]) extends Actor with LazyLogging with Retry {
+                          proxyDao: Map[ClusterTool, Function0[Future[Boolean]]],
+                          val startTime: Long = System.currentTimeMillis()) extends Actor with LazyLogging with Retry {
   import context._
 
   // the Retry trait needs a reference to the ActorSystem
@@ -160,6 +162,8 @@ class ClusterMonitorActor(val cluster: Cluster,
       // Only happens if the cluster was created with a service account other
       // than the compute engine default service account.
       _ <- if (clusterStatus == ClusterStatus.Creating || clusterStatus == ClusterStatus.Updating) removeIamRolesForUser else Future.successful(())
+      // Record metrics in NewRelic
+      _ <- recordMetrics(clusterStatus, ClusterStatus.Running).unsafeToFuture()
     } yield {
       // Finally pipe a shutdown message to this actor
       logger.info(s"Cluster ${cluster.googleProject}/${cluster.clusterName} is ready for use!")
@@ -176,6 +180,8 @@ class ClusterMonitorActor(val cluster: Cluster,
     */
   private def handleFailedCluster(errorDetails: ClusterErrorDetails, instances: Set[Instance]): Future[ClusterMonitorMessage] = {
     for {
+      clusterStatus <- getDbClusterStatus
+
       _ <- Future.sequence(List(
         // Delete the cluster in Google
         gdDAO.deleteCluster(cluster.googleProject, cluster.clusterName),
@@ -188,8 +194,12 @@ class ClusterMonitorActor(val cluster: Cluster,
         persistClusterErrors(errorDetails)
       ))
 
+      // Record metrics in NewRelic
+      _ <- recordMetrics(clusterStatus, ClusterStatus.Error).unsafeToFuture()
+
       // Decide if we should try recreating the cluster
       res <- if (shouldRecreateCluster(errorDetails.code, errorDetails.message)) {
+          // TODO add metric for cluster recreation
         // Update the database record to Deleting, shutdown this actor, and register a callback message
         // to the supervisor telling it to recreate the cluster.
         logger.info(s"Cluster ${cluster.projectNameString} is in an error state with $errorDetails. Attempting to recreate...")
@@ -227,6 +237,8 @@ class ClusterMonitorActor(val cluster: Cluster,
     logger.info(s"Cluster ${cluster.projectNameString} has been deleted.")
 
     for {
+      clusterStatus <- getDbClusterStatus
+
       // delete the init bucket so we don't continue to accrue costs after cluster is deleted
       _ <- deleteInitBucket
 
@@ -240,6 +252,9 @@ class ClusterMonitorActor(val cluster: Cluster,
         dataAccess.clusterQuery.completeDeletion(cluster.id)
       }
       _ <- authProvider.notifyClusterDeleted(cluster.internalId, cluster.auditInfo.creator, cluster.auditInfo.creator, cluster.googleProject, cluster.clusterName)
+
+      // Record metrics in NewRelic
+      _ <- recordMetrics(clusterStatus, ClusterStatus.Deleted).unsafeToFuture()
     } yield ShutdownActor(RemoveFromList(cluster))
   }
 
@@ -252,12 +267,15 @@ class ClusterMonitorActor(val cluster: Cluster,
     logger.info(s"Cluster ${cluster.projectNameString} has been stopped.")
 
     for {
+      clusterStatus <- getDbClusterStatus
       // create or update instances in the DB
       _ <- persistInstances(instances)
       // this sets the cluster status to stopped and clears the cluster IP
       _ <- dbRef.inTransaction { _.clusterQuery.updateClusterStatus(cluster.id, ClusterStatus.Stopped) }
       // reset the time at which the kernel was last found to be busy
       _ <- dbRef.inTransaction {_.clusterQuery.clearKernelFoundBusyDate(cluster.id)}
+      // Record metrics in NewRelic
+      _ <- recordMetrics(clusterStatus, ClusterStatus.Stopped).unsafeToFuture()
     } yield ShutdownActor(RemoveFromList(cluster))
   }
 
@@ -488,5 +506,15 @@ class ClusterMonitorActor(val cluster: Cluster,
 
   private def getDbClusterStatus: Future[ClusterStatus] = {
     dbRef.inTransaction { _.clusterQuery.getClusterStatus(cluster.id) } map { _.getOrElse(ClusterStatus.Unknown) }
+  }
+
+  private def recordMetrics(origStatus: ClusterStatus, finalStatus: ClusterStatus): IO[Unit] = {
+    for {
+      endTime <- IO(System.currentTimeMillis)
+      name = s"ClusterMonitor/${origStatus}_to_${finalStatus}"
+      duration = (endTime - startTime).millis
+      _ <- Metrics.newRelic.incrementCounterIO(name)
+      _ <- Metrics.newRelic.recordResponseTimeIO(name, duration)
+    } yield ()
   }
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorActor.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorActor.scala
@@ -199,7 +199,6 @@ class ClusterMonitorActor(val cluster: Cluster,
 
       // Decide if we should try recreating the cluster
       res <- if (shouldRecreateCluster(errorDetails.code, errorDetails.message)) {
-          // TODO add metric for cluster recreation
         // Update the database record to Deleting, shutdown this actor, and register a callback message
         // to the supervisor telling it to recreate the cluster.
         logger.info(s"Cluster ${cluster.projectNameString} is in an error state with $errorDetails. Attempting to recreate...")


### PR DESCRIPTION
Depends on https://github.com/broadinstitute/workbench-libs/pull/269

This adds a counter and a responseTime metric for each status transition in `ClusterMonitorActor` -- e.g. Creating->Running, Stopped->Stopped, Starting->Running, etc.

Haven't actually tested it with real NR yet, which is why the PR is marked [WIP].

Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've documented my API changes in Swagger

In all cases:

- [x] Get a thumbsworth of review and PO signoff if necessary
- [x] Verify all tests go green
- [x] Squash and merge; you can delete your branch after this
- [x] Test this change deployed correctly and works on dev environment after deployment
