### PR TITLE
IA-1897 listCluster performance regression

### DIFF
--- a/http/src/main/resources/logback.xml
+++ b/http/src/main/resources/logback.xml
@@ -64,19 +64,19 @@
 
     <!-- see https://github.com/slick/slick/blob/master/common-test-resources/logback.xml for more Slick logging -->
 
-    <!--
+
     <logger name="slick.jdbc.JdbcBackend.statement" level="DEBUG" additivity="false">
         <appender-ref ref="file"/>
         <appender-ref ref="console"/>
     </logger>
-    -->
 
-    <!--
+
+
     <logger name="slick.jdbc.JdbcBackend.benchmark" level="DEBUG" additivity="false">
         <appender-ref ref="file"/>
         <appender-ref ref="console"/>
     </logger>
-    -->
+
 
     <root level="info">
         <appender-ref ref="file"/>

--- a/http/src/main/resources/logback.xml
+++ b/http/src/main/resources/logback.xml
@@ -64,19 +64,19 @@
 
     <!-- see https://github.com/slick/slick/blob/master/common-test-resources/logback.xml for more Slick logging -->
 
-
+    <!--
     <logger name="slick.jdbc.JdbcBackend.statement" level="DEBUG" additivity="false">
         <appender-ref ref="file"/>
         <appender-ref ref="console"/>
     </logger>
+    -->
 
-
-
+    <!--
     <logger name="slick.jdbc.JdbcBackend.benchmark" level="DEBUG" additivity="false">
         <appender-ref ref="file"/>
         <appender-ref ref="console"/>
     </logger>
-
+    -->
 
     <root level="info">
         <appender-ref ref="file"/>

--- a/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changelog.xml
+++ b/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changelog.xml
@@ -46,4 +46,5 @@
     <include file="changesets/20200415_drop_notebookServiceAccount.xml" relativeToChangelogFile="true" />
     <include file="changesets/20200427_create_persistent_disk_table.xml" relativeToChangelogFile="true" />
     <include file="changesets/20200504_fix_label_table.xml" relativeToChangelogFile="true" />
