### PR TITLE
IA-1777 use different encoder for responses

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/JsonCodec.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/JsonCodec.scala
@@ -37,6 +37,7 @@ object JsonCodec {
   implicit val machineTypeEncoder: Encoder[MachineTypeName] = Encoder.encodeString.contramap(_.value)
   implicit val cloudServiceEncoder: Encoder[CloudService] = Encoder.encodeString.contramap(_.asString)
   implicit val runtimeNameEncoder: Encoder[RuntimeName] = Encoder.encodeString.contramap(_.asString)
+  implicit val urlEncoder: Encoder[URL] = Encoder.encodeString.contramap(_.toString)
   implicit val dataprocConfigEncoder: Encoder[RuntimeConfig.DataprocConfig] = Encoder.forProduct8(
     "numberOfWorkers",
     "masterMachineType",
@@ -107,11 +108,15 @@ object JsonCodec {
   )(x => DefaultLabels.unapply(x).get)
   implicit val asyncRuntimeFieldsEncoder: Encoder[AsyncRuntimeFields] =
     Encoder.forProduct4("googleId", "operationName", "stagingBucket", "hostIp")(x => AsyncRuntimeFields.unapply(x).get)
-
   implicit val clusterProjectAndNameEncoder: Encoder[RuntimeProjectAndName] = Encoder.forProduct2(
     "googleProject",
     "clusterName"
   )(x => RuntimeProjectAndName.unapply(x).get)
+  implicit val runtimeErrorEncoder: Encoder[RuntimeError] = Encoder.forProduct3(
+    "errorMessage",
+    "errorCode",
+    "timestamp"
+  )(x => RuntimeError.unapply(x).get)
 
   // Decoders
   implicit val operationNameDecoder: Decoder[OperationName] = Decoder.decodeString.map(OperationName)

--- a/http/src/main/resources/swagger/api-docs.yaml
+++ b/http/src/main/resources/swagger/api-docs.yaml
@@ -161,7 +161,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: "#/components/schemas/ListClusterResponse"
+                  $ref: "#/components/schemas/ListRuntimeResponse"
         "400":
           description: Bad Request
           content:
@@ -207,7 +207,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Cluster"
+                $ref: "#/components/schemas/GetRuntimeResponse"
         "403":
           description: User does not have permission to perform action on runtime
         "404":
@@ -1528,6 +1528,61 @@ components:
         customClusterEnvironmentVariables:
           type: object
           description: Optional environment variables to be set on the cluster.
+    GetRuntimeResponse:
+      description: ""
+      required:
+        - id
+        - runtimeName
+        - googleProject
+        - serviceAccount
+        - runtimeConfig
+        - status
+        - labels
+        - autopauseThreshold
+        - defaultClientId
+        - scopes
+      properties:
+        id:
+          type: string
+          description: The internally-referenced ID of the cluster
+        runtimeName:
+          type: string
+          description: The user-supplied name for the cluster
+        googleProject:
+          type: string
+          description: The Google Project used to create the cluster
+        serviceAccount:
+          type: string
+          description: The Google Service Account used to create the cluster
+        runtimeConfig:
+          $ref: "#/components/schemas/MachineConfig"
+        status:
+          $ref: "#/components/schemas/ClusterStatus"
+        labels:
+          type: object
+          description: The labels to be placed on the cluster. Of type Map[String,String]
+        errors:
+          type: array
+          description: The list of errors that were encountered on cluster create. Each
+            error consists of the error message, code and timestamp
+          items:
+            $ref: "#/components/schemas/ClusterError"
+        autopauseThreshold:
+          type: integer
+          description: The number of minutes of idle time to elapse before the cluster is
+            autopaused. A value of 0 is equivalent to autopause being turned
+            off.
+        defaultClientId:
+          type: string
+          description: The default Google Client ID.
+        scopes:
+          type: array
+          items:
+            type: string
+          description: The scopes for the cluster.
+        customEnvironmentVariables:
+          type: object
+          description: Optional environment variables to be set on the cluster.
     ListClusterResponse:
       description: ""
       required:
@@ -1587,6 +1642,50 @@ components:
             The date and time the cluster was last accessed, in ISO-8601 format.
 
             Date accessed is defined as the last time the cluster was created, modified, or accessed via the proxy.
+        autopauseThreshold:
+          type: integer
+          description: The number of minutes of idle time to elapse before the cluster is
+            autopaused. A value of 0 is equivalent to autopause being turned
+            off.
+        jupyterUserScriptUri:
+          type: string
+        defaultClientId:
+          type: string
+          description: The default Google Client ID.
+    ListRuntimeResponse:
+      description: ""
+      required:
+        - runtimeName
+        - googleProject
+        - serviceAccount
+        - machineConfig
+        - status
+        - labels
+        - autopauseThreshold
+        - defaultClientId
+      properties:
+        internalId:
+          type: string
+          description: Internal resource ID of the cluster
+        runtimeName:
+          type: string
+          description: The user-supplied name for the cluster
+        googleId:
+          type: string
+          description: Google's UUID for the cluster
+        googleProject:
+          type: string
+          description: The Google Project used to create the cluster
+        serviceAccount:
+          type: string
+          description: The Google Service Account used to create the cluster
+        runtimeConfig:
+          $ref: "#/components/schemas/MachineConfig"
+        status:
+          $ref: "#/components/schemas/ClusterStatus"
+        labels:
+          type: object
+          description: The labels to be placed on the cluster. Of type Map[String,String]
         autopauseThreshold:
           type: integer
           description: The number of minutes of idle time to elapse before the cluster is

--- a/http/src/main/resources/swagger/api-docs.yaml
+++ b/http/src/main/resources/swagger/api-docs.yaml
@@ -1544,32 +1544,32 @@ components:
       properties:
         id:
           type: string
-          description: The internally-referenced ID of the cluster
+          description: The internally-referenced ID of the runtime
         runtimeName:
           type: string
-          description: The user-supplied name for the cluster
+          description: The user-supplied name for the runtime
         googleProject:
           type: string
-          description: The Google Project used to create the cluster
+          description: The Google Project used to create the runtime
         serviceAccount:
           type: string
-          description: The Google Service Account used to create the cluster
+          description: The Google Service Account used to create the runtime
         runtimeConfig:
           $ref: "#/components/schemas/MachineConfig"
         status:
           $ref: "#/components/schemas/ClusterStatus"
         labels:
           type: object
-          description: The labels to be placed on the cluster. Of type Map[String,String]
+          description: The labels to be placed on the runtime. Of type Map[String,String]
         errors:
           type: array
-          description: The list of errors that were encountered on cluster create. Each
+          description: The list of errors that were encountered on runtime create. Each
             error consists of the error message, code and timestamp
           items:
             $ref: "#/components/schemas/ClusterError"
         autopauseThreshold:
           type: integer
-          description: The number of minutes of idle time to elapse before the cluster is
+          description: The number of minutes of idle time to elapse before the runtime is
             autopaused. A value of 0 is equivalent to autopause being turned
             off.
         defaultClientId:
@@ -1579,10 +1579,10 @@ components:
           type: array
           items:
             type: string
-          description: The scopes for the cluster.
+          description: The scopes for the runtime.
         customEnvironmentVariables:
           type: object
-          description: Optional environment variables to be set on the cluster.
+          description: Optional environment variables to be set on the runtime.
     ListClusterResponse:
       description: ""
       required:
@@ -1666,29 +1666,29 @@ components:
       properties:
         internalId:
           type: string
-          description: Internal resource ID of the cluster
+          description: Internal resource ID of the runtime
         runtimeName:
           type: string
-          description: The user-supplied name for the cluster
+          description: The user-supplied name for the runtime
         googleId:
           type: string
           description: Google's UUID for the cluster
         googleProject:
           type: string
-          description: The Google Project used to create the cluster
+          description: The Google Project used to create the runtime
         serviceAccount:
           type: string
-          description: The Google Service Account used to create the cluster
+          description: The Google Service Account used to create the runtime
         runtimeConfig:
           $ref: "#/components/schemas/MachineConfig"
         status:
           $ref: "#/components/schemas/ClusterStatus"
         labels:
           type: object
-          description: The labels to be placed on the cluster. Of type Map[String,String]
+          description: The labels to be placed on the runtime. Of type Map[String,String]
         autopauseThreshold:
           type: integer
-          description: The number of minutes of idle time to elapse before the cluster is
+          description: The number of minutes of idle time to elapse before the runtime is
             autopaused. A value of 0 is equivalent to autopause being turned
             off.
         jupyterUserScriptUri:

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/RuntimeRoutes.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/RuntimeRoutes.scala
@@ -5,7 +5,6 @@ package api
 import _root_.java.time.Instant
 import java.util.UUID
 
-import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
 import akka.http.scaladsl.marshalling.ToResponseMarshallable
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.server
@@ -13,14 +12,18 @@ import akka.http.scaladsl.server.Directives._
 import cats.effect.{IO, Timer}
 import cats.mtl.ApplicativeAsk
 import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
-import io.circe.Decoder
+import io.circe.{Decoder, Encoder}
 import org.broadinstitute.dsde.workbench.leonardo.JsonCodec._
 import org.broadinstitute.dsde.workbench.leonardo.api.CookieSupport
 import org.broadinstitute.dsde.workbench.leonardo.http.api.LeoRoutes.validateRuntimeNameDirective
 import org.broadinstitute.dsde.workbench.leonardo.http.api.LeoRoutesJsonCodec.dataprocConfigDecoder
-import org.broadinstitute.dsde.workbench.leonardo.http.api.LeoRoutesSprayJsonCodec._
 import org.broadinstitute.dsde.workbench.leonardo.http.api.RuntimeRoutes._
-import org.broadinstitute.dsde.workbench.leonardo.http.service.{RuntimeConfigRequest, RuntimeService}
+import org.broadinstitute.dsde.workbench.leonardo.http.service.{
+  GetRuntimeResponse,
+  ListRuntimeResponse,
+  RuntimeConfigRequest,
+  RuntimeService
+}
 import org.broadinstitute.dsde.workbench.model.google.{GcsPath, GoogleProject}
 import org.broadinstitute.dsde.workbench.model.{TraceId, UserInfo}
 
@@ -250,6 +253,89 @@ object RuntimeRoutes {
       c.getOrElse(Map.empty)
     )
   }
+
+  //TODO: add `dataprocInstances` when it's added to `RuntimeConfig` https://broadworkbench.atlassian.net/browse/IA-1778
+  implicit val getRuntimeResponseEncoder: Encoder[GetRuntimeResponse] = Encoder.forProduct20(
+    "id",
+    "runtimeName",
+    "googleProject",
+    "serviceAccount",
+    "asyncRuntimeFields",
+    "auditInfo",
+    "runtimeConfig",
+    "proxyUrl",
+    "status",
+    "labels",
+    "jupyterExtensionUri",
+    "jupyterUserScriptUri",
+    "jupyterStartUserScriptUri",
+    "errors",
+    "userJupyterExtensionConfig",
+    "autopauseThreshold",
+    "defaultClientId",
+    "runtimeImages",
+    "scopes",
+    "customEnvironmentVariables"
+  )(
+    x =>
+      (
+        x.id,
+        x.clusterName,
+        x.googleProject,
+        x.serviceAccountInfo.clusterServiceAccount.get,
+        x.asyncRuntimeFields,
+        x.auditInfo,
+        x.runtimeConfig,
+        x.clusterUrl,
+        x.status,
+        x.labels,
+        x.jupyterExtensionUri,
+        x.jupyterUserScriptUri,
+        x.jupyterStartUserScriptUri,
+        x.errors,
+        x.userJupyterExtensionConfig,
+        x.autopauseThreshold,
+        x.defaultClientId,
+        x.clusterImages,
+        x.scopes,
+        x.customClusterEnvironmentVariables
+      )
+  )
+
+  implicit val listRuntimeResponseEncoder: Encoder[ListRuntimeResponse] = Encoder.forProduct14(
+    "id",
+    "runtimeName",
+    "googleProject",
+    "serviceAccount",
+    "asyncRuntimeFields",
+    "auditInfo",
+    "runtimeConfig",
+    "proxyUrl",
+    "status",
+    "labels",
+    "jupyterExtensionUri",
+    "jupyterUserScriptUri",
+    "autopauseThreshold",
+    "defaultClientId"
+  )(
+    x =>
+      (
+        x.id,
+        x.clusterName,
+        x.googleProject,
+        x.serviceAccountInfo.clusterServiceAccount.get,
+        x.asyncRuntimeFields,
+        x.auditInfo,
+        x.machineConfig,
+        x.clusterUrl,
+        x.status,
+        x.labels,
+        x.jupyterExtensionUri,
+        x.jupyterUserScriptUri,
+        x.autopauseThreshold,
+        x.defaultClientId
+      )
+  )
 }
 
 final case class RuntimeServiceContext(traceId: TraceId, now: Instant)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/RuntimeRoutes.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/RuntimeRoutes.scala
