### PR TITLE
[IA-1446] Jc update job

### DIFF
--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -152,7 +152,7 @@ pipeline {
 
         script {
           def temp = sh( 
-            script: "cat config/conf.json | jq -r '.image_data | .[] | select(.automated_flags.include_in_custom_dataproc == true) | .name'",
+            script: "cat config/conf.json | jq -r '.image_data | .[] | select(.automated_flags.include_in_custom_dataproc == true) | select(.automated_flags.build == true) | .name'",
             returnStdout: true
           ).trim().split("\n")
 

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -88,7 +88,7 @@ def LinkedHashMap<String,String> getVersionMap(ArrayList<String> imageNames, Str
 
 def String getChangeDescription(LinkedHashMap<String,String> versionMap) {
   def title = "[jenkins-generated-pr] Automated custom image hash update"
-  def body = "$title"
+  def body = "$title\n These are the images that are baked into this custom image:\n"
   def version = ""
   println("version map in getChangeDescription: " + versionMap.toString())
   for (String image in versionMap.keySet()) {
@@ -151,13 +151,19 @@ pipeline {
         git credentialsId: 'jenkins-ssh-github', url: 'git@github.com:DataBiosphere/terra-docker.git', branch: 'master'
 
         script {
-          def temp = readFile("jenkins/imageDirs.txt").trim().split("\n")
+          def temp = sh( 
+            script: "cat config/conf.json | jq -r '.image_data | .[] | select(.automated_flags.include_in_custom_dataproc == true) | .name'",
+            returnStdout: true
+          ).trim().split("\n")
+
           images = new ArrayList<String>(Arrays.asList(temp))
 
           //non terra-docker images
           images.add('leonardo-jupyter')
           images.add('welder-server')
           images.add('openidc-proxy')
+
+          println("Images to include in custom image found in image scan: $images")
         }
       }
     }


### PR DESCRIPTION
A change to how image building/configuration was made to terra-docker, so this is needed to support the new config. It should be more flexible this way, with a flag explicitly present to enable/disable image inclusion in the custom dataproc image

Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
