### PR TITLE
[no ticket] Fix GCE resume by removing unneeded metadata entry

### DIFF
--- a/docker/build.sh
+++ b/docker/build.sh
@@ -151,14 +151,14 @@ function make_jar()
     GIT_HASH=$(git log -n 1 --pretty=format:%h)
 
     # Make jar & cache sbt dependencies.
+    EXIT_CODE=0
     docker run --rm --link $DB_CONTAINER:mysql \
                           -e GIT_HASH=$GIT_HASH \
                           -v $PWD:/working \
                           -v jar-cache:/root/.ivy \
                           -v jar-cache:/root/.ivy2 \
                           broadinstitute/scala-baseimage \
-                          /working/docker/install.sh /working
-    EXIT_CODE=$?
+                          /working/docker/install.sh /working || EXIT_CODE=$?
 
     # stop test db
     bash ./docker/run-mysql.sh stop ${TARGET} ${DB_CONTAINER}

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -151,13 +151,13 @@ function make_jar()
     GIT_HASH=$(git log -n 1 --pretty=format:%h)
 
     # Make jar & cache sbt dependencies.
-    JAR_CMD="$(docker run --rm --link $DB_CONTAINER:mysql \
+    docker run --rm --link $DB_CONTAINER:mysql \
                           -e GIT_HASH=$GIT_HASH \
                           -v $PWD:/working \
                           -v jar-cache:/root/.ivy \
                           -v jar-cache:/root/.ivy2 \
                           broadinstitute/scala-baseimage \
-                          /working/docker/install.sh /working)"
+                          /working/docker/install.sh /working
     EXIT_CODE=$?
 
     # stop test db

--- a/docker/install.sh
+++ b/docker/install.sh
@@ -7,9 +7,7 @@ cd $LEONARDO_DIR
 rm -f leonardo*.jar
 
 # Test
-export SBT_OPTS="-Dmysql.host=mysql -Dmysql.port=3306"
-sbt -J-Xms6g -J-Xmx6g -J-XX:MaxMetaspaceSize=1g "project http" test
-sbt -J-Xms6g -J-Xmx6g -J-XX:MaxMetaspaceSize=1g "project http" assembly
+SBT_OPTS="-Dmysql.host=mysql -Dmysql.port=3306" sbt -J-Xms6g -J-Xmx6g -J-XX:MaxMetaspaceSize=1g "project http" clean test assembly
 LEONARDO_JAR=$(find http/target | grep 'http-assembly.*\.jar')
 
 # new generated jar name starts with `http`, but renaming it to `leonardo*.jar`

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -115,7 +115,7 @@ vpc {
     }
   ]
   # Remove RDP and SSH rules in the default network. Also remove legacy leonardo-notebooks-rule if it exists.
-  firewallsToRemove = ["default-allow-rdp", "default-allow-ssh", "leonardo-notebooks-rule"]
+  firewallsToRemove = ["default-allow-rdp"]
   pollPeriod = 5 seconds
   maxAttempts = 24 # 2 minutes
 }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GceInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GceInterpreter.scala
@@ -205,6 +205,11 @@ class GceInterpreter[F[_]: Async: Parallel: ContextShift: Logger](
                                                     config.gceConfig.zoneName,
                                                     InstanceName(runtime.runtimeName.asString),
                                                     metadata)
