### PR TITLE
[no ticket] Remove unused field from config

### DIFF
--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -74,7 +74,6 @@ vpc {
     # Allows Leonardo proxy traffic on port 443
     {
       name = "leonardo-allow-https"
-      network = ${vpc.networkName}
       sourceRanges = ["0.0.0.0/0"]
       allowed = [
         {
@@ -87,7 +86,6 @@ vpc {
     # This is a requirement for Dataproc nodes to be able to communicate with each other within a cluster.
     {
       name = "leonardo-allow-internal"
-      network = ${vpc.networkName}
       sourceRanges = ["10.1.0.0/20"]
       allowed = [
         {
@@ -107,7 +105,6 @@ vpc {
     # IP list obtained from https://docs.google.com/document/d/1adV0LC2f_GIpl3A1AeoQuNiwcP59NToIt6VYT3xRCkU/edit
     {
       name = "leonardo-allow-broad-ssh"
-      network = ${vpc.networkName}
       sourceRanges= ["69.173.112.0/21", "69.173.127.232/29", "69.173.127.128/26", "69.173.127.0/25", "69.173.127.240/28", "69.173.127.224/30", "69.173.127.230/31", "69.173.120.0/22", "69.173.127.228/32", "69.173.126.0/24", "69.173.96.0/20", "69.173.64.0/19", "69.173.127.192/27", "69.173.124.0/23"]
       allowed = [
         {

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
@@ -101,7 +101,6 @@ object Config {
   implicit val firewallRuleConfigReader: ValueReader[FirewallRuleConfig] = ValueReader.relative { config =>
     FirewallRuleConfig(
       config.as[FirewallRuleName]("name"),
-      config.as[NetworkName]("network"),
       config.as[List[IpRange]]("sourceRanges"),
       config.as[List[Allowed]]("allowed")
     )

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/VPCConfig.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/VPCConfig.scala
@@ -18,10 +18,7 @@ final case class VPCConfig(highSecurityProjectNetworkLabel: NetworkLabel,
                            pollPeriod: FiniteDuration,
                            maxAttempts: Int)
 
-final case class FirewallRuleConfig(name: FirewallRuleName,
-                                    network: NetworkName,
-                                    sourceRanges: List[IpRange],
-                                    allowed: List[Allowed])
+final case class FirewallRuleConfig(name: FirewallRuleName, sourceRanges: List[IpRange], allowed: List[Allowed])
 
 final case class Allowed(protocol: String, port: Option[String])
 

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/VPCInterpreterSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/VPCInterpreterSpec.scala
@@ -72,7 +72,7 @@ class VPCInterpreterSpec extends FlatSpecLike with LeonardoTestSuite {
     vpcConfig.firewallsToAdd.foreach { fwConfig =>
       val fw = computeService.firewallMap.get(fwConfig.name)
       fw shouldBe 'defined
-      fw.get.getNetwork shouldBe s"projects/${project.value}/global/networks/${fwConfig.network.value}"
+      fw.get.getNetwork shouldBe s"projects/${project.value}/global/networks/${vpcConfig.networkName.value}"
       fw.get.getTargetTagsList.asScala shouldBe List(vpcConfig.networkTag.value)
       fw.get.getAllowedList.asScala.map(_.getIPProtocol).toSet shouldBe fwConfig.allowed.map(_.protocol).toSet
       fw.get.getAllowedList.asScala.flatMap(_.getPortsList.asScala).toSet shouldBe fwConfig.allowed


### PR DESCRIPTION
I just realized that the `FirewallConfig.network` field is not actually used because the network is specified in the top-level `VPCConfig`. This PR just removes the unused field.

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
