### PR TITLE
IA-1427 deprecate image and tool fields instead of removing

### DIFF
--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeonardoModel.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeonardoModel.scala
@@ -568,7 +568,20 @@ object LeonardoJsonSupport extends DefaultJsonProtocol {
 
   implicit val ClusterToolFormat = EnumEntryFormat(ClusterImageType.withName)
 
-  implicit val ClusterImageFormat = jsonFormat3(ClusterImage.apply)
+  implicit val ClusterImageFormat = new RootJsonFormat[ClusterImage] {
+    override def read(json: JsValue): ClusterImage = jsonFormat3(ClusterImage.apply).read(json)
+
+    override def write(obj: ClusterImage): JsValue = {
+      val allfields = List(
+        "imageUrl" -> obj.imageUrl.toJson,
+        "imageType" -> obj.imageType.toString.toJson,
+        "dockerImage" -> obj.imageUrl.toJson, //TODO: remove this once terra-ui stops using this field
+        "tool" -> obj.imageType.toString.toJson,  //TODO: remove this once terra-ui stops using this field
+        "timestamp" -> obj.timestamp.toJson
+      )
+      JsObject(allfields: _*)
+    }
+  }
 
   implicit val ClusterInternalIdFormat = ValueObjectFormat(ClusterInternalId)
 

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeonardoModelSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeonardoModelSpec.scala
@@ -121,10 +121,14 @@ class LeonardoModelSpec extends TestComponent with FlatSpecLike with Matchers wi
         |  "clusterImages": [
         |    { "imageType": "Jupyter",
         |      "imageUrl": "jupyter/jupyter-base:latest",
+        |      "tool": "Jupyter",
+        |      "dockerImage": "jupyter/jupyter-base:latest",
         |      "timestamp": "2018-08-07T10:12:35Z"
         |      },
         |    { "imageType": "Welder",
         |      "imageUrl": "welder/welder:latest",
+        |      "tool": "Welder",
+        |      "dockerImage": "welder/welder:latest",
         |      "timestamp": "2018-08-07T10:12:35Z"
         |      }
         |    ],


### PR DESCRIPTION
Per https://broadinstitute.slack.com/archives/CA3HY2Q3S/p1574875370231800

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
