### PR TITLE
IA-1584 IA-1625 make some fields in machineConfig non optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ Once you're done, tear down MySQL.
 ./docker/run-mysql.sh stop leonardo
 ```
 
+Do `docker restart leonardo-mysql` if you see `java.sql.SQLNonTransientConnectionException: Too many connections` error
+
 ## Run scalafmt
 Learn more about [scalafmt](https://scalameta.org/scalafmt/docs/installation.html)
 - Format main code `sbt scalafmt`

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/ClusterFixtureSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/ClusterFixtureSpec.scala
@@ -36,7 +36,7 @@ abstract class ClusterFixtureSpec extends fixture.FreeSpec with BeforeAndAfterAl
       ClusterName(clusterName),
       GoogleProject(googleProject),
       ServiceAccountInfo(None, None),
-      MachineConfig(),
+      MachineConfig(0, "", 5),
       ClusterStatus.Running,
       WorkbenchEmail(""),
       Map(),
@@ -92,7 +92,9 @@ abstract class ClusterFixtureSpec extends fixture.FreeSpec with BeforeAndAfterAl
   def getClusterRequest(): ClusterRequest = {
     val machineConfig = Some(
       MachineConfig(
-        masterMachineType = Some("n1-standard-8"),
+        numberOfWorkers = 0,
+        masterDiskSize = 500,
+        masterMachineType = "n1-standard-8",
         workerMachineType = Some("n1-standard-8")
       )
     )

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/Leonardo.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/Leonardo.scala
@@ -8,7 +8,6 @@ import org.broadinstitute.dsde.workbench.auth.AuthToken
 import org.broadinstitute.dsde.workbench.leonardo.AutomationTestJsonCodec._
 import org.broadinstitute.dsde.workbench.leonardo.ClusterStatus.ClusterStatus
 import org.broadinstitute.dsde.workbench.leonardo.JsonCodec._
-import org.broadinstitute.dsde.workbench.leonardo.StringValueClass.LabelMap
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
 import org.broadinstitute.dsde.workbench.model.google._
 import org.broadinstitute.dsde.workbench.service.RestClient

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoModelCopy.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoModelCopy.scala
@@ -3,7 +3,6 @@ package org.broadinstitute.dsde.workbench.leonardo
 import java.time.Instant
 
 import org.broadinstitute.dsde.workbench.leonardo.ClusterStatus.ClusterStatus
-import org.broadinstitute.dsde.workbench.leonardo.StringValueClass.LabelMap
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
 import org.broadinstitute.dsde.workbench.model.google._
 
@@ -84,10 +83,6 @@ case class DefaultLabels(clusterName: ClusterName,
       "tool" -> tool
     ) ++ ext ++ userScr ++ startScr ++ clusterSa ++ notebookSa
   }
-}
-
-object StringValueClass {
-  type LabelMap = Map[String, String]
 }
 
 object ClusterStatus extends Enumeration {

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
@@ -16,7 +16,6 @@ import org.broadinstitute.dsde.workbench.config.Credentials
 import org.broadinstitute.dsde.workbench.dao.Google.{googleIamDAO, googleStorageDAO}
 import org.broadinstitute.dsde.workbench.google2.GoogleStorageService
 import org.broadinstitute.dsde.workbench.leonardo.ClusterStatus.{deletableStatuses, ClusterStatus}
-import org.broadinstitute.dsde.workbench.leonardo.StringValueClass.LabelMap
 import org.broadinstitute.dsde.workbench.leonardo.notebooks.Notebook
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
 import org.broadinstitute.dsde.workbench.model.google._

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookClusterMonitoringSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookClusterMonitoringSpec.scala
@@ -67,12 +67,12 @@ class NotebookClusterMonitoringSpec extends GPAllocFixtureSpec with ParallelTest
       implicit val ronToken: AuthToken = ronAuthToken
 
       val initialMachineConfig =
-        MachineConfig(numberOfWorkers = Some(2), masterMachineType = Some("n1-standard-2"), masterDiskSize = Some(50))
+        MachineConfig(numberOfWorkers = 2, masterMachineType = "n1-standard-2", masterDiskSize = 50)
 
       withNewCluster(billingProject, request = defaultClusterRequest.copy(machineConfig = Option(initialMachineConfig))) {
         cluster =>
           // update the cluster to add another worker node and increase the master disk
-          val newMachineConfig = MachineConfig(numberOfWorkers = Some(3), masterDiskSize = Some(100))
+          val newMachineConfig = MachineConfig(numberOfWorkers = 3, masterDiskSize = 100, masterMachineType = "")
           Leonardo.cluster.update(billingProject,
                                   cluster.clusterName,
                                   ClusterRequest(machineConfig = Option(newMachineConfig)))
@@ -97,7 +97,7 @@ class NotebookClusterMonitoringSpec extends GPAllocFixtureSpec with ParallelTest
           )
 
           // now that we have confirmed that we can add a worker node, let's see what happens when we size it back down to 2 workers
-          val twoWorkersConfig = newMachineConfig.copy(numberOfWorkers = Some(2))
+          val twoWorkersConfig = newMachineConfig.copy(numberOfWorkers = 2, masterDiskSize = 500, masterMachineType = "")
           Leonardo.cluster.update(billingProject,
                                   cluster.clusterName,
                                   ClusterRequest(machineConfig = Option(twoWorkersConfig)))
@@ -123,7 +123,7 @@ class NotebookClusterMonitoringSpec extends GPAllocFixtureSpec with ParallelTest
 
           // finally, change the master machine type
           // Note this requires a cluster restart. A future enhancement may be for Leo to handle this internally.
-          val newMachineTypeConfig = twoWorkersConfig.copy(masterMachineType = Some("n1-standard-4"))
+          val newMachineTypeConfig = twoWorkersConfig.copy(masterMachineType = "n1-standard-4", masterDiskSize = 500, numberOfWorkers = 0)
           withRestartCluster(cluster) { cluster =>
             Leonardo.cluster.update(billingProject,
                                     cluster.clusterName,
@@ -166,8 +166,10 @@ class NotebookClusterMonitoringSpec extends GPAllocFixtureSpec with ParallelTest
           machineConfig = Option(
             MachineConfig(
               // need at least 2 regular workers to enable preemptibles
-              numberOfWorkers = Option(2),
-              numberOfPreemptibleWorkers = Option(10)
+              numberOfWorkers = 2,
+              masterDiskSize = 500,
+              masterMachineType = "",
+              numberOfPreemptibleWorkers = Some(10)
             )
           )
         )

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookCustomizationSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookCustomizationSpec.scala
@@ -195,7 +195,7 @@ final class NotebookCustomizationSpec extends GPAllocFixtureSpec with ParallelTe
         billingProject,
         request = defaultClusterRequest.copy(
           machineConfig = Some(
-            MachineConfig(masterMachineType = Some("n1-standard-2"))
+            MachineConfig(numberOfWorkers = 0, masterMachineType = "n1-standard-2", masterDiskSize = 500)
           ),
           toolDockerImage = Some(LeonardoConfig.Leonardo.pythonImageUrl)
         )

--- a/core/src/main/scala/org.broadinstitute.dsde.workbench.leonardo/JsonCodec.scala
+++ b/core/src/main/scala/org.broadinstitute.dsde.workbench.leonardo/JsonCodec.scala
@@ -3,29 +3,49 @@ package org.broadinstitute.dsde.workbench.leonardo
 import java.time.Instant
 
 import cats.implicits._
-import io.circe.{Decoder, Encoder}
+import io.circe.{Decoder, DecodingFailure, Encoder}
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
-import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GcsObjectName, GoogleProject}
+import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GcsObjectName, GcsPath, GoogleProject}
+import org.broadinstitute.dsde.workbench.model.google.parseGcsPath
 
 object JsonCodec {
+  val negativeNumberDecodingFailure = DecodingFailure("Negative number is not allowed", List.empty)
+  val oneWorkerSpecifiedDecodingFailure = DecodingFailure("Google Dataproc does not support clusters with 1 non-preemptible worker. Must be 0, 2 or more.", List.empty)
+  val emptyMasterMachineType = DecodingFailure("masterMachineType can not be an empty string", List.empty)
+
+  implicit val gcsBucketNameEncoder: Encoder[GcsBucketName] = Encoder.encodeString.contramap(_.value)
+  implicit val gcsObjectNameEncoder: Encoder[GcsObjectName] = Encoder.encodeString.contramap(_.value)
+
   implicit val googleProjectDecoder: Decoder[GoogleProject] = Decoder.decodeString.map(GoogleProject)
-  implicit val machineConfigDecoder: Decoder[MachineConfig] = Decoder.forProduct7(
-    "numberOfWorkers",
-    "masterMachineType",
-    "masterDiskSize",
-    "workerMachineType",
-    "workerDiskSize",
-    "numberOfWorkerLocalSSDs",
-    "numberOfPreemptibleWorkers"
-  )(MachineConfig.apply)
+  implicit val machineConfigDecoder: Decoder[MachineConfig] = Decoder.instance {
+    c =>
+      val minimumDiskSize = 10
+      for {
+          numberOfWorkersInput <- c.downField("numberOfWorkers").as[Int]
+          masterMachineType <- c.downField("masterMachineType").as[String]
+          _ <- if(masterMachineType.isEmpty) Left(emptyMasterMachineType) else Right(())
+          masterDiskSizeInput <- c.downField("masterDiskSize").as[Int].flatMap(x => if(x < 0) Left(negativeNumberDecodingFailure) else Right(x))
+          masterDiskSize = math.max(minimumDiskSize, masterDiskSizeInput)
+          res <- numberOfWorkersInput match {
+            case x if x < 0 => Left(negativeNumberDecodingFailure)
+            case 0 => Right(MachineConfig(0, masterMachineType, masterDiskSize))
+            case 1 => Left(oneWorkerSpecifiedDecodingFailure)
+            case x => for {
+              workerMachineType <- c.downField("workerMachineType").as[Option[String]]
+              workerDiskSize <- c.downField("workerDiskSize").as[Option[Int]].flatMap(x => if(x.exists(_ < 0)) Left(negativeNumberDecodingFailure) else Right(x))
+              numberOfWorkerLocalSSDs <- c.downField("numberOfWorkerLocalSSDs").as[Option[Int]].flatMap(x => if(x.exists(_ < 0)) Left(negativeNumberDecodingFailure) else Right(x))
+              numberOfPreemptibleWorkers <- c.downField("numberOfPreemptibleWorkers").as[Option[Int]].flatMap(x => if(x.exists(_ < 0)) Left(negativeNumberDecodingFailure) else Right(x))
+            } yield MachineConfig(x, masterMachineType, masterDiskSize, workerMachineType, workerDiskSize, numberOfWorkerLocalSSDs, numberOfPreemptibleWorkers)
+          }
+      } yield res
+  }
   implicit val workbenchEmailDecoder: Decoder[WorkbenchEmail] = Decoder.decodeString.map(WorkbenchEmail)
   implicit val serviceAccountInfoDecoder: Decoder[ServiceAccountInfo] = Decoder.forProduct2(
     "clusterServiceAccount",
     "notebookServiceAccount"
   )(ServiceAccountInfo.apply)
   implicit val gcsBucketNameDecoder: Decoder[GcsBucketName] = Decoder.decodeString.map(GcsBucketName)
-  implicit val gcsBucketNameEncoder: Encoder[GcsBucketName] = Encoder.encodeString.contramap(_.value)
-  implicit val gcsObjectNameEncoder: Encoder[GcsObjectName] = Encoder.encodeString.contramap(_.value)
+
   implicit val instantDecoder: Decoder[Instant] =
     Decoder.decodeString.emap(s => Either.catchNonFatal(Instant.parse(s)).leftMap(_.getMessage))
   implicit val clusterErrorDecoder: Decoder[ClusterError] = Decoder.forProduct3(
@@ -33,4 +53,15 @@ object JsonCodec {
     "errorCode",
     "timestamp"
   )(ClusterError.apply)
+  implicit val gcsPathDecoder: Decoder[GcsPath] = Decoder.decodeString.emap(s => parseGcsPath(s).leftMap(_.value))
+  implicit val userScriptPathDecoder: Decoder[UserScriptPath] = Decoder.decodeString.emap{
+    s => UserScriptPath.stringToUserScriptPath(s).leftMap(_.getMessage)
+  }
+  implicit val userJupyterExtensionConfigDecoder: Decoder[UserJupyterExtensionConfig] = Decoder.forProduct4(
+    "nbExtensions",
+    "serverExtensions",
+    "combinedExtensions",
+    "labExtensions"
+  )(UserJupyterExtensionConfig.apply)
+  implicit val containerImageDecoder: Decoder[ContainerImage] = Decoder.decodeString.emap(s => ContainerImage.stringToJupyterDockerImage(s).toRight(s"invalid container image ${s}"))
 }

--- a/core/src/main/scala/org.broadinstitute.dsde.workbench.leonardo/package.scala
+++ b/core/src/main/scala/org.broadinstitute.dsde.workbench.leonardo/package.scala
@@ -1,0 +1,6 @@
+package org.broadinstitute.dsde.workbench
+
+package object leonardo {
+  type LabelMap = Map[String, String]
+  final val autoPauseOffValue = 0
+}

--- a/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/JsonCodecSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/JsonCodecSpec.scala
@@ -1,0 +1,75 @@
+package org.broadinstitute.dsde.workbench.leonardo
+
+import org.scalatest.{FlatSpecLike, Matchers}
+import JsonCodec._
+
+class JsonCodecSpec extends LeonardoTestSuite with Matchers with FlatSpecLike {
+  "JsonCodec" should "fail to decode MachineConfig when masterMachineType is empty string" in {
+    val inputString =
+      """
+        |{
+        |   "numberOfWorkers": 0,
+        |   "masterMachineType": "",
+        |   "masterDiskSize": 500
+        |}
+        |""".stripMargin
+
+    val decodeResult = for {
+      json <- io.circe.parser.parse(inputString)
+      r <- json.as[MachineConfig]
+    } yield r
+    decodeResult shouldBe Left(emptyMasterMachineType)
+  }
+
+  it should "fail with negativeNumberDecodingFailure when numberOfPreemptibleWorkers is negative" in {
+    val inputString =
+      """
+        |{
+        |   "numberOfWorkers": 10,
+        |   "masterMachineType": "n1-standard-8",
+        |   "masterDiskSize": 500,
+        |   "numberOfPreemptibleWorkers": -1
+        |}
+        |""".stripMargin
+
+    val decodeResult = for {
+      json <- io.circe.parser.parse(inputString)
+      r <- json.as[MachineConfig]
+    } yield r
+    decodeResult shouldBe Left(negativeNumberDecodingFailure)
+  }
+
+  it should "fail with negativeNumberDecodingFailure when masterDiskSize is negative" in {
+    val inputString =
+      """
+        |{
+        |   "numberOfWorkers": 10,
+        |   "masterMachineType": "n1-standard-8",
+        |   "masterDiskSize": -1
+        |}
+        |""".stripMargin
+
+    val decodeResult = for {
+      json <- io.circe.parser.parse(inputString)
+      r <- json.as[MachineConfig]
+    } yield r
+    decodeResult shouldBe Left(negativeNumberDecodingFailure)
+  }
+
+  it should "fail with oneWorkerSpecifiedDecodingFailure when numberOfPreemptibleWorkers is negative" in {
+    val inputString =
+      """
+        |{
+        |   "numberOfWorkers": 1,
+        |   "masterMachineType": "n1-standard-8",
+        |   "masterDiskSize": 500
+        |}
+        |""".stripMargin
+
+    val decodeResult = for {
+      json <- io.circe.parser.parse(inputString)
+      r <- json.as[MachineConfig]
+    } yield r
+    decodeResult shouldBe Left(oneWorkerSpecifiedDecodingFailure)
+  }
+}

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/CorsSupport.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/CorsSupport.scala
@@ -1,4 +1,6 @@
-package org.broadinstitute.dsde.workbench.leonardo.api
+package org.broadinstitute.dsde.workbench.leonardo
+package http
+package api
 
 import akka.http.scaladsl.model.{HttpResponse, StatusCodes}
 import akka.http.scaladsl.model.headers._

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/LeoRoutes.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/LeoRoutes.scala
@@ -1,4 +1,5 @@
 package org.broadinstitute.dsde.workbench.leonardo
+package http
 package api
 
 import java.util.UUID
@@ -17,26 +18,23 @@ import cats.implicits._
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.workbench.leonardo.config.SwaggerConfig
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
-import org.broadinstitute.dsde.workbench.leonardo.service.LeonardoServiceJsonCodec.listClusterResponseWriter
-import org.broadinstitute.dsde.workbench.leonardo.model.{ClusterRequest, LeoException, RequestValidationError}
+import org.broadinstitute.dsde.workbench.leonardo.http.service.LeonardoServiceJsonCodec.listClusterResponseWriter
+import org.broadinstitute.dsde.workbench.leonardo.model.{ClusterRequest, LeoException, PropertyFilePrefix, RequestValidationError}
 import org.broadinstitute.dsde.workbench.leonardo.model.google.ClusterName
 import org.broadinstitute.dsde.workbench.leonardo.model.LeonardoJsonSupport._
-import org.broadinstitute.dsde.workbench.leonardo.service.{LeonardoService, ProxyService, StatusService}
+import org.broadinstitute.dsde.workbench.leonardo.http.service.{LeonardoService, ProxyService, StatusService}
 import org.broadinstitute.dsde.workbench.leonardo.util.CookieHelper
 import org.broadinstitute.dsde.workbench.model.ErrorReportJsonSupport._
-import org.broadinstitute.dsde.workbench.model.google.GoogleProject
-import org.broadinstitute.dsde.workbench.model.{
-  ErrorReport,
-  TraceId,
-  WorkbenchEmail,
-  WorkbenchException,
-  WorkbenchExceptionWithErrorReport
-}
+import org.broadinstitute.dsde.workbench.model.google.{GcsPath, GoogleProject}
+import org.broadinstitute.dsde.workbench.model.{ErrorReport, TraceId, WorkbenchEmail, WorkbenchException, WorkbenchExceptionWithErrorReport}
 import LeoRoutes._
 import cats.effect.{ContextShift, IO}
 import cats.mtl.ApplicativeAsk
+import io.circe.{Decoder, DecodingFailure}
+import JsonCodec._
 
 import scala.concurrent.{ExecutionContext, Future}
+import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
 
 case class AuthenticationError(email: Option[WorkbenchEmail] = None)
     extends LeoException(s"${email.map(e => s"'${e.value}'").getOrElse("Your account")} is not authenticated",
@@ -242,13 +240,15 @@ abstract class LeoRoutes(
 }
 
 object LeoRoutes {
+  val invalidPropertiesError = DecodingFailure("invalid properties", List.empty)
+
   private val clusterNameReg = "([a-z|0-9|-])*".r
   private def validateClusterName(clusterNameString: String): Either[Throwable, ClusterName] =
     clusterNameString match {
       case clusterNameReg(_) => Right(ClusterName(clusterNameString))
       case _ =>
         Left(
-          new RequestValidationError(
+          RequestValidationError(
             s"invalid cluster name ${clusterNameString}. Only lowercase alphanumeric characters, numbers and dashes are allowed in cluster name"
           )
         )
@@ -261,4 +261,50 @@ object LeoRoutes {
         case Right(c) => inner(Tuple1(c))
       }
     }
+
+  implicit val clusterRequestDecoder: Decoder[ClusterRequest] = Decoder.instance {
+    c =>
+      for {
+        labels <- c.downField("labels").as[Option[Map[String, String]]]
+        jupyterExtensionUri <- c.downField("jupyterExtensionUri").as[Option[GcsPath]]
+        jupyterUserScriptUri <- c.downField("jupyterUserScriptUri").as[Option[UserScriptPath]]
+        jupyterStartUserScriptUri <- c.downField("jupyterStartUserScriptUri").as[Option[UserScriptPath]]
+        machineConfig <- c.downField("machineConfig").as[Option[MachineConfig]]
+        properties <- c.downField("properties").as[Option[Map[String, String]]].map(_.getOrElse(Map.empty))
+        isValid = properties.keys.toList.forall { s =>
+                  val prefix = s.split(":")(0)
+                  PropertyFilePrefix.stringToObject.get(prefix).isDefined
+                }
+        _ <- if(isValid) Right(()) else Left(invalidPropertiesError)
+        stopAfterCreation <- c.downField("stopAfterCreation").as[Option[Boolean]]
+        userJupyterExtensionConfig <- c.downField("userJupyterExtensionConfig").as[Option[UserJupyterExtensionConfig]]
+        autopause <- c.downField("autopause").as[Option[Boolean]]
+        autopauseThreshold <- c.downField("autopauseThreshold").as[Option[Int]]
+        defaultClientId <- c.downField("defaultClientId").as[Option[String]]
+        jupyterDockerImage <- c.downField("jupyterDockerImage").as[Option[ContainerImage]]
+        toolDockerImage <- c.downField("toolDockerImage").as[Option[ContainerImage]]
+        welderDockerImage <- c.downField("welderDockerImage").as[Option[ContainerImage]]
+        scopes <- c.downField("scopes").as[Option[Set[String]]]
+        enableWelder <- c.downField("enableWelder").as[Option[Boolean]]
+        customClusterEnvironmentVariables <- c.downField("customClusterEnvironmentVariables").as[Option[Map[String, String]]]
+      } yield ClusterRequest(
+          labels.getOrElse(Map.empty),
+          jupyterExtensionUri,
+          jupyterUserScriptUri,
+          jupyterStartUserScriptUri,
+          machineConfig,
+          properties,
+          stopAfterCreation,
+          userJupyterExtensionConfig,
+          autopause,
+          autopauseThreshold,
+          defaultClientId,
+          jupyterDockerImage,
+          toolDockerImage,
+          welderDockerImage,
+          scopes.getOrElse(Set.empty),
+          enableWelder,
+          customClusterEnvironmentVariables.getOrElse(Map.empty)
+        )
+  }
 }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/ProxyRoutes.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/ProxyRoutes.scala
@@ -1,4 +1,6 @@
-package org.broadinstitute.dsde.workbench.leonardo.api
+package org.broadinstitute.dsde.workbench.leonardo
+package http
+package api
 
 import java.util.UUID
 
@@ -9,7 +11,7 @@ import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.{Directive0, Directive1, Route}
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.workbench.leonardo.model.google.ClusterName
-import org.broadinstitute.dsde.workbench.leonardo.service.ProxyService
+import org.broadinstitute.dsde.workbench.leonardo.http.service.ProxyService
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import akka.http.scaladsl.model.headers._
 import akka.http.scaladsl.server.RouteResult.Complete

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/StandardUserInfoDirectives.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/StandardUserInfoDirectives.scala
@@ -1,4 +1,6 @@
-package org.broadinstitute.dsde.workbench.leonardo.api
+package org.broadinstitute.dsde.workbench.leonardo
+package http
+package api
 
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import akka.http.scaladsl.server.Directive1

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/StatusRoutes.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/StatusRoutes.scala
@@ -1,8 +1,10 @@
-package org.broadinstitute.dsde.workbench.leonardo.api
+package org.broadinstitute.dsde.workbench.leonardo
+package http
+package api
 
 import akka.http.scaladsl.server
 import akka.http.scaladsl.server.Directives._
-import org.broadinstitute.dsde.workbench.leonardo.service.StatusService
+import org.broadinstitute.dsde.workbench.leonardo.http.service.StatusService
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
 import akka.http.scaladsl.model.StatusCodes
 import spray.json.{JsObject, JsString}

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/SwaggerRoutes.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/SwaggerRoutes.scala
@@ -1,4 +1,6 @@
-package org.broadinstitute.dsde.workbench.leonardo.api
+package org.broadinstitute.dsde.workbench.leonardo
+package http
+package api
 
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.server

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/UserInfoDirectives.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/UserInfoDirectives.scala
@@ -1,4 +1,6 @@
-package org.broadinstitute.dsde.workbench.leonardo.api
+package org.broadinstitute.dsde.workbench.leonardo
+package http
+package api
 
 import akka.http.scaladsl.server.Directive1
 import org.broadinstitute.dsde.workbench.model.UserInfo

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/package.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/package.scala
@@ -1,4 +1,5 @@
 package org.broadinstitute.dsde.workbench.leonardo
+package http
 
 import akka.http.scaladsl.marshalling.Marshaller
 import akka.http.scaladsl.server.directives.OnSuccessMagnet

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/DockerDAO.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/DockerDAO.scala
@@ -1,7 +1,7 @@
 package org.broadinstitute.dsde.workbench.leonardo.dao
 
 import cats.mtl.ApplicativeAsk
-import org.broadinstitute.dsde.workbench.leonardo.model.{ClusterImageType, ContainerImage}
+import org.broadinstitute.dsde.workbench.leonardo.{ClusterImageType, ContainerImage}
 import org.broadinstitute.dsde.workbench.model.TraceId
 
 trait DockerDAO[F[_]] {

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpDockerDAO.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpDockerDAO.scala
@@ -8,14 +8,9 @@ import io.chrisdavenport.log4cats.Logger
 import io.circe.Decoder
 import org.broadinstitute.dsde.workbench.leonardo.dao.HttpDockerDAO._
 import org.broadinstitute.dsde.workbench.leonardo.dao.ImageVersion.{Sha, Tag}
-import org.broadinstitute.dsde.workbench.leonardo.model.ClusterImageType.{Jupyter, RStudio}
-import org.broadinstitute.dsde.workbench.leonardo.model.ContainerRegistry.{DockerHub, GCR}
-import org.broadinstitute.dsde.workbench.leonardo.model.{
-  ClusterImageType,
-  ContainerImage,
-  ContainerRegistry,
-  LeoException
-}
+import org.broadinstitute.dsde.workbench.leonardo.ClusterImageType.{Jupyter, RStudio}
+
+import org.broadinstitute.dsde.workbench.leonardo.model.LeoException
 import org.broadinstitute.dsde.workbench.model.TraceId
 import org.http4s._
 import org.http4s.circe.CirceEntityDecoder._
@@ -23,6 +18,7 @@ import org.http4s.client.Client
 import org.http4s.client.dsl.Http4sClientDsl
 import org.http4s.client.middleware.FollowRedirect
 import org.http4s.headers.Authorization
+import ContainerRegistry._
 
 /**
  * Talks to Docker remote APIs to retrieve manifest information in order to try and figure out
@@ -93,9 +89,9 @@ class HttpDockerDAO[F[_]: Concurrent] private (httpClient: Client[F])(implicit l
                             petTokenOpt: Option[String])(implicit ev: ApplicativeAsk[F, TraceId]): F[Option[Token]] =
     parsedImage.registry match {
       // If it's a GCR repo, use the pet token
-      case GCR => Concurrent[F].pure(petTokenOpt.map(Token))
+      case ContainerRegistry.GCR => Concurrent[F].pure(petTokenOpt.map(Token))
       // If it's a Dockerhub repo, need to request a token from Dockerhub
-      case DockerHub =>
+      case ContainerRegistry.DockerHub =>
         httpClient.expectOptionOr[Token](
           Request[F](
             method = Method.GET,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/google/HttpGoogleDataprocDAO.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/google/HttpGoogleDataprocDAO.scala
@@ -1,5 +1,6 @@
 package org.broadinstitute.dsde.workbench.leonardo
-package dao.google
+package dao
+package google
 
 import java.time.Instant
 import java.util.UUID
@@ -23,7 +24,7 @@ import com.google.api.services.dataproc.model.{
 import com.google.api.services.oauth2.Oauth2
 import org.broadinstitute.dsde.workbench.google.AbstractHttpGoogleDAO
 import org.broadinstitute.dsde.workbench.google.GoogleCredentialModes._
-import org.broadinstitute.dsde.workbench.leonardo.api.AuthenticationError
+import org.broadinstitute.dsde.workbench.leonardo.http.api.AuthenticationError
 import org.broadinstitute.dsde.workbench.leonardo.model.google.DataprocRole.{Master, SecondaryWorker, Worker}
 import org.broadinstitute.dsde.workbench.leonardo.model.google.VPCConfig.{VPCNetwork, VPCSubnet}
 import org.broadinstitute.dsde.workbench.leonardo.model.google._
@@ -277,8 +278,8 @@ class HttpGoogleDataprocDAO(
 
     // Create a config for the master node, if properties are not specified in request, use defaults
     val masterConfig = new InstanceGroupConfig()
-      .setMachineTypeUri(config.machineConfig.masterMachineType.get)
-      .setDiskConfig(new DiskConfig().setBootDiskSizeGb(config.machineConfig.masterDiskSize.get))
+      .setMachineTypeUri(config.machineConfig.masterMachineType)
+      .setDiskConfig(new DiskConfig().setBootDiskSizeGb(config.machineConfig.masterDiskSize))
 
     // If a custom dataproc image is specified, set it in the InstanceGroupConfig.
     // This overrides the imageVersion set in SoftwareConfig.
@@ -304,7 +305,7 @@ class HttpGoogleDataprocDAO(
     val swConfig: SoftwareConfig = getSoftwareConfig(createClusterConfig)
 
     // If the number of workers is zero, make a Single Node cluster, else make a Standard one
-    if (createClusterConfig.machineConfig.numberOfWorkers.get == 0) {
+    if (createClusterConfig.machineConfig.numberOfWorkers == 0) {
       new DataprocClusterConfig().setSoftwareConfig(swConfig)
     } else // Standard, multi node cluster
       getMultiNodeClusterConfig(createClusterConfig).setSoftwareConfig(swConfig)
@@ -326,7 +327,7 @@ class HttpGoogleDataprocDAO(
         )
     }
 
-    val dataprocProps: Map[String, String] = if (createClusterConfig.machineConfig.numberOfWorkers.get == 0) {
+    val dataprocProps: Map[String, String] = if (createClusterConfig.machineConfig.numberOfWorkers == 0) {
       // Set a SoftwareConfig property that makes the cluster have only one node
       Map("dataproc:dataproc.allow.zero.workers" -> "true")
     } else
@@ -375,7 +376,7 @@ class HttpGoogleDataprocDAO(
       .setNumLocalSsds(createClusterConfig.machineConfig.numberOfWorkerLocalSSDs.get)
 
     val workerConfig = new InstanceGroupConfig()
-      .setNumInstances(createClusterConfig.machineConfig.numberOfWorkers.get)
+      .setNumInstances(createClusterConfig.machineConfig.numberOfWorkers)
       .setMachineTypeUri(createClusterConfig.machineConfig.workerMachineType.get)
       .setDiskConfig(workerDiskConfig)
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterImageComponent.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterImageComponent.scala
@@ -5,7 +5,7 @@ import java.time.Instant
 
 import LeoProfile.api._
 import LeoProfile.mappedColumnImplicits._
-import org.broadinstitute.dsde.workbench.leonardo.model.{ClusterImage, ClusterImageType}
+import org.broadinstitute.dsde.workbench.leonardo.model.ClusterImage
 import slick.lifted.ProvenShape
 
 import scala.concurrent.ExecutionContext

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/DbReference.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/DbReference.scala
@@ -1,4 +1,5 @@
-package org.broadinstitute.dsde.workbench.leonardo.db
+package org.broadinstitute.dsde.workbench.leonardo
+package db
 
 import java.sql.{Connection, SQLTimeoutException}
 
@@ -6,9 +7,9 @@ import cats.effect.concurrent.Semaphore
 import cats.effect.{Async, Blocker, ContextShift, IO, Resource}
 import com.google.common.base.Throwables
 import com.typesafe.scalalogging.LazyLogging
-import liquibase.database.jvm.JdbcConnection
-import liquibase.resource.{ClassLoaderResourceAccessor, ResourceAccessor}
-import liquibase.{Contexts, Liquibase}
+import _root_.liquibase.database.jvm.JdbcConnection
+import _root_.liquibase.resource.{ClassLoaderResourceAccessor, ResourceAccessor}
+import _root_.liquibase.{Contexts, Liquibase}
 import org.broadinstitute.dsde.workbench.leonardo.config.LiquibaseConfig
 import slick.basic.DatabaseConfig
 import slick.jdbc.{JdbcBackend, JdbcProfile, TransactionIsolation}

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/ExtensionComponent.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/ExtensionComponent.scala
@@ -1,7 +1,7 @@
 package org.broadinstitute.dsde.workbench.leonardo
 package db
 
-import org.broadinstitute.dsde.workbench.leonardo.model.{ExtensionType, UserJupyterExtensionConfig}
+import org.broadinstitute.dsde.workbench.leonardo.model.ExtensionType
 import LeoProfile.api._
 
 import scala.concurrent.ExecutionContext

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/LabelComponent.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/LabelComponent.scala
@@ -1,7 +1,6 @@
 package org.broadinstitute.dsde.workbench.leonardo
 package db
 
-import org.broadinstitute.dsde.workbench.leonardo.model.Cluster.LabelMap
 import LeoProfile.api._
 
 import scala.concurrent.ExecutionContext

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/LeoProfile.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/LeoProfile.scala
@@ -5,7 +5,6 @@ import java.time.Instant
 
 import io.circe.Printer
 import io.circe.syntax._
-import org.broadinstitute.dsde.workbench.leonardo.model.{ClusterImageType, UserScriptPath}
 import org.broadinstitute.dsde.workbench.leonardo.model.google.ClusterName
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
 import org.broadinstitute.dsde.workbench.model.google.{parseGcsPath, GcsPath, GoogleProject}

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeoException.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeoException.scala
@@ -2,7 +2,7 @@ package org.broadinstitute.dsde.workbench.leonardo.model
 
 import akka.http.scaladsl.model.{StatusCode, StatusCodes}
 import org.broadinstitute.dsde.workbench.model.{ErrorReport, WorkbenchException}
-import org.broadinstitute.dsde.workbench.leonardo.errorReportSource
+import org.broadinstitute.dsde.workbench.leonardo.http.errorReportSource
 
 import scala.util.control.NoStackTrace
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterDateAccessedActor.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterDateAccessedActor.scala
@@ -35,7 +35,7 @@ class ClusterDateAccessedActor(autoFreezeConfig: AutoFreezeConfig, dbRef: DbRefe
 
   override def preStart(): Unit = {
     super.preStart()
-    system.scheduler.schedule(autoFreezeConfig.dateAccessedMonitorScheduler,
+    system.scheduler.scheduleWithFixedDelay(autoFreezeConfig.dateAccessedMonitorScheduler,
                               autoFreezeConfig.dateAccessedMonitorScheduler,
                               self,
                               Flush)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorSupervisor.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorSupervisor.scala
@@ -4,6 +4,7 @@ package monitor
 import java.time.{Duration, Instant}
 import java.util.UUID
 
+import org.broadinstitute.dsde.workbench.leonardo.http._
 import akka.actor.SupervisorStrategy.Restart
 import akka.actor.{Actor, ActorRef, OneForOneStrategy, Props, Timers}
 import cats.effect.{ContextShift, IO}
@@ -124,10 +125,10 @@ class ClusterMonitorSupervisor(
   override def preStart(): Unit = {
     super.preStart()
 
-    timers.startPeriodicTimer(CheckClusterTimerKey, CheckForClusters, monitorConfig.pollPeriod)
+    timers.startTimerWithFixedDelay(CheckClusterTimerKey, CheckForClusters, monitorConfig.pollPeriod)
 
     if (autoFreezeConfig.enableAutoFreeze)
-      timers.startPeriodicTimer(AutoFreezeTimerKey, AutoFreezeClusters, autoFreezeConfig.autoFreezeCheckScheduler)
+      timers.startTimerWithFixedDelay(AutoFreezeTimerKey, AutoFreezeClusters, autoFreezeConfig.autoFreezeCheckScheduler)
   }
 
   override def receive: Receive = {

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterToolMonitor.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterToolMonitor.scala
@@ -9,7 +9,7 @@ import org.broadinstitute.dsde.workbench.google.GoogleProjectDAO
 import org.broadinstitute.dsde.workbench.leonardo.config.ClusterToolConfig
 import org.broadinstitute.dsde.workbench.leonardo.dao.ToolDAO
 import org.broadinstitute.dsde.workbench.leonardo.dao.google.GoogleDataprocDAO
-import org.broadinstitute.dsde.workbench.leonardo.db.{clusterQuery, DbReference}
+import org.broadinstitute.dsde.workbench.leonardo.db.{DbReference, clusterQuery}
 import org.broadinstitute.dsde.workbench.leonardo.model.{ClusterContainerServiceType, RunningCluster}
 import org.broadinstitute.dsde.workbench.leonardo.monitor.ClusterToolMonitor._
 import org.broadinstitute.dsde.workbench.newrelic.NewRelicMetrics
@@ -54,7 +54,7 @@ class ClusterToolMonitor(
 
   override def preStart(): Unit = {
     super.preStart()
-    timers.startPeriodicTimer(TimerKey, DetectClusterStatus, config.pollPeriod)
+    timers.startTimerWithFixedDelay(TimerKey, DetectClusterStatus, config.pollPeriod)
   }
 
   override def receive: Receive = {

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ZombieClusterMonitor.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ZombieClusterMonitor.scala
@@ -46,7 +46,7 @@ class ZombieClusterMonitor(config: ZombieClusterConfig,
 
   override def preStart(): Unit = {
     super.preStart()
-    timers.startPeriodicTimer(TimerKey, DetectZombieClusters, config.zombieCheckPeriod)
+    timers.startTimerWithFixedDelay(TimerKey, DetectZombieClusters, config.zombieCheckPeriod)
   }
 
   override def receive: Receive = {

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/package.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/package.scala
@@ -1,11 +1,10 @@
-package org.broadinstitute.dsde.workbench
+package org.broadinstitute.dsde.workbench.leonardo
 
 import org.broadinstitute.dsde.workbench.leonardo.db.DBIOOps
 import org.broadinstitute.dsde.workbench.model.ErrorReportSource
 import slick.dbio.DBIO
 
-package object leonardo {
+package object http {
   implicit val errorReportSource = ErrorReportSource("leonardo")
-  final val autoPauseOffValue = 0
   implicit def dbioToIO[A](dbio: DBIO[A]): DBIOOps[A] = new DBIOOps(dbio)
 }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/ProxyService.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/ProxyService.scala
@@ -1,28 +1,29 @@
 package org.broadinstitute.dsde.workbench.leonardo
+package http
 package service
 
 import java.time.Instant
 import java.util.concurrent.TimeUnit
 
-import cats.implicits._
 import akka.actor.{ActorRef, ActorSystem}
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.model.Uri.Host
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.headers.`Content-Disposition`
 import akka.http.scaladsl.model.ws._
-import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.{Flow, Keep, Sink, Source}
 import cats.effect.{Blocker, ContextShift, IO, Timer}
+import cats.implicits._
 import cats.mtl.ApplicativeAsk
 import com.google.common.cache.{CacheBuilder, CacheLoader}
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.workbench.leonardo.config.ProxyConfig
 import org.broadinstitute.dsde.workbench.leonardo.dao.Proxy
 import org.broadinstitute.dsde.workbench.leonardo.dao.google.GoogleDataprocDAO
-import org.broadinstitute.dsde.workbench.leonardo.db.{clusterQuery, DbReference}
-import org.broadinstitute.dsde.workbench.leonardo.dns.ClusterDnsCache._
+import org.broadinstitute.dsde.workbench.leonardo.db.{DbReference, clusterQuery}
 import org.broadinstitute.dsde.workbench.leonardo.dns.ClusterDnsCache
+import org.broadinstitute.dsde.workbench.leonardo.dns.ClusterDnsCache._
+import org.broadinstitute.dsde.workbench.leonardo.http.service.ProxyService._
 import org.broadinstitute.dsde.workbench.leonardo.model.NotebookClusterActions._
 import org.broadinstitute.dsde.workbench.leonardo.model._
 import org.broadinstitute.dsde.workbench.leonardo.model.google.ClusterName
@@ -30,7 +31,6 @@ import org.broadinstitute.dsde.workbench.leonardo.monitor.ClusterDateAccessedAct
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.broadinstitute.dsde.workbench.model.{TraceId, UserInfo}
 import org.broadinstitute.dsde.workbench.util.toScalaDuration
-import ProxyService._
 
 import scala.collection.immutable
 import scala.concurrent.{ExecutionContext, Future}
@@ -65,7 +65,6 @@ class ProxyService(
   clusterDateAccessedActor: ActorRef,
   blocker: Blocker
 )(implicit val system: ActorSystem,
-  materializer: ActorMaterializer,
   executionContext: ExecutionContext,
   timer: Timer[IO],
   cs: ContextShift[IO],
@@ -372,7 +371,7 @@ object ProxyService {
   // we will remove that path and #2 will be the sole entry point for users. At that point, we can
   // update the code in here to not rewrite any paths for Jupyter. We will also need to update the
   // paths in related areas like jupyter_notebook_config.py
-  private[service] def rewriteJupyterPath(path: Uri.Path): Uri.Path = {
+  def rewriteJupyterPath(path: Uri.Path): Uri.Path = {
     val proxyPattern = "\\/proxy\\/([^\\/]*)\\/([^\\/]*)\\/jupyter\\/?(.*)?".r
     val notebooksPattern = "\\/notebooks\\/([^\\/]*)\\/([^\\/]*)\\/jupyter\\/?(.*)?".r
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/StatusService.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/StatusService.scala
@@ -1,4 +1,5 @@
 package org.broadinstitute.dsde.workbench.leonardo
+package http
 package service
 
 import java.util.UUID
@@ -38,7 +39,7 @@ class StatusService(
 
   private val healthMonitor =
     system.actorOf(HealthMonitor.props(Set(GoogleDataproc, Sam, Database))(() => checkStatus()))
-  system.scheduler.schedule(initialDelay, pollInterval, healthMonitor, HealthMonitor.CheckAll)
+  system.scheduler.scheduleWithFixedDelay(initialDelay, pollInterval, healthMonitor, HealthMonitor.CheckAll)
 
   def getStatus(): Future[StatusCheckResponse] =
     (healthMonitor ? GetCurrentStatus).asInstanceOf[Future[StatusCheckResponse]]

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/leonardoServiceContractModel.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/leonardoServiceContractModel.scala
@@ -1,14 +1,14 @@
-package org.broadinstitute.dsde.workbench.leonardo.service
+package org.broadinstitute.dsde.workbench.leonardo
+package http
+package service
 
 import java.net.URL
 
-import org.broadinstitute.dsde.workbench.leonardo.model.Cluster.LabelMap
 import org.broadinstitute.dsde.workbench.leonardo.model.LeonardoJsonSupport._
 import org.broadinstitute.dsde.workbench.leonardo.model._
 import org.broadinstitute.dsde.workbench.leonardo.model.google.DataprocRole.SecondaryWorker
 import org.broadinstitute.dsde.workbench.leonardo.model.google.GoogleJsonSupport._
 import org.broadinstitute.dsde.workbench.leonardo.model.google.{ClusterName, ClusterStatus, Instance}
-import org.broadinstitute.dsde.workbench.leonardo.{MachineConfig, ServiceAccountInfo}
 import org.broadinstitute.dsde.workbench.model.WorkbenchIdentityJsonSupport._
 import org.broadinstitute.dsde.workbench.model.google.GoogleModelJsonSupport.{GcsPathFormat => _, _}
 import org.broadinstitute.dsde.workbench.model.google.{GcsPath, GoogleProject}

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/ClusterHelper.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/ClusterHelper.scala
@@ -413,7 +413,7 @@ class ClusterHelper(
       _ <- OptionT.liftF(log.debug(s"Using zone ${zoneUri} to resolve machine type"))
 
       // Resolve the master machine type in Google to get the total memory.
-      machineType <- OptionT.fromOption[IO](cluster.machineConfig.masterMachineType)
+      machineType <- OptionT.pure[IO](cluster.machineConfig.masterMachineType)
       resolvedMachineType <- OptionT(
         IO.fromFuture(IO(googleComputeDAO.getMachineType(cluster.googleProject, zoneUri, MachineType(machineType))))
       )

--- a/http/src/test/resources/reference.conf
+++ b/http/src/test/resources/reference.conf
@@ -79,14 +79,10 @@ clusterResources {
   welderDockerCompose = "test-welder-docker-compose.yaml"
 }
 
+//TODO: this is config really needed?
 clusterDefaults {
-  numberOfWorkers = 0
   masterMachineType = "test-master-machine-type"
-  masterDiskSize = 100
   workerMachineType = "test-worker-machine-type"
-  workerDiskSize = 100
-  numberOfWorkerLocalSSDs = 0
-  numberOfPreemptibleWorkers = 0
 }
 
 sam {
@@ -203,17 +199,6 @@ serviceAccounts {
   }
 }
 
-akka.ssl-config {
-  trustManager = {
-    stores = [
-      {
-        type = "PEM"
-        path = "http/src/test/resources/test-rootCA.pem"
-      }
-    ]
-  }
-}
-
 autoFreeze {
   #Change to true once auto freeze is ready for prod
   enableAutoFreeze = true
@@ -244,4 +229,14 @@ clusterDnsCache {
 
 leoExecutionMode {
   backLeo = true
+}
+akka.ssl-config {
+  trustManager = {
+    stores = [
+      {
+        type = "PEM"
+        path = "http/src/test/resources/test-rootCA.pem"
+      }
+    ]
+  }
 }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/CommonTestData.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/CommonTestData.scala
@@ -16,7 +16,7 @@ import org.broadinstitute.dsde.workbench.leonardo.config.Config._
 import org.broadinstitute.dsde.workbench.leonardo.config._
 import org.broadinstitute.dsde.workbench.leonardo.dao.MockSamDAO
 import org.broadinstitute.dsde.workbench.leonardo.dao.google.MockGoogleComputeDAO
-import org.broadinstitute.dsde.workbench.leonardo.model.ClusterImageType.{CustomDataProc, Jupyter, RStudio, Welder}
+import org.broadinstitute.dsde.workbench.leonardo.ClusterImageType._
 import org.broadinstitute.dsde.workbench.leonardo.model._
 import org.broadinstitute.dsde.workbench.leonardo.model.google._
 import org.broadinstitute.dsde.workbench.model.google.{
@@ -90,9 +90,9 @@ object CommonTestData {
   val clusterBucketConfig = config.as[ClusterBucketConfig]("clusterBucket")
   val contentSecurityPolicy =
     config.as[Option[String]]("jupyterConfig.contentSecurityPolicy").getOrElse("default-src: 'self'")
-  val singleNodeDefaultMachineConfig = MachineConfig(Some(clusterDefaultsConfig.numberOfWorkers),
-                                                     Some(clusterDefaultsConfig.masterMachineType),
-                                                     Some(clusterDefaultsConfig.masterDiskSize))
+  val singleNodeDefaultMachineConfig = MachineConfig(clusterDefaultsConfig.numberOfWorkers,
+                                                     clusterDefaultsConfig.masterMachineType,
+                                                     clusterDefaultsConfig.masterDiskSize)
   val testClusterRequest = ClusterRequest(
     Map("bam" -> "yes", "vcf" -> "no", "foo" -> "bar"),
     None,
@@ -161,7 +161,7 @@ object CommonTestData {
       serviceAccountInfo = serviceAccountInfo,
       dataprocInfo = Some(makeDataprocInfo(index)),
       auditInfo = auditInfo,
-      machineConfig = MachineConfig(Some(0), Some(""), Some(500)),
+      machineConfig = MachineConfig(0, "", 500),
       properties = Map.empty,
       clusterUrl = Cluster.getClusterUrl(project, clusterName, Set(jupyterImage), Map.empty),
       status = ClusterStatus.Unknown,
@@ -189,7 +189,7 @@ object CommonTestData {
     serviceAccountInfo = serviceAccountInfo,
     dataprocInfo = Some(DataprocInfo(UUID.randomUUID(), OperationName("op"), GcsBucketName("testStagingBucket1"), None)),
     auditInfo = AuditInfo(userEmail, Instant.now(), None, Instant.now(), None),
-    machineConfig = MachineConfig(Some(0), Some(""), Some(500)),
+    machineConfig = MachineConfig(0, "", 500),
     properties = Map.empty,
     clusterUrl = Cluster.getClusterUrl(project, name1, Set(jupyterImage), Map.empty),
     status = ClusterStatus.Unknown,

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/LeoRoutesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/LeoRoutesSpec.scala
@@ -1,4 +1,5 @@
 package org.broadinstitute.dsde.workbench.leonardo
+package http
 package api
 
 import java.time.Instant
@@ -10,11 +11,11 @@ import akka.http.scaladsl.testkit.{RouteTestTimeout, ScalatestRouteTest}
 import akka.testkit.TestDuration
 import org.broadinstitute.dsde.workbench.leonardo.ClusterEnrichments._
 import org.broadinstitute.dsde.workbench.leonardo.CommonTestData._
-import org.broadinstitute.dsde.workbench.leonardo.RoutesTestJsonSupport._
-import org.broadinstitute.dsde.workbench.leonardo.db.{clusterQuery, TestComponent}
+import org.broadinstitute.dsde.workbench.leonardo.db.{TestComponent, clusterQuery}
+import org.broadinstitute.dsde.workbench.leonardo.http.api.RoutesTestJsonSupport._
+import org.broadinstitute.dsde.workbench.leonardo.http.service.ListClusterResponse
 import org.broadinstitute.dsde.workbench.leonardo.model._
 import org.broadinstitute.dsde.workbench.leonardo.model.google._
-import org.broadinstitute.dsde.workbench.leonardo.service.ListClusterResponse
 import org.broadinstitute.dsde.workbench.model.google._
 import org.broadinstitute.dsde.workbench.model.{UserInfo, WorkbenchEmail, WorkbenchUserId}
 import org.scalatest.FlatSpec
@@ -368,7 +369,8 @@ class LeoRoutesSpec
                                  stopAfterCreation = None,
                                  properties = Map.empty)
     Put(s"/api/cluster/v2/${googleProject.value}/$invalidClusterName", request.toJson) ~> timedLeoRoutes.route ~> check {
-      responseAs[String] shouldBe (s"invalid cluster name $invalidClusterName. Only lowercase alphanumeric characters, numbers and dashes are allowed in cluster name")
+      val expectedResponse = """"invalid cluster name MyCluster. Only lowercase alphanumeric characters, numbers and dashes are allowed in cluster name""""
+      responseAs[String] shouldBe expectedResponse
       status shouldEqual StatusCodes.BadRequest
     }
   }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/MockUserInfoDirectives.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/MockUserInfoDirectives.scala
@@ -1,4 +1,6 @@
-package org.broadinstitute.dsde.workbench.leonardo.api
+package org.broadinstitute.dsde.workbench.leonardo
+package http
+package api
 
 import akka.http.scaladsl.server.Directive1
 import akka.http.scaladsl.server.Directives.provide

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/ProxyRoutesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/ProxyRoutesSpec.scala
@@ -1,4 +1,6 @@
-package org.broadinstitute.dsde.workbench.leonardo.api
+package org.broadinstitute.dsde.workbench.leonardo
+package http
+package api
 
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
@@ -10,8 +12,8 @@ import akka.http.scaladsl.testkit.{RouteTestTimeout, ScalatestRouteTest}
 import akka.stream.scaladsl.{Keep, Sink, Source}
 import org.broadinstitute.dsde.workbench.leonardo.db.TestComponent
 import org.broadinstitute.dsde.workbench.leonardo.model.google.ClusterName
-import org.broadinstitute.dsde.workbench.leonardo.service.TestProxy
-import org.broadinstitute.dsde.workbench.leonardo.service.TestProxy.Data
+import org.broadinstitute.dsde.workbench.leonardo.http.service.TestProxy
+import org.broadinstitute.dsde.workbench.leonardo.http.service.TestProxy.Data
 import org.broadinstitute.dsde.workbench.leonardo.{CommonTestData, GcsPathUtils, LeonardoTestSuite}
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.scalatest.concurrent.ScalaFutures

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/ProxyServiceSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/ProxyServiceSpec.scala
@@ -1,8 +1,9 @@
 package org.broadinstitute.dsde.workbench.leonardo
-package service
+package http
+package api
 
 import org.scalatest.{FlatSpec, Matchers}
-import ProxyService._
+import org.broadinstitute.dsde.workbench.leonardo.http.service.ProxyService._
 import akka.http.scaladsl.model.Uri
 
 class ProxyServiceSpec extends FlatSpec with Matchers with LeonardoTestSuite {

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/RoutesTestJsonSupport.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/RoutesTestJsonSupport.scala
@@ -1,18 +1,17 @@
 package org.broadinstitute.dsde.workbench.leonardo
+package http
+package api
 
 import java.net.URL
 import java.time.Instant
 import java.util.UUID
 
-import org.broadinstitute.dsde.workbench.leonardo.model.Cluster.LabelMap
 import org.broadinstitute.dsde.workbench.leonardo.model.{
   AuditInfo,
   Cluster,
   ClusterImage,
   ClusterInternalId,
-  DataprocInfo,
-  UserJupyterExtensionConfig,
-  UserScriptPath
+  DataprocInfo
 }
 import org.broadinstitute.dsde.workbench.leonardo.model.google.{ClusterName, ClusterStatus, IP, Instance, OperationName}
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
@@ -23,7 +22,7 @@ import org.broadinstitute.dsde.workbench.leonardo.model.LeonardoJsonSupport._
 import org.broadinstitute.dsde.workbench.model.google.GoogleModelJsonSupport.{GcsPathFormat => _, _}
 import org.broadinstitute.dsde.workbench.model.WorkbenchIdentityJsonSupport._
 import org.broadinstitute.dsde.workbench.leonardo.model.google.GoogleJsonSupport._
-import org.broadinstitute.dsde.workbench.leonardo.service.ListClusterResponse
+import org.broadinstitute.dsde.workbench.leonardo.http.service.ListClusterResponse
 import spray.json.DefaultJsonProtocol
 
 object RoutesTestJsonSupport extends DefaultJsonProtocol {

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/StatusRoutesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/StatusRoutesSpec.scala
@@ -1,4 +1,6 @@
-package org.broadinstitute.dsde.workbench.leonardo.api
+package org.broadinstitute.dsde.workbench.leonardo
+package http
+package api
 
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
 import akka.http.scaladsl.model.StatusCodes
@@ -11,7 +13,7 @@ import org.broadinstitute.dsde.workbench.leonardo.dao.{ResourceTypeName, SamDAO}
 import org.broadinstitute.dsde.workbench.leonardo.db.{DbSingleton, TestComponent}
 import org.broadinstitute.dsde.workbench.leonardo.model.ClusterInternalId
 import org.broadinstitute.dsde.workbench.leonardo.model.google.ClusterName
-import org.broadinstitute.dsde.workbench.leonardo.service.StatusService
+import org.broadinstitute.dsde.workbench.leonardo.http.service.StatusService
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.broadinstitute.dsde.workbench.model.{TraceId, UserInfo, ValueObject, WorkbenchEmail}
 import org.broadinstitute.dsde.workbench.util.health.StatusJsonSupport._

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/TestLeoRoutes.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/TestLeoRoutes.scala
@@ -1,4 +1,6 @@
-package org.broadinstitute.dsde.workbench.leonardo.api
+package org.broadinstitute.dsde.workbench.leonardo
+package http
+package api
 
 import java.io.ByteArrayInputStream
 
@@ -18,7 +20,7 @@ import org.broadinstitute.dsde.workbench.leonardo.dao.{MockDockerDAO, MockWelder
 import org.broadinstitute.dsde.workbench.leonardo.db.DbSingleton
 import org.broadinstitute.dsde.workbench.leonardo.dns.ClusterDnsCache
 import org.broadinstitute.dsde.workbench.leonardo.monitor.NoopActor
-import org.broadinstitute.dsde.workbench.leonardo.service.{LeonardoService, MockProxyService, StatusService}
+import org.broadinstitute.dsde.workbench.leonardo.http.service.{LeonardoService, MockProxyService, StatusService}
 import org.broadinstitute.dsde.workbench.leonardo.util.{BucketHelper, ClusterHelper}
 import org.broadinstitute.dsde.workbench.model.UserInfo
 import org.scalactic.source.Position

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpDockerDAOSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpDockerDAOSpec.scala
@@ -5,8 +5,8 @@ import java.util.UUID
 import cats.effect.IO
 import cats.mtl.ApplicativeAsk
 import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
-import org.broadinstitute.dsde.workbench.leonardo.model.ClusterImageType.{Jupyter, RStudio}
-import org.broadinstitute.dsde.workbench.leonardo.model.ContainerImage.{DockerHub, GCR}
+import org.broadinstitute.dsde.workbench.leonardo.ClusterImageType.{Jupyter, RStudio}
+import org.broadinstitute.dsde.workbench.leonardo.ContainerImage.{DockerHub, GCR}
 import org.broadinstitute.dsde.workbench.model.TraceId
 import org.http4s.client.blaze.BlazeClientBuilder
 import org.http4s.client.middleware.Logger

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/MockDockerDAO.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/MockDockerDAO.scala
@@ -1,9 +1,9 @@
-package org.broadinstitute.dsde.workbench.leonardo.dao
+package org.broadinstitute.dsde.workbench.leonardo
+package dao
 
 import cats.effect.IO
 import cats.mtl.ApplicativeAsk
-import org.broadinstitute.dsde.workbench.leonardo.model.ClusterImageType.Jupyter
-import org.broadinstitute.dsde.workbench.leonardo.model.{ClusterImageType, ContainerImage}
+import org.broadinstitute.dsde.workbench.leonardo.ClusterImageType.Jupyter
 import org.broadinstitute.dsde.workbench.model.TraceId
 
 class MockDockerDAO(tool: ClusterImageType = Jupyter) extends DockerDAO[IO] {

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/google/MockGoogleDataprocDAO.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/google/MockGoogleDataprocDAO.scala
@@ -37,16 +37,12 @@ class MockGoogleDataprocDAO(ok: Boolean = true) extends GoogleDataprocDAO {
       clusters += clusterName -> operation
 
       val masterInstance = Set(InstanceKey(googleProject, ZoneUri("my-zone"), InstanceName("master-instance")))
-      val workerInstances = config.machineConfig.numberOfWorkers
-        .map(
-          num =>
+      val workerInstances =
             List
-              .tabulate(num) { i =>
+              .tabulate(config.machineConfig.numberOfWorkers) { i =>
                 InstanceKey(googleProject, ZoneUri("my-zone"), InstanceName(s"worker-instance-$i"))
               }
               .toSet
-        )
-        .getOrElse(Set.empty)
       val secondaryWorkerInstances = config.machineConfig.numberOfPreemptibleWorkers
         .map(
           num =>

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponentSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponentSpec.scala
@@ -44,9 +44,9 @@ class ClusterComponentSpec extends TestComponent with FlatSpecLike with GcsPathU
     val cluster2 = makeCluster(2).copy(status = ClusterStatus.Creating)
 
     val cluster3 = makeCluster(3).copy(
-      machineConfig = MachineConfig(Some(3),
-                                    Some("test-master-machine-type"),
-                                    Some(500),
+      machineConfig = MachineConfig(3,
+                                    "test-master-machine-type",
+                                    500,
                                     Some("test-worker-machine-type"),
                                     Some(200),
                                     Some(2),
@@ -315,9 +315,9 @@ class ClusterComponentSpec extends TestComponent with FlatSpecLike with GcsPathU
   it should "update master machine type" in isolatedDbTest {
     val savedCluster1 = makeCluster(1)
       .copy(
-        machineConfig = MachineConfig(Some(3),
-                                      Some("test-master-machine-type"),
-                                      Some(500),
+        machineConfig = MachineConfig(3,
+                                      "test-master-machine-type",
+                                      500,
                                       Some("test-worker-machine-type"),
                                       Some(200),
                                       Some(2),
@@ -329,16 +329,16 @@ class ClusterComponentSpec extends TestComponent with FlatSpecLike with GcsPathU
     dbFutureValue { clusterQuery.updateMasterMachineType(savedCluster1.id, newMachineType, Instant.now) }
 
     dbFutureValue { clusterQuery.getClusterById(savedCluster1.id) }
-      .flatMap(_.machineConfig.masterMachineType) shouldBe
+      .map(_.machineConfig.masterMachineType) shouldBe
       Option(newMachineType.value)
   }
 
   it should "update master disk size" in isolatedDbTest {
     val savedCluster1 = makeCluster(1)
       .copy(
-        machineConfig = MachineConfig(Some(3),
-                                      Some("test-master-machine-type"),
-                                      Some(500),
+        machineConfig = MachineConfig(3,
+                                      "test-master-machine-type",
+                                      500,
                                       Some("test-worker-machine-type"),
                                       Some(200),
                                       Some(2),
@@ -349,8 +349,8 @@ class ClusterComponentSpec extends TestComponent with FlatSpecLike with GcsPathU
     val newDiskSize = 1000
     dbFutureValue { clusterQuery.updateMasterDiskSize(savedCluster1.id, newDiskSize, Instant.now) }
 
-    dbFutureValue { clusterQuery.getClusterById(savedCluster1.id) }.flatMap(_.machineConfig.masterDiskSize) shouldBe
-      Option(newDiskSize)
+    dbFutureValue { clusterQuery.getClusterById(savedCluster1.id) }.map(_.machineConfig.masterDiskSize) shouldBe
+      Some(newDiskSize)
   }
 
   it should "list monitored clusters" in isolatedDbTest {

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterImageComponentSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterImageComponentSpec.scala
@@ -1,7 +1,7 @@
 package org.broadinstitute.dsde.workbench.leonardo.db
 
 import org.broadinstitute.dsde.workbench.leonardo.CommonTestData
-import org.broadinstitute.dsde.workbench.leonardo.model.ClusterImageType.{Jupyter, RStudio}
+import org.broadinstitute.dsde.workbench.leonardo.ClusterImageType.{Jupyter, RStudio}
 import org.scalatest.FlatSpecLike
 import CommonTestData._
 import scala.concurrent.ExecutionContext.Implicits.global

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/ExtensionComponentSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/ExtensionComponentSpec.scala
@@ -1,4 +1,5 @@
-package org.broadinstitute.dsde.workbench.leonardo.db
+package org.broadinstitute.dsde.workbench.leonardo
+package db
 
 import java.sql.SQLException
 

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/AuthProviderSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/AuthProviderSpec.scala
@@ -1,4 +1,5 @@
 package org.broadinstitute.dsde.workbench.leonardo
+package http
 package service
 
 import java.time.Instant
@@ -141,10 +142,9 @@ class AuthProviderSpec
       val proxy = proxyWithAuthProvider(spyProvider)
 
       // create
-      val cluster1 = leo.createCluster(userInfo, project, cluster1Name, testClusterRequest).unsafeToFuture.futureValue
-
+      val cluster1 = leo.createCluster(userInfo, project, cluster1Name, testClusterRequest).unsafeRunSync()
       // get status
-      val clusterStatus = leo.getActiveClusterDetails(userInfo, project, cluster1Name).unsafeToFuture.futureValue
+      val clusterStatus = leo.getActiveClusterDetails(userInfo, project, cluster1Name).unsafeRunSync()
 
       cluster1 shouldEqual clusterStatus
 

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/MockProxyService.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/MockProxyService.scala
@@ -1,8 +1,9 @@
-package org.broadinstitute.dsde.workbench.leonardo.service
+package org.broadinstitute.dsde.workbench.leonardo
+package http
+package service
 
 import akka.actor.ActorSystem
 import akka.http.scaladsl.model.Uri.Host
-import akka.stream.ActorMaterializer
 import cats.effect.{Blocker, ContextShift, IO, Timer}
 import org.broadinstitute.dsde.workbench.leonardo.config.ProxyConfig
 import org.broadinstitute.dsde.workbench.leonardo.dao.google.GoogleDataprocDAO
@@ -24,7 +25,6 @@ class MockProxyService(
   authProvider: LeoAuthProvider[IO],
   clusterDnsCache: ClusterDnsCache[IO]
 )(implicit system: ActorSystem,
-  materializer: ActorMaterializer,
   executionContext: ExecutionContext,
   timer: Timer[IO],
   cs: ContextShift[IO],

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/TestProxy.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/TestProxy.scala
@@ -1,4 +1,6 @@
-package org.broadinstitute.dsde.workbench.leonardo.service
+package org.broadinstitute.dsde.workbench.leonardo
+package http
+package service
 
 import java.io.InputStream
 import java.security.{KeyStore, SecureRandom}
@@ -6,7 +8,7 @@ import java.security.{KeyStore, SecureRandom}
 import javax.net.ssl.{KeyManagerFactory, SSLContext, TrustManagerFactory}
 import akka.http.scaladsl.Http.ServerBinding
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
-import akka.http.scaladsl.model.headers.{`Access-Control-Allow-Origin`, `Content-Disposition`, ContentDispositionTypes}
+import akka.http.scaladsl.model.headers.{ContentDispositionTypes, `Access-Control-Allow-Origin`, `Content-Disposition`}
 import akka.http.scaladsl.model.HttpResponse
 import akka.http.scaladsl.model.ws.{BinaryMessage, Message, TextMessage}
 import akka.http.scaladsl.server.Directives._
@@ -15,14 +17,14 @@ import akka.http.scaladsl.testkit.RouteTest
 import akka.http.scaladsl.{ConnectionContext, Http, HttpsConnectionContext}
 import akka.stream.scaladsl.{Flow, Sink, Source}
 import org.broadinstitute.dsde.workbench.leonardo.config.ProxyConfig
-import org.broadinstitute.dsde.workbench.leonardo.service.TestProxy.Data
+import org.broadinstitute.dsde.workbench.leonardo.http.service.TestProxy.Data
 import org.scalatest.concurrent.ScalaFutures
 
 import scala.collection.immutable
 import spray.json.DefaultJsonProtocol._
 import spray.json.RootJsonFormat
-import scala.concurrent.duration._
 
+import scala.concurrent.duration._
 import scala.concurrent.Future
 
 trait TestProxy { this: ScalaFutures =>

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/ClusterHelperSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/ClusterHelperSpec.scala
@@ -1,4 +1,5 @@
-package org.broadinstitute.dsde.workbench.leonardo.util
+package org.broadinstitute.dsde.workbench.leonardo
+package util
 
 import java.time.Instant
 
@@ -15,9 +16,8 @@ import org.broadinstitute.dsde.workbench.leonardo.db.{DbSingleton, TestComponent
 import org.broadinstitute.dsde.workbench.leonardo.model.google.ClusterStatus.Creating
 import org.broadinstitute.dsde.workbench.leonardo.model.google.VPCConfig.{VPCNetwork, VPCSubnet}
 import org.broadinstitute.dsde.workbench.leonardo.model.google.{ClusterName, CreateClusterConfig, Operation}
-import org.broadinstitute.dsde.workbench.leonardo.model.{ClusterImage, ClusterImageType, MemorySize}
+import org.broadinstitute.dsde.workbench.leonardo.model.{ClusterImage, MemorySize}
 import org.broadinstitute.dsde.workbench.leonardo.monitor.FakeGoogleStorageService
-import org.broadinstitute.dsde.workbench.leonardo.LeoLenses
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.scalatest.concurrent.ScalaFutures

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,8 +3,8 @@ import sbt._
 object Dependencies {
   val scalaV = "2.12"
 
-  val akkaV = "2.5.22"
-  val akkaHttpV = "10.1.8"
+  val akkaV = "2.6.1"
+  val akkaHttpV = "10.1.11"
   val jacksonV = "2.9.9"
   val jacksonDatabindV = "2.9.9.2" // jackson-databind has a security patch on the 2.9.9 branch
   val googleV = "1.23.0"
@@ -57,12 +57,11 @@ object Dependencies {
   val ravenLogback: ModuleID =    "com.getsentry.raven"         % "raven-logback"   % "8.0.3" excludeAll (excludeJacksonCore, excludeSlf4j, excludeLogbackCore, excludeLogbackClassic)
   val scalaLogging: ModuleID =    "com.typesafe.scala-logging"  %% "scala-logging"  % scalaLoggingV
   val swaggerUi: ModuleID =       "org.webjars"                 % "swagger-ui"      % "2.2.5"
-  val ficus: ModuleID =           "com.iheart"                  %% "ficus"          % "1.4.3"
+  val ficus: ModuleID =           "com.iheart"                  %% "ficus"          % "1.4.7"
   val httpClient: ModuleID =      "org.apache.httpcomponents"   % "httpclient"      % "4.5.5" // upgrading a transitive dependency to avoid security warnings
   val enumeratum: ModuleID =      "com.beachape"                %% "enumeratum"     % "1.5.13"
 
   val akkaActor: ModuleID =         "com.typesafe.akka" %% "akka-actor"           % akkaV excludeAll (excludeTypesafeSslConfig)
-  val akkaContrib: ModuleID =       "com.typesafe.akka" %% "akka-contrib"         % akkaV excludeAll (excludeTypesafeConfig)
   val akkaSlf4j: ModuleID =         "com.typesafe.akka" %% "akka-slf4j"           % akkaV
   val akkaHttp: ModuleID =          "com.typesafe.akka" %% "akka-http"            % akkaHttpV excludeAll (excludeAkkaActor)
   val akkaHttpSprayJson: ModuleID = "com.typesafe.akka" %% "akka-http-spray-json" % akkaHttpV
@@ -91,8 +90,8 @@ object Dependencies {
 
   val slick: ModuleID =           "com.typesafe.slick"  %% "slick"                % slickV excludeAll (excludeTypesafeConfig, excludeReactiveStream)
   val hikariCP: ModuleID =        "com.typesafe.slick"  %% "slick-hikaricp"       % slickV excludeAll (excludeSlf4j)
-  val mysql: ModuleID =           "mysql"               % "mysql-connector-java"  % "8.0.11"
-  val liquibase: ModuleID =       "org.liquibase"       % "liquibase-core"        % "3.5.3"
+  val mysql: ModuleID =           "mysql"               % "mysql-connector-java"  % "8.0.18"
+  val liquibase: ModuleID =       "org.liquibase"       % "liquibase-core"        % "3.8.5"
   val sealerate: ModuleID =       "ca.mrvisser"         %% "sealerate"            % "0.0.5"
   val googleCloudNio: ModuleID =  "com.google.cloud"    % "google-cloud-nio"      % "0.107.0-alpha" % "test" // brought in for FakeStorageInterpreter
 
@@ -109,7 +108,9 @@ object Dependencies {
     workbenchGoogle2,
     workbenchGoogle2Test,
     workbenchNewRelic,
-    workbenchNewRelicTest
+    workbenchNewRelicTest,
+    sealerate,
+    enumeratum
   )
 
   val rootDependencies = Seq(
@@ -130,7 +131,6 @@ object Dependencies {
     httpClient,
     enumeratum,
     akkaActor,
-    akkaContrib,
     akkaSlf4j,
     akkaHttp,
     akkaHttpSprayJson,
@@ -141,20 +141,20 @@ object Dependencies {
     googleOAuth2,
     googleSourceRepositories,
     mockito,
-    slick,
     hikariCP,
-    mysql,
-    liquibase,
     workbenchUtil,
     workbenchGoogle,
     workbenchGoogleTest,
     workbenchMetrics,
-    sealerate,
     "org.typelevel" %% "cats-mtl-core"  % "0.7.0",
     "org.typelevel" %% "cats-effect"    % "2.0.0", //forcing cats 2.0.0
     googleCloudNio,
     "com.github.julien-truffaut" %%  "monocle-core"  % monocleV,
-    "com.github.julien-truffaut" %%  "monocle-macro" % monocleV
+    "com.github.julien-truffaut" %%  "monocle-macro" % monocleV,
+    slick,
+    mysql,
+    liquibase,
+    "de.heikoseeberger" %% "akka-http-circe" % "1.30.0"
   )
 
   val serviceTestV = "0.16-e6493d5"

--- a/project/Merging.scala
+++ b/project/Merging.scala
@@ -3,6 +3,7 @@ import sbtassembly.{MergeStrategy, PathList}
 object Merging {
   def customMergeStrategy(oldStrategy: (String) => MergeStrategy):(String => MergeStrategy) = {
     case PathList("org", "joda", "time", "base", "BaseDateTime.class") => MergeStrategy.first
+    case "reference.conf" => MergeStrategy.concat
     case x => oldStrategy(x)
   }
 }


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-1584

1. upgrade akka, akka-http version
2. add `"de.heikoseeberger" %% "akka-http-circe" % "1.30.0"` marshallers for circe
3. Make some machine config fields non optional..I'm thinking maybe all of them should be required from DB perspective?
4. Moved a few data types to `core`

TODO:
Test metrics are still working

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
