### PR TITLE
[no ticket] Fix 500 error for malformed proxy requests

### DIFF
--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/ProxyService.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/ProxyService.scala
@@ -116,7 +116,7 @@ class ProxyService(
         logger.error(
           s"${ev.ask.unsafeRunSync()} | Unable to look up an internal ID for cluster ${googleProject.value} / ${clusterName.value}"
         )
-        Future.failed[ClusterInternalId](ProxyException(googleProject, clusterName))
+        Future.failed[ClusterInternalId](ClusterNotFoundException(googleProject, clusterName))
     }
 
   /*


### PR DESCRIPTION
Fix an issue @dmohs reported: we will now throw 404 instead of 500 for proxy requests where the cluster cannot be found.

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
