### PR TITLE
Zombify if leo doesn't have permission to view a cluster in google

### DIFF
--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ZombieClusterMonitor.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ZombieClusterMonitor.scala
@@ -105,6 +105,7 @@ class ZombieClusterMonitor(config: ZombieClusterConfig,
         //if we fail because of a permission error, we consider the cluster a zombie, as the permissions have been clean-up elsewhere
         //this occurs in the case of free credits projects, which are managed elsewhere
         case e: GoogleJsonResponseException if e.getStatusCode == 403 =>
+          logger.info(s"Unable to check status of project ${googleProject.value} for zombie cluster detection due to a 403 from google. We are assuming this is a free credits project that has been cleaned up, and zombifying", e)
           false
         case e =>
           logger.warn(s"Unable to check status of project ${googleProject.value} for zombie cluster detection", e)

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ZombieClusterMonitorSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ZombieClusterMonitorSpec.scala
@@ -2,7 +2,6 @@ package org.broadinstitute.dsde.workbench.leonardo.monitor
 
 import akka.actor.{ActorRef, ActorSystem, Terminated}
 import akka.testkit.TestKit
-import com.google.api.client.googleapis.json.GoogleJsonResponseException
 import com.google.api.client.googleapis.testing.json.GoogleJsonResponseExceptionFactoryTesting
 import com.google.api.client.testing.json.MockJsonFactory
 import org.broadinstitute.dsde.workbench.google.GoogleProjectDAO
@@ -13,11 +12,9 @@ import org.broadinstitute.dsde.workbench.leonardo.dao.google.GoogleDataprocDAO
 import org.broadinstitute.dsde.workbench.leonardo.db.{TestComponent, clusterQuery}
 import org.broadinstitute.dsde.workbench.leonardo.model.google.{ClusterName, ClusterStatus}
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
-import org.mockito.Mockito._
 import org.scalatest.concurrent.Eventually.eventually
 import org.scalatest.time.{Seconds, Span}
 import org.scalatest.{BeforeAndAfterAll, FlatSpecLike}
-import org.scalatestplus.mockito.MockitoSugar
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
@@ -29,8 +26,7 @@ class ZombieClusterMonitorSpec
     with FlatSpecLike
     with BeforeAndAfterAll
     with TestComponent
-    with GcsPathUtils
-    with MockitoSugar { testKit =>
+    with GcsPathUtils { testKit =>
 
   val testCluster1 = makeCluster(1).copy(status = ClusterStatus.Running)
   val testCluster2 = makeCluster(2).copy(status = ClusterStatus.Running)


### PR DESCRIPTION
unplanned, doing this to clean up leo log, which has this massive block repeated endlessly when free credits projects are cleaned up (in dev):

```
[WARN] [18:58:57.709] [leonardo-akka.actor.default-dispatcher-1134] o.b.d.w.l.m.ZombieClusterMonitor - Unable to check status of cluster fccredits-calcium-taupe-6838/saturn-100271339377034276912-fccredits-calcium-taup for zombie cluster detection
org.broadinstitute.dsde.workbench.model.WorkbenchException: Call to Google API failed for fccredits-calcium-taupe-6838 / saturn-100271339377034276912-fccredits-calcium-taup. Status: 403. Message: Permission denied on resource project fccredits-calcium-taupe-6838.
	at org.broadinstitute.dsde.workbench.leonardo.dao.google.HttpGoogleDataprocDAO$GoogleExceptionSupport$$anonfun$handleGoogleException$1.applyOrElse(HttpGoogleDataprocDAO.scala:472)
	at org.broadinstitute.dsde.workbench.leonardo.dao.google.HttpGoogleDataprocDAO$GoogleExceptionSupport$$anonfun$handleGoogleException$1.applyOrElse(HttpGoogleDataprocDAO.scala:467)
	at scala.runtime.AbstractPartialFunction.apply(AbstractPartialFunction.scala:38)
	at scala.util.Failure.recover(Try.scala:234)
	at scala.concurrent.Future.$anonfun$recover$1(Future.scala:395)
	at scala.concurrent.impl.Promise.liftedTree1$1(Promise.scala:33)
	at scala.concurrent.impl.Promise.$anonfun$transform$1(Promise.scala:33)
	at scala.concurrent.impl.CallbackRunnable.run(Promise.scala:64)
	at akka.dispatch.BatchingExecutor$AbstractBatch.processBatch(BatchingExecutor.scala:55)
	at akka.dispatch.BatchingExecutor$BlockableBatch.$anonfun$run$1(BatchingExecutor.scala:92)
	at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:23)
	at scala.concurrent.BlockContext$.withBlockContext(BlockContext.scala:85)
	at akka.dispatch.BatchingExecutor$BlockableBatch.run(BatchingExecutor.scala:92)
	at akka.dispatch.TaskInvocation.run(AbstractDispatcher.scala:40)
	at akka.dispatch.ForkJoinExecutorConfigurator$AkkaForkJoinTask.exec(ForkJoinExecutorConfigurator.scala:49)
	at akka.dispatch.forkjoin.ForkJoinTask.doExec(ForkJoinTask.java:260)
	at akka.dispatch.forkjoin.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1339)
	at akka.dispatch.forkjoin.ForkJoinPool.runWorker(ForkJoinPool.java:1979)
	at akka.dispatch.forkjoin.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:107)
Caused by: com.google.api.client.googleapis.json.GoogleJsonResponseException: 403 Forbidden
{
  "code" : 403,
  "errors" : [ {
    "domain" : "global",
    "message" : "Permission denied on resource project fccredits-calcium-taupe-6838.",
    "reason" : "forbidden"
  } ],
  "message" : "Permission denied on resource project fccredits-calcium-taupe-6838.",
  "status" : "PERMISSION_DENIED"
}
	at com.google.api.client.googleapis.json.GoogleJsonResponseException.from(GoogleJsonResponseException.java:150)
	at com.google.api.client.googleapis.services.json.AbstractGoogleJsonClientRequest.newExceptionOnError(AbstractGoogleJsonClientRequest.java:113)
	at com.google.api.client.googleapis.services.json.AbstractGoogleJsonClientRequest.newExceptionOnError(AbstractGoogleJsonClientRequest.java:40)
	at com.google.api.client.googleapis.services.AbstractGoogleClientRequest$1.interceptResponse(AbstractGoogleClientRequest.java:443)
	at com.google.api.client.http.HttpRequest.execute(HttpRequest.java:1092)
	at com.google.api.client.googleapis.services.AbstractGoogleClientRequest.executeUnparsed(AbstractGoogleClientRequest.java:541)
	at com.google.api.client.googleapis.services.AbstractGoogleClientRequest.executeUnparsed(AbstractGoogleClientRequest.java:474)
	at org.broadinstitute.dsde.workbench.google.GoogleUtilities.$anonfun$executeGoogleCall$1(GoogleUtilities.scala:156)
	at scala.util.Try$.apply(Try.scala:213)
	at org.broadinstitute.dsde.workbench.google.GoogleUtilities.executeGoogleCall(GoogleUtilities.scala:156)
	at org.broadinstitute.dsde.workbench.google.GoogleUtilities.executeGoogleCall$(GoogleUtilities.scala:153)
	at org.broadinstitute.dsde.workbench.google.AbstractHttpGoogleDAO.executeGoogleCall(AbstractHttpGoogleDAO.scala:14)
	at org.broadinstitute.dsde.workbench.google.GoogleUtilities.executeGoogleRequest(GoogleUtilities.scala:137)
	at org.broadinstitute.dsde.workbench.google.GoogleUtilities.executeGoogleRequest$(GoogleUtilities.scala:136)
	at org.broadinstitute.dsde.workbench.google.AbstractHttpGoogleDAO.executeGoogleRequest(AbstractHttpGoogleDAO.scala:14)
	at org.broadinstitute.dsde.workbench.leonardo.dao.google.HttpGoogleDataprocDAO.$anonfun$getCluster$1(HttpGoogleDataprocDAO.scala:395)
	at akka.dispatch.MonitorableThreadFactory$AkkaForkJoinWorkerThread$$anon$3.block(ThreadPoolBuilder.scala:172)
	at akka.dispatch.forkjoin.ForkJoinPool.managedBlock(ForkJoinPool.java:3641)
	at akka.dispatch.MonitorableThreadFactory$AkkaForkJoinWorkerThread.blockOn(ThreadPoolBuilder.scala:170)
	at akka.dispatch.BatchingExecutor$BlockableBatch.blockOn(BatchingExecutor.scala:108)
	at scala.concurrent.package$.blocking(package.scala:146)
	at org.broadinstitute.dsde.workbench.google.GoogleUtilities.$anonfun$retryWithRecover$2(GoogleUtilities.scala:132)
	at scala.concurrent.Future$.$anonfun$apply$1(Future.scala:659)
	at scala.util.Success.$anonfun$map$1(Try.scala:255)
	at scala.util.Success.map(Try.scala:213)
	at scala.concurrent.Future.$anonfun$map$1(Future.scala:292)
	... 14 common frames omitted
[INFO] [18:58:57.711] [leonardo-akka.actor.default-dispatcher-1134] o.b.d.w.l.m.ZombieClusterMonitor - Detected 0 zombie clusters across 0 projects.
```