### PR TITLE
[no ticket] use google2 library for downloading dataproc logs

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
@@ -64,9 +64,9 @@ trait LeonardoTestUtils
   lazy val voldyAuthToken = UserAuthToken(voldyCreds, AuthTokenScopes.userLoginScopes)
   lazy val ronEmail = ronCreds.email
 
-  val clusterPatience = PatienceConfig(timeout = scaled(Span(10, Minutes)), interval = scaled(Span(20, Seconds)))
+  val clusterPatience = PatienceConfig(timeout = scaled(Span(15, Minutes)), interval = scaled(Span(20, Seconds)))
   val clusterStopAfterCreatePatience =
-    PatienceConfig(timeout = scaled(Span(20, Minutes)), interval = scaled(Span(20, Seconds)))
+    PatienceConfig(timeout = scaled(Span(30, Minutes)), interval = scaled(Span(20, Seconds)))
   val localizePatience = PatienceConfig(timeout = scaled(Span(1, Minutes)), interval = scaled(Span(1, Seconds)))
   val saPatience = PatienceConfig(timeout = scaled(Span(1, Minutes)), interval = scaled(Span(1, Seconds)))
   val storagePatience = PatienceConfig(timeout = scaled(Span(1, Minutes)), interval = scaled(Span(1, Seconds)))

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
@@ -552,11 +552,7 @@ trait LeonardoTestUtils
           val downloadLogs = for {
             blob <- storage
               .listBlobsWithPrefix(stagingBucketName, "google-cloud-dataproc-metainfo", true)
-              .filter(
-                b =>
-                  b.getName.endsWith("dataproc-initialization-script-0_output") || b.getName
-                    .endsWith("dataproc-startup-script_output")
-              )
+              .filter(_.getName.endsWith("output"))
             blobName = blob.getName
             shortName = new File(blobName).getName
             path = new File(logDir, s"${cluster.googleProject.value}-${cluster.clusterName.string}-${shortName}.log").toPath
@@ -568,9 +564,9 @@ trait LeonardoTestUtils
         .flatMap {
           case None => IO(logger.error(s"Cluster ${cluster.projectNameString} does not have a staging bucket"))
           case Some(logs) if logs.isEmpty =>
-            IO(logger.warn(s"Unable to find logs for cluster ${cluster.projectNameString}"))
+            IO(logger.warn(s"Unable to find output logs for cluster ${cluster.projectNameString}"))
           case Some(logs) =>
-            IO(logger.info(s"Downloaded logs for cluster ${cluster.projectNameString}: ${logs.mkString(",")}"))
+            IO(logger.info(s"Downloaded output logs for cluster ${cluster.projectNameString}: ${logs.mkString(",")}"))
         }
     }
 

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookClusterMonitoringSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookClusterMonitoringSpec.scala
@@ -256,22 +256,20 @@ class NotebookClusterMonitoringSpec extends GPAllocFixtureSpec with ParallelTest
                                              labels = Map(deployWelderLabel -> "true"),
                                              welderDockerImage = Some(LeonardoConfig.Leonardo.oldWelderDockerImage))
       ) { cluster =>
-        withWebDriver { implicit driver =>
-          // Verify welder is running with old version
-          val statusResponse = Welder.getWelderStatus(cluster).unsafeRunSync()
-          val oldWelderHash = LeonardoConfig.Leonardo.oldWelderDockerImage.split(":")(1)
-          statusResponse.gitHeadCommit should startWith(oldWelderHash)
+        // Verify welder is running with old version
+        val statusResponse = Welder.getWelderStatus(cluster).unsafeRunSync()
+        val oldWelderHash = LeonardoConfig.Leonardo.oldWelderDockerImage.split(":")(1)
+        statusResponse.gitHeadCommit should startWith(oldWelderHash)
 
-          // Stop the cluster
-          stopAndMonitor(cluster.googleProject, cluster.clusterName)
+        // Stop the cluster
+        stopAndMonitor(cluster.googleProject, cluster.clusterName)
 
-          // Start the cluster
-          startAndMonitor(cluster.googleProject, cluster.clusterName)
+        // Start the cluster
+        startAndMonitor(cluster.googleProject, cluster.clusterName)
 
-          // Verify welder is now running
-          val curWelderHash = LeonardoConfig.Leonardo.curWelderDockerImage.split(":")(1)
-          Welder.getWelderStatus(cluster).unsafeRunSync().gitHeadCommit should startWith(curWelderHash)
-        }
+        // Verify welder is now running
+        val curWelderHash = LeonardoConfig.Leonardo.curWelderDockerImage.split(":")(1)
+        Welder.getWelderStatus(cluster).unsafeRunSync().gitHeadCommit should startWith(curWelderHash)
       }
     }
 

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookCustomizationSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookCustomizationSpec.scala
@@ -3,7 +3,7 @@ package org.broadinstitute.dsde.workbench.leonardo.notebooks
 import org.broadinstitute.dsde.workbench.ResourceFile
 import org.broadinstitute.dsde.workbench.auth.AuthToken
 import org.broadinstitute.dsde.workbench.dao.Google.googleStorageDAO
