### PR TITLE
[IA-1557] RStudio needs to set CSP in order to work in an iframe

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/Notebook.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/Notebook.scala
@@ -26,7 +26,7 @@ object Notebook extends RestClient with LazyLogging {
     mapper.readValue(response, classOf[NotebookContentItem])
 
   def notebooksBasePath(googleProject: GoogleProject, clusterName: ClusterName): String =
-    s"notebooks/${googleProject.value}/${clusterName.string}"
+    s"proxy/${googleProject.value}/${clusterName.string}/jupyter"
 
   def notebooksTreePath(googleProject: GoogleProject, clusterName: ClusterName): String =
     s"${notebooksBasePath(googleProject, clusterName)}/tree"

--- a/http/src/main/resources/jupyter/jupyter_notebook_config.py
+++ b/http/src/main/resources/jupyter/jupyter_notebook_config.py
@@ -40,11 +40,8 @@ if os.environ['WELDER_ENABLED'] == 'true':
   mgr_class = 'WelderContentsManager'
 c.NotebookApp.contents_manager_class = 'jupyter_delocalize.' + mgr_class
 
-# Unset Content-Security-Policy so Jupyter can be rendered in an iframe
+# Content-Security-Policy is set by the Leo proxy so Jupyter can be rendered in an iframe
 # See https://jupyter-notebook.readthedocs.io/en/latest/public_server.html?highlight=server#embedding-the-notebook-in-another-website
 c.NotebookApp.tornado_settings = {
-    'static_url_prefix':'/notebooks/' + fragment + '/static/',
-    'headers': {
-        'Content-Security-Policy': $(contentSecurityPolicy)
-    }
+    'static_url_prefix':'/notebooks/' + fragment + '/static/'
 }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/Boot.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/Boot.scala
@@ -86,7 +86,6 @@ object Boot extends IOApp with LazyLogging {
                                             appDependencies.googleDirectoryDAO,
                                             appDependencies.googleIamDAO,
                                             appDependencies.googleProjectDAO,
-                                            contentSecurityPolicy,
                                             appDependencies.blocker)
 
       val leonardoService = new LeonardoService(dataprocConfig,
@@ -151,7 +150,7 @@ object Boot extends IOApp with LazyLogging {
                                             appDependencies.samDAO,
                                             appDependencies.dbReference,
                                             dataprocConfig)
-      val leoRoutes = new LeoRoutes(leonardoService, proxyService, statusService, swaggerConfig)
+      val leoRoutes = new LeoRoutes(leonardoService, proxyService, statusService, swaggerConfig, contentSecurityPolicy)
       with StandardUserInfoDirectives
 
       (for {

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/LeoRoutes.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/LeoRoutes.scala
@@ -46,7 +46,8 @@ abstract class LeoRoutes(
   val leonardoService: LeonardoService,
   val proxyService: ProxyService,
   val statusService: StatusService,
-  val swaggerConfig: SwaggerConfig
+  val swaggerConfig: SwaggerConfig,
+  val contentSecurityPolicy: String
 )(implicit val system: ActorSystem, val materializer: Materializer, val executionContext: ExecutionContext)
     extends LazyLogging
     with CookieHelper

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeonardoModel.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeonardoModel.scala
@@ -353,7 +353,6 @@ final case class ClusterTemplateValues private (googleProject: String,
                                                 jupyterStartUserScriptOutputBaseUri: String,
                                                 jupyterServiceAccountCredentials: String,
                                                 loginHint: String,
-                                                contentSecurityPolicy: String,
                                                 jupyterServerExtensions: String,
                                                 jupyterNbExtensions: String,
                                                 jupyterCombinedExtensions: String,
@@ -380,8 +379,7 @@ object ClusterTemplateValues {
             dataprocConfig: DataprocConfig,
             proxyConfig: ProxyConfig,
             clusterFilesConfig: ClusterFilesConfig,
-            clusterResourcesConfig: ClusterResourcesConfig,
-            contentSecurityPolicy: String): ClusterTemplateValues =
+            clusterResourcesConfig: ClusterResourcesConfig): ClusterTemplateValues =
     ClusterTemplateValues(
       cluster.googleProject.value,
       cluster.clusterName.value,
@@ -427,7 +425,6 @@ object ClusterTemplateValues {
         n <- initBucketName
       } yield GcsPath(n, GcsObjectName(serviceAccountCredentialsFilename)).toUri).getOrElse(""),
       cluster.auditInfo.creator.value,
-      contentSecurityPolicy,
       cluster.userJupyterExtensionConfig.map(x => x.serverExtensions.values.mkString(" ")).getOrElse(""),
       cluster.userJupyterExtensionConfig.map(x => x.nbExtensions.values.mkString(" ")).getOrElse(""),
       cluster.userJupyterExtensionConfig.map(x => x.combinedExtensions.values.mkString(" ")).getOrElse(""),

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/ClusterHelper.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/ClusterHelper.scala
@@ -55,7 +55,6 @@ class ClusterHelper(
   googleDirectoryDAO: GoogleDirectoryDAO,
   googleIamDAO: GoogleIamDAO,
   googleProjectDAO: GoogleProjectDAO,
-  contentSecurityPolicy: String,
   blocker: Blocker
 )(implicit val executionContext: ExecutionContext,
   val system: ActorSystem,
@@ -396,8 +395,7 @@ class ClusterHelper(
       dataprocConfig,
       proxyConfig,
       clusterFilesConfig,
-      clusterResourcesConfig,
-      contentSecurityPolicy
+      clusterResourcesConfig
     ).toMap
 
     // Jupyter allows setting of arbitrary environment variables on cluster creation if they are passed in to
@@ -428,7 +426,8 @@ class ClusterHelper(
           clusterResourcesConfig.rstudioDockerCompose,
           clusterResourcesConfig.proxyDockerCompose,
           clusterResourcesConfig.proxySiteConf,
-          clusterResourcesConfig.welderDockerCompose
+          clusterResourcesConfig.welderDockerCompose,
+          clusterResourcesConfig.jupyterNotebookConfigUri
         )
       )
       bytes <- Stream.eval(TemplateHelper.resourceStream(r, blocker).compile.to[Array])
@@ -439,7 +438,6 @@ class ClusterHelper(
       r <- Stream.emits(
         Seq(
           clusterResourcesConfig.initActionsScript,
-          clusterResourcesConfig.jupyterNotebookConfigUri,
           clusterResourcesConfig.jupyterNotebookFrontendConfigUri
         )
       )
@@ -612,8 +610,7 @@ class ClusterHelper(
       dataprocConfig,
       proxyConfig,
       clusterFilesConfig,
-      clusterResourcesConfig,
-      contentSecurityPolicy
+      clusterResourcesConfig
     )
     val replacements: Map[String, String] = clusterInit.toMap ++
       Map(
@@ -639,8 +636,7 @@ class ClusterHelper(
       dataprocConfig,
       proxyConfig,
       clusterFilesConfig,
-      clusterResourcesConfig,
-      contentSecurityPolicy
+      clusterResourcesConfig
     ).toMap
 
     TemplateHelper

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/LeoRoutesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/LeoRoutesSpec.scala
@@ -29,7 +29,7 @@ class LeoRoutesSpec extends FlatSpec with ScalatestRouteTest with CommonTestData
   private val googleProject = GoogleProject("test-project")
   private val googleProject2 = GoogleProject("test-project2")
   private val clusterName = ClusterName("test-cluster")
-  val invalidUserLeoRoutes = new LeoRoutes(leonardoService, proxyService, statusService, swaggerConfig)
+  val invalidUserLeoRoutes = new LeoRoutes(leonardoService, proxyService, statusService, swaggerConfig, contentSecurityPolicy)
   with MockUserInfoDirectives {
     override val userInfo: UserInfo =
       UserInfo(OAuth2BearerToken(tokenValue), WorkbenchUserId("badUser"), WorkbenchEmail("badUser@example.com"), 0)

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/ProxyRoutesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/ProxyRoutesSpec.scala
@@ -312,5 +312,6 @@ class ProxyRoutesSpec
       if (optionsRequest) Some(`Access-Control-Allow-Methods`(OPTIONS, POST, PUT, GET, DELETE, HEAD, PATCH))
       else None
     )
+    header("Content-Security-Policy") shouldBe Some(RawHeader("Content-Security-Policy", contentSecurityPolicy))
   }
 }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/StatusRoutesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/StatusRoutesSpec.scala
@@ -101,7 +101,7 @@ class StatusRoutesSpec
     }
     val badDataproc = new MockGoogleDataprocDAO(false)
     val statusService = new StatusService(badDataproc, badSam, DbSingleton.ref, dataprocConfig, pollInterval = 1.second)
-    val leoRoutes = new LeoRoutes(leonardoService, proxyService, statusService, swaggerConfig)
+    val leoRoutes = new LeoRoutes(leonardoService, proxyService, statusService, swaggerConfig, contentSecurityPolicy)
     with MockUserInfoDirectives {
       override val userInfo: UserInfo = defaultUserInfo
     }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/TestLeoRoutes.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/TestLeoRoutes.scala
@@ -85,7 +85,6 @@ trait TestLeoRoutes { this: ScalatestRouteTest with Matchers with ScalaFutures w
                       mockGoogleDirectoryDAO,
                       mockGoogleIamDAO,
                       mockGoogleProjectDAO,
-                      contentSecurityPolicy,
                       blocker)
   val leonardoService = new LeonardoService(dataprocConfig,
                                             MockWelderDAO,
@@ -106,11 +105,11 @@ trait TestLeoRoutes { this: ScalatestRouteTest with Matchers with ScalaFutures w
   val statusService =
     new StatusService(mockGoogleDataprocDAO, mockSamDAO, DbSingleton.ref, dataprocConfig, pollInterval = 1.second)
   val timedUserInfo = defaultUserInfo.copy(tokenExpiresIn = tokenAge)
-  val leoRoutes = new LeoRoutes(leonardoService, proxyService, statusService, swaggerConfig)
+  val leoRoutes = new LeoRoutes(leonardoService, proxyService, statusService, swaggerConfig, contentSecurityPolicy)
   with MockUserInfoDirectives {
     override val userInfo: UserInfo = defaultUserInfo
   }
-  val timedLeoRoutes = new LeoRoutes(leonardoService, proxyService, statusService, swaggerConfig)
+  val timedLeoRoutes = new LeoRoutes(leonardoService, proxyService, statusService, swaggerConfig, contentSecurityPolicy)
   with MockUserInfoDirectives {
     override val userInfo: UserInfo = timedUserInfo
   }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeonardoModelSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeonardoModelSpec.scala
@@ -202,8 +202,7 @@ class LeonardoModelSpec extends TestComponent with FlatSpecLike with Matchers wi
       dataprocConfig,
       proxyConfig,
       clusterFilesConfig,
-      clusterResourcesConfig,
-      contentSecurityPolicy
+      clusterResourcesConfig
     )
     val clusterInitMap = clusterInit.toMap
 
@@ -215,7 +214,7 @@ class LeonardoModelSpec extends TestComponent with FlatSpecLike with Matchers wi
     clusterInitMap("welderDockerImage") shouldBe welderImage.imageUrl
     clusterInitMap("welderEnabled") shouldBe "true"
 
-    clusterInitMap.size shouldBe 36
+    clusterInitMap.size shouldBe 35
   }
 
   "DockerRegistry regex" should "match expected image url format" in {

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorSpec.scala
@@ -169,7 +169,6 @@ class ClusterMonitorSpec
                                           directoryDAO,
                                           iamDAO,
                                           projectDAO,
-                                          contentSecurityPolicy,
                                           blocker)
     val supervisorActor = system.actorOf(
       TestClusterSupervisorActor.props(

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorSupervisorSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorSupervisorSpec.scala
@@ -83,7 +83,6 @@ class ClusterMonitorSupervisorSpec
                                           mockGoogleDirectoryDAO,
                                           iamDAO,
                                           projectDAO,
-                                          contentSecurityPolicy,
                                           blocker)
 
     implicit def clusterToolToToolDao = ToolDAO.clusterToolToToolDao(MockJupyterDAO, MockWelderDAO, MockRStudioDAO)
@@ -159,7 +158,6 @@ class ClusterMonitorSupervisorSpec
                                           mockGoogleDirectoryDAO,
                                           iamDAO,
                                           projectDAO,
-                                          contentSecurityPolicy,
                                           blocker)
 
     implicit def clusterToolToToolDao = ToolDAO.clusterToolToToolDao(jupyterProxyDAO, MockWelderDAO, MockRStudioDAO)
@@ -229,7 +227,6 @@ class ClusterMonitorSupervisorSpec
                                           mockGoogleDirectoryDAO,
                                           iamDAO,
                                           projectDAO,
-                                          contentSecurityPolicy,
                                           blocker)
 
     implicit def clusterToolToToolDao = ToolDAO.clusterToolToToolDao(jupyterProxyDAO, MockWelderDAO, MockRStudioDAO)
@@ -301,7 +298,6 @@ class ClusterMonitorSupervisorSpec
                                           mockGoogleDirectoryDAO,
                                           iamDAO,
                                           projectDAO,
-                                          contentSecurityPolicy,
                                           blocker)
 
     implicit def clusterToolToToolDao = ToolDAO.clusterToolToToolDao(jupyterProxyDAO, MockWelderDAO, MockRStudioDAO)

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/AuthProviderSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/AuthProviderSpec.scala
@@ -93,7 +93,6 @@ class AuthProviderSpec
                       mockGoogleDirectoryDAO,
                       mockGoogleIamDAO,
                       mockGoogleProjectDAO,
-                      contentSecurityPolicy,
                       blocker)
   val clusterDnsCache = new ClusterDnsCache(proxyConfig, DbSingleton.ref, dnsCacheConfig)
 

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoServiceSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoServiceSpec.scala
@@ -115,7 +115,6 @@ class LeonardoServiceSpec
                                       directoryDAO,
                                       iamDAO,
                                       projectDAO,
