### PR TITLE
IA-1757 Back Leo: add disk PubSub messaging and algebra

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/kubernetesModels.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/kubernetesModels.scala
@@ -3,7 +3,7 @@ package org.broadinstitute.dsde.workbench.leonardo
 import ca.mrvisser.sealerate
 import org.broadinstitute.dsde.workbench.google2.GKEModels.{KubernetesClusterId, KubernetesClusterName, NodepoolName}
 import org.broadinstitute.dsde.workbench.google2.KubernetesModels.KubernetesApiServerIp
-import org.broadinstitute.dsde.workbench.google2.KubernetesSerializableName.KubernetesNamespaceName
+import org.broadinstitute.dsde.workbench.google2.KubernetesSerializableName.NamespaceName
 import org.broadinstitute.dsde.workbench.google2.{Location, MachineTypeName, NetworkName, SubnetworkName}
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
@@ -21,7 +21,7 @@ case class KubernetesCluster(id: KubernetesClusterLeoId,
                              samResourceId: KubernetesClusterSamResourceId,
                              auditInfo: AuditInfo,
                              asyncFields: Option[KubernetesClusterAsyncFields],
-                             namespaces: Set[KubernetesNamespaceName],
+                             namespaces: Set[NamespaceName],
                              labels: LabelMap,
                              nodepools: Set[Nodepool],
                              //TODO: populate this

--- a/http/src/main/resources/swagger/api-docs.yaml
+++ b/http/src/main/resources/swagger/api-docs.yaml
@@ -1631,9 +1631,7 @@ components:
           schema:
             $ref: "#/components/schemas/UpdateDiskRequest"
           example:
-            updateSize: 600
-            updateDiskType: "SSD"
-            updateBlockSize: 16384
+            size: 600
     # legacy
     ClusterRequest:
       content:

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/DiskRoutes.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/DiskRoutes.scala
@@ -191,10 +191,8 @@ object DiskRoutes {
   implicit val updateDiskRequestDecoder: Decoder[UpdateDiskRequest] = Decoder.instance { x =>
     for {
       l <- x.downField("labels").as[LabelMap]
-      us <- x.downField("updateSize").as[Option[DiskSize]]
-      ud <- x.downField("updateDiskType").as[Option[DiskType]]
-      ub <- x.downField("updateBlockSize").as[Option[BlockSize]]
-    } yield UpdateDiskRequest(l, us, ud, ub)
+      us <- x.downField("size").as[DiskSize]
+    } yield UpdateDiskRequest(l, us)
   }
 
   implicit val getDiskResponseEncoder: Encoder[GetPersistentDiskResponse] = Encoder.forProduct12(
@@ -303,7 +301,4 @@ final case class CreateDiskRequest(labels: LabelMap,
                                    diskType: Option[DiskType],
                                    blockSize: Option[BlockSize])
 
-final case class UpdateDiskRequest(labels: LabelMap,
-                                   size: Option[DiskSize],
-                                   diskType: Option[DiskType],
-                                   blockSize: Option[BlockSize])
+final case class UpdateDiskRequest(labels: LabelMap, size: DiskSize)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/KubernetesClusterComponent.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/KubernetesClusterComponent.scala
@@ -14,7 +14,7 @@ import LeoProfile.mappedColumnImplicits._
 import cats.data.Chain
 import cats.implicits._
 import nodepoolQuery.unmarshalNodepool
-import org.broadinstitute.dsde.workbench.google2.KubernetesSerializableName.KubernetesNamespaceName
+import org.broadinstitute.dsde.workbench.google2.KubernetesSerializableName.NamespaceName
 import org.broadinstitute.dsde.workbench.leonardo.db.LeoProfile.{dummyDate, unmarshalDestroyedDate}
 
 import scala.concurrent.ExecutionContext
@@ -210,7 +210,7 @@ object kubernetesClusterQuery extends TableQuery(new KubernetesClusterTable(_)) 
 
   private def unmarshalKubernetesCluster(cr: KubernetesClusterRecord,
                                          nodepools: Set[Nodepool],
-                                         namespaces: Set[KubernetesNamespaceName],
+                                         namespaces: Set[NamespaceName],
                                          labels: LabelMap): KubernetesCluster =
     KubernetesCluster(
       cr.id,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/LeoProfile.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/LeoProfile.scala
@@ -8,7 +8,7 @@ import io.circe.syntax._
 import org.broadinstitute.dsde.workbench.google2.{DiskName, ZoneName}
 import org.broadinstitute.dsde.workbench.google2.GKEModels.{KubernetesClusterName, NodepoolName}
 import org.broadinstitute.dsde.workbench.google2.KubernetesModels.KubernetesApiServerIp
-import org.broadinstitute.dsde.workbench.google2.KubernetesSerializableName.KubernetesNamespaceName
+import org.broadinstitute.dsde.workbench.google2.KubernetesSerializableName.NamespaceName
 import org.broadinstitute.dsde.workbench.google2.{Location, MachineTypeName, NetworkName, SubnetworkName}
 import org.broadinstitute.dsde.workbench.leonardo.SamResource.PersistentDiskSamResource
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
@@ -132,8 +132,8 @@ private[leonardo] object LeoProfile extends MySQLProfile {
 
     implicit val kubernetesNamespaceIdColumnType: BaseColumnType[KubernetesNamespaceId] =
       MappedColumnType.base[KubernetesNamespaceId, Long](_.id, KubernetesNamespaceId.apply)
-    implicit val kubernetesNamespaceNameColumnType: BaseColumnType[KubernetesNamespaceName] =
-      MappedColumnType.base[KubernetesNamespaceName, String](_.value, KubernetesNamespaceName.apply)
+    implicit val kubernetesNamespaceNameColumnType: BaseColumnType[NamespaceName] =
+      MappedColumnType.base[NamespaceName, String](_.value, NamespaceName.apply)
 
     implicit val nodepoolIdColumnType: BaseColumnType[NodepoolLeoId] =
       MappedColumnType.base[NodepoolLeoId, Long](_.id, NodepoolLeoId.apply)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/PersistentDiskComponent.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/PersistentDiskComponent.scala
@@ -112,6 +112,12 @@ object persistentDiskQuery extends TableQuery(new PersistentDiskTable(_)) {
       .map(d => (d.status, d.destroyedDate, d.dateAccessed))
       .update((DiskStatus.Deleted, destroyedDate, destroyedDate))
 
+  def updateGoogleId(id: DiskId, googleId: GoogleId, dateAccessed: Instant) =
+    findByIdQuery(id).map(d => (d.googleId, d.dateAccessed)).update((Some(googleId), dateAccessed))
+
+  def updateSize(id: DiskId, newSize: DiskSize, dateAccessed: Instant) =
+    findByIdQuery(id).map(d => (d.size, d.dateAccessed)).update((newSize, dateAccessed))
+
   // TODO add other queries as needed
 
   private[db] def marshalPersistentDisk(disk: PersistentDisk): PersistentDiskRecord =

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/leoPubsubMessageSubscriberModels.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/leoPubsubMessageSubscriberModels.scala
@@ -150,11 +150,7 @@ object LeoPubsubMessage {
     val messageType: LeoPubsubMessageType = LeoPubsubMessageType.UpdateRuntime
   }
 
-  final case class UpdateDiskMessage(diskId: DiskId,
-                                     newSize: Option[DiskSize],
-                                     newDiskType: Option[DiskType],
-                                     newBlockSize: Option[BlockSize],
-                                     traceId: Option[TraceId])
+  final case class UpdateDiskMessage(diskId: DiskId, newSize: DiskSize, traceId: Option[TraceId])
       extends LeoPubsubMessage {
     val messageType: LeoPubsubMessageType = LeoPubsubMessageType.UpdateDisk
   }
@@ -200,7 +196,7 @@ object LeoPubsubCodec {
                         "traceId")(CreateDiskMessage.apply)
 
   implicit val updateDiskDecoder: Decoder[UpdateDiskMessage] =
-    Decoder.forProduct5("diskId", "newSize", "newDiskType", "newBlockSize", "traceId")(UpdateDiskMessage.apply)
+    Decoder.forProduct3("diskId", "newSize", "traceId")(UpdateDiskMessage.apply)
 
   implicit val deleteDiskDecoder: Decoder[DeleteDiskMessage] =
     Decoder.forProduct2("diskId", "traceId")(DeleteDiskMessage.apply)
@@ -345,8 +341,8 @@ object LeoPubsubCodec {
     )
 
   implicit val updateDiskMessageEncoder: Encoder[UpdateDiskMessage] =
-    Encoder.forProduct6("messageType", "diskId", "newSize", "newDiskType", "newBlockSize", "traceId")(x =>
-      (x.messageType, x.diskId, x.newSize, x.newDiskType, x.newBlockSize, x.traceId)
+    Encoder.forProduct4("messageType", "diskId", "newSize", "traceId")(x =>
+      (x.messageType, x.diskId, x.newSize, x.traceId)
     )
 
   implicit val deleteDiskMessageEncoder: Encoder[DeleteDiskMessage] =

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoService.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoService.scala
@@ -54,6 +54,15 @@ case class RuntimeNotFoundException(googleProject: GoogleProject, runtimeName: R
 case class DiskNotFoundException(googleProject: GoogleProject, diskName: DiskName)
     extends LeoException(s"Persistent disk ${googleProject.value}/${diskName.value} not found", StatusCodes.NotFound)
 
+case class DiskNotResizableException(googleProject: GoogleProject,
+                                     diskName: DiskName,
+                                     currentDiskSize: DiskSize,
+                                     newDiskSize: DiskSize)
+    extends LeoException(
+      s"Invalid value for disk size. New disk size ${newDiskSize.asString}GB must be larger than existing size of ${currentDiskSize.asString}GB for persistent disk ${googleProject.value}/${diskName.value}",
+      StatusCodes.BadRequest
+    )
+
 case class RuntimeAlreadyExistsException(googleProject: GoogleProject, runtimeName: RuntimeName, status: RuntimeStatus)
     extends LeoException(
       s"Runtime ${googleProject.value}/${runtimeName.asString} already exists in ${status.toString} status",

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/DataprocInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/DataprocInterpreter.scala
@@ -15,7 +15,13 @@ import org.broadinstitute.dsde.workbench.google.GoogleIamDAO.MemberType
 import org.broadinstitute.dsde.workbench.google.GoogleUtilities.RetryPredicates._
 import org.broadinstitute.dsde.workbench.google._
 import org.broadinstitute.dsde.workbench.google2.DataprocRole.Master
-import org.broadinstitute.dsde.workbench.google2.{DiskName, GoogleComputeService, MachineTypeName, ZoneName}
+import org.broadinstitute.dsde.workbench.google2.{
+  DiskName,
+  GoogleComputeService,
+  GoogleDiskService,
+  MachineTypeName,
+  ZoneName
+}
 import org.broadinstitute.dsde.workbench.leonardo.CustomImage.DataprocCustomImage
 import org.broadinstitute.dsde.workbench.leonardo.dao.WelderDAO
 import org.broadinstitute.dsde.workbench.leonardo.dao.google._
@@ -52,6 +58,7 @@ class DataprocInterpreter[F[_]: Timer: Async: Parallel: ContextShift: Logger](
   vpcAlg: VPCAlgebra[F],
   gdDAO: GoogleDataprocDAO,
   googleComputeService: GoogleComputeService[F],
+  googleDiskService: GoogleDiskService[F],
   googleDirectoryDAO: GoogleDirectoryDAO,
   googleIamDAO: GoogleIamDAO,
   googleProjectDAO: GoogleProjectDAO,
@@ -349,10 +356,9 @@ class DataprocInterpreter[F[_]: Timer: Async: Parallel: ContextShift: Logger](
       instance.dataprocRole match {
         case Master =>
           // Note for Dataproc the disk name is the same as the instance name
-          googleComputeService.resizeDisk(instance.key.project,
-                                          instance.key.zone,
-                                          DiskName(instance.key.name.value),
-                                          params.diskSize.gb)
+          googleDiskService
+            .resizeDisk(instance.key.project, instance.key.zone, DiskName(instance.key.name.value), params.diskSize.gb)
+            .void
         case _ => Async[F].unit
       }
     }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GceInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GceInterpreter.scala
@@ -15,6 +15,7 @@ import org.broadinstitute.dsde.workbench.google2.{
   SubnetworkName,
   ZoneName
 }
+import org.broadinstitute.dsde.workbench.google2.GoogleDiskService
 import org.broadinstitute.dsde.workbench.leonardo.dao.WelderDAO
 import org.broadinstitute.dsde.workbench.leonardo.dao.google._
 import org.broadinstitute.dsde.workbench.leonardo.db.DbReference
@@ -42,6 +43,7 @@ class GceInterpreter[F[_]: Async: Parallel: ContextShift: Logger](
   bucketHelper: BucketHelper[F],
   vpcAlg: VPCAlgebra[F],
   googleComputeService: GoogleComputeService[F],
+  googleDiskService: GoogleDiskService[F],
   welderDao: WelderDAO[F],
   blocker: Blocker
 )(implicit val executionContext: ExecutionContext, metrics: OpenTelemetryMetrics[F], dbRef: DbReference[F])
@@ -241,10 +243,12 @@ class GceInterpreter[F[_]: Async: Parallel: ContextShift: Logger](
     Async[F].unit
 
   override def updateDiskSize(params: UpdateDiskSizeParams)(implicit ev: ApplicativeAsk[F, TraceId]): F[Unit] =
-    googleComputeService.resizeDisk(params.runtime.googleProject,
-                                    config.gceConfig.zoneName,
-                                    DiskName(params.runtime.runtimeName.asString),
-                                    params.diskSize.gb)
+    googleDiskService
+      .resizeDisk(params.runtime.googleProject,
+                  config.gceConfig.zoneName,
+                  DiskName(params.runtime.runtimeName.asString),
+                  params.diskSize.gb)
+      .void
 
   override def resizeCluster(params: ResizeClusterParams)(implicit ev: ApplicativeAsk[F, TraceId]): F[Unit] =
     Async[F].unit

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/KubernetesTestData.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/KubernetesTestData.scala
@@ -2,7 +2,7 @@ package org.broadinstitute.dsde.workbench.leonardo
 
 import org.broadinstitute.dsde.workbench.google2.GKEModels.{KubernetesClusterName, NodepoolName}
 import org.broadinstitute.dsde.workbench.google2.KubernetesModels.KubernetesApiServerIp
-import org.broadinstitute.dsde.workbench.google2.KubernetesSerializableName.KubernetesNamespaceName
+import org.broadinstitute.dsde.workbench.google2.KubernetesSerializableName.NamespaceName
 import org.broadinstitute.dsde.workbench.google2.{Location, MachineTypeName}
 import org.broadinstitute.dsde.workbench.leonardo.CommonTestData._
 
@@ -14,8 +14,8 @@ object KubernetesTestData {
   val location = Location("us-central1-a")
 
   val apiServerIp = KubernetesApiServerIp("0.0.0.0")
-  val namespace0 = KubernetesNamespaceName("namespace00")
-  val namespace1 = KubernetesNamespaceName("namespace01")
+  val namespace0 = NamespaceName("namespace00")
+  val namespace1 = NamespaceName("namespace01")
 
   val nodepoolName0 = NodepoolName("nodepoolname00")
   val nodepoolName1 = NodepoolName("nodepoolname01")

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/TestLeoRoutes.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/TestLeoRoutes.scala
@@ -19,7 +19,7 @@ import org.broadinstitute.dsde.workbench.google.mock.{
 import org.broadinstitute.dsde.workbench.google2.mock.FakeGoogleStorageInterpreter
 import org.broadinstitute.dsde.workbench.leonardo.CommonTestData._
 import org.broadinstitute.dsde.workbench.leonardo.config.Config
-import org.broadinstitute.dsde.workbench.leonardo.dao.google.MockGoogleComputeService
+import org.broadinstitute.dsde.workbench.leonardo.dao.google.{MockGoogleComputeService, MockGoogleDiskService}
 import org.broadinstitute.dsde.workbench.leonardo.dao.{MockDockerDAO, MockWelderDAO}
 import org.broadinstitute.dsde.workbench.leonardo.db.TestComponent
 import org.broadinstitute.dsde.workbench.leonardo.dns.ClusterDnsCache
@@ -91,6 +91,7 @@ trait TestLeoRoutes {
                                 vpcInterp,
                                 mockGoogleDataprocDAO,
                                 MockGoogleComputeService,
+                                MockGoogleDiskService,
                                 mockGoogleDirectoryDAO,
                                 mockGoogleIamDAO,
                                 mockGoogleProjectDAO,
@@ -101,6 +102,7 @@ trait TestLeoRoutes {
                            bucketHelper,
                            vpcInterp,
                            MockGoogleComputeService,
+                           MockGoogleDiskService,
                            MockWelderDAO,
                            blocker)
   val runtimeInstances = new RuntimeInstances[IO](dataprocInterp, gceInterp)

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/google/MockGoogleComputeService.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/google/MockGoogleComputeService.scala
@@ -5,7 +5,6 @@ import cats.mtl.ApplicativeAsk
 import com.google.cloud.compute.v1._
 import org.broadinstitute.dsde.workbench.DoneCheckable
 import org.broadinstitute.dsde.workbench.google2.{
-  DiskName,
   FirewallRuleName,
   GoogleComputeService,
   InstanceName,
@@ -69,10 +68,6 @@ class MockGoogleComputeService extends GoogleComputeService[IO] {
   override def getMachineType(project: GoogleProject, zone: ZoneName, machineTypeName: MachineTypeName)(
     implicit ev: ApplicativeAsk[IO, TraceId]
   ): IO[Option[MachineType]] = IO.pure(Some(MachineType.newBuilder().setMemoryMb(7680).build))
-
-  override def resizeDisk(project: GoogleProject, zone: ZoneName, diskName: DiskName, newSizeGb: Int)(
-    implicit ev: ApplicativeAsk[IO, TraceId]
-  ): IO[Unit] = IO.unit
 
   override def getZones(project: GoogleProject, regionName: RegionName)(
     implicit ev: ApplicativeAsk[IO, TraceId]

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/google/MockGoogleDiskService.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/google/MockGoogleDiskService.scala
@@ -1,0 +1,30 @@
+package org.broadinstitute.dsde.workbench.leonardo.dao.google
+
+import cats.effect.IO
+import cats.mtl.ApplicativeAsk
+import com.google.cloud.compute.v1.{Disk, Operation}
+import fs2.Stream
+import org.broadinstitute.dsde.workbench.google2.{DiskName, GoogleDiskService, ZoneName}
+import org.broadinstitute.dsde.workbench.model.TraceId
+import org.broadinstitute.dsde.workbench.model.google.GoogleProject
+
+// TODO move to wb-libs
+class MockGoogleDiskService extends GoogleDiskService[IO] {
+  override def createDisk(project: GoogleProject, zone: ZoneName, disk: Disk)(
+    implicit ev: ApplicativeAsk[IO, TraceId]
+  ): IO[Operation] = IO.pure(Operation.newBuilder().setId("op").setName("opName").setTargetId("target").build())
+
+  override def deleteDisk(project: GoogleProject, zone: ZoneName, diskName: DiskName)(
+    implicit ev: ApplicativeAsk[IO, TraceId]
+  ): IO[Operation] = IO.pure(Operation.newBuilder().setId("op").setName("opName").setTargetId("target").build())
+
+  override def listDisks(project: GoogleProject, zone: ZoneName)(
+    implicit ev: ApplicativeAsk[IO, TraceId]
+  ): Stream[IO, Disk] = Stream(Disk.newBuilder().setName("disk").build())
+
+  override def resizeDisk(project: GoogleProject, zone: ZoneName, diskName: DiskName, newSizeGb: Int)(
+    implicit ev: ApplicativeAsk[IO, TraceId]
+  ): IO[Operation] = IO.pure(Operation.newBuilder().setId("op").setName("opName").setTargetId("target").build())
+}
+
+object MockGoogleDiskService extends MockGoogleDiskService

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriberSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriberSpec.scala
@@ -2,7 +2,6 @@ package org.broadinstitute.dsde.workbench.leonardo
 package monitor
 
 import java.time.Instant
-import java.util.UUID
 
 import akka.actor.ActorSystem
 import akka.testkit.TestKit
@@ -352,8 +351,7 @@ class LeoPubsubMessageSubscriberSpec
     val leoSubscriber = makeLeoSubscriber()
 
     val res = for {
-      samResourceId <- IO(DiskSamResourceId(UUID.randomUUID.toString))
-      disk <- makePersistentDisk(DiskId(1)).copy(samResourceId = samResourceId, status = DiskStatus.Creating).save()
+      disk <- makePersistentDisk(DiskId(1)).copy(status = DiskStatus.Creating).save()
       tr <- traceId.ask
       now <- IO(Instant.now)
       _ <- leoSubscriber.messageResponder(CreateDiskMessage.fromDisk(disk, Some(tr)), now)

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ZombieRuntimeMonitorSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ZombieRuntimeMonitorSpec.scala
@@ -10,13 +10,13 @@ import com.google.cloud.compute.v1.{Instance, Operation}
 import fs2.Stream
 import org.broadinstitute.dsde.workbench.google.GoogleProjectDAO
 import org.broadinstitute.dsde.workbench.google.mock.{MockGoogleDataprocDAO, MockGoogleProjectDAO}
-import org.broadinstitute.dsde.workbench.google2.{GoogleComputeService, InstanceName, MachineTypeName, ZoneName}
+import org.broadinstitute.dsde.workbench.google2.{GoogleComputeService, GoogleDiskService, InstanceName, MachineTypeName, ZoneName}
 import org.broadinstitute.dsde.workbench.leonardo.TestUtils.clusterEq
 import org.broadinstitute.dsde.workbench.leonardo.CommonTestData._
 import org.broadinstitute.dsde.workbench.leonardo.config.Config
 import org.broadinstitute.dsde.workbench.leonardo.config.Config.{dataprocInterpreterConfig, gceInterpreterConfig}
-import org.broadinstitute.dsde.workbench.leonardo.dao.google.{GoogleDataprocDAO, MockGoogleComputeService}
-import org.broadinstitute.dsde.workbench.leonardo.db.{clusterQuery, TestComponent}
+import org.broadinstitute.dsde.workbench.leonardo.dao.google.{GoogleDataprocDAO, MockGoogleComputeService, MockGoogleDiskService}
+import org.broadinstitute.dsde.workbench.leonardo.db.{TestComponent, clusterQuery}
 import org.broadinstitute.dsde.workbench.leonardo.util.{DataprocInterpreter, GceInterpreter, RuntimeInstances}
 import org.broadinstitute.dsde.workbench.model.TraceId
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
@@ -427,11 +427,12 @@ class ZombieRuntimeMonitorSpec
   private def withZombieMonitor[A](
     gdDAO: GoogleDataprocDAO = new MockGoogleDataprocDAO,
     gce: GoogleComputeService[IO] = new MockGoogleComputeService,
+    disk: GoogleDiskService[IO] = new MockGoogleDiskService,
     googleProjectDAO: GoogleProjectDAO = new MockGoogleProjectDAO
   )(validations: () => A): A = {
     val dataprocInterp =
-      new DataprocInterpreter(dataprocInterpreterConfig, null, null, gdDAO, gce, null, null, null, null, blocker)
-    val gceInterp = new GceInterpreter(gceInterpreterConfig, null, null, gce, null, blocker)
+      new DataprocInterpreter(dataprocInterpreterConfig, null, null, gdDAO, gce, disk,null, null, null, null, blocker)
+    val gceInterp = new GceInterpreter(gceInterpreterConfig, null, null, gce, disk,null, blocker)
 
     implicit val runtimeInstances = new RuntimeInstances[IO](dataprocInterp, gceInterp)
     val zombieClusterMonitor = ZombieRuntimeMonitor[IO](Config.zombieRuntimeMonitorConfig, googleProjectDAO)

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/AuthProviderSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/AuthProviderSpec.scala
@@ -21,7 +21,7 @@ import org.broadinstitute.dsde.workbench.leonardo.CommonTestData._
 import org.broadinstitute.dsde.workbench.leonardo.SamResource.RuntimeSamResource
 import org.broadinstitute.dsde.workbench.leonardo.auth.MockLeoAuthProvider
 import org.broadinstitute.dsde.workbench.leonardo.config.{Config, ProxyConfig}
-import org.broadinstitute.dsde.workbench.leonardo.dao.google.MockGoogleComputeService
+import org.broadinstitute.dsde.workbench.leonardo.dao.google.{MockGoogleComputeService, MockGoogleDiskService}
 import org.broadinstitute.dsde.workbench.leonardo.dao.{MockDockerDAO, MockWelderDAO}
 import org.broadinstitute.dsde.workbench.leonardo.db._
 import org.broadinstitute.dsde.workbench.leonardo.dns.ClusterDnsCache
@@ -84,6 +84,7 @@ class AuthProviderSpec
                                 vpcInterp,
                                 mockGoogleDataprocDAO,
                                 MockGoogleComputeService,
+                                MockGoogleDiskService,
                                 mockGoogleDirectoryDAO,
                                 mockGoogleIamDAO,
                                 mockGoogleProjectDAO,
@@ -94,6 +95,7 @@ class AuthProviderSpec
                            bucketHelper,
                            vpcInterp,
                            MockGoogleComputeService,
+                           MockGoogleDiskService,
                            mockWelderDAO,
                            blocker)
   implicit val runtimeInstances = new RuntimeInstances[IO](dataprocInterp, gceInterp)

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/DiskServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/DiskServiceInterpSpec.scala
@@ -181,7 +181,7 @@ class DiskServiceInterpSpec extends FlatSpec with LeonardoTestSuite with TestCom
         val res = for {
           diskSamResource <- IO(PersistentDiskSamResource(UUID.randomUUID.toString))
           disk <- makePersistentDisk(DiskId(1)).copy(samResource = diskSamResource, status = status).save()
-          req = UpdateDiskRequest(Map.empty, Some(DiskSize(600)), None, None)
+          req = UpdateDiskRequest(Map.empty, DiskSize(600))
           fail <- diskService
             .updateDisk(userInfo, disk.googleProject, disk.name, req)
             .attempt
@@ -199,11 +199,11 @@ class DiskServiceInterpSpec extends FlatSpec with LeonardoTestSuite with TestCom
       context <- ctx.ask
       diskSamResource <- IO(PersistentDiskSamResource(UUID.randomUUID.toString))
       disk <- makePersistentDisk(DiskId(1)).copy(samResource = diskSamResource).save()
-      req = UpdateDiskRequest(Map.empty, Some(DiskSize(600)), None, None)
+      req = UpdateDiskRequest(Map.empty, DiskSize(600))
       _ <- diskService.updateDisk(userInfo, disk.googleProject, disk.name, req)
       message <- publisherQueue.dequeue1
     } yield {
-      val expectedMessage = UpdateDiskMessage(disk.id, Some(DiskSize(600)), None, None, Some(context.traceId))
+      val expectedMessage = UpdateDiskMessage(disk.id, DiskSize(600), Some(context.traceId))
       message shouldBe expectedMessage
     }
 

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoServiceSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoServiceSpec.scala
@@ -23,7 +23,7 @@ import org.broadinstitute.dsde.workbench.leonardo.RuntimeImageType.{Jupyter, Pro
 import org.broadinstitute.dsde.workbench.leonardo.SamResource.RuntimeSamResource
 import org.broadinstitute.dsde.workbench.leonardo.auth.WhitelistAuthProvider
 import org.broadinstitute.dsde.workbench.leonardo.config.Config
-import org.broadinstitute.dsde.workbench.leonardo.dao.google.MockGoogleComputeService
+import org.broadinstitute.dsde.workbench.leonardo.dao.google.{MockGoogleComputeService, MockGoogleDiskService}
 import org.broadinstitute.dsde.workbench.leonardo.dao.{MockDockerDAO, MockSamDAO, MockWelderDAO}
 import org.broadinstitute.dsde.workbench.leonardo.db._
 import org.broadinstitute.dsde.workbench.leonardo.model._
@@ -101,6 +101,7 @@ class LeonardoServiceSpec
                                                  vpcInterp,
                                                  gdDAO,
                                                  MockGoogleComputeService,
+                                                 MockGoogleDiskService,
                                                  directoryDAO,
                                                  iamDAO,
                                                  projectDAO,
@@ -110,6 +111,7 @@ class LeonardoServiceSpec
                                        bucketHelper,
                                        vpcInterp,
                                        MockGoogleComputeService,
+                                       MockGoogleDiskService,
                                        MockWelderDAO,
                                        blocker)
     implicit val runtimeInstances = new RuntimeInstances[IO](dataprocInterp, gceInterp)

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/DataprocInterpreterSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/DataprocInterpreterSpec.scala
@@ -16,7 +16,7 @@ import org.broadinstitute.dsde.workbench.leonardo.CommonTestData._
 import org.broadinstitute.dsde.workbench.leonardo.RuntimeStatus.Creating
 import org.broadinstitute.dsde.workbench.leonardo.config.Config
 import org.broadinstitute.dsde.workbench.leonardo.dao.MockWelderDAO
-import org.broadinstitute.dsde.workbench.leonardo.dao.google.{CreateClusterConfig, MockGoogleComputeService}
+import org.broadinstitute.dsde.workbench.leonardo.dao.google.{CreateClusterConfig, MockGoogleComputeService, MockGoogleDiskService}
 import org.broadinstitute.dsde.workbench.leonardo.db.TestComponent
 import org.broadinstitute.dsde.workbench.leonardo.monitor.LeoPubsubMessage.CreateRuntimeMessage
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
@@ -56,6 +56,7 @@ class DataprocInterpreterSpec
                                                    vpcInterp,
                                                    mockGoogleDataprocDAO,
                                                    MockGoogleComputeService,
+                                                   MockGoogleDiskService,
                                                    mockGoogleDirectoryDAO,
                                                    mockGoogleIamDAO,
                                                    mockGoogleProjectDAO,
@@ -153,6 +154,7 @@ class DataprocInterpreterSpec
                                                             vpcInterp,
                                                             erroredDataprocDAO,
                                                             MockGoogleComputeService,
+                                                            MockGoogleDiskService,
                                                             mockGoogleDirectoryDAO,
                                                             mockGoogleIamDAO,
                                                             mockGoogleProjectDAO,
@@ -187,6 +189,7 @@ class DataprocInterpreterSpec
                                                             vpcInterp,
                                                             erroredDataprocDAO,
                                                             MockGoogleComputeService,
+                                                            MockGoogleDiskService,
                                                             mockGoogleDirectoryDAO,
                                                             mockGoogleIamDAO,
                                                             mockGoogleProjectDAO,
@@ -215,6 +218,7 @@ class DataprocInterpreterSpec
                                                             vpcInterp,
                                                             mockGoogleDataprocDAO,
                                                             MockGoogleComputeService,
+                                                            MockGoogleDiskService,
                                                             mockGoogleDirectoryDAO,
                                                             erroredIamDAO,
                                                             mockGoogleProjectDAO,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -20,7 +20,7 @@ object Dependencies {
   val workbenchUtilV = "0.5-4c7acd5"
   val workbenchModelV = "0.13-31cacc4"
   val workbenchGoogleV = "0.21-2a218f3"
-  val workbenchGoogle2V = "0.9-8051635"
+  val workbenchGoogle2V = "0.10-b09d90f"
   val workbenchMetricsV = "0.3-c5b80d2"
   val workbenchOpenTelemetryV = "0.1-e66171c"
 


### PR DESCRIPTION
PR to add message handler methods to LeoPubsubSubscriber for `CreateDisk`, `DeleteDisk` and `UpdateDisk` 

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
