### PR TITLE
[no ticket] Only monitor tools on Running clusters

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponent.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponent.scala
@@ -169,14 +169,6 @@ trait ClusterComponent extends LeoComponent {
       }
     }
 
-    def listActiveOnly(): DBIO[Seq[Cluster]] = {
-      clusterQuery
-        .filter { _.status inSetBind ClusterStatus.activeStatuses.map(_.toString) }
-        .result map { recs =>
-          recs.map(rec => unmarshalCluster(rec, Seq.empty, List.empty, Map.empty, List.empty, List.empty, List.empty))
-        }
-    }
-
     def listMonitoredClusterOnly(): DBIO[Seq[Cluster]] = {
       clusterQuery
         .filter { _.status inSetBind ClusterStatus.monitoredStatuses.map(_.toString) }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponent.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponent.scala
@@ -204,6 +204,14 @@ trait ClusterComponent extends LeoComponent {
         }
     }
 
+    def listRunningOnly(): DBIO[Seq[Cluster]] = {
+      clusterQuery
+        .filter { _.status === ClusterStatus.Running.toString }
+        .result map { recs =>
+        recs.map(rec => unmarshalCluster(rec, Seq.empty, List.empty, Map.empty, List.empty, List.empty, List.empty))
+      }
+    }
+
     def countByClusterServiceAccountAndStatuses(clusterServiceAccount: WorkbenchEmail, statuses: Set[ClusterStatus]) = {
       clusterQuery
         .filter { _.clusterServiceAccount === Option(clusterServiceAccount.value) }


### PR DESCRIPTION
This was just something I noticed while testing a different PR. The `ClusterToolMonitor` was flagging clusters in `Creating`, `Stopped`, etc status. It is expected that tools aren't running on those clusters, so we probably shouldn't alert. I changed `ClusterToolMonitor` to only look at `Running` clusters.

Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've documented my API changes in Swagger

In all cases:

- [x] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
