### PR TITLE
[no ticket] Prune unneeded images in the init script

### DIFF
--- a/http/src/main/resources/jupyter/init-actions.sh
+++ b/http/src/main/resources/jupyter/init-actions.sh
@@ -452,10 +452,15 @@ END
 
       log 'Starting Jupyter Notebook...'
       retry 3 docker exec -d ${JUPYTER_SERVER_NAME} ${JUPYTER_SCRIPTS}/run-jupyter.sh ${NOTEBOOKS_DIR}
-      log 'All done!'
 
       STEP_TIMINGS+=($(date +%s))
     fi
+
+    # Remove any unneeded cached images to save disk space.
+    # Do this asynchronously so it doesn't hold up cluster creation
+    log 'Pruning docker images...'
+    docker image prune -a -f &
 fi
 
+log 'All done!'
 log "Timings: ${STEP_TIMINGS[@]}"


### PR DESCRIPTION
Manually tested. This saves about 19G of disk on the cluster, which is significant with our 50G default disk size.

Init log (shows it runs async):
```
+ log 'Pruning docker images...'
++ date +%Y-%m-%dT%H:%M:%S%z
+ echo '[2020-01-17T19:28:57+0000]: Pruning docker images...'
[2020-01-17T19:28:57+0000]: Pruning docker images...
+ docker image prune -a -f
+ log 'All done!'
++ date +%Y-%m-%dT%H:%M:%S%z
+ echo '[2020-01-17T19:28:57+0000]: All done!'
[2020-01-17T19:28:57+0000]: All done!
```

Before this change:
```
root@saturn-e2b5ca36-f227-49a4-bbce-f03c6e63bcfd-m:~# docker images
REPOSITORY                                                  TAG                 IMAGE ID            CREATED             SIZE
us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk           0.0.9               fa56053c1ee7        21 hours ago        5.49GB
us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r              0.0.8               73e1447d7f1c        21 hours ago        2.9GB
us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python         0.0.7               d06fc60a507f        22 hours ago        4.87GB
us.gcr.io/broad-dsp-gcr-public/welder-server                ed93873             ad9a3d123b1f        3 days ago          1.81GB
us.gcr.io/broad-dsp-gcr-public/terra-jupyter-hail           0.0.5               f73d54d71136        10 days ago         5.44GB
us.gcr.io/broad-dsp-gcr-public/terra-jupyter-bioconductor   0.0.9               2742e8b364da        4 weeks ago         4.52GB
us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base           0.0.6               cf52c97a772e        5 weeks ago         2.35GB
us.gcr.io/anvil-gcr-public/anvil-rstudio-bioconductor       0.0.3               ffaa06c46e4e        5 weeks ago         4.32GB
us.gcr.io/anvil-gcr-public/anvil-rstudio-base               0.0.2               a816f564af5b        6 weeks ago         2.5GB
us.gcr.io/broad-dsp-gcr-public/leonardo-jupyter             5c51ce6935da        4ed49e25e0ba        4 months ago        6.39GB
broadinstitute/openidc-proxy                                2.3.1_2             b1514b13020b        2 years ago         311MB
```
```
root@saturn-e2b5ca36-f227-49a4-bbce-f03c6e63bcfd-m:~# df -kh | grep sda
Filesystem      Size  Used Avail Use% Mounted on
/dev/sda1        50G   34G   14G  71% /
```

After this change:
```
root@saturn-267854b2-57a3-42a8-97fb-40d6642975e2-m:~# docker images
REPOSITORY                                          TAG                 IMAGE ID            CREATED             SIZE
us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk   0.0.9               fa56053c1ee7        21 hours ago        5.49GB
us.gcr.io/broad-dsp-gcr-public/welder-server        ed93873             ad9a3d123b1f        3 days ago          1.81GB
broadinstitute/openidc-proxy                        2.3.1_2             b1514b13020b        2 years ago         311MB
```
```
root@saturn-267854b2-57a3-42a8-97fb-40d6642975e2-m:~# df -kh | grep sda
Filesystem      Size  Used Avail Use% Mounted on
/dev/sda1        50G   15G   33G  32% /
```

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
