### PR TITLE
[no ticket] more fix

### DIFF
--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
@@ -26,9 +26,9 @@ class LeoPubsubMessageSubscriber[F[_]: Async: Timer: ContextShift: Concurrent](
 )(implicit executionContext: ExecutionContext, logger: StructuredLogger[F]) {
   private[monitor] def messageResponder(message: LeoPubsubMessage): F[Unit] =
     message match {
-      case msg @ StopUpdateMessage(_, _, _) =>
+      case msg: StopUpdateMessage =>
         handleStopUpdateMessage(msg)
-      case msg @ ClusterTransitionFinishedMessage(_, _) =>
+      case msg: ClusterTransitionFinishedMessage =>
         handleClusterTransitionFinished(msg)
     }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,9 +17,9 @@ object Dependencies {
   val monocleV = "2.0.0"
 
   val workbenchUtilV = "0.5-4c7acd5"
-  val workbenchModelV = "0.13-db13244-SNAP"
+  val workbenchModelV = "0.13-31cacc4"
   val workbenchGoogleV = "0.21-890a74f"
-  val workbenchGoogle2V = "0.6-6b294a2-SNAP"
+  val workbenchGoogle2V = "0.6-31cacc4"
   val workbenchMetricsV = "0.3-c5b80d2"
   val workbenchNewRelicV = "0.3-8bae8e8"
 


### PR DESCRIPTION
Since the processor stream only runs in backleo, we shouldn't run subscriber.start in front leo...subscriber.start and processor should run on the same instance

I think this is the real fix

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
