### PR TITLE
[QA-1004] Don't install the github version of mlr in test

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookRKernelSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookRKernelSpec.scala
@@ -98,9 +98,10 @@ class NotebookRKernelSpec extends ClusterFixtureSpec with NotebookTestUtils {
           // it may take a little while to install
           val installTimeout = 5.minutes
 
-          val installOutput = notebookPage.executeCell("""devtools::install_github("mlr-org/mlr")""", installTimeout)
+          val installOutput = notebookPage.executeCell("""install.packages('mlr')""", installTimeout)
           installOutput shouldBe 'defined
-          installOutput.get should include("Downloading GitHub repo mlr-org/mlr@master")
+          installOutput.get should include("Installing package into")
+          installOutput.get should include("/home/jupyter-user/.rpackages")
           installOutput.get should not include ("Installation failed")
 
           // Make sure it was installed correctly; if not, this will return an error


### PR DESCRIPTION
This test started failing.. hopefully the CRAN version is more stable. The below commands work when I do them manually on an R image.

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
