### PR TITLE
[IA-1810] template welder memory correctly

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookPyKernelSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookPyKernelSpec.scala
@@ -75,8 +75,8 @@ class NotebookPyKernelSpec extends ClusterFixtureSpec with NotebookTestUtils {
       val contentSecurityHeader = headers.find(_.name == "Content-Security-Policy")
       contentSecurityHeader shouldBe 'defined
       contentSecurityHeader.get.value should include("https://bvdp-saturn-dev.appspot.com")
-      contentSecurityHeader.get.value should not include("https://bvdp-saturn-prod.appspot.com")
-      contentSecurityHeader.get.value should not include("*.terra.bio")
+      contentSecurityHeader.get.value should not include ("https://bvdp-saturn-prod.appspot.com")
+      contentSecurityHeader.get.value should not include ("*.terra.bio")
     }
 
     "should allow BigQuerying via the command line" in { clusterFixture =>

--- a/http/src/main/resources/init-resources/gce-init.sh
+++ b/http/src/main/resources/init-resources/gce-init.sh
@@ -126,6 +126,7 @@ if [[ "$RUNTIME_OPERATION" == 'creating' ]]; then
     export RSTUDIO_DOCKER_IMAGE=$(rstudioDockerImage)
     export PROXY_DOCKER_IMAGE=$(proxyDockerImage)
     export MEM_LIMIT=$(memLimit)
+    export WELDER_MEM_LIMIT=$(welderMemLimit)
 
     SERVER_CRT=$(jupyterServerCrt)
     SERVER_KEY=$(jupyterServerKey)

--- a/http/src/main/resources/init-resources/init-actions.sh
+++ b/http/src/main/resources/init-resources/init-actions.sh
@@ -115,6 +115,7 @@ if [[ "${ROLE}" == 'Master' ]]; then
     export WELDER_ENABLED=$(welderEnabled)
     export NOTEBOOKS_DIR=$(notebooksDir)
     export MEM_LIMIT=$(memLimit)
+    export WELDER_MEM_LIMIT=$(welderMemLimit)
 
     SERVER_CRT=$(jupyterServerCrt)
     SERVER_KEY=$(jupyterServerKey)

--- a/http/src/main/resources/init-resources/startup.sh
+++ b/http/src/main/resources/init-resources/startup.sh
@@ -60,6 +60,7 @@ export DISABLE_DELOCALIZATION=$(disableDelocalization)
 export STAGING_BUCKET=$(stagingBucketName)
 export JUPYTER_START_USER_SCRIPT_URI=$(jupyterStartUserScriptUri)
 export JUPYTER_START_USER_SCRIPT_OUTPUT_URI=$(jupyterStartUserScriptOutputUri)
+export WELDER_MEM_LIMIT=$(welderMemLimit)
 
 JUPYTER_HOME=/etc/jupyter
 

--- a/http/src/main/resources/init-resources/welder-docker-compose.yaml
+++ b/http/src/main/resources/init-resources/welder-docker-compose.yaml
@@ -26,8 +26,8 @@ services:
     env_file:
       - /etc/google_application_credentials.env
     # See https://docs.docker.com/engine/reference/run/#user-memory-constraints
-    mem_limit: 512m
-    mem_reservation: 512m
+    mem_limit: ${WELDER_MEM_LIMIT}
+    mem_reservation: ${WELDER_MEM_LIMIT}
     # disable swap by setting it to the same value as mem_limit
-    memswap_limit: 512m
+    memswap_limit: ${WLEDER_MEM_LIMIT}
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/RuntimeRoutes.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/RuntimeRoutes.scala
@@ -19,7 +19,11 @@ import org.broadinstitute.dsde.workbench.leonardo.api.CookieSupport
 import org.broadinstitute.dsde.workbench.leonardo.http.api.LeoRoutes.validateRuntimeNameDirective
 import org.broadinstitute.dsde.workbench.leonardo.http.api.LeoRoutesJsonCodec.dataprocConfigDecoder
 import org.broadinstitute.dsde.workbench.leonardo.http.api.RuntimeRoutes._
-import org.broadinstitute.dsde.workbench.leonardo.http.service.{GetRuntimeResponse, RuntimeConfigRequest, RuntimeService}
+import org.broadinstitute.dsde.workbench.leonardo.http.service.{
+  GetRuntimeResponse,
+  RuntimeConfigRequest,
+  RuntimeService
+}
 import org.broadinstitute.dsde.workbench.model.google.{GcsPath, GoogleProject}
 import org.broadinstitute.dsde.workbench.model.{TraceId, UserInfo}
 
@@ -436,12 +440,12 @@ final case class UpdateRuntimeRequest(updatedRuntimeConfig: Option[UpdateRuntime
                                       updateAutopauseThreshold: Option[FiniteDuration])
 
 final case class ListRuntimeResponse2(id: Long,
-                                     internalId: RuntimeInternalId,
-                                     clusterName: RuntimeName,
-                                     googleProject: GoogleProject,
-                                     auditInfo: AuditInfo,
-                                     machineConfig: RuntimeConfig,
-                                     proxyUrl: URL,
-                                     status: RuntimeStatus,
-                                     labels: LabelMap,
-                                     patchInProgress: Boolean)
+                                      internalId: RuntimeInternalId,
+                                      clusterName: RuntimeName,
+                                      googleProject: GoogleProject,
+                                      auditInfo: AuditInfo,
+                                      machineConfig: RuntimeConfig,
+                                      proxyUrl: URL,
+                                      status: RuntimeStatus,
+                                      labels: LabelMap,
+                                      patchInProgress: Boolean)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/RuntimeServiceDbQueries.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/RuntimeServiceDbQueries.scala
@@ -53,14 +53,18 @@ object RuntimeServiceDbQueries {
       }
     }
 
