### PR TITLE
[IA-1391] Fail gracefully if welder-deploy doesn't work

### DIFF
--- a/http/src/main/resources/jupyter/startup.sh
+++ b/http/src/main/resources/jupyter/startup.sh
@@ -33,7 +33,7 @@ if [ "$DEPLOY_WELDER" == "true" ] ; then
 
     # Enable welder in /etc/jupyter/nbconfig/notebook.json (which powers the front-end extensions like edit.js and safe.js)
     docker exec -u root -i $JUPYTER_SERVER_NAME bash -c \
-      "test -f /etc/jupyter/nbconfig/notebook.json && jq '.welderEnabled=\"true\"' /etc/jupyter/nbconfig/notebook.json > /etc/jupyter/nbconfig/notebook.json.tmp && mv /etc/jupyter/nbconfig/notebook.json.tmp /etc/jupyter/nbconfig/notebook.json"
+      "test -f /etc/jupyter/nbconfig/notebook.json && jq '.welderEnabled=\"true\"' /etc/jupyter/nbconfig/notebook.json > /etc/jupyter/nbconfig/notebook.json.tmp && mv /etc/jupyter/nbconfig/notebook.json.tmp /etc/jupyter/nbconfig/notebook.json || true"
 fi
 
 if [ "$UPDATE_WELDER" == "true" ] ; then

--- a/http/src/main/resources/jupyter/startup.sh
+++ b/http/src/main/resources/jupyter/startup.sh
@@ -33,7 +33,7 @@ if [ "$DEPLOY_WELDER" == "true" ] ; then
 
     # Enable welder in /etc/jupyter/nbconfig/notebook.json (which powers the front-end extensions like edit.js and safe.js)
     docker exec -u root -i $JUPYTER_SERVER_NAME bash -c \
-      "jq '.welderEnabled=\"true\"' /etc/jupyter/nbconfig/notebook.json > /etc/jupyter/nbconfig/notebook.json.tmp && mv /etc/jupyter/nbconfig/notebook.json.tmp /etc/jupyter/nbconfig/notebook.json"
+      "test -f /etc/jupyter/nbconfig/notebook.json && jq '.welderEnabled=\"true\"' /etc/jupyter/nbconfig/notebook.json > /etc/jupyter/nbconfig/notebook.json.tmp && mv /etc/jupyter/nbconfig/notebook.json.tmp /etc/jupyter/nbconfig/notebook.json"
 fi
 
 if [ "$UPDATE_WELDER" == "true" ] ; then

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -39,8 +39,8 @@ dataproc {
   # The current value is only used for integration testing.
   updateWelderLabel = "TEST_ONLY_UPDATE_WELDER"
 
-  # Leo will prevent starting any clusters that were created before this date.
-  clusterCutoffDate = "2019-06-04"
+  # Leo will prevent deploying welder to any clusters that were created before this date.
+  deployWelderCutoffDate = "2019-08-01"
 }
 
 # cluster scripts and config

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -38,6 +38,9 @@ dataproc {
   # TODO: change this to 'saturnVersion' once ready to enable in production for Terra clusters.
   # The current value is only used for integration testing.
   updateWelderLabel = "TEST_ONLY_UPDATE_WELDER"
+
+  # Leo will prevent starting any clusters that were created before this date.
+  clusterCutoffDate = "2019-06-04"
 }
 
 # cluster scripts and config

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/DataprocConfig.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/DataprocConfig.scala
@@ -28,5 +28,5 @@ case class DataprocConfig(
                            customDataprocImage: Option[String],
                            deployWelderLabel: Option[String],
                            updateWelderLabel: Option[String],
-                           clusterCutoffDate: Option[String]
+                           deployWelderCutoffDate: Option[String]
                          )

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/DataprocConfig.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/DataprocConfig.scala
@@ -27,5 +27,6 @@ case class DataprocConfig(
                            welderDisabledNotebooksDir: String, // TODO: remove once welder is rolled out to all clusters
                            customDataprocImage: Option[String],
                            deployWelderLabel: Option[String],
-                           updateWelderLabel: Option[String]
+                           updateWelderLabel: Option[String],
+                           clusterCutoffDate: Option[String]
                          )

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/package.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/package.scala
@@ -43,7 +43,7 @@ package object config {
       config.getAs[String]("customDataprocImage"),
       config.getAs[String]("deployWelderLabel"),
       config.getAs[String]("updateWelderLabel"),
-      config.getAs[String]("clusterCutoffDate")
+      config.getAs[String]("deployWelderCutoffDate")
     )
   }
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/package.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/package.scala
@@ -42,7 +42,8 @@ package object config {
       config.getString("welderDisabledNotebooksDir"),
       config.getAs[String]("customDataprocImage"),
       config.getAs[String]("deployWelderLabel"),
-      config.getAs[String]("updateWelderLabel")
+      config.getAs[String]("updateWelderLabel"),
+      config.getAs[String]("clusterCutoffDate")
     )
   }
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponent.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponent.scala
@@ -379,6 +379,11 @@ trait ClusterComponent extends LeoComponent {
       findByIdQuery(id).map(c => (c.status, c.dateAccessed)).update(newStatus.toString, Timestamp.from(Instant.now))
     }
 
