### PR TITLE
[IA-1623] Fix ClusterToolMonitor spam

### DIFF
--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponent.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponent.scala
@@ -712,7 +712,7 @@ object clusterQuery extends TableQuery(new ClusterTable(_)) {
   }
 
   private def unmarshalRunningCluster(clusterImages: Seq[(ClusterRecord, ClusterImageRecord)]): Seq[RunningCluster] = {
-    val clusterImageMap: Map[RunningCluster, Chain[ClusterContainerServiceType]] = clusterImages.toList.foldMap {
+    val clusterContainerMap: Map[RunningCluster, Chain[ClusterContainerServiceType]] = clusterImages.toList.foldMap {
       case (clusterRec, clusterImageRec) =>
         val containers = Chain.fromSeq(
           ClusterContainerServiceType.imageTypeToClusterContainerServiceType.get(clusterImageRec.imageType).toSeq
@@ -720,7 +720,7 @@ object clusterQuery extends TableQuery(new ClusterTable(_)) {
         Map(RunningCluster(clusterRec.googleProject, clusterRec.clusterName, List.empty) -> containers)
     }
 
-    clusterImageMap.toSeq.map {
+    clusterContainerMap.toSeq.map {
       case (runningCluster, containers) => runningCluster.copy(containers = containers.toList)
     }
   }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponent.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponent.scala
@@ -236,6 +236,15 @@ object clusterQuery extends TableQuery(new ClusterTable(_)) {
     } yield (cluster, label)
   }
 
+  // select * from cluster c
+  // join cluster_image ci on c.id = ce.cluster_id
+  val clusterJoinClusterImageQuery
+    : Query[(ClusterTable, ClusterImageTable), (ClusterRecord, ClusterImageRecord), Seq] = {
+    for {
+      (cluster, image) <- clusterQuery join clusterImageQuery on (_.id === _.clusterId)
+    } yield (cluster, image)
+  }
+
   def fullClusterQueryByUniqueKey(googleProject: GoogleProject,
                                   clusterName: ClusterName,
                                   destroyedDateOpt: Option[Instant]) = {
@@ -323,8 +332,8 @@ object clusterQuery extends TableQuery(new ClusterTable(_)) {
     }
 
   def listRunningOnly(implicit ec: ExecutionContext): DBIO[Seq[RunningCluster]] =
-    clusterQuery.filter { _.status === ClusterStatus.Running.toString }.result map { recs =>
-      recs.map(rec => RunningCluster(rec.googleProject, rec.clusterName, rec.welderEnabled))
+    clusterJoinClusterImageQuery.filter { _._1.status === ClusterStatus.Running.toString }.result map {
+      unmarshalRunningCluster
     }
 
   def countActiveByClusterServiceAccount(clusterServiceAccount: WorkbenchEmail) =
@@ -700,6 +709,20 @@ object clusterQuery extends TableQuery(new ClusterTable(_)) {
                          List.empty,
                          List.empty)
     }.toSeq
+  }
+
+  private def unmarshalRunningCluster(clusterImages: Seq[(ClusterRecord, ClusterImageRecord)]): Seq[RunningCluster] = {
+    val clusterImageMap: Map[RunningCluster, Chain[ClusterContainerServiceType]] = clusterImages.toList.foldMap {
+      case (clusterRec, clusterImageRec) =>
+        val containers = Chain.fromSeq(
+          ClusterContainerServiceType.imageTypeToClusterContainerServiceType.get(clusterImageRec.imageType).toSeq
+        )
+        Map(RunningCluster(clusterRec.googleProject, clusterRec.clusterName, List.empty) -> containers)
+    }
+
+    clusterImageMap.toSeq.map {
+      case (runningCluster, containers) => runningCluster.copy(containers = containers.toList)
+    }
   }
 
   private def unmarshalFullCluster(

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponent.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponent.scala
@@ -9,7 +9,6 @@ import cats.implicits._
 import org.broadinstitute.dsde.workbench.leonardo.model.Cluster.LabelMap
 import org.broadinstitute.dsde.workbench.leonardo.model._
 import org.broadinstitute.dsde.workbench.leonardo.model.google._
-import org.broadinstitute.dsde.workbench.leonardo.monitor.RunningCluster
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
 import org.broadinstitute.dsde.workbench.model.google.{
   parseGcsPath,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeonardoModel.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeonardoModel.scala
@@ -160,6 +160,10 @@ case class ClusterImage(imageType: ClusterImageType, imageUrl: String, timestamp
 
 case class ClusterInternalId(value: String) extends ValueObject
 
+final case class RunningCluster(googleProject: GoogleProject,
+                                clusterName: ClusterName,
+                                containers: List[ClusterContainerServiceType])
+
 // The cluster itself
 final case class Cluster(id: Long = 0, // DB AutoInc
                          internalId: ClusterInternalId,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterToolMonitor.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterToolMonitor.scala
@@ -10,10 +10,8 @@ import org.broadinstitute.dsde.workbench.leonardo.config.ClusterToolConfig
 import org.broadinstitute.dsde.workbench.leonardo.dao.ToolDAO
 import org.broadinstitute.dsde.workbench.leonardo.dao.google.GoogleDataprocDAO
 import org.broadinstitute.dsde.workbench.leonardo.db.{clusterQuery, DbReference}
-import org.broadinstitute.dsde.workbench.leonardo.model.google.ClusterName
-import org.broadinstitute.dsde.workbench.leonardo.model.ClusterContainerServiceType
+import org.broadinstitute.dsde.workbench.leonardo.model.{ClusterContainerServiceType, RunningCluster}
 import org.broadinstitute.dsde.workbench.leonardo.monitor.ClusterToolMonitor._
-import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.broadinstitute.dsde.workbench.newrelic.NewRelicMetrics
 
 import scala.concurrent.ExecutionContext
@@ -95,7 +93,3 @@ class ClusterToolMonitor(
         }
     }
 }
-
-final case class RunningCluster(googleProject: GoogleProject,
-                                clusterName: ClusterName,
-                                containers: List[ClusterContainerServiceType])

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/MockRStudioDAO.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/MockRStudioDAO.scala
@@ -4,7 +4,9 @@ import cats.effect.IO
 import org.broadinstitute.dsde.workbench.leonardo.model.google.ClusterName
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 
-object MockRStudioDAO extends RStudioDAO[IO] {
+class MockRStudioDAO(isUp: Boolean = true) extends RStudioDAO[IO] {
   override def isProxyAvailable(googleProject: GoogleProject, clusterName: ClusterName): IO[Boolean] =
-    IO.pure(true)
+    IO.pure(isUp)
 }
+
+object MockRStudioDAO extends MockRStudioDAO(true)

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterToolMonitorSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterToolMonitorSpec.scala
@@ -71,7 +71,7 @@ class ClusterToolMonitorSpec
     }
   }
 
-  it should "report all services are down for a Jupyter image" in isolatedDbTest {
+  it should "report services are down for a Jupyter image" in isolatedDbTest {
     welderEnabledCluster.save()
 
     withServiceActor(welderDAO = new MockWelderDAO(false), jupyterDAO = new MockJupyterDAO(false)) {
@@ -89,7 +89,7 @@ class ClusterToolMonitorSpec
     }
   }
 
-  it should "report all services are down for a RStudio image" in isolatedDbTest {
+  it should "report services are down for a RStudio image" in isolatedDbTest {
     rstudioCluster.save()
 
     withServiceActor(welderDAO = new MockWelderDAO(false), rstudioDAO = new MockRStudioDAO(false)) {


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-1623

Basically updated `ClusterToolMonitor` to query the CLUSTER_IMAGE table and check status only for the enabled tools.

Unit tests pass, haven't tested in a fiab yet.

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
