### PR TITLE
[QA-1027] fix selenium check for 'kernel died'

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookCustomizationSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookCustomizationSpec.scala
@@ -208,11 +208,12 @@ final class NotebookCustomizationSpec extends GPAllocFixtureSpec with ParallelTe
                 |result = [numpy.random.bytes(1024*1024) for x in range(6*1024)]
                 |print(len(result))
                 |""".stripMargin
-            notebookPage.addCodeAndExecute(cell, 5.minutes)
-
+            notebookPage.addCodeAndExecute(cell, wait = false, timeout = 5.minutes)
             // Kernel should restart automatically and still be functional
             notebookPage.validateKernelDiedAndDismiss()
-            notebookPage.executeCell("print('Still alive!')", cellNumberOpt = Some(1)).get shouldBe "Still alive!"
+            notebookPage
+              .executeCell("print('Still alive!')", timeout = 2.minutes, cellNumberOpt = Some(1))
+              .get shouldBe "Still alive!"
           }
         }
       }

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookCustomizationSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookCustomizationSpec.scala
@@ -211,7 +211,7 @@ final class NotebookCustomizationSpec extends GPAllocFixtureSpec with ParallelTe
             notebookPage.addCodeAndExecute(cell, 5.minutes)
 
             // Kernel should restart automatically and still be functional
-            notebookPage.dismissKernelDied()
+            notebookPage.validateKernelDiedAndDismiss()
             notebookPage.executeCell("print('Still alive!')", cellNumberOpt = Some(1)).get shouldBe "Still alive!"
           }
         }

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookPage.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookPage.scala
@@ -334,6 +334,9 @@ class NotebookPage(override val url: String)(implicit override val authToken: Au
   def kernelNotificationText: String =
     find(id("notification_kernel")).map(_.underlying.getCssValue("display")).getOrElse("")
 
+  def isKernelDead: Boolean =
+    find(jupyterModal).exists(_.text == "Kernel Restarting")
+
   def modeExists(): Boolean =
     find(modeBanner).size > 0
 
@@ -403,11 +406,11 @@ class NotebookPage(override val url: String)(implicit override val authToken: Au
       await notVisible jupyterModal
     }
 
-  def dismissKernelDied(): Unit =
-    if (find(jupyterModal).exists(_.text == "Kernel Restarting")) {
-      click on confirmKernelDiedButton
-      await notVisible jupyterModal
-    }
+  def validateKernelDiedAndDismiss(timeout: FiniteDuration = 5.minutes): Unit = {
+    await condition (isKernelDead, timeout.toSeconds)
+    click on (await enabled confirmKernelDiedButton)
+    await notVisible jupyterModal
+  }
 
 }
 

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookPage.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookPage.scala
@@ -245,15 +245,15 @@ class NotebookPage(override val url: String)(implicit override val authToken: Au
   }
 
   //TODO: this function is duplicative of the above but does not have the bug
-  def addCodeAndExecute(code: String, timeout: FiniteDuration = 1 minute): Unit = {
+  def addCodeAndExecute(code: String, wait: Boolean = true, timeout: FiniteDuration = 1 minute): Unit = {
     dismissNotebookChanged()
     await enabled cells
     val cell = lastCell
     click on cell
     val jsEscapedCode = StringEscapeUtils.escapeEcmaScript(code)
     executeScript(s"""arguments[0].CodeMirror.setValue("$jsEscapedCode");""", cell)
-    clickRunCell(timeout)
-    await condition (!cellsAreRunning, timeout.toSeconds)
+    clickRunCell(timeout, wait)
+    if (wait) await condition (!cellsAreRunning, timeout.toSeconds)
   }
 
   def translateMarkup(code: String, timeout: FiniteDuration = 1 minute): String = {
@@ -300,9 +300,9 @@ class NotebookPage(override val url: String)(implicit override val authToken: Au
     await condition (isKernelReady && kernelNotificationText == "none", timeout.toSeconds)
   }
 
-  def clickRunCell(timeout: FiniteDuration = 2.minutes): Unit = {
+  def clickRunCell(timeout: FiniteDuration = 2.minutes, wait: Boolean = true): Unit = {
     click on runCellButton
-    awaitReadyKernel(timeout)
+    if (wait) awaitReadyKernel(timeout)
   }
 
   def awaitReadyKernel(timeout: FiniteDuration): Unit = {


### PR DESCRIPTION
Occasional `NotebookCustomizationSpec should recover from out-of-memory errors` tests are failing w/ this screenshot:

![image](https://user-images.githubusercontent.com/5368863/74071745-ba8d3e80-49d2-11ea-984f-69b0c76a021c.png)

The observed behavior is correct but I think the previous selenium check was race-y. It was possible for the `dismissKernelDied` method to return (and not fail) if the modal didn't appear yet. Changed code to wait for the modal to appear before dismissing.


---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
