### PR TITLE
IA-1875 More improvement

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookClusterMonitoringSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookClusterMonitoringSpec.scala
@@ -12,7 +12,6 @@ import org.broadinstitute.dsde.workbench.model.google.{parseGcsPath, EmailGcsEnt
 import org.broadinstitute.dsde.workbench.service.Sam
 
 import org.scalatest.tagobjects.Retryable
-import org.scalatest.time.{Seconds, Span}
 import org.scalatest.{DoNotDiscover, ParallelTestExecution}
 
 import scala.concurrent.duration._

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/GceRuntimeMonitor.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/GceRuntimeMonitor.scala
@@ -41,7 +41,7 @@ object GceMonitorState {
 }
 
 final case class MonitorContext(start: Instant, runtimeId: Long, traceId: TraceId) {
-  override def toString: String = s"runtimeId(${runtimeId}), traceId(${traceId.asString}))"
+  override def toString: String = s"${runtimeId}/${traceId.asString}"
 }
 
 final case class GceMonitorConfig(initialDelay: FiniteDuration,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/GceRuntimeMonitorInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/GceRuntimeMonitorInterp.scala
@@ -459,14 +459,14 @@ class GceRuntimeMonitorInterp[F[_]: Timer: Parallel](
             case Some(x) =>
               logger
                 .info(
-                  s"Runtime ${runtimeAndRuntimeConfig.runtime.projectNameString}'s tools(${toolsToCheck}) is not ready yet and has taken ${timeElapsed.toSeconds} seconds so far. Checking again in ${config.pollingInterval}. ${message
+                  s"${monitorContext} | Runtime ${runtimeAndRuntimeConfig.runtime.projectNameString}'s tools(${toolsToCheck}) is not ready yet and has taken ${timeElapsed.toSeconds} seconds so far. Checking again in ${config.pollingInterval}. ${message
                     .getOrElse("")}"
                 )
                 .as(((), Some(CheckTools(x, runtimeAndRuntimeConfig, toolsToCheck))))
             case None =>
               logger
                 .info(
-                  s"Runtime ${runtimeAndRuntimeConfig.runtime.projectNameString} is not in final state yet and has taken ${timeElapsed.toSeconds} seconds so far. Checking again in ${config.pollingInterval}. ${message
+                  s"${monitorContext} | Runtime ${runtimeAndRuntimeConfig.runtime.projectNameString} is not in final state yet and has taken ${timeElapsed.toSeconds} seconds so far. Checking again in ${config.pollingInterval}. ${message
                     .getOrElse("")}"
                 )
                 .as(((), Some(Check(runtimeAndRuntimeConfig))))


### PR DESCRIPTION
Looked at logs a bit closer. There were redelivered messages. Not sure exactly why...Found https://github.com/googleapis/google-cloud-python/issues/9252, which may happen with java client as well...Regardless whether this is something the client should fix, we should make things as idempotent as we can...Currently when we redeliver the same message, Leonardo will mark the runtime as Errored, while in reality the runtime was created fine.

Another thing worth considering is adding some logic for deduping messages in leo

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
