### PR TITLE
[QA-998] Fix NotebookCustomizationSpec scopes assertion

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookCustomizationSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookCustomizationSpec.scala
@@ -112,6 +112,9 @@ final class NotebookCustomizationSpec extends GPAllocFixtureSpec with ParallelTe
             val query =
               """! bq query --disable_ssl_validation --format=json "SELECT COUNT(*) AS scullion_count FROM publicdata.samples.shakespeare WHERE word='scullion'" """
 
+            // Result should fail due to insufficient scopes.
+            // Note we used to check for 'Invalid credential' in the result but the error message from
+            // Google does not seem stable.
             val result = notebookPage.executeCell(query, timeout = 5.minutes).get
             result should include("BigQuery error in query operation")
             result should not include "scullion_count"

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookCustomizationSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookCustomizationSpec.scala
@@ -114,7 +114,7 @@ final class NotebookCustomizationSpec extends GPAllocFixtureSpec with ParallelTe
 
             val result = notebookPage.executeCell(query, timeout = 5.minutes).get
             result should include("BigQuery error in query operation")
-            result.replace(System.lineSeparator(), " ") should include("Invalid credential")
+            result should not include "scullion_count"
           }
         }
       }


### PR DESCRIPTION
That "Invalid credential" message does not seem stable, removing it.


---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