-                                      contentSecurityPolicy,
                                       blocker)
 
     leo = new LeonardoService(dataprocConfig,
@@ -497,7 +496,6 @@ class LeonardoServiceSpec
                                                     directoryDAO,
                                                     iamDAO,
                                                     projectDAO,
-                                                    contentSecurityPolicy,
                                                     blocker)
 
     val subnetMap = Map("subnet-label" -> "correctSubnet", "network-label" -> "incorrectNetwork")
@@ -522,7 +520,6 @@ class LeonardoServiceSpec
                                                       directoryDAO,
                                                       iamDAO,
                                                       projectDAO,
-                                                      contentSecurityPolicy,
                                                       blocker)
     clusterHelperWithNoSubnet.getClusterVPCSettings(Map()) shouldBe Some(VPCNetwork("test-network"))
   }
@@ -680,8 +677,7 @@ class LeonardoServiceSpec
       dataprocConfig,
       proxyConfig,
       clusterFilesConfig,
-      clusterResourcesConfig,
-      contentSecurityPolicy
+      clusterResourcesConfig
     )
     val replacements: Map[String, String] = clusterInit.toMap
 

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/ClusterHelperSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/ClusterHelperSpec.scala
@@ -64,7 +64,6 @@ class ClusterHelperSpec
                                         mockGoogleDirectoryDAO,
                                         mockGoogleIamDAO,
                                         mockGoogleProjectDAO,
