### PR TITLE
[QA-925] Use patience for downloading dataproc logs

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
@@ -241,7 +241,7 @@ trait LeonardoTestUtils
       }
 
     val runningOrErroredCluster = Try {
-      implicit val patienceConfig: PatienceConfig =
+      implicit val createPatience: PatienceConfig =
         if (stopAfterCreate) clusterStopAfterCreatePatience else clusterPatience
       eventually {
         val cluster = Leonardo.cluster.get(googleProject, clusterName)
@@ -249,7 +249,7 @@ trait LeonardoTestUtils
       }
     }
     // Save the cluster init log file whether or not the cluster created successfully
-    implicit val patienceConfig = downloadDataprocLogsPatience
+    implicit val downloadPatience = downloadDataprocLogsPatience
     saveDataprocLogFiles(creatingCluster).unsafeToFuture().futureValue
 
     // If the cluster is running, grab the jupyter.log and welder.log files for debugging.

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
@@ -72,6 +72,7 @@ trait LeonardoTestUtils
   val storagePatience = PatienceConfig(timeout = scaled(Span(1, Minutes)), interval = scaled(Span(1, Seconds)))
   val startPatience = PatienceConfig(timeout = scaled(Span(5, Minutes)), interval = scaled(Span(1, Seconds)))
   val getAfterCreatePatience = PatienceConfig(timeout = scaled(Span(5, Minutes)), interval = scaled(Span(2, Seconds)))
