### PR TITLE
[IA-1675] don't put UI in path

### DIFF
--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorActor.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorActor.scala
@@ -789,7 +789,7 @@ class ClusterMonitorActor(
                                             cloudService: CloudService): IO[Unit] =
     for {
       endTime <- IO(System.currentTimeMillis)
-      metricsName = s"monitor/${runtimeUI.asString}/transition/${origStatus}_to_${finalStatus}"
+      metricsName = s"monitor/transition/${origStatus}_to_${finalStatus}"
       duration = (endTime - startTime).millis
       tags = Map("cloudService" -> cloudService.asString, "ui_client" -> runtimeUI.asString)
       _ <- openTelemetryMetrics.incrementCounter(metricsName, 1, tags)


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-1675

Now that we put ui as a label, we don't really need to put ui in metrics name. Having it in UI actually makes it less desirable

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
