### PR TITLE
[IA-1401] Lower expiry time for clusterInternalIdCache

### DIFF
--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -70,7 +70,7 @@ clusterDefaults {
 
 clusterDnsCache {
   cacheExpiryTime = 5 seconds
-  cacheMaxSize = 5000
+  cacheMaxSize = 10000
 }
 
 mysql {
@@ -96,8 +96,10 @@ proxy {
   jupyterPort = 443
   jupyterProtocol = "tcp"
   dnsPollPeriod = 15 seconds
-  cacheExpiryTime = 60 minutes
-  cacheMaxSize = 100
+  tokenCacheExpiryTime = 60 minutes
+  tokenCacheMaxSize = 10000
+  internalIdCacheExpiryTime = 2 minutes
+  internalIdCacheMaxSize = 10000
 }
 
 monitor {

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
@@ -105,8 +105,10 @@ object Config {
       config.getString("jupyterProtocol"),
       config.getString("jupyterDomain"),
       toScalaDuration(config.getDuration("dnsPollPeriod")),
-      toScalaDuration(config.getDuration("cacheExpiryTime")),
-      config.getInt("cacheMaxSize")
+      toScalaDuration(config.getDuration("tokenCacheExpiryTime")),
+      config.getInt("tokenCacheMaxSize"),
+      toScalaDuration(config.getDuration("internalIdCacheExpiryTime")),
+      config.getInt("internalIdCacheMaxSize")
     )
   }
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/ProxyConfig.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/ProxyConfig.scala
@@ -9,6 +9,8 @@ case class ProxyConfig(
   jupyterProtocol: String,
   jupyterDomain: String,
   dnsPollPeriod: FiniteDuration,
-  cacheExpiryTime: FiniteDuration,
-  cacheMaxSize: Int
+  tokenCacheExpiryTime: FiniteDuration,
+  tokenCacheMaxSize: Int,
+  internalIdCacheExpiryTime: FiniteDuration,
+  internalIdCacheMaxSize: Int
 )

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/ProxyService.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/ProxyService.scala
@@ -72,8 +72,8 @@ class ProxyService(
   /* Cache for the bearer token and corresponding google user email */
   private[leonardo] val googleTokenCache = CacheBuilder
     .newBuilder()
-    .expireAfterWrite(proxyConfig.cacheExpiryTime.toMinutes, TimeUnit.MINUTES)
-    .maximumSize(proxyConfig.cacheMaxSize)
+    .expireAfterWrite(proxyConfig.tokenCacheExpiryTime.toSeconds, TimeUnit.SECONDS)
+    .maximumSize(proxyConfig.tokenCacheMaxSize)
     .build(
       new CacheLoader[String, Future[(UserInfo, Instant)]] {
         def load(key: String) =
@@ -94,8 +94,8 @@ class ProxyService(
   /* Cache for the cluster internal id from the database */
   private[leonardo] val clusterInternalIdCache = CacheBuilder
     .newBuilder()
-    .expireAfterWrite(proxyConfig.cacheExpiryTime.toMinutes, TimeUnit.MINUTES)
-    .maximumSize(proxyConfig.cacheMaxSize)
+    .expireAfterWrite(proxyConfig.internalIdCacheExpiryTime.toSeconds, TimeUnit.SECONDS)
+    .maximumSize(proxyConfig.internalIdCacheMaxSize)
     .build(
       new CacheLoader[(GoogleProject, ClusterName), Future[Option[ClusterInternalId]]] {
         def load(key: (GoogleProject, ClusterName)) = {


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-1401

AoU is occasionally seeing 404s on proxy endpoints after clusters are deleted and recreated with the same name.

All proxy endpoints go through [authCheck](https://github.com/DataBiosphere/leonardo/blob/develop/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/ProxyService.scala#L132) which looks up the clusterInternalId (cached by `(project, name)`) and asks Sam for permission (which is also cached). If Sam says the user doesn't have `GetClusterStatus` permission, the proxy endpoint returns 404 (e.g. pretend the cluster doesn't exist).

This PR lowers the TTL for the `clusterInternalIdCache` to 2 minutes. Previously it was 1 hour; so if a cluster was deleted/recreated within that window it was likely an old internalId was still cached which no longer exists in Sam. It is unlikely/impossible for a cluster to be deleted/recreated within 2 minutes.

This does mean the proxy will be making more frequent DB queries. I think this is probably OK -- the query to retrieve a cluster's internalId should be pretty light, since it looks up a single record entirely using indexes.

Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've documented my API changes in Swagger

In all cases:

- [x] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
