### PR TITLE
IA-1672 only monitor cluster once it's been created in google

### DIFF
--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorSupervisor.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorSupervisor.scala
@@ -322,7 +322,7 @@ class ClusterMonitorSupervisor(
 
             case c if c.status == ClusterStatus.Updating => IO(self ! ClusterUpdated(c))
 
-            case c if c.status == ClusterStatus.Creating => IO(self ! ClusterCreated(c, c.stopAfterCreation))
+            case c if c.status == ClusterStatus.Creating && c.dataprocInfo.isDefined => IO(self ! ClusterCreated(c, c.stopAfterCreation))
 
             case c => IO(logger.warn(s"Unhandled status(${c.status}) in ClusterMonitorSupervisor"))
           }


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-1672

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
