### PR TITLE
IA-1589 IA-1798 Fix a bug where user script and startup script failure doesn't get propagated properly

### DIFF
--- a/http/src/main/resources/init-resources/gce-init.sh
+++ b/http/src/main/resources/init-resources/gce-init.sh
@@ -102,7 +102,7 @@ export JUPYTER_SERVER_NAME=$(jupyterServerName)
 export JUPYTER_DOCKER_IMAGE=$(jupyterDockerImage)
 export JUPYTER_START_USER_SCRIPT_URI=$(jupyterStartUserScriptUri)
 # Include a timestamp suffix to differentiate different startup logs across restarts.
-export JUPYTER_START_USER_SCRIPT_OUTPUT_URI="$(jupyterStartUserScriptOutputBaseUri)-$(date -u "+%Y.%m.%d-%H.%M.%S").txt"
+export JUPYTER_START_USER_SCRIPT_OUTPUT_URI=$(jupyterStartUserScriptOutputUri)
 export NOTEBOOKS_DIR=$(notebooksDir)
 export WELDER_SERVER_NAME=$(welderServerName)
 export WELDER_DOCKER_IMAGE=$(welderDockerImage)

--- a/http/src/main/resources/init-resources/init-actions.sh
+++ b/http/src/main/resources/init-resources/init-actions.sh
@@ -132,7 +132,7 @@ if [[ "${ROLE}" == 'Master' ]]; then
     JUPYTER_USER_SCRIPT_OUTPUT_URI=$(jupyterUserScriptOutputUri)
     JUPYTER_START_USER_SCRIPT_URI=$(jupyterStartUserScriptUri)
     # Include a timestamp suffix to differentiate different startup logs across restarts.
-    JUPYTER_START_USER_SCRIPT_OUTPUT_URI="$(jupyterStartUserScriptOutputBaseUri)-$(date -u "+%Y.%m.%d-%H.%M.%S").txt"
+    JUPYTER_START_USER_SCRIPT_OUTPUT_URI="$(jupyterStartUserScriptOutputUri)"
     JUPYTER_NOTEBOOK_CONFIG_URI=$(jupyterNotebookConfigUri)
     JUPYTER_NOTEBOOK_FRONTEND_CONFIG_URI=$(jupyterNotebookFrontendConfigUri)
     CUSTOM_ENV_VARS_CONFIG_URI=$(customEnvVarsConfigUri)

--- a/http/src/main/resources/init-resources/startup.sh
+++ b/http/src/main/resources/init-resources/startup.sh
@@ -59,8 +59,7 @@ export WELDER_DOCKER_IMAGE=$(welderDockerImage)
 export DISABLE_DELOCALIZATION=$(disableDelocalization)
 export STAGING_BUCKET=$(stagingBucketName)
 export JUPYTER_START_USER_SCRIPT_URI=$(jupyterStartUserScriptUri)
-# Include a timestamp suffix to differentiate different startup logs across restarts.
-export JUPYTER_START_USER_SCRIPT_OUTPUT_URI="$(jupyterStartUserScriptOutputBaseUri)-$(date -u "+%Y.%m.%d-%H.%M.%S").txt"
+export JUPYTER_START_USER_SCRIPT_OUTPUT_URI=$(jupyterStartUserScriptOutputUri)
 
 JUPYTER_HOME=/etc/jupyter
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/HttpRoutes.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/HttpRoutes.scala
@@ -14,12 +14,7 @@ import akka.http.scaladsl.server.{Directive0, ExceptionHandler, Route}
 import akka.stream.scaladsl.Sink
 import cats.effect.{ContextShift, IO, Timer}
 import org.broadinstitute.dsde.workbench.leonardo.config.SwaggerConfig
-import org.broadinstitute.dsde.workbench.leonardo.http.service.{
-  LeonardoService,
-  ProxyService,
-  RuntimeService,
-  StatusService
-}
+import org.broadinstitute.dsde.workbench.leonardo.http.service.{LeonardoService, ProxyService, RuntimeService, StatusService}
 import org.broadinstitute.dsde.workbench.leonardo.model.{LeoException, RequestValidationError}
 import org.broadinstitute.dsde.workbench.model.ErrorReportJsonSupport._
 import org.broadinstitute.dsde.workbench.model.{ErrorReport, WorkbenchException, WorkbenchExceptionWithErrorReport}

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/HttpRoutes.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/HttpRoutes.scala
@@ -14,7 +14,12 @@ import akka.http.scaladsl.server.{Directive0, ExceptionHandler, Route}
 import akka.stream.scaladsl.Sink
 import cats.effect.{ContextShift, IO, Timer}
 import org.broadinstitute.dsde.workbench.leonardo.config.SwaggerConfig
-import org.broadinstitute.dsde.workbench.leonardo.http.service.{LeonardoService, ProxyService, RuntimeService, StatusService}
+import org.broadinstitute.dsde.workbench.leonardo.http.service.{
+  LeonardoService,
+  ProxyService,
+  RuntimeService,
+  StatusService
+}
 import org.broadinstitute.dsde.workbench.leonardo.model.{LeoException, RequestValidationError}
 import org.broadinstitute.dsde.workbench.model.ErrorReportJsonSupport._
 import org.broadinstitute.dsde.workbench.model.{ErrorReport, WorkbenchException, WorkbenchExceptionWithErrorReport}

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/RuntimeRoutes.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/RuntimeRoutes.scala
@@ -2,7 +2,6 @@ package org.broadinstitute.dsde.workbench.leonardo
 package http
 package api
 
-import _root_.java.time.Instant
 import java.util.UUID
 
 import akka.http.scaladsl.marshalling.ToResponseMarshallable
