### PR TITLE
[QA-1037] Fix automation test `withNewNotebook` retries

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookTestUtils.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookTestUtils.scala
@@ -111,7 +111,7 @@ trait NotebookTestUtils extends LeonardoTestUtils {
           s"Cannot make new notebook on ${cluster.googleProject.value} / ${cluster.clusterName.string} for ${kernel}"
       )(30 seconds, 2 minutes) { () =>
         Future(
-          notebooksListPage.withNewNotebook(kernel, timeout) { notebookPage =>
+          notebooksListPage.open.withNewNotebook(kernel, timeout) { notebookPage =>
             val res = testCode(notebookPage)
             notebookPage.saveAndCheckpoint()
             res


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/QA-1037

We retry `withNewNotebook` calls in automation tests, but I don't think the retries are working.

It retries once:
```
10:47:14 [scala-execution-context-global-346      ] INFO  [w.l.n.NotebookRKernelSpec:applyOrElse] - Cannot make new notebook on gpalloc-qa-master-0nnbgna / automation-test-afrznwykz for RKernel: 4 retries remaining, retrying in 30 seconds
org.broadinstitute.dsde.workbench.leonardo.KernelNotReadyException: Jupyter kernel is NOT ready after waiting Timeout(Span(120, Seconds))
	at org.broadinstitute.dsde.workbench.leonardo.notebooks.NotebookPage.awaitReadyKernel(NotebookPage.scala:324)
	at org.broadinstitute.dsde.workbench.leonardo.notebooks.NotebooksListPage.withNewNotebook(NotebooksListPage.scala:89)
	at org.broadinstitute.dsde.workbench.leonardo.notebooks.NotebookTestUtils.$anonfun$withNewNotebook$4(NotebookTestUtils.scala:114)
```

But then the second try fails because the `notebooksListPage` is no longer visible:
```
10:49:44 [scala-execution-context-global-559      ] INFO  [w.l.n.NotebookRKernelSpec:applyOrElse] - Cannot make new notebook on gpalloc-qa-master-0nnbgna / automation-test-afrznwykz for RKernel: retries remain but predicate failed, not retrying
org.openqa.selenium.TimeoutException: Expected condition failed: waiting for org.broadinstitute.dsde.workbench.service.test.WebBrowserUtil$await$$anon$1@97c06e1 (tried for 120 second(s) with 500 milliseconds interval)
Build info: version: '3.141.59', revision: 'e82be7d358', time: '2018-11-14T08:17:03'
System info: host: '1726ac477929', ip: '172.18.0.8', os.name: 'Linux', os.arch: 'amd64', os.version: '3.10.0-862.3.3.el7.x86_64', java.version: '1.8.0_151'
Driver info: org.openqa.selenium.remote.RemoteWebDriver
Capabilities {acceptInsecureCerts: false, acceptSslCerts: false, applicationCacheEnabled: false, browserConnectionEnabled: false, browserName: chrome, chrome: {chromedriverVersion: 2.45.615279 (12b89733300bd2..., userDataDir: /tmp/.org.chromium.Chromium...}, cssSelectorsEnabled: true, databaseEnabled: false, goog:chromeOptions: {debuggerAddress: localhost:37981}, handlesAlerts: true, hasTouchScreen: false, javascriptEnabled: true, locationContextEnabled: true, mobileEmulationEnabled: false, nativeEvents: true, networkConnectionEnabled: false, pageLoadStrategy: normal, platform: LINUX, platformName: LINUX, proxy: Proxy(), rotatable: false, setWindowRect: true, strictFileInteractability: false, takesHeapSnapshot: true, takesScreenshot: true, timeouts: {implicit: 0, pageLoad: 300000, script: 30000}, unexpectedAlertBehaviour: ignore, unhandledPromptBehavior: ignore, version: 71.0.3578.98, webStorageEnabled: true, webdriver.remote.sessionid: 1c4e3f6a7bb2dc9aca80c892805...}
Session ID: 1c4e3f6a7bb2dc9aca80c892805428c1
	at org.openqa.selenium.support.ui.WebDriverWait.timeoutException(WebDriverWait.java:95)
	at org.openqa.selenium.support.ui.FluentWait.until(FluentWait.java:272)
	at org.broadinstitute.dsde.workbench.service.test.WebBrowserUtil$await$.withWaitForCondition(WebBrowserUtil.scala:156)
	at org.broadinstitute.dsde.workbench.service.test.WebBrowserUtil$await$.visible(WebBrowserUtil.scala:149)
	at org.broadinstitute.dsde.workbench.leonardo.notebooks.NotebooksListPage.$anonfun$withNewNotebook$1(NotebooksListPage.scala:82)
	at org.broadinstitute.dsde.workbench.service.test.WebBrowserUtil.switchToNewTab(WebBrowserUtil.scala:259)
```

This code makes it call `open` on `notebooksListPage` each retry so the state is hopefully reset.

Given time it'd be nice to refactor some of this code a bit, there's a mixture of patterns being used: `Future` and `retryUntilSuccessOrTimeout`, ScalaTest `eventually`, Selenium `await`, etc. It's probably kind of brittle. But the code as is seems to be working, hoping this will fix retries.



---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