-import org.broadinstitute.dsde.workbench.leonardo.{GPAllocFixtureSpec, LeonardoConfig}
+import org.broadinstitute.dsde.workbench.leonardo.GPAllocFixtureSpec
 import org.broadinstitute.dsde.workbench.model.google.{EmailGcsEntity, GcsEntityTypes, GcsObjectName, GcsRoles}
 import org.broadinstitute.dsde.workbench.service.Sam
 import org.broadinstitute.dsde.workbench.service.util.Tags

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookDataSyncingSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookDataSyncingSpec.scala
@@ -5,7 +5,6 @@ import java.math.BigInteger
 import java.security.MessageDigest
 import java.time.Instant
 
-import akka.http.scaladsl.model.HttpResponse
 import org.broadinstitute.dsde.workbench.ResourceFile
 import org.broadinstitute.dsde.workbench.google2.GcsBlobName
 import org.broadinstitute.dsde.workbench.leonardo._

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookPyKernelSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookPyKernelSpec.scala
@@ -39,9 +39,7 @@ class NotebookPyKernelSpec extends ClusterFixtureSpec with NotebookTestUtils {
         withWebDriver { implicit driver =>
           withNewNotebook(clusterFixture.cluster, kernel) { notebookPage =>
             // install a package that is not installed by default
-            notebookPage.executeCell("import fuzzywuzzy").getOrElse("") should include(
-              if (kernel == Python2) "ImportError" else "ModuleNotFoundError"
-            )
+            notebookPage.executeCell("import fuzzywuzzy").getOrElse("") should include("ModuleNotFoundError")
             pipInstall(notebookPage, kernel, "fuzzywuzzy")
             notebookPage.saveAndCheckpoint()
 

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookRKernelSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookRKernelSpec.scala
@@ -22,7 +22,7 @@ class NotebookRKernelSpec extends ClusterFixtureSpec with NotebookTestUtils {
           notebookPage.executeCell("""Sys.getenv("LC_ALL")""") shouldBe Some("'en_US.UTF-8'")
 
           // Make sure unicode characters display correctly
-          notebookPage.executeCell("""install.packages("skimr")""")
+          notebookPage.executeCell("""install.packages("skimr")""", timeout = 5.minutes)
           notebookPage.executeCell("library(skimr)")
 
           val output = notebookPage.executeCell("""data(iris)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,6 +8,7 @@ object Dependencies {
   val jacksonV      = "2.9.9"
   val jacksonDatabindV = "2.9.9.2"  // jackson-databind has a security patch on the 2.9.9 branch
   val googleV       = "1.23.0"
+  val automationGoogleV = "1.30.5"
   val scalaLoggingV = "3.9.0"
   val scalaTestV    = "3.0.8"
   val slickV        = "3.2.3"
@@ -183,7 +184,7 @@ object Dependencies {
       excludeApacheHttpClient,
       excludeGoogleJsr305,
       excludeJacksonCore),
-    "com.google.api-client" % "google-api-client"   % "1.23.0" excludeAll (
+    "com.google.api-client" % "google-api-client"   % automationGoogleV excludeAll (
       excludeGuavaJdk5,
       excludeApacheHttpClient,
       excludeGoogleJsr305,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -16,7 +16,7 @@ object Dependencies {
   val workbenchUtilV    = "0.5-4c7acd5"
   val workbenchModelV   = "0.13-6dc016b"
   val workbenchGoogleV  = "0.21-58c913d"
-  val workbenchGoogle2V = "0.6-8bae8e8"
+  val workbenchGoogle2V = "0.6-f846fad"
   val workbenchMetricsV = "0.3-c5b80d2"
   val workbenchNewRelicV = "0.3-8bae8e8"
 
@@ -67,7 +67,7 @@ object Dependencies {
   val akkaHttpTestKit: ModuleID =   "com.typesafe.akka"   %%  "akka-http-testkit"    % akkaHttpV % "test"
 
   val googleDataproc: ModuleID =    "com.google.apis"     % "google-api-services-dataproc" % s"v1-rev91-$googleV" excludeAll(excludeGuavaJDK5, excludeJacksonCore, excludeFindbugsJsr, excludeHttpComponent, excludeFirestore)
-  val googleRpc: ModuleID = "io.grpc" % "grpc-core" % "1.24.0" excludeAll(excludeGuava, excludeGson, excludeFindbugsJsr, excludeAutoValueAnnotation, excludeAutoValue)
+  val googleRpc: ModuleID = "io.grpc" % "grpc-core" % "1.24.1" excludeAll(excludeGuava, excludeGson, excludeFindbugsJsr, excludeAutoValueAnnotation, excludeAutoValue)
   val googleOAuth2: ModuleID = "com.google.auth" % "google-auth-library-oauth2-http" % "0.9.1" excludeAll(excludeGuava, excludeFindbugsJsr, excludeGoogleApiClient, excludeGoogleApiClientJackson2, excludeGoogleHttpClient, excludeHttpComponent)
   val googleSourceRepositories: ModuleID = "com.google.apis" % "google-api-services-sourcerepo" % s"v1-rev21-$googleV" excludeAll(excludeGuavaJDK5)
 


### PR DESCRIPTION
I was looking at some tests where the cluster was stuck in `Creating`. Unfortunately the test wasn't able to download any logs from the staging bucket, and the staging bucket did not exist in the cloud console. While looking at the automation code I decided to reimplement the functionality using `google2`, and add better logging for error cases.

Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
