### PR TITLE
IA-1907 consolidate sam calls

### DIFF
--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/auth/sam/SamAuthProvider.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/auth/sam/SamAuthProvider.scala
@@ -141,7 +141,6 @@ class SamAuthProvider[F[_]: Effect: Logger](samDao: SamDAO[F],
     }
   }
 
-
   override def hasPersistentDiskPermission(
     samResource: PersistentDiskSamResource,
     userInfo: UserInfo,
@@ -153,11 +152,10 @@ class SamAuthProvider[F[_]: Effect: Logger](samDao: SamDAO[F],
     checkPersistentDiskPermissionWithProjectFallback(samResource, authorization, action, googleProject)
   }
 
-  def getNotebookClusterActions(internalId: RuntimeInternalId, userInfo: UserInfo)(implicit ev: ApplicativeAsk[F, TraceId]): F[List[String]] = {
+  def getNotebookClusterActions(internalId: RuntimeInternalId,
+                                userInfo: UserInfo)(implicit ev: ApplicativeAsk[F, TraceId]): F[List[String]] = {
     val authorization = Authorization(Credentials.Token(AuthScheme.Bearer, userInfo.accessToken.token))
-    samDao.getListOfResourcePermissions(internalId.asString,
-      ResourceTypeName.NotebookCluster,
-      authorization)
+    samDao.getListOfResourcePermissions(internalId.asString, ResourceTypeName.NotebookCluster, authorization)
   }
 
   private def checkRuntimePermissionWithProjectFallback(

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/auth/sam/SamAuthProvider.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/auth/sam/SamAuthProvider.scala
@@ -153,11 +153,9 @@ class SamAuthProvider[F[_]: Effect: Logger](samDao: SamDAO[F],
     checkPersistentDiskPermissionWithProjectFallback(samResource, authorization, action, googleProject)
   }
 
-
-  //We want to return a list of Notebookclusteractions List[NotebookClusterActions.NotebookClusterAction]
-  def getNotebookClusterActions(internalId: RuntimeInternalId, userInfo: UserInfo): List[String] = {
+  def getNotebookClusterActions(internalId: RuntimeInternalId, userInfo: UserInfo)(implicit ev: ApplicativeAsk[F, TraceId]): F[List[String]] = {
     val authorization = Authorization(Credentials.Token(AuthScheme.Bearer, userInfo.accessToken.token))
-    samDao.getListOfResourcePermissions[String](internalId.asString,
+    samDao.getListOfResourcePermissions(internalId.asString,
       ResourceTypeName.NotebookCluster,
       authorization)
   }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/auth/sam/SamAuthProvider.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/auth/sam/SamAuthProvider.scala
@@ -141,6 +141,7 @@ class SamAuthProvider[F[_]: Effect: Logger](samDao: SamDAO[F],
     }
   }
 
+
   override def hasPersistentDiskPermission(
     samResource: PersistentDiskSamResource,
     userInfo: UserInfo,
@@ -152,11 +153,20 @@ class SamAuthProvider[F[_]: Effect: Logger](samDao: SamDAO[F],
     checkPersistentDiskPermissionWithProjectFallback(samResource, authorization, action, googleProject)
   }
 
+
+  //We want to return a list of Notebookclusteractions List[NotebookClusterActions.NotebookClusterAction]
+  def getNotebookClusterActions(internalId: RuntimeInternalId, userInfo: UserInfo): List[String] = {
+    val authorization = Authorization(Credentials.Token(AuthScheme.Bearer, userInfo.accessToken.token))
+    samDao.getListOfResourcePermissions[String](internalId.asString,
+      ResourceTypeName.NotebookCluster,
+      authorization)
+  }
+
   private def checkRuntimePermissionWithProjectFallback(
-    samResource: RuntimeSamResource,
-    authorization: Authorization,
-    action: RuntimeAction,
-    googleProject: GoogleProject
+                                                         samResource: RuntimeSamResource,
+                                                         authorization: Authorization,
+                                                         action: RuntimeAction,
+                                                         googleProject: GoogleProject
   )(implicit ev: ApplicativeAsk[F, TraceId]): F[Boolean] =
     for {
       traceId <- ev.ask

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/auth/sam/SamAuthProvider.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/auth/sam/SamAuthProvider.scala
@@ -152,15 +152,14 @@ class SamAuthProvider[F[_]: Effect: Logger](samDao: SamDAO[F],
     checkPersistentDiskPermissionWithProjectFallback(samResource, authorization, action, googleProject)
   }
 
-  private def convertNotebookClusterActionsToString(action: String): NotebookClusterAction = {
+  private def convertNotebookClusterActionsToString(action: String): NotebookClusterAction =
     action match {
-      case "connect" => NotebookClusterAction.ConnectToCluster
-      case "modify" => NotebookClusterAction.ModifyCluster
-      case "sync" => NotebookClusterAction.SyncDataToCluster
-      case "stop_start" =>  NotebookClusterAction.StopStartCluster
-      case "delete" => NotebookClusterAction.DeleteCluster
+      case "connect"    => NotebookClusterAction.ConnectToCluster
+      case "modify"     => NotebookClusterAction.ModifyCluster
+      case "sync"       => NotebookClusterAction.SyncDataToCluster
+      case "stop_start" => NotebookClusterAction.StopStartCluster
+      case "delete"     => NotebookClusterAction.DeleteCluster
     }
-  }
 
   def getNotebookClusterActions(internalId: RuntimeInternalId, userInfo: UserInfo)(
     implicit ev: ApplicativeAsk[F, TraceId]
@@ -168,10 +167,9 @@ class SamAuthProvider[F[_]: Effect: Logger](samDao: SamDAO[F],
 
     val authorization = Authorization(Credentials.Token(AuthScheme.Bearer, userInfo.accessToken.token))
 
-    for{
+    for {
       listOfPermissions <- samDao
-                              .getListOfResourcePermissions(internalId.asString, ResourceTypeName.NotebookCluster, authorization)
-
+        .getListOfResourcePermissions(internalId.asString, ResourceTypeName.NotebookCluster, authorization)
 
     } yield {
       listOfPermissions.map(x => convertNotebookClusterActionsToString(x))

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpSamDAO.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpSamDAO.scala
@@ -81,13 +81,14 @@ class HttpSamDAO[F[_]: Effect](httpClient: Client[F], config: HttpSamDaoConfig, 
       )(onError)
     } yield res
 
-  def getListOfResourcePermissions(resourceId: String, resourceTypeName: ResourceTypeName, authHeader: Authorization)(
+  def getListOfResourcePermissions(resource: SamResource, authHeader: Authorization)(
     implicit ev: ApplicativeAsk[F, TraceId]
   ): F[List[String]] =
     httpClient.expectOr[List[String]](
       Request[F](
         method = Method.GET,
-        uri = config.samUri.withPath(s"/api/resources/v1/${resourceTypeName.toString}/${resourceId}/actions"),
+        uri =
+          config.samUri.withPath(s"/api/resources/v1/${resource.resourceType.asString}/${resource.resourceId}/actions"),
         headers = Headers.of(authHeader)
       )
     )(onError)
@@ -103,7 +104,6 @@ class HttpSamDAO[F[_]: Effect](httpClient: Client[F], config: HttpSamDaoConfig, 
         headers = Headers.of(authHeader)
       )
     )(onError)
-
 
   def createResource(resource: SamResource, creatorEmail: WorkbenchEmail, googleProject: GoogleProject)(
     implicit ev: ApplicativeAsk[F, TraceId]

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpSamDAO.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpSamDAO.scala
@@ -81,10 +81,10 @@ class HttpSamDAO[F[_]: Effect](httpClient: Client[F], config: HttpSamDaoConfig, 
       )(onError)
     } yield res
 
-  def getListOfResourcePermissions[A](resourceId: String,
+  def getListOfResourcePermissions(resourceId: String,
                             resourceTypeName: ResourceTypeName,
-                            authHeader: Authorization): List[A] =
-    httpClient.expectOr[List[A]](
+                            authHeader: Authorization)(implicit ev: ApplicativeAsk[F, TraceId]): F[List[String]] =
+    httpClient.expectOr[List[String]](
       Request[F](
         method = Method.GET,
         uri = config.samUri.withPath(s"/api/resources/v1/${resourceTypeName.toString}/${resourceId}/action"),

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpSamDAO.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpSamDAO.scala
@@ -87,7 +87,7 @@ class HttpSamDAO[F[_]: Effect](httpClient: Client[F], config: HttpSamDaoConfig, 
     httpClient.expectOr[List[String]](
       Request[F](
         method = Method.GET,
-        uri = config.samUri.withPath(s"/api/resources/v1/${resourceTypeName.toString}/${resourceId}/action"),
+        uri = config.samUri.withPath(s"/api/resources/v1/${resourceTypeName.toString}/${resourceId}/actions"),
         headers = Headers.of(authHeader)
       )
     )(onError)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpSamDAO.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpSamDAO.scala
@@ -81,9 +81,9 @@ class HttpSamDAO[F[_]: Effect](httpClient: Client[F], config: HttpSamDaoConfig, 
       )(onError)
     } yield res
 
-  def getListOfResourcePermissions(resourceId: String,
-                            resourceTypeName: ResourceTypeName,
-                            authHeader: Authorization)(implicit ev: ApplicativeAsk[F, TraceId]): F[List[String]] =
+  def getListOfResourcePermissions(resourceId: String, resourceTypeName: ResourceTypeName, authHeader: Authorization)(
+    implicit ev: ApplicativeAsk[F, TraceId]
+  ): F[List[String]] =
     httpClient.expectOr[List[String]](
       Request[F](
         method = Method.GET,
@@ -91,7 +91,6 @@ class HttpSamDAO[F[_]: Effect](httpClient: Client[F], config: HttpSamDaoConfig, 
         headers = Headers.of(authHeader)
       )
     )(onError)
-
 
   def getResourcePolicies[A](
     authHeader: Authorization,
@@ -104,6 +103,7 @@ class HttpSamDAO[F[_]: Effect](httpClient: Client[F], config: HttpSamDaoConfig, 
         headers = Headers.of(authHeader)
       )
     )(onError)
+
 
   def createResource(resource: SamResource, creatorEmail: WorkbenchEmail, googleProject: GoogleProject)(
     implicit ev: ApplicativeAsk[F, TraceId]

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpSamDAO.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpSamDAO.scala
@@ -81,6 +81,18 @@ class HttpSamDAO[F[_]: Effect](httpClient: Client[F], config: HttpSamDaoConfig, 
       )(onError)
     } yield res
 
+  def getListOfResourcePermissions[A](resourceId: String,
+                            resourceTypeName: ResourceTypeName,
+                            authHeader: Authorization): List[A] =
+    httpClient.expectOr[List[A]](
+      Request[F](
+        method = Method.GET,
+        uri = config.samUri.withPath(s"/api/resources/v1/${resourceTypeName.toString}/${resourceId}/action"),
+        headers = Headers.of(authHeader)
+      )
+    )(onError)
+
+
   def getResourcePolicies[A](
     authHeader: Authorization,
     resourceType: SamResourceType

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/SamDAO.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/SamDAO.scala
@@ -29,6 +29,12 @@ trait SamDAO[F[_]] {
                      creatorEmail: WorkbenchEmail,
                      googleProject: GoogleProject)(implicit ev: ApplicativeAsk[F, TraceId]): F[Unit]
 
+  def getListOfResourcePermissions[A](resourceId: String,
+                                      resourceTypeName: ResourceTypeName,
+                                      authHeader: Authorization): List[A]
+
+
+
   def getPetServiceAccount(authorization: Authorization, googleProject: GoogleProject)(
     implicit ev: ApplicativeAsk[F, TraceId]
   ): F[Option[WorkbenchEmail]]

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/SamDAO.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/SamDAO.scala
@@ -29,9 +29,10 @@ trait SamDAO[F[_]] {
                      creatorEmail: WorkbenchEmail,
                      googleProject: GoogleProject)(implicit ev: ApplicativeAsk[F, TraceId]): F[Unit]
 
-  def getListOfResourcePermissions[A](resourceId: String,
+
+  def getListOfResourcePermissions(resourceId: String,
                                       resourceTypeName: ResourceTypeName,
-                                      authHeader: Authorization): List[A]
+                                      authHeader: Authorization)(implicit ev: ApplicativeAsk[F, TraceId]): F[List[String]]
 
 
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/SamDAO.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/SamDAO.scala
@@ -36,6 +36,7 @@ trait SamDAO[F[_]] {
 
 
 
+
   def getPetServiceAccount(authorization: Authorization, googleProject: GoogleProject)(
     implicit ev: ApplicativeAsk[F, TraceId]
   ): F[Option[WorkbenchEmail]]

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/SamDAO.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/SamDAO.scala
@@ -29,13 +29,9 @@ trait SamDAO[F[_]] {
                      creatorEmail: WorkbenchEmail,
                      googleProject: GoogleProject)(implicit ev: ApplicativeAsk[F, TraceId]): F[Unit]
 
-
-  def getListOfResourcePermissions(resourceId: String,
-                                      resourceTypeName: ResourceTypeName,
-                                      authHeader: Authorization)(implicit ev: ApplicativeAsk[F, TraceId]): F[List[String]]
-
-
-
+  def getListOfResourcePermissions(resource: SamResource, authHeader: Authorization)(
+    implicit ev: ApplicativeAsk[F, TraceId]
+  ): F[List[String]]
 
   def getPetServiceAccount(authorization: Authorization, googleProject: GoogleProject)(
     implicit ev: ApplicativeAsk[F, TraceId]

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeoAuthProvider.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeoAuthProvider.scala
@@ -54,10 +54,11 @@ trait LeoAuthProvider[F[_]] {
 
   /**
    *
+   *
    * @param internalId
    * @return returns a list of Cluster Actions that the user has access to
    */
-  def getNotebookClusterActions(internalId: RuntimeInternalId, userInfo: UserInfo): List[String]
+  def getNotebookClusterActions(internalId: RuntimeInternalId, userInfo: UserInfo)(implicit ev: ApplicativeAsk[F, TraceId]): F[List[String]]
 
 
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeoAuthProvider.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeoAuthProvider.scala
@@ -51,6 +51,17 @@ trait LeoAuthProvider[F[_]] {
                            action: RuntimeAction,
                            googleProject: GoogleProject)(implicit ev: ApplicativeAsk[F, TraceId]): F[Boolean]
 
+
+  /**
+   *
+   * @param internalId
+   * @return returns a list of Cluster Actions that the user has access to
+   */
+  def getNotebookClusterActions(internalId: RuntimeInternalId, userInfo: UserInfo): List[String]
+
+
+
+
   def hasPersistentDiskPermission(samResource: PersistentDiskSamResource,
                                   userInfo: UserInfo,
                                   action: PersistentDiskAction,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeoAuthProvider.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeoAuthProvider.scala
@@ -51,7 +51,7 @@ trait LeoAuthProvider[F[_]] {
                            action: RuntimeAction,
                            googleProject: GoogleProject)(implicit ev: ApplicativeAsk[F, TraceId]): F[Boolean]
 
-  def getRuntimeActions(samResource: SamResource, userInfo: UserInfo)(
+  def getRuntimeActions(samResource: RuntimeSamResource, userInfo: UserInfo)(
     implicit ev: ApplicativeAsk[F, TraceId]
   ): F[List[RuntimeAction]]
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeoAuthProvider.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeoAuthProvider.scala
@@ -51,15 +51,15 @@ trait LeoAuthProvider[F[_]] {
                            action: RuntimeAction,
                            googleProject: GoogleProject)(implicit ev: ApplicativeAsk[F, TraceId]): F[Boolean]
 
-
   /**
    *
    *
    * @param internalId
    * @return returns a list of Cluster Actions that the user has access to
    */
-  def getNotebookClusterActions(internalId: RuntimeInternalId, userInfo: UserInfo)(implicit ev: ApplicativeAsk[F, TraceId]): F[List[String]]
-
+  def getNotebookClusterActions(internalId: RuntimeInternalId, userInfo: UserInfo)(
+    implicit ev: ApplicativeAsk[F, TraceId]
+  ): F[List[String]]
 
 
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeoAuthProvider.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeoAuthProvider.scala
@@ -59,7 +59,7 @@ trait LeoAuthProvider[F[_]] {
    */
   def getNotebookClusterActions(internalId: RuntimeInternalId, userInfo: UserInfo)(
     implicit ev: ApplicativeAsk[F, TraceId]
-  ): F[List[String]]
+  ): F[List[NotebookClusterAction]]
 
 
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeoAuthProvider.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeoAuthProvider.scala
@@ -51,17 +51,9 @@ trait LeoAuthProvider[F[_]] {
                            action: RuntimeAction,
                            googleProject: GoogleProject)(implicit ev: ApplicativeAsk[F, TraceId]): F[Boolean]
 
-  /**
-   *
-   *
-   * @param internalId
-   * @return returns a list of Cluster Actions that the user has access to
-   */
-  def getNotebookClusterActions(internalId: RuntimeInternalId, userInfo: UserInfo)(
+  def getRuntimeActions(samResource: SamResource, userInfo: UserInfo)(
     implicit ev: ApplicativeAsk[F, TraceId]
-  ): F[List[NotebookClusterAction]]
-
-
+  ): F[List[RuntimeAction]]
 
   def hasPersistentDiskPermission(samResource: PersistentDiskSamResource,
                                   userInfo: UserInfo,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/RuntimeServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/RuntimeServiceInterp.scala
@@ -207,7 +207,7 @@ class RuntimeServiceInterp[F[_]: Parallel](config: RuntimeServiceConfig,
       // Note: the general pattern is to 404 (e.g. pretend the runtime doesn't exist) if the caller doesn't have
       // GetClusterStatus permission. We return 403 if the user can view the runtime but can't perform some other action.
 
-      listOfPermissions = authProvider.getNotebookClusterActions(runtime.internalId, userInfo)
+      listOfPermissions <- authProvider.getNotebookClusterActions(runtime.internalId, userInfo)
 
       hasStatusPermission = listOfPermissions.contains("status")
 
@@ -261,7 +261,7 @@ class RuntimeServiceInterp[F[_]: Parallel](config: RuntimeServiceConfig,
       // Note: the general pattern is to 404 (e.g. pretend the runtime doesn't exist) if the caller doesn't have
       // GetClusterStatus permission. We return 403 if the user can view the runtime but can't perform some other action.
 
-      listOfPermissions = authProvider.getNotebookClusterActions(runtime.internalId, userInfo)
+      listOfPermissions <- authProvider.getNotebookClusterActions(runtime.internalId, userInfo)
 
       hasStatusPermission = listOfPermissions.contains("status")
 
@@ -297,7 +297,7 @@ class RuntimeServiceInterp[F[_]: Parallel](config: RuntimeServiceConfig,
       // Note: the general pattern is to 404 (e.g. pretend the runtime doesn't exist) if the caller doesn't have
       // GetClusterStatus permission. We return 403 if the user can view the runtime but can't perform some other action.
 
-      listOfPermissions = authProvider.getNotebookClusterActions(runtime.internalId, userInfo)
+      listOfPermissions <- authProvider.getNotebookClusterActions(runtime.internalId, userInfo)
 
       hasStatusPermission = listOfPermissions.contains("status")
 
@@ -339,7 +339,7 @@ class RuntimeServiceInterp[F[_]: Parallel](config: RuntimeServiceConfig,
       // Note: the general pattern is to 404 (e.g. pretend the runtime doesn't exist) if the caller doesn't have
       // GetClusterStatus permission. We return 403 if the user can view the runtime but can't perform some other action.
 
-      listOfPermissions = authProvider.getNotebookClusterActions(runtime.internalId, userInfo)
+      listOfPermissions <- authProvider.getNotebookClusterActions(runtime.internalId, userInfo)
 
       hasStatusPermission = listOfPermissions.contains("status")
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/RuntimeServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/RuntimeServiceInterp.scala
@@ -206,15 +206,22 @@ class RuntimeServiceInterp[F[_]: Parallel](config: RuntimeServiceConfig,
       // throw 404 if no GetClusterStatus permission
       // Note: the general pattern is to 404 (e.g. pretend the runtime doesn't exist) if the caller doesn't have
       // GetClusterStatus permission. We return 403 if the user can view the runtime but can't perform some other action.
-      hasPermission <- authProvider.hasRuntimePermission(runtime.samResource, userInfo, GetRuntimeStatus, googleProject)
+
+      listOfPermissions = authProvider.getNotebookClusterActions(runtime.internalId, userInfo)
+
+      hasStatusPermission = listOfPermissions.contains("status")
+
       _ <- ctx.span.traverse(s => F.delay(s.addAnnotation("Sam | Done first hasNotebookClusterPermission")))
-      _ <- if (hasPermission) F.unit else F.raiseError[Unit](RuntimeNotFoundException(googleProject, runtimeName))
+
+      _ <- if (hasStatusPermission) F.unit else F.raiseError[Unit](RuntimeNotFoundException(googleProject, runtimeName))
+
       // throw 403 if no DeleteCluster permission
-      hasDeletePermission <- authProvider.hasRuntimePermission(runtime.samResource,
-                                                               userInfo,
-                                                               DeleteRuntime,
-                                                               googleProject)
+
+
+      hasDeletePermission = listOfPermissions.contains("delete")
+
       _ <- ctx.span.traverse(s => F.delay(s.addAnnotation("Sam | Done 2nd hasNotebookClusterPermission")))
+
       _ <- if (hasDeletePermission) F.unit else F.raiseError[Unit](AuthorizationError(Some(userInfo.userEmail)))
       // throw 409 if the cluster is not deletable
       _ <- if (runtime.status.isDeletable) F.unit
@@ -253,15 +260,20 @@ class RuntimeServiceInterp[F[_]: Parallel](config: RuntimeServiceConfig,
       // throw 404 if no GetClusterStatus permission
       // Note: the general pattern is to 404 (e.g. pretend the runtime doesn't exist) if the caller doesn't have
       // GetClusterStatus permission. We return 403 if the user can view the runtime but can't perform some other action.
-      hasPermission <- authProvider.hasRuntimePermission(runtime.samResource, userInfo, GetRuntimeStatus, googleProject)
+
+      listOfPermissions = authProvider.getNotebookClusterActions(runtime.internalId, userInfo)
+
+      hasStatusPermission = listOfPermissions.contains("status")
+
       _ <- ctx.span.traverse(s => F.delay(s.addAnnotation("Done Sam call for cluster permission")))
-      _ <- if (hasPermission) F.unit else F.raiseError[Unit](RuntimeNotFoundException(googleProject, runtimeName))
+
+      _ <- if (hasStatusPermission) F.unit else F.raiseError[Unit](RuntimeNotFoundException(googleProject, runtimeName))
+
       // throw 403 if no StopStartCluster permission
-      hasStopPermission <- authProvider.hasRuntimePermission(runtime.samResource,
-                                                             userInfo,
-                                                             StopStartRuntime,
-                                                             googleProject)
+      hasStopPermission = listOfPermissions.contains("stop_start")
+
       _ <- ctx.span.traverse(s => F.delay(s.addAnnotation("Done 2nd sam hasNotebookClusterPermission check")))
+
       _ <- if (hasStopPermission) F.unit else F.raiseError[Unit](AuthorizationError(Some(userInfo.userEmail)))
       // throw 409 if the cluster is not stoppable
       _ <- if (runtime.status.isStoppable) F.unit
@@ -284,16 +296,24 @@ class RuntimeServiceInterp[F[_]: Parallel](config: RuntimeServiceConfig,
       // throw 404 if no GetClusterStatus permission
       // Note: the general pattern is to 404 (e.g. pretend the runtime doesn't exist) if the caller doesn't have
       // GetClusterStatus permission. We return 403 if the user can view the runtime but can't perform some other action.
-      hasPermission <- authProvider.hasRuntimePermission(runtime.samResource, userInfo, GetRuntimeStatus, googleProject)
+
+      listOfPermissions = authProvider.getNotebookClusterActions(runtime.internalId, userInfo)
+
+      hasStatusPermission = listOfPermissions.contains("status")
+
+      _ <- if (hasStatusPermission) F.unit else F.raiseError[Unit](RuntimeNotFoundException(googleProject, runtimeName))
+
+
+
       _ <- ctx.span.traverse(s => F.delay(s.addAnnotation("Done Sam call for cluster permission")))
-      _ <- if (hasPermission) F.unit else F.raiseError[Unit](RuntimeNotFoundException(googleProject, runtimeName))
-      // throw 403 if no StopStartCluster permission
-      hasStartPermission <- authProvider.hasRuntimePermission(runtime.samResource,
-                                                              userInfo,
-                                                              StopStartRuntime,
-                                                              googleProject)
-      _ <- ctx.span.traverse(s => F.delay(s.addAnnotation("Done 2nd Sam call for cluster permission")))
+
+      hasStartPermission = listOfPermissions.contains("stop_start")
       _ <- if (hasStartPermission) F.unit else F.raiseError[Unit](AuthorizationError(Some(userInfo.userEmail)))
+
+      // throw 403 if no StopStartCluster permission
+
+      _ <- ctx.span.traverse(s => F.delay(s.addAnnotation("Done 2nd Sam call for cluster permission")))
+
       // throw 409 if the cluster is not startable
       _ <- if (runtime.status.isStartable) F.unit
       else
@@ -318,12 +338,17 @@ class RuntimeServiceInterp[F[_]: Parallel](config: RuntimeServiceConfig,
       // throw 404 if no GetClusterStatus permission
       // Note: the general pattern is to 404 (e.g. pretend the runtime doesn't exist) if the caller doesn't have
       // GetClusterStatus permission. We return 403 if the user can view the runtime but can't perform some other action.
-      hasPermission <- authProvider.hasRuntimePermission(runtime.samResource, userInfo, GetRuntimeStatus, googleProject)
-      _ <- if (hasPermission) F.unit else F.raiseError[Unit](RuntimeNotFoundException(googleProject, runtimeName))
-      hasModifyPermission <- authProvider.hasRuntimePermission(runtime.samResource,
-                                                               userInfo,
-                                                               ModifyRuntime,
-                                                               googleProject)
+
+      listOfPermissions = authProvider.getNotebookClusterActions(runtime.internalId, userInfo)
+
+      hasStatusPermission = listOfPermissions.contains("status")
+
+      _ <- if (hasStatusPermission) F.unit else F.raiseError[Unit](RuntimeNotFoundException(googleProject, runtimeName))
+
+
+      // throw 403 if no ModifyCluster permission
+      hasModifyPermission = listOfPermissions.contains("modify")
+
       _ <- if (hasModifyPermission) F.unit else F.raiseError[Unit](AuthorizationError(Some(userInfo.userEmail)))
       // throw 409 if the cluster is not updatable
       _ <- if (runtime.status.isUpdatable) F.unit

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/RuntimeServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/RuntimeServiceInterp.scala
@@ -226,6 +226,7 @@ class RuntimeServiceInterp[F[_]: Parallel](config: RuntimeServiceConfig,
       _ <- if (runtime.status.isDeletable) F.unit
       else F.raiseError[Unit](RuntimeCannotBeDeletedException(runtime.googleProject, runtime.runtimeName))
       // delete the runtime
+
       _ <- if (runtime.asyncRuntimeFields.isDefined) {
         clusterQuery.updateClusterStatus(runtime.id, RuntimeStatus.PreDeleting, ctx.now).transaction >> publisherQueue
           .enqueue1(
@@ -245,6 +246,7 @@ class RuntimeServiceInterp[F[_]: Parallel](config: RuntimeServiceConfig,
               config.zombieRuntimeMonitorConfig.deletionConfirmationLabelKey,
               "false")
         .transaction
+      _ <- log.info(s"AT THE END OF DELETE")
     } yield ()
 
   def stopRuntime(userInfo: UserInfo, googleProject: GoogleProject, runtimeName: RuntimeName)(

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/RuntimeServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/RuntimeServiceInterp.scala
@@ -207,8 +207,8 @@ class RuntimeServiceInterp[F[_]: Parallel](config: RuntimeServiceConfig,
       // Note: the general pattern is to 404 (e.g. pretend the runtime doesn't exist) if the caller doesn't have
       // GetClusterStatus permission. We return 403 if the user can view the runtime but can't perform some other action.
 
-      listOfPermissions <- authProvider.getNotebookClusterActions(runtime.internalId, userInfo)
-      hasStatusPermission = listOfPermissions.toSet.contains(NotebookClusterAction.GetClusterStatus)
+      listOfPermissions <- authProvider.getRuntimeActions(runtime.samResource, userInfo)
+      hasStatusPermission = listOfPermissions.toSet.contains(RuntimeAction.GetRuntimeStatus)
 
       _ <- ctx.span.traverse(s => F.delay(s.addAnnotation("Sam | Done first hasNotebookClusterPermission")))
 
@@ -216,7 +216,7 @@ class RuntimeServiceInterp[F[_]: Parallel](config: RuntimeServiceConfig,
 
       // throw 403 if no DeleteCluster permission
 
-      hasDeletePermission = listOfPermissions.toSet.contains(NotebookClusterAction.DeleteCluster)
+      hasDeletePermission = listOfPermissions.toSet.contains(RuntimeAction.DeleteRuntime)
 
       _ <- ctx.span.traverse(s => F.delay(s.addAnnotation("Sam | Done 2nd hasNotebookClusterPermission")))
 
@@ -260,16 +260,16 @@ class RuntimeServiceInterp[F[_]: Parallel](config: RuntimeServiceConfig,
       // Note: the general pattern is to 404 (e.g. pretend the runtime doesn't exist) if the caller doesn't have
       // GetClusterStatus permission. We return 403 if the user can view the runtime but can't perform some other action.
 
-      listOfPermissions <- authProvider.getNotebookClusterActions(runtime.internalId, userInfo)
+      listOfPermissions <- authProvider.getRuntimeActions(runtime.samResource, userInfo)
 
-      hasStatusPermission = listOfPermissions.toSet.contains(NotebookClusterAction.GetClusterStatus)
+      hasStatusPermission = listOfPermissions.toSet.contains(RuntimeAction.GetRuntimeStatus)
 
       _ <- ctx.span.traverse(s => F.delay(s.addAnnotation("Done Sam call for cluster permission")))
 
       _ <- if (hasStatusPermission) F.unit else F.raiseError[Unit](RuntimeNotFoundException(googleProject, runtimeName))
 
       // throw 403 if no StopStartCluster permission
-      hasStopPermission = listOfPermissions.toSet.contains(NotebookClusterAction.StopStartCluster)
+      hasStopPermission = listOfPermissions.toSet.contains(RuntimeAction.StopStartRuntime)
 
       _ <- ctx.span.traverse(s => F.delay(s.addAnnotation("Done 2nd sam hasNotebookClusterPermission check")))
 
@@ -296,15 +296,15 @@ class RuntimeServiceInterp[F[_]: Parallel](config: RuntimeServiceConfig,
       // Note: the general pattern is to 404 (e.g. pretend the runtime doesn't exist) if the caller doesn't have
       // GetClusterStatus permission. We return 403 if the user can view the runtime but can't perform some other action.
 
-      listOfPermissions <- authProvider.getNotebookClusterActions(runtime.internalId, userInfo)
+      listOfPermissions <- authProvider.getRuntimeActions(runtime.samResource, userInfo)
 
-      hasStatusPermission = listOfPermissions.toSet.contains(NotebookClusterAction.GetClusterStatus)
+      hasStatusPermission = listOfPermissions.toSet.contains(RuntimeAction.GetRuntimeStatus)
 
       _ <- if (hasStatusPermission) F.unit else F.raiseError[Unit](RuntimeNotFoundException(googleProject, runtimeName))
 
       _ <- ctx.span.traverse(s => F.delay(s.addAnnotation("Done Sam call for cluster permission")))
 
-      hasStartPermission = listOfPermissions.contains(NotebookClusterAction.StopStartCluster)
+      hasStartPermission = listOfPermissions.contains(RuntimeAction.StopStartRuntime)
       _ <- if (hasStartPermission) F.unit else F.raiseError[Unit](AuthorizationError(Some(userInfo.userEmail)))
 
       // throw 403 if no StopStartCluster permission
@@ -336,14 +336,14 @@ class RuntimeServiceInterp[F[_]: Parallel](config: RuntimeServiceConfig,
       // Note: the general pattern is to 404 (e.g. pretend the runtime doesn't exist) if the caller doesn't have
       // GetClusterStatus permission. We return 403 if the user can view the runtime but can't perform some other action.
 
-      listOfPermissions <- authProvider.getNotebookClusterActions(runtime.internalId, userInfo)
+      listOfPermissions <- authProvider.getRuntimeActions(runtime.samResource, userInfo)
 
-      hasStatusPermission = listOfPermissions.toSet.contains(NotebookClusterAction.GetClusterStatus)
+      hasStatusPermission = listOfPermissions.toSet.contains(RuntimeAction.GetRuntimeStatus)
 
       _ <- if (hasStatusPermission) F.unit else F.raiseError[Unit](RuntimeNotFoundException(googleProject, runtimeName))
 
       // throw 403 if no ModifyCluster permission
-      hasModifyPermission = listOfPermissions.contains(NotebookClusterAction.ModifyCluster)
+      hasModifyPermission = listOfPermissions.contains(RuntimeAction.ModifyRuntime)
 
       _ <- if (hasModifyPermission) F.unit else F.raiseError[Unit](AuthorizationError(Some(userInfo.userEmail)))
       // throw 409 if the cluster is not updatable

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/RuntimeServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/RuntimeServiceInterp.scala
@@ -262,7 +262,6 @@ class RuntimeServiceInterp[F[_]: Parallel](config: RuntimeServiceConfig,
 
       listOfPermissions <- authProvider.getNotebookClusterActions(runtime.internalId, userInfo)
 
-
       hasStatusPermission = listOfPermissions.contains("status")
 
       _ <- ctx.span.traverse(s => F.delay(s.addAnnotation("Done Sam call for cluster permission")))
@@ -346,7 +345,6 @@ class RuntimeServiceInterp[F[_]: Parallel](config: RuntimeServiceConfig,
       hasStatusPermission = listOfPermissions.contains("status")
 
       _ <- if (hasStatusPermission) F.unit else F.raiseError[Unit](RuntimeNotFoundException(googleProject, runtimeName))
-
 
       // throw 403 if no ModifyCluster permission
       hasModifyPermission = listOfPermissions.contains("modify")

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/RuntimeServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/RuntimeServiceInterp.scala
@@ -208,9 +208,8 @@ class RuntimeServiceInterp[F[_]: Parallel](config: RuntimeServiceConfig,
       // GetClusterStatus permission. We return 403 if the user can view the runtime but can't perform some other action.
 
       listOfPermissions <- authProvider.getNotebookClusterActions(runtime.internalId, userInfo)
-
       hasStatusPermission = listOfPermissions.contains("status")
-
+      
       _ <- ctx.span.traverse(s => F.delay(s.addAnnotation("Sam | Done first hasNotebookClusterPermission")))
 
       _ <- if (hasStatusPermission) F.unit else F.raiseError[Unit](RuntimeNotFoundException(googleProject, runtimeName))
@@ -263,9 +262,11 @@ class RuntimeServiceInterp[F[_]: Parallel](config: RuntimeServiceConfig,
 
       listOfPermissions <- authProvider.getNotebookClusterActions(runtime.internalId, userInfo)
 
+
       hasStatusPermission = listOfPermissions.contains("status")
 
       _ <- ctx.span.traverse(s => F.delay(s.addAnnotation("Done Sam call for cluster permission")))
+
 
       _ <- if (hasStatusPermission) F.unit else F.raiseError[Unit](RuntimeNotFoundException(googleProject, runtimeName))
 
@@ -306,6 +307,7 @@ class RuntimeServiceInterp[F[_]: Parallel](config: RuntimeServiceConfig,
 
 
       _ <- ctx.span.traverse(s => F.delay(s.addAnnotation("Done Sam call for cluster permission")))
+
 
       hasStartPermission = listOfPermissions.contains("stop_start")
       _ <- if (hasStartPermission) F.unit else F.raiseError[Unit](AuthorizationError(Some(userInfo.userEmail)))

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/StatusRoutesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/StatusRoutesSpec.scala
@@ -95,6 +95,8 @@ class StatusRoutesSpec
       override def getCachedPetAccessToken(userEmail: WorkbenchEmail, googleProject: GoogleProject)(
         implicit ev: ApplicativeAsk[IO, TraceId]
       ): IO[Option[String]] = ???
+
+      override def getListOfResourcePermissions(resourceId: String, resourceTypeName: ResourceTypeName, authHeader: Authorization)(implicit ev: ApplicativeAsk[IO, TraceId]): IO[List[String]] = ???
     }
     val badDataproc = new MockGoogleDataprocDAO(false)
     val statusService =

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/StatusRoutesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/StatusRoutesSpec.scala
@@ -96,7 +96,7 @@ class StatusRoutesSpec
         implicit ev: ApplicativeAsk[IO, TraceId]
       ): IO[Option[String]] = ???
 
-      override def getListOfResourcePermissions(resourceId: String, resourceTypeName: ResourceTypeName, authHeader: Authorization)(implicit ev: ApplicativeAsk[IO, TraceId]): IO[List[String]] = ???
+      override def getListOfResourcePermissions(resource: SamResource, authHeader: Authorization)(implicit ev: ApplicativeAsk[IO, TraceId]): IO[List[String]] = ???
     }
     val badDataproc = new MockGoogleDataprocDAO(false)
     val statusService =

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/auth/MockLeoAuthProvider.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/auth/MockLeoAuthProvider.scala
@@ -91,11 +91,6 @@ class MockLeoAuthProvider(authConfig: Config, saProvider: ServiceAccountProvider
                                      googleProject: GoogleProject)(implicit ev: ApplicativeAsk[IO, TraceId]): IO[Unit] =
     notifyInternal
 
-  /**
-   *
-   *
-   * @param internalId
-   * @return returns a list of Cluster Actions that the user has access to
-   */
-  override def getNotebookClusterActions(internalId: RuntimeInternalId, userInfo: UserInfo)(implicit ev: ApplicativeAsk[IO, TraceId]): IO[List[NotebookClusterAction]] = IO.pure(List.empty)
+
+  override def getRuntimeActions(samResource: SamResource, userInfo: UserInfo)(implicit ev: ApplicativeAsk[IO, TraceId]): IO[List[RuntimeAction]] = IO.pure(List.empty)
 }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/auth/MockLeoAuthProvider.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/auth/MockLeoAuthProvider.scala
@@ -97,5 +97,5 @@ class MockLeoAuthProvider(authConfig: Config, saProvider: ServiceAccountProvider
    * @param internalId
    * @return returns a list of Cluster Actions that the user has access to
    */
-  override def getNotebookClusterActions(internalId: RuntimeInternalId, userInfo: UserInfo)(implicit ev: ApplicativeAsk[IO, TraceId]): IO[List[String]] = IO.pure(List.empty)
+  override def getNotebookClusterActions(internalId: RuntimeInternalId, userInfo: UserInfo)(implicit ev: ApplicativeAsk[IO, TraceId]): IO[List[NotebookClusterAction]] = IO.pure(List.empty)
 }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/auth/MockLeoAuthProvider.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/auth/MockLeoAuthProvider.scala
@@ -92,5 +92,5 @@ class MockLeoAuthProvider(authConfig: Config, saProvider: ServiceAccountProvider
     notifyInternal
 
 
-  override def getRuntimeActions(samResource: SamResource, userInfo: UserInfo)(implicit ev: ApplicativeAsk[IO, TraceId]): IO[List[RuntimeAction]] = IO.pure(List.empty)
+  override def getRuntimeActions(samResource: RuntimeSamResource, userInfo: UserInfo)(implicit ev: ApplicativeAsk[IO, TraceId]): IO[List[RuntimeAction]] = IO.pure(List.empty)
 }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/auth/MockLeoAuthProvider.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/auth/MockLeoAuthProvider.scala
@@ -91,4 +91,11 @@ class MockLeoAuthProvider(authConfig: Config, saProvider: ServiceAccountProvider
                                      googleProject: GoogleProject)(implicit ev: ApplicativeAsk[IO, TraceId]): IO[Unit] =
     notifyInternal
 
+  /**
+   *
+   *
+   * @param internalId
+   * @return returns a list of Cluster Actions that the user has access to
+   */
+  override def getNotebookClusterActions(internalId: RuntimeInternalId, userInfo: UserInfo)(implicit ev: ApplicativeAsk[IO, TraceId]): IO[List[String]] = IO.pure(List.empty)
 }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/auth/WhitelistAuthProvider.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/auth/WhitelistAuthProvider.scala
@@ -70,4 +70,9 @@ class WhitelistAuthProvider(config: Config, saProvider: ServiceAccountProvider[I
                             googleProject: GoogleProject)(implicit ev: ApplicativeAsk[IO, TraceId]): IO[Unit] = IO.unit
 
   override def serviceAccountProvider: ServiceAccountProvider[IO] = saProvider
+
+  override def getRuntimeActions(samResource: SamResource, userInfo: UserInfo)(implicit ev: ApplicativeAsk[IO, TraceId]): IO[List[RuntimeAction]] =
+    if (checkWhitelist(userInfo) == IO.pure(true)) IO.pure(RuntimeAction.allActions.toList)
+    else IO.pure(List.empty)
+
 }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/auth/WhitelistAuthProvider.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/auth/WhitelistAuthProvider.scala
@@ -71,7 +71,7 @@ class WhitelistAuthProvider(config: Config, saProvider: ServiceAccountProvider[I
 
   override def serviceAccountProvider: ServiceAccountProvider[IO] = saProvider
 
-  override def getRuntimeActions(samResource: SamResource, userInfo: UserInfo)(implicit ev: ApplicativeAsk[IO, TraceId]): IO[List[RuntimeAction]] =
+  override def getRuntimeActions(samResource: RuntimeSamResource, userInfo: UserInfo)(implicit ev: ApplicativeAsk[IO, TraceId]): IO[List[RuntimeAction]] =
     if (checkWhitelist(userInfo) == IO.pure(true)) IO.pure(RuntimeAction.allActions.toList)
     else IO.pure(List.empty)
 

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpSamDAOSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpSamDAOSpec.scala
@@ -24,7 +24,7 @@ import org.http4s.client.middleware.{Retry, RetryPolicy}
 
 import scala.util.control.NoStackTrace
 
-class HttpSamDAOSpec extends FlatSpec with Matchers with BeforeAndAfterAll {
+class   HttpSamDAOSpec extends FlatSpec with Matchers with BeforeAndAfterAll {
   implicit val timer = IO.timer(global)
   implicit val cs = IO.contextShift(global)
   val blocker = Blocker.liftExecutionContext(global)

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/MockSamDAO.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/MockSamDAO.scala
@@ -105,7 +105,7 @@ class MockSamDAO extends SamDAO[IO] {
   override def getStatus(implicit ev: ApplicativeAsk[IO, TraceId]): IO[StatusCheckResponse] =
     IO.pure(StatusCheckResponse(true, Map.empty))
 
-  override def getListOfResourcePermissions(resourceId: String, resourceTypeName: ResourceTypeName, authHeader: Authorization)(implicit ev: ApplicativeAsk[IO, TraceId]): IO[List[String]] = IO.pure(List.empty)
+  override def getListOfResourcePermissions(resource: SamResource, authHeader: Authorization)(implicit ev: ApplicativeAsk[IO, TraceId]): IO[List[String]] = IO.pure(List.empty)
 }
 
 object MockSamDAO {

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/MockSamDAO.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/MockSamDAO.scala
@@ -104,6 +104,8 @@ class MockSamDAO extends SamDAO[IO] {
 
   override def getStatus(implicit ev: ApplicativeAsk[IO, TraceId]): IO[StatusCheckResponse] =
     IO.pure(StatusCheckResponse(true, Map.empty))
+
+  override def getListOfResourcePermissions(resourceId: String, resourceTypeName: ResourceTypeName, authHeader: Authorization)(implicit ev: ApplicativeAsk[IO, TraceId]): IO[List[String]] = IO.pure(List.empty)
 }
 
 object MockSamDAO {

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/mocks.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/mocks.scala
@@ -104,14 +104,7 @@ object MockAuthProvider extends LeoAuthProvider[IO] {
                                      googleProject: GoogleProject)(implicit ev: ApplicativeAsk[IO, TraceId]): IO[Unit] =
     IO.unit
 
-  /**
-   *
-   *
-   * @param internalId
-   * @return returns a list of Cluster Actions that the user has access to
-   */
-
-  override def getNotebookClusterActions(internalId: RuntimeInternalId, userInfo: UserInfo)(implicit ev: ApplicativeAsk[IO, TraceId]): IO[List[NotebookClusterAction]] = ???
+  override def getRuntimeActions(samResource: SamResource, userInfo: UserInfo)(implicit ev: ApplicativeAsk[IO, TraceId]): IO[List[RuntimeAction]] = ???
 }
 
 object FakeGooglePublisher extends GooglePublisher[IO] {

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/mocks.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/mocks.scala
@@ -110,8 +110,8 @@ object MockAuthProvider extends LeoAuthProvider[IO] {
    * @param internalId
    * @return returns a list of Cluster Actions that the user has access to
    */
-  override def getNotebookClusterActions(internalId: RuntimeInternalId, userInfo: UserInfo)(implicit ev: ApplicativeAsk[IO, TraceId]): IO[List[String]] = ???
 
+  override def getNotebookClusterActions(internalId: RuntimeInternalId, userInfo: UserInfo)(implicit ev: ApplicativeAsk[IO, TraceId]): IO[List[NotebookClusterAction]] = ???
 }
 
 object FakeGooglePublisher extends GooglePublisher[IO] {

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/mocks.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/mocks.scala
@@ -103,6 +103,15 @@ object MockAuthProvider extends LeoAuthProvider[IO] {
                                      creatorEmail: WorkbenchEmail,
                                      googleProject: GoogleProject)(implicit ev: ApplicativeAsk[IO, TraceId]): IO[Unit] =
     IO.unit
+
+  /**
+   *
+   *
+   * @param internalId
+   * @return returns a list of Cluster Actions that the user has access to
+   */
+  override def getNotebookClusterActions(internalId: RuntimeInternalId, userInfo: UserInfo)(implicit ev: ApplicativeAsk[IO, TraceId]): IO[List[String]] = ???
+
 }
 
 object FakeGooglePublisher extends GooglePublisher[IO] {

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/mocks.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/mocks.scala
@@ -104,7 +104,7 @@ object MockAuthProvider extends LeoAuthProvider[IO] {
                                      googleProject: GoogleProject)(implicit ev: ApplicativeAsk[IO, TraceId]): IO[Unit] =
     IO.unit
 
-  override def getRuntimeActions(samResource: SamResource, userInfo: UserInfo)(implicit ev: ApplicativeAsk[IO, TraceId]): IO[List[RuntimeAction]] = ???
+  override def getRuntimeActions(samResource: RuntimeSamResource, userInfo: UserInfo)(implicit ev: ApplicativeAsk[IO, TraceId]): IO[List[RuntimeAction]] = ???
 }
 
 object FakeGooglePublisher extends GooglePublisher[IO] {

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/RuntimeServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/RuntimeServiceInterpSpec.scala
@@ -369,6 +369,8 @@ class RuntimeServiceInterpSpec extends FlatSpec with LeonardoTestSuite with Test
             .getActiveClusterByNameMinimal(testRuntime.googleProject, testRuntime.runtimeName)
             .transaction
           message <- publisherQueue.tryDequeue1
+
+
         } yield {
           dbRuntimeOpt.get.status shouldBe RuntimeStatus.Deleting
           message shouldBe (None)


### PR DESCRIPTION
We were looking for a way to consolidate the Sam calls, which checked for Notebook Action permissions. We built out a new method with would call the resources API to return of list of permissions that a particular user had for a cluster. 

Using that list, we would check to see if a particular permission was within that list. This way, we did not have to call Sam more than once per request.

This is still a WIP.
---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
