### PR TITLE
IA-1467 Quote command to handle workspace names with spaces

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookClusterMonitoringSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookClusterMonitoringSpec.scala
@@ -256,10 +256,10 @@ class NotebookClusterMonitoringSpec extends GPAllocFixtureSpec with ParallelTest
         withWebDriver { implicit driver =>
           withNewNotebookInSubfolder(cluster, Python3) { notebookPage =>
             notebookPage.executeCell("import os")
-            notebookPage.executeCell("os.getenv('GOOGLE_PROJECT')").get shouldBe billingProject.value
-            notebookPage.executeCell("os.getenv('WORKSPACE_NAMESPACE')").get shouldBe billingProject.value
-            notebookPage.executeCell("os.getenv('WORKSPACE_NAME')").get shouldBe "Untitled Folder"
-            notebookPage.executeCell("os.getenv('OWNER_EMAIL')").get shouldBe ronEmail
+            notebookPage.executeCell("os.getenv('GOOGLE_PROJECT')").get shouldBe s"'${billingProject.value}'"
+            notebookPage.executeCell("os.getenv('WORKSPACE_NAMESPACE')").get shouldBe s"'${billingProject.value}'"
+            notebookPage.executeCell("os.getenv('WORKSPACE_NAME')").get shouldBe "'Untitled Folder'"
+            notebookPage.executeCell("os.getenv('OWNER_EMAIL')").get shouldBe s"'${ronEmail}'"
             // workspace bucket is not wired up in tests
             notebookPage.executeCell("os.getenv('WORKSPACE_BUCKET')") shouldBe None
           }

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookClusterMonitoringSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookClusterMonitoringSpec.scala
@@ -254,13 +254,14 @@ class NotebookClusterMonitoringSpec extends GPAllocFixtureSpec with ParallelTest
 
       withNewCluster(billingProject, request = defaultClusterRequest.copy(jupyterDockerImage = None, enableWelder = Some(true))) { cluster =>
         withWebDriver { implicit driver =>
-          withNewNotebook(cluster, Python3) { notebookPage =>
-            notebookPage.executeCell("! echo $GOOGLE_PROJECT").get shouldBe billingProject.value
-            notebookPage.executeCell("! echo $WORKSPACE_NAMESPACE").get shouldBe billingProject.value
-            notebookPage.executeCell("! echo $WORKSPACE_NAME").get shouldBe "jupyter-user"
-            notebookPage.executeCell("! echo $OWNER_EMAIL").get shouldBe ronEmail
+          withNewNotebookInSubfolder(cluster, Python3) { notebookPage =>
+            notebookPage.executeCell("import os")
+            notebookPage.executeCell("os.getenv('GOOGLE_PROJECT')").get shouldBe billingProject.value
+            notebookPage.executeCell("os.getenv('WORKSPACE_NAMESPACE')").get shouldBe billingProject.value
+            notebookPage.executeCell("os.getenv('WORKSPACE_NAME')").get shouldBe "Untitled Folder"
+            notebookPage.executeCell("os.getenv('OWNER_EMAIL')").get shouldBe ronEmail
             // workspace bucket is not wired up in tests
-            notebookPage.executeCell("! echo $WORKSPACE_BUCKET").get shouldBe ""
+            notebookPage.executeCell("os.getenv('WORKSPACE_BUCKET')") shouldBe None
           }
         }
       }

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookPyKernelSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookPyKernelSpec.scala
@@ -163,13 +163,14 @@ class NotebookPyKernelSpec extends ClusterFixtureSpec with NotebookTestUtils {
     Seq(Python3).foreach { kernel =>
       s"should have the workspace-related environment variables set in ${kernel.toString} kernel" in { clusterFixture =>
         withWebDriver { implicit driver =>
-          withNewNotebook(clusterFixture.cluster, kernel) { notebookPage =>
-            notebookPage.executeCell("! echo $GOOGLE_PROJECT").get shouldBe clusterFixture.cluster.googleProject.value
-            notebookPage.executeCell("! echo $WORKSPACE_NAMESPACE").get shouldBe clusterFixture.cluster.googleProject.value
-            notebookPage.executeCell("! echo $WORKSPACE_NAME").get shouldBe "jupyter-user"
-            notebookPage.executeCell("! echo $OWNER_EMAIL").get shouldBe ronEmail
+          withNewNotebookInSubfolder(clusterFixture.cluster, Python3) { notebookPage =>
+            notebookPage.executeCell("import os")
+            notebookPage.executeCell("os.getenv('GOOGLE_PROJECT')").get shouldBe clusterFixture.cluster.googleProject.value
+            notebookPage.executeCell("os.getenv('WORKSPACE_NAMESPACE')").get shouldBe clusterFixture.cluster.googleProject.value
+            notebookPage.executeCell("os.getenv('WORKSPACE_NAME')").get shouldBe "Untitled Folder"
+            notebookPage.executeCell("os.getenv('OWNER_EMAIL')").get shouldBe ronEmail
             // workspace bucket is not wired up in tests
-            notebookPage.executeCell("! echo $WORKSPACE_BUCKET").get shouldBe ""
+            notebookPage.executeCell("os.getenv('WORKSPACE_BUCKET')") shouldBe None
           }
         }
       }

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookPyKernelSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookPyKernelSpec.scala
@@ -165,10 +165,10 @@ class NotebookPyKernelSpec extends ClusterFixtureSpec with NotebookTestUtils {
         withWebDriver { implicit driver =>
           withNewNotebookInSubfolder(clusterFixture.cluster, Python3) { notebookPage =>
             notebookPage.executeCell("import os")
-            notebookPage.executeCell("os.getenv('GOOGLE_PROJECT')").get shouldBe clusterFixture.cluster.googleProject.value
-            notebookPage.executeCell("os.getenv('WORKSPACE_NAMESPACE')").get shouldBe clusterFixture.cluster.googleProject.value
-            notebookPage.executeCell("os.getenv('WORKSPACE_NAME')").get shouldBe "Untitled Folder"
-            notebookPage.executeCell("os.getenv('OWNER_EMAIL')").get shouldBe ronEmail
+            notebookPage.executeCell("os.getenv('GOOGLE_PROJECT')").get shouldBe s"'${clusterFixture.cluster.googleProject.value}'"
+            notebookPage.executeCell("os.getenv('WORKSPACE_NAMESPACE')").get shouldBe s"'${clusterFixture.cluster.googleProject.value}'"
+            notebookPage.executeCell("os.getenv('WORKSPACE_NAME')").get shouldBe "'Untitled Folder'"
+            notebookPage.executeCell("os.getenv('OWNER_EMAIL')").get shouldBe s"'${ronEmail}'"
             // workspace bucket is not wired up in tests
             notebookPage.executeCell("os.getenv('WORKSPACE_BUCKET')") shouldBe None
           }

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookRKernelSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookRKernelSpec.scala
@@ -146,10 +146,11 @@ class NotebookRKernelSpec extends ClusterFixtureSpec with NotebookTestUtils {
 
     s"should have the workspace-related environment variables set" in { clusterFixture =>
       withWebDriver { implicit driver =>
-        withNewNotebook(clusterFixture.cluster, RKernel) { notebookPage =>
+        withNewNotebookInSubfolder(clusterFixture.cluster, RKernel) { notebookPage =>
           notebookPage.executeCell("Sys.getenv('GOOGLE_PROJECT')").get shouldBe s"'${clusterFixture.cluster.googleProject.value}'"
           notebookPage.executeCell("Sys.getenv('WORKSPACE_NAMESPACE')").get shouldBe s"'${clusterFixture.cluster.googleProject.value}'"
-          notebookPage.executeCell("Sys.getenv('WORKSPACE_NAME')").get shouldBe "'jupyter-user'"
+          notebookPage.executeCell("Sys.getenv('WORKSPACE_NAME')").get shouldBe "'Untitled Folder'"
+          notebookPage.executeCell("Sys.getenv('OWNER_EMAIL')").get shouldBe s"'${ronEmail}'"
           // workspace bucket is not wired up in tests
           notebookPage.executeCell("Sys.getenv('WORKSPACE_BUCKET')").get shouldBe "''"
         }

--- a/http/src/main/resources/jupyter/init-actions.sh
+++ b/http/src/main/resources/jupyter/init-actions.sh
@@ -372,7 +372,7 @@ if [[ "${ROLE}" == 'Master' ]]; then
       # fix for https://broadworkbench.atlassian.net/browse/IA-1453
       # TODO: remove this when we stop supporting the legacy docker image
       if [ ! -z ${WELDER_DOCKER_IMAGE} ] && [ "${WELDER_ENABLED}" == "true" ] ; then
-        retry 3 docker exec -u root ${JUPYTER_SERVER_NAME} sed -i -e 's/export WORKSPACE_NAME=.*/export WORKSPACE_NAME="$(basename "$(dirname "$PWD")")"/' ${JUPYTER_HOME}/scripts/kernel/kernel_bootstrap.sh
+        retry 3 docker exec -u root ${JUPYTER_SERVER_NAME} sed -i -e 's/export WORKSPACE_NAME=.*/export WORKSPACE_NAME="$(basename "$(dirname "$(pwd)")")"/' ${JUPYTER_HOME}/scripts/kernel/kernel_bootstrap.sh
       fi
 
       STEP_TIMINGS+=($(date +%s))

--- a/http/src/main/resources/jupyter/init-actions.sh
+++ b/http/src/main/resources/jupyter/init-actions.sh
@@ -372,7 +372,7 @@ if [[ "${ROLE}" == 'Master' ]]; then
       # fix for https://broadworkbench.atlassian.net/browse/IA-1453
       # TODO: remove this when we stop supporting the legacy docker image
       if [ ! -z ${WELDER_DOCKER_IMAGE} ] && [ "${WELDER_ENABLED}" == "true" ] ; then
-        retry 3 docker exec -u root ${JUPYTER_SERVER_NAME} sed -i -e 's/"$(basename "$PWD")"/"$(basename $(dirname "$PWD"))"/' ${JUPYTER_HOME}/scripts/kernel/kernel_bootstrap.sh
+        retry 3 docker exec -u root ${JUPYTER_SERVER_NAME} sed -i -e 's/export WORKSPACE_NAME=.*/export WORKSPACE_NAME="$(basename "$(dirname "$PWD")")"/' ${JUPYTER_HOME}/scripts/kernel/kernel_bootstrap.sh
       fi
 
       STEP_TIMINGS+=($(date +%s))

--- a/http/src/main/resources/jupyter/startup.sh
+++ b/http/src/main/resources/jupyter/startup.sh
@@ -62,7 +62,7 @@ docker exec -d $JUPYTER_SERVER_NAME /bin/bash -c "export WELDER_ENABLED=$WELDER_
 if [ "$WELDER_ENABLED" == "true" ] ; then
     # fix for https://broadworkbench.atlassian.net/browse/IA-1453
     # TODO: remove this when we stop supporting the legacy docker image
-    docker exec -u root jupyter-server sed -i -e 's/export WORKSPACE_NAME=.*/export WORKSPACE_NAME="$(basename "$(dirname "$PWD")")"/' /etc/jupyter/scripts/kernel/kernel_bootstrap.sh
+    docker exec -u root jupyter-server sed -i -e 's/export WORKSPACE_NAME=.*/export WORKSPACE_NAME="$(basename "$(dirname "$(pwd)")")"/' /etc/jupyter/scripts/kernel/kernel_bootstrap.sh
 
     echo "Starting Welder on cluster $GOOGLE_PROJECT / $CLUSTER_NAME..."
     docker exec -d $WELDER_SERVER_NAME /opt/docker/bin/entrypoint.sh

--- a/http/src/main/resources/jupyter/startup.sh
+++ b/http/src/main/resources/jupyter/startup.sh
@@ -62,7 +62,7 @@ docker exec -d $JUPYTER_SERVER_NAME /bin/bash -c "export WELDER_ENABLED=$WELDER_
 if [ "$WELDER_ENABLED" == "true" ] ; then
     # fix for https://broadworkbench.atlassian.net/browse/IA-1453
     # TODO: remove this when we stop supporting the legacy docker image
-    docker exec -u root jupyter-server sed -i -e 's/"$(basename "$PWD")"/"$(basename $(dirname "$PWD"))"/' /etc/jupyter/scripts/kernel/kernel_bootstrap.sh
+    docker exec -u root jupyter-server sed -i -e 's/export WORKSPACE_NAME=.*/export WORKSPACE_NAME="$(basename "$(dirname "$PWD")")"/' /etc/jupyter/scripts/kernel/kernel_bootstrap.sh
 
     echo "Starting Welder on cluster $GOOGLE_PROJECT / $CLUSTER_NAME..."
     docker exec -d $WELDER_SERVER_NAME /opt/docker/bin/entrypoint.sh


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-1467

The fix:
```
export WORKSPACE_NAME="$(basename $(dirname "$PWD"))"
```
needs to be 
```
export WORKSPACE_NAME="$(basename "$(dirname "$PWD")")"
```

I also added an auto test which tests the EVs in a directory with spaces.

Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
