### PR TITLE
IA-1512 Log traceId and timestamp when messages are published

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeoPubsubSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeoPubsubSpec.scala
@@ -13,7 +13,7 @@ class LeoPubsubSpec extends ClusterFixtureSpec with LeonardoTestUtils {
   "Google publisher should be able to auth" taggedAs Tags.SmokeTest in { _ =>
     logger.info(s"publisher config is: ${LeonardoConfig.Leonardo.publisherConfig}")
 
-    val publisher = GooglePublisher.resource[IO, String](LeonardoConfig.Leonardo.publisherConfig)
+    val publisher = GooglePublisher.resource[IO](LeonardoConfig.Leonardo.publisherConfig)
 
     publisher
       .use { _ =>
@@ -23,7 +23,7 @@ class LeoPubsubSpec extends ClusterFixtureSpec with LeonardoTestUtils {
   }
 
   "Google publisher should publish" in { _ =>
-    val publisher = GooglePublisher.resource[IO, String](LeonardoConfig.Leonardo.publisherConfig)
+    val publisher = GooglePublisher.resource[IO](LeonardoConfig.Leonardo.publisherConfig)
     val queue = InspectableQueue.bounded[IO, String](100).unsafeRunSync()
 
     publisher

--- a/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestSuite.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestSuite.scala
@@ -1,16 +1,17 @@
 package org.broadinstitute.dsde.workbench.leonardo
 
 import cats.effect.{Blocker, ContextShift, IO, Timer}
-import io.chrisdavenport.log4cats.Logger
+import io.chrisdavenport.log4cats.StructuredLogger
 import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
 import org.broadinstitute.dsde.workbench.newrelic.mock.FakeNewRelicMetricsInterpreter
 import org.scalatest.Matchers
+
 import scala.concurrent.ExecutionContext.global
 
 trait LeonardoTestSuite extends Matchers {
   implicit val metrics = FakeNewRelicMetricsInterpreter
   implicit val timer: Timer[IO] = IO.timer(global)
   implicit val cs: ContextShift[IO] = IO.contextShift(global)
-  implicit val loggerIO: Logger[IO] = Slf4jLogger.getLogger[IO]
+  implicit val loggerIO: StructuredLogger[IO] = Slf4jLogger.getLogger[IO]
   val blocker = Blocker.liftExecutionContext(global)
 }

--- a/http/src/main/resources/logback.xml
+++ b/http/src/main/resources/logback.xml
@@ -10,11 +10,11 @@
 
     <appender name="file" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>log/leonardo.log</file>
-        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
-            <fieldNames>
-                <level>severity</level>
-            </fieldNames>
-        </encoder>
+<!--        <encoder class="net.logstash.logback.encoder.LogstashEncoder">-->
+<!--            <fieldNames>-->
+<!--                <level>severity</level>-->
+<!--            </fieldNames>-->
+<!--        </encoder>-->
         <append>true</append>
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
             <!-- daily rollover -->
@@ -32,12 +32,12 @@
     <appender name="SYSLOG" class="ch.qos.logback.classic.net.SyslogAppender">
         <syslogHost>127.0.0.1</syslogHost>
         <facility>AUDIT</facility>
-<!--        <suffixPattern>[%level] [%d{HH:mm:ss.SSS}] [%thread] %logger{36} - %msg%n</suffixPattern>-->
-        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
-            <fieldNames>
-                <level>severity</level>
-            </fieldNames>
-        </encoder>
+        <suffixPattern>[%level] [%d{HH:mm:ss.SSS}] [%thread] %logger{36} - %msg%n</suffixPattern>
+<!--        <encoder class="net.logstash.logback.encoder.LogstashEncoder">-->
+<!--            <fieldNames>-->
+<!--                <level>severity</level>-->
+<!--            </fieldNames>-->
+<!--        </encoder>-->
     </appender>
 
     <!-- Configure the Sentry appender, overriding the logging threshold to the WARN level -->

--- a/http/src/main/resources/logback.xml
+++ b/http/src/main/resources/logback.xml
@@ -10,6 +10,11 @@
 
     <appender name="file" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>log/leonardo.log</file>
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+            <fieldNames>
+                <level>severity</level>
+            </fieldNames>
+        </encoder>
         <append>true</append>
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
             <!-- daily rollover -->
@@ -27,7 +32,12 @@
     <appender name="SYSLOG" class="ch.qos.logback.classic.net.SyslogAppender">
         <syslogHost>127.0.0.1</syslogHost>
         <facility>AUDIT</facility>
-        <suffixPattern>[%level] [%d{HH:mm:ss.SSS}] [%thread] %logger{36} - %msg%n</suffixPattern>
+<!--        <suffixPattern>[%level] [%d{HH:mm:ss.SSS}] [%thread] %logger{36} - %msg%n</suffixPattern>-->
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+            <fieldNames>
+                <level>severity</level>
+            </fieldNames>
+        </encoder>
     </appender>
 
     <!-- Configure the Sentry appender, overriding the logging threshold to the WARN level -->
@@ -44,7 +54,6 @@
         <appender-ref ref="SYSLOG"/>
         <appender-ref ref="Sentry" />
     </logger>
-
 
     <logger name="akka" level="info" additivity="false">
         <appender-ref ref="file"/>

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/Boot.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/Boot.scala
@@ -210,7 +210,7 @@ object Boot extends IOApp {
     }
   }
 
-  private def conertToPubsubMessagePipe[F[_]]: Pipe[F, LeoPubsubMessage, PubsubMessage] =
+  private def convertToPubsubMessagePipe[F[_]]: Pipe[F, LeoPubsubMessage, PubsubMessage] =
     in =>
       in.map { msg =>
         val stringMessage = msg.asJson.noSpaces
@@ -269,7 +269,7 @@ object Boot extends IOApp {
 
       publisherQueue <- Resource.liftF(InspectableQueue.bounded[F, LeoPubsubMessage](pubsubConfig.queueSize))
 
-      publisherStream = Stream.eval(Logger[F].info(s"Initializing publisher for ${publisherConfig.projectTopicName}")) ++ (publisherQueue.dequeue through conertToPubsubMessagePipe through googlePublisher.publishNative)
+      publisherStream = Stream.eval(Logger[F].info(s"Initializing publisher for ${publisherConfig.projectTopicName}")) ++ (publisherQueue.dequeue through convertToPubsubMessagePipe through googlePublisher.publishNative)
 
       subscriberQueue <- Resource.liftF(InspectableQueue.bounded[F, Event[LeoPubsubMessage]](pubsubConfig.queueSize))
       subscriber <- GoogleSubscriber.resource(subscriberConfig, subscriberQueue)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorActor.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorActor.scala
@@ -406,8 +406,9 @@ class ClusterMonitorActor(
       }
       // reset the time at which the kernel was last found to be busy
       _ <- dbRef.inTransaction { clusterQuery.clearKernelFoundBusyDate(cluster.id, now) }
+      traceId = TraceId(UUID.randomUUID())
       _ <- publisherQueue.enqueue1(
-        ClusterTransitionFinishedMessage(ClusterFollowupDetails(clusterId, ClusterStatus.Stopped))
+        ClusterTransitionFinishedMessage(ClusterFollowupDetails(clusterId, ClusterStatus.Stopped), Some(traceId))
       )
       // Record metrics in NewRelic
       _ <- recordStatusTransitionMetrics(cluster.status, ClusterStatus.Stopped)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorSupervisor.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorSupervisor.scala
@@ -12,13 +12,7 @@ import cats.mtl.ApplicativeAsk
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.workbench.google.GoogleStorageDAO
 import org.broadinstitute.dsde.workbench.google2.GoogleStorageService
-import org.broadinstitute.dsde.workbench.leonardo.config.{
-  AutoFreezeConfig,
-  ClusterBucketConfig,
-  DataprocConfig,
-  ImageConfig,
-  MonitorConfig
-}
+import org.broadinstitute.dsde.workbench.leonardo.config._
 import org.broadinstitute.dsde.workbench.leonardo.dao.google.{GoogleComputeDAO, GoogleDataprocDAO}
 import org.broadinstitute.dsde.workbench.leonardo.dao.{JupyterDAO, RStudioDAO, ToolDAO, WelderDAO}
 import org.broadinstitute.dsde.workbench.leonardo.db.{clusterQuery, DbReference}

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
@@ -65,14 +65,13 @@ class LeoPubsubMessageSubscriber[F[_]: Async: Timer: ContextShift: Concurrent](
   val process: Stream[F, Unit] = (subscriber.messages through messageHandler).repeat
 
   private def ack(event: Event[LeoPubsubMessage]): F[Unit] = {
-    logger.debug(s"acking message: ${event.msg}") >> Async[F].delay(
+    logger.info(s"acking message: ${event}") >> Async[F].delay(
       event.consumer.ack()
     )
   }
 
   private def handleStopUpdateMessage(message: StopUpdateMessage): F[Unit] =
-    dbRef
-      .inTransaction { clusterQuery.getClusterById(message.clusterId) }
+    dbRef.inTransaction { clusterQuery.getClusterById(message.clusterId) }
       .flatMap {
         case Some(resolvedCluster)
             if ClusterStatus.stoppableStatuses.contains(resolvedCluster.status) && !message.updatedMachineConfig.masterMachineType.isEmpty =>

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ZombieClusterMonitor.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ZombieClusterMonitor.scala
@@ -11,7 +11,7 @@ import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.workbench.google.GoogleProjectDAO
 import org.broadinstitute.dsde.workbench.leonardo.config.ZombieClusterConfig
 import org.broadinstitute.dsde.workbench.leonardo.dao.google.GoogleDataprocDAO
-import org.broadinstitute.dsde.workbench.leonardo.db.{DbReference, clusterErrorQuery, clusterQuery}
+import org.broadinstitute.dsde.workbench.leonardo.db.{clusterErrorQuery, clusterQuery, DbReference}
 import org.broadinstitute.dsde.workbench.leonardo.model.Cluster
 import org.broadinstitute.dsde.workbench.leonardo.model.google.ClusterStatus
 import org.broadinstitute.dsde.workbench.leonardo.monitor.ZombieClusterMonitor._
@@ -105,7 +105,10 @@ class ZombieClusterMonitor(config: ZombieClusterConfig,
         //if we fail because of a permission error, we consider the cluster a zombie, as the permissions have been clean-up elsewhere
         //this occurs in the case of free credits projects, which are managed elsewhere
         case e: GoogleJsonResponseException if e.getStatusCode == 403 =>
-          logger.info(s"Unable to check status of project ${googleProject.value} for zombie cluster detection due to a 403 from google. We are assuming this is a free credits project that has been cleaned up, and zombifying", e)
+          logger.info(
+            s"Unable to check status of project ${googleProject.value} for zombie cluster detection due to a 403 from google. We are assuming this is a free credits project that has been cleaned up, and zombifying",
+            e
+          )
           false
         case e =>
           logger.warn(s"Unable to check status of project ${googleProject.value} for zombie cluster detection", e)

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorSpec.scala
@@ -20,20 +20,14 @@ import org.broadinstitute.dsde.workbench.google2.{GcsBlobName, GetMetadataRespon
 import org.broadinstitute.dsde.workbench.leonardo.ClusterEnrichments.clusterEq
 import org.broadinstitute.dsde.workbench.leonardo.dao._
 import org.broadinstitute.dsde.workbench.leonardo.dao.google.{GoogleComputeDAO, GoogleDataprocDAO}
-import org.broadinstitute.dsde.workbench.leonardo.db.{clusterQuery, DbSingleton, TestComponent}
+import org.broadinstitute.dsde.workbench.leonardo.db.{DbSingleton, TestComponent, clusterQuery}
 import org.broadinstitute.dsde.workbench.leonardo.model._
 import org.broadinstitute.dsde.workbench.leonardo.model.google.DataprocRole.{Master, Worker}
 import org.broadinstitute.dsde.workbench.leonardo.model.google.{InstanceStatus, _}
 import org.broadinstitute.dsde.workbench.leonardo.util.{BucketHelper, ClusterHelper, QueueFactory}
 import org.broadinstitute.dsde.workbench.model.google.GcsLifecycleTypes.GcsLifecycleType
 import org.broadinstitute.dsde.workbench.model.google.GcsRoles.GcsRole
-import org.broadinstitute.dsde.workbench.model.google.{
-  GcsBucketName,
-  GcsEntity,
-  GcsObjectName,
-  GoogleProject,
-  ServiceAccountKeyId
-}
+import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GcsEntity, GcsObjectName, GoogleProject, ServiceAccountKeyId}
 import org.broadinstitute.dsde.workbench.model.{TraceId, WorkbenchEmail}
 import org.mockito.ArgumentMatchers.{any, eq => mockitoEq}
 import org.mockito.Mockito._

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/TestClusterSupervisorActor.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/TestClusterSupervisorActor.scala
@@ -7,18 +7,12 @@ import cats.effect.{ContextShift, IO}
 import fs2.concurrent.InspectableQueue
 import org.broadinstitute.dsde.workbench.google.GoogleStorageDAO
 import org.broadinstitute.dsde.workbench.google2.GoogleStorageService
-import org.broadinstitute.dsde.workbench.leonardo.config.{
-  AutoFreezeConfig,
-  ClusterBucketConfig,
-  DataprocConfig,
-  ImageConfig,
-  MonitorConfig
-}
+import org.broadinstitute.dsde.workbench.leonardo.config.{AutoFreezeConfig, ClusterBucketConfig, DataprocConfig, ImageConfig, MonitorConfig}
 import org.broadinstitute.dsde.workbench.leonardo.dao.google.{GoogleComputeDAO, GoogleDataprocDAO}
 import org.broadinstitute.dsde.workbench.leonardo.dao.{JupyterDAO, RStudioDAO, ToolDAO, WelderDAO}
 import org.broadinstitute.dsde.workbench.leonardo.db.DbReference
 import org.broadinstitute.dsde.workbench.leonardo.model.{Cluster, LeoAuthProvider}
-import org.broadinstitute.dsde.workbench.leonardo.util.{ClusterHelper}
+import org.broadinstitute.dsde.workbench.leonardo.util.ClusterHelper
 import org.broadinstitute.dsde.workbench.newrelic.mock.FakeNewRelicMetricsInterpreter
 
 import scala.concurrent.ExecutionContext.global

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoServiceSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoServiceSpec.scala
@@ -1204,13 +1204,11 @@ class LeonardoServiceSpec
 
     finalQueueSize shouldBe 1
 
-    val message = queue.dequeue1.unsafeRunSync()
-    message.isInstanceOf[StopUpdateMessage] shouldBe true
+    val message = queue.dequeue1.unsafeRunSync().asInstanceOf[StopUpdateMessage]
 
-    val castMessage = message.asInstanceOf[StopUpdateMessage]
-    castMessage.messageType shouldBe "stopUpdate"
-    castMessage.updatedMachineConfig shouldBe newConfig
-    castMessage.clusterId shouldBe clusterCreateResponse.id
+    message.messageType shouldBe "stopUpdate"
+    message.updatedMachineConfig shouldBe newConfig
+    message.clusterId shouldBe clusterCreateResponse.id
   }
 
   it should "update the master disk size for a cluster" in isolatedDbTest {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -19,7 +19,7 @@ object Dependencies {
   val workbenchUtilV = "0.5-4c7acd5"
   val workbenchModelV = "0.13-db13244-SNAP"
   val workbenchGoogleV = "0.21-890a74f"
-  val workbenchGoogle2V = "0.6-8ad0760-SNAP"
+  val workbenchGoogle2V = "0.6-707125c-SNAP"
   val workbenchMetricsV = "0.3-c5b80d2"
   val workbenchNewRelicV = "0.3-8bae8e8"
 
@@ -109,7 +109,8 @@ object Dependencies {
     workbenchGoogle2,
     workbenchGoogle2Test,
     workbenchNewRelic,
-    workbenchNewRelicTest
+    workbenchNewRelicTest,
+    "net.logstash.logback" % "logstash-logback-encoder" % "6.2" // for structured logging in logback
   )
 
   val rootDependencies = Seq(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,9 +17,9 @@ object Dependencies {
   val monocleV = "2.0.0"
 
   val workbenchUtilV = "0.5-4c7acd5"
-  val workbenchModelV = "0.13-6dc016b"
+  val workbenchModelV = "0.13-db13244-SNAP"
   val workbenchGoogleV = "0.21-890a74f"
-  val workbenchGoogle2V = "0.6-c91d96b"
+  val workbenchGoogle2V = "0.6-8ad0760-SNAP"
   val workbenchMetricsV = "0.3-c5b80d2"
   val workbenchNewRelicV = "0.3-8bae8e8"
 


### PR DESCRIPTION
This may not fix the subscriber problem. But it should give us more info what went wrong in dev.

This PR is using a SNAP version of google2 generated from https://github.com/broadinstitute/workbench-libs/pull/280...I'm waiting on Doug's thumb for that PR. But I think meanwhile we can try out the SNAP version, and I'll have follow up PR to use real published one

google2 lib will now log
```
[INFO] [17:37:25.335] [Gax-56] o.b.dsde.workbench.leonardo.Boot - Successfully enqueue data: "{\"messageType\":\"transitionFinished\",\"clusterFollowupDetails\":{\"clusterId\":3,\"clusterStatus\":\"Stopped\"}}"
attributes {
  key: "traceId"
  value: "f90bbc12-1b25-4a1e-9be0-e896eadc984d"
}
message_id: "974934262316894"
publish_time {
  seconds: 1581010645
  nanos: 91000000
}
```

Tested in fiab and everything works as expected

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
