### PR TITLE
IA-1433 - add retries to IAM calls in Leo and IA-1434 - clusters stuck in Deleting state

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 jdk:
-  - oraclejdk8
+  - openjdk8
 
 language: scala
 

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoServiceSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoServiceSpec.scala
@@ -509,7 +509,7 @@ class LeonardoServiceSpec extends TestKit(ActorSystem("leonardotest")) with Flat
   }
 
   it should "delete a cluster that has status Error and does not have a google id" in isolatedDbTest {
-    //we meed to use a special version of the MockGoogleIamDAO to simulate an error when adding IAM roles
+    //we need to use a special version of the MockGoogleIamDAO to simulate an error when adding IAM roles
     val iamDAO = new ErroredMockGoogleIamDAO
     val clusterHelper = new ClusterHelper(DbSingleton.ref, dataprocConfig, mockGoogleDataprocDAO, computeDAO, iamDAO)
     val failingLeo = new LeonardoService(dataprocConfig, MockWelderDAO, clusterFilesConfig, clusterResourcesConfig, clusterDefaultsConfig, proxyConfig, swaggerConfig, autoFreezeConfig, mockGoogleDataprocDAO, computeDAO, projectDAO, storageDAO, mockPetGoogleDAO, DbSingleton.ref, authProvider, serviceAccountProvider, bucketHelper, clusterHelper, contentSecurityPolicy)

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoServiceSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoServiceSpec.scala
@@ -518,8 +518,12 @@ class LeonardoServiceSpec extends TestKit(ActorSystem("leonardotest")) with Flat
     val clusterCreateResponse =
       failingLeo.processClusterCreationRequest(userInfo, project, name1, testClusterRequest).futureValue
 
+    // confirm the cluster is in Error status and doesn't have a google id
     eventually(timeout(Span(5, Minutes))) {
-      dbFutureValue { _.clusterQuery.getClusterStatus(clusterCreateResponse.id) } shouldBe Some(ClusterStatus.Error)
+      val dbClusterOpt = dbFutureValue { _.clusterQuery.getClusterById(clusterCreateResponse.id) }
+      dbClusterOpt shouldBe 'defined
+      dbClusterOpt.get.status shouldBe ClusterStatus.Error
+      dbClusterOpt.get.dataprocInfo.googleId shouldBe None
     }
 
     // delete the cluster

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoServiceSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoServiceSpec.scala
@@ -494,15 +494,39 @@ class LeonardoServiceSpec extends TestKit(ActorSystem("leonardotest")) with Flat
           gdDAO.clusters should contain key clusterName
         }
 
-        // change cluster status to Running so that it can be deleted
-        dbFutureValue { _.clusterQuery.setToRunning(cluster.id, IP("numbers.and.dots")) }
+        // change cluster status to Error
+        dbFutureValue { _.clusterQuery.updateClusterStatus(cluster.id, ClusterStatus.Error) }
 
         // delete the cluster
         leo.deleteCluster(userInfo, project, clusterName).futureValue
 
         // check that the cluster no longer exists
         gdDAO.clusters should not contain key(clusterName)
+
+        // cluster should be in Deleting state (the cluster monitor transitions it to Deleted)
+        dbFutureValue { _.clusterQuery.getClusterStatus(cluster.id) } shouldBe Some(ClusterStatus.Deleting)
     }
+  }
+
+  it should "delete a cluster that has status Error and does not have a google id" in isolatedDbTest {
+    //we meed to use a special version of the MockGoogleIamDAO to simulate an error when adding IAM roles
+    val iamDAO = new ErroredMockGoogleIamDAO
+    val clusterHelper = new ClusterHelper(DbSingleton.ref, dataprocConfig, mockGoogleDataprocDAO, computeDAO, iamDAO)
+    val failingLeo = new LeonardoService(dataprocConfig, MockWelderDAO, clusterFilesConfig, clusterResourcesConfig, clusterDefaultsConfig, proxyConfig, swaggerConfig, autoFreezeConfig, mockGoogleDataprocDAO, computeDAO, projectDAO, storageDAO, mockPetGoogleDAO, DbSingleton.ref, authProvider, serviceAccountProvider, bucketHelper, clusterHelper, contentSecurityPolicy)
+
+    // create the cluster
+    val clusterCreateResponse =
+      failingLeo.processClusterCreationRequest(userInfo, project, name1, testClusterRequest).futureValue
+
+    eventually(timeout(Span(5, Minutes))) {
+      dbFutureValue { _.clusterQuery.getClusterStatus(clusterCreateResponse.id) } shouldBe Some(ClusterStatus.Error)
+    }
+
+    // delete the cluster
+    leo.deleteCluster(userInfo, project, name1).futureValue
+
+    // cluster should be in Deleted state
+    dbFutureValue { _.clusterQuery.getClusterStatus(clusterCreateResponse.id) } shouldBe Some(ClusterStatus.Deleted)
   }
 
   it should "delete a cluster's instances" in isolatedDbTest {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -12,7 +12,7 @@ object Dependencies {
 
   val workbenchUtilV    = "0.5-4c7acd5"
   val workbenchModelV   = "0.13-6dc016b"
-  val workbenchGoogleV  = "0.21-52d830c"
+  val workbenchGoogleV  = "0.21-58c913d"
   val workbenchGoogle2V = "0.5-32be5dd"
   val workbenchMetricsV = "0.3-c5b80d2"
   val workbenchNewRelicV = "0.2-ad29822"


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-1433
https://broadworkbench.atlassian.net/browse/IA-1434

\<your comments for this PR go here\>

Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
