### PR TITLE
[no ticket] Handle GPAlloc failures better

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/ClusterFixtureSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/ClusterFixtureSpec.scala
@@ -121,12 +121,15 @@ abstract class ClusterFixtureSpec extends fixture.FreeSpec with BeforeAndAfterAl
     logger.info("beforeAll")
     if (!debug) {
       sys.props.get(gpallocProjectKey) match {
+        case Some(msg) if msg.startsWith(gpallocErrorPrefix) =>
+          clusterCreationFailureMsg = msg
         case Some(billingProject) =>
           Either.catchNonFatal(createRonCluster(GoogleProject(billingProject))).handleError { e =>
             clusterCreationFailureMsg = e.getMessage
             ronCluster = null
           }
-        case None => clusterCreationFailureMsg = "leonardo.billingProject system property is not set"
+        case None =>
+          clusterCreationFailureMsg = "leonardo.billingProject system property is not set"
       }
     }
 

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/cluster/ClusterAutopauseSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/cluster/ClusterAutopauseSpec.scala
@@ -11,7 +11,6 @@ class ClusterAutopauseSpec extends GPAllocFixtureSpec with ParallelTestExecution
   implicit val ronToken: AuthToken = ronAuthToken
 
   "autopause should work" in { billingProject =>
-
     val clusterName = randomClusterName
     val clusterRequest = defaultClusterRequest.copy(autopause = Some(true), autopauseThreshold = Some(1))
 


### PR DESCRIPTION
I noticed logs in tests like this:
```
[ScalaTest-9                             ] INFO  [o.b.d.w.l.Leonardo$      :create] - Create cluster: PUT /api/cluster/v2/Failed To Claim Project: {"causes":[],"message":"A resource of this type and name already exists","source":"sam","stackTrace":[],"statusCode":409}/automation-test-asuqwxq9z
```

It looks like it's interpolating a GPAlloc error message into a createCluster URL. This PR makes `ClusterFixtureSpec` fail when it encounters a GPAlloc error.

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