@@ -254,7 +254,8 @@ object RuntimeRoutes {
     )
   }
 
-  //TODO: add `dataprocInstances` when it's added to `RuntimeConfig` https://broadworkbench.atlassian.net/browse/IA-1778
+  // we're reusing same `GetRuntimeResponse` in LeonardoService.scala as well, but we don't want to encode this object the same way the legacy
+  // API does
   implicit val getRuntimeResponseEncoder: Encoder[GetRuntimeResponse] = Encoder.forProduct20(
     "id",
     "runtimeName",
@@ -302,6 +303,8 @@ object RuntimeRoutes {
       )
   )
 
+  // we're reusing same `GetRuntimeResponse` in LeonardoService.scala as well, but we don't want to encode this object the same way the legacy
+  // API does
   implicit val listRuntimeResponseEncoder: Encoder[ListRuntimeResponse] = Encoder.forProduct14(
     "id",
     "runtimeName",


### PR DESCRIPTION
Notice `cluster` is being used in get/list runtime apis when working with Wilson on automation test. Hence created https://broadworkbench.atlassian.net/browse/IA-1777

Use different encoder for `GetRuntimeResponse` and `ListRuntimeResponse` in runtime routes so that we're not returning fields like `clusterName`.

What's in swagger doc is not a complete list of what we return currently. It should be easy to add those additional fields if we need to.

for `dataprocInstances` field previously returned in `getClusterResponse`, I'm leaving it out in new route's encoder because I'd like to refactor `Instance` table to reference `RuntimeConfig` table instead of `Cluster`. And we can add `dataprocInstances` in `runtimeConfig` field once that's done.

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
