### PR TITLE
[WIP] [IA-1156] Move async cluster creation to back Leo

### DIFF
--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/Boot.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/Boot.scala
@@ -80,15 +80,15 @@ object Boot extends IOApp with LazyLogging {
     val googleStorageDAO = new HttpGoogleStorageDAO(dataprocConfig.applicationName, Pem(leoServiceAccountEmail, leoServiceAccountPemFile), "google")
     val googleProjectDAO = new HttpGoogleProjectDAO(dataprocConfig.applicationName, Pem(leoServiceAccountEmail, leoServiceAccountPemFile), "google")
     val clusterDnsCache = new ClusterDnsCache(proxyConfig, dbRef, clusterDnsCacheConfig)
-    val bucketHelper = new BucketHelper(dataprocConfig, gdDAO, googleComputeDAO, googleStorageDAO, serviceAccountProvider)
-    val clusterHelper = new ClusterHelper(dbRef, dataprocConfig, gdDAO, googleComputeDAO, googleIamDAO)
     implicit def unsafeLogger = Slf4jLogger.getLogger[IO]
     implicit val lineBacker = Linebacker.fromExecutionContext[IO](scala.concurrent.ExecutionContext.global)
 
     createDependencies(leoServiceAccountJsonFile).use {
       appDependencies =>
         val welderDao = new HttpWelderDAO(clusterDnsCache)
-        val leonardoService = new LeonardoService(dataprocConfig, welderDao, clusterFilesConfig, clusterResourcesConfig, clusterDefaultsConfig, proxyConfig, swaggerConfig, autoFreezeConfig, gdDAO, googleComputeDAO, googleProjectDAO, googleStorageDAO, petGoogleStorageDAO, dbRef, authProvider, serviceAccountProvider, bucketHelper, clusterHelper, contentSecurityPolicy)
+        val bucketHelper = new BucketHelper(dataprocConfig, gdDAO, googleComputeDAO, googleStorageDAO, appDependencies.google2StorageDao, serviceAccountProvider)
+        val clusterHelper = new ClusterHelper(dbRef, dataprocConfig, proxyConfig, clusterResourcesConfig, clusterFilesConfig, bucketHelper, gdDAO, googleComputeDAO, googleIamDAO, googleProjectDAO, contentSecurityPolicy)
+        val leonardoService = new LeonardoService(dataprocConfig, welderDao, clusterFilesConfig, clusterResourcesConfig, clusterDefaultsConfig, proxyConfig, swaggerConfig, autoFreezeConfig, petGoogleStorageDAO, dbRef, authProvider, serviceAccountProvider, bucketHelper, clusterHelper, contentSecurityPolicy)
         if(leoExecutionModeConfig.backLeo) {
           val jupyterDAO = new HttpJupyterDAO(clusterDnsCache)
           val rstudioDAO = new HttpRStudioDAO(clusterDnsCache)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/Boot.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/Boot.scala
@@ -92,7 +92,7 @@ object Boot extends IOApp with LazyLogging {
         if(leoExecutionModeConfig.backLeo) {
           val jupyterDAO = new HttpJupyterDAO(clusterDnsCache)
           val rstudioDAO = new HttpRStudioDAO(clusterDnsCache)
-          system.actorOf(ClusterMonitorSupervisor.props(monitorConfig, dataprocConfig, clusterBucketConfig, gdDAO, googleComputeDAO, googleStorageDAO, appDependencies.google2StorageDao, dbRef, authProvider, autoFreezeConfig, jupyterDAO, rstudioDAO, welderDao, leonardoService, clusterHelper))
+          system.actorOf(ClusterMonitorSupervisor.props(monitorConfig, dataprocConfig, clusterBucketConfig, gdDAO, googleComputeDAO, googleStorageDAO, appDependencies.google2StorageDao, dbRef, authProvider, autoFreezeConfig, jupyterDAO, rstudioDAO, welderDao, clusterHelper))
           system.actorOf(ZombieClusterMonitor.props(zombieClusterMonitorConfig, gdDAO, googleProjectDAO, dbRef))
           system.actorOf(ClusterToolMonitor.props(clusterToolMonitorConfig, gdDAO, googleProjectDAO, dbRef, Map(ClusterTool.Jupyter ->  jupyterDAO, ClusterTool.Welder -> welderDao), Metrics.newRelic))
         }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/ProxyRoutes.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/ProxyRoutes.scala
@@ -3,19 +3,19 @@ package org.broadinstitute.dsde.workbench.leonardo.api
 import akka.actor.ActorSystem
 import akka.event.{Logging, LoggingAdapter}
 import akka.http.scaladsl.model._
-import akka.http.scaladsl.server.Directives._
-import akka.http.scaladsl.server.{Directive0, Directive1, Route}
-import com.typesafe.scalalogging.LazyLogging
-import org.broadinstitute.dsde.workbench.leonardo.model.google.ClusterName
-import org.broadinstitute.dsde.workbench.leonardo.service.{AuthenticationError, ProxyService}
-import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import akka.http.scaladsl.model.headers._
+import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.RouteResult.Complete
 import akka.http.scaladsl.server.directives.{DebuggingDirectives, LogEntry, LoggingMagnet}
+import akka.http.scaladsl.server.{Directive0, Directive1, Route}
 import akka.stream.Materializer
+import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.workbench.leonardo.model.NotebookClusterActions.ConnectToCluster
+import org.broadinstitute.dsde.workbench.leonardo.model.google.ClusterName
+import org.broadinstitute.dsde.workbench.leonardo.service.ProxyService
 import org.broadinstitute.dsde.workbench.leonardo.util.CookieHelper
 import org.broadinstitute.dsde.workbench.model.UserInfo
+import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 
 import scala.concurrent.ExecutionContext
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/google/GoogleDataprocDAO.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/google/GoogleDataprocDAO.scala
@@ -3,11 +3,16 @@ package org.broadinstitute.dsde.workbench.leonardo.dao.google
 import java.time.Instant
 import java.util.UUID
 
+import akka.http.scaladsl.model.StatusCodes
+import org.broadinstitute.dsde.workbench.leonardo.model.LeoException
 import org.broadinstitute.dsde.workbench.leonardo.model.google._
 import org.broadinstitute.dsde.workbench.model.UserInfo
 import org.broadinstitute.dsde.workbench.model.google._
 
 import scala.concurrent.Future
+
+case class DataprocDisabledException(errorMsg: String)
+  extends LeoException(s"${errorMsg}", StatusCodes.Forbidden)
 
 trait GoogleDataprocDAO {
   def createCluster(googleProject: GoogleProject, clusterName: ClusterName, createClusterConfig: CreateClusterConfig): Future[Operation]

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/google/HttpGoogleDataprocDAO.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/google/HttpGoogleDataprocDAO.scala
@@ -19,6 +19,7 @@ import org.broadinstitute.dsde.workbench.google.AbstractHttpGoogleDAO
 import org.broadinstitute.dsde.workbench.google.GoogleCredentialModes._
 import org.broadinstitute.dsde.workbench.leonardo.api.AuthenticationError
 import org.broadinstitute.dsde.workbench.leonardo.model.google.DataprocRole.{Master, SecondaryWorker, Worker}
+import org.broadinstitute.dsde.workbench.leonardo.model.google.VPCConfig.{VPCNetwork, VPCSubnet}
 import org.broadinstitute.dsde.workbench.leonardo.model.google._
 import org.broadinstitute.dsde.workbench.metrics.GoogleInstrumentedService
 import org.broadinstitute.dsde.workbench.metrics.GoogleInstrumentedService.GoogleInstrumentedService
@@ -213,10 +214,10 @@ class HttpGoogleDataprocDAO(appName: String,
         .setTags(List(networkTag.value).asJava)
 
       config.clusterVPCSettings match {
-        case Some(Right(subnet)) =>
-          baseConfig.setSubnetworkUri(subnet.value)
-        case Some(Left(network)) =>
-          baseConfig.setNetworkUri(network.value)
+        case Some(VPCSubnet(value)) =>
+          baseConfig.setSubnetworkUri(value)
+        case Some(VPCNetwork(value)) =>
+          baseConfig.setNetworkUri(value)
         case _ =>
           baseConfig
       }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/google/HttpGoogleDataprocDAO.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/google/HttpGoogleDataprocDAO.scala
@@ -17,9 +17,9 @@ import com.google.api.services.dataproc.model.{Cluster => DataprocCluster, Clust
 import com.google.api.services.oauth2.Oauth2
 import org.broadinstitute.dsde.workbench.google.AbstractHttpGoogleDAO
 import org.broadinstitute.dsde.workbench.google.GoogleCredentialModes._
+import org.broadinstitute.dsde.workbench.leonardo.api.AuthenticationError
 import org.broadinstitute.dsde.workbench.leonardo.model.google.DataprocRole.{Master, SecondaryWorker, Worker}
 import org.broadinstitute.dsde.workbench.leonardo.model.google._
-import org.broadinstitute.dsde.workbench.leonardo.service.{AuthenticationError, DataprocDisabledException}
 import org.broadinstitute.dsde.workbench.metrics.GoogleInstrumentedService
 import org.broadinstitute.dsde.workbench.metrics.GoogleInstrumentedService.GoogleInstrumentedService
 import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GoogleProject}

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/google/package.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/google/package.scala
@@ -1,6 +1,10 @@
 package org.broadinstitute.dsde.workbench.leonardo.dao
 
+import akka.http.scaladsl.model.StatusCodes
+import com.google.api.client.googleapis.json.GoogleJsonResponseException
 import org.broadinstitute.dsde.workbench.google.GoogleUtilities.RetryPredicates._
+
+import scala.collection.JavaConverters._
 
 package object google {
 
@@ -12,5 +16,15 @@ package object google {
     whenInvalidValueOnBucketCreation _,
     whenNonHttpIOException _
   )
+
+  final val when401: Throwable => Boolean = {
+    case g: GoogleJsonResponseException if g.getStatusCode == StatusCodes.Unauthorized.intValue => true
+    case _ => false
+  }
+
+  final val whenGoogleZoneCapacityIssue: Throwable => Boolean = {
+    case t: GoogleJsonResponseException => t.getStatusCode == 429 && t.getDetails.getErrors.asScala.head.getReason.equalsIgnoreCase("rateLimitExceeded")
+    case _ => false
+  }
 
 }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/google/package.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/google/package.scala
@@ -1,6 +1,5 @@
 package org.broadinstitute.dsde.workbench.leonardo.dao
 
-import akka.http.scaladsl.model.StatusCodes
 import com.google.api.client.googleapis.json.GoogleJsonResponseException
 import org.broadinstitute.dsde.workbench.google.GoogleUtilities.RetryPredicates._
 
@@ -17,8 +16,13 @@ package object google {
     whenNonHttpIOException _
   )
 
+  final val when400: Throwable => Boolean = {
+    case t: GoogleJsonResponseException => t.getStatusCode == 400
+    case _ => false
+  }
+
   final val when401: Throwable => Boolean = {
-    case g: GoogleJsonResponseException if g.getStatusCode == StatusCodes.Unauthorized.intValue => true
+    case t: GoogleJsonResponseException => t.getStatusCode == 401
     case _ => false
   }
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponent.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponent.scala
@@ -172,7 +172,6 @@ trait ClusterComponent extends LeoComponent {
     def listMonitoredClusterOnly(): DBIO[Seq[Cluster]] = {
       clusterQuery
         .filter { _.status inSetBind ClusterStatus.monitoredStatuses.map(_.toString) }
-        .filter { _.googleId.isDefined }
         .result map { recs =>
           recs.map(rec => unmarshalCluster(rec, Seq.empty, List.empty, Map.empty, List.empty, List.empty, List.empty))
         }
@@ -253,6 +252,14 @@ trait ClusterComponent extends LeoComponent {
     def getClusterById(id: Long): DBIO[Option[Cluster]] = {
       fullClusterQuery.filter { _._1.id === id }.result map { recs =>
         unmarshalFullCluster(recs).headOption
+      }
+    }
+
+    def getMinimalClusterById(id: Long): DBIO[Option[Cluster]] = {
+      findByIdQuery(id).result.headOption.map { recOpt =>
+        recOpt map { rec =>
+          unmarshalCluster(rec, Seq.empty, List.empty, Map.empty, List.empty, List.empty, List.empty)
+        }
       }
     }
 
@@ -373,6 +380,12 @@ trait ClusterComponent extends LeoComponent {
         .map(c => (c.initBucket, c.serviceAccountKeyId, c.googleId, c.operationName, c.stagingBucket, c.dateAccessed))
         .update(initBucket.map(_.toUri), serviceAccountKey.map(_.id.value), cluster.dataprocInfo.googleId,
           cluster.dataprocInfo.operationName.map(_.value), cluster.dataprocInfo.stagingBucket.map(_.value), Timestamp.from(Instant.now))
+    }
+
+    def clearAsyncClusterCreationFields(cluster: Cluster): DBIO[Int] = {
+      findByIdQuery(cluster.id)
+        .map(c => (c.initBucket, c.serviceAccountKeyId, c.googleId, c.operationName, c.stagingBucket, c.dateAccessed))
+        .update(None, None, None, None, None, Timestamp.from(Instant.now))
     }
 
     def updateClusterStatus(id: Long, newStatus: ClusterStatus): DBIO[Int] = {

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeonardoModel.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeonardoModel.scala
@@ -351,7 +351,7 @@ object ClusterInitValues {
       GcsPath(initBucketName, GcsObjectName(clusterResourcesConfig.jupyterNotebookConfigUri.value)).toUri,
       GcsPath(initBucketName, GcsObjectName(clusterResourcesConfig.jupyterNotebookFrontendConfigUri.value)).toUri,
       cluster.defaultClientId.getOrElse(""),
-      cluster.welderEnabled.toString,  // TODO: remove this and conditional below when welder is rolled out to all clusters
+      cluster.welderEnabled.toString,  // TODO: remove this and conditional below when we sunset FireCloud, which does not have welder enabled
       if (cluster.welderEnabled) dataprocConfig.welderEnabledNotebooksDir else dataprocConfig.welderDisabledNotebooksDir
     )
 }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/google/GoogleModel.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/google/GoogleModel.scala
@@ -1,10 +1,13 @@
 package org.broadinstitute.dsde.workbench.leonardo.model.google
 
+import java.io.File
 import java.time.Instant
 import java.util.UUID
 
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
 import enumeratum._
+import org.broadinstitute.dsde.workbench.google2.GcsBlobName
+import org.broadinstitute.dsde.workbench.leonardo.model.ClusterResource
 import org.broadinstitute.dsde.workbench.model.{ValueObject, ValueObjectFormat, WorkbenchEmail}
 import org.broadinstitute.dsde.workbench.model.google.GoogleModelJsonSupport._
 import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GcsPath, GoogleProject}
@@ -136,6 +139,12 @@ case class Instance(key: InstanceKey,
                     ip: Option[IP],
                     dataprocRole: Option[DataprocRole],
                     createdDate: Instant)
+
+case class GcsResource(gcsBlobName: GcsBlobName, content: Array[Byte])
+object GcsResource {
+  def apply(file: File, content: Array[Byte]): GcsResource = GcsResource(GcsBlobName(file.getName), content)
+  def apply(clusterResource: ClusterResource, content: Array[Byte]): GcsResource = GcsResource(GcsBlobName(clusterResource.value), content)
+}
 
 object GoogleJsonSupport extends SprayJsonSupport with DefaultJsonProtocol {
   implicit object UUIDFormat extends JsonFormat[UUID] {

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorActor.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorActor.scala
@@ -283,7 +283,7 @@ class ClusterMonitorActor(val cluster: Cluster,
     val future = for {
       clusterResult <- clusterHelper.createGoogleCluster(cluster).unsafeToFuture()
       (cluster, initBucket, saKey) = clusterResult
-      _ <- dbRef.inTransaction { _.clusterQuery.updateAsyncClusterCreationFields(Option(GcsPath(initBucket, GcsObjectName(""))), saKey, cluster) }
+      _ <- dbRef.inTransaction { _.clusterQuery.updateAsyncClusterCreationFields(Some(GcsPath(initBucket, GcsObjectName(""))), saKey, cluster) }
       _ = logger.info(s"Cluster ${cluster.projectNameString} was successfully created. Will monitor the creation process.")
     } yield NotReadyCluster(cluster.status, Set.empty)
 
@@ -295,7 +295,7 @@ class ClusterMonitorActor(val cluster: Cluster,
         case _ =>
           s"Failed to create cluster ${cluster.projectNameString} due to ${e.toString}"
       }
-      FailedCluster(ClusterErrorDetails(-1, Option(errorMessage)), Set.empty)
+      FailedCluster(ClusterErrorDetails(-1, Some(errorMessage)), Set.empty)
     }
   }
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoService.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoService.scala
@@ -1,6 +1,7 @@
 package org.broadinstitute.dsde.workbench.leonardo
 package service
 
+import java.text.SimpleDateFormat
 import java.time.Instant
 import java.util.UUID
 
@@ -23,6 +24,7 @@ import org.broadinstitute.dsde.workbench.leonardo.model.ClusterTool.{Jupyter, RS
 import org.broadinstitute.dsde.workbench.leonardo.model.LeonardoJsonSupport._
 import org.broadinstitute.dsde.workbench.leonardo.model.NotebookClusterActions._
 import org.broadinstitute.dsde.workbench.leonardo.model.ProjectActions._
+import org.broadinstitute.dsde.workbench.leonardo.model.WelderAction._
 import org.broadinstitute.dsde.workbench.leonardo.model._
 import org.broadinstitute.dsde.workbench.leonardo.model.google.ClusterStatus.Stopped
 import org.broadinstitute.dsde.workbench.leonardo.model.google._
@@ -34,6 +36,7 @@ import spray.json._
 
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
+import scala.util.Try
 import scala.util.control.NonFatal
 
 case class AuthorizationError(email: Option[WorkbenchEmail] = None)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/BucketHelper.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/BucketHelper.scala
@@ -65,7 +65,7 @@ class BucketHelper(dataprocConfig: DataprocConfig,
       ownerAcl = Map(StorageRole.ObjectAdmin ->  NonEmptyList(leoEntity, bucketSAs))
 
       // TODO set retryPolicy?
-      _ <- google2StorageDAO.createBucket(googleProject, bucketName)
+      _ <- google2StorageDAO.insertBucket(googleProject, bucketName)
       _ <- google2StorageDAO.setIamPolicy(bucketName, readerAcl ++ ownerAcl)
     } yield ()
   }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/BucketHelper.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/BucketHelper.scala
@@ -1,155 +1,92 @@
 package org.broadinstitute.dsde.workbench.leonardo.util
 
 import akka.actor.ActorSystem
-import akka.http.scaladsl.model.StatusCodes
-import cats.data.OptionT
+import cats.data.{NonEmptyList, OptionT}
+import cats.effect.{ContextShift, IO}
 import cats.implicits._
+import com.google.cloud.Identity
 import com.typesafe.scalalogging.LazyLogging
+import fs2._
 import org.broadinstitute.dsde.workbench.google.GoogleStorageDAO
+import org.broadinstitute.dsde.workbench.google2.{GcsBlobName, GoogleStorageService, StorageRole}
 import org.broadinstitute.dsde.workbench.leonardo.config.DataprocConfig
 import org.broadinstitute.dsde.workbench.leonardo.dao.google.{GoogleComputeDAO, GoogleDataprocDAO}
-import org.broadinstitute.dsde.workbench.leonardo.model.{LeoException, ServiceAccountInfo, ServiceAccountProvider}
+import org.broadinstitute.dsde.workbench.leonardo.model.{ServiceAccountInfo, ServiceAccountProvider}
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
-import org.broadinstitute.dsde.workbench.model.google.GcsEntityTypes.{Group, User}
-import org.broadinstitute.dsde.workbench.model.google.GcsRoles.{GcsRole, Owner, Reader}
-import org.broadinstitute.dsde.workbench.model.google.ProjectTeamTypes.{Editors, Owners, Viewers}
-import org.broadinstitute.dsde.workbench.model.google.{EmailGcsEntity, GcsBucketName, GcsEntity, GoogleProject, ProjectGcsEntity, ProjectNumber}
+import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GoogleProject}
 import org.broadinstitute.dsde.workbench.util.Retry
 
-import scala.concurrent.duration._
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.ExecutionContext
 
-case class NoGoogleProjectNumberException(googleProject: GoogleProject)
-  extends LeoException(
-    s"Project number could not be found for Google project $googleProject",
-    StatusCodes.NotFound)
-
-/**
-  * Created by rtitle on 2/7/18.
-  */
 class BucketHelper(dataprocConfig: DataprocConfig,
                    gdDAO: GoogleDataprocDAO,
                    googleComputeDAO: GoogleComputeDAO,
                    googleStorageDAO: GoogleStorageDAO,
+                   google2StorageDAO: GoogleStorageService[IO],
                    serviceAccountProvider: ServiceAccountProvider)
-                  (implicit val executionContext: ExecutionContext, val system: ActorSystem)
+                  (implicit val executionContext: ExecutionContext, val system: ActorSystem, contextShift: ContextShift[IO])
   extends LazyLogging with Retry {
 
   /**
     * Creates the dataproc init bucket and sets the necessary ACLs.
     */
-  def createInitBucket(googleProject: GoogleProject, bucketName: GcsBucketName, serviceAccountInfo: ServiceAccountInfo): Future[GcsBucketName] = {
+  def createInitBucket(googleProject: GoogleProject, bucketName: GcsBucketName, serviceAccountInfo: ServiceAccountInfo): Stream[IO, Unit] = {
     for {
       // The init bucket is created in the cluster's project.
       // Leo service account -> Owner
       // available service accounts ((cluster or default SA) and notebook SA, if they exist) -> Reader
-      bucketSAs <- getBucketSAs(googleProject, serviceAccountInfo)
-      leoEntity = userEntity(serviceAccountProvider.getLeoServiceAccountAndKey._1)
-      // When we receive a lot of simultaneous cluster creation requests in the same project,
-      // we hit Google bucket creation/deletion request quota of one per approx. two seconds.
-      // Therefore, we are adding a second layer of retries on top of the one existing within
-      // the googleStorageDAO.createBucket method
-      _ <- retryUntilSuccessOrTimeout(failureLogMessage = s"Init bucket creation failed for Google project '$googleProject'")(30 seconds, 5 minutes) { () =>
-        googleStorageDAO.createBucket(googleProject, bucketName, bucketSAs, List(leoEntity))
-      }
-    } yield bucketName
+      bucketSAs <- Stream.eval(getBucketSAs(googleProject, serviceAccountInfo))
+
+      leoEntity = Identity.user(serviceAccountProvider.getLeoServiceAccountAndKey._1.value)
+      readerAcl = NonEmptyList.fromList(bucketSAs).map(readers => Map(StorageRole.ObjectViewer -> readers)).getOrElse(Map.empty)
+      ownerAcl = Map(StorageRole.ObjectAdmin -> NonEmptyList.one(leoEntity))
+
+      // TODO set retryPolicy?
+      _ <- google2StorageDAO.insertBucket(googleProject, bucketName)
+      _ <- google2StorageDAO.setIamPolicy(bucketName, readerAcl ++ ownerAcl)
+    } yield ()
   }
 
   /**
     * Creates the dataproc staging bucket and sets the necessary ACLs.
     */
-  def createStagingBucket(userEmail: WorkbenchEmail, googleProject: GoogleProject, bucketName: GcsBucketName, serviceAccountInfo: ServiceAccountInfo): Future[GcsBucketName] = {
+  def createStagingBucket(userEmail: WorkbenchEmail, googleProject: GoogleProject, bucketName: GcsBucketName, serviceAccountInfo: ServiceAccountInfo): Stream[IO, Unit] = {
     for {
       // The staging bucket is created in the cluster's project.
       // Leo service account -> Owner
       // Available service accounts ((cluster or default SA) and notebook SA, if they exist) -> Owner
       // Additional readers (users and groups) are specified by the service account provider.
-      // Convenience values for projects (to address https://github.com/DataBiosphere/leonardo/issues/317)
-      //    viewers-<project number> -> Reader
-      //    editors-<project number> -> Owner
-      //    owners-<project number> -> Owner
-      bucketSAs <- getBucketSAs(googleProject, serviceAccountInfo)
-      leoEntity = userEntity(serviceAccountProvider.getLeoServiceAccountAndKey._1)
-      providerReaders <- serviceAccountProvider.listUsersStagingBucketReaders(userEmail).map(_.map(userEntity))
-      providerGroups <- serviceAccountProvider.listGroupsStagingBucketReaders(userEmail).map(_.map(groupEntity))
+      bucketSAs <- Stream.eval(getBucketSAs(googleProject, serviceAccountInfo))
+      providerReaders <- Stream.eval(IO.fromFuture(IO(serviceAccountProvider.listUsersStagingBucketReaders(userEmail)))).map(_.map(email => Identity.user(email.value)))
+      providerGroups <- Stream.eval(IO.fromFuture(IO(serviceAccountProvider.listGroupsStagingBucketReaders(userEmail)))).map(_.map(email => Identity.group(email.value)))
 
-      projectNumberOpt <- googleComputeDAO.getProjectNumber(googleProject)
-      (projectViewers, projectEditors, projectOwners) <- getConvenienceEntities(googleProject, projectNumberOpt)
+      leoEntity = Identity.user(serviceAccountProvider.getLeoServiceAccountAndKey._1.value)
+      readerAcl = NonEmptyList.fromList(providerReaders ++ providerGroups).map(readers => Map(StorageRole.ObjectViewer -> readers)).getOrElse(Map.empty)
+      ownerAcl = Map(StorageRole.ObjectAdmin ->  NonEmptyList(leoEntity, bucketSAs))
 
-      readers = providerReaders ++ providerGroups :+ projectViewers
-      owners = List(leoEntity) ++ bucketSAs :+ projectEditors :+ projectOwners
-
-      // When we receive a lot of simultaneous cluster creation requests in the same project,
-      // we hit Google bucket creation/deletion request quota of one per approx. two seconds.
-      // Therefore, we are adding a second layer of retries on top of the one existing within
-      // the googleStorageDAO.createBucket method
-      _ <- retryUntilSuccessOrTimeout(failureLogMessage = s"Staging bucket creation failed for Google project '$googleProject'")(30 seconds, 5 minutes) { () =>
-        googleStorageDAO.createBucket(googleProject, bucketName, readers, owners)
-      }
-    } yield bucketName
-  }
-
-  /**
-    * Sets ACLs on an existing user bucket so that it can be accessed in a dataproc cluster.
-    */
-  def updateUserBucket(bucketName: GcsBucketName, googleProject: GoogleProject, serviceAccountInfo: ServiceAccountInfo): Future[Unit] = {
-    for {
-      // available service accounts ((cluster or default SA) and notebook SA, if they exist) -> Reader
-      bucketSAs <- getBucketSAs(googleProject, serviceAccountInfo)
-
-      _ <- setBucketAcls(bucketName, bucketSAs, List.empty)
+      // TODO set retryPolicy?
+      _ <- google2StorageDAO.createBucket(googleProject, bucketName)
+      _ <- google2StorageDAO.setIamPolicy(bucketName, readerAcl ++ ownerAcl)
     } yield ()
   }
 
-  private def getConvenienceEntities(googleProject: GoogleProject,
-                                     googleProjectNumberOpt: Option[Long]): Future[(GcsEntity, GcsEntity, GcsEntity)] = {
-
-    def createEntities(projectNumber: Long): (GcsEntity, GcsEntity, GcsEntity) = {
-      val projectViewers = ProjectGcsEntity(Viewers, ProjectNumber(projectNumber.toString))
-      val projectEditors = ProjectGcsEntity(Editors, ProjectNumber(projectNumber.toString))
-      val projectOwners = ProjectGcsEntity(Owners, ProjectNumber(projectNumber.toString))
-
-      (projectViewers, projectEditors, projectOwners)
-    }
-
-    googleProjectNumberOpt match {
-      case Some(projectNumber) => Future(createEntities(projectNumber))
-      case _ => Future.failed(NoGoogleProjectNumberException(googleProject))
-    }
+  def storeObject(bucketName: GcsBucketName, objectName: GcsBlobName, objectContents: Array[Byte], objectType: String): Stream[IO, Unit] = {
+    google2StorageDAO.createBlob(bucketName, objectName, objectContents, objectType).void
   }
 
-  private def setBucketAcls(bucketName: GcsBucketName, readers: List[GcsEntity], owners: List[GcsEntity]): Future[Unit] = {
-    def setBucketAndDefaultAcls(entity: GcsEntity, role: GcsRole) = {
-      for {
-        _ <- googleStorageDAO.setBucketAccessControl(bucketName, entity, role)
-        _ <- googleStorageDAO.setDefaultObjectAccessControl(bucketName, entity, role)
-      } yield ()
-    }
-
-    def flatMapList(entities: List[GcsEntity], role: GcsRole): Future[Unit] = {
-      entities match {
-        case Nil => Future.unit
-        case head :: tail =>
-          setBucketAndDefaultAcls(head, role).flatMap(_ => flatMapList(tail, role))
-      }
-    }
-
-    for {
-      _ <- flatMapList(readers, Reader)
-      _ <- flatMapList(owners, Owner)
-    } yield ()
+  def deleteInitBucket(initBucketName: GcsBucketName): IO[Unit] = {
+    // TODO: implement deleteBucket in google2
+    IO.fromFuture(IO(googleStorageDAO.deleteBucket(initBucketName, recurse = true)))
   }
 
-  private def getBucketSAs(googleProject: GoogleProject, serviceAccountInfo: ServiceAccountInfo): Future[List[GcsEntity]] = {
+  private def getBucketSAs(googleProject: GoogleProject, serviceAccountInfo: ServiceAccountInfo): IO[List[Identity]] = {
     // cluster SA orElse compute engine default SA
-    val clusterOrComputeDefault = OptionT.fromOption[Future](serviceAccountInfo.clusterServiceAccount) orElse OptionT(googleComputeDAO.getComputeEngineDefaultServiceAccount(googleProject))
+    val clusterOrComputeDefault = OptionT.fromOption[IO](serviceAccountInfo.clusterServiceAccount) orElse
+      OptionT(IO.fromFuture(IO(googleComputeDAO.getComputeEngineDefaultServiceAccount(googleProject))))
 
     // List(cluster or default SA, notebook SA) if they exist
     clusterOrComputeDefault.value.map { clusterOrDefaultSAOpt =>
-      List(clusterOrDefaultSAOpt, serviceAccountInfo.notebookServiceAccount).flatten.map(userEntity)
+      List(clusterOrDefaultSAOpt, serviceAccountInfo.notebookServiceAccount).flatten.map(email => Identity.user(email.value))
     }
   }
-
-  private def userEntity(email: WorkbenchEmail) = EmailGcsEntity(User, email)
-  private def groupEntity(email: WorkbenchEmail) = EmailGcsEntity(Group, email)
 }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/ClusterHelper.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/ClusterHelper.scala
@@ -1,30 +1,42 @@
 package org.broadinstitute.dsde.workbench.leonardo.util
 
+import java.nio.charset.Charset
+
 import akka.actor.ActorSystem
 import cats.effect._
 import cats.implicits._
 import com.google.api.client.http.HttpResponseException
 import com.typesafe.scalalogging.LazyLogging
+import fs2._
 import org.broadinstitute.dsde.workbench.google.GoogleIamDAO
-import org.broadinstitute.dsde.workbench.leonardo.config.DataprocConfig
+import org.broadinstitute.dsde.workbench.leonardo.config.{ClusterFilesConfig, ClusterResourcesConfig, DataprocConfig, ProxyConfig}
 import org.broadinstitute.dsde.workbench.leonardo.dao.google.{GoogleComputeDAO, GoogleDataprocDAO}
 import org.broadinstitute.dsde.workbench.leonardo.db.DbReference
-import org.broadinstitute.dsde.workbench.leonardo.model.{LeoException, ServiceAccountInfo}
+import org.broadinstitute.dsde.workbench.leonardo.model.{Cluster, ClusterInitValues, LeoException, ServiceAccountInfo}
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
-import org.broadinstitute.dsde.workbench.model.google.{GoogleProject, ServiceAccountKey, ServiceAccountKeyId}
+import org.broadinstitute.dsde.workbench.model.google._
 import org.broadinstitute.dsde.workbench.google.GoogleUtilities.RetryPredicates._
+import org.broadinstitute.dsde.workbench.google2.GcsBlobName
+import org.broadinstitute.dsde.workbench.leonardo.model.google.DataprocRole.Master
+import org.broadinstitute.dsde.workbench.leonardo.model.google.{FirewallRule, FirewallRuleName, FirewallRulePort, FirewallRuleProtocol, MachineType, NetworkTag, VPCNetworkName}
+import org.broadinstitute.dsde.workbench.leonardo.util.TemplateHelper.GcsResource
 import org.broadinstitute.dsde.workbench.util.Retry
 
-import scala.concurrent.ExecutionContext
+import scala.concurrent.{ExecutionContext, Future}
 
 case class ClusterIamSetupException(googleProject: GoogleProject)
   extends LeoException(s"Error occurred setting up IAM roles in project ${googleProject.value}")
 
 class ClusterHelper(dbRef: DbReference,
                     dataprocConfig: DataprocConfig,
+                    proxyConfig: ProxyConfig,
+                    clusterResourcesConfig: ClusterResourcesConfig,
+                    clusterFilesConfig: ClusterFilesConfig,
+                    bucketHelper: BucketHelper,
                     gdDAO: GoogleDataprocDAO,
                     googleComputeDAO: GoogleComputeDAO,
-                    googleIamDAO: GoogleIamDAO)
+                    googleIamDAO: GoogleIamDAO,
+                    contentSecurityPolicy: String)
                    (implicit val executionContext: ExecutionContext, val system: ActorSystem, val contextShift: ContextShift[IO]) extends LazyLogging with Retry {
 
   def createClusterIamRoles(googleProject: GoogleProject, serviceAccountInfo: ServiceAccountInfo): IO[Unit] = {
@@ -117,12 +129,244 @@ class ClusterHelper(dbRef: DbReference,
     } getOrElse IO.unit
   }
 
+  def resizeCluster(cluster: Cluster, numWorkers: Option[Int], numPreemptibles: Option[Int]): IO[Unit] = {
+    for {
+      // IAM roles should already exist for a non-deleted cluster; this method is a no-op if the roles already exist.
+      _ <- createClusterIamRoles(cluster.googleProject, cluster.serviceAccountInfo)
+
+      // Resize the cluster in Google
+      // TODO: implement google2 version of GoogleComputeDAO
+      _ <- IO.fromFuture(IO(gdDAO.resizeCluster(cluster.googleProject, cluster.clusterName, numWorkers, numPreemptibles)))
+    } yield ()
+  }
+
+  def setMasterMachineType(cluster: Cluster, machineType: MachineType): IO[Unit] = {
+    cluster.instances.toList.traverse { instance =>
+      instance.dataprocRole match {
+        case Some(Master) =>
+          // TODO: implement google2 version of GoogleComputeDAO
+          IO.fromFuture(IO(googleComputeDAO.setMachineType(instance.key, machineType)))
+        case _ =>
+          // Note: we don't support changing the machine type for worker instances. While this is possible
+          // in GCP, Spark settings are auto-tuned to machine size. Dataproc recommends adding or removing nodes,
+          // and rebuilding the cluster if new worker machine/disk sizes are needed.
+          IO.unit
+      }
+    }.void
+  }
+
+  def updateMasterDiskSize(cluster: Cluster, diskSize: Int): IO[Unit] = {
+    cluster.instances.toList.traverse { instance =>
+      instance.dataprocRole match {
+        case Some(Master) =>
+          // TODO: implement google2 version of GoogleComputeDAO
+          IO.fromFuture(IO(googleComputeDAO.resizeDisk(instance.key, diskSize)))
+        case _ =>
+          // Note: we don't support changing the machine type for worker instances. While this is possible
+          // in GCP, Spark settings are auto-tuned to machine size. Dataproc recommends adding or removing nodes,
+          // and rebuilding the cluster if new worker machine/disk sizes are needed.
+          IO.unit
+      }
+    }.void
+  }
+
+  def deleteCluster(cluster: Cluster): IO[Unit] = {
+    IO.fromFuture(IO(gdDAO.deleteCluster(cluster.googleProject, cluster.clusterName)))
+  }
+
+  def stopCluster(cluster: Cluster): IO[Unit] = {
+    for {
+      // First remove all its preemptible instances, if any
+      _ <- if (cluster.machineConfig.numberOfPreemptibleWorkers.exists(_ > 0))
+        IO.fromFuture(IO(gdDAO.resizeCluster(cluster.googleProject, cluster.clusterName, numPreemptibles = Some(0))))
+      else IO.unit
+
+      // Now stop each instance individually
+      _ <- cluster.nonPreemptibleInstances.toList.traverse { instance =>
+        IO.fromFuture(IO(googleComputeDAO.stopInstance(instance.key)))
+      }
+    } yield ()
+  }
+
+  def startCluster(cluster: Cluster, metadata: Map[String, String]): IO[Unit] = {
+    for {
+      // Add back the preemptible instances, if any
+      _ <- if (cluster.machineConfig.numberOfPreemptibleWorkers.exists(_ > 0))
+        IO.fromFuture(IO(gdDAO.resizeCluster(cluster.googleProject, cluster.clusterName, numPreemptibles = cluster.machineConfig.numberOfPreemptibleWorkers)))
+      else IO.unit
+
+      // Start each instance individually
+      _ <- cluster.nonPreemptibleInstances.toList.traverse { instance =>
+        // Install a startup script on the master node so Jupyter starts back up again once the instance is restarted
+        IO.fromFuture(IO(instance.dataprocRole match {
+          case Some(Master) =>
+            googleComputeDAO.addInstanceMetadata(instance.key, metadata) >>
+              googleComputeDAO.startInstance(instance.key)
+          case _ =>
+            googleComputeDAO.startInstance(instance.key)
+        }))
+      }
+
+    } yield ()
+  }
+
+  def createGoogleCluster(cluster: Cluster): IO[(Cluster, GcsBucketName, Option[ServiceAccountKey])] = {
+    val initBucketName = generateUniqueBucketName("leoinit-"+cluster.clusterName.value)
+    val stagingBucketName = generateUniqueBucketName("leostaging-"+cluster.clusterName.value)
+
+    // Generate a service account key for the notebook service account (if present) to localize on the cluster.
+    // We don't need to do this for the cluster service account because its credentials are already
+    // on the metadata server.
+    generateServiceAccountKey(cluster.googleProject, cluster.serviceAccountInfo.notebookServiceAccount).flatMap { serviceAccountKeyOpt =>
+      for {
+        // Create the firewall rule in the google project if it doesn't already exist, so we can access the cluster
+        _ <- IO.fromFuture(IO(googleComputeDAO.updateFirewallRule(cluster.googleProject, firewallRule)))
+
+        // Set up IAM roles necessary to create a cluster.
+        _ <- createClusterIamRoles(cluster.googleProject, cluster.serviceAccountInfo)
+
+        // Create the bucket in the cluster's google project and populate with initialization files.
+        // ACLs are granted so the cluster service account can access the files at initialization time.
+        _ <- bucketHelper.createInitBucket(cluster.googleProject, initBucketName, cluster.serviceAccountInfo).compile.drain
+        _ <- initializeBucketObjects(cluster, initBucketName, serviceAccountKeyOpt).compile.drain
+
+        // Create the cluster staging bucket. ACLs are granted so the user/pet can access it.
+        _ <- bucketHelper.createStagingBucket(cluster.auditInfo.creator, cluster.googleProject, stagingBucketName, cluster.serviceAccountInfo).compile.drain
+      } yield ???
+
+    }
+
+    // memoized
+    val serviceAccountKeyFuture = generateServiceAccountKey(cluster.googleProject, cluster.serviceAccountInfo.notebookServiceAccount)
+    val serviceAccountKeyIO = IO.fromFuture(IO(serviceAccountKeyFuture))
+
+    val ioResult: IO[(Cluster, GcsBucketName, Option[ServiceAccountKey])] = for {
+      // Create the firewall rule in the google project if it doesn't already exist, so we can access the cluster
+      _ <- IO.fromFuture(IO(googleComputeDAO.updateFirewallRule(cluster.googleProject, firewallRule)))
+
+      // Generate a service account key for the notebook service account (if present) to localize on the cluster.
+      // We don't need to do this for the cluster service account because its credentials are already
+      // on the metadata server.
+      serviceAccountKeyOpt <- serviceAccountKeyIO
+
+      // Add Dataproc Worker role to the cluster service account, if present.
+      // This is needed to be able to spin up Dataproc clusters.
+      // If the Google Compute default service account is being used, this is not necessary.
+      _ <- IO.fromFuture(IO(addDataprocWorkerRoleToServiceAccount(cluster.googleProject, cluster.serviceAccountInfo.clusterServiceAccount)))
+
+      // Create the bucket in the cluster's google project and populate with initialization files.
+      // ACLs are granted so the cluster service account can access the files at initialization time.
+      _ <- bucketHelper.createInitBucket(cluster.googleProject, initBucketName, cluster.serviceAccountInfo).compile.drain
+      _ <- initializeBucketObjects(cluster, initBucketName, serviceAccountKeyOpt).compile.drain
+
+      // Create the cluster staging bucket. ACLs are granted so the user/pet can access it.
+      _ <- bucketHelper.createStagingBucket(cluster.auditInfo.creator, cluster.googleProject, stagingBucketName, cluster.serviceAccountInfo)
+
+      // build cluster configuration
+      machineConfig = cluster.machineConfig
+      initScript = GcsPath(initBucketName, GcsObjectName(clusterResourcesConfig.initActionsScript.value))
+      //   autopauseThreshold = cluster.autopauseThreshold
+      //  clusterScopes = if(clusterRequest.scopes.isEmpty) dataprocConfig.defaultScopes else clusterRequest.scopes
+      credentialsFileName = cluster.serviceAccountInfo.notebookServiceAccount.map(_ => s"/etc/${ClusterInitValues.serviceAccountCredentialsFilename}")
+
+      // decide whether to use VPC network
+      lookupProjectLabels = dataprocConfig.projectVPCNetworkLabel.isDefined || dataprocConfig.projectVPCSubnetLabel.isDefined
+      projectLabels <- if (lookupProjectLabels) IO.fromFuture(IO(googleProjectDAO.getLabels(cluster.googleProject.value))) else IO(Map.empty[String, String])
+      clusterVPCSettings = getClusterVPCSettings(projectLabels)
+
+      // Create the cluster
+      createClusterConfig = CreateClusterConfig(machineConfig, initScript, cluster.serviceAccountInfo.clusterServiceAccount, credentialsFileName, stagingBucketName, cluster.scopes, clusterVPCSettings, cluster.properties)
+      retryResult <- IO.fromFuture(IO(retryExponentially(whenGoogleZoneCapacityIssue, "Cluster creation failed because zone with adequate resources was not found") { () =>
+        gdDAO.createCluster(cluster.googleProject, cluster.clusterName, createClusterConfig)
+      }))
+
+
+      operation <- retryResult match {
+        case Right((errors, op)) if errors == List.empty => IO(op)
+        case Right((errors, op)) =>
+          Metrics.newRelic.incrementCounterIO("zoneCapacityClusterCreationFailure", errors.length)
+            .as(op)
+        case Left(errors) =>
+          Metrics.newRelic.incrementCounterIO("zoneCapacityClusterCreationFailure", errors.filter(whenGoogleZoneCapacityIssue).length)
+            .flatMap(_ => IO.raiseError(errors.head))
+      }
+
+      cluster = Cluster.createFinal(cluster, operation, stagingBucketName)
+    } yield (cluster, initBucketName, serviceAccountKeyOpt)
+
+
+    ioResult.handleErrorWith { throwable =>
+      cleanUpGoogleResourcesOnError(cluster.googleProject,
+        cluster.clusterName, initBucketName,
+        cluster.serviceAccountInfo, serviceAccountKeyIO) >> IO.raiseError(throwable)
+    }
+
+  }
+
+  private def firewallRule = FirewallRule(
+    name = FirewallRuleName(dataprocConfig.firewallRuleName),
+    protocol = FirewallRuleProtocol(proxyConfig.jupyterProtocol),
+    ports = List(FirewallRulePort(proxyConfig.jupyterPort.toString)),
+    network = dataprocConfig.vpcNetwork.map(VPCNetworkName),
+    targetTags = List(NetworkTag(dataprocConfig.networkTag)))
+
   // See https://cloud.google.com/dataproc/docs/guides/dataproc-images#custom_image_uri
   private def parseImageProject(customDataprocImage: String): Option[GoogleProject] = {
     val regex = ".*projects/(.*)/global/images/(.*)".r
     customDataprocImage match {
       case regex(project, _) => Some(GoogleProject(project))
       case _ => None
+    }
+  }
+
+  /* Process the templated cluster init script and put all initialization files in the init bucket */
+  private def initializeBucketObjects(cluster: Cluster, initBucketName: GcsBucketName, serviceAccountKey: Option[ServiceAccountKey]): Stream[IO, Unit] = {
+    // Build a mapping of (name, value) pairs with which to apply templating logic to resources
+    val replacements = ClusterInitValues(cluster, initBucketName, serviceAccountKey, dataprocConfig, proxyConfig, clusterFilesConfig, clusterResourcesConfig, contentSecurityPolicy).toMap
+
+    // Raw files to upload to the bucket, no additional processing needed.
+    val rawFilesToUpload = Stream.emits(
+      Seq(
+        clusterFilesConfig.jupyterServerCrt,
+        clusterFilesConfig.jupyterServerKey,
+        clusterFilesConfig.jupyterRootCaPem
+      )
+    ).evalMap { f =>
+      TemplateHelper.readFile[IO](f, executionContext)
+    }
+
+    val rawResourcesToUpload = Stream.emits(
+      Seq(
+        clusterResourcesConfig.jupyterDockerCompose,
+        clusterResourcesConfig.rstudioDockerCompose,
+        clusterResourcesConfig.proxyDockerCompose,
+        clusterResourcesConfig.proxySiteConf,
+        clusterResourcesConfig.welderDockerCompose,
+        clusterResourcesConfig.initVmScript
+      )
+    ).evalMap { resource =>
+      TemplateHelper.readResource(resource, executionContext)
+    }
+
+    val templatedResourcesToUpload = Stream.emits(
+      Seq(
+        clusterResourcesConfig.initActionsScript,
+        clusterResourcesConfig.jupyterNotebookConfigUri,
+        clusterResourcesConfig.jupyterNotebookFrontendConfigUri
+      )
+    ).evalMap { resource =>
+      TemplateHelper.templateResource(replacements, resource, executionContext)
+    }
+
+    val privateKey = Stream.emit(
+      for {
+        k <- serviceAccountKey
+        d <- k.privateKeyData.decode
+      } yield GcsResource(GcsBlobName(ClusterInitValues.serviceAccountCredentialsFilename), d.getBytes(Charset.defaultCharset))
+    ).unNone
+
+    (rawFilesToUpload ++ rawResourcesToUpload ++ templatedResourcesToUpload ++ privateKey).evalMap[IO, Unit] { resource =>
+      bucketHelper.storeObject(initBucketName, resource.gcsBlobName, resource.content, "text/plain")
     }
   }
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/ClusterHelper.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/ClusterHelper.scala
@@ -113,11 +113,6 @@ class ClusterHelper(dbRef: DbReference,
     List(dataprocWorkerIO, computeImageUserIO).parSequence_
   }
 
-  private def when400(throwable: Throwable): Boolean = throwable match {
-    case t: HttpResponseException => t.getStatusCode == 400
-    case _ => false
-  }
-
   def generateServiceAccountKey(googleProject: GoogleProject, serviceAccountEmailOpt: Option[WorkbenchEmail]): IO[Option[ServiceAccountKey]] = {
     serviceAccountEmailOpt.traverse { email =>
       IO.fromFuture(IO(googleIamDAO.createServiceAccountKey(googleProject, email)))

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/TemplateHelper.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/TemplateHelper.scala
@@ -11,43 +11,31 @@ import scala.concurrent.ExecutionContext
 
 object TemplateHelper {
 
-  def readFile[F[_]: ContextShift: Sync](file: File, blockingEc: ExecutionContext): F[Array[Byte]] = {
-    fileStream(file, blockingEc)
-      .compile.to[Array]
-  }
-
-  def templatefile[F[_]: ContextShift: Sync](replacementMap: Map[String, String], file: File, blockingEc: ExecutionContext): F[Array[Byte]] = {
+  def templateFile[F[_]: ContextShift: Sync](replacementMap: Map[String, String], file: File, blockingEc: ExecutionContext): Stream[F, Byte] = {
     fileStream(file, blockingEc)
       .through(text.utf8Decode)
       .map(template(replacementMap))
       .through(text.utf8Encode)
-      .compile.to[Array]
   }
 
-  def readResource[F[_]: ContextShift: Sync](clusterResource: ClusterResource, blockingEc: ExecutionContext): F[Array[Byte]] = {
-    resourceStream(clusterResource, blockingEc)
-      .compile.to[Array]
-  }
-
-  def templateResource[F[_]: ContextShift: Sync](replacementMap: Map[String, String], clusterResource: ClusterResource, blockingEc: ExecutionContext): F[Array[Byte]] = {
+  def templateResource[F[_]: ContextShift: Sync](replacementMap: Map[String, String], clusterResource: ClusterResource, blockingEc: ExecutionContext): Stream[F, Byte] = {
     resourceStream(clusterResource, blockingEc)
       .through(text.utf8Decode)
       .map(template(replacementMap))
       .through(text.utf8Encode)
-      .compile.to[Array]
+  }
+
+  def fileStream[F[_]: ContextShift: Sync](file: File, blockingEc: ExecutionContext): Stream[F, Byte] = {
+    io.file.readAll[F](file.toPath, blockingEc, 4096)
+  }
+
+  def resourceStream[F[_]: ContextShift: Sync](clusterResource: ClusterResource, blockingEc: ExecutionContext): Stream[F, Byte] = {
+    val inputStream = Sync[F].delay(getClass().getResourceAsStream(s"${ClusterResourcesConfig.basePath}/${clusterResource.value}"))
+    io.readInputStream[F](inputStream, 4096, blockingEc)
   }
 
   private def template(replacementMap: Map[String, String])(str: String): String = {
     replacementMap.foldLeft(str)((a, b) => a.replaceAllLiterally("$(" + b._1 + ")", "\"" + b._2 + "\""))
-  }
-
-  private def fileStream[F[_]: ContextShift: Sync](file: File, blockingEc: ExecutionContext): Stream[F, Byte] = {
-    io.file.readAll[F](file.toPath, blockingEc, 4096)
-  }
-
-  private def resourceStream[F[_]: ContextShift: Sync](clusterResource: ClusterResource, blockingEc: ExecutionContext): Stream[F, Byte] = {
-    val inputStream = Sync[F].delay(getClass().getResourceAsStream(s"${ClusterResourcesConfig.basePath}/${clusterResource.value}"))
-    io.readInputStream[F](inputStream, 4096, blockingEc)
   }
 
 }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/TemplateHelper.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/TemplateHelper.scala
@@ -1,0 +1,113 @@
+package org.broadinstitute.dsde.workbench.leonardo.util
+
+import java.io.File
+
+import cats.effect.IO
+import org.broadinstitute.dsde.workbench.leonardo.config.ClusterResourcesConfig
+import org.broadinstitute.dsde.workbench.leonardo.model.ClusterResource
+
+import scala.io.Source
+import cats.effect._
+import cats.implicits._
+import fs2._
+import fs2.io._
+import org.broadinstitute.dsde.workbench.google2.GcsBlobName
+import org.broadinstitute.dsde.workbench.model.google.GcsObjectName
+
+import scala.concurrent.ExecutionContext
+
+
+object TemplateHelper {
+
+
+  case class GcsResource(gcsBlobName: GcsBlobName, content: Array[Byte])
+
+
+  def readFile[F[_]: ContextShift: Sync](file: File, blockingEc: ExecutionContext): F[GcsResource] = {
+    fileStream(file, blockingEc)
+      .compile.to[Array]
+      .map { data => GcsResource(GcsBlobName(file.getName), data) }
+  }
+
+  def templatefile[F[_]: ContextShift: Sync](replacementMap: Map[String, String], file: File, blockingEc: ExecutionContext): F[GcsResource] = {
+    fileStream(file, blockingEc)
+      .through(text.utf8Decode)
+      .map(template(replacementMap))
+      .through(text.utf8Encode)
+      .compile.to[Array]
+      .map { data => GcsResource(GcsBlobName(file.getName), data) }
+  }
+
+  def readResource[F[_]: ContextShift: Sync](clusterResource: ClusterResource, blockingEc: ExecutionContext): F[GcsResource] = {
+    resourceStream(clusterResource, blockingEc)
+      .compile.to[Array]
+      .map { data => GcsResource(GcsBlobName(clusterResource.value), data) }
+  }
+
+  def templateResource[F[_]: ContextShift: Sync](replacementMap: Map[String, String], clusterResource: ClusterResource, blockingEc: ExecutionContext): F[GcsResource] = {
+    resourceStream(clusterResource, blockingEc)
+      .through(text.utf8Decode)
+      .map(template(replacementMap))
+      .through(text.utf8Encode)
+      .compile.to[Array]
+      .map { data => GcsResource(GcsBlobName(clusterResource.value), data) }
+  }
+
+  private def template(replacementMap: Map[String, String])(str: String): String = {
+    replacementMap.foldLeft(str)((a, b) => a.replaceAllLiterally("$(" + b._1 + ")", "\"" + b._2 + "\""))
+  }
+
+  private def fileStream[F[_]: ContextShift: Sync](file: File, blockingEc: ExecutionContext): Stream[F, Byte] = {
+    io.file.readAll[F](file.toPath, blockingEc, 4096)
+  }
+
+  private def resourceStream[F[_]: ContextShift: Sync](clusterResource: ClusterResource, blockingEc: ExecutionContext): Stream[F, Byte] = {
+    val inputStream = Sync[F].delay(getClass().getResourceAsStream(s"${ClusterResourcesConfig.basePath}/${clusterResource.value}"))
+    io.readInputStream[F](inputStream, 4096, blockingEc)
+  }
+
+
+  //
+  //  private def getFileContent(file: File, blockingEc: ExecutionContext): Stream[IO, String] = {
+  //    io.file.readAll[IO](file.toPath, blockingEc, 4096)
+  //      .through(text.utf8Decode)
+  //      .through(text.lines)
+  //  }
+  //
+  //
+  //  private def getResourceContent(clusterResource: ClusterResource, blockingEc: ExecutionContext): Stream[IO, String] = {
+  //    val inputStream = IO(getClass().getResourceAsStream(s"${ClusterResourcesConfig.basePath}/${clusterResource.value}"))
+  //    io.readInputStream[IO](inputStream, 4096, blockingEc)
+  //      .through(text.utf8Decode)
+  //      .through(text.lines)
+  //  }
+  //
+  //  private def template(replacementMap: Map[String, String]): Pipe[IO, String, String] = in =>
+  //    in.map { line =>
+  //      replacementMap.foldLeft(line)((a, b) => a.replaceAllLiterally("$(" + b._1 + ")", "\"" + b._2 + "\""))
+  //    }
+
+
+
+  //  private def resourceContent(blockingEc: ExecutionContext): Pipe[IO, ClusterResource, (GcsObjectName, Array[Byte])] = in =>
+  //    in.evalMap { f =>
+  //      io.file.readAll(f.toPath, blockingEc, 4096).compile.toList
+  //    }
+  //
+  //
+  //  // Process a string using map of replacement values. Each value in the replacement map replaces its key in the string.
+  //  private[service] def template(raw: String, replacementMap: Map[String, String]): String = {
+  //    replacementMap.foldLeft(raw)((a, b) => a.replaceAllLiterally("$(" + b._1 + ")", "\"" + b._2 + "\""))
+  //  }
+  //
+  //  private[service] def templateFile(file: File, replacementMap: Map[String, String]): String = {
+  //    val raw = Source.fromFile(file).mkString
+  //    template(raw, replacementMap)
+  //  }
+  //
+  //  private[service] def templateResource(resource: ClusterResource, replacementMap: Map[String, String]): String = {
+  //    val raw = Source.fromResource(s"${ClusterResourcesConfig.basePath}/${resource.value}").mkString
+  //    template(raw, replacementMap)
+  //  }
+
+}

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/TemplateHelper.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/TemplateHelper.scala
@@ -2,55 +2,39 @@ package org.broadinstitute.dsde.workbench.leonardo.util
 
 import java.io.File
 
-import cats.effect.IO
+import cats.effect._
+import fs2._
 import org.broadinstitute.dsde.workbench.leonardo.config.ClusterResourcesConfig
 import org.broadinstitute.dsde.workbench.leonardo.model.ClusterResource
 
-import scala.io.Source
-import cats.effect._
-import cats.implicits._
-import fs2._
-import fs2.io._
-import org.broadinstitute.dsde.workbench.google2.GcsBlobName
-import org.broadinstitute.dsde.workbench.model.google.GcsObjectName
-
 import scala.concurrent.ExecutionContext
-
 
 object TemplateHelper {
 
-
-  case class GcsResource(gcsBlobName: GcsBlobName, content: Array[Byte])
-
-
-  def readFile[F[_]: ContextShift: Sync](file: File, blockingEc: ExecutionContext): F[GcsResource] = {
+  def readFile[F[_]: ContextShift: Sync](file: File, blockingEc: ExecutionContext): F[Array[Byte]] = {
     fileStream(file, blockingEc)
       .compile.to[Array]
-      .map { data => GcsResource(GcsBlobName(file.getName), data) }
   }
 
-  def templatefile[F[_]: ContextShift: Sync](replacementMap: Map[String, String], file: File, blockingEc: ExecutionContext): F[GcsResource] = {
+  def templatefile[F[_]: ContextShift: Sync](replacementMap: Map[String, String], file: File, blockingEc: ExecutionContext): F[Array[Byte]] = {
     fileStream(file, blockingEc)
       .through(text.utf8Decode)
       .map(template(replacementMap))
       .through(text.utf8Encode)
       .compile.to[Array]
-      .map { data => GcsResource(GcsBlobName(file.getName), data) }
   }
 
-  def readResource[F[_]: ContextShift: Sync](clusterResource: ClusterResource, blockingEc: ExecutionContext): F[GcsResource] = {
+  def readResource[F[_]: ContextShift: Sync](clusterResource: ClusterResource, blockingEc: ExecutionContext): F[Array[Byte]] = {
     resourceStream(clusterResource, blockingEc)
       .compile.to[Array]
-      .map { data => GcsResource(GcsBlobName(clusterResource.value), data) }
   }
 
-  def templateResource[F[_]: ContextShift: Sync](replacementMap: Map[String, String], clusterResource: ClusterResource, blockingEc: ExecutionContext): F[GcsResource] = {
+  def templateResource[F[_]: ContextShift: Sync](replacementMap: Map[String, String], clusterResource: ClusterResource, blockingEc: ExecutionContext): F[Array[Byte]] = {
     resourceStream(clusterResource, blockingEc)
       .through(text.utf8Decode)
       .map(template(replacementMap))
       .through(text.utf8Encode)
       .compile.to[Array]
-      .map { data => GcsResource(GcsBlobName(clusterResource.value), data) }
   }
 
   private def template(replacementMap: Map[String, String])(str: String): String = {
@@ -65,49 +49,5 @@ object TemplateHelper {
     val inputStream = Sync[F].delay(getClass().getResourceAsStream(s"${ClusterResourcesConfig.basePath}/${clusterResource.value}"))
     io.readInputStream[F](inputStream, 4096, blockingEc)
   }
-
-
-  //
-  //  private def getFileContent(file: File, blockingEc: ExecutionContext): Stream[IO, String] = {
-  //    io.file.readAll[IO](file.toPath, blockingEc, 4096)
-  //      .through(text.utf8Decode)
-  //      .through(text.lines)
-  //  }
-  //
-  //
-  //  private def getResourceContent(clusterResource: ClusterResource, blockingEc: ExecutionContext): Stream[IO, String] = {
-  //    val inputStream = IO(getClass().getResourceAsStream(s"${ClusterResourcesConfig.basePath}/${clusterResource.value}"))
-  //    io.readInputStream[IO](inputStream, 4096, blockingEc)
-  //      .through(text.utf8Decode)
-  //      .through(text.lines)
-  //  }
-  //
-  //  private def template(replacementMap: Map[String, String]): Pipe[IO, String, String] = in =>
-  //    in.map { line =>
-  //      replacementMap.foldLeft(line)((a, b) => a.replaceAllLiterally("$(" + b._1 + ")", "\"" + b._2 + "\""))
-  //    }
-
-
-
-  //  private def resourceContent(blockingEc: ExecutionContext): Pipe[IO, ClusterResource, (GcsObjectName, Array[Byte])] = in =>
-  //    in.evalMap { f =>
-  //      io.file.readAll(f.toPath, blockingEc, 4096).compile.toList
-  //    }
-  //
-  //
-  //  // Process a string using map of replacement values. Each value in the replacement map replaces its key in the string.
-  //  private[service] def template(raw: String, replacementMap: Map[String, String]): String = {
-  //    replacementMap.foldLeft(raw)((a, b) => a.replaceAllLiterally("$(" + b._1 + ")", "\"" + b._2 + "\""))
-  //  }
-  //
-  //  private[service] def templateFile(file: File, replacementMap: Map[String, String]): String = {
-  //    val raw = Source.fromFile(file).mkString
-  //    template(raw, replacementMap)
-  //  }
-  //
-  //  private[service] def templateResource(resource: ClusterResource, replacementMap: Map[String, String]): String = {
-  //    val raw = Source.fromResource(s"${ClusterResourcesConfig.basePath}/${resource.value}").mkString
-  //    template(raw, replacementMap)
-  //  }
 
 }


### PR DESCRIPTION
_Note: this is a work-in-progress, opening for early feedback. Unit tests do not work yet!_

Please read this first. There is a lot of refactoring here. I will try to describe what the refactoring means in terms of front/back Leo.

## Front Leo
* Relevant classes: `LeonardoService`
* No more async cluster creation. In fact, `LeonardoService` does not do anything async to the request.
* `LeonardoService` no longer talks to Google for createCluster requests. (It only talks to Sam and the Leo DB.)
* `LeonardoService` _still_ talks to Google for deleteCluster, stopCluster, startCluster, and updateCluster. We could potentially move those Google calls to back Leo as well if there is a need for it (but in a separate PR).
* As a result of this, `LeonardoService` is a bit smaller: 667 lines instead of 1147. It also hopefully performs better in the case of many simultaneous cluster creation requests.

## Back Leo
* Relevant classes: `ClusterMonitorSupervisor`, `ClusterMonitorActor`
* Logic is mostly the same, although `ClusterMonitorActor` now performs cluster creation as part of the `Creating` phase.
* Removed weird callback to `LeonardoService` from `ClusterMonitorSupervisor`. It is now able to use `ClusterHelper` (a shared component) instead.

## Shared
* Relevant classes: `ClusterHelper`, `BucketHelper`, `TemplateHelper`
   * Note: if you have feedback on names I'm all ears; I don't love the word "helper".
* The intent of these classes is to contain useful Leo functionality that is shared between front and back Leo. While the DAOs are a thin layer on top of Google APIs, think of the Helper classes as orchestrating calls to the Google DAOs to fulfill Leo business logic.
* `ClusterHelper` has functionality around managing Dataproc clusters, including create, stop, start, etc. A lot of the `LeonardoService` code moved here. 
* `BucketHelper` has functionality around GCS, including creating buckets, populating them, permissioning them, etc. This was a pre-existing class but I updated it to use the `google2` storage interpreter.
* `TemplateHelper` contains our templating engine. I rewrote it to use `fs2.Stream` instead of `scala.io.Source`.

Any early feedback welcome; next steps are code cleanup, fixing unit tests, and doing a lot of testing to hopefully catch any regressions.


Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
