### PR TITLE
[IA-1901] warm up R in jupyter startup script

### DIFF
--- a/http/src/main/resources/init-resources/startup.sh
+++ b/http/src/main/resources/init-resources/startup.sh
@@ -124,7 +124,7 @@ if [ ! -z "$JUPYTER_DOCKER_IMAGE" ] ; then
     # See IA-1901: Jupyter UI stalls indefinitely on initial R kernel connection after cluster create/resume
     # The intent of this is to "warm up" R at VM creation time to hopefully prevent issues when the Jupyter
     # kernel tries to connect to it.
-    docker exec ${JUPYTER_SERVER_NAME} /bin/bash -c "R -e '1+1'" || true
+    docker exec $JUPYTER_SERVER_NAME /bin/bash -c "R -e '1+1'" || true
 
     docker exec -d $JUPYTER_SERVER_NAME /bin/bash -c "export WELDER_ENABLED=$WELDER_ENABLED && export NOTEBOOKS_DIR=$NOTEBOOKS_DIR && (/etc/jupyter/scripts/run-jupyter.sh $NOTEBOOKS_DIR || /usr/local/bin/jupyter notebook)"
 

--- a/http/src/main/resources/init-resources/startup.sh
+++ b/http/src/main/resources/init-resources/startup.sh
@@ -121,6 +121,11 @@ if [ ! -z "$JUPYTER_DOCKER_IMAGE" ] ; then
     # update container MEM_LIMIT to reflect VM's MEM_LIMIT
     docker update $JUPYTER_SERVER_NAME --memory $MEM_LIMIT
 
+    # See IA-1901: Jupyter UI stalls indefinitely on initial R kernel connection after cluster create/resume
+    # The intent of this is to "warm up" R at VM creation time to hopefully prevent issues when the Jupyter
+    # kernel tries to connect to it.
+    docker exec ${JUPYTER_SERVER_NAME} /bin/bash -c "R -e '1+1'" || true
+
     docker exec -d $JUPYTER_SERVER_NAME /bin/bash -c "export WELDER_ENABLED=$WELDER_ENABLED && export NOTEBOOKS_DIR=$NOTEBOOKS_DIR && (/etc/jupyter/scripts/run-jupyter.sh $NOTEBOOKS_DIR || /usr/local/bin/jupyter notebook)"
 
     if [ "$WELDER_ENABLED" == "true" ] ; then

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/LeoRoutes.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/LeoRoutes.scala
@@ -11,7 +11,6 @@ import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server._
 import akka.stream.Materializer
 import cats.effect.{ContextShift, IO}
-import cats.implicits._
 import cats.mtl.ApplicativeAsk
 import com.typesafe.scalalogging.LazyLogging
 import LeoRoutesJsonCodec._

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/ProxyService.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/ProxyService.scala
@@ -312,7 +312,7 @@ class ProxyService(
     // Initialize a Flow for the WebSocket conversation.
     // `Message` is the root of the ADT for WebSocket messages. A Message may be a TextMessage or a BinaryMessage.
     val flow =
-      Flow.fromSinkAndSourceCoupledMat(Sink.asPublisher[Message](fanout = false), Source.asSubscriber[Message])(
+      Flow.fromSinkAndSourceMat(Sink.asPublisher[Message](fanout = false), Source.asSubscriber[Message])(
         Keep.both
       )
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -18,7 +18,7 @@ object Dependencies {
 
   val workbenchUtilV = "0.5-4c7acd5"
   val workbenchModelV = "0.13-31cacc4"
-  val workbenchGoogleV = "0.21-96ad43c"
+  val workbenchGoogleV = "0.21-a6ee6de-SNAP"
   val workbenchGoogle2V = "0.8-e08439a"
   val workbenchMetricsV = "0.3-c5b80d2"
   val workbenchOpenTelemetryV = "0.1-73d6a64"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -18,8 +18,7 @@ object Dependencies {
 
   val workbenchUtilV = "0.5-4c7acd5"
   val workbenchModelV = "0.13-31cacc4"
-  // TODO: revert to non-SNAP and remove this comment once https://github.com/broadinstitute/workbench-libs/pull/307 is merged
-  val workbenchGoogleV = "0.21-a6ee6de-SNAP"
+  val workbenchGoogleV = "0.21-2a218f3"
   val workbenchGoogle2V = "0.8-e08439a"
   val workbenchMetricsV = "0.3-c5b80d2"
   val workbenchOpenTelemetryV = "0.1-73d6a64"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -18,6 +18,7 @@ object Dependencies {
 
   val workbenchUtilV = "0.5-4c7acd5"
   val workbenchModelV = "0.13-31cacc4"
+  // TODO: revert to non-SNAP and remove this comment once https://github.com/broadinstitute/workbench-libs/pull/307 is merged
   val workbenchGoogleV = "0.21-a6ee6de-SNAP"
   val workbenchGoogle2V = "0.8-e08439a"
   val workbenchMetricsV = "0.3-c5b80d2"


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-1901

Two fixes here:
1. Adopt https://github.com/broadinstitute/workbench-libs/pull/307 to fix a NPE that has been happening for a while (an AoU user reported seeing it though it seems to happen for non-AoU as well)
2. Try to work around the issue where the R kernel is hanging on VM startup. It seems to _not_ hang if you run a dummy R command before the Jupyter kernel starts up. Not sure exactly why

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
