### PR TITLE
[IA-1247] Increase getAfterCreatePatience to address flaky test

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
@@ -65,7 +65,7 @@ trait LeonardoTestUtils extends WebBrowserSpec with Matchers with Eventually wit
   val saPatience = PatienceConfig(timeout = scaled(Span(1, Minutes)), interval = scaled(Span(1, Seconds)))
   val storagePatience = PatienceConfig(timeout = scaled(Span(1, Minutes)), interval = scaled(Span(1, Seconds)))
   val startPatience = PatienceConfig(timeout = scaled(Span(5, Minutes)), interval = scaled(Span(1, Seconds)))
-  val getAfterCreatePatience = PatienceConfig(timeout = scaled(Span(30, Seconds)), interval = scaled(Span(2, Seconds)))
+  val getAfterCreatePatience = PatienceConfig(timeout = scaled(Span(5, Minutes)), interval = scaled(Span(2, Seconds)))
 
   val multiExtensionClusterRequest = UserJupyterExtensionConfig(
     nbExtensions = Map("map" -> "gmaps"),

--- a/docker/jupyter/Dockerfile
+++ b/docker/jupyter/Dockerfile
@@ -16,6 +16,7 @@ RUN echo "deb $DEBIAN_REPO/debian stretch main"                   > /etc/apt/sou
  && echo "deb $DEBIAN_REPO/debian-security stretch/updates main" >> /etc/apt/sources.list \
  && echo "deb $DEBIAN_REPO/debian stretch-backports main"        >> /etc/apt/sources.list \
  && echo "deb $DEBIAN_REPO/debian testing main"                  >> /etc/apt/sources.list \
+ && echo "deb $DEBIAN_REPO/debian buster main"                   >> /etc/apt/sources.list \
  && echo 'APT::Default-Release "oldstable";' | tee -a /etc/apt/apt.conf.d/00local \
  && apt-get update \
  && apt-get -yq dist-upgrade \
@@ -344,7 +345,7 @@ ENV PIP_USER=true
 
 # using aptitude for R packages so that all dependencies are automatically installed
 RUN aptitude update && aptitude install -y apt-utils \
- && aptitude update && aptitude -t stretch-cran35 install -y \
+ && aptitude update && aptitude -t buster install -y \
     r-base=3.5.2-1 \
     r-base-dev=3.5.2-1 \
     r-base-core=3.5.2-1 \

--- a/docker/jupyter/Dockerfile
+++ b/docker/jupyter/Dockerfile
@@ -16,6 +16,7 @@ RUN echo "deb $DEBIAN_REPO/debian stretch main"                   > /etc/apt/sou
  && echo "deb $DEBIAN_REPO/debian-security stretch/updates main" >> /etc/apt/sources.list \
  && echo "deb $DEBIAN_REPO/debian stretch-backports main"        >> /etc/apt/sources.list \
  && echo "deb $DEBIAN_REPO/debian testing main"                  >> /etc/apt/sources.list \
+ && echo "deb $DEBIAN_REPO/debian buster main"                   >> /etc/apt/sources.list \
  && echo 'APT::Default-Release "oldstable";' | tee -a /etc/apt/apt.conf.d/00local \
  && apt-get update \
  && apt-get -yq dist-upgrade \
@@ -343,12 +344,12 @@ ENV PIP_USER=true
 
 # using aptitude for R packages so that all dependencies are automatically installed
 RUN aptitude update && aptitude install -y apt-utils \
- && aptitude update && aptitude -t stretch-cran35 install -y \
+ && aptitude update && aptitude -t buster install -y \
     r-base=3.5.2-1 \
     r-base-dev=3.5.2-1 \
     r-base-core=3.5.2-1 \
     r-recommended=3.5.2-1 \
- && aptitude install -t stretch-cran35 -y \
+ && aptitude install -t buster -y \
     fonts-dejavu \
     tzdata \
     gfortran \

--- a/docker/jupyter/Dockerfile
+++ b/docker/jupyter/Dockerfile
@@ -345,7 +345,7 @@ ENV PIP_USER=true
 
 # using aptitude for R packages so that all dependencies are automatically installed
 RUN aptitude update && aptitude install -y apt-utils \
- && aptitude update && aptitude -t buster install -y \
+ && aptitude update && aptitude -t stretch-cran35 install -y \
     r-base=3.5.2-1 \
     r-base-dev=3.5.2-1 \
     r-base-core=3.5.2-1 \

--- a/docker/jupyter/Dockerfile
+++ b/docker/jupyter/Dockerfile
@@ -349,7 +349,7 @@ RUN aptitude update && aptitude install -y apt-utils \
     r-base-dev=3.5.2-1 \
     r-base-core=3.5.2-1 \
     r-recommended=3.5.2-1 \
- && aptitude install -t buster -y \
+ && aptitude install -t stretch-cran35 -y \
     fonts-dejavu \
     tzdata \
     gfortran \

--- a/docker/jupyter/Dockerfile
+++ b/docker/jupyter/Dockerfile
@@ -10,13 +10,12 @@ USER root
 
 ENV DEBIAN_FRONTEND noninteractive
 ENV DEBIAN_REPO http://cdn-fastly.deb.debian.org
-ENV CRAN_REPO http://cran.mtu.edu
+ENV CRAN_REPO http://cran.case.edu
 
 RUN echo "deb $DEBIAN_REPO/debian stretch main"                   > /etc/apt/sources.list \
  && echo "deb $DEBIAN_REPO/debian-security stretch/updates main" >> /etc/apt/sources.list \
  && echo "deb $DEBIAN_REPO/debian stretch-backports main"        >> /etc/apt/sources.list \
  && echo "deb $DEBIAN_REPO/debian testing main"                  >> /etc/apt/sources.list \
- && echo "deb $DEBIAN_REPO/debian buster main"                   >> /etc/apt/sources.list \
  && echo 'APT::Default-Release "oldstable";' | tee -a /etc/apt/apt.conf.d/00local \
  && apt-get update \
  && apt-get -yq dist-upgrade \
@@ -52,6 +51,7 @@ RUN echo "deb $DEBIAN_REPO/debian stretch main"                   > /etc/apt/sou
     git \
     locales \
     jq \
+    apt-transport-https \
 
  # R separately because it depends on gnupg installed above
  && echo "deb $CRAN_REPO/bin/linux/debian stretch-cran35/"       >> /etc/apt/sources.list \
@@ -344,7 +344,7 @@ ENV PIP_USER=true
 
 # using aptitude for R packages so that all dependencies are automatically installed
 RUN aptitude update && aptitude install -y apt-utils \
- && aptitude update && aptitude -t buster install -y \
+ && aptitude update && aptitude -t stretch-cran35 install -y \
     r-base=3.5.2-1 \
     r-base-dev=3.5.2-1 \
     r-base-core=3.5.2-1 \


### PR DESCRIPTION
JIRA: https://broadworkbench.atlassian.net/browse/IA-1247

This is occasionally failing: https://github.com/DataBiosphere/leonardo/blob/develop/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala#L188

The tests only give 30s patience, but verify fields that are populated asynchronously by Leo. Increased it to 5 minutes to hopefully account for occasional slowness due to retries of Google calls.

Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've documented my API changes in Swagger

In all cases:

- [x] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
