### PR TITLE
[No ticket] Jc jira readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,6 @@ If you would like to see what we are working you can visit our [active sprint](h
 
 Swagger API documentation: https://notebooks.firecloud.org/
 
-## Configurability
-
-Documentation on how to configure Leo is Coming Soon™. Until then, a brief overview: there are two points at which Leonardo is pluggable.
-
 ### Authorization provider
 
 Leo provides two modes of authorization out of the box:

--- a/README.md
+++ b/README.md
@@ -10,9 +10,6 @@ If you would like to see what we are working you can visit our [active sprint](h
 
 Swagger API documentation: https://notebooks.firecloud.org/
 
-## Project status
-This project is under active development. It is not yet ready for independent production deployment. See the [roadmap](https://github.com/DataBiosphere/leonardo/wiki#roadmap) section of the wiki for details.
-
 ## Configurability
 
 Documentation on how to configure Leo is Coming Soon™. Until then, a brief overview: there are two points at which Leonardo is pluggable.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Leo provisions Spark clusters through [Google Dataproc](https://cloud.google.com
 
 For more information and an overview, see the [wiki](https://github.com/broadinstitute/leonardo/wiki).
 
+If you would like to see what we are working you can visit our [active sprint](https://broadworkbench.atlassian.net/secure/RapidBoard.jspa?rapidView=35&projectKey=IA) or our [backlog](https://broadworkbench.atlassian.net/secure/RapidBoard.jspa?rapidView=35&projectKey=IA&view=planning&selectedIssue=IA-1753&epics=visible&issueLimit=100&selectedEpic=IA-1715) on JIRA. You will need to set-up an account, but it is open to the public.
+
 Swagger API documentation: https://notebooks.firecloud.org/
 
 ## Project status

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Leo provisions Spark clusters through [Google Dataproc](https://cloud.google.com
 
 For more information and an overview, see the [wiki](https://github.com/broadinstitute/leonardo/wiki).
 
-If you would like to see what we are working you can visit our [active sprint](https://broadworkbench.atlassian.net/secure/RapidBoard.jspa?rapidView=35&projectKey=IA) or our [backlog](https://broadworkbench.atlassian.net/secure/RapidBoard.jspa?rapidView=35&projectKey=IA&view=planning&selectedIssue=IA-1753&epics=visible&issueLimit=100&selectedEpic=IA-1715) on JIRA. You will need to set-up an account, but it is open to the public.
+We use JIRA instead of the issues page on Github. If you would like to see what we are working you can visit our [active sprint](https://broadworkbench.atlassian.net/secure/RapidBoard.jspa?rapidView=35&projectKey=IA) or our [backlog](https://broadworkbench.atlassian.net/secure/RapidBoard.jspa?rapidView=35&projectKey=IA&view=planning&selectedIssue=IA-1753&epics=visible&issueLimit=100&selectedEpic=IA-1715) on JIRA. You will need to set-up an account, but it is open to the public.
 
 Swagger API documentation: https://notebooks.firecloud.org/
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Leo provisions Spark clusters through [Google Dataproc](https://cloud.google.com
 
 For more information and an overview, see the [wiki](https://github.com/broadinstitute/leonardo/wiki).
 
-We use JIRA instead of the issues page on Github. If you would like to see what we are working you can visit our [active sprint](https://broadworkbench.atlassian.net/secure/RapidBoard.jspa?rapidView=35&projectKey=IA) or our [backlog](https://broadworkbench.atlassian.net/secure/RapidBoard.jspa?rapidView=35&projectKey=IA&view=planning&selectedIssue=IA-1753&epics=visible&issueLimit=100&selectedEpic=IA-1715) on JIRA. You will need to set-up an account, but it is open to the public.
+We use JIRA instead of the issues page on Github. If you would like to see what we are working you can visit our [active sprint](https://broadworkbench.atlassian.net/secure/RapidBoard.jspa?rapidView=35&projectKey=IA) or our [backlog](https://broadworkbench.atlassian.net/secure/RapidBoard.jspa?rapidView=35&projectKey=IA&view=planning&selectedIssue=IA-1753&epics=visible&issueLimit=100&selectedEpic=IA-1715) on JIRA. You will need to set-up an account to access, but it is open to the public.
 
 Swagger API documentation: https://notebooks.firecloud.org/
 


### PR DESCRIPTION
Updating the readme to reference our JIRA page for issues, and cleaning up some old comments.

Not sure if there is a better place to link to the swagger, since our current link is the old swagger and we have a goal to deprecate it @Qi77Qi. It may be best to just link to the .yaml file in the repo, since I don't know if its a good idea to post links to any services we are running on an open source readme