### PR TITLE
[IA-1603] Private GCR images no longer work

### DIFF
--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/DockerDAO.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/DockerDAO.scala
@@ -2,10 +2,12 @@ package org.broadinstitute.dsde.workbench.leonardo.dao
 
 import cats.mtl.ApplicativeAsk
 import org.broadinstitute.dsde.workbench.leonardo.model.{ClusterImageType, ContainerImage}
-import org.broadinstitute.dsde.workbench.model.TraceId
+import org.broadinstitute.dsde.workbench.model.{TraceId, UserInfo}
 
 trait DockerDAO[F[_]] {
 
-  def detectTool(image: ContainerImage)(implicit ev: ApplicativeAsk[F, TraceId]): F[Option[ClusterImageType]]
+  def detectTool(image: ContainerImage, userInfo: UserInfo)(
+    implicit ev: ApplicativeAsk[F, TraceId]
+  ): F[Option[ClusterImageType]]
 
 }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/DockerDAO.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/DockerDAO.scala
@@ -6,7 +6,7 @@ import org.broadinstitute.dsde.workbench.model.TraceId
 
 trait DockerDAO[F[_]] {
 
-  def detectTool(image: ContainerImage, tokenOpt: Option[String] = None)(
+  def detectTool(image: ContainerImage, petTokenOpt: Option[String] = None)(
     implicit ev: ApplicativeAsk[F, TraceId]
   ): F[Option[ClusterImageType]]
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/DockerDAO.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/DockerDAO.scala
@@ -2,11 +2,11 @@ package org.broadinstitute.dsde.workbench.leonardo.dao
 
 import cats.mtl.ApplicativeAsk
 import org.broadinstitute.dsde.workbench.leonardo.model.{ClusterImageType, ContainerImage}
-import org.broadinstitute.dsde.workbench.model.{TraceId, UserInfo}
+import org.broadinstitute.dsde.workbench.model.TraceId
 
 trait DockerDAO[F[_]] {
 
-  def detectTool(image: ContainerImage, userInfo: UserInfo)(
+  def detectTool(image: ContainerImage, tokenOpt: Option[String] = None)(
     implicit ev: ApplicativeAsk[F, TraceId]
   ): F[Option[ClusterImageType]]
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpDockerDAO.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpDockerDAO.scala
@@ -50,7 +50,6 @@ class HttpDockerDAO[F[_]: Concurrent] private (httpClient: Client[F])(implicit l
     for {
       parsed <- parseImage(image)
       token <- tokenOpt.fold(getToken(parsed))(t => Concurrent[F].pure(Some(Token(t))))
-      _ <- Concurrent[F].delay(println("XXX token is " + token))
       digest <- parsed.imageVersion match {
         case Tag(_)      => getManifestConfig(parsed, token).map(_.digest)
         case Sha(digest) => Concurrent[F].pure(digest)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpDockerDAO.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpDockerDAO.scala
@@ -16,7 +16,7 @@ import org.broadinstitute.dsde.workbench.leonardo.model.{
   ContainerRegistry,
   LeoException
 }
-import org.broadinstitute.dsde.workbench.model.{TraceId, UserInfo}
+import org.broadinstitute.dsde.workbench.model.TraceId
 import org.http4s._
 import org.http4s.circe.CirceEntityDecoder._
 import org.http4s.client.Client
@@ -44,16 +44,18 @@ class HttpDockerDAO[F[_]: Concurrent] private (httpClient: Client[F])(implicit l
     extends DockerDAO[F]
     with Http4sClientDsl[F] {
 
-  override def detectTool(image: ContainerImage,
-                          userInfo: UserInfo)(implicit ev: ApplicativeAsk[F, TraceId]): F[Option[ClusterImageType]] =
+  override def detectTool(image: ContainerImage, tokenOpt: Option[String])(
+    implicit ev: ApplicativeAsk[F, TraceId]
+  ): F[Option[ClusterImageType]] =
     for {
       parsed <- parseImage(image)
-      tokenOpt <- getToken(parsed, userInfo)
+      token <- tokenOpt.fold(getToken(parsed))(t => Concurrent[F].pure(Some(Token(t))))
+      _ <- Concurrent[F].delay(println("XXX token is " + token))
       digest <- parsed.imageVersion match {
-        case Tag(_)      => getManifestConfig(parsed, tokenOpt).map(_.digest)
+        case Tag(_)      => getManifestConfig(parsed, token).map(_.digest)
         case Sha(digest) => Concurrent[F].pure(digest)
       }
-      containerConfig <- getContainerConfig(parsed, digest, tokenOpt)
+      containerConfig <- getContainerConfig(parsed, digest, token)
       envSet = containerConfig.env.toSet
       tool = clusterToolEnv
         .find {
@@ -88,12 +90,9 @@ class HttpDockerDAO[F[_]: Concurrent] private (httpClient: Client[F])(implicit l
     )(onError)
 
   //curl --silent "https://auth.docker.io/token?scope=repository%3Alibrary/nginx%3Apull&service=registry.docker.io" | jq '.token'
-  private[dao] def getToken(parsedImage: ParsedImage,
-                            userInfo: UserInfo)(implicit ev: ApplicativeAsk[F, TraceId]): F[Option[Token]] =
+  private[dao] def getToken(parsedImage: ParsedImage)(implicit ev: ApplicativeAsk[F, TraceId]): F[Option[Token]] =
     parsedImage.registry match {
-      // For GCR, the token is the user's Google access token
-      case GCR => Concurrent[F].pure(Some(Token(userInfo.accessToken.token)))
-      // For Dockerhub, we need to request a Dockerhub token
+      case GCR => Concurrent[F].pure(None)
       case DockerHub =>
         httpClient.expectOptionOr[Token](
           Request[F](

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpDockerDAOSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpDockerDAOSpec.scala
@@ -1,23 +1,20 @@
 package org.broadinstitute.dsde.workbench.leonardo.dao
 
-import java.util.UUID
-
 import cats.effect.IO
-import cats.mtl.ApplicativeAsk
 import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
+import org.broadinstitute.dsde.workbench.leonardo.CommonTestData
 import org.broadinstitute.dsde.workbench.leonardo.model.ClusterImageType.{Jupyter, RStudio}
 import org.broadinstitute.dsde.workbench.leonardo.model.ContainerImage.{DockerHub, GCR}
-import org.broadinstitute.dsde.workbench.model.TraceId
 import org.http4s.client.blaze.BlazeClientBuilder
 import org.http4s.client.middleware.Logger
+import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers}
 
 import scala.concurrent.ExecutionContext.global
 
-class HttpDockerDAOSpec extends FlatSpec with Matchers with BeforeAndAfterAll {
+class HttpDockerDAOSpec extends FlatSpec with Matchers with BeforeAndAfterAll with ScalaFutures with CommonTestData {
   implicit val cs = IO.contextShift(global)
   implicit def unsafeLogger = Slf4jLogger.getLogger[IO]
-  implicit val traceId = ApplicativeAsk.const[IO, TraceId](TraceId(UUID.randomUUID()))
 
   val jupyterImages = List(
     // dockerhub no tag
@@ -83,7 +80,7 @@ class HttpDockerDAOSpec extends FlatSpec with Matchers with BeforeAndAfterAll {
     case (tool, images) =>
       images.foreach { image =>
         it should s"detect tool=$tool for image $image" in withDockerDAO { dockerDAO =>
-          val response = dockerDAO.detectTool(image).attempt.unsafeRunSync().toOption.flatten
+          val response = dockerDAO.detectTool(image, userInfo).attempt.unsafeRunSync().toOption.flatten
           response shouldBe tool
         }
       }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpDockerDAOSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpDockerDAOSpec.scala
@@ -1,20 +1,23 @@
 package org.broadinstitute.dsde.workbench.leonardo.dao
 
+import java.util.UUID
+
 import cats.effect.IO
+import cats.mtl.ApplicativeAsk
 import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
-import org.broadinstitute.dsde.workbench.leonardo.CommonTestData
 import org.broadinstitute.dsde.workbench.leonardo.model.ClusterImageType.{Jupyter, RStudio}
 import org.broadinstitute.dsde.workbench.leonardo.model.ContainerImage.{DockerHub, GCR}
+import org.broadinstitute.dsde.workbench.model.TraceId
 import org.http4s.client.blaze.BlazeClientBuilder
 import org.http4s.client.middleware.Logger
-import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers}
 
 import scala.concurrent.ExecutionContext.global
 
-class HttpDockerDAOSpec extends FlatSpec with Matchers with BeforeAndAfterAll with ScalaFutures with CommonTestData {
+class HttpDockerDAOSpec extends FlatSpec with Matchers with BeforeAndAfterAll {
   implicit val cs = IO.contextShift(global)
   implicit def unsafeLogger = Slf4jLogger.getLogger[IO]
+  implicit val traceId = ApplicativeAsk.const[IO, TraceId](TraceId(UUID.randomUUID()))
 
   val jupyterImages = List(
     // dockerhub no tag
@@ -80,7 +83,7 @@ class HttpDockerDAOSpec extends FlatSpec with Matchers with BeforeAndAfterAll wi
     case (tool, images) =>
       images.foreach { image =>
         it should s"detect tool=$tool for image $image" in withDockerDAO { dockerDAO =>
-          val response = dockerDAO.detectTool(image, userInfo).attempt.unsafeRunSync().toOption.flatten
+          val response = dockerDAO.detectTool(image).attempt.unsafeRunSync().toOption.flatten
           response shouldBe tool
         }
       }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/MockDockerDAO.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/MockDockerDAO.scala
@@ -4,12 +4,12 @@ import cats.effect.IO
 import cats.mtl.ApplicativeAsk
 import org.broadinstitute.dsde.workbench.leonardo.model.ClusterImageType.Jupyter
 import org.broadinstitute.dsde.workbench.leonardo.model.{ClusterImageType, ContainerImage}
-import org.broadinstitute.dsde.workbench.model.{TraceId, UserInfo}
+import org.broadinstitute.dsde.workbench.model.TraceId
 
 class MockDockerDAO(tool: ClusterImageType = Jupyter) extends DockerDAO[IO] {
   override def detectTool(
     image: ContainerImage,
-    userInfo: UserInfo
+    tokenOpt: Option[String]
   )(implicit ev: ApplicativeAsk[IO, TraceId]): IO[Option[ClusterImageType]] =
     IO.pure(Some(tool))
 }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/MockDockerDAO.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/MockDockerDAO.scala
@@ -4,11 +4,12 @@ import cats.effect.IO
 import cats.mtl.ApplicativeAsk
 import org.broadinstitute.dsde.workbench.leonardo.model.ClusterImageType.Jupyter
 import org.broadinstitute.dsde.workbench.leonardo.model.{ClusterImageType, ContainerImage}
-import org.broadinstitute.dsde.workbench.model.TraceId
+import org.broadinstitute.dsde.workbench.model.{TraceId, UserInfo}
 
 class MockDockerDAO(tool: ClusterImageType = Jupyter) extends DockerDAO[IO] {
   override def detectTool(
-    image: ContainerImage
+    image: ContainerImage,
+    userInfo: UserInfo
   )(implicit ev: ApplicativeAsk[IO, TraceId]): IO[Option[ClusterImageType]] =
     IO.pure(Some(tool))
 }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/MockDockerDAO.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/MockDockerDAO.scala
@@ -9,7 +9,7 @@ import org.broadinstitute.dsde.workbench.model.TraceId
 class MockDockerDAO(tool: ClusterImageType = Jupyter) extends DockerDAO[IO] {
   override def detectTool(
     image: ContainerImage,
-    tokenOpt: Option[String]
+    petTokenOpt: Option[String]
   )(implicit ev: ApplicativeAsk[IO, TraceId]): IO[Option[ClusterImageType]] =
     IO.pure(Some(tool))
 }


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-1603

The fix was to pass the pet's Google token to GCR APIs during image auto-detection. I verified this on a private GCR repo I created in a test project.

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
