### PR TITLE
IA-1888 Terra's content security policy and use of JavaScript libraries

### DIFF
--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -278,6 +278,9 @@ contentSecurityPolicy {
   objectSrc = [
     "'none'"
   ]
+  reportUri = [
+    "https://terra.report-uri.com/r/d/csp/reportOnly"
+  ]
 }
 
 swagger {

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -256,7 +256,7 @@ contentSecurityPolicy {
     "'unsafe-inline'",
     "'unsafe-eval'",
     "https://apis.google.com",
-    "https://cdn.jsdelivr.net/npm"
+    "https://cdn.jsdelivr.net"
   ]
   styleSrc = [
     "'self'",

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -255,7 +255,8 @@ contentSecurityPolicy {
     "data:",
     "'unsafe-inline'",
     "'unsafe-eval'",
-    "https://apis.google.com"
+    "https://apis.google.com",
+    "https://cdn.jsdelivr.net/npm"
   ]
   styleSrc = [
     "'self'",

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -248,11 +248,13 @@ contentSecurityPolicy {
   frameAncestors = [
     "'none'"
   ]
-  # TODO: try to remove unsafe-inline
-  # see https://broadworkbench.atlassian.net/browse/IA-1763
   scriptSrc = [
     "'self'",
+    # Note: data: is insecure but needed to support tools like plotly and facets.
+    # See discussion in https://github.com/DataBiosphere/leonardo/pull/1399
     "data:",
+    # Note: 'unsafe-inline' in insecure but is needed by Jupyter UI.
+    # See https://broadworkbench.atlassian.net/browse/IA-1763
     "'unsafe-inline'",
     "'unsafe-eval'",
     "https://apis.google.com",

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -252,14 +252,15 @@ contentSecurityPolicy {
   # see https://broadworkbench.atlassian.net/browse/IA-1763
   scriptSrc = [
     "'self'",
-    "data:text/javascript",
+    "data:",
     "'unsafe-inline'",
     "'unsafe-eval'",
     "https://apis.google.com"
   ]
   styleSrc = [
     "'self'",
-    "'unsafe-inline'"
+    "'unsafe-inline'",
+    "data:"
   ]
   connectSrc = [
     "'self'",

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
@@ -24,6 +24,7 @@ import org.broadinstitute.dsde.workbench.leonardo.config.ContentSecurityPolicyCo
   ConnectSrc,
   FrameAncestors,
   ObjectSrc,
+  ReportUri,
   ScriptSrc,
   StyleSrc
 }
@@ -228,7 +229,8 @@ object Config {
         config.as[ScriptSrc]("scriptSrc"),
         config.as[StyleSrc]("styleSrc"),
         config.as[ConnectSrc]("connectSrc"),
-        config.as[ObjectSrc]("objectSrc")
+        config.as[ObjectSrc]("objectSrc"),
+        config.as[ReportUri]("reportUri")
       )
   }
 
@@ -348,6 +350,7 @@ object Config {
   implicit val styleSrcReader: ValueReader[StyleSrc] = traversableReader[List, String].map(StyleSrc)
   implicit val connectSrcReader: ValueReader[ConnectSrc] = traversableReader[List, String].map(ConnectSrc)
   implicit val objectSrcReader: ValueReader[ObjectSrc] = traversableReader[List, String].map(ObjectSrc)
+  implicit val reportUriReader: ValueReader[ReportUri] = traversableReader[List, String].map(ReportUri)
   implicit val leoPubsubMessageSubscriberConfigReader: ValueReader[LeoPubsubMessageSubscriberConfig] =
     ValueReader.relative { config =>
       LeoPubsubMessageSubscriberConfig(

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/ContentSecurityPolicyConfig.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/ContentSecurityPolicyConfig.scala
@@ -4,6 +4,7 @@ import org.broadinstitute.dsde.workbench.leonardo.config.ContentSecurityPolicyCo
   ConnectSrc,
   FrameAncestors,
   ObjectSrc,
+  ReportUri,
   ScriptSrc,
   StyleSrc
 }
@@ -14,9 +15,10 @@ final case class ContentSecurityPolicyConfig(frameAncestors: FrameAncestors,
                                              scriptSrc: ScriptSrc,
                                              styleSrc: StyleSrc,
                                              connectSrc: ConnectSrc,
-                                             objectSrc: ObjectSrc) {
+                                             objectSrc: ObjectSrc,
+                                             reportUri: ReportUri) {
   def asString: String = {
-    val components = List(frameAncestors, scriptSrc, styleSrc, connectSrc, objectSrc)
+    val components = List(frameAncestors, scriptSrc, styleSrc, connectSrc, objectSrc, reportUri)
     components.map(c => s"${c.name} ${c.values.mkString(" ")}").mkString("; ")
   }
 }
@@ -40,5 +42,8 @@ object ContentSecurityPolicyComponent {
   }
   final case class ObjectSrc(values: List[String]) extends ContentSecurityPolicyComponent {
     override def name: String = "object-src"
+  }
+  final case class ReportUri(values: List[String]) extends ContentSecurityPolicyComponent {
+    override def name: String = "report-uri"
   }
 }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/config/ContentSecurityPolicyConfigSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/config/ContentSecurityPolicyConfigSpec.scala
@@ -5,6 +5,7 @@ import org.broadinstitute.dsde.workbench.leonardo.config.ContentSecurityPolicyCo
   ConnectSrc,
   FrameAncestors,
   ObjectSrc,
+  ReportUri,
   ScriptSrc,
   StyleSrc
 }
@@ -61,17 +62,22 @@ class ContentSecurityPolicyConfigSpec extends LeonardoTestSuite with FlatSpecLik
         List(
           "'none'"
         )
+      ),
+      ReportUri(
+        List(
+          "https://terra.report-uri.com/r/d/csp/reportOnly"
+        )
       )
     )
 
     test.asString shouldBe
-      "frame-ancestors 'self' *.terra.bio https://bvdp-saturn-prod.appspot.com https://all-of-us-rw-staging.appspot.com https://all-of-us-rw-stable.appspot.com https://stable.fake-research-aou.org https://workbench.researchallofus.org terra.biodatacatalyst.nhlbi.nih.gov; script-src 'self' data: 'unsafe-inline' 'unsafe-eval' https://apis.google.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' data:; connect-src 'self' wss://*.broadinstitute.org:* wss://notebooks.firecloud.org:* *.googleapis.com https://*.npmjs.org https://data.broadinstitute.org https://s3.amazonaws.com/igv.broadinstitute.org/ https://s3.amazonaws.com/igv.org.genomes/ https://raw.githubusercontent.com/PAIR-code/facets/1.0.0/facets-dist/facets-jupyter.html https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/1.3.3/webcomponents-lite.js; object-src 'none'"
+      "frame-ancestors 'self' *.terra.bio https://bvdp-saturn-prod.appspot.com https://all-of-us-rw-staging.appspot.com https://all-of-us-rw-stable.appspot.com https://stable.fake-research-aou.org https://workbench.researchallofus.org terra.biodatacatalyst.nhlbi.nih.gov; script-src 'self' data: 'unsafe-inline' 'unsafe-eval' https://apis.google.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' data:; connect-src 'self' wss://*.broadinstitute.org:* wss://notebooks.firecloud.org:* *.googleapis.com https://*.npmjs.org https://data.broadinstitute.org https://s3.amazonaws.com/igv.broadinstitute.org/ https://s3.amazonaws.com/igv.org.genomes/ https://raw.githubusercontent.com/PAIR-code/facets/1.0.0/facets-dist/facets-jupyter.html https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/1.3.3/webcomponents-lite.js; object-src 'none'; report-uri https://terra.report-uri.com/r/d/csp/reportOnly"
 
   }
 
   it should "parse config values correctly" in {
     CommonTestData.contentSecurityPolicy shouldBe
-      "frame-ancestors 'none'; script-src 'self' data: 'unsafe-inline' 'unsafe-eval' https://apis.google.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' data:; connect-src 'self' wss://*.broadinstitute.org:* wss://notebooks.firecloud.org:* *.googleapis.com https://*.npmjs.org https://data.broadinstitute.org https://s3.amazonaws.com/igv.broadinstitute.org/ https://s3.amazonaws.com/igv.org.genomes/ https://raw.githubusercontent.com/PAIR-code/facets/1.0.0/facets-dist/facets-jupyter.html https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/1.3.3/webcomponents-lite.js; object-src 'none'"
+      "frame-ancestors 'none'; script-src 'self' data: 'unsafe-inline' 'unsafe-eval' https://apis.google.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' data:; connect-src 'self' wss://*.broadinstitute.org:* wss://notebooks.firecloud.org:* *.googleapis.com https://*.npmjs.org https://data.broadinstitute.org https://s3.amazonaws.com/igv.broadinstitute.org/ https://s3.amazonaws.com/igv.org.genomes/ https://raw.githubusercontent.com/PAIR-code/facets/1.0.0/facets-dist/facets-jupyter.html https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/1.3.3/webcomponents-lite.js; object-src 'none'; report-uri https://terra.report-uri.com/r/d/csp/reportOnly"
   }
 
 }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/config/ContentSecurityPolicyConfigSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/config/ContentSecurityPolicyConfigSpec.scala
@@ -29,16 +29,18 @@ class ContentSecurityPolicyConfigSpec extends LeonardoTestSuite with FlatSpecLik
       ScriptSrc(
         List(
           "'self'",
-          "data:text/javascript",
+          "data:",
           "'unsafe-inline'",
           "'unsafe-eval'",
-          "https://apis.google.com"
+          "https://apis.google.com",
+          "https://cdn.jsdelivr.net"
         )
       ),
       StyleSrc(
         List(
           "'self'",
-          "'unsafe-inline'"
+          "'unsafe-inline'",
+          "data:"
         )
       ),
       ConnectSrc(
@@ -63,13 +65,13 @@ class ContentSecurityPolicyConfigSpec extends LeonardoTestSuite with FlatSpecLik
     )
 
     test.asString shouldBe
-      "frame-ancestors 'self' *.terra.bio https://bvdp-saturn-prod.appspot.com https://all-of-us-rw-staging.appspot.com https://all-of-us-rw-stable.appspot.com https://stable.fake-research-aou.org https://workbench.researchallofus.org terra.biodatacatalyst.nhlbi.nih.gov; script-src 'self' data:text/javascript 'unsafe-inline' 'unsafe-eval' https://apis.google.com; style-src 'self' 'unsafe-inline'; connect-src 'self' wss://*.broadinstitute.org:* wss://notebooks.firecloud.org:* *.googleapis.com https://*.npmjs.org https://data.broadinstitute.org https://s3.amazonaws.com/igv.broadinstitute.org/ https://s3.amazonaws.com/igv.org.genomes/ https://raw.githubusercontent.com/PAIR-code/facets/1.0.0/facets-dist/facets-jupyter.html https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/1.3.3/webcomponents-lite.js; object-src 'none'"
+      "frame-ancestors 'self' *.terra.bio https://bvdp-saturn-prod.appspot.com https://all-of-us-rw-staging.appspot.com https://all-of-us-rw-stable.appspot.com https://stable.fake-research-aou.org https://workbench.researchallofus.org terra.biodatacatalyst.nhlbi.nih.gov; script-src 'self' data: 'unsafe-inline' 'unsafe-eval' https://apis.google.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' data:; connect-src 'self' wss://*.broadinstitute.org:* wss://notebooks.firecloud.org:* *.googleapis.com https://*.npmjs.org https://data.broadinstitute.org https://s3.amazonaws.com/igv.broadinstitute.org/ https://s3.amazonaws.com/igv.org.genomes/ https://raw.githubusercontent.com/PAIR-code/facets/1.0.0/facets-dist/facets-jupyter.html https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/1.3.3/webcomponents-lite.js; object-src 'none'"
 
   }
 
   it should "parse config values correctly" in {
     CommonTestData.contentSecurityPolicy shouldBe
-      "frame-ancestors 'none'; script-src 'self' data:text/javascript 'unsafe-inline' 'unsafe-eval' https://apis.google.com; style-src 'self' 'unsafe-inline'; connect-src 'self' wss://*.broadinstitute.org:* wss://notebooks.firecloud.org:* *.googleapis.com https://*.npmjs.org https://data.broadinstitute.org https://s3.amazonaws.com/igv.broadinstitute.org/ https://s3.amazonaws.com/igv.org.genomes/ https://raw.githubusercontent.com/PAIR-code/facets/1.0.0/facets-dist/facets-jupyter.html https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/1.3.3/webcomponents-lite.js; object-src 'none'"
+      "frame-ancestors 'none'; script-src 'self' data: 'unsafe-inline' 'unsafe-eval' https://apis.google.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' data:; connect-src 'self' wss://*.broadinstitute.org:* wss://notebooks.firecloud.org:* *.googleapis.com https://*.npmjs.org https://data.broadinstitute.org https://s3.amazonaws.com/igv.broadinstitute.org/ https://s3.amazonaws.com/igv.org.genomes/ https://raw.githubusercontent.com/PAIR-code/facets/1.0.0/facets-dist/facets-jupyter.html https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/1.3.3/webcomponents-lite.js; object-src 'none'"
   }
 
 }


