### PR TITLE
[no ticket] Fix label table w/ new migration

### DIFF
--- a/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changelog.xml
+++ b/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changelog.xml
@@ -45,4 +45,5 @@
     <include file="changesets/20200320_cluster_patch_in_progress.xml" relativeToChangelogFile="true" />
     <include file="changesets/20200415_drop_notebookServiceAccount.xml" relativeToChangelogFile="true" />
     <include file="changesets/20200427_create_persistent_disk_table.xml" relativeToChangelogFile="true" />
+    <include file="changesets/20200504_fix_label_table.xml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/20200504_fix_label_table.xml
+++ b/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/20200504_fix_label_table.xml
@@ -3,7 +3,7 @@
     <changeSet logicalFilePath="leonardo" author="rtitle" id="fix-label-table">
         <dropUniqueConstraint uniqueColumns="resourceId, resourceType, key" tableName="LABEL" constraintName="IDX_LABEL_UNIQUE" />
 
-        <sql>ALTER TABLE leotestdb.LABEL DROP INDEX FK_CLUSTER_ID</sql>
+        <dropIndex tableName="LABEL" indexName="FK_CLUSTER_ID" />
 
         <addNotNullConstraint columnName="resourceId" columnDataType="varchar(254)" tableName="LABEL"/>
 

--- a/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/20200504_fix_label_table.xml
+++ b/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/20200504_fix_label_table.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog logicalFilePath="leonardo" xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+    <changeSet logicalFilePath="leonardo" author="rtitle" id="fix-label-table">
+        <dropUniqueConstraint uniqueColumns="resourceId, resourceType, key" tableName="LABEL" constraintName="IDX_LABEL_UNIQUE" />
+
+        <sql>ALTER TABLE leotestdb.LABEL DROP INDEX FK_CLUSTER_ID</sql>
+
+        <addNotNullConstraint columnName="resourceId" columnDataType="varchar(254)" tableName="LABEL"/>
+
+        <sql>UPDATE LABEL SET resourceType = 'runtime'</sql>
+
+        <addUniqueConstraint tableName="LABEL" columnNames="resourceId, resourceType, key" constraintName="IDX_LABEL_UNIQUE" />
+    </changeSet>
+</databaseChangeLog>


### PR DESCRIPTION
My previous `LABEL` migration wasn't completely correct.

## Before:
```
mysql> DESCRIBE LABEL;
+--------------+--------------+------+-----+---------+-------+
| Field        | Type         | Null | Key | Default | Extra |
+--------------+--------------+------+-----+---------+-------+
| resourceId   | varchar(254) | YES  | MUL | NULL    |       |
| key          | varchar(254) | NO   |     | NULL    |       |
| value        | varchar(254) | NO   |     | NULL    |       |
| resourceType | varchar(254) | NO   |     | NULL    |       |
+--------------+--------------+------+-----+---------+-------+
4 rows in set (0.00 sec)

mysql> SHOW INDEX FROM LABEL;
+-------+------------+------------------+--------------+--------------+-----------+-------------+----------+--------+------+------------+---------+---------------+
| Table | Non_unique | Key_name         | Seq_in_index | Column_name  | Collation | Cardinality | Sub_part | Packed | Null | Index_type | Comment | Index_comment |
+-------+------------+------------------+--------------+--------------+-----------+-------------+----------+--------+------+------------+---------+---------------+
| LABEL |          0 | IDX_LABEL_UNIQUE |            1 | resourceId   | A         |           0 |     NULL | NULL   | YES  | BTREE      |         |               |
| LABEL |          0 | IDX_LABEL_UNIQUE |            2 | resourceType | A         |           0 |     NULL | NULL   |      | BTREE      |         |               |
| LABEL |          0 | IDX_LABEL_UNIQUE |            3 | key          | A         |           0 |     NULL | NULL   |      | BTREE      |         |               |
| LABEL |          1 | FK_CLUSTER_ID    |            1 | resourceId   | A         |           0 |     NULL | NULL   | YES  | BTREE      |         |               |
+-------+------------+------------------+--------------+--------------+-----------+-------------+----------+--------+------+------------+---------+---------------+
4 rows in set (0.00 sec)

```
Issues:
- `resourceId` was nullable
- `resourceType` was not populated on any existing records
- `FK_CLUSTER_ID` index still existed

## After:
```
mysql> DESCRIBE LABEL;
+--------------+--------------+------+-----+---------+-------+
| Field        | Type         | Null | Key | Default | Extra |
+--------------+--------------+------+-----+---------+-------+
| resourceId   | varchar(254) | NO   | PRI | NULL    |       |
| key          | varchar(254) | NO   | PRI | NULL    |       |
| value        | varchar(254) | NO   |     | NULL    |       |
| resourceType | varchar(254) | NO   | PRI | NULL    |       |
+--------------+--------------+------+-----+---------+-------+
4 rows in set (0.00 sec)

mysql> SHOW INDEX FROM LABEL;
+-------+------------+------------------+--------------+--------------+-----------+-------------+----------+--------+------+------------+---------+---------------+
| Table | Non_unique | Key_name         | Seq_in_index | Column_name  | Collation | Cardinality | Sub_part | Packed | Null | Index_type | Comment | Index_comment |
+-------+------------+------------------+--------------+--------------+-----------+-------------+----------+--------+------+------------+---------+---------------+
| LABEL |          0 | IDX_LABEL_UNIQUE |            1 | resourceId   | A         |           0 |     NULL | NULL   |      | BTREE      |         |               |
| LABEL |          0 | IDX_LABEL_UNIQUE |            2 | resourceType | A         |           0 |     NULL | NULL   |      | BTREE      |         |               |
| LABEL |          0 | IDX_LABEL_UNIQUE |            3 | key          | A         |           0 |     NULL | NULL   |      | BTREE      |         |               |
+-------+------------+------------------+--------------+--------------+-----------+-------------+----------+--------+------+------------+---------+---------------+
3 rows in set (0.00 sec)
```

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