@@ -144,8 +143,8 @@ class RuntimeRoutes(runtimeService: RuntimeService[IO], userInfoDirectives: User
                                         runtimeName: RuntimeName,
                                         req: CreateRuntime2Request): IO[ToResponseMarshallable] =
     for {
-      context <- RuntimeServiceContext.generate
-      implicit0(ctx: ApplicativeAsk[IO, RuntimeServiceContext]) = ApplicativeAsk.const[IO, RuntimeServiceContext](
+      context <- AppContext.generate
+      implicit0(ctx: ApplicativeAsk[IO, AppContext]) = ApplicativeAsk.const[IO, AppContext](
         context
       )
       _ <- runtimeService.createRuntime(
@@ -160,8 +159,8 @@ class RuntimeRoutes(runtimeService: RuntimeService[IO], userInfoDirectives: User
                                      googleProject: GoogleProject,
                                      runtimeName: RuntimeName): IO[ToResponseMarshallable] =
     for {
-      context <- RuntimeServiceContext.generate
-      implicit0(ctx: ApplicativeAsk[IO, RuntimeServiceContext]) = ApplicativeAsk.const[IO, RuntimeServiceContext](
+      context <- AppContext.generate
+      implicit0(ctx: ApplicativeAsk[IO, AppContext]) = ApplicativeAsk.const[IO, AppContext](
         context
       )
       resp <- runtimeService.getRuntime(userInfo, googleProject, runtimeName)
@@ -171,8 +170,8 @@ class RuntimeRoutes(runtimeService: RuntimeService[IO], userInfoDirectives: User
                                        googleProject: Option[GoogleProject],
                                        params: Map[String, String]): IO[ToResponseMarshallable] =
     for {
-      context <- RuntimeServiceContext.generate
-      implicit0(ctx: ApplicativeAsk[IO, RuntimeServiceContext]) = ApplicativeAsk.const[IO, RuntimeServiceContext](
+      context <- AppContext.generate
+      implicit0(ctx: ApplicativeAsk[IO, AppContext]) = ApplicativeAsk.const[IO, AppContext](
         context
       )
       resp <- runtimeService.listRuntimes(userInfo, googleProject, params)
@@ -182,8 +181,8 @@ class RuntimeRoutes(runtimeService: RuntimeService[IO], userInfoDirectives: User
                                         googleProject: GoogleProject,
                                         runtimeName: RuntimeName): IO[ToResponseMarshallable] =
     for {
-      context <- RuntimeServiceContext.generate
-      implicit0(ctx: ApplicativeAsk[IO, RuntimeServiceContext]) = ApplicativeAsk.const[IO, RuntimeServiceContext](
+      context <- AppContext.generate
+      implicit0(ctx: ApplicativeAsk[IO, AppContext]) = ApplicativeAsk.const[IO, AppContext](
         context
       )
       _ <- runtimeService.deleteRuntime(userInfo, googleProject, runtimeName)
@@ -193,8 +192,8 @@ class RuntimeRoutes(runtimeService: RuntimeService[IO], userInfoDirectives: User
                                       googleProject: GoogleProject,
                                       runtimeName: RuntimeName): IO[ToResponseMarshallable] =
     for {
-      context <- RuntimeServiceContext.generate
-      implicit0(ctx: ApplicativeAsk[IO, RuntimeServiceContext]) = ApplicativeAsk.const[IO, RuntimeServiceContext](
+      context <- AppContext.generate
+      implicit0(ctx: ApplicativeAsk[IO, AppContext]) = ApplicativeAsk.const[IO, AppContext](
         context
       )
       _ <- runtimeService.stopRuntime(userInfo, googleProject, runtimeName)
@@ -204,8 +203,8 @@ class RuntimeRoutes(runtimeService: RuntimeService[IO], userInfoDirectives: User
                                        googleProject: GoogleProject,
                                        runtimeName: RuntimeName): IO[ToResponseMarshallable] =
     for {
-      context <- RuntimeServiceContext.generate
-      implicit0(ctx: ApplicativeAsk[IO, RuntimeServiceContext]) = ApplicativeAsk.const[IO, RuntimeServiceContext](
+      context <- AppContext.generate
+      implicit0(ctx: ApplicativeAsk[IO, AppContext]) = ApplicativeAsk.const[IO, AppContext](
         context
       )
       _ <- runtimeService.startRuntime(userInfo, googleProject, runtimeName)
@@ -216,8 +215,8 @@ class RuntimeRoutes(runtimeService: RuntimeService[IO], userInfoDirectives: User
                                         runtimeName: RuntimeName,
                                         req: UpdateRuntimeRequest): IO[ToResponseMarshallable] =
     for {
-      context <- RuntimeServiceContext.generate
-      implicit0(ctx: ApplicativeAsk[IO, RuntimeServiceContext]) = ApplicativeAsk.const[IO, RuntimeServiceContext](
+      context <- AppContext.generate
+      implicit0(ctx: ApplicativeAsk[IO, AppContext]) = ApplicativeAsk.const[IO, AppContext](
         context
       )
       _ <- runtimeService.updateRuntime(userInfo, googleProject, runtimeName, req)
@@ -412,15 +411,6 @@ object RuntimeRoutes {
         x.defaultClientId
       )
   )
-}
-
-final case class RuntimeServiceContext(traceId: TraceId, now: Instant)
-object RuntimeServiceContext {
-  def generate(implicit timer: Timer[IO]): IO[RuntimeServiceContext] =
-    for {
-      traceId <- IO(UUID.randomUUID())
-      now <- nowInstant[IO]
-    } yield RuntimeServiceContext(TraceId(traceId), now)
 }
 
 final case class CreateRuntime2Request(labels: LabelMap,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/LeonardoServiceDbQueries.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/LeonardoServiceDbQueries.scala
@@ -75,14 +75,18 @@ object LeonardoServiceDbQueries {
       }
     }
 
-    val clusterQueryFilteredByLabelAndJoinedWithRuntimeAndPatch = clusterLabelRuntimeConfigQuery(clusterQueryFilteredByLabel)
+    val clusterQueryFilteredByLabelAndJoinedWithRuntimeAndPatch = clusterLabelRuntimeConfigQuery(
+      clusterQueryFilteredByLabel
+    )
 
     clusterQueryFilteredByLabelAndJoinedWithRuntimeAndPatch.result.map { x =>
-      val clusterLabelMap: Map[(ClusterRecord, Option[RuntimeConfig], Option[PatchRecord]), Map[String, Chain[String]]] = x.toList.foldMap {
-        case (((clusterRec, labelRecOpt), runTimeConfigRecOpt), patchRecOpt) =>
-          val labelMap = labelRecOpt.map(labelRec => labelRec.key -> Chain(labelRec.value)).toMap
-          Map((clusterRec, runTimeConfigRecOpt.map(_.runtimeConfig), patchRecOpt) -> labelMap)
-      }
+      val clusterLabelMap
+        : Map[(ClusterRecord, Option[RuntimeConfig], Option[PatchRecord]), Map[String, Chain[String]]] =
+        x.toList.foldMap {
+          case (((clusterRec, labelRecOpt), runTimeConfigRecOpt), patchRecOpt) =>
+            val labelMap = labelRecOpt.map(labelRec => labelRec.key -> Chain(labelRec.value)).toMap
+            Map((clusterRec, runTimeConfigRecOpt.map(_.runtimeConfig), patchRecOpt) -> labelMap)
+        }
 
       clusterLabelMap.map {
         case ((clusterRec, runTimeConfigRecOpt, patchRecOpt), labelMap) =>
@@ -101,7 +105,7 @@ object LeonardoServiceDbQueries {
           )
           val patchInProgress = patchRecOpt match {
             case Some(patchRec) => patchRec.inProgress
-            case None => false
+            case None           => false
           }
           ListRuntimeResponse(
             clusterRec.id,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/PatchComponent.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/PatchComponent.scala
@@ -7,7 +7,10 @@ import LeoProfile.mappedColumnImplicits._
 import org.broadinstitute.dsde.workbench.google2.MachineTypeName
 import org.broadinstitute.dsde.workbench.leonardo.monitor.RuntimePatchDetails
 
-case class PatchRecord(clusterId: Long, status: RuntimeStatus, masterMachineType: Option[MachineTypeName], inProgress: Boolean)
+case class PatchRecord(clusterId: Long,
+                       status: RuntimeStatus,
+                       masterMachineType: Option[MachineTypeName],
+                       inProgress: Boolean)
 
 class PatchTable(tag: Tag) extends Table[PatchRecord](tag, "CLUSTER_PATCH") {
   def clusterId = column[Long]("clusterId", O.PrimaryKey)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/models.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/models.scala
@@ -7,7 +7,6 @@ import cats.effect.{IO, Timer}
 import org.broadinstitute.dsde.workbench.leonardo.http.nowInstant
 import org.broadinstitute.dsde.workbench.model.TraceId
 
-
 final case class AppContext(traceId: TraceId, now: Instant)
 object AppContext {
   def generate(implicit timer: Timer[IO]): IO[AppContext] =

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/models.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/models.scala
@@ -1,0 +1,18 @@
+package org.broadinstitute.dsde.workbench.leonardo
+
+import java.time.Instant
+import java.util.UUID
+
+import cats.effect.{IO, Timer}
+import org.broadinstitute.dsde.workbench.leonardo.http.nowInstant
+import org.broadinstitute.dsde.workbench.model.TraceId
+
+
+final case class AppContext(traceId: TraceId, now: Instant)
+object AppContext {
+  def generate(implicit timer: Timer[IO]): IO[AppContext] =
+    for {
+      traceId <- IO(UUID.randomUUID())
+      now <- nowInstant[IO]
+    } yield AppContext(TraceId(traceId), now)
+}

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorActor.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorActor.scala
@@ -499,9 +499,9 @@ class ClusterMonitorActor(
             startUpScriptSuccess <- checkUserScripts(userStartupScript, google2StorageDAO)
             r <- (userScriptSuccess, startUpScriptSuccess) match {
               case (true, true) => continueCheckRuntimeInGoogle(runtimeAndRuntimeConfig, runtimeStatus)
-              case (false, true) => IO.pure(FailedCluster(runtimeAndRuntimeConfig, RuntimeErrorDetails(-1, Some("user script failed")), Set.empty): ClusterMonitorMessage)
-              case (true, false) => IO.pure(FailedCluster(runtimeAndRuntimeConfig, RuntimeErrorDetails(-1, Some("user start up script failed")), Set.empty): ClusterMonitorMessage)
-              case (false, false) => IO.pure(FailedCluster(runtimeAndRuntimeConfig, RuntimeErrorDetails(-1, Some("both user script and startUp script failed")), Set.empty): ClusterMonitorMessage)
+              case (false, true) => IO.pure(FailedCluster(runtimeAndRuntimeConfig, RuntimeErrorDetails(-1, Some(s"user script ${userScript} failed")), Set.empty): ClusterMonitorMessage)
+              case (true, false) => IO.pure(FailedCluster(runtimeAndRuntimeConfig, RuntimeErrorDetails(-1, Some(s"user start up script ${userStartupScript} failed")), Set.empty): ClusterMonitorMessage)
+              case (false, false) => IO.pure(FailedCluster(runtimeAndRuntimeConfig, RuntimeErrorDetails(-1, Some(s"both user script ${userScript} and startUp ${userStartupScript} script failed")), Set.empty): ClusterMonitorMessage)
             }
           } yield r
         case CloudService.Dataproc =>

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/package.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/package.scala
@@ -10,7 +10,6 @@ import cats.implicits._
 import cats.mtl.ApplicativeAsk
 import fs2._
 import org.broadinstitute.dsde.workbench.leonardo.db.DBIOOps
-import org.broadinstitute.dsde.workbench.leonardo.http.api.RuntimeServiceContext
 import org.broadinstitute.dsde.workbench.leonardo.util.CloudServiceOps
 import org.broadinstitute.dsde.workbench.model.{ErrorReportSource, TraceId}
 import slick.dbio.DBIO
@@ -33,7 +32,7 @@ package object http {
   // converts an ApplicativeAsk[F, RuntimeServiceContext] to an  ApplicativeAsk[F, TraceId]
   // (you'd think ApplicativeAsk would have a `map` function)
   implicit def ctxConversion[F[_]: Applicative](
-    implicit as: ApplicativeAsk[F, RuntimeServiceContext]
+    implicit as: ApplicativeAsk[F, AppContext]
   ): ApplicativeAsk[F, TraceId] =
     new ApplicativeAsk[F, TraceId] {
       override val applicative: Applicative[F] = Applicative[F]
@@ -44,4 +43,6 @@ package object http {
   // convenience to get now as a F[Instant] using a Timer
   def nowInstant[F[_]: Timer: Functor]: F[Instant] =
     Timer[F].clock.realTime(TimeUnit.MILLISECONDS).map(Instant.ofEpochMilli)
+
+  val userScriptStartupOutputUriMetadataKey = "user-startup-script-output-url"
 }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoService.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoService.scala
@@ -30,7 +30,12 @@ import org.broadinstitute.dsde.workbench.leonardo.model.ProjectActions._
 import org.broadinstitute.dsde.workbench.leonardo.model._
 import org.broadinstitute.dsde.workbench.leonardo.monitor.RuntimePatchDetails
 import org.broadinstitute.dsde.workbench.leonardo.monitor.LeoPubsubMessage
-import org.broadinstitute.dsde.workbench.leonardo.monitor.LeoPubsubMessage.{CreateRuntimeMessage, StartRuntimeMessage, StopRuntimeMessage, StopUpdateMessage}
+import org.broadinstitute.dsde.workbench.leonardo.monitor.LeoPubsubMessage.{
+  CreateRuntimeMessage,
+  StartRuntimeMessage,
+  StopRuntimeMessage,
+  StopUpdateMessage
+}
 import org.broadinstitute.dsde.workbench.leonardo.util._
 import org.broadinstitute.dsde.workbench.model.google._
 import org.broadinstitute.dsde.workbench.model.{TraceId, UserInfo, WorkbenchEmail, WorkbenchException}

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/RuntimeService.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/RuntimeService.scala
@@ -3,10 +3,7 @@ package http
 package service
 
 import cats.mtl.ApplicativeAsk
-import org.broadinstitute.dsde.workbench.leonardo.http.api.{
-  CreateRuntime2Request,
-  UpdateRuntimeRequest
-}
+import org.broadinstitute.dsde.workbench.leonardo.http.api.{CreateRuntime2Request, UpdateRuntimeRequest}
 import org.broadinstitute.dsde.workbench.model.UserInfo
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/RuntimeService.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/RuntimeService.scala
@@ -5,7 +5,6 @@ package service
 import cats.mtl.ApplicativeAsk
 import org.broadinstitute.dsde.workbench.leonardo.http.api.{
   CreateRuntime2Request,
-  RuntimeServiceContext,
   UpdateRuntimeRequest
 }
 import org.broadinstitute.dsde.workbench.model.UserInfo
@@ -15,30 +14,30 @@ trait RuntimeService[F[_]] {
   def createRuntime(userInfo: UserInfo,
                     googleProject: GoogleProject,
                     runtimeName: RuntimeName,
-                    req: CreateRuntime2Request)(implicit as: ApplicativeAsk[F, RuntimeServiceContext]): F[Unit]
+                    req: CreateRuntime2Request)(implicit as: ApplicativeAsk[F, AppContext]): F[Unit]
 
   def getRuntime(userInfo: UserInfo, googleProject: GoogleProject, runtimeName: RuntimeName)(
-    implicit as: ApplicativeAsk[F, RuntimeServiceContext]
+    implicit as: ApplicativeAsk[F, AppContext]
   ): F[GetRuntimeResponse]
 
   def listRuntimes(userInfo: UserInfo, googleProject: Option[GoogleProject], params: Map[String, String])(
-    implicit as: ApplicativeAsk[F, RuntimeServiceContext]
+    implicit as: ApplicativeAsk[F, AppContext]
   ): F[Vector[ListRuntimeResponse]]
 
   def deleteRuntime(userInfo: UserInfo, googleProject: GoogleProject, runtimeName: RuntimeName)(
-    implicit as: ApplicativeAsk[F, RuntimeServiceContext]
+    implicit as: ApplicativeAsk[F, AppContext]
   ): F[Unit]
 
   def stopRuntime(userInfo: UserInfo, googleProject: GoogleProject, runtimeName: RuntimeName)(
-    implicit as: ApplicativeAsk[F, RuntimeServiceContext]
+    implicit as: ApplicativeAsk[F, AppContext]
   ): F[Unit]
 
   def startRuntime(userInfo: UserInfo, googleProject: GoogleProject, runtimeName: RuntimeName)(
-    implicit as: ApplicativeAsk[F, RuntimeServiceContext]
+    implicit as: ApplicativeAsk[F, AppContext]
   ): F[Unit]
 
   def updateRuntime(userInfo: UserInfo,
                     googleProject: GoogleProject,
                     runtimeName: RuntimeName,
-                    req: UpdateRuntimeRequest)(implicit as: ApplicativeAsk[F, RuntimeServiceContext]): F[Unit]
+                    req: UpdateRuntimeRequest)(implicit as: ApplicativeAsk[F, AppContext]): F[Unit]
 }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/BaseRuntimeInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/BaseRuntimeInterpreter.scala
@@ -11,9 +11,16 @@ import org.broadinstitute.dsde.workbench.google2.MachineTypeName
 import org.broadinstitute.dsde.workbench.leonardo.RuntimeImageType.Welder
 import org.broadinstitute.dsde.workbench.leonardo.WelderAction._
 import org.broadinstitute.dsde.workbench.leonardo.dao.WelderDAO
-import org.broadinstitute.dsde.workbench.leonardo.db.{DbReference, RuntimeConfigQueries, clusterQuery, labelQuery}
+import org.broadinstitute.dsde.workbench.leonardo.db.{clusterQuery, labelQuery, DbReference, RuntimeConfigQueries}
 import org.broadinstitute.dsde.workbench.leonardo.http._
-import org.broadinstitute.dsde.workbench.leonardo.{AppContext, Runtime, RuntimeConfig, RuntimeImage, RuntimeOperation, WelderAction}
+import org.broadinstitute.dsde.workbench.leonardo.{
+  AppContext,
+  Runtime,
+  RuntimeConfig,
+  RuntimeImage,
+  RuntimeOperation,
+  WelderAction
+}
 import org.broadinstitute.dsde.workbench.model.TraceId
 import org.broadinstitute.dsde.workbench.newrelic.NewRelicMetrics
 
@@ -133,10 +140,9 @@ abstract private[util] class BaseRuntimeInterpreter[F[_]: Async: ContextShift: L
     } yield ()
 
   // Startup script to run after the runtime is resumed
-  protected def getStartupScript(runtime: Runtime,
-                                 welderAction: Option[WelderAction],
-                                 now: Instant,
-                                 blocker: Blocker)(implicit ev: ApplicativeAsk[F, AppContext]): F[Map[String, String]] = {
+  protected def getStartupScript(runtime: Runtime, welderAction: Option[WelderAction], now: Instant, blocker: Blocker)(
+    implicit ev: ApplicativeAsk[F, AppContext]
+  ): F[Map[String, String]] = {
     val googleKey = "startup-script" // required; see https://cloud.google.com/compute/docs/startupscript
 
     val templateConfig = RuntimeTemplateValuesConfig.fromRuntime(
@@ -157,16 +163,16 @@ abstract private[util] class BaseRuntimeInterpreter[F[_]: Async: ContextShift: L
       ctx <- ev.ask
       replacements = RuntimeTemplateValues(templateConfig, Some(ctx.now))
       mp <- TemplateHelper
-            .templateResource[F](replacements.toMap, config.clusterResourcesConfig.startupScript, blocker)
-            .through(fs2.text.utf8Decode)
-            .compile
-            .string
-            .map { s =>
-              Map(
-                googleKey -> s,
-                userScriptStartupOutputUriMetadataKey -> replacements.jupyterStartUserScriptOutputUri
-              )
-            }
+        .templateResource[F](replacements.toMap, config.clusterResourcesConfig.startupScript, blocker)
+        .through(fs2.text.utf8Decode)
+        .compile
+        .string
+        .map { s =>
+          Map(
+            googleKey -> s,
+            userScriptStartupOutputUriMetadataKey -> replacements.jupyterStartUserScriptOutputUri
+          )
+        }
     } yield mp
   }
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/DataprocInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/DataprocInterpreter.scala
@@ -133,7 +133,10 @@ class DataprocInterpreter[F[_]: Async: Parallel: ContextShift: Logger](
         )
         templateValues = RuntimeTemplateValues(templateParams, Some(ctx.now))
         _ <- bucketHelper
-          .initializeBucketObjects(initBucketName, templateParams.serviceAccountKey, templateValues, params.customEnvironmentVariables)
+          .initializeBucketObjects(initBucketName,
+                                   templateParams.serviceAccountKey,
+                                   templateValues,
+                                   params.customEnvironmentVariables)
           .compile
           .drain
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GceInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GceInterpreter.scala
@@ -1,4 +1,5 @@
-package org.broadinstitute.dsde.workbench.leonardo.util
+package org.broadinstitute.dsde.workbench.leonardo
+package util
 
 import akka.actor.ActorSystem
 import cats.Parallel
@@ -7,26 +8,20 @@ import cats.implicits._
 import cats.mtl.ApplicativeAsk
 import com.google.cloud.compute.v1._
 import io.chrisdavenport.log4cats.Logger
-import org.broadinstitute.dsde.workbench.google2.{
-  DiskName,
-  GoogleComputeService,
-  InstanceName,
-  MachineTypeName,
-  SubnetworkName,
-  ZoneName
-}
-import org.broadinstitute.dsde.workbench.leonardo._
+import org.broadinstitute.dsde.workbench.google2.{DiskName, GoogleComputeService, InstanceName, MachineTypeName, SubnetworkName, ZoneName}
 import org.broadinstitute.dsde.workbench.leonardo.dao.google._
 import org.broadinstitute.dsde.workbench.leonardo.dao.WelderDAO
 import org.broadinstitute.dsde.workbench.leonardo.db.DbReference
 import org.broadinstitute.dsde.workbench.leonardo.model._
 import org.broadinstitute.dsde.workbench.leonardo.util.RuntimeInterpreterConfig.GceInterpreterConfig
-import org.broadinstitute.dsde.workbench.model.google.{generateUniqueBucketName, GcsObjectName, GcsPath, GoogleProject}
+import org.broadinstitute.dsde.workbench.model.google.{GcsObjectName, GcsPath, GoogleProject, generateUniqueBucketName}
 import org.broadinstitute.dsde.workbench.model.{TraceId, WorkbenchEmail}
 import org.broadinstitute.dsde.workbench.newrelic.NewRelicMetrics
-
+import org.broadinstitute.dsde.workbench.leonardo.http.ctxConversion
 import scala.collection.JavaConverters._
 import scala.concurrent.ExecutionContext
+import GceInterpreter._
+import org.broadinstitute.dsde.workbench.leonardo.http.userScriptStartupOutputUriMetadataKey
 
 final case class InstanceResourceConstaintsException(project: GoogleProject, machineType: MachineTypeName)
     extends LeoException(
@@ -52,9 +47,10 @@ class GceInterpreter[F[_]: Async: Parallel: ContextShift: Logger](
 
   override def createRuntime(
     params: CreateRuntimeParams
-  )(implicit ev: ApplicativeAsk[F, TraceId]): F[CreateRuntimeResponse] =
+  )(implicit ev: ApplicativeAsk[F, AppContext]): F[CreateRuntimeResponse] =
     // TODO clean up on error
     for {
+      ctx <- ev.ask
       // Set up VPC and firewall
       (network, subnetwork) <- vpcAlg.setUpProjectNetwork(
         SetUpProjectNetworkParams(params.runtimeProjectAndName.googleProject)
@@ -99,7 +95,9 @@ class GceInterpreter[F[_]: Async: Parallel: ContextShift: Logger](
         Some(resourceConstraints)
       )
 
-      _ <- bucketHelper.initializeBucketObjects(initBucketName, templateParams, params.customEnvironmentVariables).compile.drain
+      templateValues = RuntimeTemplateValues(templateParams, Some(ctx.now))
+
+      _ <- bucketHelper.initializeBucketObjects(initBucketName, templateParams.serviceAccountKey, templateValues, params.customEnvironmentVariables).compile.drain
 
       serviceAccount <- params.serviceAccountInfo.clusterServiceAccount.fold(
         Async[F].raiseError[WorkbenchEmail](MissingServiceAccountException(params.runtimeProjectAndName))
@@ -143,6 +141,12 @@ class GceInterpreter[F[_]: Async: Parallel: ContextShift: Logger](
                 .setValue(initScript.toUri)
                 .build()
             )
+            .addItems(
+              Items.newBuilder
+                .setKey(userScriptStartupOutputUriMetadataKey)
+                .setValue(templateValues.jupyterStartUserScriptOutputUri)
+                .build()
+            )
             .build()
         )
         .putAllLabels(Map("leonardo" -> "true").asJava)
@@ -169,15 +173,7 @@ class GceInterpreter[F[_]: Async: Parallel: ContextShift: Logger](
       )
       status <- googleComputeService
         .getInstance(params.googleProject, zoneName, InstanceName(params.runtimeName.asString))
-        .map { instance =>
-          instance.fold[RuntimeStatus](RuntimeStatus.Deleted)(
-            s =>
-              GceInstanceStatus
-                .withNameInsensitiveOption(s.getStatus)
-                .map(RuntimeStatus.fromGceInstanceStatus)
-                .getOrElse(RuntimeStatus.Unknown)
-          )
-        }
+        .map(instanceStatusToRuntimeStatus)
     } yield status
 
   override protected def stopGoogleRuntime(runtime: Runtime, runtimeConfig: RuntimeConfig)(
@@ -196,11 +192,13 @@ class GceInterpreter[F[_]: Async: Parallel: ContextShift: Logger](
 
   override protected def startGoogleRuntime(runtime: Runtime,
                                             welderAction: Option[WelderAction],
-                                            runtimeConfig: RuntimeConfig)(
-    implicit ev: ApplicativeAsk[F, TraceId]
+                                            runtimeConfig: RuntimeConfig
+                                           )(
+    implicit ev: ApplicativeAsk[F, AppContext]
   ): F[Unit] =
     for {
-      metadata <- getStartupScript(runtime, welderAction, blocker)
+      ctx <- ev.ask
+      metadata <- getStartupScript(runtime, welderAction, ctx.now, blocker)
       // remove the startup-script-url metadata entry if present which is only used at creation time
       _ <- googleComputeService.modifyInstanceMetadata(
         runtime.googleProject,
@@ -267,4 +265,14 @@ class GceInterpreter[F[_]: Async: Parallel: ContextShift: Logger](
       .setSubnetwork(buildSubnetworkUri(runtimeProjectAndName.googleProject, config.gceConfig.regionName, subnetwork))
       .addAccessConfigs(AccessConfig.newBuilder().setName("Leonardo VM external IP").build)
       .build
+}
+
+object GceInterpreter {
+  def instanceStatusToRuntimeStatus(instance: Option[Instance]): RuntimeStatus = instance.fold[RuntimeStatus](RuntimeStatus.Deleted)(
+    s =>
+      GceInstanceStatus
+        .withNameInsensitiveOption(s.getStatus)
+        .map(RuntimeStatus.fromGceInstanceStatus)
+        .getOrElse(RuntimeStatus.Unknown)
+  )
 }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/RuntimeAlgebra.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/RuntimeAlgebra.scala
@@ -26,12 +26,12 @@ import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GcsPath, G
  * Currently has interpreters for Dataproc and GCE.
  */
 trait RuntimeAlgebra[F[_]] {
-  def createRuntime(params: CreateRuntimeParams)(implicit ev: ApplicativeAsk[F, TraceId]): F[CreateRuntimeResponse]
+  def createRuntime(params: CreateRuntimeParams)(implicit ev: ApplicativeAsk[F, AppContext]): F[CreateRuntimeResponse]
   def getRuntimeStatus(params: GetRuntimeStatusParams)(implicit ev: ApplicativeAsk[F, TraceId]): F[RuntimeStatus]
   def deleteRuntime(params: DeleteRuntimeParams)(implicit ev: ApplicativeAsk[F, TraceId]): F[Unit]
   def finalizeDelete(params: FinalizeDeleteParams)(implicit ev: ApplicativeAsk[F, TraceId]): F[Unit]
   def stopRuntime(params: StopRuntimeParams)(implicit ev: ApplicativeAsk[F, TraceId]): F[Unit]
-  def startRuntime(params: StartRuntimeParams)(implicit ev: ApplicativeAsk[F, TraceId]): F[Unit]
+  def startRuntime(params: StartRuntimeParams)(implicit ev: ApplicativeAsk[F, AppContext]): F[Unit]
   def updateMachineType(params: UpdateMachineTypeParams)(implicit ev: ApplicativeAsk[F, TraceId]): F[Unit]
   def updateDiskSize(params: UpdateDiskSizeParams)(implicit ev: ApplicativeAsk[F, TraceId]): F[Unit]
   def resizeCluster(params: ResizeClusterParams)(implicit ev: ApplicativeAsk[F, TraceId]): F[Unit]

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/RuntimeTemplateValues.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/RuntimeTemplateValues.scala
@@ -148,7 +148,7 @@ object RuntimeTemplateValues {
   val serviceAccountCredentialsFilename = "service-account-credentials.json"
   val customEnvVarFilename = "custom_env_vars.env"
 
-  def apply(config: RuntimeTemplateValuesConfig, now: Option[Instant] = None): RuntimeTemplateValues =
+  def apply(config: RuntimeTemplateValuesConfig, now: Option[Instant]): RuntimeTemplateValues =
     RuntimeTemplateValues(
       config.runtimeProjectAndName.googleProject.value,
       config.runtimeProjectAndName.runtimeName.asString,
@@ -225,9 +225,11 @@ object RuntimeTemplateValues {
 
   def jupyterUserScriptOutputUriPath(stagingBucketName: GcsBucketName): GcsPath = GcsPath(stagingBucketName, GcsObjectName("userscript_output.txt"))
   private def jupyterUserStartScriptOutputUriPath(stagingBucketName: GcsBucketName, now: Instant): GcsPath = {
-    val formatter = DateTimeFormatter.ofLocalizedDateTime( FormatStyle.SHORT )
+    val formatter = DateTimeFormatter.ofLocalizedDateTime(FormatStyle.SHORT)
         .withZone( ZoneId.systemDefault() )
     val formatedNow = formatter.format(now)
-    GcsPath(stagingBucketName, GcsObjectName(s"startscript_output_${formatedNow}.txt"))
+      .replace(" ", "_")
+      .replace("/", "_")
+    GcsPath(stagingBucketName, GcsObjectName(s"startscript_output/${formatedNow}.txt"))
   }
 }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/RuntimeTemplateValues.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/RuntimeTemplateValues.scala
@@ -191,7 +191,9 @@ object RuntimeTemplateValues {
       config.jupyterUserScriptUri.map(_.asString).getOrElse(""),
       config.stagingBucketName.map(n => jupyterUserScriptOutputUriPath(n).toUri).getOrElse(""),
       config.jupyterStartUserScriptUri.map(_.asString).getOrElse(""),
-      config.stagingBucketName.map(n => jupyterUserStartScriptOutputUriPath(n, now.getOrElse(Instant.now)).toUri).getOrElse(""), //TODO: remove this complication
+      config.stagingBucketName
+        .map(n => jupyterUserStartScriptOutputUriPath(n, now.getOrElse(Instant.now)).toUri)
+        .getOrElse(""), //TODO: remove this complication
       (for {
         _ <- config.serviceAccountKey
         n <- config.initBucketName
@@ -223,11 +225,14 @@ object RuntimeTemplateValues {
       (config.welderAction == Some(DisableDelocalization)).toString
     )
 
-  def jupyterUserScriptOutputUriPath(stagingBucketName: GcsBucketName): GcsPath = GcsPath(stagingBucketName, GcsObjectName("userscript_output.txt"))
+  def jupyterUserScriptOutputUriPath(stagingBucketName: GcsBucketName): GcsPath =
+    GcsPath(stagingBucketName, GcsObjectName("userscript_output.txt"))
   private def jupyterUserStartScriptOutputUriPath(stagingBucketName: GcsBucketName, now: Instant): GcsPath = {
-    val formatter = DateTimeFormatter.ofLocalizedDateTime(FormatStyle.SHORT)
-        .withZone( ZoneId.systemDefault() )
-    val formatedNow = formatter.format(now)
+    val formatter = DateTimeFormatter
+      .ofLocalizedDateTime(FormatStyle.SHORT)
+      .withZone(ZoneId.systemDefault())
+    val formatedNow = formatter
+      .format(now)
       .replace(" ", "_")
       .replace("/", "_")
     GcsPath(stagingBucketName, GcsObjectName(s"startscript_output/${formatedNow}.txt"))

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/MockToolDAO.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/MockToolDAO.scala
@@ -1,0 +1,13 @@
+package org.broadinstitute.dsde.workbench.leonardo.dao
+
+import cats.effect.IO
+import org.broadinstitute.dsde.workbench.leonardo.{RuntimeContainerServiceType, RuntimeName}
+import org.broadinstitute.dsde.workbench.model.google.GoogleProject
+
+class MockToolDAO(isProxyAvailable: Boolean) extends ToolDAO[RuntimeContainerServiceType] {
+  override def isProxyAvailable(googleProject: GoogleProject, runtimeName: RuntimeName): IO[Boolean] = IO.pure(isProxyAvailable)
+}
+
+object MockToolDAO {
+  def apply(isProxyAvailable: Boolean): MockToolDAO = new MockToolDAO(isProxyAvailable)
+}

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/MockToolDAO.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/MockToolDAO.scala
@@ -5,7 +5,8 @@ import org.broadinstitute.dsde.workbench.leonardo.{RuntimeContainerServiceType, 
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 
 class MockToolDAO(isProxyAvailable: Boolean) extends ToolDAO[RuntimeContainerServiceType] {
-  override def isProxyAvailable(googleProject: GoogleProject, runtimeName: RuntimeName): IO[Boolean] = IO.pure(isProxyAvailable)
+  override def isProxyAvailable(googleProject: GoogleProject, runtimeName: RuntimeName): IO[Boolean] =
+    IO.pure(isProxyAvailable)
 }
 
 object MockToolDAO {

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriberSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriberSpec.scala
@@ -27,7 +27,10 @@ import org.broadinstitute.dsde.workbench.leonardo.http._
 import org.broadinstitute.dsde.workbench.leonardo.model.LeoAuthProvider
 import org.broadinstitute.dsde.workbench.leonardo.monitor.LeoPubsubCodec._
 import org.broadinstitute.dsde.workbench.leonardo.monitor.LeoPubsubMessage._
-import org.broadinstitute.dsde.workbench.leonardo.monitor.PubsubHandleMessageError.{ClusterInvalidState, ClusterNotStopped}
+import org.broadinstitute.dsde.workbench.leonardo.monitor.PubsubHandleMessageError.{
+  ClusterInvalidState,
+  ClusterNotStopped
+}
 import org.broadinstitute.dsde.workbench.leonardo.util._
 import org.mockito.Mockito
 import org.scalatest.concurrent._

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriberSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriberSpec.scala
@@ -7,6 +7,7 @@ import akka.actor.ActorSystem
 import akka.testkit.TestKit
 import cats.effect.IO
 import cats.implicits._
+import cats.mtl.ApplicativeAsk
 import com.google.cloud.pubsub.v1.AckReplyConsumer
 import com.google.protobuf.Timestamp
 import fs2.concurrent.InspectableQueue
@@ -26,10 +27,7 @@ import org.broadinstitute.dsde.workbench.leonardo.http._
 import org.broadinstitute.dsde.workbench.leonardo.model.LeoAuthProvider
 import org.broadinstitute.dsde.workbench.leonardo.monitor.LeoPubsubCodec._
 import org.broadinstitute.dsde.workbench.leonardo.monitor.LeoPubsubMessage._
-import org.broadinstitute.dsde.workbench.leonardo.monitor.PubsubHandleMessageError.{
-  ClusterInvalidState,
-  ClusterNotStopped
-}
+import org.broadinstitute.dsde.workbench.leonardo.monitor.PubsubHandleMessageError.{ClusterInvalidState, ClusterNotStopped}
 import org.broadinstitute.dsde.workbench.leonardo.util._
 import org.mockito.Mockito
 import org.scalatest.concurrent._
@@ -56,6 +54,7 @@ class LeoPubsubMessageSubscriberSpec
   val projectDAO = new MockGoogleProjectDAO
   val authProvider = mock[LeoAuthProvider[IO]]
   val currentTime = Instant.now
+  implicit val appContext: ApplicativeAsk[IO, AppContext] = ApplicativeAsk.const(AppContext.generate.unsafeRunSync())
 
   val mockPetGoogleStorageDAO: String => GoogleStorageDAO = _ => {
     new MockGoogleStorageDAO

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/MockRuntimeServiceInterp.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/MockRuntimeServiceInterp.scala
@@ -1,14 +1,13 @@
-package org.broadinstitute.dsde.workbench.leonardo.service
+package org.broadinstitute.dsde.workbench.leonardo
+package service
 
 import cats.effect.IO
 import cats.mtl.ApplicativeAsk
 import org.broadinstitute.dsde.workbench.leonardo.http.api.{
   CreateRuntime2Request,
-  RuntimeServiceContext,
   UpdateRuntimeRequest
 }
 import org.broadinstitute.dsde.workbench.leonardo.http.service.{GetRuntimeResponse, ListRuntimeResponse, RuntimeService}
-import org.broadinstitute.dsde.workbench.leonardo.{CommonTestData, RuntimeName}
 import org.broadinstitute.dsde.workbench.model.UserInfo
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 
@@ -18,31 +17,31 @@ object MockRuntimeServiceInterp extends RuntimeService[IO] {
     googleProject: GoogleProject,
     runtimeName: RuntimeName,
     req: CreateRuntime2Request
-  )(implicit as: ApplicativeAsk[IO, RuntimeServiceContext]): IO[Unit] =
+  )(implicit as: ApplicativeAsk[IO, AppContext]): IO[Unit] =
     IO.unit
 
   override def getRuntime(userInfo: UserInfo, googleProject: GoogleProject, runtimeName: RuntimeName)(
-    implicit as: ApplicativeAsk[IO, RuntimeServiceContext]
+    implicit as: ApplicativeAsk[IO, AppContext]
   ): IO[GetRuntimeResponse] =
     IO.pure(GetRuntimeResponse.fromRuntime(CommonTestData.testCluster, CommonTestData.defaultRuntimeConfig))
 
   override def listRuntimes(userInfo: UserInfo, googleProject: Option[GoogleProject], params: Map[String, String])(
-    implicit as: ApplicativeAsk[IO, RuntimeServiceContext]
+    implicit as: ApplicativeAsk[IO, AppContext]
   ): IO[Vector[ListRuntimeResponse]] =
     IO.pure(Vector(ListRuntimeResponse.fromRuntime(CommonTestData.testCluster, CommonTestData.defaultRuntimeConfig)))
 
   override def deleteRuntime(userInfo: UserInfo, googleProject: GoogleProject, runtimeName: RuntimeName)(
-    implicit as: ApplicativeAsk[IO, RuntimeServiceContext]
+    implicit as: ApplicativeAsk[IO, AppContext]
   ): IO[Unit] =
     IO.unit
 
   override def stopRuntime(userInfo: UserInfo, googleProject: GoogleProject, runtimeName: RuntimeName)(
-    implicit as: ApplicativeAsk[IO, RuntimeServiceContext]
+    implicit as: ApplicativeAsk[IO, AppContext]
   ): IO[Unit] =
     IO.unit
 
   override def startRuntime(userInfo: UserInfo, googleProject: GoogleProject, runtimeName: RuntimeName)(
-    implicit as: ApplicativeAsk[IO, RuntimeServiceContext]
+    implicit as: ApplicativeAsk[IO, AppContext]
   ): IO[Unit] =
     IO.unit
 
@@ -51,5 +50,5 @@ object MockRuntimeServiceInterp extends RuntimeService[IO] {
     googleProject: GoogleProject,
     runtimeName: RuntimeName,
     req: UpdateRuntimeRequest
-  )(implicit as: ApplicativeAsk[IO, RuntimeServiceContext]): IO[Unit] = IO.unit
+  )(implicit as: ApplicativeAsk[IO, AppContext]): IO[Unit] = IO.unit
 }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/MockRuntimeServiceInterp.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/MockRuntimeServiceInterp.scala
@@ -3,10 +3,7 @@ package service
 
 import cats.effect.IO
 import cats.mtl.ApplicativeAsk
-import org.broadinstitute.dsde.workbench.leonardo.http.api.{
-  CreateRuntime2Request,
-  UpdateRuntimeRequest
-}
+import org.broadinstitute.dsde.workbench.leonardo.http.api.{CreateRuntime2Request, UpdateRuntimeRequest}
 import org.broadinstitute.dsde.workbench.leonardo.http.service.{GetRuntimeResponse, ListRuntimeResponse, RuntimeService}
 import org.broadinstitute.dsde.workbench.model.UserInfo
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/RuntimeServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/RuntimeServiceInterpSpec.scala
@@ -16,7 +16,6 @@ import org.broadinstitute.dsde.workbench.leonardo.dao.MockDockerDAO
 import org.broadinstitute.dsde.workbench.leonardo.db.{clusterQuery, labelQuery, RuntimeConfigQueries, TestComponent}
 import org.broadinstitute.dsde.workbench.leonardo.http.api.{
   CreateRuntime2Request,
-  RuntimeServiceContext,
   UpdateRuntimeConfigRequest,
   UpdateRuntimeRequest
 }
@@ -62,8 +61,8 @@ class RuntimeServiceInterpSpec extends FlatSpec with LeonardoTestSuite with Test
     Map.empty
   )
 
-  implicit val ctx: ApplicativeAsk[IO, RuntimeServiceContext] = ApplicativeAsk.const[IO, RuntimeServiceContext](
-    RuntimeServiceContext(model.TraceId("traceId"), Instant.now())
+  implicit val ctx: ApplicativeAsk[IO, AppContext] = ApplicativeAsk.const[IO, AppContext](
+    AppContext(model.TraceId("traceId"), Instant.now())
   )
 
   "RuntimeService" should "fail with AuthorizationError if user doesn't have project level permission" in {

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/DataprocInterpreterSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/DataprocInterpreterSpec.scala
@@ -6,6 +6,7 @@ import java.time.Instant
 import akka.actor.ActorSystem
 import akka.testkit.TestKit
 import cats.effect.IO
+import cats.mtl.ApplicativeAsk
 import com.google.api.client.googleapis.json.GoogleJsonResponseException
 import com.google.api.client.googleapis.testing.json.GoogleJsonResponseExceptionFactoryTesting
 import com.google.api.client.testing.json.MockJsonFactory
@@ -36,9 +37,11 @@ class DataprocInterpreterSpec
     with TestComponent
     with Matchers
     with BeforeAndAfterAll
-    with ScalaFutures {
+    with ScalaFutures
+    with LeonardoTestSuite {
 
   implicit val nr = FakeNewRelicMetricsInterpreter
+  implicit val appContext: ApplicativeAsk[IO, AppContext] = ApplicativeAsk.const(AppContext.generate.unsafeRunSync())
 
   val mockGoogleIamDAO = new MockGoogleIamDAO
   val mockGoogleDirectoryDAO = new MockGoogleDirectoryDAO


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-1798


Status from gce doesn't indicate whether or not a user script or startup script runs successfully. Hence we're checking metadata for both script output files in order to tell whether runtime creation is successful or not.

For user script, since the output file name is the same (since we only create the runtime once), it's easy to check the file metadata. But for user startup script, since every time runtime restarts, we generate a different output file, hence this PR persists the output path to instance metadata during runtime creation time (only in the case of gce)

<img width="537" alt="Screen Shot 2020-04-03 at 11 15 29 AM" src="https://user-images.githubusercontent.com/32771737/78376599-8d0cdd80-759c-11ea-9611-2f2c889836ea.png">
<img width="879" alt="Screen Shot 2020-04-03 at 11 15 20 AM" src="https://user-images.githubusercontent.com/32771737/78376608-90a06480-759c-11ea-8533-db61e00de7a5.png">

Tested manually...File format is updated a bit to make things easier to find

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
