### PR TITLE
[IA-982] Jc test autopause

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/ClusterFixtureSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/ClusterFixtureSpec.scala
@@ -12,7 +12,7 @@ import cats.implicits._
 /**
  * trait BeforeAndAfterAll - One cluster per Scalatest Spec.
  */
-abstract class ClusterFixtureSpec extends fixture.FreeSpec with BeforeAndAfterAll with LeonardoTestUtils with Retries {
+abstract class ClusterFixtureSpec extends fixture.FreeSpec with BeforeAndAfterAll with LeonardoTestUtils with Retries with GPAllocBeforeAndAfterAll {
 
   implicit val ronToken: AuthToken = ronAuthToken
 
@@ -43,7 +43,8 @@ abstract class ClusterFixtureSpec extends fixture.FreeSpec with BeforeAndAfterAl
       None,
       List(),
       Instant.now(),
-      false
+      false,
+      0
     )
 
   /**

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/ClusterFixtureSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/ClusterFixtureSpec.scala
@@ -12,7 +12,7 @@ import cats.implicits._
 /**
  * trait BeforeAndAfterAll - One cluster per Scalatest Spec.
  */
-abstract class ClusterFixtureSpec extends fixture.FreeSpec with BeforeAndAfterAll with LeonardoTestUtils with Retries with GPAllocBeforeAndAfterAll {
+abstract class ClusterFixtureSpec extends fixture.FreeSpec with BeforeAndAfterAll with LeonardoTestUtils with Retries {
 
   implicit val ronToken: AuthToken = ronAuthToken
 

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/Leonardo.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/Leonardo.scala
@@ -126,7 +126,7 @@ object AutomationTestJsonCodec {
                                                                        Option[List[ClusterError]],
                                                                        Instant,
                                                                        Boolean,
-                                                                        Int](
+                                                                       Int](
     "clusterName",
     "googleProject",
     "serviceAccountInfo",

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/Leonardo.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/Leonardo.scala
@@ -114,7 +114,7 @@ object AutomationTestJsonCodec {
   implicit val clusterStatusDecoder: Decoder[ClusterStatus] =
     Decoder.decodeString.emap(s => ClusterStatus.withNameOpt(s).toRight(s"Invalid cluster status ${s}"))
 
-  implicit val clusterDecoder: Decoder[Cluster] = Decoder.forProduct11[Cluster,
+  implicit val clusterDecoder: Decoder[Cluster] = Decoder.forProduct12[Cluster,
                                                                        ClusterName,
                                                                        GoogleProject,
                                                                        ServiceAccountInfo,
@@ -125,7 +125,8 @@ object AutomationTestJsonCodec {
                                                                        Option[GcsBucketName],
                                                                        Option[List[ClusterError]],
                                                                        Instant,
-                                                                       Boolean](
+                                                                       Boolean,
+                                                                        Int](
     "clusterName",
     "googleProject",
     "serviceAccountInfo",
@@ -136,9 +137,10 @@ object AutomationTestJsonCodec {
     "stagingBucket",
     "errors",
     "dateAccessed",
-    "stopAfterCreation"
-  ) { (cn, gp, sa, mc, status, c, l, sb, e, da, sc) =>
-    Cluster(cn, gp, sa, mc, status, c, l, sb, e.getOrElse(List.empty), da, sc)
+    "stopAfterCreation",
+    "autopauseThreshold"
+  ) { (cn, gp, sa, mc, status, c, l, sb, e, da, sc, at) =>
+    Cluster(cn, gp, sa, mc, status, c, l, sb, e.getOrElse(List.empty), da, sc, at)
   }
 }
 

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoModelCopy.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoModelCopy.scala
@@ -22,7 +22,8 @@ case class Cluster(clusterName: ClusterName,
                    stagingBucket: Option[GcsBucketName],
                    errors: List[ClusterError],
                    dateAccessed: Instant,
-                   stopAfterCreation: Boolean) {
+                   stopAfterCreation: Boolean,
+                   autopauseThreshold: Int) {
   def projectNameString: String = s"${googleProject.value}/${clusterName.string}"
 }
 

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoSuite.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoSuite.scala
@@ -1,7 +1,7 @@
 package org.broadinstitute.dsde.workbench.leonardo
 
 import org.broadinstitute.dsde.workbench.fixture.BillingFixtures
-import org.broadinstitute.dsde.workbench.leonardo.cluster.{ClusterPatchSpec, ClusterStatusTransitionsSpec}
+import org.broadinstitute.dsde.workbench.leonardo.cluster.{ClusterAutopauseSpec, ClusterPatchSpec, ClusterStatusTransitionsSpec}
 import org.broadinstitute.dsde.workbench.leonardo.lab.LabSpec
 import org.broadinstitute.dsde.workbench.leonardo.notebooks._
 import org.broadinstitute.dsde.workbench.leonardo.rstudio.RStudioSpec
@@ -100,7 +100,8 @@ final class LeonardoSuite
       new NotebookRKernelSpec,
       new RStudioSpec,
       new LeoPubsubSpec,
-      new ClusterPatchSpec
+      new ClusterPatchSpec,
+      new ClusterAutopauseSpec
     )
     with TestSuite
     with GPAllocBeforeAndAfterAll

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
@@ -282,7 +282,10 @@ trait LeonardoTestUtils
   def deleteCluster(googleProject: GoogleProject, clusterName: ClusterName, monitor: Boolean)(
     implicit token: AuthToken
   ): Unit = {
-    saveClusterLogFiles(googleProject, clusterName, List("jupyter.log", "welder.log"), "delete")
+    //we cannot save the log if the cluster isn't running
+    if (Leonardo.cluster.get(googleProject, clusterName).status == ClusterStatus.Running) {
+      saveClusterLogFiles(googleProject, clusterName, List("jupyter.log", "welder.log"), "delete")
+    }
     try {
       Leonardo.cluster.delete(googleProject, clusterName) shouldBe
         "The request has been accepted for processing, but the processing has not been completed."

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/cluster/ClusterAutopauseSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/cluster/ClusterAutopauseSpec.scala
@@ -1,12 +1,11 @@
 package org.broadinstitute.dsde.workbench.leonardo.cluster
 
 import org.broadinstitute.dsde.workbench.auth.AuthToken
-import org.broadinstitute.dsde.workbench.leonardo.{ClusterFixtureSpec, ClusterStatus, GPAllocFixtureSpec, Leonardo, LeonardoTestUtils}
-import org.scalatest.time.{Minutes, Seconds, Span}
+import org.broadinstitute.dsde.workbench.leonardo.{ClusterStatus, GPAllocFixtureSpec, Leonardo, LeonardoTestUtils}
+import org.scalatest.time.{Seconds, Span}
 import org.scalatest.{DoNotDiscover, ParallelTestExecution}
 
 @DoNotDiscover
-//class ClusterAutopauseSpec extends ClusterFixtureSpec with LeonardoTestUtils {
 class ClusterAutopauseSpec extends GPAllocFixtureSpec with ParallelTestExecution with LeonardoTestUtils {
 
   implicit val ronToken: AuthToken = ronAuthToken

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/cluster/ClusterAutopauseSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/cluster/ClusterAutopauseSpec.scala
@@ -18,7 +18,7 @@ class ClusterAutopauseSpec extends ClusterFixtureSpec with LeonardoTestUtils {
       clusterRequest = defaultClusterRequest.copy(autopause = Some(true), autopauseThreshold = Some(1))
     )
 
-    eventually(timeout(Span(5, Minutes)), interval(Span(10, Seconds))) {
+    eventually(timeout(Span(90, Seconds)), interval(Span(10, Seconds))) {
       val cluster = Leonardo.cluster.get(clusterFixture.cluster.googleProject, clusterFixture.cluster.clusterName)
       cluster.autopauseThreshold shouldBe 1
       cluster.status shouldBe ClusterStatus.Stopping

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/cluster/ClusterAutopauseSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/cluster/ClusterAutopauseSpec.scala
@@ -1,0 +1,28 @@
+package org.broadinstitute.dsde.workbench.leonardo.cluster
+
+import org.broadinstitute.dsde.workbench.leonardo.{Cluster, ClusterFixtureSpec, ClusterStatus, Leonardo, LeonardoTestUtils}
+import org.scalatest.time.{Minutes, Seconds, Span}
+import org.scalatest.DoNotDiscover
+
+//@DoNotDiscover
+class ClusterAutopauseSpec extends ClusterFixtureSpec with LeonardoTestUtils {
+
+  "patch autopause then pause properly" in { clusterFixture =>
+    val x: Cluster = Leonardo.cluster.get(clusterFixture.cluster.googleProject, clusterFixture.cluster.clusterName)
+
+    logger.info(s"original autopause threshold: ${x.autopauseThreshold}")
+
+    Leonardo.cluster.update(
+      clusterFixture.cluster.googleProject,
+      clusterFixture.cluster.clusterName,
+      clusterRequest = defaultClusterRequest.copy(autopause = Some(true), autopauseThreshold = Some(1))
+    )
+
+    eventually(timeout(Span(2, Minutes)), interval(Span(30, Seconds))) {
+      val cluster = Leonardo.cluster.get(clusterFixture.cluster.googleProject, clusterFixture.cluster.clusterName)
+      cluster.autopauseThreshold shouldBe 1
+      cluster.status shouldBe ClusterStatus.Stopping
+    }
+
+  }
+}

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/cluster/ClusterAutopauseSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/cluster/ClusterAutopauseSpec.scala
@@ -1,16 +1,14 @@
 package org.broadinstitute.dsde.workbench.leonardo.cluster
 
-import org.broadinstitute.dsde.workbench.leonardo.{Cluster, ClusterFixtureSpec, ClusterStatus, Leonardo, LeonardoTestUtils}
+import org.broadinstitute.dsde.workbench.leonardo.{ClusterFixtureSpec, ClusterStatus, Leonardo, LeonardoTestUtils}
 import org.scalatest.time.{Minutes, Seconds, Span}
 import org.scalatest.DoNotDiscover
 
-//@DoNotDiscover
+@DoNotDiscover
 class ClusterAutopauseSpec extends ClusterFixtureSpec with LeonardoTestUtils {
 
   "patch autopause then pause properly" in { clusterFixture =>
-    val x: Cluster = Leonardo.cluster.get(clusterFixture.cluster.googleProject, clusterFixture.cluster.clusterName)
-
-    logger.info(s"original autopause threshold: ${x.autopauseThreshold}")
+    Leonardo.cluster.get(clusterFixture.cluster.googleProject, clusterFixture.cluster.clusterName).autopauseThreshold shouldBe 0
 
     Leonardo.cluster.update(
       clusterFixture.cluster.googleProject,
@@ -18,7 +16,7 @@ class ClusterAutopauseSpec extends ClusterFixtureSpec with LeonardoTestUtils {
       clusterRequest = defaultClusterRequest.copy(autopause = Some(true), autopauseThreshold = Some(1))
     )
 
-    eventually(timeout(Span(2, Minutes)), interval(Span(30, Seconds))) {
+    eventually(timeout(Span(5, Minutes)), interval(Span(10, Seconds))) {
       val cluster = Leonardo.cluster.get(clusterFixture.cluster.googleProject, clusterFixture.cluster.clusterName)
       cluster.autopauseThreshold shouldBe 1
       cluster.status shouldBe ClusterStatus.Stopping

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/cluster/ClusterAutopauseSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/cluster/ClusterAutopauseSpec.scala
@@ -8,7 +8,9 @@ import org.scalatest.DoNotDiscover
 class ClusterAutopauseSpec extends ClusterFixtureSpec with LeonardoTestUtils {
 
   "patch autopause then pause properly" in { clusterFixture =>
-    Leonardo.cluster.get(clusterFixture.cluster.googleProject, clusterFixture.cluster.clusterName).autopauseThreshold shouldBe 0
+    Leonardo.cluster
+      .get(clusterFixture.cluster.googleProject, clusterFixture.cluster.clusterName)
+      .autopauseThreshold shouldBe 0
 
     Leonardo.cluster.update(
       clusterFixture.cluster.googleProject,

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/package.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/package.scala
@@ -2,5 +2,6 @@ package org.broadinstitute.dsde.workbench
 
 package object leonardo {
   type LabelMap = Map[String, String]
+  //this value is the default for autopause, if none is specified. An autopauseThreshold of 0 indicates no autopause
   final val autoPauseOffValue = 0
 }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoService.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoService.scala
@@ -723,7 +723,7 @@ class LeonardoService(
         .toVector
     }
 
-  private def calculateAutopauseThreshold(autopause: Option[Boolean], autopauseThreshold: Option[Int]): Int =
+  private[service] def calculateAutopauseThreshold(autopause: Option[Boolean], autopauseThreshold: Option[Int]): Int =
     autopause match {
       case None =>
         autoFreezeConfig.autoFreezeAfter.toMinutes.toInt

--- a/http/src/test/resources/reference.conf
+++ b/http/src/test/resources/reference.conf
@@ -207,7 +207,6 @@ serviceAccounts {
 }
 
 autoFreeze {
-  #Change to true once auto freeze is ready for prod
   enableAutoFreeze = true
   dateAccessedMonitorScheduler = 1 second
   autoFreezeAfter = 15 minutes

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoServiceSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoServiceSpec.scala
@@ -1098,6 +1098,13 @@ class LeonardoServiceSpec
     dbFutureValue { clusterQuery.getClusterById(cluster.id) }.get.autopauseThreshold shouldBe 7
   }
 
+  it should "calculate autopause threshold properly" in {
+    leo.calculateAutopauseThreshold(None, None) shouldBe 0
+    leo.calculateAutopauseThreshold(Some(false), None) shouldBe autoPauseOffValue
+    leo.calculateAutopauseThreshold(Some(true), None) shouldBe autoFreezeConfig.autoFreezeAfter.toMinutes.toInt
+    leo.calculateAutopauseThreshold(Some(true), Some(30)) shouldBe Some(30)
+  }
+
   it should "update the master machine type for a cluster" in isolatedDbTest {
     // create the cluster
     val cluster =
@@ -1491,4 +1498,5 @@ class LeonardoServiceSpec
     val duplicateLabel = Map("_labels" -> "foo=bar,foo=biz")
     LeonardoService.processLabelMap(duplicateLabel) shouldBe (Right(Map("foo" -> "biz")))
   }
+
 }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoServiceSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoServiceSpec.scala
@@ -1099,10 +1099,10 @@ class LeonardoServiceSpec
   }
 
   it should "calculate autopause threshold properly" in {
-    leo.calculateAutopauseThreshold(None, None) shouldBe 0
+    leo.calculateAutopauseThreshold(None, None) shouldBe autoFreezeConfig.autoFreezeAfter.toMinutes.toInt
     leo.calculateAutopauseThreshold(Some(false), None) shouldBe autoPauseOffValue
     leo.calculateAutopauseThreshold(Some(true), None) shouldBe autoFreezeConfig.autoFreezeAfter.toMinutes.toInt
-    leo.calculateAutopauseThreshold(Some(true), Some(30)) shouldBe Some(30)
+    leo.calculateAutopauseThreshold(Some(true), Some(30)) shouldBe 30
   }
 
   it should "update the master machine type for a cluster" in isolatedDbTest {


### PR DESCRIPTION
- Add a test for autopause
- Modifies the save cluster log function to only attempt the save if the cluster is running, as it throws an exception otherwise