### PR TITLE
[PROD-292] listClusters returns empty list for AoU service account

### DIFF
--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoService.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoService.scala
@@ -800,12 +800,12 @@ class LeonardoService(protected val dataprocConfig: DataprocConfig,
     } yield {
       // Making the assumption that users will always be able to access clusters that they create
       // Fix for https://github.com/DataBiosphere/leonardo/issues/821
-      val visibleClusters = samVisibleClusters ::: clusterList
+      val userCreatedClusters: List[(GoogleProject, ClusterInternalId)] = clusterList
         .filter(_.auditInfo.creator == userInfo.userEmail)
-        .map(c => (c.googleProject, c.clusterName))
+        .map(c => (c.googleProject, c.internalId))
         .toList
-      val visibleClustersSet = visibleClusters.toSet
-      clusterList.filter(c => visibleClustersSet.contains((c.googleProject, c.clusterName)))
+      val visibleClustersSet = (samVisibleClusters ::: userCreatedClusters).toSet
+      clusterList.filter(c => visibleClustersSet.contains((c.googleProject, c.internalId)))
     }
 
   private[service] def getActiveCluster(googleProject: GoogleProject,


### PR DESCRIPTION
See https://broadworkbench.atlassian.net/browse/PROD-292

I think this was introduced in the Sam client upgrade. The bug is in `listClusters`. The intended behavior is for `listClusters` to return clusters the caller created; and clusters in projects which the caller is an owner of. As a result of this bug we were only returning the former, not the latter.

The fix is pretty trivial: we essentially got the types wrong on a `.contains` call. See inline.

Also added a unit test for this case.

Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
