### PR TITLE
[IA-1558] Hail import_table method broken

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookHailSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookHailSpec.scala
@@ -109,19 +109,8 @@ class NotebookHailSpec extends ClusterFixtureSpec with NotebookTestUtils {
               importResult.get should include ("Finished type imputation")
 
               // Verify the Hail table
-              val tableResult = notebookPage.executeCell("table.show()")
-              val expectedTableResult =
-                """+---------------------------------+
-                  || Sample     Height  Status  Age  |
-                  |+---------------------------------+
-                  || str                             |
-                  |+---------------------------------+
-                  || "PT-1234    154.1   ADHD    24" |
-                  || "PT-1236    160.9   Control 19" |
-                  || "PT-1238    NA      ADHD    89" |
-                  || "PT-1239    170.3   Control 55" |
-                  |+---------------------------------+""".stripMargin
-              tableResult shouldBe Some(expectedTableResult)
+              val tableResult = notebookPage.executeCell("table.count()")
+              tableResult shouldBe Some("4")
             }
           }
         }

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookHailSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookHailSpec.scala
@@ -105,7 +105,8 @@ class NotebookHailSpec extends ClusterFixtureSpec with NotebookTestUtils {
 
               // Import the TSV into a Hail table
               val importResult = notebookPage.executeCell(s"table = hl.import_table('${tsvUri}', impute=True)")
-              importResult shouldBe None
+              importResult shouldBe 'defined
+              importResult.get should include ("Finished type imputation")
 
               // Verify the Hail table
               val tableResult = notebookPage.executeCell("table.show()")

--- a/http/src/main/resources/jupyter/jupyter-docker-compose.yaml
+++ b/http/src/main/resources/jupyter/jupyter-docker-compose.yaml
@@ -24,6 +24,7 @@ services:
       - /usr/bin/pyspark:/usr/bin/pyspark
       - /hadoop:/hadoop
       - /hadoop_gcs_connector_metadata_cache:/hadoop_gcs_connector_metadata_cache
+      - /usr/local/share/google/dataproc:/usr/local/share/google/dataproc
     restart: always
     environment:
       GOOGLE_PROJECT: "${GOOGLE_PROJECT}"

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/ClusterHelper.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/ClusterHelper.scala
@@ -427,6 +427,9 @@ class ClusterHelper(
           clusterResourcesConfig.proxyDockerCompose,
           clusterResourcesConfig.proxySiteConf,
           clusterResourcesConfig.welderDockerCompose,
+          // Note: jupyter_notebook_config.py is non-templated and gets copied inside the Jupyter container.
+          // So technically we could just put it in the Jupyter base image itself. However we would still need
+          // it here to support legacy images where it is not present in the container.
           clusterResourcesConfig.jupyterNotebookConfigUri
         )
       )


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-1558

Root cause was the directory containing `gcs-connector.jar` changed in the Dataproc upgrade. The new directory needs to be mounted in the Jupyter container.

Also added an automation test which verifies importing a Hail table from GCS.

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
