### PR TITLE
[no ticket] fix a bug in wb-libs

### DIFF
--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
@@ -62,7 +62,7 @@ class LeoPubsubMessageSubscriber[F[_]: Async: Timer: ContextShift: Concurrent](
     }
   }
 
-  val process: Stream[F, Unit] = (subscriber.messages through messageHandler).repeat
+  val process: Stream[F, Unit] = subscriber.messages through messageHandler
 
   private def ack(event: Event[LeoPubsubMessage]): F[Unit] = {
     logger.info(s"acking message: ${event}") >> Async[F].delay(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -19,7 +19,7 @@ object Dependencies {
   val workbenchUtilV = "0.5-4c7acd5"
   val workbenchModelV = "0.13-db13244-SNAP"
   val workbenchGoogleV = "0.21-890a74f"
-  val workbenchGoogle2V = "0.6-707125c-SNAP"
+  val workbenchGoogle2V = "0.6-6b294a2-SNAP"
   val workbenchMetricsV = "0.3-c5b80d2"
   val workbenchNewRelicV = "0.3-8bae8e8"
 


### PR DESCRIPTION
Previously there was a line in wb-libs
```
Effect[F].delay(message.getData.toStringUtf8.asInstanceOf[MessageType])
```
This line isn't working as expected due to type erasure.

Expected behavior is `F` should fail and message will be acked, but `F` never fails.

```
@ def is[A](s: String): Unit = s.asInstanceOf[A]
defined function is

@ is[Boolean]("sadf")


```
Notice no exception is thrown

Hence invalid message are still being enqueued into subscriber's internal queue and not getting acked anywhere

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