-    val clusterQueryFilteredByLabelAndJoinedWithRuntimeAndPatch = clusterLabelRuntimeConfigQuery(clusterQueryFilteredByLabel)
+    val clusterQueryFilteredByLabelAndJoinedWithRuntimeAndPatch = clusterLabelRuntimeConfigQuery(
+      clusterQueryFilteredByLabel
+    )
 
     clusterQueryFilteredByLabelAndJoinedWithRuntimeAndPatch.result.map { x =>
-      val clusterLabelMap: Map[(ClusterRecord, Option[RuntimeConfig], Option[PatchRecord]), Map[String, Chain[String]]] = x.toList.foldMap {
-        case (((clusterRec, labelRecOpt), runTimeConfigRecOpt), patchRecOpt) =>
-          val labelMap = labelRecOpt.map(labelRec => labelRec.key -> Chain(labelRec.value)).toMap
-          Map((clusterRec, runTimeConfigRecOpt.map(_.runtimeConfig), patchRecOpt) -> labelMap)
-      }
+      val clusterLabelMap
+        : Map[(ClusterRecord, Option[RuntimeConfig], Option[PatchRecord]), Map[String, Chain[String]]] =
+        x.toList.foldMap {
+          case (((clusterRec, labelRecOpt), runTimeConfigRecOpt), patchRecOpt) =>
+            val labelMap = labelRecOpt.map(labelRec => labelRec.key -> Chain(labelRec.value)).toMap
+            Map((clusterRec, runTimeConfigRecOpt.map(_.runtimeConfig), patchRecOpt) -> labelMap)
+        }
 
       clusterLabelMap.map {
         case ((clusterRec, runTimeConfigRecOpt, patchRecOpt), labelMap) =>
@@ -68,7 +72,7 @@ object RuntimeServiceDbQueries {
 
           val patchInProgress = patchRecOpt match {
             case Some(patchRec) => patchRec.inProgress
-            case None => false
+            case None           => false
           }
           ListRuntimeResponse2(
             clusterRec.id,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/RuntimeService.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/RuntimeService.scala
@@ -3,7 +3,11 @@ package http
 package service
 
 import cats.mtl.ApplicativeAsk
-import org.broadinstitute.dsde.workbench.leonardo.http.api.{CreateRuntime2Request, ListRuntimeResponse2, UpdateRuntimeRequest}
+import org.broadinstitute.dsde.workbench.leonardo.http.api.{
+  CreateRuntime2Request,
+  ListRuntimeResponse2,
+  UpdateRuntimeRequest
+}
 import org.broadinstitute.dsde.workbench.model.UserInfo
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/RuntimeServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/RuntimeServiceInterp.scala
@@ -19,15 +19,33 @@ import org.broadinstitute.dsde.workbench.google2.{GcsBlobName, GoogleStorageServ
 import org.broadinstitute.dsde.workbench.leonardo.RuntimeImageType.{Jupyter, Proxy, Welder}
 import org.broadinstitute.dsde.workbench.leonardo.config.{AutoFreezeConfig, DataprocConfig, GceConfig, ImageConfig}
 import org.broadinstitute.dsde.workbench.leonardo.dao.DockerDAO
-import org.broadinstitute.dsde.workbench.leonardo.db.{DbReference, LeonardoServiceDbQueries, RuntimeConfigQueries, RuntimeServiceDbQueries, SaveCluster, clusterQuery}
-import org.broadinstitute.dsde.workbench.leonardo.http.api.{CreateRuntime2Request, ListRuntimeResponse2, UpdateRuntimeConfigRequest, UpdateRuntimeRequest}
+import org.broadinstitute.dsde.workbench.leonardo.db.{
+  clusterQuery,
+  DbReference,
+  LeonardoServiceDbQueries,
+  RuntimeConfigQueries,
+  RuntimeServiceDbQueries,
+  SaveCluster
+}
+import org.broadinstitute.dsde.workbench.leonardo.http.api.{
+  CreateRuntime2Request,
+  ListRuntimeResponse2,
+  UpdateRuntimeConfigRequest,
+  UpdateRuntimeRequest
+}
 import org.broadinstitute.dsde.workbench.leonardo.http.service.LeonardoService._
 import org.broadinstitute.dsde.workbench.leonardo.http.service.RuntimeServiceInterp._
 import org.broadinstitute.dsde.workbench.leonardo.model._
 import org.broadinstitute.dsde.workbench.leonardo.monitor.LeoPubsubMessage
-import org.broadinstitute.dsde.workbench.leonardo.monitor.LeoPubsubMessage.{CreateRuntimeMessage, DeleteRuntimeMessage, StartRuntimeMessage, StopRuntimeMessage, UpdateRuntimeMessage}
+import org.broadinstitute.dsde.workbench.leonardo.monitor.LeoPubsubMessage.{
+  CreateRuntimeMessage,
+  DeleteRuntimeMessage,
+  StartRuntimeMessage,
+  StopRuntimeMessage,
+  UpdateRuntimeMessage
+}
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
-import org.broadinstitute.dsde.workbench.model.{TraceId, UserInfo, WorkbenchEmail, google}
+import org.broadinstitute.dsde.workbench.model.{google, TraceId, UserInfo, WorkbenchEmail}
 
 import scala.concurrent.ExecutionContext
 
@@ -552,9 +570,12 @@ object RuntimeServiceInterp {
       config.autoFreezeConfig
     ) //TODO: use FiniteDuration for autopauseThreshold field in Cluster
     val clusterScopes = req.runtimeConfig match {
-      case Some(rq) if rq.cloudService == CloudService.GCE => if (req.scopes.isEmpty) config.gceConfig.defaultScopes else req.scopes
-      case Some(rq) if rq.cloudService == CloudService.Dataproc => if (req.scopes.isEmpty) config.dataprocConfig.defaultScopes else req.scopes
-      case None => if (req.scopes.isEmpty) config.gceConfig.defaultScopes else req.scopes //default to create gce runtime if runtimeConfig is not specified
+      case Some(rq) if rq.cloudService == CloudService.GCE =>
+        if (req.scopes.isEmpty) config.gceConfig.defaultScopes else req.scopes
+      case Some(rq) if rq.cloudService == CloudService.Dataproc =>
+        if (req.scopes.isEmpty) config.dataprocConfig.defaultScopes else req.scopes
+      case None =>
+        if (req.scopes.isEmpty) config.gceConfig.defaultScopes else req.scopes //default to create gce runtime if runtimeConfig is not specified
     }
 
     for {

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/RuntimeTemplateValues.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/RuntimeTemplateValues.scala
@@ -46,6 +46,7 @@ case class RuntimeTemplateValues private (googleProject: String,
                                           notebooksDir: String,
                                           customEnvVarsConfigUri: String,
                                           memLimit: String,
+                                          welderMemLimit: String,
                                           runtimeOperation: String,
                                           deployWelder: String,
                                           updateWelder: String,
@@ -56,25 +57,25 @@ case class RuntimeTemplateValues private (googleProject: String,
 
 }
 
-case class RuntimeTemplateValuesConfig(runtimeProjectAndName: RuntimeProjectAndName,
-                                       stagingBucketName: Option[GcsBucketName],
-                                       runtimeImages: Set[RuntimeImage],
-                                       initBucketName: Option[GcsBucketName],
-                                       jupyterUserScriptUri: Option[UserScriptPath],
-                                       jupyterStartUserScriptUri: Option[UserScriptPath],
-                                       serviceAccountKey: Option[ServiceAccountKey],
-                                       userJupyterExtensionConfig: Option[UserJupyterExtensionConfig],
-                                       defaultClientId: Option[String],
-                                       welderEnabled: Boolean,
-                                       auditInfo: AuditInfo,
-                                       imageConfig: ImageConfig,
-                                       welderConfig: WelderConfig,
-                                       proxyConfig: ProxyConfig,
-                                       clusterFilesConfig: ClusterFilesConfig,
-                                       clusterResourcesConfig: ClusterResourcesConfig,
-                                       clusterResourceConstraints: Option[RuntimeResourceConstraints],
-                                       runtimeOperation: RuntimeOperation,
-                                       welderAction: Option[WelderAction])
+case class RuntimeTemplateValuesConfig private (runtimeProjectAndName: RuntimeProjectAndName,
+                                                stagingBucketName: Option[GcsBucketName],
+                                                runtimeImages: Set[RuntimeImage],
+                                                initBucketName: Option[GcsBucketName],
+                                                jupyterUserScriptUri: Option[UserScriptPath],
+                                                jupyterStartUserScriptUri: Option[UserScriptPath],
+                                                serviceAccountKey: Option[ServiceAccountKey],
+                                                userJupyterExtensionConfig: Option[UserJupyterExtensionConfig],
+                                                defaultClientId: Option[String],
+                                                welderEnabled: Boolean,
+                                                auditInfo: AuditInfo,
+                                                imageConfig: ImageConfig,
+                                                welderConfig: WelderConfig,
+                                                proxyConfig: ProxyConfig,
+                                                clusterFilesConfig: ClusterFilesConfig,
+                                                clusterResourcesConfig: ClusterResourcesConfig,
+                                                clusterResourceConstraints: Option[RuntimeResourceConstraints],
+                                                runtimeOperation: RuntimeOperation,
+                                                welderAction: Option[WelderAction])
 object RuntimeTemplateValuesConfig {
   def fromCreateRuntimeParams(
     params: CreateRuntimeParams,
@@ -219,6 +220,7 @@ object RuntimeTemplateValues {
         .map(n => GcsPath(n, GcsObjectName(config.clusterResourcesConfig.customEnvVarsConfigUri.asString)).toUri)
         .getOrElse(""),
       config.clusterResourceConstraints.map(_.memoryLimit.toString).getOrElse(""),
+      config.welderConfig.welderReservedMemory.map(_.toString).getOrElse(""),
       config.runtimeOperation.asString,
       (config.welderAction == Some(DeployWelder)).toString,
       (config.welderAction == Some(UpdateWelder)).toString,
@@ -227,7 +229,7 @@ object RuntimeTemplateValues {
 
   def jupyterUserScriptOutputUriPath(stagingBucketName: GcsBucketName): GcsPath =
     GcsPath(stagingBucketName, GcsObjectName("userscript_output.txt"))
-  private def jupyterUserStartScriptOutputUriPath(stagingBucketName: GcsBucketName, now: Instant): GcsPath = {
+  private[util] def jupyterUserStartScriptOutputUriPath(stagingBucketName: GcsBucketName, now: Instant): GcsPath = {
     val formatter = DateTimeFormatter
       .ofLocalizedDateTime(FormatStyle.SHORT)
       .withZone(ZoneId.systemDefault())

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/HttpRoutesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/HttpRoutesSpec.scala
@@ -14,7 +14,14 @@ import org.broadinstitute.dsde.workbench.leonardo._
 import org.broadinstitute.dsde.workbench.leonardo.api.HttpRoutesSpec._
 import org.broadinstitute.dsde.workbench.leonardo.db.TestComponent
 import org.broadinstitute.dsde.workbench.leonardo.http.api.RoutesTestJsonSupport.runtimeConfigRequestEncoder
-import org.broadinstitute.dsde.workbench.leonardo.http.api.{CreateRuntime2Request, HttpRoutes, ListRuntimeResponse2, TestLeoRoutes, UpdateRuntimeConfigRequest, UpdateRuntimeRequest}
+import org.broadinstitute.dsde.workbench.leonardo.http.api.{
+  CreateRuntime2Request,
+  HttpRoutes,
+  ListRuntimeResponse2,
+  TestLeoRoutes,
+  UpdateRuntimeConfigRequest,
+  UpdateRuntimeRequest
+}
 import org.broadinstitute.dsde.workbench.leonardo.http.service.{GetRuntimeResponse, RuntimeConfigRequest}
 import org.broadinstitute.dsde.workbench.leonardo.service.MockRuntimeServiceInterp
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/config/ContentSecurityPolicyConfigSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/config/ContentSecurityPolicyConfigSpec.scala
@@ -12,7 +12,7 @@ import org.scalatest.FlatSpecLike
 
 class ContentSecurityPolicyConfigSpec extends LeonardoTestSuite with FlatSpecLike {
 
-  it should "generate a valid string" in {
+  "ContentSecurityPolicyConfig" should "generate a valid string" in {
     val test = ContentSecurityPolicyConfig(
       FrameAncestors(
         List(

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/config/ContentSecurityPolicyConfigSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/config/ContentSecurityPolicyConfigSpec.scala
@@ -12,7 +12,7 @@ import org.scalatest.FlatSpecLike
 
 class ContentSecurityPolicyConfigSpec extends LeonardoTestSuite with FlatSpecLike {
 
-  "ContentSecurityPolicyConfig" should "generate a valid string" in {
+  it should "generate a valid string" in {
     val test = ContentSecurityPolicyConfig(
       FrameAncestors(
         List(

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/google/MockGoogleComputeService.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/google/MockGoogleComputeService.scala
@@ -4,7 +4,18 @@ import cats.effect.IO
 import cats.mtl.ApplicativeAsk
 import com.google.cloud.compute.v1._
 import org.broadinstitute.dsde.workbench.DoneCheckable
-import org.broadinstitute.dsde.workbench.google2.{DiskName, FirewallRuleName, GoogleComputeService, InstanceName, MachineTypeName, NetworkName, OperationName, RegionName, SubnetworkName, ZoneName}
+import org.broadinstitute.dsde.workbench.google2.{
+  DiskName,
+  FirewallRuleName,
+  GoogleComputeService,
+  InstanceName,
+  MachineTypeName,
+  NetworkName,
+  OperationName,
+  RegionName,
+  SubnetworkName,
+  ZoneName
+}
 import org.broadinstitute.dsde.workbench.model.TraceId
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/AuthProviderSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/AuthProviderSpec.scala
@@ -172,7 +172,7 @@ class AuthProviderSpec
       proxy.proxyLocalize(userInfo, GoogleProject(googleProject), RuntimeName(clusterName), syncRequest).unsafeRunSync()
 
       val updateAsyncClusterCreationFields = UpdateAsyncClusterCreationFields(
-        Some(GcsPath(initBucketPath, GcsObjectName(""))),
+        Some(GcsPath(initBucketName, GcsObjectName(""))),
         Some(serviceAccountKey),
         cluster1.id,
         Some(makeDataprocInfo(1)),

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/MockRuntimeServiceInterp.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/MockRuntimeServiceInterp.scala
@@ -3,7 +3,11 @@ package service
 
 import cats.effect.IO
 import cats.mtl.ApplicativeAsk
-import org.broadinstitute.dsde.workbench.leonardo.http.api.{CreateRuntime2Request, ListRuntimeResponse2, UpdateRuntimeRequest}
+import org.broadinstitute.dsde.workbench.leonardo.http.api.{
+  CreateRuntime2Request,
+  ListRuntimeResponse2,
+  UpdateRuntimeRequest
+}
 import org.broadinstitute.dsde.workbench.leonardo.http.service.{GetRuntimeResponse, RuntimeService}
 import org.broadinstitute.dsde.workbench.model.UserInfo
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
@@ -25,20 +29,22 @@ object MockRuntimeServiceInterp extends RuntimeService[IO] {
   override def listRuntimes(userInfo: UserInfo, googleProject: Option[GoogleProject], params: Map[String, String])(
     implicit as: ApplicativeAsk[IO, AppContext]
   ): IO[Vector[ListRuntimeResponse2]] =
-    IO.pure(Vector(
-      ListRuntimeResponse2(
-        CommonTestData.testCluster.id,
-        CommonTestData.testCluster.internalId,
-        CommonTestData.testCluster.runtimeName,
-        CommonTestData.testCluster.googleProject,
-        CommonTestData.testCluster.auditInfo,
-        CommonTestData.defaultRuntimeConfig,
-        CommonTestData.testCluster.proxyUrl,
-        CommonTestData.testCluster.status,
-        CommonTestData.testCluster.labels,
-        CommonTestData.testCluster.patchInProgress
+    IO.pure(
+      Vector(
+        ListRuntimeResponse2(
+          CommonTestData.testCluster.id,
+          CommonTestData.testCluster.internalId,
+          CommonTestData.testCluster.runtimeName,
+          CommonTestData.testCluster.googleProject,
+          CommonTestData.testCluster.auditInfo,
+          CommonTestData.defaultRuntimeConfig,
+          CommonTestData.testCluster.proxyUrl,
+          CommonTestData.testCluster.status,
+          CommonTestData.testCluster.labels,
+          CommonTestData.testCluster.patchInProgress
+        )
       )
-    ))
+    )
 
   override def deleteRuntime(userInfo: UserInfo, googleProject: GoogleProject, runtimeName: RuntimeName)(
     implicit as: ApplicativeAsk[IO, AppContext]

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/DataprocInterpreterSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/DataprocInterpreterSpec.scala
@@ -224,61 +224,6 @@ class DataprocInterpreterSpec
     erroredDataprocDAO.invocationCount shouldBe 7
   }
 
-  // TODO
-//  it should "choose the correct VPC subnet and network settings" in isolatedDbTest {
-//    // if config isn't set up to look at labels (which the default one isn't), the labels don't matter
-//    // and we should fall back to the config
-//    val decoySubnetMap = Map("subnet-label" -> "incorrectSubnet", "network-label" -> "incorrectNetwork")
-//    clusterHelper.getClusterVPCSettings(decoySubnetMap) shouldBe Some(VPCSubnet("test-subnet"))
-//
-//    // label behaviour should be: project-subnet, project-network, config-subnet, config-network
-//    val configWithProjectLabels =
-//      dataprocConfig.copy(projectVPCSubnetLabel = Some("subnet-label"), projectVPCNetworkLabel = Some("network-label"))
-//    val clusterHelperWithLabels = new ClusterHelper(configWithProjectLabels,
-//                                                    imageConfig,
-//                                                    googleGroupsConfig,
-//                                                    proxyConfig,
-//                                                    clusterResourcesConfig,
-//                                                    clusterFilesConfig,
-//                                                    monitorConfig,
-//                                                    welderConfig,
-//                                                    bucketHelper,
-//                                                    mockGoogleDataprocDAO,
-//                                                    mockGoogleComputeDAO,
-//                                                    mockGoogleDirectoryDAO,
-//                                                    mockGoogleIamDAO,
-//                                                    mockGoogleProjectDAO,
-//                                                    MockWelderDAO,
-//                                                    blocker)
-//
-//    val subnetMap = Map("subnet-label" -> "correctSubnet", "network-label" -> "incorrectNetwork")
-//    clusterHelperWithLabels.getClusterVPCSettings(subnetMap) shouldBe Some(VPCSubnet("correctSubnet"))
-//
-//    val networkMap = Map("network-label" -> "correctNetwork")
-//    clusterHelperWithLabels.getClusterVPCSettings(networkMap) shouldBe Some(VPCNetwork("correctNetwork"))
-//
-//    clusterHelperWithLabels.getClusterVPCSettings(Map()) shouldBe Some(VPCSubnet("test-subnet"))
-//
-//    val configWithNoSubnet = dataprocConfig.copy(vpcSubnet = None)
-//    val clusterHelperWithNoSubnet = new ClusterHelper(configWithNoSubnet,
-//                                                      imageConfig,
-//                                                      googleGroupsConfig,
-//                                                      proxyConfig,
-//                                                      clusterResourcesConfig,
-//                                                      clusterFilesConfig,
-//                                                      monitorConfig,
-//                                                      welderConfig,
-//                                                      bucketHelper,
-//                                                      mockGoogleDataprocDAO,
-//                                                      mockGoogleComputeDAO,
-//                                                      mockGoogleDirectoryDAO,
-//                                                      mockGoogleIamDAO,
-//                                                      mockGoogleProjectDAO,
-//                                                      MockWelderDAO,
-//                                                      blocker)
-//    clusterHelperWithNoSubnet.getClusterVPCSettings(Map()) shouldBe Some(VPCNetwork("test-network"))
-//  }
-
   it should "retry 409 errors when adding IAM roles" in isolatedDbTest {
     implicit val patienceConfig = PatienceConfig(timeout = 5.minutes)
     val erroredIamDAO = new ErroredMockGoogleIamDAO(409)

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/RuntimeTemplateValuesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/RuntimeTemplateValuesSpec.scala
@@ -1,0 +1,88 @@
+package org.broadinstitute.dsde.workbench.leonardo.util
+
+import org.broadinstitute.dsde.workbench.leonardo.http.nowInstant
+import org.broadinstitute.dsde.workbench.leonardo.{CommonTestData, LeonardoTestSuite, RuntimeOperation, WelderAction}
+import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GcsObjectName, GcsPath}
+import org.scalatest.FlatSpecLike
+
+class RuntimeTemplateValuesSpec extends LeonardoTestSuite with FlatSpecLike {
+
+  "RuntimeTemplateValues" should "generate correct template values from a Runtime" in {
+    val config = RuntimeTemplateValuesConfig.fromRuntime(
+      CommonTestData.testCluster,
+      Some(CommonTestData.initBucketName),
+      None,
+      CommonTestData.imageConfig,
+      CommonTestData.welderConfig,
+      CommonTestData.proxyConfig,
+      CommonTestData.clusterFilesConfig,
+      CommonTestData.clusterResourcesConfig,
+      Some(CommonTestData.clusterResourceConstraints),
+      RuntimeOperation.Restarting,
+      Some(WelderAction.UpdateWelder)
+    )
+
+    val test = for {
+      now <- nowInstant
+      result = RuntimeTemplateValues(config, Some(now))
+    } yield {
+      // note: alphabetized
+      result.clusterName shouldBe CommonTestData.testCluster.runtimeName.asString
+      result.customEnvVarsConfigUri shouldBe GcsPath(CommonTestData.initBucketName,
+                                                     GcsObjectName("custom_env_vars.env")).toUri
+      result.deployWelder shouldBe "false"
+      result.disableDelocalization shouldBe "false"
+      result.googleClientId shouldBe "clientId"
+      result.googleProject shouldBe CommonTestData.testCluster.googleProject.value
+      result.jupyterCombinedExtensions shouldBe ""
+      result.jupyterDockerCompose shouldBe GcsPath(CommonTestData.initBucketName,
+                                                   GcsObjectName("test-jupyter-docker-compose.yaml")).toUri
+      result.jupyterDockerComposeGce shouldBe GcsPath(CommonTestData.initBucketName,
+                                                      GcsObjectName("test-jupyter-docker-compose-gce.yaml")).toUri
+      result.jupyterDockerImage shouldBe CommonTestData.jupyterImage.imageUrl
+      result.jupyterLabExtensions shouldBe ""
+      result.jupyterNbExtensions shouldBe ""
+      result.jupyterNotebookConfigUri shouldBe GcsPath(CommonTestData.initBucketName,
+                                                       GcsObjectName("jupyter_notebook_config.py")).toUri
+      result.jupyterNotebookFrontendConfigUri shouldBe GcsPath(CommonTestData.initBucketName,
+                                                               GcsObjectName("notebook.json")).toUri
+      result.jupyterServerCrt shouldBe GcsPath(CommonTestData.initBucketName, GcsObjectName("test-server.crt")).toUri
+      result.jupyterServerExtensions shouldBe ""
+      result.jupyterServerKey shouldBe GcsPath(CommonTestData.initBucketName, GcsObjectName("test-server.key")).toUri
+      result.jupyterServerName shouldBe "jupyter-server"
+      result.jupyterServiceAccountCredentials shouldBe ""
+      result.jupyterStartUserScriptOutputUri shouldBe RuntimeTemplateValues
+        .jupyterUserStartScriptOutputUriPath(CommonTestData.stagingBucketName, now)
+        .toUri
+      result.jupyterStartUserScriptUri shouldBe GcsPath(GcsBucketName("bucket-name"), GcsObjectName("startScript")).toUri
+      result.jupyterUserScriptOutputUri shouldBe GcsPath(CommonTestData.stagingBucketName,
+                                                         GcsObjectName("userscript_output.txt")).toUri
+      result.jupyterUserScriptUri shouldBe GcsPath(GcsBucketName("bucket-name"), GcsObjectName("userScript")).toUri
+      result.loginHint shouldBe CommonTestData.auditInfo.creator.value
+      result.memLimit shouldBe "3758096384b" // 3.5 GB
+      result.notebooksDir shouldBe "/home/jupyter-user/notebooks"
+      result.proxyDockerCompose shouldBe GcsPath(CommonTestData.initBucketName,
+                                                 GcsObjectName("test-proxy-docker-compose.yaml")).toUri
+      result.proxyDockerImage shouldBe CommonTestData.proxyImage.imageUrl
+      result.proxyServerName shouldBe "proxy-server"
+      result.proxySiteConf shouldBe GcsPath(CommonTestData.initBucketName, GcsObjectName("test-site.conf")).toUri
+      result.rootCaPem shouldBe GcsPath(CommonTestData.initBucketName, GcsObjectName("test-server.pem")).toUri
+      result.rstudioDockerCompose shouldBe GcsPath(CommonTestData.initBucketName,
+                                                   GcsObjectName("test-rstudio-docker-compose.yaml")).toUri
+      result.rstudioDockerImage shouldBe ""
+      result.rstudioServerName shouldBe "rstudio-server"
+      result.runtimeOperation shouldBe RuntimeOperation.Restarting.asString
+      result.stagingBucketName shouldBe CommonTestData.stagingBucketName.value
+      result.updateWelder shouldBe "true"
+      result.welderDockerCompose shouldBe GcsPath(CommonTestData.initBucketName,
+                                                  GcsObjectName("test-welder-docker-compose.yaml")).toUri
+      result.welderDockerImage shouldBe CommonTestData.welderImage.imageUrl
+      result.welderEnabled shouldBe "true"
+      result.welderMemLimit shouldBe "805306368b" // 768 MB
+      result.welderServerName shouldBe "welder-server"
+    }
+
+    test.unsafeRunSync()
+  }
+
+}


### PR DESCRIPTION
See https://broadworkbench.atlassian.net/browse/IA-1810

Some months ago we increased `welderReservedMemory` in `reference.conf`, but the `mem_limit` in `welder-docker-compose.yaml` was still hard-coded to 512m. This adds `welderMemLimit` as a template field. Also added a spec for `RuntimeTemplateValues`.

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
