### PR TITLE
IA-1535 reduce concurrent cluster creation requests

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookBioconductorKernelSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookBioconductorKernelSpec.scala
@@ -24,7 +24,6 @@ import org.broadinstitute.dsde.workbench.service.util.Tags
 import org.scalatest.DoNotDiscover
 
 import scala.concurrent.duration._
-import scala.language.postfixOps
 
 /**
   * This spec verifies notebook functionality specifically around the R-Bioconductor kernel.


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-1535

I'm hoping reducing the number of concurrent cluster creation requests will make tests more reliable

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
