### PR TITLE
QA-984 Change translate test to be more stable

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookCustomizationSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookCustomizationSpec.scala
@@ -87,7 +87,7 @@ final class NotebookCustomizationSpec extends GPAllocFixtureSpec with ParallelTe
                   serverExt.get should include("jupyter_nbextensions_configurator  enabled")
 
                   // Exercise the translate extension
-                  notebookPage.translateMarkup("Hello") should include("Salut")
+                  notebookPage.translateMarkup("Yes") should include("Oui")
                 }
               }
           }


### PR DESCRIPTION
This test is failing again, 
```
"Bonjour" did not include substring "Salut"
```

Hopefully this translation is more stable. :)

Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
