### PR TITLE
[no ticket] Fix generated `clusterUrl` for getCluster response

### DIFF
--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/ImageConfig.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/ImageConfig.scala
@@ -7,4 +7,3 @@ final case class ImageConfig(
   rstudioImageRegex: String,
   dockerhubImageRegex: String
 )
-

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeonardoModel.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeonardoModel.scala
@@ -13,7 +13,7 @@ import enumeratum.{Enum, EnumEntry}
 import org.broadinstitute.dsde.workbench.leonardo.config._
 import org.broadinstitute.dsde.workbench.leonardo.model.Cluster._
 import org.broadinstitute.dsde.workbench.leonardo.model.ClusterContainerServiceType.JupyterService
-import org.broadinstitute.dsde.workbench.leonardo.model.ClusterImageType.{Jupyter, RStudio, Welder}
+import org.broadinstitute.dsde.workbench.leonardo.model.ClusterImageType.{CustomDataProc, Jupyter, RStudio, Welder}
 import org.broadinstitute.dsde.workbench.leonardo.model.google.DataprocRole.SecondaryWorker
 import org.broadinstitute.dsde.workbench.leonardo.model.google.GoogleJsonSupport._
 import org.broadinstitute.dsde.workbench.leonardo.model.google._
@@ -245,7 +245,7 @@ object Cluster {
                     labels: Map[String, String]): URL = {
     val tool = clusterImages
       .map(_.imageType)
-      .filterNot(_ == Welder)
+      .filterNot(Set(Welder, CustomDataProc).contains)
       .headOption
       .orElse(labels.get("tool").flatMap(ClusterImageType.withNameInsensitiveOption))
       .flatMap(ClusterContainerServiceType.imageTypeToClusterContainerServiceType.get)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoService.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoService.scala
@@ -841,7 +841,7 @@ class LeonardoService(protected val dataprocConfig: DataprocConfig,
 
       val imageChanged = cluster.clusterImages.find(_.imageType == Welder) match {
         case Some(welderImage) if welderImage.imageUrl != imageConfig.welderDockerImage => true
-        case _                                                                             => false
+        case _                                                                          => false
       }
 
       if (labelFound && imageChanged) UpdateWelder

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/CommonTestData.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/CommonTestData.scala
@@ -16,7 +16,7 @@ import org.broadinstitute.dsde.workbench.leonardo.config.Config._
 import org.broadinstitute.dsde.workbench.leonardo.config._
 import org.broadinstitute.dsde.workbench.leonardo.dao.MockSamDAO
 import org.broadinstitute.dsde.workbench.leonardo.dao.google.MockGoogleComputeDAO
-import org.broadinstitute.dsde.workbench.leonardo.model.ClusterImageType.{Jupyter, RStudio, Welder}
+import org.broadinstitute.dsde.workbench.leonardo.model.ClusterImageType.{CustomDataProc, Jupyter, RStudio, Welder}
 import org.broadinstitute.dsde.workbench.leonardo.model._
 import org.broadinstitute.dsde.workbench.leonardo.model.google._
 import org.broadinstitute.dsde.workbench.model.google.{
@@ -135,6 +135,7 @@ trait CommonTestData { this: ScalaFutures =>
   val jupyterImage = ClusterImage(Jupyter, "jupyter/jupyter-base:latest", Instant.now)
   val rstudioImage = ClusterImage(RStudio, "rocker/tidyverse:latest", Instant.now)
   val welderImage = ClusterImage(Welder, "welder/welder:latest", Instant.now)
+  val customDataprocImage = ClusterImage(CustomDataProc, "custom_dataproc", Instant.now)
 
   def makeDataprocInfo(index: Int): DataprocInfo =
     DataprocInfo(

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/LeoRoutesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/LeoRoutesSpec.scala
@@ -29,11 +29,12 @@ class LeoRoutesSpec extends FlatSpec with ScalatestRouteTest with CommonTestData
   private val googleProject = GoogleProject("test-project")
   private val googleProject2 = GoogleProject("test-project2")
   private val clusterName = ClusterName("test-cluster")
-  val invalidUserLeoRoutes = new LeoRoutes(leonardoService, proxyService, statusService, swaggerConfig, contentSecurityPolicy)
-  with MockUserInfoDirectives {
-    override val userInfo: UserInfo =
-      UserInfo(OAuth2BearerToken(tokenValue), WorkbenchUserId("badUser"), WorkbenchEmail("badUser@example.com"), 0)
-  }
+  val invalidUserLeoRoutes =
+    new LeoRoutes(leonardoService, proxyService, statusService, swaggerConfig, contentSecurityPolicy)
+    with MockUserInfoDirectives {
+      override val userInfo: UserInfo =
+        UserInfo(OAuth2BearerToken(tokenValue), WorkbenchUserId("badUser"), WorkbenchEmail("badUser@example.com"), 0)
+    }
 
   val defaultClusterRequest = ClusterRequest(Map.empty, None, properties = Map.empty)
   "LeoRoutes" should "200 on ping" in {

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/ProxyRoutesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/ProxyRoutesSpec.scala
@@ -92,7 +92,7 @@ class ProxyRoutesSpec
       }
       // should still 404 even if a cache entry is present
       proxyService.clusterInternalIdCache.put((GoogleProject(googleProject), ClusterName(newName)),
-        Future.successful(Some(internalId)))
+                                              Future.successful(Some(internalId)))
       Get(s"/$prefix/$googleProject/$newName").addHeader(Cookie(tokenCookie)) ~> leoRoutes.route ~> check {
         status shouldEqual StatusCodes.NotFound
       }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeonardoModelSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeonardoModelSpec.scala
@@ -249,4 +249,38 @@ class LeonardoModelSpec extends TestComponent with FlatSpecLike with Matchers wi
     ))
     ContainerImage.stringToJupyterDockerImage("asd/asdf") shouldBe (Some(ContainerImage.DockerHub("asd/asdf")))
   }
+
+  "Cluster" should "generate a correct cluster URL" in {
+    val expectedBase = s"http://leonardo/proxy/$project/$name0/"
+
+    // No images or labels -> default to Jupyter
+    Cluster.getClusterUrl(project, name0, Set.empty, Map.empty).toString shouldBe expectedBase + "jupyter"
+
+    // images only
+    Cluster.getClusterUrl(project, name0, Set(jupyterImage), Map.empty).toString shouldBe expectedBase + "jupyter"
+    Cluster
+      .getClusterUrl(project, name0, Set(welderImage, customDataprocImage, jupyterImage), Map.empty)
+      .toString shouldBe expectedBase + "jupyter"
+    Cluster.getClusterUrl(project, name0, Set(rstudioImage), Map.empty).toString shouldBe expectedBase + "rstudio"
+    Cluster
+      .getClusterUrl(project, name0, Set(welderImage, customDataprocImage, rstudioImage), Map.empty)
+      .toString shouldBe expectedBase + "rstudio"
+
+    // labels only
+    Cluster
+      .getClusterUrl(project, name0, Set.empty, Map("tool" -> "Jupyter", "foo" -> "bar"))
+      .toString shouldBe expectedBase + "jupyter"
+    Cluster
+      .getClusterUrl(project, name0, Set.empty, Map("tool" -> "RStudio", "foo" -> "bar"))
+      .toString shouldBe expectedBase + "rstudio"
+    Cluster.getClusterUrl(project, name0, Set.empty, Map("foo" -> "bar")).toString shouldBe expectedBase + "jupyter"
+
+    // images and labels -> images take precedence
+    Cluster
+      .getClusterUrl(project,
+                     name0,
+                     Set(welderImage, customDataprocImage, rstudioImage),
+                     Map("tool" -> "Jupyter", "foo" -> "bar"))
+      .toString shouldBe expectedBase + "rstudio"
+  }
 }


### PR DESCRIPTION
I noticed that `clusterUrl` contained the wrong URL (e.g. `https://notebooks.firecloud.org/proxy/broad-firecloud-dsde/rt-rstudio-test/jupyter`) for an RStudio image. This fixes it and adds a unit test.

Also ran scalafmt which picked up some unrelated changes (in a separate commit).

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