+    // for testing only
+    def updateClusterCreatedDate(id: Long, createdDate: Instant): DBIO[Int] = {
+      findByIdQuery(id).map { _.createdDate }.update(Timestamp.from(createdDate))
+    }
+
     def updateDateAccessed(id: Long, dateAccessed: Instant): DBIO[Int] = {
       findByIdQuery(id).filter { _.dateAccessed < Timestamp.from(dateAccessed)}.map(_.dateAccessed).update(Timestamp.from(dateAccessed))
     }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeonardoModel.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeonardoModel.scala
@@ -428,6 +428,16 @@ object ExtensionType extends Enum[ExtensionType] {
   case object LabExtension extends ExtensionType
 }
 
+sealed trait WelderAction extends EnumEntry
+object WelderAction extends Enum[WelderAction] {
+  val values = findValues
+
+  case object DeployWelder extends WelderAction
+  case object UpdateWelder extends WelderAction
+  case object NoAction extends WelderAction
+  case object ClusterOutOfDate extends WelderAction
+}
+
 object LeonardoJsonSupport extends SprayJsonSupport with DefaultJsonProtocol {
   implicit object URLFormat extends JsonFormat[URL] {
     def write(obj: URL) = JsString(obj.toString)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoService.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoService.scala
@@ -71,8 +71,8 @@ case class ClusterCannotBeStartedException(googleProject: GoogleProject, cluster
 case class ClusterOutOfDateException()
   extends LeoException(
     "Your notebook runtime is out of date, and cannot be started due to recent updates in Terra. If you generated " +
-    "data or copied external files to the runtime that you want to keep please contact support. Otherwise, simply " +
-    "delete your existing runtime and create a new one.", StatusCodes.Conflict)
+    "data or copied external files to the runtime that you want to keep please contact support by emailing " +
+    "Terra-support@broadinstitute.zendesk.com. Otherwise, simply delete your existing runtime and create a new one.", StatusCodes.Conflict)
 
 case class ClusterCannotBeUpdatedException(cluster: Cluster)
   extends LeoException(s"Cluster ${cluster.projectNameString} cannot be updated in ${cluster.status} status", StatusCodes.Conflict)

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoServiceSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoServiceSpec.scala
@@ -1329,8 +1329,9 @@ class LeonardoServiceSpec extends TestKit(ActorSystem("leonardotest")) with Flat
     gdDAO.clusters should not contain key(name1)
 
     // create the cluster
+    val request = testClusterRequest.copy(labels = Map("TEST_ONLY_DEPLOY_WELDER" -> "yes"))
     val clusterCreateResponse =
-      leo.processClusterCreationRequest(userInfo, project, name1, testClusterRequest).futureValue
+      leo.processClusterCreationRequest(userInfo, project, name1, request).futureValue
 
     eventually {
       // check that the cluster was created


### PR DESCRIPTION
See https://broadworkbench.atlassian.net/browse/IA-1391

Makes Leo `startCluster` fail with a friendly error if trying to start a cluster that's too old.

Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