### PR DESCRIPTION
@adrazhi looking for your input here (not sure you're gonna like this one..)

cc @sharmatime and @deflaux as well.

We've had multiple user complaints of JS libraries not loading in Terra notebooks due to CSP. Specifically:

1. [plotly](https://plotly.com/r/) and [facets](https://github.com/PAIR-code/facets)
   * For some reason unbeknownst to me these libraries load scripts from `data:` URIs. Our current CSP has `data:text/javascript` but I discovered you can't specify the content type after the scheme. Setting just `data:` fixes both of these libraries.
   * CSP evaluator doesn't like this, it says:
      ```
      data: URI in script-src allows the execution of unsafe scripts.
      ```

2. [altair](https://altair-viz.github.io/) 
   * This library needs `https://cdn.jsdelivr.net` added to `script-src`. CSP evaluator doesn't like this either, it says:
      ```
      cdn.jsdelivr.net is known to host Angular libraries which allow to bypass this CSP.
      ```

3. Separately, I tried to remove `'unsafe-inline'` from `script-src` but this prevents notebooks from loading at all. Apparently Jupyter needs this in order to work at all:
https://jupyter-notebook.readthedocs.io/en/stable/public_server.html#content-security-policy-csp

So I worry I'm adding even more insecure things to CSP. I'm open to any alternatives. If these changes are acceptable though I'd like to push them through to unblock some users trying to use Terra notebooks.

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
