### PR TITLE
[PROD-340] OOM issues in AoU notebooks

### DIFF
--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -25,7 +25,7 @@ dataproc {
   legacyCustomDataprocImage = "projects/broad-dsp-gcr-public/global/images/custom-leo-image-1-2-79-debian9-625a2bc"
   customDataprocImage = "projects/broad-dsp-gcr-public/global/images/custom-leo-image-1-4-15-debian9-625a2bc"
 
-  dataprocReservedMemory = 5g
+  dataprocReservedMemory = 6g
 }
 
 image {

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/ClusterHelperSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/ClusterHelperSpec.scala
@@ -282,8 +282,8 @@ class ClusterHelperSpec
   it should "calculate cluster resource constraints" in isolatedDbTest {
     val resourceConstraints = clusterHelper.getClusterResourceContraints(testCluster).unsafeRunSync()
 
-    // 7680m (in mock compute dao) - 5g (dataproc allocated) - 512m (welder allocated) = 2048m
-    resourceConstraints.memoryLimit shouldBe MemorySize.fromMb(2048)
+    // 7680m (in mock compute dao) - 6g (dataproc allocated) - 512m (welder allocated) = 1024m
+    resourceConstraints.memoryLimit shouldBe MemorySize.fromMb(1024)
   }
 
   private class ErroredMockGoogleDataprocDAO(statusCode: Int = 400) extends MockGoogleDataprocDAO {


### PR DESCRIPTION
See https://broadworkbench.atlassian.net/browse/PROD-340

For an `n1-highmem-4` machine (which AoU uses), the previous `mem_limit` was calculated to be `20.5G`. I observed only 20G available memory on the VM when I ssh'd in (soo close). Indeed I was able to crash the VM by using all available memory in the kernel.

With this change, the OOM graceful exit works as expected for `n1-highmem-4` machine type. I re-verified `n1-standard-2`, `n1-standard-4`, and `n1-standard-8` machine types as well.

Note - this is just a band-aid fix until we move to GCE. Not only will GCE free up a ton of memory compared to Dataproc, but we'll have a lot more control over the environment and shouldn't have to make estimations like this.

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've documented my API changes in Swagger

In all cases:

- [x] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