-                                        contentSecurityPolicy,
                                         blocker)
 
   override def beforeAll(): Unit =
@@ -147,7 +146,6 @@ class ClusterHelperSpec
                                                  mockGoogleDirectoryDAO,
                                                  mockGoogleIamDAO,
                                                  mockGoogleProjectDAO,
-                                                 contentSecurityPolicy,
                                                  blocker)
 
     val exception = erroredClusterHelper.createCluster(testCluster).unsafeToFuture().failed.futureValue
@@ -177,7 +175,6 @@ class ClusterHelperSpec
                                                  mockGoogleDirectoryDAO,
                                                  mockGoogleIamDAO,
                                                  mockGoogleProjectDAO,
-                                                 contentSecurityPolicy,
                                                  blocker)
 
     val exception = erroredClusterHelper.createCluster(testCluster).unsafeToFuture().failed.futureValue
@@ -208,7 +205,6 @@ class ClusterHelperSpec
                                                     mockGoogleDirectoryDAO,
                                                     mockGoogleIamDAO,
                                                     mockGoogleProjectDAO,
-                                                    contentSecurityPolicy,
                                                     blocker)
 
     val subnetMap = Map("subnet-label" -> "correctSubnet", "network-label" -> "incorrectNetwork")
@@ -233,7 +229,6 @@ class ClusterHelperSpec
                                                       mockGoogleDirectoryDAO,
                                                       mockGoogleIamDAO,
                                                       mockGoogleProjectDAO,
-                                                      contentSecurityPolicy,
                                                       blocker)
     clusterHelperWithNoSubnet.getClusterVPCSettings(Map()) shouldBe Some(VPCNetwork("test-network"))
   }
@@ -254,7 +249,6 @@ class ClusterHelperSpec
                                                  mockGoogleDirectoryDAO,
                                                  erroredIamDAO,
                                                  mockGoogleProjectDAO,
-                                                 contentSecurityPolicy,
                                                  blocker)
 
     val exception = erroredClusterHelper.createCluster(testCluster).unsafeToFuture().failed.futureValue


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-1557

Previously we relied on Jupyter to set `Content-Security-Policy`, meaning we plumbed the value from Leo `reference.conf` to `jupyter_notebook_config.py` on the cluster. Unfortunately this approach is Jupyter-specific, and RStudio server doesn't seem to have an equivalent way to set CSP.

However, I can't think of a reason that the _tool_ needs to set it -- I think the Leo proxy could just set it instead. That's what I did in this PR. I verified in a local Terra that Jupyter and RStudio loads in an iframe.

![image](https://user-images.githubusercontent.com/5368863/70938797-e7495900-2014-11ea-8e99-0af0c97479e7.png)

@zarsky-broad fyi

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