+      // remove the startup-script-url metadata entry if present which is only used at creation time
+      _ <- googleComputeService.removeInstanceMetadata(runtime.googleProject,
+                                                       config.gceConfig.zoneName,
+                                                       InstanceName(runtime.runtimeName.asString),
+                                                       Set("startup-script-url"))
       _ <- googleComputeService.startInstance(runtime.googleProject,
                                               config.gceConfig.zoneName,
                                               InstanceName(runtime.runtimeName.asString))

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GceInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GceInterpreter.scala
@@ -201,15 +201,14 @@ class GceInterpreter[F[_]: Async: Parallel: ContextShift: Logger](
   ): F[Unit] =
     for {
       metadata <- getStartupScript(runtime, welderAction, blocker)
-      _ <- googleComputeService.addInstanceMetadata(runtime.googleProject,
-                                                    config.gceConfig.zoneName,
-                                                    InstanceName(runtime.runtimeName.asString),
-                                                    metadata)
       // remove the startup-script-url metadata entry if present which is only used at creation time
-      _ <- googleComputeService.removeInstanceMetadata(runtime.googleProject,
-                                                       config.gceConfig.zoneName,
-                                                       InstanceName(runtime.runtimeName.asString),
-                                                       Set("startup-script-url"))
+      _ <- googleComputeService.modifyInstanceMetadata(
+        runtime.googleProject,
+        config.gceConfig.zoneName,
+        InstanceName(runtime.runtimeName.asString),
+        metadataToAdd = metadata,
+        metadataToRemove = Set("startup-script-url")
+      )
       _ <- googleComputeService.startInstance(runtime.googleProject,
                                               config.gceConfig.zoneName,
                                               InstanceName(runtime.runtimeName.asString))

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/google/MockGoogleComputeService.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/google/MockGoogleComputeService.scala
@@ -43,10 +43,20 @@ class MockGoogleComputeService extends GoogleComputeService[IO] {
     implicit ev: ApplicativeAsk[IO, TraceId]
   ): IO[Operation] = IO.pure(Operation.newBuilder().setId("op").setName("opName").setTargetId("target").build())
 
-  override def addInstanceMetadata(project: GoogleProject,
-                                   zone: ZoneName,
-                                   instanceName: InstanceName,
-                                   metadata: Map[String, String])(implicit ev: ApplicativeAsk[IO, TraceId]): IO[Unit] =
+  override def addInstanceMetadata(
+    project: GoogleProject,
+    zone: ZoneName,
+    instanceName: InstanceName,
+    metadataToAdd: Map[String, String]
+  )(implicit ev: ApplicativeAsk[IO, TraceId]): IO[Unit] =
+    IO.unit
+
+  override def removeInstanceMetadata(
+    project: GoogleProject,
+    zone: ZoneName,
+    instanceName: InstanceName,
+    metadataToRemove: Set[String]
+  )(implicit ev: ApplicativeAsk[IO, TraceId]): IO[Unit] =
     IO.unit
 
   override def addFirewallRule(project: GoogleProject, firewall: Firewall)(

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/google/MockGoogleComputeService.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/google/MockGoogleComputeService.scala
@@ -43,18 +43,11 @@ class MockGoogleComputeService extends GoogleComputeService[IO] {
     implicit ev: ApplicativeAsk[IO, TraceId]
   ): IO[Operation] = IO.pure(Operation.newBuilder().setId("op").setName("opName").setTargetId("target").build())
 
-  override def addInstanceMetadata(
+  override def modifyInstanceMetadata(
     project: GoogleProject,
     zone: ZoneName,
     instanceName: InstanceName,
-    metadataToAdd: Map[String, String]
-  )(implicit ev: ApplicativeAsk[IO, TraceId]): IO[Unit] =
-    IO.unit
-
-  override def removeInstanceMetadata(
-    project: GoogleProject,
-    zone: ZoneName,
-    instanceName: InstanceName,
+    metadataToAdd: Map[String, String],
     metadataToRemove: Set[String]
   )(implicit ev: ApplicativeAsk[IO, TraceId]): IO[Unit] =
     IO.unit

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -19,8 +19,7 @@ object Dependencies {
   val workbenchUtilV = "0.5-4c7acd5"
   val workbenchModelV = "0.13-31cacc4"
   val workbenchGoogleV = "0.21-96ad43c"
-  // TODO change to non-snap once https://github.com/broadinstitute/workbench-libs/pull/293 is merged
-  val workbenchGoogle2V = "0.7-48b0a0f-SNAP"
+  val workbenchGoogle2V = "0.7-51bf177"
   val workbenchMetricsV = "0.3-c5b80d2"
   val workbenchNewRelicV = "0.3-8bae8e8"
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -19,7 +19,8 @@ object Dependencies {
   val workbenchUtilV = "0.5-4c7acd5"
   val workbenchModelV = "0.13-31cacc4"
   val workbenchGoogleV = "0.21-96ad43c"
-  val workbenchGoogle2V = "0.7-f3b5a5a"
+  // TODO change to non-snap once https://github.com/broadinstitute/workbench-libs/pull/293 is merged
+  val workbenchGoogle2V = "0.7-f3bde3c-SNAP"
   val workbenchMetricsV = "0.3-c5b80d2"
   val workbenchNewRelicV = "0.3-8bae8e8"
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -20,7 +20,7 @@ object Dependencies {
   val workbenchModelV = "0.13-31cacc4"
   val workbenchGoogleV = "0.21-96ad43c"
   // TODO change to non-snap once https://github.com/broadinstitute/workbench-libs/pull/293 is merged
-  val workbenchGoogle2V = "0.7-f3bde3c-SNAP"
+  val workbenchGoogle2V = "0.7-48b0a0f-SNAP"
   val workbenchMetricsV = "0.3-c5b80d2"
   val workbenchNewRelicV = "0.3-8bae8e8"
 

--- a/project/Merging.scala
+++ b/project/Merging.scala
@@ -3,6 +3,7 @@ import sbtassembly.{MergeStrategy, PathList}
 object Merging {
   def customMergeStrategy(oldStrategy: (String) => MergeStrategy):(String => MergeStrategy) = {
     case PathList("org", "joda", "time", "base", "BaseDateTime.class") => MergeStrategy.first
+    case "module-info.class" => MergeStrategy.discard  // JDK 8 does not use the file module-info.class so it is safe to discard the file.
     case "reference.conf" => MergeStrategy.concat
     case x => oldStrategy(x)
   }


### PR DESCRIPTION
I think this fixes the problem with GCE `resume`. Previously we had duplicated startup scripts defined via instance metadata:
* `startup-script-url` -- used only for creation and points to `gce-init.sh`
* `startup-script` -- used for resume

This PR removes the `startup-script-url` metadata entry at start time when it's no longer needed.

See https://github.com/broadinstitute/workbench-libs/pull/293

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
