### PR TITLE
[IA-1286] Remove templated vars in google_sign_in.js

### DIFF
--- a/docker/jupyter/custom/google_sign_in.js
+++ b/docker/jupyter/custom/google_sign_in.js
@@ -10,6 +10,8 @@
 
 // define default values for config parameters
 var params = {
+    googleProject: '',
+    clusterName: '',
     loginHint: '',
     googleClientId: ''
 };
@@ -68,13 +70,8 @@ function startTimer() {
 
 
     function statusCheck() {
-        // Leonardo has logic to find/replace templated values in the format $(...).
-        // TEMPLATED CODE
-        var googleProject = $(googleProject);
-        var clusterName = $(clusterName);
-
         var xhttp = new XMLHttpRequest();
-        xhttp.open("GET", "/notebooks/" + googleProject + "/" + clusterName + "/api/status", true);
+        xhttp.open("GET", "/notebooks/" + params.googleProject + "/" + params.clusterName + "/api/status", true);
         xhttp.send();
     }
     setInterval(statusCheck, 60000)


### PR DESCRIPTION
JIRA: https://broadworkbench.atlassian.net/browse/IA-1286

@calbach noticed this. I think it is related to the changes in https://github.com/DataBiosphere/leonardo/pull/1031. 

I double checked the other JS extension code and didn't see any other stray `$(...)` templated vars.

Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
