### PR TITLE
QA-1099 comment out updating test in NotebookClusterMonitoringSpec

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookClusterMonitoringSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookClusterMonitoringSpec.scala
@@ -62,159 +62,159 @@ class NotebookClusterMonitoringSpec extends GPAllocFixtureSpec with ParallelTest
       }
     }
 
-    // make sure adding a worker and changing the master machine type/disk works
-    "should update the cluster to add/remove worker nodes and change master machine type/disk" in { billingProject =>
-      implicit val ronToken: AuthToken = ronAuthToken
-
-      val initialMachineConfig =
-        RuntimeConfigRequest.DataprocConfig(
-          numberOfWorkers = Some(2),
-          masterMachineType = Some("n1-standard-2"),
-          masterDiskSize = Some(50),
-          workerMachineType = None,
-          workerDiskSize = None,
-          numberOfWorkerLocalSSDs = None,
-          numberOfPreemptibleWorkers = None,
-          properties = Map.empty
-        )
-
-      withNewCluster(billingProject,
-                     request = defaultClusterRequest
-                       .copy(machineConfig = Some(initialMachineConfig))) { cluster =>
-        // update the cluster to add another worker node and increase the master disk
-        val newMachineConfig =
-          RuntimeConfigRequest.DataprocConfig(
-            numberOfWorkers = Some(3),
-            masterDiskSize = Some(100),
-            masterMachineType = Some("n1-standard-2"),
-            workerMachineType = None,
-            workerDiskSize = None,
-            numberOfWorkerLocalSSDs = None,
-            numberOfPreemptibleWorkers = None,
-            properties = Map.empty
-          )
-        Leonardo.cluster.update(
-          billingProject,
-          cluster.clusterName,
-          ClusterRequest(machineConfig = Some(newMachineConfig))
-        )
-
-        eventually(timeout(Span(60, Seconds)), interval(Span(5, Seconds))) {
-          val status = Leonardo.cluster.get(billingProject, cluster.clusterName).status
-          status shouldBe ClusterStatus.Updating
-        }
-
-        val timeToAddWorker = time {
-          eventually(timeout(Span(420, Seconds)), interval(Span(30, Seconds))) {
-            val clusterResponse = Leonardo.cluster.get(billingProject, cluster.clusterName)
-
-            Some(
-              clusterResponse.machineConfig
-                .asInstanceOf[RuntimeConfig.DataprocConfig]
-                .numberOfWorkers
-            ) shouldBe newMachineConfig.numberOfWorkers
-            Some(
-              clusterResponse.machineConfig
-                .asInstanceOf[RuntimeConfig.DataprocConfig]
-                .masterMachineType
-                .value
-            ) shouldBe initialMachineConfig.masterMachineType
-            Some(
-              clusterResponse.machineConfig
-                .asInstanceOf[RuntimeConfig.DataprocConfig]
-                .masterDiskSize
-                .gb
-            ) shouldBe newMachineConfig.masterDiskSize
-            clusterResponse.status shouldBe ClusterStatus.Running
-          }
-        }
-
-        logger.info(
-          s"Adding worker to ${cluster.projectNameString}} took ${timeToAddWorker.duration.toSeconds} seconds"
-        )
-
-        // now that we have confirmed that we can add a worker node, let's see what happens when we size it back down to 2 workers
-        val twoWorkersConfig =
-          newMachineConfig.copy(numberOfWorkers = Some(2),
-                                masterDiskSize = Some(500),
-                                masterMachineType = Some("n1-standard-2"))
-        Leonardo.cluster.update(
-          billingProject,
-          cluster.clusterName,
-          ClusterRequest(machineConfig = Some(twoWorkersConfig))
-        )
-
-        eventually(timeout(Span(60, Seconds)), interval(Span(5, Seconds))) {
-          val status = Leonardo.cluster.get(billingProject, cluster.clusterName).status
-          status shouldBe ClusterStatus.Updating
-        }
-
-        val timeToRemoveWorker = time {
-          eventually(timeout(Span(420, Seconds)), interval(Span(30, Seconds))) {
-            val clusterResponse = Leonardo.cluster.get(billingProject, cluster.clusterName)
-            Some(
-              clusterResponse.machineConfig
-                .asInstanceOf[RuntimeConfig.DataprocConfig]
-                .numberOfWorkers
-            ) shouldBe twoWorkersConfig.numberOfWorkers
-            Some(
-              clusterResponse.machineConfig
-                .asInstanceOf[RuntimeConfig.DataprocConfig]
-                .masterMachineType
-                .value
-            ) shouldBe initialMachineConfig.masterMachineType
-            Some(
-              clusterResponse.machineConfig
-                .asInstanceOf[RuntimeConfig.DataprocConfig]
-                .masterDiskSize
-                .gb
-            ) shouldBe twoWorkersConfig.masterDiskSize
-            clusterResponse.status shouldBe ClusterStatus.Running
-          }
-        }
-
-        logger.info(
-          s"Removing worker to ${cluster.projectNameString}} took ${timeToRemoveWorker.duration.toSeconds} seconds"
-        )
-
-        // finally, change the master machine type
-        // Note this requires a cluster restart. A future enhancement may be for Leo to handle this internally.
-        val newMachineTypeConfig =
-          twoWorkersConfig.copy(masterMachineType = Some("n1-standard-4"),
-                                masterDiskSize = Some(500),
-                                numberOfWorkers = Some(2))
-        withRestartCluster(cluster) { cluster =>
-          Leonardo.cluster.update(
-            billingProject,
-            cluster.clusterName,
-            ClusterRequest(machineConfig = Some(newMachineTypeConfig))
-          )
-          // cluster status should still be Stopped
-          val status = Leonardo.cluster.get(billingProject, cluster.clusterName).status
-          status shouldBe ClusterStatus.Stopped
-        }
-
-        val clusterResponse = Leonardo.cluster.get(billingProject, cluster.clusterName)
-        Some(
-          clusterResponse.machineConfig
-            .asInstanceOf[RuntimeConfig.DataprocConfig]
-            .numberOfWorkers
-        ) shouldBe newMachineTypeConfig.numberOfWorkers
-        Some(
-          clusterResponse.machineConfig
-            .asInstanceOf[RuntimeConfig.DataprocConfig]
-            .masterMachineType
-            .value
-        ) shouldBe newMachineTypeConfig.masterMachineType
-        Some(
-          clusterResponse.machineConfig
-            .asInstanceOf[RuntimeConfig.DataprocConfig]
-            .masterDiskSize
-            .gb
-        ) shouldBe newMachineTypeConfig.masterDiskSize
-        clusterResponse.status shouldBe ClusterStatus.Running
-      }
-    }
+//    // make sure adding a worker and changing the master machine type/disk works
+//    "should update the cluster to add/remove worker nodes and change master machine type/disk" in { billingProject =>
+//      implicit val ronToken: AuthToken = ronAuthToken
+//
+//      val initialMachineConfig =
+//        RuntimeConfigRequest.DataprocConfig(
+//          numberOfWorkers = Some(2),
+//          masterMachineType = Some("n1-standard-2"),
+//          masterDiskSize = Some(50),
+//          workerMachineType = None,
+//          workerDiskSize = None,
+//          numberOfWorkerLocalSSDs = None,
+//          numberOfPreemptibleWorkers = None,
+//          properties = Map.empty
+//        )
+//
+//      withNewCluster(billingProject,
+//                     request = defaultClusterRequest
+//                       .copy(machineConfig = Some(initialMachineConfig))) { cluster =>
+//        // update the cluster to add another worker node and increase the master disk
+//        val newMachineConfig =
+//          RuntimeConfigRequest.DataprocConfig(
+//            numberOfWorkers = Some(3),
+//            masterDiskSize = Some(100),
+//            masterMachineType = Some("n1-standard-2"),
+//            workerMachineType = None,
+//            workerDiskSize = None,
+//            numberOfWorkerLocalSSDs = None,
+//            numberOfPreemptibleWorkers = None,
+//            properties = Map.empty
+//          )
+//        Leonardo.cluster.update(
+//          billingProject,
+//          cluster.clusterName,
+//          ClusterRequest(machineConfig = Some(newMachineConfig))
+//        )
+//
+//        eventually(timeout(Span(60, Seconds)), interval(Span(5, Seconds))) {
+//          val status = Leonardo.cluster.get(billingProject, cluster.clusterName).status
+//          status shouldBe ClusterStatus.Updating
+//        }
+//
+//        val timeToAddWorker = time {
+//          eventually(timeout(Span(420, Seconds)), interval(Span(30, Seconds))) {
+//            val clusterResponse = Leonardo.cluster.get(billingProject, cluster.clusterName)
+//
+//            Some(
+//              clusterResponse.machineConfig
+//                .asInstanceOf[RuntimeConfig.DataprocConfig]
+//                .numberOfWorkers
+//            ) shouldBe newMachineConfig.numberOfWorkers
+//            Some(
+//              clusterResponse.machineConfig
+//                .asInstanceOf[RuntimeConfig.DataprocConfig]
+//                .masterMachineType
+//                .value
+//            ) shouldBe initialMachineConfig.masterMachineType
+//            Some(
+//              clusterResponse.machineConfig
+//                .asInstanceOf[RuntimeConfig.DataprocConfig]
+//                .masterDiskSize
+//                .gb
+//            ) shouldBe newMachineConfig.masterDiskSize
+//            clusterResponse.status shouldBe ClusterStatus.Running
+//          }
+//        }
+//
+//        logger.info(
+//          s"Adding worker to ${cluster.projectNameString}} took ${timeToAddWorker.duration.toSeconds} seconds"
+//        )
+//
+//        // now that we have confirmed that we can add a worker node, let's see what happens when we size it back down to 2 workers
+//        val twoWorkersConfig =
+//          newMachineConfig.copy(numberOfWorkers = Some(2),
+//                                masterDiskSize = Some(500),
+//                                masterMachineType = Some("n1-standard-2"))
+//        Leonardo.cluster.update(
+//          billingProject,
+//          cluster.clusterName,
+//          ClusterRequest(machineConfig = Some(twoWorkersConfig))
+//        )
+//
+//        eventually(timeout(Span(60, Seconds)), interval(Span(5, Seconds))) {
+//          val status = Leonardo.cluster.get(billingProject, cluster.clusterName).status
+//          status shouldBe ClusterStatus.Updating
+//        }
+//
+//        val timeToRemoveWorker = time {
+//          eventually(timeout(Span(420, Seconds)), interval(Span(30, Seconds))) {
+//            val clusterResponse = Leonardo.cluster.get(billingProject, cluster.clusterName)
+//            Some(
+//              clusterResponse.machineConfig
+//                .asInstanceOf[RuntimeConfig.DataprocConfig]
+//                .numberOfWorkers
+//            ) shouldBe twoWorkersConfig.numberOfWorkers
+//            Some(
+//              clusterResponse.machineConfig
+//                .asInstanceOf[RuntimeConfig.DataprocConfig]
+//                .masterMachineType
+//                .value
+//            ) shouldBe initialMachineConfig.masterMachineType
+//            Some(
+//              clusterResponse.machineConfig
+//                .asInstanceOf[RuntimeConfig.DataprocConfig]
+//                .masterDiskSize
+//                .gb
+//            ) shouldBe twoWorkersConfig.masterDiskSize
+//            clusterResponse.status shouldBe ClusterStatus.Running
+//          }
+//        }
+//
+//        logger.info(
+//          s"Removing worker to ${cluster.projectNameString}} took ${timeToRemoveWorker.duration.toSeconds} seconds"
+//        )
+//
+//        // finally, change the master machine type
+//        // Note this requires a cluster restart. A future enhancement may be for Leo to handle this internally.
+//        val newMachineTypeConfig =
+//          twoWorkersConfig.copy(masterMachineType = Some("n1-standard-4"),
+//                                masterDiskSize = Some(500),
+//                                numberOfWorkers = Some(2))
+//        withRestartCluster(cluster) { cluster =>
+//          Leonardo.cluster.update(
+//            billingProject,
+//            cluster.clusterName,
+//            ClusterRequest(machineConfig = Some(newMachineTypeConfig))
+//          )
+//          // cluster status should still be Stopped
+//          val status = Leonardo.cluster.get(billingProject, cluster.clusterName).status
+//          status shouldBe ClusterStatus.Stopped
+//        }
+//
+//        val clusterResponse = Leonardo.cluster.get(billingProject, cluster.clusterName)
+//        Some(
+//          clusterResponse.machineConfig
+//            .asInstanceOf[RuntimeConfig.DataprocConfig]
+//            .numberOfWorkers
+//        ) shouldBe newMachineTypeConfig.numberOfWorkers
+//        Some(
+//          clusterResponse.machineConfig
+//            .asInstanceOf[RuntimeConfig.DataprocConfig]
+//            .masterMachineType
+//            .value
+//        ) shouldBe newMachineTypeConfig.masterMachineType
+//        Some(
+//          clusterResponse.machineConfig
+//            .asInstanceOf[RuntimeConfig.DataprocConfig]
+//            .masterDiskSize
+//            .gb
+//        ) shouldBe newMachineTypeConfig.masterDiskSize
+//        clusterResponse.status shouldBe ClusterStatus.Running
+//      }
+//    }
 
     "should pause and resume a cluster with preemptible instances" in { billingProject =>
       implicit val ronToken: AuthToken = ronAuthToken


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/QA-1099

Old patch route will be removed soonish anyway so ignoring the test for now to reduce some flakiness...

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
