### PR TITLE
[no ticket] Fix flakey LeoPubsubMessageSubscriberSpec

### DIFF
--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
@@ -423,11 +423,10 @@ object Config {
   val vpcConfig = config.as[VPCConfig]("vpc")
   val topic = ProjectTopicName.of(pubsubConfig.pubsubGoogleProject.value, pubsubConfig.topicName)
 
-  val subscriberConfig: SubscriberConfig = SubscriberConfig(
-    applicationConfig.leoServiceAccountJsonFile.toString,
-    topic,
-    config.as[FiniteDuration]("pubsub.ackDeadLine"),
-    None)
+  val subscriberConfig: SubscriberConfig = SubscriberConfig(applicationConfig.leoServiceAccountJsonFile.toString,
+                                                            topic,
+                                                            config.as[FiniteDuration]("pubsub.ackDeadLine"),
+                                                            None)
 
   private val retryConfig = GoogleTopicAdminInterpreter.defaultRetryConfig
   val publisherConfig: PublisherConfig =

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
@@ -389,10 +389,7 @@ class LeoPubsubMessageSubscriber[F[_]: Timer: ContextShift](
             }
           } yield ()
         } else {
-          for {
-            _ <- runtimeConfig.cloudService.interpreter.updateMachineType(UpdateMachineTypeParams(runtime, m, now))
-            _ <- RuntimeConfigQueries.updateMachineType(runtime.runtimeConfigId, m, now).transaction
-          } yield ()
+          runtimeConfig.cloudService.interpreter.updateMachineType(UpdateMachineTypeParams(runtime, m, now))
         }
       }
     } yield ()

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
@@ -220,13 +220,16 @@ class LeoPubsubMessageSubscriber[F[_]: Timer: ContextShift](
           errorMessage = e match {
             case leoEx: LeoException =>
               Some(ErrorReport.loggableString(leoEx.toErrorReport))
-            case ee: com.google.api.gax.rpc.AbortedException if ee.getStatusCode().getCode == 409 && ee.getMessage().contains("already exists") =>
+            case ee: com.google.api.gax.rpc.AbortedException
+                if ee.getStatusCode().getCode == 409 && ee.getMessage().contains("already exists") =>
               None //this could happen when pubsub redelivers an event unexpectedly
             case _ =>
               Some(s"Failed to create cluster ${msg.runtimeProjectAndName} due to ${e.getMessage}")
           }
-          _ <- errorMessage.traverse(m => (clusterErrorQuery.save(msg.runtimeId, RuntimeError(m, -1, now)) >>
-            clusterQuery.updateClusterStatus(msg.runtimeId, RuntimeStatus.Error, now)).transaction[F])
+          _ <- errorMessage.traverse(m =>
+            (clusterErrorQuery.save(msg.runtimeId, RuntimeError(m, -1, now)) >>
+              clusterQuery.updateClusterStatus(msg.runtimeId, RuntimeStatus.Error, now)).transaction[F]
+          )
         } yield ()
     }
   }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/MockGceRuntimeMonitor.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/MockGceRuntimeMonitor.scala
@@ -7,7 +7,7 @@ import fs2.Stream
 import org.broadinstitute.dsde.workbench.model.TraceId
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 
-object MockGceRuntimeMonitor extends GceRuntimeMonitor[IO] {
+class MockGceRuntimeMonitor extends GceRuntimeMonitor[IO] {
   def process(runtimeId: Long)(implicit ev: ApplicativeAsk[IO, TraceId]): Stream[IO, Unit] = Stream.emit(()).covary[IO]
 
   // Function used for transitions that we can get an Operation
@@ -16,3 +16,4 @@ object MockGceRuntimeMonitor extends GceRuntimeMonitor[IO] {
                 operation: com.google.cloud.compute.v1.Operation,
                 action: RuntimeStatus)(implicit ev: ApplicativeAsk[IO, TraceId]): IO[Unit] = IO.unit
 }
+object MockGceRuntimeMonitor extends MockGceRuntimeMonitor


### PR DESCRIPTION
I think there was a race condition in the tests for `handleUpdateRuntimeMessage` because the stop-start happens asynchronously. This PR adds tests for the following:

1. process `UpdateRuntimeMessage`, transitions to `Stopping`, doesn't do the update yet
2. process `UpdateRuntimeMessage`, transition from `Stopping` -> `Stopped` -> `Starting`, makes the update
3. process `UpdateRuntimeMessage`, does not need to transition, makes the update immediately

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
