### PR TITLE
[IA-1703] ZombieMonitorActor causing CPU spikes

### DIFF
--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -170,7 +170,7 @@ jupyterConfig {
 
 zombieClusterMonitor {
   enableZombieClusterMonitor = true
-  pollPeriod = 30 minutes
+  pollPeriod = 6 hours
   creationHangTolerance = 1 hour
 }
 

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -170,7 +170,7 @@ jupyterConfig {
 
 zombieClusterMonitor {
   enableZombieClusterMonitor = true
-  pollPeriod = 6 hours
+  pollPeriod = 4 hours
   creationHangTolerance = 1 hour
 }
 

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -172,6 +172,7 @@ zombieClusterMonitor {
   enableZombieClusterMonitor = true
   pollPeriod = 4 hours
   creationHangTolerance = 1 hour
+  concurrency = 100
 }
 
 clusterToolMonitor {

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/Boot.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/Boot.scala
@@ -138,8 +138,7 @@ object Boot extends IOApp {
         system.actorOf(
           ZombieClusterMonitor.props(zombieClusterMonitorConfig,
                                      appDependencies.googleDataprocDAO,
-                                     appDependencies.googleProjectDAO,
-                                     appDependencies.dbReference)
+                                     appDependencies.googleProjectDAO)
         )
         system.actorOf(
           ClusterToolMonitor.props(clusterToolMonitorConfig,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
@@ -202,7 +202,8 @@ object Config {
     ZombieClusterConfig(
       config.getBoolean("enableZombieClusterMonitor"),
       toScalaDuration(config.getDuration("pollPeriod")),
-      toScalaDuration(config.getDuration("creationHangTolerance"))
+      toScalaDuration(config.getDuration("creationHangTolerance")),
+      config.getInt("concurrency")
     )
   }
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/ZombieClusterConfig.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/ZombieClusterConfig.scala
@@ -4,4 +4,5 @@ import scala.concurrent.duration.FiniteDuration
 
 case class ZombieClusterConfig(enableZombieClusterDetection: Boolean,
                                zombieCheckPeriod: FiniteDuration,
-                               creationHangTolerance: FiniteDuration)
+                               creationHangTolerance: FiniteDuration,
+                               concurrency: Int)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/ZombieMonitorQueries.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/ZombieMonitorQueries.scala
@@ -1,0 +1,32 @@
+package org.broadinstitute.dsde.workbench.leonardo.db
+
+import cats.data.Chain
+import cats.implicits._
+import org.broadinstitute.dsde.workbench.leonardo.AuditInfo
+import org.broadinstitute.dsde.workbench.leonardo.db.LeoProfile.api._
+import org.broadinstitute.dsde.workbench.leonardo.model.google.{ClusterName, ClusterStatus}
+import org.broadinstitute.dsde.workbench.model.google.GoogleProject
+import slick.dbio.DBIO
+
+import scala.concurrent.ExecutionContext
+
+object ZombieMonitorQueries {
+
+  def listZombieQuery(implicit ec: ExecutionContext): DBIO[Map[GoogleProject, Chain[PotentialZombieCluster]]] =
+    clusterQuery.filter { _.status inSetBind ClusterStatus.activeStatuses.map(_.toString) }.result.map { cs =>
+      cs.toList.foldMap { c =>
+        Map(
+          c.googleProject -> Chain(
+            PotentialZombieCluster(c.id, c.googleProject, c.clusterName, ClusterStatus.withName(c.status), c.auditInfo)
+          )
+        )
+      }
+    }
+
+}
+
+case class PotentialZombieCluster(id: Long,
+                                  googleProject: GoogleProject,
+                                  clusterName: ClusterName,
+                                  status: ClusterStatus,
+                                  auditInfo: AuditInfo)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/ZombieMonitorQueries.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/ZombieMonitorQueries.scala
@@ -25,8 +25,8 @@ object ZombieMonitorQueries {
 
 }
 
-case class PotentialZombieCluster(id: Long,
-                                  googleProject: GoogleProject,
-                                  clusterName: ClusterName,
-                                  status: ClusterStatus,
-                                  auditInfo: AuditInfo)
+final case class PotentialZombieCluster(id: Long,
+                                        googleProject: GoogleProject,
+                                        clusterName: ClusterName,
+                                        status: ClusterStatus,
+                                        auditInfo: AuditInfo)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorSupervisor.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorSupervisor.scala
@@ -322,7 +322,8 @@ class ClusterMonitorSupervisor(
 
             case c if c.status == ClusterStatus.Updating => IO(self ! ClusterUpdated(c))
 
-            case c if c.status == ClusterStatus.Creating && c.dataprocInfo.isDefined => IO(self ! ClusterCreated(c, c.stopAfterCreation))
+            case c if c.status == ClusterStatus.Creating && c.dataprocInfo.isDefined =>
+              IO(self ! ClusterCreated(c, c.stopAfterCreation))
 
             case c => IO(logger.warn(s"Unhandled status(${c.status}) in ClusterMonitorSupervisor"))
           }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ZombieClusterMonitor.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ZombieClusterMonitor.scala
@@ -47,7 +47,7 @@ class ZombieClusterMonitor(
     with Timers {
   import context._
 
-  val concurrency = 20
+  val concurrency = 100
 
   override def preStart(): Unit = {
     super.preStart()

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ZombieClusterMonitor.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ZombieClusterMonitor.scala
@@ -4,28 +4,29 @@ package monitor
 import java.time.{Duration, Instant}
 
 import akka.actor.{Actor, Props, Timers}
-import cats.effect.IO
+import cats.data.Chain
+import cats.effect.concurrent.Semaphore
+import cats.effect.{ContextShift, IO}
 import cats.implicits._
 import com.google.api.client.googleapis.json.GoogleJsonResponseException
-import com.typesafe.scalalogging.LazyLogging
+import io.chrisdavenport.log4cats.Logger
 import org.broadinstitute.dsde.workbench.google.GoogleProjectDAO
 import org.broadinstitute.dsde.workbench.leonardo.config.ZombieClusterConfig
 import org.broadinstitute.dsde.workbench.leonardo.dao.google.GoogleDataprocDAO
-import org.broadinstitute.dsde.workbench.leonardo.db.{clusterErrorQuery, clusterQuery, DbReference}
-import org.broadinstitute.dsde.workbench.leonardo.model.Cluster
+import org.broadinstitute.dsde.workbench.leonardo.db._
 import org.broadinstitute.dsde.workbench.leonardo.model.google.ClusterStatus
 import org.broadinstitute.dsde.workbench.leonardo.monitor.ZombieClusterMonitor._
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.broadinstitute.dsde.workbench.newrelic.NewRelicMetrics
 
-import scala.concurrent.Future
-
 object ZombieClusterMonitor {
 
-  def props(config: ZombieClusterConfig,
-            gdDAO: GoogleDataprocDAO,
-            googleProjectDAO: GoogleProjectDAO,
-            dbRef: DbReference[IO])(implicit metrics: NewRelicMetrics[IO]): Props =
+  def props(
+    config: ZombieClusterConfig,
+    gdDAO: GoogleDataprocDAO,
+    googleProjectDAO: GoogleProjectDAO,
+    dbRef: DbReference[IO]
+  )(implicit metrics: NewRelicMetrics[IO], cs: ContextShift[IO], logger: Logger[IO]): Props =
     Props(new ZombieClusterMonitor(config, gdDAO, googleProjectDAO, dbRef))
 
   sealed trait ZombieClusterMonitorMessage
@@ -36,14 +37,17 @@ object ZombieClusterMonitor {
 /**
  * This monitor periodically sweeps the Leo database and checks for clusters which no longer exist in Google.
  */
-class ZombieClusterMonitor(config: ZombieClusterConfig,
-                           gdDAO: GoogleDataprocDAO,
-                           googleProjectDAO: GoogleProjectDAO,
-                           dbRef: DbReference[IO])(implicit metrics: NewRelicMetrics[IO])
+class ZombieClusterMonitor(
+  config: ZombieClusterConfig,
+  gdDAO: GoogleDataprocDAO,
+  googleProjectDAO: GoogleProjectDAO,
+  dbRef: DbReference[IO]
+)(implicit metrics: NewRelicMetrics[IO], cs: ContextShift[IO], logger: Logger[IO])
     extends Actor
-    with Timers
-    with LazyLogging {
+    with Timers {
   import context._
+
+  val concurrency = 20
 
   override def preStart(): Unit = {
     super.preStart()
@@ -52,86 +56,92 @@ class ZombieClusterMonitor(config: ZombieClusterConfig,
 
   override def receive: Receive = {
     case DetectZombieClusters =>
-      val now = Instant.now()
-      // Get active clusters from the Leo DB, grouped by project
-      val zombieClusters = getActiveClustersFromDatabase.unsafeToFuture().flatMap { clusterMap =>
-        clusterMap.toList.flatTraverse {
+      (for {
+        now <- IO(Instant.now)
+        semaphore <- Semaphore[IO](concurrency)
+        // Get active clusters from the Leo DB, grouped by project
+        clusterMap <- getActiveClustersFromDatabase
+        _ <- logger.info(
+          s"Starting zombie detection across ${clusterMap.size} projects with concurrency of $concurrency"
+        )
+        zombies <- clusterMap.toList.parFlatTraverse {
           case (project, clusters) =>
-            // Check if the project is active
-            isProjectActiveInGoogle(project).flatMap {
-              case true =>
-                // If the project is active, check each individual cluster
-                logger.debug(s"Project ${project.value} containing ${clusters.size} clusters is active in Google")
-                clusters.toList.traverseFilter { cluster =>
-                  isClusterActiveInGoogle(cluster, now).map {
-                    case true =>
-                      logger.debug(s"Cluster ${cluster.projectNameString} is active in Google")
-                      None
-                    case false =>
-                      logger.info(s"Cluster ${cluster.projectNameString} is a zombie!")
-                      Some(cluster)
+            semaphore.withPermit(
+              // Check if the project is active
+              isProjectActiveInGoogle(project).flatMap {
+                case true =>
+                  // If the project is active, check each individual cluster
+                  clusters.toList.traverseFilter { cluster =>
+                    isClusterActiveInGoogle(cluster, now).map {
+                      case true  => None
+                      case false => Some(cluster)
+                    }
                   }
-                }
-              case false =>
-                // If the project is inactive, all clusters in the project are zombies
-                logger.debug(s"Project ${project.value} containing ${clusters.size} clusters is inactive in Google")
-                Future.successful(clusters.toList)
-            }
+                case false =>
+                  // If the project is inactive, all clusters in the project are zombies
+                  IO.pure(clusters.toList)
+              }
+            )
         }
-      }
-
-      // Error out each detected zombie cluster
-      zombieClusters.flatMap { cs =>
-        logger.info(s"Detected ${cs.size} zombie clusters across ${cs.map(_.googleProject).toSet.size} projects.")
-        cs.traverse { cluster =>
-          handleZombieCluster(cluster).unsafeToFuture()
-        }
-      }
-
+        _ <- logger.info(
+          s"Detected ${zombies.size} zombie clusters across ${zombies.map(_.googleProject).toSet.size} projects."
+        )
+        // Error out each detected zombie cluster
+        _ <- zombies.parTraverse(handleZombieCluster)
+      } yield ()).unsafeRunSync
   }
 
-  private def getActiveClustersFromDatabase: IO[Map[GoogleProject, Seq[Cluster]]] =
+  private def getActiveClustersFromDatabase: IO[Map[GoogleProject, Chain[PotentialZombieCluster]]] =
     dbRef.inTransaction {
-      clusterQuery.listActiveWithLabels.map { clusters =>
-        clusters.groupBy(_.googleProject)
-      }
+      ZombieMonitorQueries.listZombieQuery
     }
 
-  private def isProjectActiveInGoogle(googleProject: GoogleProject): Future[Boolean] =
+  private def isProjectActiveInGoogle(googleProject: GoogleProject): IO[Boolean] = {
     // Check the project and its billing info
-    (googleProjectDAO.isProjectActive(googleProject.value), googleProjectDAO.isBillingActive(googleProject.value))
-      .mapN(_ && _)
-      .recover {
-        //if we fail because of a permission error, we consider the cluster a zombie, as the permissions have been clean-up elsewhere
-        //this occurs in the case of free credits projects, which are managed elsewhere
-        case e: GoogleJsonResponseException if e.getStatusCode == 403 =>
-          logger.info(
-            s"Unable to check status of project ${googleProject.value} for zombie cluster detection due to a 403 from google. We are assuming this is a free credits project that has been cleaned up, and zombifying",
-            e
-          )
-          false
-        case e =>
-          logger.warn(s"Unable to check status of project ${googleProject.value} for zombie cluster detection", e)
-          true
-      }
+    val res = for {
+      isProjectActive <- IO.fromFuture(IO(googleProjectDAO.isProjectActive(googleProject.value)))
+      isBillingActive <- IO.fromFuture(IO(googleProjectDAO.isBillingActive(googleProject.value)))
+    } yield isProjectActive && isBillingActive
 
-  private def isClusterActiveInGoogle(cluster: Cluster, now: Instant): Future[Boolean] = {
+    res.recoverWith {
+      case e: GoogleJsonResponseException if e.getStatusCode == 403 =>
+        logger
+          .info(e)(
+            s"Unable to check status of project ${googleProject.value} for zombie cluster detection " +
+              s"due to a 403 from google. We are assuming this is a free credits project that has been cleaned up, and zombifying"
+          )
+          .as(false)
+
+      case e =>
+        logger
+          .warn(e)(s"Unable to check status of project ${googleProject.value} for zombie cluster detection")
+          .as(true)
+    }
+  }
+
+  private def isClusterActiveInGoogle(cluster: PotentialZombieCluster, now: Instant): IO[Boolean] = {
     val secondsSinceClusterCreation: Long = Duration.between(cluster.auditInfo.createdDate, now).getSeconds
     //this or'd with the google cluster status gives creating clusters a grace period before they are marked as zombies
-    val isWithinHangTolerance = cluster.status == ClusterStatus.Creating && secondsSinceClusterCreation < config.creationHangTolerance.toSeconds
-
-    gdDAO.getClusterStatus(cluster.googleProject, cluster.clusterName) map { clusterStatus =>
-      (ClusterStatus.activeStatuses contains clusterStatus) || isWithinHangTolerance
-    } recover {
-      case e =>
-        logger.warn(s"Unable to check status of cluster ${cluster.projectNameString} for zombie cluster detection", e)
-        true
+    if (cluster.status == ClusterStatus.Creating && secondsSinceClusterCreation < config.creationHangTolerance.toSeconds) {
+      IO.pure(true)
+    } else {
+      IO.fromFuture(IO(gdDAO.getClusterStatus(cluster.googleProject, cluster.clusterName)))
+        .map(ClusterStatus.activeStatuses contains)
+        .recoverWith {
+          case e =>
+            logger
+              .warn(e)(
+                s"Unable to check status of cluster ${cluster.googleProject} / ${cluster.clusterName} for zombie cluster detection"
+              )
+              .as(true)
+        }
     }
+
   }
 
-  private def handleZombieCluster(cluster: Cluster): IO[Unit] =
+  private def handleZombieCluster(cluster: PotentialZombieCluster): IO[Unit] =
     for {
-      _ <- IO(logger.info(s"Deleting zombie cluster: ${cluster.projectNameString}"))
+      _ <- logger.info(s"Deleting zombie cluster: ${cluster.googleProject} / ${cluster.clusterName}")
       _ <- metrics.incrementCounter("zombieClusters")
       now <- IO(Instant.now)
       _ <- dbRef.inTransaction {

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ZombieClusterMonitor.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ZombieClusterMonitor.scala
@@ -84,7 +84,7 @@ class ZombieClusterMonitor(
             )
         }
         _ <- logger.info(
-          s"Detected ${zombies.size} zombie clusters across ${zombies.map(_.googleProject).toSet.size} projects."
+          s"Detected ${zombies.size} zombie clusters in ${zombies.map(_.googleProject).toSet.size} projects."
         )
         // Error out each detected zombie cluster
         _ <- zombies.parTraverse(handleZombieCluster)

--- a/http/src/test/resources/reference.conf
+++ b/http/src/test/resources/reference.conf
@@ -222,6 +222,7 @@ zombieClusterMonitor {
   enableZombieClusterMonitor = true
   pollPeriod = 1 second
   creationHangTolerance = 9 second
+  concurrency = 100
 }
 
 clusterToolMonitor {

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriberSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriberSpec.scala
@@ -18,12 +18,21 @@ import org.broadinstitute.dsde.workbench.leonardo.ClusterEnrichments.clusterEq
 import org.broadinstitute.dsde.workbench.leonardo.CommonTestData._
 import org.broadinstitute.dsde.workbench.leonardo.dao.WelderDAO
 import org.broadinstitute.dsde.workbench.leonardo.dao.google.MockGoogleComputeDAO
-import org.broadinstitute.dsde.workbench.leonardo.db.{RuntimeConfigId, RuntimeConfigQueries, TestComponent, clusterQuery, followupQuery}
+import org.broadinstitute.dsde.workbench.leonardo.db.{
+  clusterQuery,
+  followupQuery,
+  RuntimeConfigId,
+  RuntimeConfigQueries,
+  TestComponent
+}
 import org.broadinstitute.dsde.workbench.leonardo.model.LeoAuthProvider
 import org.broadinstitute.dsde.workbench.leonardo.model.google.ClusterStatus
 import org.broadinstitute.dsde.workbench.leonardo.monitor.LeoPubsubCodec._
 import org.broadinstitute.dsde.workbench.leonardo.monitor.LeoPubsubMessage._
-import org.broadinstitute.dsde.workbench.leonardo.monitor.PubsubHandleMessageError.{ClusterInvalidState, ClusterNotStopped}
+import org.broadinstitute.dsde.workbench.leonardo.monitor.PubsubHandleMessageError.{
+  ClusterInvalidState,
+  ClusterNotStopped
+}
 import org.broadinstitute.dsde.workbench.leonardo.util.{BucketHelper, ClusterHelper, QueueFactory}
 import org.mockito.Mockito
 import org.scalatest.concurrent._

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ZombieClusterMonitorSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ZombieClusterMonitorSpec.scala
@@ -309,7 +309,7 @@ class ZombieClusterMonitorSpec
     googleProjectDAO: GoogleProjectDAO = new MockGoogleProjectDAO
   )(testCode: ActorRef => T): T = {
     val actor =
-      system.actorOf(ZombieClusterMonitor.props(zombieClusterConfig, gdDAO, googleProjectDAO, dbRef))
+      system.actorOf(ZombieClusterMonitor.props(zombieClusterConfig, gdDAO, googleProjectDAO))
     val testResult = Try(testCode(actor))
     // shut down the actor and wait for it to terminate
     testKit watch actor

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoServiceSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoServiceSpec.scala
@@ -1078,7 +1078,7 @@ class LeonardoServiceSpec
     // check that the cluster is stopped
     val dbCluster = dbFutureValue { clusterQuery.getClusterById(stoppedCluster.id) }
     dbCluster.map(_.status) shouldBe Some(ClusterStatus.Stopped)
-    
+
     val caught = the[ClusterCannotBeUpdatedException] thrownBy {
       leo
         .updateCluster(
@@ -1087,7 +1087,9 @@ class LeonardoServiceSpec
           stoppedCluster.clusterName,
           testClusterRequest.copy(
             runtimeConfig = Some(
-              RuntimeConfigRequest.DataprocConfig(numberOfWorkers = Some(2), masterMachineType = None, masterDiskSize = None)
+              RuntimeConfigRequest.DataprocConfig(numberOfWorkers = Some(2),
+                                                  masterMachineType = None,
+                                                  masterDiskSize = None)
             )
           )
         )

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/ClusterHelperSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/ClusterHelperSpec.scala
@@ -79,7 +79,8 @@ class ClusterHelperSpec
       .futureValue
 
   "ClusterHelper" should "create a google cluster" in isolatedDbTest {
-    val clusterCreationRes = clusterHelper.createCluster(testCluster.toCreateCluster(defaultRuntimeConfig, None)).unsafeToFuture().futureValue
+    val clusterCreationRes =
+      clusterHelper.createCluster(testCluster.toCreateCluster(defaultRuntimeConfig, None)).unsafeToFuture().futureValue
 
     // verify the mock dataproc DAO
     mockGoogleDataprocDAO.clusters.size shouldBe 1
@@ -116,7 +117,8 @@ class ClusterHelperSpec
           )
       )(testCluster)
 
-    val res = clusterHelper.createCluster(cluster.toCreateCluster(defaultRuntimeConfig, None)).unsafeToFuture().futureValue
+    val res =
+      clusterHelper.createCluster(cluster.toCreateCluster(defaultRuntimeConfig, None)).unsafeToFuture().futureValue
     res.customDataprocImage shouldBe Config.dataprocConfig.customDataprocImage
     val clusterWithLegacyImage = LeoLenses.clusterToClusterImages
       .modify(
@@ -129,7 +131,10 @@ class ClusterHelperSpec
       )(testCluster)
 
     val resForLegacyImage =
-      clusterHelper.createCluster(clusterWithLegacyImage.toCreateCluster(defaultRuntimeConfig, None)).unsafeToFuture().futureValue
+      clusterHelper
+        .createCluster(clusterWithLegacyImage.toCreateCluster(defaultRuntimeConfig, None))
+        .unsafeToFuture()
+        .futureValue
 
     resForLegacyImage.customDataprocImage shouldBe Config.dataprocConfig.legacyCustomDataprocImage
   }
@@ -154,7 +159,11 @@ class ClusterHelperSpec
                                                  blocker)
 
     val exception =
-      erroredClusterHelper.createCluster(testCluster.toCreateCluster(defaultRuntimeConfig, None)).unsafeToFuture().failed.futureValue
+      erroredClusterHelper
+        .createCluster(testCluster.toCreateCluster(defaultRuntimeConfig, None))
+        .unsafeToFuture()
+        .failed
+        .futureValue
     exception shouldBe a[GoogleJsonResponseException]
 
     // verify Google DAOs have been cleaned up
@@ -186,7 +195,11 @@ class ClusterHelperSpec
                                                  blocker)
 
     val exception =
-      erroredClusterHelper.createCluster(testCluster.toCreateCluster(defaultRuntimeConfig, None)).unsafeToFuture().failed.futureValue
+      erroredClusterHelper
+        .createCluster(testCluster.toCreateCluster(defaultRuntimeConfig, None))
+        .unsafeToFuture()
+        .failed
+        .futureValue
     exception shouldBe a[GoogleJsonResponseException]
 
     erroredDataprocDAO.invocationCount shouldBe 7
@@ -267,7 +280,11 @@ class ClusterHelperSpec
                                                  blocker)
 
     val exception =
-      erroredClusterHelper.createCluster(testCluster.toCreateCluster(defaultRuntimeConfig, None)).unsafeToFuture().failed.futureValue
+      erroredClusterHelper
+        .createCluster(testCluster.toCreateCluster(defaultRuntimeConfig, None))
+        .unsafeToFuture()
+        .failed
+        .futureValue
     exception shouldBe a[GoogleJsonResponseException]
 
     erroredIamDAO.invocationCount should be > 2
@@ -275,7 +292,9 @@ class ClusterHelperSpec
 
   it should "calculate cluster resource constraints" in isolatedDbTest {
     val runtimeConfig = RuntimeConfig.DataprocConfig(0, "", 500)
-    val resourceConstraints = clusterHelper.getClusterResourceContraints(testClusterClusterProjectAndName, runtimeConfig.machineType).unsafeRunSync()
+    val resourceConstraints = clusterHelper
+      .getClusterResourceContraints(testClusterClusterProjectAndName, runtimeConfig.machineType)
+      .unsafeRunSync()
 
     // 7680m (in mock compute dao) - 6g (dataproc allocated) - 512m (welder allocated) = 1024m
     resourceConstraints.memoryLimit shouldBe MemorySize.fromMb(1024)


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-1703

This PR does 3 things:
1. Makes `ZombieMonitorActor` query for only the fields it needs (previously it was joining to labels)
2. Decrease zombie detection frequency from 30 mins to 4 hours
3. Make `ZombieMonitorActor` use `IO` instead of `Future` and use a `Semaphore` to control concurrency

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
