### PR TITLE
IA-1237 don't run spark init script

### DIFF
--- a/http/src/main/resources/jupyter/init-actions.sh
+++ b/http/src/main/resources/jupyter/init-actions.sh
@@ -229,7 +229,7 @@ if [[ "${ROLE}" == 'Master' ]]; then
       retry 3 docker exec -u root ${JUPYTER_SERVER_NAME} ${JUPYTER_SCRIPTS}/kernel/kernelspec.sh ${JUPYTER_SCRIPTS}/kernel ${KERNELSPEC_HOME}
 
       # Install hail addition if the image is old leonardo jupyter image or it's a hail specific image
-      if [[ ${JUPYTER_DOCKER_IMAGE} == *"leonardo-jupyter"* ]] || [[ ${JUPYTER_DOCKER_IMAGE} == *"hail"* ]] ; then
+      if [[ ${JUPYTER_DOCKER_IMAGE} == *"leonardo-jupyter"* ]] ; then
         log 'Installing Hail additions to Jupydocker spark.conf...'
 
         # Install the Hail additions to Spark conf.


### PR DESCRIPTION
Part of https://broadworkbench.atlassian.net/browse/IA-1237

No change to jupyter image initialization.
But going forward, we won't install pyspark kernal for hail either since using spark from within hail is recommended.


Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