+  val downloadDataprocLogsPatience = PatienceConfig(timeout = scaled(Span(5, Minutes)), interval = scaled(Span(10, Seconds)))
 
   val multiExtensionClusterRequest = UserJupyterExtensionConfig(
     nbExtensions = Map("map" -> "gmaps"),
@@ -232,9 +233,6 @@ trait LeonardoTestUtils
     // wait for "Running", "Stopped", or error (fail fast)
     val stopAfterCreate = clusterRequest.stopAfterCreation.getOrElse(false)
 
-    implicit val patienceConfig: PatienceConfig =
-      if (stopAfterCreate) clusterStopAfterCreatePatience else clusterPatience
-
     val expectedStatuses =
       if (stopAfterCreate) {
         List(ClusterStatus.Stopped, ClusterStatus.Error)
@@ -243,13 +241,16 @@ trait LeonardoTestUtils
       }
 
     val runningOrErroredCluster = Try {
+      implicit val patienceConfig: PatienceConfig =
+        if (stopAfterCreate) clusterStopAfterCreatePatience else clusterPatience
       eventually {
         val cluster = Leonardo.cluster.get(googleProject, clusterName)
         verifyCluster(cluster, googleProject, clusterName, expectedStatuses, clusterRequest, true)
       }
     }
     // Save the cluster init log file whether or not the cluster created successfully
-    saveDataprocLogFiles(creatingCluster).unsafeRunSync()
+    implicit val patienceConfig = downloadDataprocLogsPatience
+    saveDataprocLogFiles(creatingCluster).unsafeToFuture().futureValue
 
     // If the cluster is running, grab the jupyter.log and welder.log files for debugging.
     runningOrErroredCluster.foreach { cluster =>

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -184,11 +184,13 @@ object Dependencies {
     "ch.qos.logback"  % "logback-classic" % "1.2.3"  % "test",
     "com.google.apis" % "google-api-services-oauth2" % "v1-rev142-1.23.0" excludeAll (
       excludeGuavaJdk5,
+      excludeGuava,
       excludeApacheHttpClient,
       excludeGoogleJsr305,
       excludeJacksonCore),
     "com.google.api-client" % "google-api-client"   % automationGoogleV excludeAll (
       excludeGuavaJdk5,
+      excludeGuava,
       excludeApacheHttpClient,
       excludeGoogleJsr305,
       excludeJacksonCore),

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -13,6 +13,7 @@ object Dependencies {
   val scalaTestV    = "3.0.8"
   val slickV        = "3.2.3"
   val http4sVersion = "0.21.0-M5" //remove http4s related dependencies once workbench-libs are upgraded
+  val guavaV        = "28.0-jre"
 
   val workbenchUtilV    = "0.5-4c7acd5"
   val workbenchModelV   = "0.13-6dc016b"
@@ -99,6 +100,7 @@ object Dependencies {
   val http4sBlazeClient = "org.http4s" %% "http4s-blaze-client" % http4sVersion
   val http4sDsl = "org.http4s"      %% "http4s-dsl"          % http4sVersion
   val fs2Io: ModuleID = "co.fs2" %% "fs2-io" % "2.0.1"
+  val guava: ModuleID = "com.google.guava" % "guava" % guavaV
 
   val coreDependencies = List(
     workbenchModel,
@@ -125,6 +127,7 @@ object Dependencies {
     ficus,
     httpClient,
     enumeratum,
+    guava,
 
     akkaActor,
     akkaContrib,
@@ -179,7 +182,6 @@ object Dependencies {
     "com.fasterxml.jackson.core" % "jackson-core"         % jacksonV,
     "com.fasterxml.jackson.module" % ("jackson-module-scala_" + scalaV) % jacksonV,
     "ch.qos.logback"  % "logback-classic" % "1.2.3"  % "test",
-    "com.google.guava" % "guava" % "28.0-jre",
     "com.google.apis" % "google-api-services-oauth2" % "v1-rev142-1.23.0" excludeAll (
       excludeGuavaJdk5,
       excludeApacheHttpClient,
@@ -205,6 +207,7 @@ object Dependencies {
     "com.typesafe.scala-logging" %% "scala-logging" % "3.8.0",
     "org.apache.commons" % "commons-text"           % "1.2",
     googleRpc,
+    guava,
 
     workbenchUtil,
     workbenchModel,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -77,15 +77,15 @@ object Dependencies {
 
   // Exclude workbench-libs transitive dependencies so we can control the library versions individually.
   // workbench-google pulls in workbench-{util, model, metrics} and workbcan ench-metrics pulls in workbench-util.
-  val workbenchUtil: ModuleID       = "org.broadinstitute.dsde.workbench" %% "workbench-util"    % workbenchUtilV   excludeAll(excludeWorkbenchModel, excludeGoogleError)
-  val workbenchModel: ModuleID      = "org.broadinstitute.dsde.workbench" %% "workbench-model"   % workbenchModelV  excludeAll(excludeGoogleError)
-  val workbenchGoogle: ModuleID     = "org.broadinstitute.dsde.workbench" %% "workbench-google"  % workbenchGoogleV excludeAll(excludeWorkbenchUtil, excludeWorkbenchModel, excludeWorkbenchMetrics, excludeIoGrpc, excludeFindbugsJsr, excludeGoogleApiClient, excludeGoogleError, excludeHttpComponent, excludeAutoValue, excludeAutoValueAnnotation)
-  val workbenchGoogle2: ModuleID     = "org.broadinstitute.dsde.workbench" %% "workbench-google2"  % workbenchGoogle2V excludeAll(excludeWorkbenchUtil, excludeWorkbenchModel, excludeWorkbenchMetrics, excludeIoGrpc, excludeFindbugsJsr, excludeGoogleApiClient, excludeGoogleError, excludeHttpComponent, excludeAutoValue, excludeAutoValueAnnotation, excludeFirestore)
-  val workbenchGoogleTest: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-google"  % workbenchGoogleV % "test" classifier "tests" excludeAll(excludeWorkbenchUtil, excludeWorkbenchModel)
-  val workbenchGoogle2Test: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-google2" % workbenchGoogle2V % "test" classifier "tests" //for generators
-  val workbenchMetrics: ModuleID    = "org.broadinstitute.dsde.workbench" %% "workbench-metrics" % workbenchMetricsV excludeAll(excludeWorkbenchUtil, excludeSlf4j)
-  val workbenchNewRelic: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-newrelic" % workbenchNewRelicV
-  val workbenchNewRelicTest: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-newrelic" % workbenchNewRelicV % "test" classifier "tests"
+  val workbenchUtil: ModuleID       = "org.broadinstitute.dsde.workbench" %% "workbench-util"    % workbenchUtilV   excludeAll(excludeWorkbenchModel, excludeGoogleError, excludeGuava)
+  val workbenchModel: ModuleID      = "org.broadinstitute.dsde.workbench" %% "workbench-model"   % workbenchModelV  excludeAll(excludeGoogleError, excludeGuava)
+  val workbenchGoogle: ModuleID     = "org.broadinstitute.dsde.workbench" %% "workbench-google"  % workbenchGoogleV excludeAll(excludeWorkbenchUtil, excludeWorkbenchModel, excludeWorkbenchMetrics, excludeIoGrpc, excludeFindbugsJsr, excludeGoogleApiClient, excludeGoogleError, excludeHttpComponent, excludeAutoValue, excludeAutoValueAnnotation, excludeGuava)
+  val workbenchGoogle2: ModuleID     = "org.broadinstitute.dsde.workbench" %% "workbench-google2"  % workbenchGoogle2V excludeAll(excludeWorkbenchUtil, excludeWorkbenchModel, excludeWorkbenchMetrics, excludeIoGrpc, excludeFindbugsJsr, excludeGoogleApiClient, excludeGoogleError, excludeHttpComponent, excludeAutoValue, excludeAutoValueAnnotation, excludeFirestore, excludeGuava)
+  val workbenchGoogleTest: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-google"  % workbenchGoogleV % "test" classifier "tests" excludeAll(excludeWorkbenchUtil, excludeWorkbenchModel, excludeGuava)
+  val workbenchGoogle2Test: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-google2" % workbenchGoogle2V % "test" classifier "tests" excludeAll(excludeGuava) //for generators
+  val workbenchMetrics: ModuleID    = "org.broadinstitute.dsde.workbench" %% "workbench-metrics" % workbenchMetricsV excludeAll(excludeWorkbenchUtil, excludeSlf4j, excludeGuava)
+  val workbenchNewRelic: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-newrelic" % workbenchNewRelicV excludeAll(excludeGuava)
+  val workbenchNewRelicTest: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-newrelic" % workbenchNewRelicV % "test" classifier "tests" excludeAll(excludeGuava)
 
 
   val slick: ModuleID =     "com.typesafe.slick" %% "slick"                 % slickV excludeAll(excludeTypesafeConfig, excludeReactiveStream)
@@ -168,7 +168,8 @@ object Dependencies {
 
   val workbenchServiceTest: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-service-test" % serviceTestV % "test" classifier "tests" excludeAll (
     excludeWorkbenchModel,
-    excludeWorkbenchGoogle)
+    excludeWorkbenchGoogle,
+    excludeGuava)
 
   val automationDependencies = List(
     // proactively pull in latest versions of Jackson libs, instead of relying on the versions


### PR DESCRIPTION
See https://broadworkbench.atlassian.net/browse/QA-925

This is the issue where Leo tests are not being reported. I think it happened around when I merged https://github.com/DataBiosphere/leonardo/pull/1127/. My theory is that the `unsafeRunSync` was blocking and preventing test reporting somehow. Changed it to use ScalaTest `Patience` instead.

Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
