### PR TITLE
IA-1855 improve subscriber

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/ClusterFixtureSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/ClusterFixtureSpec.scala
@@ -118,10 +118,14 @@ abstract class ClusterFixtureSpec extends fixture.FreeSpec with BeforeAndAfterAl
             toolDockerImage = toolDockerImage,
             autopause = Some(false)
           )
-          Either.catchNonFatal(createNewCluster(GoogleProject(billingProject), request = request)(ronAuthToken)).handleError { e =>
-            clusterCreationFailureMsg = e.getMessage
-            null
-          }.map(c => ronCluster = c).void
+          Either
+            .catchNonFatal(createNewCluster(GoogleProject(billingProject), request = request)(ronAuthToken))
+            .handleError { e =>
+              clusterCreationFailureMsg = e.getMessage
+              null
+            }
+            .map(c => ronCluster = c)
+            .void
         case None =>
           clusterCreationFailureMsg = "leonardo.billingProject system property is not set"
       }
@@ -133,9 +137,9 @@ abstract class ClusterFixtureSpec extends fixture.FreeSpec with BeforeAndAfterAl
     if (!debug) {
       sys.props.get(gpallocProjectKey) match {
         case Some(billingProject) =>
-          if(ronCluster != null)
+          if (ronCluster != null)
             deleteCluster(GoogleProject(billingProject), ronCluster.clusterName, false)(ronAuthToken)
-        case None                 => throw new RuntimeException("leonardo.billingProject system property is not set")
+        case None => throw new RuntimeException("leonardo.billingProject system property is not set")
       }
     }
     super.afterAll()

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -331,6 +331,9 @@ pubsub {
   #pubsubGoogleProject = "broad-dsde-dev"
   #topicName = "leonardo-pubsub"
   queueSize = 100
+  subscriber {
+    concurrency = 20
+  }
 }
 
 autoFreeze {

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -331,9 +331,10 @@ pubsub {
   #pubsubGoogleProject = "broad-dsde-dev"
   #topicName = "leonardo-pubsub"
   queueSize = 100
+  ackDeadLine = 5 minutes
   subscriber {
     concurrency = 20
-    timeout = 55 seconds
+    timeout = 295 seconds // slightly less than ackDeadline
   }
 }
 

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -333,6 +333,7 @@ pubsub {
   queueSize = 100
   subscriber {
     concurrency = 20
+    timeout = 55 seconds
   }
 }
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/Boot.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/Boot.scala
@@ -209,7 +209,9 @@ object Boot extends IOApp {
 
           // only needed for backleo
           val pubsubSubscriber =
-            new LeoPubsubMessageSubscriber[IO](appDependencies.subscriber, gceRuntimeMonitor)
+            new LeoPubsubMessageSubscriber[IO](leoPubsubMessageSubscriberConfig,
+                                               appDependencies.subscriber,
+                                               gceRuntimeMonitor)
 
           val autopauseMonitor = AutopauseMonitor(
             autoFreezeConfig,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
@@ -30,7 +30,7 @@ import org.broadinstitute.dsde.workbench.leonardo.config.ContentSecurityPolicyCo
 }
 import org.broadinstitute.dsde.workbench.leonardo.dao.HttpSamDaoConfig
 import org.broadinstitute.dsde.workbench.leonardo.model.ServiceAccountProviderConfig
-import org.broadinstitute.dsde.workbench.leonardo.monitor.GceMonitorConfig
+import org.broadinstitute.dsde.workbench.leonardo.monitor.{GceMonitorConfig, LeoPubsubMessageSubscriberConfig}
 import org.broadinstitute.dsde.workbench.leonardo.util.RuntimeInterpreterConfig.{
   DataprocInterpreterConfig,
   GceInterpreterConfig
@@ -350,6 +350,12 @@ object Config {
   implicit val styleSrcReader: ValueReader[StyleSrc] = traversableReader[List, String].map(StyleSrc)
   implicit val connectSrcReader: ValueReader[ConnectSrc] = traversableReader[List, String].map(ConnectSrc)
   implicit val objectSrcReader: ValueReader[ObjectSrc] = traversableReader[List, String].map(ObjectSrc)
+  implicit val leoPubsubMessageSubscriberConfigReader: ValueReader[LeoPubsubMessageSubscriberConfig] =
+    ValueReader.relative { config =>
+      LeoPubsubMessageSubscriberConfig(
+        config.getInt("concurrency")
+      )
+    }
 
   val applicationConfig = config.as[ApplicationConfig]("application")
   val googleGroupsConfig = config.as[GoogleGroupsConfig]("groups")
@@ -445,4 +451,6 @@ object Config {
                                                   clusterFilesConfig,
                                                   monitorConfig)
   val vpcInterpreterConfig = VPCInterpreterConfig(vpcConfig)
+
+  val leoPubsubMessageSubscriberConfig = config.as[LeoPubsubMessageSubscriberConfig]("pubsub.subscriber")
 }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
@@ -354,7 +354,7 @@ object Config {
     ValueReader.relative { config =>
       LeoPubsubMessageSubscriberConfig(
         config.getInt("concurrency"),
-        toScalaDuration(config.getDuration("timeout"))
+        config.as[FiniteDuration]("timeout")
       )
     }
 
@@ -428,7 +428,7 @@ object Config {
   val subscriberConfig: SubscriberConfig = SubscriberConfig(
     applicationConfig.leoServiceAccountJsonFile.toString,
     topic,
-    1 minute,
+    config.as[FiniteDuration]("pubsub.ackDeadLine"),
     None)
 
   private val retryConfig = GoogleTopicAdminInterpreter.defaultRetryConfig

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorSupervisor.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorSupervisor.scala
@@ -274,7 +274,7 @@ class ClusterMonitorSupervisor(
             case c if c.status == RuntimeStatus.Creating && c.asyncRuntimeFields.isDefined =>
               IO(self ! ClusterCreated(c, c.stopAfterCreation))
 
-            case c => IO(logger.warn(s"Unhandled status(${c.status}) in ClusterMonitorSupervisor"))
+            case c => IO(logger.warn(s"${c.projectNameString} unhandled status(${c.status}). Not going to monitor"))
           }
         case Left(e) =>
           IO(logger.error("Error starting cluster monitor", e))

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
@@ -58,7 +58,7 @@ class LeoPubsubMessageSubscriber[F[_]: Timer: ContextShift](
       implicit val appContext = ApplicativeAsk.const[F, AppContext](AppContext(traceId, now))
       val res = for {
         res <- messageResponder(event.msg, now)
-          .timeout(55 seconds)
+          .timeout(config.timeout)
           .attempt // set timeout to 55 seconds because subscriber's ack deadline is 1 minute
         _ <- res match {
           case Left(e) =>
@@ -448,4 +448,4 @@ object PubsubHandleMessageError {
   }
 }
 
-final case class LeoPubsubMessageSubscriberConfig(concurrency: Int)
+final case class LeoPubsubMessageSubscriberConfig(concurrency: Int, timeout: FiniteDuration)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
@@ -10,7 +10,6 @@ import cats.mtl.ApplicativeAsk
 import fs2.{Pipe, Stream}
 import org.broadinstitute.dsde.workbench.google2.{Event, GoogleSubscriber, MachineTypeName}
 import org.broadinstitute.dsde.workbench.leonardo.RuntimeStatus.{Starting, Stopped}
-import org.broadinstitute.dsde.workbench.leonardo.config.Config.subscriberConfig
 import org.broadinstitute.dsde.workbench.leonardo.db._
 import org.broadinstitute.dsde.workbench.leonardo.http._
 import org.broadinstitute.dsde.workbench.leonardo.model.LeoException
@@ -19,10 +18,13 @@ import org.broadinstitute.dsde.workbench.leonardo.util._
 import org.broadinstitute.dsde.workbench.model.google.{GcsObjectName, GcsPath}
 import org.broadinstitute.dsde.workbench.model.{ErrorReport, TraceId, WorkbenchException}
 
+import cats.effect.implicits._
 import scala.concurrent.ExecutionContext
+import scala.concurrent.duration._
 import scala.util.control.NoStackTrace
 
 class LeoPubsubMessageSubscriber[F[_]: Timer: ContextShift](
+  config: LeoPubsubMessageSubscriberConfig,
   subscriber: GoogleSubscriber[F, LeoPubsubMessage],
   gceRuntimeMonitor: GceRuntimeMonitor[F]
 )(implicit executionContext: ExecutionContext,
@@ -52,11 +54,12 @@ class LeoPubsubMessageSubscriber[F[_]: Timer: ContextShift](
   private[monitor] def messageHandler: Pipe[F, Event[LeoPubsubMessage], Unit] = in => {
     in.evalMap { event =>
       val traceId = event.traceId.getOrElse(TraceId("None"))
-
       val now = Instant.ofEpochMilli(com.google.protobuf.util.Timestamps.toMillis(event.publishedTime))
       implicit val appContext = ApplicativeAsk.const[F, AppContext](AppContext(traceId, now))
       val res = for {
-        res <- messageResponder(event.msg, now).attempt
+        res <- messageResponder(event.msg, now)
+          .timeout(55 seconds)
+          .attempt // set timeout to 55 seconds because subscriber's ack deadline is 1 minute
         _ <- res match {
           case Left(e) =>
             e match {
@@ -81,9 +84,11 @@ class LeoPubsubMessageSubscriber[F[_]: Timer: ContextShift](
     }
   }
 
-  val process: Stream[F, Unit] =
-    (Stream.eval(logger.info(s"starting subscriber ${subscriberConfig.projectTopicName}")) ++ (subscriber.messages through messageHandler))
-      .handleErrorWith(error => Stream.eval(logger.error(error)("Failed to initialize message processor")))
+  val process: Stream[F, Unit] = (subscriber.messages through messageHandler)
+    .chunkLimit(config.concurrency)
+    .map(c => Stream.chunk(c).covary[F])
+    .parJoin(config.concurrency)
+    .handleErrorWith(error => Stream.eval(logger.error(error)("Failed to initialize message processor")))
 
   private def ack(event: Event[LeoPubsubMessage]): F[Unit] =
     logger.info(s"acking message: ${event}") >> F.delay(
@@ -212,7 +217,7 @@ class LeoPubsubMessageSubscriber[F[_]: Timer: ContextShift](
     createCluster.handleErrorWith {
       case e =>
         for {
-          _ <- logger.error(e)(s"Failed to create cluster ${msg.runtimeProjectAndName} in Google")
+          _ <- logger.error(e)(s"Failed to create runtime ${msg.runtimeProjectAndName} in Google")
           errorMessage = e match {
             case leoEx: LeoException =>
               ErrorReport.loggableString(leoEx.toErrorReport)
@@ -442,3 +447,5 @@ object PubsubHandleMessageError {
     val isRetryable: Boolean = false
   }
 }
+
+final case class LeoPubsubMessageSubscriberConfig(concurrency: Int)

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriberSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriberSpec.scala
@@ -512,7 +512,7 @@ class LeoPubsubMessageSubscriberSpec
   def makeLeoSubscriber() = {
     val googleSubscriber = mock[GoogleSubscriber[IO, LeoPubsubMessage]]
 
-    new LeoPubsubMessageSubscriber[IO](googleSubscriber, MockGceRuntimeMonitor)
+    new LeoPubsubMessageSubscriber[IO](LeoPubsubMessageSubscriberConfig(1), googleSubscriber, MockGceRuntimeMonitor)
   }
 
 }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriberSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriberSpec.scala
@@ -36,6 +36,7 @@ import org.scalatest.concurrent._
 import org.scalatest.{FlatSpecLike, Matchers}
 import org.scalatestplus.mockito.MockitoSugar
 
+import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.util.Left
 
@@ -512,7 +513,7 @@ class LeoPubsubMessageSubscriberSpec
   def makeLeoSubscriber() = {
     val googleSubscriber = mock[GoogleSubscriber[IO, LeoPubsubMessage]]
 
-    new LeoPubsubMessageSubscriber[IO](LeoPubsubMessageSubscriberConfig(1), googleSubscriber, MockGceRuntimeMonitor)
+    new LeoPubsubMessageSubscriber[IO](LeoPubsubMessageSubscriberConfig(1, 30 seconds), googleSubscriber, MockGceRuntimeMonitor)
   }
 
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -19,7 +19,7 @@ object Dependencies {
   val workbenchUtilV = "0.5-4c7acd5"
   val workbenchModelV = "0.13-31cacc4"
   val workbenchGoogleV = "0.21-96ad43c"
-  val workbenchGoogle2V = "0.8-026b2b3"
+  val workbenchGoogle2V = "0.8-f8faa88"
   val workbenchMetricsV = "0.3-c5b80d2"
   val workbenchOpenTelemetryV = "0.1-73d6a64"
 


### PR DESCRIPTION
1. set timeout on the IO that we’re running before ack msgs 
2. process messages from queue with some concurrency

LeoPubsubMessageSubscriber.scala  has main fix

TODO:
~~bump wb-libs with other improvements~~

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
