### PR TITLE
[IA-1385] Don't prematurely remove Sam resources

### DIFF
--- a/docker/install.sh
+++ b/docker/install.sh
@@ -8,8 +8,8 @@ rm -f leonardo*.jar
 
 # Test
 export SBT_OPTS="-Dmysql.host=mysql -Dmysql.port=3306"
-sbt -J-Xms4g -J-Xmx4g "project http" test
-sbt -J-Xms6g -J-Xmx6g "project http" assembly
+sbt -J-Xms6g -J-Xmx6g -J-XX:MaxMetaspaceSize=1g "project http" test
+sbt -J-Xms6g -J-Xmx6g -J-XX:MaxMetaspaceSize=1g "project http" assembly
 LEONARDO_JAR=$(find http/target | grep 'http-assembly.*\.jar')
 
 # new generated jar name starts with `http`, but renaming it to `leonardo*.jar`

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorSpec.scala
@@ -634,7 +634,7 @@ class ClusterMonitorSpec extends TestKit(ActorSystem("leonardotest")) with FlatS
       val dpWorkerTimes = if (clusterServiceAccount(creatingCluster.googleProject).isDefined) times(1) else never()
       verify(iamDAO, dpWorkerTimes).removeIamRolesForUser(any[GoogleProject], any[WorkbenchEmail], mockitoEq(Set("roles/dataproc.worker")))
       verify(iamDAO, dpWorkerTimes).addIamRolesForUser(any[GoogleProject], any[WorkbenchEmail], mockitoEq(Set("roles/dataproc.worker")))
-      val imageUserTimes = if (dataprocConfig.customDataprocImage.isDefined) times(2) else never()
+      val imageUserTimes = if (dataprocConfig.customDataprocImage.isDefined) times(1) else never()
       verify(iamDAO, imageUserTimes).removeIamRolesForUser(any[GoogleProject], any[WorkbenchEmail], mockitoEq(Set("roles/compute.imageUser")))
       verify(iamDAO, imageUserTimes).addIamRolesForUser(any[GoogleProject], any[WorkbenchEmail], mockitoEq(Set("roles/compute.imageUser")))
       verify(iamDAO, if (notebookServiceAccount(creatingCluster.googleProject).isDefined) times(1) else never()).removeServiceAccountKey(any[GoogleProject], any[WorkbenchEmail], any[ServiceAccountKeyId])

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoServiceSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoServiceSpec.scala
@@ -1058,9 +1058,9 @@ class LeonardoServiceSpec extends TestKit(ActorSystem("leonardotest")) with Flat
       dbFutureValue { _.clusterQuery.getClusterStatus(clusterCreateResponse.id) } shouldBe Some(ClusterStatus.Error)
     }
 
-    // We make at most 2 IAM calls - they should not have been retried
-    // Assertion is <= 2 because calls are made in parallel with parSequence, so 1 or both may have been tried.
-    iamDAO.invocationCount should be <= 2
+    // We make at most 3 IAM calls - they should not have been retried
+    // Assertion is <= 3 because calls are made in parallel with parSequence, so 1 or both may have been tried.
+    iamDAO.invocationCount should be <= 3
   }
 
   it should "retry 409 errors when adding IAM roles" in isolatedDbTest {
@@ -1082,7 +1082,7 @@ class LeonardoServiceSpec extends TestKit(ActorSystem("leonardotest")) with Flat
     }
 
     // IAM calls should have been retried exponentially
-    iamDAO.invocationCount should be > 2
+    iamDAO.invocationCount should be > 3
   }
 
   it should "update the autopause threshold for a cluster" in isolatedDbTest {


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-1385

Hoping this fixes the issue where `Error`'d clusters are un-gettable and un-deletable.

Also snuck in another fix to the IAM stuff based on recent revelations from Google.

Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
