### PR TITLE
[no ticket] Update dataproc custom image

### DIFF
--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -25,8 +25,8 @@ dataproc {
   # Unset to use project-level defaults. Note a VPC/subnet with the literal name "default" may not exist.
   #vpcNetwork = "default"
   #vpcSubnet = "default"
-  customDataprocImage = "projects/broad-dsp-gcr-public/global/images/custom-leo-image-08a4ad8"   # updated 8/26
-  jupyterImage = "us.gcr.io/broad-dsp-gcr-public/leonardo-jupyter:5c51ce6935da"           # updated 8/26
+  customDataprocImage = "projects/broad-dsp-gcr-public/global/images/custom-leo-image-5f387b3"   # updated 10/22/19
+  jupyterImage = "us.gcr.io/broad-dsp-gcr-public/leonardo-jupyter:5c51ce6935da"                  # updated 8/26/19
 
   # Set to deploy welder to clusters with the given label
   # TODO: change this to 'saturnVersion' once ready to enable in production for Terra clusters.


### PR DESCRIPTION
So, our existing dataproc image expires on Friday 10/25. :) This means no new clusters can be created with it (existing clusters will still work).

On 10/22 I built a new dataproc image containing:
- terra-jupyter-base:0.0.3
- terra-jupyter-hail:0.0.1
- terra-jupyter-r:0.0.3
- terra-jupyter-python:0.0.2
- terra-jupyter-bioconductor:0.0.2
- leonardo-jupyter:5c51ce6935da
- welder-server:6036f82

Note: the `terra-jupyter` images are 1 version behind the latest. Due to a build issue we didn't get new image versions from [this PR](https://github.com/DataBiosphere/terra-docker/pull/49). Once the terra-docker build is fixed we should consider bumping the dataproc image again.

I will confirm automation tests and maybe manually create some clusters with this new dataproc image. We should get this deployed this week.


Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