+    <include file="changesets/20200505_change_label_resource_id_type.xml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/20200505_change_label_resource_id_type.xml
+++ b/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/20200505_change_label_resource_id_type.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog logicalFilePath="leonardo" xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+    <!-- See https://broadworkbench.atlassian.net/browse/IA-1897 -->
+    <changeSet logicalFilePath="leonardo" author="rtitle" id="change-label-resource-id-type">
+        <!-- Add `resourceId2` column with correct type and populate it from `resourceId` -->
+        <addColumn tableName="LABEL">
+            <column name="resourceId2" type="bigint(20)">
+                <constraints nullable="true" />
+            </column>
+        </addColumn>
+        <sql>UPDATE LABEL SET `resourceId2` = CAST(`resourceId` AS UNSIGNED INTEGER)</sql>
+
+        <!-- Drop the existing `IDX_LABEL_UNIQUE` constraint and `resourceId` column -->
+        <dropUniqueConstraint uniqueColumns="resourceId, resourceType, key" tableName="LABEL" constraintName="IDX_LABEL_UNIQUE" />
+        <dropColumn tableName="LABEL" columnName="resourceId" />
+
+        <!-- Rename `resourceId2` to `resourceId` and re-add not-null and unique constraints -->
+        <renameColumn tableName="LABEL" oldColumnName="resourceId2" newColumnName="resourceId" columnDataType="bigint(20)" />
+        <addNotNullConstraint columnName="resourceId" columnDataType="bigint(20)" tableName="LABEL"/>
+        <addUniqueConstraint tableName="LABEL" columnNames="resourceId, resourceType, key" constraintName="IDX_LABEL_UNIQUE" />
+    </changeSet>
+</databaseChangeLog>

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponent.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponent.scala
@@ -197,8 +197,9 @@ object clusterQuery extends TableQuery(new ClusterTable(_)) {
   //   left join label l on c.id = l.clusterId
   val clusterLabelQuery: Query[(ClusterTable, Rep[Option[LabelTable]]), (ClusterRecord, Option[LabelRecord]), Seq] = {
     for {
-      (cluster, label) <- clusterQuery joinLeft labelQuery on { case (c, lbl) =>
-        lbl.resourceId === c.id && lbl.resourceType === LabelResourceType.runtime
+      (cluster, label) <- clusterQuery joinLeft labelQuery on {
+        case (c, lbl) =>
+          lbl.resourceId === c.id && lbl.resourceType === LabelResourceType.runtime
       }
     } yield (cluster, label)
   }
@@ -260,7 +261,9 @@ object clusterQuery extends TableQuery(new ClusterTable(_)) {
       (((((((cluster, instance), error), label), extension), image), scopes), patch) <- baseClusterQuery joinLeft
         instanceQuery on (_.id === _.clusterId) joinLeft
         clusterErrorQuery on (_._1.id === _.clusterId) joinLeft
-        labelQuery on { case (c, lbl) => lbl.resourceId === c._1._1.id && lbl.resourceType === LabelResourceType.runtime } joinLeft
+        labelQuery on {
+        case (c, lbl) => lbl.resourceId === c._1._1.id && lbl.resourceType === LabelResourceType.runtime
+      } joinLeft
         extensionQuery on (_._1._1._1.id === _.clusterId) joinLeft
         clusterImageQuery on (_._1._1._1._1.id === _.clusterId) joinLeft
         scopeQuery on (_._1._1._1._1._1.id === _.clusterId) joinLeft

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/LabelComponent.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/LabelComponent.scala
@@ -22,8 +22,8 @@ class LabelTable(tag: Tag) extends Table[LabelRecord](tag, "LABEL") {
 }
 
 object labelQuery extends TableQuery(new LabelTable(_)) {
-  val runtimeLabels = labelQuery.filter(_.resourceType === LabelResourceType.runtime)
-  val diskLabels = labelQuery.filter(_.resourceType === LabelResourceType.persistentDisk)
+//  val runtimeLabels = labelQuery.filter(_.resourceType === LabelResourceType.runtime)
+//  val diskLabels = labelQuery.filter(_.resourceType === LabelResourceType.persistentDisk)
 
   def save(resourceId: Long, resourceType: LabelResourceType, key: String, value: String): DBIO[Int] =
     labelQuery += LabelRecord(resourceId, resourceType, key, value)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/LabelComponent.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/LabelComponent.scala
@@ -22,8 +22,6 @@ class LabelTable(tag: Tag) extends Table[LabelRecord](tag, "LABEL") {
 }
 
 object labelQuery extends TableQuery(new LabelTable(_)) {
-//  val runtimeLabels = labelQuery.filter(_.resourceType === LabelResourceType.runtime)
-//  val diskLabels = labelQuery.filter(_.resourceType === LabelResourceType.persistentDisk)
 
   def save(resourceId: Long, resourceType: LabelResourceType, key: String, value: String): DBIO[Int] =
     labelQuery += LabelRecord(resourceId, resourceType, key, value)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/LeonardoServiceDbQueries.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/LeonardoServiceDbQueries.scala
@@ -17,14 +17,16 @@ import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GoogleProj
 
 import scala.concurrent.ExecutionContext
 
+// TODO deprecated in favor of RuntimeServiceDbQueries
 object LeonardoServiceDbQueries {
 
   type ClusterJoinLabel = Query[(ClusterTable, Rep[Option[LabelTable]]), (ClusterRecord, Option[LabelRecord]), Seq]
 
   def clusterLabelQuery(baseQuery: Query[ClusterTable, ClusterRecord, Seq]): ClusterJoinLabel =
     for {
-      (cluster, label) <- baseQuery.joinLeft(labelQuery).on { case (c, lbl) =>
-        lbl.resourceId === c.id && lbl.resourceType === LabelResourceType.runtime
+      (cluster, label) <- baseQuery.joinLeft(labelQuery).on {
+        case (c, lbl) =>
+          lbl.resourceId === c.id && lbl.resourceType === LabelResourceType.runtime
       }
     } yield (cluster, label)
 
@@ -64,9 +66,7 @@ object LeonardoServiceDbQueries {
       clusterQueryJoinedWithLabel.filter {
         case (clusterRec, _) =>
           labelQuery
-            .filter { lbl =>
-              lbl.resourceId === clusterRec.id && lbl.resourceType === LabelResourceType.runtime
-            }
+            .filter(lbl => lbl.resourceId === clusterRec.id && lbl.resourceType === LabelResourceType.runtime)
             // The following confusing line is equivalent to the much simpler:
             // .filter { lbl => (lbl.key, lbl.value) inSetBind labelMap.toSet }
             // Unfortunately slick doesn't support inSet/inSetBind for tuples.

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/PersistentDiskComponent.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/PersistentDiskComponent.scala
@@ -71,7 +71,11 @@ object persistentDiskQuery extends TableQuery(new PersistentDiskTable(_)) {
       .filter(_.destroyedDate === dummyDate)
 
   private[db] def joinLabelQuery(baseQuery: Query[PersistentDiskTable, PersistentDiskRecord, Seq]) =
-    baseQuery joinLeft labelQuery.diskLabels on (_.id === _.resourceId.mapTo[DiskId])
+    for {
+      (disk, label) <- baseQuery joinLeft labelQuery on { case (d, lbl) =>
+        lbl.resourceId.mapTo[DiskId] === d.id && lbl.resourceType === LabelResourceType.persistentDisk
+      }
+    } yield (disk, label)
 
   def save(disk: PersistentDisk): DBIO[DiskId] =
     (persistentDiskQuery returning persistentDiskQuery.map(_.id)) += marshalPersistentDisk(disk)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/PersistentDiskComponent.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/PersistentDiskComponent.scala
@@ -72,8 +72,9 @@ object persistentDiskQuery extends TableQuery(new PersistentDiskTable(_)) {
 
   private[db] def joinLabelQuery(baseQuery: Query[PersistentDiskTable, PersistentDiskRecord, Seq]) =
     for {
-      (disk, label) <- baseQuery joinLeft labelQuery on { case (d, lbl) =>
-        lbl.resourceId.mapTo[DiskId] === d.id && lbl.resourceType === LabelResourceType.persistentDisk
+      (disk, label) <- baseQuery joinLeft labelQuery on {
+        case (d, lbl) =>
+          lbl.resourceId.mapTo[DiskId] === d.id && lbl.resourceType === LabelResourceType.persistentDisk
       }
     } yield (disk, label)
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/RuntimeServiceDbQueries.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/RuntimeServiceDbQueries.scala
@@ -18,8 +18,9 @@ object RuntimeServiceDbQueries {
 
   def clusterLabelQuery(baseQuery: Query[ClusterTable, ClusterRecord, Seq]): ClusterJoinLabel =
     for {
-      (cluster, label) <- baseQuery.joinLeft(labelQuery).on { case (c, lbl) =>
-        lbl.resourceId === c.id && lbl.resourceType === LabelResourceType.runtime
+      (cluster, label) <- baseQuery.joinLeft(labelQuery).on {
+        case (c, lbl) =>
+          lbl.resourceId === c.id && lbl.resourceType === LabelResourceType.runtime
       }
     } yield (cluster, label)
 
@@ -41,9 +42,7 @@ object RuntimeServiceDbQueries {
       clusterQueryJoinedWithLabel.filter {
         case (clusterRec, _) =>
           labelQuery
-            .filter { lbl =>
-              lbl.resourceId === clusterRec.id && lbl.resourceType === LabelResourceType.runtime
-            }
+            .filter(lbl => lbl.resourceId === clusterRec.id && lbl.resourceType === LabelResourceType.runtime)
             // The following confusing line is equivalent to the much simpler:
             // .filter { lbl => (lbl.key, lbl.value) inSetBind labelMap.toSet }
             // Unfortunately slick doesn't support inSet/inSetBind for tuples.

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/RuntimeServiceDbQueries.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/RuntimeServiceDbQueries.scala
@@ -18,7 +18,9 @@ object RuntimeServiceDbQueries {
 
   def clusterLabelQuery(baseQuery: Query[ClusterTable, ClusterRecord, Seq]): ClusterJoinLabel =
     for {
-      (cluster, label) <- baseQuery.joinLeft(labelQuery.runtimeLabels).on(_.id === _.resourceId)
+      (cluster, label) <- baseQuery.joinLeft(labelQuery).on { case (c, lbl) =>
+        lbl.resourceId === c.id && lbl.resourceType === LabelResourceType.runtime
+      }
     } yield (cluster, label)
 
   // new runtime route return a lot less fields than legacy listCluster API
@@ -38,9 +40,9 @@ object RuntimeServiceDbQueries {
     } else {
       clusterQueryJoinedWithLabel.filter {
         case (clusterRec, _) =>
-          labelQuery.runtimeLabels
-            .filter {
-              _.resourceId === clusterRec.id
+          labelQuery
+            .filter { lbl =>
+              lbl.resourceId === clusterRec.id && lbl.resourceType === LabelResourceType.runtime
             }
             // The following confusing line is equivalent to the much simpler:
             // .filter { lbl => (lbl.key, lbl.value) inSetBind labelMap.toSet }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/LeonardoServiceDbQueriesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/LeonardoServiceDbQueriesSpec.scala
@@ -9,6 +9,7 @@ import org.scalatest.concurrent.ScalaFutures
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
+// TODO deprecated in favor of RuntimeServiceDbQueriesSpec
 class LeonardoServiceDbQueriesSpec extends FlatSpecLike with TestComponent with GcsPathUtils with ScalaFutures {
   it should "get by labels" in isolatedDbTest {
 

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/RuntimeServiceDbQueriesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/RuntimeServiceDbQueriesSpec.scala
@@ -1,0 +1,63 @@
+package org.broadinstitute.dsde.workbench.leonardo
+package http
+package db
+
+import cats.effect.IO
+import org.broadinstitute.dsde.workbench.leonardo.db.{LabelResourceType, RuntimeServiceDbQueries, TestComponent, labelQuery}
+import org.broadinstitute.dsde.workbench.leonardo.CommonTestData._
+import org.scalatest.FlatSpecLike
+import org.scalatest.concurrent.ScalaFutures
+
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class RuntimeServiceDbQueriesSpec extends FlatSpecLike with TestComponent with GcsPathUtils with ScalaFutures {
+
+  "RuntimeServiceDbQueries" should "list runtimes" in isolatedDbTest {
+    val res = for {
+      list1 <- RuntimeServiceDbQueries.listClusters(Map.empty, false, None).transaction
+      c1 <- IO(makeCluster(1).save())
+      list2 <- RuntimeServiceDbQueries.listClusters(Map.empty, false, None).transaction
+      c2 <- IO(makeCluster(2).save())
+      list3 <- RuntimeServiceDbQueries.listClusters(Map.empty, false, None).transaction
+    } yield {
+      list1 shouldEqual List.empty
+      list2 shouldEqual List(c1)
+      list3.toSet shouldEqual Set(c1, c2)
+    }
+
+    res.unsafeRunSync()
+  }
+
+  it should "list by labels" in isolatedDbTest {
+    val res = for {
+      c1 <- IO(makeCluster(1).save())
+      c2 <- IO(makeCluster(2).save())
+      labels1 = Map("googleProject" -> c1.googleProject.value, "clusterName" -> c1.runtimeName.asString, "creator" -> c1.auditInfo.creator.value)
+      labels2 = Map("googleProject" -> c2.googleProject.value, "clusterName" -> c2.runtimeName.asString, "creator" -> c2.auditInfo.creator.value)
+      list1 <- RuntimeServiceDbQueries.listClusters(labels1, false, None).transaction
+      list2 <- RuntimeServiceDbQueries.listClusters(labels2, false, None).transaction
+      _ <- labelQuery.saveAllForResource(c1.id, LabelResourceType.Runtime, labels1).transaction
+      _ <- labelQuery.saveAllForResource(c2.id, LabelResourceType.Runtime, labels2).transaction
+      list3 <- RuntimeServiceDbQueries.listClusters(labels1, false, None).transaction
+      list4 <- RuntimeServiceDbQueries.listClusters(labels2, false, None).transaction
+      list5 <- RuntimeServiceDbQueries.listClusters(Map("googleProject" -> c1.googleProject.value), false, None).transaction
+    } yield {
+      list1 shouldEqual List.empty
+      list2 shouldEqual List.empty
+      list3 shouldEqual List(c1)
+      list4 shouldEqual List(c2)
+      list5.toSet shouldEqual Set(c1, c2)
+    }
+
+    res.unsafeRunSync()
+  }
+
+  it should "list by project" in isolatedDbTest {
+
+  }
+
+  it should "list including deleted" in isolatedDbTest {
+
+  }
+
+}

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/RuntimeServiceDbQueriesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/RuntimeServiceDbQueriesSpec.scala
@@ -3,8 +3,15 @@ package http
 package db
 
 import cats.effect.IO
-import org.broadinstitute.dsde.workbench.leonardo.db.{LabelResourceType, RuntimeServiceDbQueries, TestComponent, labelQuery}
 import org.broadinstitute.dsde.workbench.leonardo.CommonTestData._
+import org.broadinstitute.dsde.workbench.leonardo.config.Config
+import org.broadinstitute.dsde.workbench.leonardo.db.{
+  labelQuery,
+  LabelResourceType,
+  RuntimeServiceDbQueries,
+  TestComponent
+}
+import org.broadinstitute.dsde.workbench.leonardo.http.api.ListRuntimeResponse2
 import org.scalatest.FlatSpecLike
 import org.scalatest.concurrent.ScalaFutures
 
@@ -21,43 +28,97 @@ class RuntimeServiceDbQueriesSpec extends FlatSpecLike with TestComponent with G
       list3 <- RuntimeServiceDbQueries.listClusters(Map.empty, false, None).transaction
     } yield {
       list1 shouldEqual List.empty
-      list2 shouldEqual List(c1)
-      list3.toSet shouldEqual Set(c1, c2)
+      val c1Expected = toListRuntimeResponse(c1, Map.empty)
+      val c2Expected = toListRuntimeResponse(c2, Map.empty)
+      list2 shouldEqual List(c1Expected)
+      list3.toSet shouldEqual Set(c1Expected, c2Expected)
     }
 
     res.unsafeRunSync()
   }
 
-  it should "list by labels" in isolatedDbTest {
+  it should "list runtimes by labels" in isolatedDbTest {
     val res = for {
       c1 <- IO(makeCluster(1).save())
       c2 <- IO(makeCluster(2).save())
-      labels1 = Map("googleProject" -> c1.googleProject.value, "clusterName" -> c1.runtimeName.asString, "creator" -> c1.auditInfo.creator.value)
-      labels2 = Map("googleProject" -> c2.googleProject.value, "clusterName" -> c2.runtimeName.asString, "creator" -> c2.auditInfo.creator.value)
+      labels1 = Map("googleProject" -> c1.googleProject.value,
+                    "clusterName" -> c1.runtimeName.asString,
+                    "creator" -> c1.auditInfo.creator.value)
+      labels2 = Map("googleProject" -> c2.googleProject.value,
+                    "clusterName" -> c2.runtimeName.asString,
+                    "creator" -> c2.auditInfo.creator.value)
       list1 <- RuntimeServiceDbQueries.listClusters(labels1, false, None).transaction
       list2 <- RuntimeServiceDbQueries.listClusters(labels2, false, None).transaction
       _ <- labelQuery.saveAllForResource(c1.id, LabelResourceType.Runtime, labels1).transaction
       _ <- labelQuery.saveAllForResource(c2.id, LabelResourceType.Runtime, labels2).transaction
       list3 <- RuntimeServiceDbQueries.listClusters(labels1, false, None).transaction
       list4 <- RuntimeServiceDbQueries.listClusters(labels2, false, None).transaction
-      list5 <- RuntimeServiceDbQueries.listClusters(Map("googleProject" -> c1.googleProject.value), false, None).transaction
+      list5 <- RuntimeServiceDbQueries
+        .listClusters(Map("googleProject" -> c1.googleProject.value), false, None)
+        .transaction
     } yield {
       list1 shouldEqual List.empty
       list2 shouldEqual List.empty
-      list3 shouldEqual List(c1)
-      list4 shouldEqual List(c2)
-      list5.toSet shouldEqual Set(c1, c2)
+      val c1Expected = toListRuntimeResponse(c1, labels1)
+      val c2Expected = toListRuntimeResponse(c2, labels2)
+      list3 shouldEqual List(c1Expected)
+      list4 shouldEqual List(c2Expected)
+      list5.toSet shouldEqual Set(c1Expected, c2Expected)
     }
 
     res.unsafeRunSync()
   }
 
-  it should "list by project" in isolatedDbTest {
+  it should "list runtimes by project" in isolatedDbTest {
+    val res = for {
+      c1 <- IO(makeCluster(1).save())
+      c2 <- IO(makeCluster(2).save())
+      list1 <- RuntimeServiceDbQueries.listClusters(Map.empty, false, Some(project)).transaction
+      list2 <- RuntimeServiceDbQueries.listClusters(Map.empty, false, Some(project2)).transaction
+    } yield {
+      val c1Expected = toListRuntimeResponse(c1, Map.empty)
+      val c2Expected = toListRuntimeResponse(c2, Map.empty)
+      list1.toSet shouldEqual Set(c1Expected, c2Expected)
+      list2 shouldEqual List.empty
+    }
 
+    res.unsafeRunSync()
   }
 
-  it should "list including deleted" in isolatedDbTest {
+  it should "list runtimes including deleted" in isolatedDbTest {
+    val res = for {
+      c1 <- IO(makeCluster(1).copy(status = RuntimeStatus.Deleted).save())
+      c2 <- IO(makeCluster(2).copy(status = RuntimeStatus.Deleted).save())
+      c3 <- IO(makeCluster(3).save())
+      list1 <- RuntimeServiceDbQueries.listClusters(Map.empty, true, None).transaction
+      list2 <- RuntimeServiceDbQueries.listClusters(Map.empty, false, None).transaction
+    } yield {
+      val c1Expected = toListRuntimeResponse(c1, Map.empty)
+      val c2Expected = toListRuntimeResponse(c2, Map.empty)
+      val c3Expected = toListRuntimeResponse(c3, Map.empty)
+      list1.toSet shouldEqual Set(c1Expected, c2Expected, c3Expected)
+      list2 shouldEqual List(c3Expected)
+    }
 
+    res.unsafeRunSync()
   }
+
+  private def toListRuntimeResponse(runtime: Runtime, labels: LabelMap): ListRuntimeResponse2 =
+    ListRuntimeResponse2(
+      runtime.id,
+      runtime.internalId,
+      runtime.runtimeName,
+      runtime.googleProject,
+      runtime.auditInfo,
+      CommonTestData.defaultDataprocRuntimeConfig,
+      Runtime.getProxyUrl(Config.proxyConfig.proxyUrlBase,
+                          runtime.googleProject,
+                          runtime.runtimeName,
+                          Set.empty,
+                          labels),
+      runtime.status,
+      labels,
+      false
+    )
 
 }


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-1897

The real fix here is to make `LABEL.resourceId` the same type as `CLUSTER.id` and `PERSISTENT_DISK.id`. MySQL can join columns with different types but there's a significant performance penalty as it has to convert one type to the other for each row.

Also improved some slick code although I don't think slick was really to blame in this case. (Still pro moving to writing direct SQL though)

I tested this on dev by manually making the schema changes (will revert before merge) and running some slick-generated SQL queries. 

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
