### PR TITLE
Added PoC for hardening debian9 custom image via ansible playbook IA-1683

### DIFF
--- a/jenkins/dataproc-custom-images/deb9-CIS-playbook.yml
+++ b/jenkins/dataproc-custom-images/deb9-CIS-playbook.yml
@@ -1,0 +1,6 @@
+- name: Harden Server
+  hosts: localhost
+  become: yes
+
+  roles:
+    - Debian9-CIS

--- a/jenkins/dataproc-custom-images/prepare-custom-leonardo-jupyter-dataproc-image.sh
+++ b/jenkins/dataproc-custom-images/prepare-custom-leonardo-jupyter-dataproc-image.sh
@@ -38,6 +38,9 @@ docker_image_var_names="welder_server leonardo_jupyter terra_jupyter_base terra_
 # The version of python to install
 python_version="3.7.4"
 
+# The version of ansible to install
+ansible_version="2.7.0.0"
+
 #
 # Functions
 #
@@ -201,3 +204,17 @@ make install
 ldconfig
 python3 --version
 log "Finished installing Python $python_version"
+
+# Installing ansible
+log "Installing Ansible ${ansible_version:?} on the dataproc VM..."
+apt-get install -y python3-pip
+pip3 install paramiko
+pip3 install "ansible==${ansible_version}"
+
+# Install ansible role via ansible galaxy
+apt-get install -y git
+ansible-galaxy install -p roles -r requirements.yml
+
+# Run CIS hardening
+log "Running Ansible CIS hardening playbook in the Dataproc VM..."
+ansible-playbook deb9-cis-playbook.yml

--- a/jenkins/dataproc-custom-images/requirements.yml
+++ b/jenkins/dataproc-custom-images/requirements.yml
@@ -1,0 +1,1 @@
+- src: https://github.com/florianutz/Debian9-CIS.git


### PR DESCRIPTION
Modified ~/jenkins/dataproc-custom-images/ to include a CIS hardening ansible-playbook. Custom images generated from this script should be automatically configured to meet CIS benchmarks.

Related to https://broadworkbench.atlassian.net/browse/IA-1683.

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
