### PR TITLE
IA-1117 terra python3 image tests

### DIFF
--- a/automation/src/test/resources/reference.conf
+++ b/automation/src/test/resources/reference.conf
@@ -1,1 +1,2 @@
 leonardo.rImageUrl = "us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:0.0.3"
+leonardo.pythonImageUrl = "us.gcr.io/broad-dsp-gcr-public/terra-python3:0.0.1"

--- a/automation/src/test/resources/reference.conf
+++ b/automation/src/test/resources/reference.conf
@@ -1,2 +1,2 @@
 leonardo.rImageUrl = "us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:0.0.3"
-leonardo.pythonImageUrl = "us.gcr.io/broad-dsp-gcr-public/terra-python3:0.0.1"
+leonardo.pythonImageUrl = "us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.1"

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/ClusterFixtureSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/ClusterFixtureSpec.scala
@@ -18,7 +18,7 @@ abstract class ClusterFixtureSpec extends fixture.FreeSpec with BeforeAndAfterAl
 
   //To use, comment out the lines in after all that clean-up and run the test once normally. Then, instantiate a mock cluster in your test file via the `mockCluster` method in NotebookTestUtils with the project/cluster created
   //You must also set debug to true. Example usage (goes in the Spec you are creating):
-  //Consider adding autopause = Some(false) to the cluster request if you encounter issues with autopause 
+  //Consider adding autopause = Some(false) to the cluster request if you encounter issues with autopause
   //
   //example usage:
   //  debug = true

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoConfig.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoConfig.scala
@@ -10,6 +10,7 @@ object LeonardoConfig extends CommonConfig {
     val apiUrl: String = leonardo.getString("apiUrl")
     val notebooksServiceAccountEmail: String = leonardo.getString("notebooksServiceAccountEmail")
     val rImageUrl: String = leonardo.getString("rImageUrl")
+    val pythonImageUrl: String = leonardo.getString("pythonImageUrl")
   }
 
   // for qaEmail and pathToQAPem and pathToQAJson

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookPyKernelSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookPyKernelSpec.scala
@@ -1,6 +1,6 @@
 package org.broadinstitute.dsde.workbench.leonardo.notebooks
 
-import org.broadinstitute.dsde.workbench.leonardo.{ClusterFixtureSpec, Leonardo}
+import org.broadinstitute.dsde.workbench.leonardo.{ClusterFixtureSpec, Leonardo, LeonardoConfig}
 import org.broadinstitute.dsde.workbench.service.Orchestration
 import org.broadinstitute.dsde.workbench.service.util.Tags
 import org.scalatest.DoNotDiscover
