### PR TITLE
IA-1299 Enforce minimum disk size of 50

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/JsonCodec.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/JsonCodec.scala
@@ -19,6 +19,7 @@ import org.broadinstitute.dsde.workbench.model.google.{
 object JsonCodec {
   // Errors
   val negativeNumberDecodingFailure = DecodingFailure("Negative number is not allowed", List.empty)
+  val minimumDiskSizeDecodingFailure = DecodingFailure("Minimum required disk size is 50GB", List.empty)
   val oneWorkerSpecifiedDecodingFailure = DecodingFailure(
     "Google Dataproc does not support clusters with 1 non-preemptible worker. Must be 0, 2 or more.",
     List.empty
@@ -134,7 +135,7 @@ object JsonCodec {
   implicit val urlDecoder: Decoder[URL] =
     Decoder.decodeString.emap(s => Either.catchNonFatal(new URL(s)).leftMap(_.getMessage))
   implicit val diskSizeDecoder: Decoder[DiskSize] =
-    Decoder.decodeInt.emap(d => if (d < 50) Left("Minimum disk size is 50GB.") else Right(DiskSize(d)))
+    Decoder.decodeInt.emap(d => if (d < 50) Left("Minimum required disk size is 50GB") else Right(DiskSize(d)))
   implicit val workbenchEmailDecoder: Decoder[WorkbenchEmail] = Decoder.decodeString.map(WorkbenchEmail)
   implicit val runtimeImageTypeDecoder: Decoder[RuntimeImageType] = Decoder.decodeString.emap(s =>
     RuntimeImageType.stringToRuntimeImageType.get(s).toRight(s"invalid RuntimeImageType ${s}")

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/JsonCodec.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/JsonCodec.scala
@@ -134,7 +134,7 @@ object JsonCodec {
   implicit val urlDecoder: Decoder[URL] =
     Decoder.decodeString.emap(s => Either.catchNonFatal(new URL(s)).leftMap(_.getMessage))
   implicit val diskSizeDecoder: Decoder[DiskSize] =
-    Decoder.decodeInt.emap(d => if (d < 0) Left("Negative number is not allowed") else Right(DiskSize(d)))
+    Decoder.decodeInt.emap(d => if (d < 50) Left("Minimum disk size is 50GB.") else Right(DiskSize(d)))
   implicit val workbenchEmailDecoder: Decoder[WorkbenchEmail] = Decoder.decodeString.map(WorkbenchEmail)
   implicit val runtimeImageTypeDecoder: Decoder[RuntimeImageType] = Decoder.decodeString.emap(s =>
     RuntimeImageType.stringToRuntimeImageType.get(s).toRight(s"invalid RuntimeImageType ${s}")

--- a/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/JsonCodecSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/JsonCodecSpec.scala
@@ -83,4 +83,9 @@ class JsonCodecSpec extends LeonardoTestSuite with Matchers with FlatSpecLike {
     val res = decode[RuntimeConfig](inputString)
     res.left shouldBe LeftProjection(Left(DecodingFailure("Minimum required disk size is 50GB", List(DownField("masterDiskSize")))))
   }
+
+  it should "fail with minimumDiskSizeDecodingFailure when decoding a disk size of 10" in {
+    val res = decode[DiskSize]("10")
+    res.left shouldBe LeftProjection(Left(DecodingFailure("Minimum required disk size is 50GB", List())))
+  }
 }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/HttpRoutesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/HttpRoutesSpec.scala
@@ -138,7 +138,7 @@ class HttpRoutesSpec
 
   it should "update a runtime" in {
     val request = UpdateRuntimeRequest(
-      Some(UpdateRuntimeConfigRequest.GceConfig(Some(MachineTypeName("n1-micro-2")), Some(DiskSize(20)))),
+      Some(UpdateRuntimeConfigRequest.GceConfig(Some(MachineTypeName("n1-micro-2")), Some(DiskSize(50)))),
       true,
       Some(true),
       Some(5.minutes)

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/LeoRoutesJsonCodecSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/LeoRoutesJsonCodecSpec.scala
@@ -70,23 +70,6 @@ class LeoRoutesJsonCodecSpec extends FlatSpec with Matchers {
     decodeResult.leftMap(_.getMessage) shouldBe Left("Minimum required disk size is 50GB: DownField(masterDiskSize)")
   }
 
-  it should "fail with minimumDiskSizeDecodingFailure when masterDiskSize is less than 50" in {
-    val inputString =
-      """
-        |{
-        |   "numberOfWorkers": 10,
-        |   "masterMachineType": "n1-standard-8",
-        |   "masterDiskSize": 35
-        |}
-        |""".stripMargin
-
-    val decodeResult = for {
-      json <- io.circe.parser.parse(inputString)
-      r <- json.as[RuntimeConfigRequest.DataprocConfig]
-    } yield r
-    decodeResult.leftMap(_.getMessage) shouldBe Left("Minimum required disk size is 50GB: DownField(masterDiskSize)")
-  }
-
   it should "fail with oneWorkerSpecifiedDecodingFailure when numberOfPreemptibleWorkers is negative" in {
     val inputString =
       """

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/LeoRoutesJsonCodecSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/LeoRoutesJsonCodecSpec.scala
@@ -53,7 +53,7 @@ class LeoRoutesJsonCodecSpec extends FlatSpec with Matchers {
     decodeResult shouldBe Left(negativeNumberDecodingFailure)
   }
 
-  it should "fail with negativeNumberDecodingFailure when masterDiskSize is negative" in {
+  it should "fail with minimumDiskSizeDecodingFailure when masterDiskSize is negative" in {
     val inputString =
       """
         |{
@@ -67,7 +67,24 @@ class LeoRoutesJsonCodecSpec extends FlatSpec with Matchers {
       json <- io.circe.parser.parse(inputString)
       r <- json.as[RuntimeConfigRequest.DataprocConfig]
     } yield r
-    decodeResult.leftMap(_.getMessage) shouldBe Left("Negative number is not allowed: DownField(masterDiskSize)")
+    decodeResult.leftMap(_.getMessage) shouldBe Left("Minimum required disk size is 50GB: DownField(masterDiskSize)")
+  }
+
+  it should "fail with minimumDiskSizeDecodingFailure when masterDiskSize is less than 50" in {
+    val inputString =
+      """
+        |{
+        |   "numberOfWorkers": 10,
+        |   "masterMachineType": "n1-standard-8",
+        |   "masterDiskSize": 35
+        |}
+        |""".stripMargin
+
+    val decodeResult = for {
+      json <- io.circe.parser.parse(inputString)
+      r <- json.as[RuntimeConfigRequest.DataprocConfig]
+    } yield r
+    decodeResult.leftMap(_.getMessage) shouldBe Left("Minimum required disk size is 50GB: DownField(masterDiskSize)")
   }
 
   it should "fail with oneWorkerSpecifiedDecodingFailure when numberOfPreemptibleWorkers is negative" in {


### PR DESCRIPTION
When we decode both GCE and Dataproc config, we are now enforcing a minimum disk size of 50GB. These changes reflect that and add two unit tests for validation.
---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
