### PR TITLE
[no ticket] Apply R fix to creation scripts too

### DIFF
--- a/http/src/main/resources/init-resources/init-actions.sh
+++ b/http/src/main/resources/init-resources/init-actions.sh
@@ -470,6 +470,11 @@ END
 
       STEP_TIMINGS+=($(date +%s))
 
+      # See IA-1901: Jupyter UI stalls indefinitely on initial R kernel connection after cluster create/resume
+      # The intent of this is to "warm up" R at VM creation time to hopefully prevent issues when the Jupyter
+      # kernel tries to connect to it.
+      docker exec $JUPYTER_SERVER_NAME /bin/bash -c "R -e '1+1'" || true
+
       log 'Starting Jupyter Notebook...'
       retry 3 docker exec -d ${JUPYTER_SERVER_NAME} ${JUPYTER_SCRIPTS}/run-jupyter.sh ${NOTEBOOKS_DIR}
 


### PR DESCRIPTION
AoU is still seeing the R issue. I think they are seeing it for freshly-created clusters. I had added the fix to `startup.sh` which is used for cluster _resumes_, but neglected to add it to the init scripts used for cluster _creation_. I reproduced the same behavior in Terra.

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
