### PR TITLE
[IA-1610] RStudio shutdown script not running reliably

### DIFF
--- a/automation/src/test/resources/reference.conf
+++ b/automation/src/test/resources/reference.conf
@@ -7,3 +7,4 @@ leonardo.oldWelderImage = "us.gcr.io/broad-dsp-gcr-public/welder-server:6a783a5"
 leonardo.currentWelderImage = "us.gcr.io/broad-dsp-gcr-public/welder-server:60e28bc" # This needs to be exactly the same in http/src/main/resources/reference.conf
 leonardo.bioconductorImageUrl = "us.gcr.io/broad-dsp-gcr-public/terra-jupyter-bioconductor:0.0.9"
 leonardo.rstudioBaseImageUrl = "us.gcr.io/anvil-gcr-public/anvil-rstudio-base:0.0.2"
+leonardo.rstudioBioconductorImageUrl = "us.gcr.io/anvil-gcr-public/anvil-rstudio-bioconductor:0.0.3"

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -289,7 +289,7 @@ pipeline {
                     --zone us-central1-a \
                     --gcs-bucket $BUCKET_NAME \
                     --project-id=$GOOGLE_PROJECT \
-                    --disk-size=30
+                    --disk-size=50
                 """
               )
             }

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -130,16 +130,15 @@ pipeline {
           description: "The bucket where the image will be stored")
     string(name: "dataproc_versions", defaultValue: "1.2.79-debian9 1.4.15-debian9",
           description: "A custom image will be build for each of these dataproc versions")
-    string(name: "terra_jupyter_base", defaultValue: "0.0.1")
-    string(name: "terra_jupyter_hail", defaultValue: "0.0.1",
-          description: "Is not currently baked into the image, but is here for future functionality")
-    string(name: "terra_jupyter_r", defaultValue: "0.0.3")
-    string(name: "terra_jupyter_python", defaultValue: "0.0.1")
-    string(name: "terra_jupyter_bioconductor", defaultValue: "0.0.2",
-          description: "Is not currently baked into the image, but is here for future functionality")
+    string(name: "terra_jupyter_base", defaultValue: "0.0.6")
+    string(name: "terra_jupyter_hail", defaultValue: "0.0.5")
+    string(name: "terra_jupyter_r", defaultValue: "0.0.7")
+    string(name: "terra_jupyter_python", defaultValue: "0.0.6")
+    string(name: "terra_jupyter_bioconductor", defaultValue: "0.0.9")
+    string(name: "terra_jupyter_gatk", defaultValue: "0.0.8")
     string(name: "leonardo_jupyter", defaultValue: "5c51ce6935da",
           description: "The tag of the jupyter image to pull in docker image build. Used in the prepare script.")
-    string(name: "welder_server", defaultValue: "6a783a5",
+    string(name: "welder_server", defaultValue: "60e28bc",
           description: "The tag of the welder image to pull in docker image build. Used in the prepare script. Please note this default is possibly an old hash.")
     string(name: "openidc_proxy", defaultValue: "2.3.1_2",
           description:"The tag of the openidc proxy image to pull in docker image build. Used in the prepare script.")
@@ -162,6 +161,8 @@ pipeline {
           images.add('leonardo-jupyter')
           images.add('welder-server')
           images.add('openidc-proxy')
+          images.add('anvil-rstudio-base')
+          images.add('anvil-rstudio-bioconductor')
 
           println("Images to include in custom image found in image scan: $images")
         }

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -147,7 +147,7 @@ pipeline {
   stages {
     stage('Terra docker image scan') {
       steps {
-        git credentialsId: 'jenkins-ssh-github', url: 'git@github.com:DataBiosphere/terra-docker.git', branch: 'master'
+        git credentialsId: 'jenkins-ssh-github', url: 'git@github.com:DataBiosphere/terra-docker.git', branch: 'rt-update-dataproc'
 
         script {
           def temp = sh( 
@@ -171,7 +171,7 @@ pipeline {
 
     stage('Leonardo Git') {
       steps {
-        git credentialsId: 'jenkins-ssh-github', url: 'git@github.com:DataBiosphere/leonardo.git', branch: 'develop'
+        git credentialsId: 'jenkins-ssh-github', url: 'git@github.com:DataBiosphere/leonardo.git', branch: 'rt-ia-1610'
       }
     }
 

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -149,7 +149,7 @@ pipeline {
   stages {
     stage('Terra docker image scan') {
       steps {
-        git credentialsId: 'jenkins-ssh-github', url: 'git@github.com:DataBiosphere/terra-docker.git', branch: 'rt-update-dataproc'
+        git credentialsId: 'jenkins-ssh-github', url: 'git@github.com:DataBiosphere/terra-docker.git', branch: 'master'
 
         script {
           def temp = sh( 
@@ -173,7 +173,7 @@ pipeline {
 
     stage('Leonardo Git') {
       steps {
-        git credentialsId: 'jenkins-ssh-github', url: 'git@github.com:DataBiosphere/leonardo.git', branch: 'rt-ia-1610'
+        git credentialsId: 'jenkins-ssh-github', url: 'git@github.com:DataBiosphere/leonardo.git', branch: 'develop'
       }
     }
 

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -136,6 +136,8 @@ pipeline {
     string(name: "terra_jupyter_python", defaultValue: "0.0.6")
     string(name: "terra_jupyter_bioconductor", defaultValue: "0.0.9")
     string(name: "terra_jupyter_gatk", defaultValue: "0.0.8")
+    string(name: "anvil_rstudio_base", defaultValue: "0.0.2")
+    string(name: "anvil_rstudio_bioconductor", defaultValue: "0.0.3")
     string(name: "leonardo_jupyter", defaultValue: "5c51ce6935da",
           description: "The tag of the jupyter image to pull in docker image build. Used in the prepare script.")
     string(name: "welder_server", defaultValue: "60e28bc",

--- a/jenkins/dataproc-custom-images/prepare-custom-leonardo-jupyter-dataproc-image.sh
+++ b/jenkins/dataproc-custom-images/prepare-custom-leonardo-jupyter-dataproc-image.sh
@@ -16,22 +16,20 @@ set -e -x
 # the image tags are set via jenkins automation
 #
 
-#filled out by jenkins job
+# The versions below don't matter; they are replaced by the Jenkins job
 terra_jupyter_base="us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:0.0.6"
 terra_jupyter_python="us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.6"
 terra_jupyter_r="us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:0.0.7"
-
-#bioconductor and hail currently are not baked into the custom image
 terra_jupyter_bioconductor="us.gcr.io/broad-dsp-gcr-public/terra-jupyter-bioconductor:0.0.9"
 terra_jupyter_hail="us.gcr.io/broad-dsp-gcr-public/terra-jupyter-hail:0.0.5"
 terra_jupyter_gatk="us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:0.0.8"
-anvil_rstudio_base="us.gcr.io/anvil-gcr-public/anvil-rstudio-base:0.0.2"
-anvil_rstudio_bioconductor="us.gcr.io/anvil-gcr-public/anvil-rstudio-bioconductor:0.0.3"
 
 #leonardo_jupyter will be discontinued soon
 leonardo_jupyter="us.gcr.io/broad-dsp-gcr-public/leonardo-jupyter:5c51ce6935da"
 welder_server="us.gcr.io/broad-dsp-gcr-public/welder-server:60e28bc"
 openidc_proxy="broadinstitute/openidc-proxy:2.3.1_2"
+anvil_rstudio_base="us.gcr.io/anvil-gcr-public/anvil-rstudio-base:0.0.2"
+anvil_rstudio_bioconductor="us.gcr.io/anvil-gcr-public/anvil-rstudio-bioconductor:0.0.3"
 
 # this array determines which of the above images are baked into the custom image
 # the entry must match the var name above, which must correspond to a valid docker URI

--- a/jenkins/dataproc-custom-images/prepare-custom-leonardo-jupyter-dataproc-image.sh
+++ b/jenkins/dataproc-custom-images/prepare-custom-leonardo-jupyter-dataproc-image.sh
@@ -17,22 +17,25 @@ set -e -x
 #
 
 #filled out by jenkins job
-terra_jupyter_base="us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:0.0.1"
-terra_jupyter_python="us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.1"
-terra_jupyter_r="us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:0.0.3"
+terra_jupyter_base="us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:0.0.6"
+terra_jupyter_python="us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.6"
+terra_jupyter_r="us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:0.0.7"
 
 #bioconductor and hail currently are not baked into the custom image
-terra_jupyter_bioconductor="us.gcr.io/broad-dsp-gcr-public/terra-jupyter-bioconductor:0.0.2"
-terra_jupyter_hail="us.gcr.io/broad-dsp-gcr-public/terra-jupyter-hail:0.0.1"
+terra_jupyter_bioconductor="us.gcr.io/broad-dsp-gcr-public/terra-jupyter-bioconductor:0.0.9"
+terra_jupyter_hail="us.gcr.io/broad-dsp-gcr-public/terra-jupyter-hail:0.0.5"
+terra_jupyter_gatk="us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:0.0.8"
+anvil_rstudio_base="us.gcr.io/anvil-gcr-public/anvil-rstudio-base:0.0.2"
+anvil_rstudio_bioconductor="us.gcr.io/anvil-gcr-public/anvil-rstudio-bioconductor:0.0.3"
 
 #leonardo_jupyter will be discontinued soon
 leonardo_jupyter="us.gcr.io/broad-dsp-gcr-public/leonardo-jupyter:5c51ce6935da"
-welder_server="us.gcr.io/broad-dsp-gcr-public/welder-server:6a783a5"
+welder_server="us.gcr.io/broad-dsp-gcr-public/welder-server:60e28bc"
 openidc_proxy="broadinstitute/openidc-proxy:2.3.1_2"
 
 # this array determines which of the above images are baked into the custom image
 # the entry must match the var name above, which must correspond to a valid docker URI
-docker_image_var_names="welder_server leonardo_jupyter terra_jupyter_base terra_jupyter_python openidc_proxy"
+docker_image_var_names="welder_server leonardo_jupyter terra_jupyter_base terra_jupyter_python terra_jupyter_r terra_jupyter_bioconductor terra_jupyter_hail terra_jupyter_gatk openidc_proxy anvil_rstudio_base anvil_rstudio_bioconductor"
 
 #
 # Functions
@@ -158,6 +161,18 @@ if [[ -n ${docker_image_var_names:?} ]]; then
 else
     log "ERROR-VAR_NULL_OR_UNSET: docker_image_var_names. Will not pull docker images."
 fi
+
+log 'Making systemd additions...'
+mkdir -p /etc/systemd/system/google-startup-scripts.service.d
+cat > /etc/systemd/system/google-startup-scripts.service.d/override.conf <<EOF
+[Unit]
+After=docker.service
+EOF
+mkdir -p /etc/systemd/system/google-shutdown-scripts.service.d
+cat > /etc/systemd/system/google-shutdown-scripts.service.d/override.conf <<EOF
+[Unit]
+After=docker.service
+EOF
 
 # Install Python 3.6.8
 export PYTHON_VERSION="3.6.8"


### PR DESCRIPTION
The real fix is some systemd changes to make our startup/shutdown scripts dependent on `docker.service`.

But since I was updating the Dataproc image anyway, I updated all the docker image versions and added `terra-jupyter-gatk`, `terra-rstudio-base`, and `terra-rstudio-bioconductor`.

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