@@ -9,10 +9,12 @@ import scala.concurrent.duration.DurationLong
 import scala.language.postfixOps
 
 /**
-  * This spec verifies notebook functionality specifically around the Python 2 and 3 kernels.
+  * This spec verifies notebook functionality specifically around the Python 3 kernel.
   */
 @DoNotDiscover
 class NotebookPyKernelSpec extends ClusterFixtureSpec with NotebookTestUtils {
+
+  override val jupyterDockerImage: Option[String] = Some(LeonardoConfig.Leonardo.pythonImageUrl)
 
   "NotebookPyKernelSpec" - {
 
@@ -27,13 +29,13 @@ class NotebookPyKernelSpec extends ClusterFixtureSpec with NotebookTestUtils {
               |bx.bitset.sys.copyright""".stripMargin
 
           notebookPage.executeCell("1+1") shouldBe Some("2")
-          notebookPage.executeCell(getPythonVersion) shouldBe Some("3.6.8")
+          notebookPage.executeCell(getPythonVersion) shouldBe Some("3.7.4")
           notebookPage.executeCell(getBxPython).get should include("Copyright (c)")
         }
       }
     }
 
-    Seq(Python2, Python3).foreach { kernel =>
+    Seq(Python3).foreach { kernel =>
       s"should be able to pip install packages using ${kernel.string}" in { clusterFixture =>
         withWebDriver { implicit driver =>
           withNewNotebook(clusterFixture.cluster, kernel) { notebookPage =>
@@ -133,13 +135,13 @@ class NotebookPyKernelSpec extends ClusterFixtureSpec with NotebookTestUtils {
     }
 
 
-    Seq(Python2, Python3).foreach { kernel =>
+    Seq(Python3).foreach { kernel =>
       s"should preinstall google cloud subpackages for ${kernel.string}" in { clusterFixture =>
         withWebDriver { implicit driver =>
           withNewNotebook(clusterFixture.cluster, kernel) { notebookPage =>
             //all other packages cannot be tested for their versions in this manner
             //warnings are ignored because they are benign warnings that show up for python2 because of compilation against an older numpy
-            notebookPage.executeCell("import warnings; warnings.simplefilter('ignore')\nfrom google.cloud import bigquery\nprint(bigquery.__version__)") shouldBe Some("1.7.0")
+            notebookPage.executeCell("import warnings; warnings.simplefilter('ignore')\nfrom google.cloud import bigquery\nprint(bigquery.__version__)") shouldBe Some("1.9.0")
             notebookPage.executeCell("from google.cloud import datastore\nprint(datastore.__version__)") shouldBe Some("1.7.0")
             notebookPage.executeCell("from google.cloud import storage\nprint(storage.__version__)") shouldBe Some("1.13.0")
           }
@@ -148,7 +150,7 @@ class NotebookPyKernelSpec extends ClusterFixtureSpec with NotebookTestUtils {
     }
 
     // https://github.com/DataBiosphere/leonardo/issues/797
-    Seq(Python2, Python3).foreach { kernel =>
+    Seq(Python3).foreach { kernel =>
       s"should be able to import ggplot for ${kernel.toString}" in { clusterFixture =>
         withWebDriver { implicit driver =>
           withNewNotebook(clusterFixture.cluster, kernel) { notebookPage =>
@@ -159,7 +161,7 @@ class NotebookPyKernelSpec extends ClusterFixtureSpec with NotebookTestUtils {
       }
     }
 
-    Seq(Python2, Python3).foreach { kernel =>
+    Seq(Python3).foreach { kernel =>
       s"should have the workspace-related environment variables set in ${kernel.toString} kernel" in { clusterFixture =>
         withWebDriver { implicit driver =>
           withNewNotebook(clusterFixture.cluster, kernel) { notebookPage =>
@@ -192,7 +194,7 @@ class NotebookPyKernelSpec extends ClusterFixtureSpec with NotebookTestUtils {
       clusterFixture.cluster.serviceAccountInfo.notebookServiceAccount shouldBe None
 
       withWebDriver { implicit driver =>
-        withNewNotebook(clusterFixture.cluster, PySpark2) { notebookPage =>
+        withNewNotebook(clusterFixture.cluster, Python3) { notebookPage =>
           // should not have notebook credentials because Leo is not configured to use a notebook service account
           verifyNoNotebookCredentials(notebookPage)
         }

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookTestUtils.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookTestUtils.scala
@@ -58,17 +58,18 @@ trait NotebookTestUtils extends LeonardoTestUtils {
     // verify google-authn
     notebookPage.executeCell("import google.auth") shouldBe None
     notebookPage.executeCell("credentials, project_id = google.auth.default()") shouldBe None
-    notebookPage.executeCell("print credentials.service_account_email") shouldBe Some("default")
+    notebookPage.executeCell("print(credentials.service_account_email)") shouldBe Some("default")
 
     // verify FISS
     notebookPage.executeCell("import firecloud.api as fapi") shouldBe None
     notebookPage.executeCell("fiss_credentials, project = fapi.google.auth.default()") shouldBe None
-    notebookPage.executeCell("print fiss_credentials.service_account_email") shouldBe Some("default")
+    notebookPage.executeCell("print(fiss_credentials.service_account_email)") shouldBe Some("default")
 
     // verify Spark
-    notebookPage.executeCell("hadoop_config = sc._jsc.hadoopConfiguration()") shouldBe None
-    notebookPage.executeCell("print hadoop_config.get('google.cloud.auth.service.account.enable')") shouldBe Some("None")
-    notebookPage.executeCell("print hadoop_config.get('google.cloud.auth.service.account.json.keyfile')") shouldBe Some("None")
+    //TODO: re-enable with spark image
+//    notebookPage.executeCell("hadoop_config = sc._jsc.hadoopConfiguration()") shouldBe None
+//    notebookPage.executeCell("print(hadoop_config.get('google.cloud.auth.service.account.enable'))") shouldBe Some("None")
+//    notebookPage.executeCell("print(hadoop_config.get('google.cloud.auth.service.account.json.keyfile'))") shouldBe Some("None")
   }
 
   def withNotebooksListPage[T](cluster: Cluster)(testCode: NotebooksListPage => T)(implicit webDriver: WebDriver, token: AuthToken): T = {


### PR DESCRIPTION
Removing python2 and spark (temporarily) from tests.

All tests for python3 are passing now, with the python3 image.

It may be worth adding an explicit test for each package we import.

Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
