### PR TITLE
IA-1828 Upgrade scalatest to 3.1.2

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
@@ -21,8 +21,7 @@ import org.broadinstitute.dsde.workbench.model.google._
 import org.broadinstitute.dsde.workbench.service.test.{RandomUtil, WebBrowserSpec}
 import org.broadinstitute.dsde.workbench.service.{RestException, Sam}
 import org.broadinstitute.dsde.workbench.util._
-import org.scalactic.source.Position
-import org.scalatest.concurrent.PatienceConfiguration.Timeout
+import org.scalatest.concurrent.PatienceConfiguration.{Interval, Timeout}
 import org.scalatest.concurrent.{Eventually, ScalaFutures}
 import org.scalatest.time.{Minutes, Seconds, Span}
 import org.scalatest.{Matchers, Suite}
@@ -266,13 +265,14 @@ trait LeonardoTestUtils
     logger.info(s"Time it took to get cluster create response with: ${clusterTimeResult.duration.toMillis} millis")
 
     // verify with get()
-    val creatingCluster = eventually {
-      verifyCluster(Leonardo.cluster.get(googleProject, clusterName),
-                    googleProject,
-                    clusterName,
-                    List(ClusterStatus.Creating),
-                    clusterRequest)
-    }(getAfterCreatePatience, implicitly[Position])
+    val creatingCluster =
+      eventually(Timeout(getAfterCreatePatience.timeout), Interval(getAfterCreatePatience.interval)) {
+        verifyCluster(Leonardo.cluster.get(googleProject, clusterName),
+                      googleProject,
+                      clusterName,
+                      List(ClusterStatus.Creating),
+                      clusterRequest)
+      }
 
     if (monitor) {
       monitorCreate(googleProject, clusterName, clusterRequest, creatingCluster)
@@ -296,15 +296,16 @@ trait LeonardoTestUtils
     logger.info(s"Time it took to get runtime create response with: ${runtimeTimeResult.duration}")
 
     // verify with get()
-    val creatingRuntime = eventually {
-      verifyRuntime(
-        Leonardo.cluster.getRuntime(googleProject, runtimeName),
-        googleProject,
-        runtimeName,
-        List(ClusterStatus.Creating),
-        runtimeRequest
-      )
-    }(getAfterCreatePatience, implicitly[Position])
+    val creatingRuntime =
+      eventually(Timeout(getAfterCreatePatience.timeout), Interval(getAfterCreatePatience.interval)) {
+        verifyRuntime(
+          Leonardo.cluster.getRuntime(googleProject, runtimeName),
+          googleProject,
+          runtimeName,
+          List(ClusterStatus.Creating),
+          runtimeRequest
+        )
+      }
 
     if (monitor) {
       val runningRuntime = monitorCreateRuntime(googleProject, runtimeName, runtimeRequest, creatingRuntime)

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/lab/LabNotebookPage.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/lab/LabNotebookPage.scala
@@ -3,14 +3,14 @@ package org.broadinstitute.dsde.workbench.leonardo.lab
 import com.typesafe.scalalogging.LazyLogging
 import org.apache.commons.text.StringEscapeUtils
 import org.broadinstitute.dsde.workbench.auth.AuthToken
-import org.scalatest.Matchers.convertToAnyShouldWrapper
+import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
 import org.scalatest.concurrent.Eventually
 import org.scalatest.concurrent.PatienceConfiguration.{Interval, Timeout}
 import org.scalatest.exceptions.TestFailedDueToTimeoutException
 import org.scalatest.time.{Seconds, Span}
 import org.broadinstitute.dsde.workbench.leonardo.KernelNotReadyException
 import org.openqa.selenium.{By, TimeoutException, WebDriver, WebElement}
-
+import org.scalatestplus.selenium.WebBrowser._
 import scala.collection.JavaConverters._
 import scala.concurrent.duration._
 import scala.language.postfixOps

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/lab/LabNotebookPage.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/lab/LabNotebookPage.scala
@@ -10,7 +10,6 @@ import org.scalatest.exceptions.TestFailedDueToTimeoutException
 import org.scalatest.time.{Seconds, Span}
 import org.broadinstitute.dsde.workbench.leonardo.KernelNotReadyException
 import org.openqa.selenium.{By, TimeoutException, WebDriver, WebElement}
-import org.scalatestplus.selenium.WebBrowser._
 import scala.collection.JavaConverters._
 import scala.concurrent.duration._
 import scala.language.postfixOps

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/lab/LabPage.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/lab/LabPage.scala
@@ -2,6 +2,7 @@ package org.broadinstitute.dsde.workbench.leonardo.lab
 
 import org.broadinstitute.dsde.workbench.page.CookieAuthedPage
 import org.openqa.selenium.WebDriver
+import org.scalatestplus.selenium.WebBrowser._
 
 trait LabPage extends CookieAuthedPage[LabPage] {
   implicit val webDriver: WebDriver

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/lab/LabPage.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/lab/LabPage.scala
@@ -2,7 +2,6 @@ package org.broadinstitute.dsde.workbench.leonardo.lab
 
 import org.broadinstitute.dsde.workbench.page.CookieAuthedPage
 import org.openqa.selenium.WebDriver
-import org.scalatestplus.selenium.WebBrowser._
 
 trait LabPage extends CookieAuthedPage[LabPage] {
   implicit val webDriver: WebDriver

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/DummyClientPage.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/DummyClientPage.scala
@@ -5,7 +5,6 @@ import org.broadinstitute.dsde.workbench.page.PageUtil
 import org.broadinstitute.dsde.workbench.service.test.WebBrowserUtil
 import org.openqa.selenium.WebDriver
 import org.scalatestplus.selenium.Page
-import org.scalatestplus.selenium.WebBrowser._
 
 /**
  * Created by rtitle on 1/4/18.

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/DummyClientPage.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/DummyClientPage.scala
@@ -5,6 +5,7 @@ import org.broadinstitute.dsde.workbench.page.PageUtil
 import org.broadinstitute.dsde.workbench.service.test.WebBrowserUtil
 import org.openqa.selenium.WebDriver
 import org.scalatestplus.selenium.Page
+import org.scalatestplus.selenium.WebBrowser._
 
 /**
  * Created by rtitle on 1/4/18.

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookPage.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookPage.scala
@@ -8,7 +8,8 @@ import org.scalatest.concurrent.Eventually
 import org.scalatest.concurrent.PatienceConfiguration.{Interval, Timeout}
 import org.scalatest.exceptions.TestFailedDueToTimeoutException
 import org.scalatest.time.{Seconds, Span}
-import org.scalatest.Matchers.convertToAnyShouldWrapper
+import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
+import org.scalatestplus.selenium.WebBrowser._
 
 import scala.concurrent.duration._
 import scala.collection.JavaConverters._
@@ -16,8 +17,8 @@ import org.broadinstitute.dsde.workbench.leonardo.KernelNotReadyException
 import org.broadinstitute.dsde.workbench.auth.AuthToken
 import org.broadinstitute.dsde.workbench.leonardo.notebooks.Notebook.NotebookMode
 
-class NotebookPage(override val url: String)(implicit override val authToken: AuthToken,
-                                             implicit override val webDriver: WebDriver)
+class NotebookPage(val url: String)(implicit override val authToken: AuthToken,
+                                    implicit override val webDriver: WebDriver)
     extends JupyterPage
     with Eventually
     with LazyLogging {

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookPage.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookPage.scala
@@ -9,7 +9,6 @@ import org.scalatest.concurrent.PatienceConfiguration.{Interval, Timeout}
 import org.scalatest.exceptions.TestFailedDueToTimeoutException
 import org.scalatest.time.{Seconds, Span}
 import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
-import org.scalatestplus.selenium.WebBrowser._
 
 import scala.concurrent.duration._
 import scala.collection.JavaConverters._

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebooksListPage.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebooksListPage.scala
@@ -5,6 +5,7 @@ import java.io.File
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.workbench.auth.AuthToken
 import org.openqa.selenium.WebDriver
+import org.scalatestplus.selenium.WebBrowser._
 
 import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.duration._

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebooksListPage.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebooksListPage.scala
@@ -5,7 +5,6 @@ import java.io.File
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.workbench.auth.AuthToken
 import org.openqa.selenium.WebDriver
-import org.scalatestplus.selenium.WebBrowser._
 
 import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.duration._

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/page/CookieAuthedPage.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/page/CookieAuthedPage.scala
@@ -4,7 +4,6 @@ import org.broadinstitute.dsde.workbench.auth.AuthToken
 import org.broadinstitute.dsde.workbench.service.test.WebBrowserUtil
 import org.openqa.selenium.WebDriver
 import org.scalatestplus.selenium.Page
-import org.scalatestplus.selenium.WebBrowser._
 
 import scala.util.{Failure, Success, Try}
 

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/page/CookieAuthedPage.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/page/CookieAuthedPage.scala
@@ -4,6 +4,7 @@ import org.broadinstitute.dsde.workbench.auth.AuthToken
 import org.broadinstitute.dsde.workbench.service.test.WebBrowserUtil
 import org.openqa.selenium.WebDriver
 import org.scalatestplus.selenium.Page
+import org.scalatestplus.selenium.WebBrowser._
 
 import scala.util.{Failure, Success, Try}
 

--- a/build.sbt
+++ b/build.sbt
@@ -20,6 +20,8 @@ lazy val automation = project.in(file("automation"))
   .settings(automationSettings)
   .dependsOn(core % "test->test;compile->compile")
 
+scalafixDependencies in ThisBuild += "org.scalatest" %% "autofix" % "3.1.0.0"
+
 Revolver.settings
 
 Revolver.enableDebugging(port = 5051, suspend = false)

--- a/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/AsyncTaskProcessorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/AsyncTaskProcessorSpec.scala
@@ -7,11 +7,12 @@ import cats.effect.concurrent.Deferred
 import fs2.Stream
 import fs2.concurrent.InspectableQueue
 import org.broadinstitute.dsde.workbench.leonardo.AsyncTaskProcessor.{Config, Task}
-import org.scalatest.{FlatSpec, Matchers}
 
 import scala.concurrent.duration._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class AsyncTaskProcessorSpec extends FlatSpec with Matchers with LeonardoTestSuite {
+class AsyncTaskProcessorSpec extends AnyFlatSpec with Matchers with LeonardoTestSuite {
   val config = Config(20, 5)
   val queue = InspectableQueue.bounded[IO, Task[IO]](config.queueBound).unsafeRunSync()
   val asyncTaskProcessor = new AsyncTaskProcessor[IO](

--- a/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/JsonCodecSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/JsonCodecSpec.scala
@@ -1,13 +1,16 @@
 package org.broadinstitute.dsde.workbench.leonardo
 
-import org.scalatest.{FlatSpecLike, Matchers}
 import JsonCodec._
 import io.circe.CursorOp.DownField
 import io.circe.DecodingFailure
 import io.circe.parser._
 import org.broadinstitute.dsde.workbench.google2.MachineTypeName
 
-class JsonCodecSpec extends LeonardoTestSuite with Matchers with FlatSpecLike {
+import scala.util.Either.LeftProjection
+import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.matchers.should.Matchers
+
+class JsonCodecSpec extends LeonardoTestSuite with Matchers with AnyFlatSpecLike {
   "JsonCodec" should "decode DataprocConfig properly" in {
     val inputString =
       """

--- a/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/JsonCodecSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/JsonCodecSpec.scala
@@ -6,7 +6,6 @@ import io.circe.DecodingFailure
 import io.circe.parser._
 import org.broadinstitute.dsde.workbench.google2.MachineTypeName
 
-import scala.util.Either.LeftProjection
 import org.scalatest.flatspec.AnyFlatSpecLike
 import org.scalatest.matchers.should.Matchers
 

--- a/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestSuite.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestSuite.scala
@@ -6,13 +6,14 @@ import cats.effect.{Blocker, ContextShift, IO, Timer}
 import io.chrisdavenport.log4cats.StructuredLogger
 import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
 import org.broadinstitute.dsde.workbench.openTelemetry.FakeOpenTelemetryMetricsInterpreter
-import org.scalatest.{Assertion, Assertions, Matchers}
+import org.scalatest.{Assertion, Assertions}
 import fs2.Stream
 import org.scalatest.prop.Configuration
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 
 import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext.global
+import org.scalatest.matchers.should.Matchers
 
 trait LeonardoTestSuite extends Matchers {
   implicit val metrics = FakeOpenTelemetryMetricsInterpreter

--- a/http/src/main/resources/swagger/api-docs.yaml
+++ b/http/src/main/resources/swagger/api-docs.yaml
@@ -2299,6 +2299,7 @@ components:
         runtimeConfig:
           oneOf:
             - $ref: "#/components/schemas/GceConfig"
+            - $ref: "#/components/schemas/GceWithPdConfig"
             - $ref: "#/components/schemas/MachineConfig"
           discriminator:
             propertyName: cloudService

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/DataprocRuntimeMonitor.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/DataprocRuntimeMonitor.scala
@@ -375,7 +375,7 @@ class DataprocRuntimeMonitor[F[_]: Parallel](
           ctx <- ev.ask
           duration = (ctx.now.toEpochMilli - monitorContext.start.toEpochMilli).millis
           _ <- logger.info(
-            s"Runtime ${runtimeAndRuntimeConfig.runtime.projectNameString} has been deleted after ${duration.toSeconds} seconds."
+            s"${monitorContext} | Runtime ${runtimeAndRuntimeConfig.runtime.projectNameString} has been deleted after ${duration.toSeconds} seconds."
           )
 
           // delete the init bucket so we don't continue to accrue costs after cluster is deleted

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/GceRuntimeMonitor.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/GceRuntimeMonitor.scala
@@ -358,7 +358,7 @@ class GceRuntimeMonitor[F[_]: Parallel](
       ctx <- ev.ask
       duration = (ctx.now.toEpochMilli - monitorContext.start.toEpochMilli).millis
       _ <- logger.info(
-        s"Runtime ${runtimeAndRuntimeConfig.runtime.projectNameString} has been deleted after ${duration.toSeconds} seconds."
+        s"${monitorContext} | Runtime ${runtimeAndRuntimeConfig.runtime.projectNameString} has been deleted after ${duration.toSeconds} seconds."
       )
 
       // delete the init bucket so we don't continue to accrue costs after cluster is deleted

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/TestUtils.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/TestUtils.scala
@@ -2,7 +2,8 @@ package org.broadinstitute.dsde.workbench.leonardo
 
 import org.broadinstitute.dsde.workbench.leonardo.http.service.CreateRuntimeResponse
 import org.scalactic.Equality
-import org.scalatest.{Assertion, Matchers}
+import org.scalatest.Assertion
+import org.scalatest.matchers.should.Matchers
 
 object TestUtils extends Matchers {
   // When in scope, Equality instances override Scalatest's default equality ignoring the id field

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/HttpRoutesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/HttpRoutesSpec.scala
@@ -29,12 +29,13 @@ import org.broadinstitute.dsde.workbench.leonardo.service.{
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
 import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GcsObjectName, GcsPath, GoogleProject}
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{FlatSpec, Matchers}
 
 import scala.concurrent.duration._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 class HttpRoutesSpec
-    extends FlatSpec
+    extends AnyFlatSpec
     with ScalatestRouteTest
     with LeonardoTestSuite
     with ScalaFutures

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/LeoRoutesJsonCodecSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/LeoRoutesJsonCodecSpec.scala
@@ -12,7 +12,7 @@ import org.broadinstitute.dsde.workbench.leonardo.JsonCodec.{
 }
 import org.broadinstitute.dsde.workbench.leonardo.http.RuntimeConfigRequest
 import org.broadinstitute.dsde.workbench.leonardo.http.api.LeoRoutesJsonCodec._
-import org.broadinstitute.dsde.workbench.leonardo.http.service.{CreateRuntimeRequest, RuntimeConfigRequest}
+import org.broadinstitute.dsde.workbench.leonardo.http.service.CreateRuntimeRequest
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/LeoRoutesJsonCodecSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/LeoRoutesJsonCodecSpec.scala
@@ -12,10 +12,11 @@ import org.broadinstitute.dsde.workbench.leonardo.JsonCodec.{
 }
 import org.broadinstitute.dsde.workbench.leonardo.http.RuntimeConfigRequest
 import org.broadinstitute.dsde.workbench.leonardo.http.api.LeoRoutesJsonCodec._
-import org.broadinstitute.dsde.workbench.leonardo.http.service.CreateRuntimeRequest
-import org.scalatest.{FlatSpec, Matchers}
+import org.broadinstitute.dsde.workbench.leonardo.http.service.{CreateRuntimeRequest, RuntimeConfigRequest}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class LeoRoutesJsonCodecSpec extends FlatSpec with Matchers {
+class LeoRoutesJsonCodecSpec extends AnyFlatSpec with Matchers {
   "JsonCodec" should "fail to decode MachineConfig when masterMachineType is empty string" in {
     val inputString =
       """

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/LeoRoutesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/LeoRoutesSpec.scala
@@ -20,13 +20,14 @@ import org.broadinstitute.dsde.workbench.leonardo.http.service.{CreateRuntimeReq
 import org.broadinstitute.dsde.workbench.leonardo.monitor.LeoPubsubMessage
 import org.broadinstitute.dsde.workbench.model.google._
 import org.broadinstitute.dsde.workbench.model.{UserInfo, WorkbenchEmail, WorkbenchUserId}
-import org.scalatest.{Assertion, FlatSpec}
+import org.scalatest.Assertion
 import slick.dbio.DBIO
 
 import scala.concurrent.duration._
+import org.scalatest.flatspec.AnyFlatSpec
 
 class LeoRoutesSpec
-    extends FlatSpec
+    extends AnyFlatSpec
     with ScalatestRouteTest
     with LeonardoTestSuite
     with TestComponent

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/ProxyRoutesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/ProxyRoutesSpec.scala
@@ -16,7 +16,7 @@ import org.broadinstitute.dsde.workbench.leonardo.http.service.TestProxy.Data
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.time.{Seconds, Span}
-import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, FlatSpec}
+import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll}
 
 import scala.collection.immutable
 import scala.concurrent.duration._
@@ -25,12 +25,13 @@ import cats.effect.IO
 import fs2.concurrent.InspectableQueue
 import org.broadinstitute.dsde.workbench.leonardo.config.ProxyConfig
 import org.broadinstitute.dsde.workbench.leonardo.monitor.UpdateDateAccessMessage
+import org.scalatest.flatspec.AnyFlatSpec
 
 /**
  * Created by rtitle on 8/10/17.
  */
 class ProxyRoutesSpec
-    extends FlatSpec
+    extends AnyFlatSpec
     with BeforeAndAfterAll
     with BeforeAndAfter
     with ScalatestRouteTest

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/ProxyServiceSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/ProxyServiceSpec.scala
@@ -2,11 +2,12 @@ package org.broadinstitute.dsde.workbench.leonardo
 package http
 package api
 
-import org.scalatest.{FlatSpec, Matchers}
 import org.broadinstitute.dsde.workbench.leonardo.http.service.ProxyService._
 import akka.http.scaladsl.model.Uri
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class ProxyServiceSpec extends FlatSpec with Matchers with LeonardoTestSuite {
+class ProxyServiceSpec extends AnyFlatSpec with Matchers with LeonardoTestSuite {
   "ProxyService" should "be able to rewrite Jupyter path correctly" in {
     val pathBeforeRewrite1 = Uri.Path("/notebooks/project1/cluster1/jupyter")
     val expectedPath1 = Uri.Path("/notebooks/project1/cluster1/")

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/StatusRoutesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/StatusRoutesSpec.scala
@@ -20,15 +20,16 @@ import org.broadinstitute.dsde.workbench.util.health.{HealthMonitor, StatusCheck
 import org.http4s.EntityDecoder
 import org.http4s.headers.Authorization
 import org.scalatest.concurrent.Eventually.eventually
-import org.scalatest.{FlatSpec, Matchers}
 
 import scala.concurrent.duration._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
  * Created by rtitle on 10/26/17.
  */
 class StatusRoutesSpec
-    extends FlatSpec
+    extends AnyFlatSpec
     with Matchers
     with ScalatestRouteTest
     with LeonardoTestSuite

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/TestLeoRoutes.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/TestLeoRoutes.scala
@@ -54,12 +54,12 @@ import org.broadinstitute.dsde.workbench.leonardo.util.{
 }
 import org.broadinstitute.dsde.workbench.model.UserInfo
 import org.scalactic.source.Position
-import org.scalatest.Matchers
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.time.{Seconds, Span}
 
 import scala.concurrent.duration._
 import scala.util.matching.Regex
+import org.scalatest.matchers.should.Matchers
 
 trait TestLeoRoutes {
   this: ScalatestRouteTest with Matchers with ScalaFutures with LeonardoTestSuite with TestComponent =>

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/auth/sam/SamAuthProviderSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/auth/sam/SamAuthProviderSpec.scala
@@ -25,10 +25,12 @@ import org.broadinstitute.dsde.workbench.leonardo.model.PersistentDiskAction.{
 }
 
 import scala.concurrent.duration._
+import org.scalatest.freespec.AnyFreeSpecLike
+import org.scalatest.matchers.should.Matchers
 
 class SamAuthProviderSpec
     extends TestKit(ActorSystem("leonardotest"))
-    with FreeSpecLike
+    with AnyFreeSpecLike
     with Matchers
     with TestComponent
     with ScalaFutures

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/config/ContentSecurityPolicyConfigSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/config/ContentSecurityPolicyConfigSpec.scala
@@ -9,9 +9,9 @@ import org.broadinstitute.dsde.workbench.leonardo.config.ContentSecurityPolicyCo
   ScriptSrc,
   StyleSrc
 }
-import org.scalatest.FlatSpecLike
+import org.scalatest.flatspec.AnyFlatSpecLike
 
-class ContentSecurityPolicyConfigSpec extends LeonardoTestSuite with FlatSpecLike {
+class ContentSecurityPolicyConfigSpec extends LeonardoTestSuite with AnyFlatSpecLike {
 
   "ContentSecurityPolicyConfig" should "generate a valid string" in {
     val test = ContentSecurityPolicyConfig(

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpDockerDAOSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpDockerDAOSpec.scala
@@ -7,11 +7,13 @@ import org.broadinstitute.dsde.workbench.leonardo.RuntimeImageType.{Jupyter, RSt
 import org.broadinstitute.dsde.workbench.leonardo.http.service.InvalidImage
 import org.http4s.client.blaze.BlazeClientBuilder
 import org.http4s.client.middleware.Logger
-import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers}
+import org.scalatest.BeforeAndAfterAll
 
 import scala.concurrent.ExecutionContext.global
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class HttpDockerDAOSpec extends FlatSpec with Matchers with BeforeAndAfterAll with LeonardoTestSuite {
+class HttpDockerDAOSpec extends AnyFlatSpec with Matchers with BeforeAndAfterAll with LeonardoTestSuite {
   val jupyterImages = List(
     // dockerhub no tag
     DockerHub("broadinstitute/leonardo-notebooks"),

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpJupyterDAOSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpJupyterDAOSpec.scala
@@ -1,21 +1,18 @@
-package org.broadinstitute.dsde.workbench.leonardo.dao
+package org.broadinstitute.dsde.workbench.leonardo
+package dao
 
-import akka.http.scaladsl.testkit.ScalatestRouteTest
-import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.BeforeAndAfterAll
 import io.circe.parser
 import org.broadinstitute.dsde.workbench.leonardo.CommonTestData.{dnsCacheConfig, proxyConfig}
 import org.broadinstitute.dsde.workbench.leonardo.dao.ExecutionState.Idle
+import org.broadinstitute.dsde.workbench.leonardo.db.TestComponent
+import org.broadinstitute.dsde.workbench.leonardo.dns.ClusterDnsCache
+import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import org.broadinstitute.dsde.workbench.leonardo.dao.HttpJupyterDAO.sessionDecoder
+import scala.concurrent.ExecutionContext.Implicits.global
 
-class HttpJupyterDAOSpec
-    extends AnyFlatSpec
-    with Matchers
-    with LeonardoTestSuite
-    with BeforeAndAfterAll
-    with ScalatestRouteTest
-    with ScalaFutures {
+class HttpJupyterDAOSpec extends AnyFlatSpec with Matchers with LeonardoTestSuite with TestComponent {
   "HttpJupyterDAO" should "decode jupyter list sessions response successfully" in {
     val response =
       """

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpJupyterDAOSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpJupyterDAOSpec.scala
@@ -1,19 +1,22 @@
 package org.broadinstitute.dsde.workbench.leonardo.dao
 
+import akka.http.scaladsl.testkit.ScalatestRouteTest
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.BeforeAndAfterAll
 import io.circe.parser
 import org.broadinstitute.dsde.workbench.leonardo.CommonTestData.{dnsCacheConfig, proxyConfig}
 import org.broadinstitute.dsde.workbench.leonardo.dao.ExecutionState.Idle
-import org.broadinstitute.dsde.workbench.leonardo.dao.HttpJupyterDAO.sessionDecoder
-import org.broadinstitute.dsde.workbench.leonardo.db.TestComponent
-import org.broadinstitute.dsde.workbench.leonardo.dns.ClusterDnsCache
-import org.broadinstitute.dsde.workbench.leonardo.{FakeHttpClient, LeonardoTestSuite, RuntimeName}
-import org.broadinstitute.dsde.workbench.model.google.GoogleProject
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-import scala.concurrent.ExecutionContext.Implicits.global
-
-class HttpJupyterDAOSpec extends FlatSpec with LeonardoTestSuite with Matchers with TestComponent {
-  it should "decode jupyter list sessions response successfully" in {
+class HttpJupyterDAOSpec
+    extends AnyFlatSpec
+    with Matchers
+    with LeonardoTestSuite
+    with BeforeAndAfterAll
+    with ScalatestRouteTest
+    with ScalaFutures {
+  "HttpJupyterDAO" should "decode jupyter list sessions response successfully" in {
     val response =
       """
         |[

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpSamDAOSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpSamDAOSpec.scala
@@ -8,7 +8,7 @@ import org.broadinstitute.dsde.workbench.util.health.{StatusCheckResponse, Subsy
 import org.http4s.circe.CirceEntityEncoder._
 import org.http4s.client.Client
 import org.http4s.{HttpApp, Response, Status, Uri}
-import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers}
+import org.scalatest.BeforeAndAfterAll
 import io.circe.parser._
 import org.broadinstitute.dsde.workbench.leonardo.model.ServiceAccountProviderConfig
 import org.broadinstitute.dsde.workbench.model.{TraceId, WorkbenchEmail}
@@ -23,8 +23,10 @@ import cats.mtl.ApplicativeAsk
 import org.http4s.client.middleware.{Retry, RetryPolicy}
 
 import scala.util.control.NoStackTrace
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class HttpSamDAOSpec extends FlatSpec with Matchers with BeforeAndAfterAll {
+class HttpSamDAOSpec extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
   implicit val timer = IO.timer(global)
   implicit val cs = IO.contextShift(global)
   val blocker = Blocker.liftExecutionContext(global)

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/MockSamDAO.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/MockSamDAO.scala
@@ -50,6 +50,8 @@ class MockSamDAO extends SamDAO[IO] {
           .map(_.contains(action)) //open the option to peek the set: Option[Bool]
           .getOrElse(false) //unpack the resulting option and handle the disk never having existed
         IO.pure(res)
+      case SamResourceType.App =>
+        IO.pure(true) //TODO: fix this properly
     }
 
   override def getResourcePolicies[A](

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponentSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponentSpec.scala
@@ -11,13 +11,13 @@ import org.broadinstitute.dsde.workbench.google2.MachineTypeName
 import org.broadinstitute.dsde.workbench.leonardo.TestUtils.{clusterEq, clusterSeqEq, stripFieldsForListCluster}
 import org.broadinstitute.dsde.workbench.leonardo.CommonTestData._
 import org.broadinstitute.dsde.workbench.leonardo.monitor.{RuntimePatchDetails, RuntimeToMonitor}
-import org.scalatest.FlatSpecLike
 import org.broadinstitute.dsde.workbench.leonardo.http.dbioToIO
 import org.scalatest.concurrent.ScalaFutures
 
 import scala.concurrent.ExecutionContext.Implicits.global
+import org.scalatest.flatspec.AnyFlatSpecLike
 
-class ClusterComponentSpec extends FlatSpecLike with TestComponent with GcsPathUtils with ScalaFutures {
+class ClusterComponentSpec extends AnyFlatSpecLike with TestComponent with GcsPathUtils with ScalaFutures {
   "ClusterComponent" should "list, save, get, and delete" in isolatedDbTest {
     dbFutureValue(clusterQuery.listWithLabels) shouldEqual Seq()
 

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterErrorComponentSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterErrorComponentSpec.scala
@@ -4,11 +4,11 @@ package db
 import java.time.Instant
 import java.time.temporal.ChronoUnit
 
-import org.scalatest.FlatSpecLike
 import CommonTestData._
 import scala.concurrent.ExecutionContext.Implicits.global
+import org.scalatest.flatspec.AnyFlatSpecLike
 
-class ClusterErrorComponentSpec extends FlatSpecLike with TestComponent with GcsPathUtils {
+class ClusterErrorComponentSpec extends AnyFlatSpecLike with TestComponent with GcsPathUtils {
 
   "ClusterErrorComponent" should "save, and get" in isolatedDbTest {
     val savedCluster1 = makeCluster(1).save()

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterImageComponentSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterImageComponentSpec.scala
@@ -2,11 +2,11 @@ package org.broadinstitute.dsde.workbench.leonardo.db
 
 import org.broadinstitute.dsde.workbench.leonardo.CommonTestData
 import org.broadinstitute.dsde.workbench.leonardo.RuntimeImageType.{Jupyter, RStudio}
-import org.scalatest.FlatSpecLike
 import CommonTestData._
 import scala.concurrent.ExecutionContext.Implicits.global
+import org.scalatest.flatspec.AnyFlatSpecLike
 
-class ClusterImageComponentSpec extends FlatSpecLike with TestComponent {
+class ClusterImageComponentSpec extends AnyFlatSpecLike with TestComponent {
 
   "ClusterImageComponent" should "save and get" in isolatedDbTest {
     val cluster = makeCluster(1).save()

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/ExtensionComponentSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/ExtensionComponentSpec.scala
@@ -4,12 +4,12 @@ package db
 import java.sql.SQLException
 
 import org.broadinstitute.dsde.workbench.leonardo.CommonTestData._
-import org.scalatest.FlatSpecLike
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.util.Random
+import org.scalatest.flatspec.AnyFlatSpecLike
 
-class ExtensionComponentSpec extends FlatSpecLike with TestComponent with GcsPathUtils {
+class ExtensionComponentSpec extends AnyFlatSpecLike with TestComponent with GcsPathUtils {
   "ExtensionComponent" should "save, get,and delete" in isolatedDbTest {
     val savedCluster1 = makeCluster(1)
       .copy(userJupyterExtensionConfig = Some(userExtConfig), jupyterUserScriptUri = Some(jupyterUserScriptUri))

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/FollowupComponentSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/FollowupComponentSpec.scala
@@ -6,11 +6,11 @@ import org.broadinstitute.dsde.workbench.google2.MachineTypeName
 import org.broadinstitute.dsde.workbench.leonardo.CommonTestData._
 import org.broadinstitute.dsde.workbench.leonardo.db.{patchQuery, TestComponent}
 import org.broadinstitute.dsde.workbench.leonardo.monitor.RuntimePatchDetails
-import org.scalatest.FlatSpecLike
 
 import scala.concurrent.ExecutionContext.Implicits.global
+import org.scalatest.flatspec.AnyFlatSpecLike
 
-class PatchComponentSpec extends FlatSpecLike with TestComponent {
+class PatchComponentSpec extends AnyFlatSpecLike with TestComponent {
   "PatchComponent" should "update a record when there's already an existing record" in isolatedDbTest {
     val cluster = makeCluster(1).save()
     val patchDetails = RuntimePatchDetails(cluster.id, RuntimeStatus.Stopped)

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/InstanceComponentSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/InstanceComponentSpec.scala
@@ -1,16 +1,16 @@
 package org.broadinstitute.dsde.workbench.leonardo.db
 
 import org.broadinstitute.dsde.workbench.leonardo.{CommonTestData, GceInstanceStatus, GcsPathUtils, IP, RuntimeConfigId}
-import org.scalatest.FlatSpecLike
 import CommonTestData._
 import org.broadinstitute.dsde.workbench.leonardo.TestUtils.clusterEq
 
 import scala.concurrent.ExecutionContext.Implicits.global
+import org.scalatest.flatspec.AnyFlatSpecLike
 
 /**
  * Created by rtitle on 2/19/18.
  */
-class InstanceComponentSpec extends FlatSpecLike with TestComponent with GcsPathUtils {
+class InstanceComponentSpec extends AnyFlatSpecLike with TestComponent with GcsPathUtils {
 
   val cluster1 = makeCluster(1)
 

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/KubernetesClusterComponentSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/KubernetesClusterComponentSpec.scala
@@ -10,11 +10,11 @@ import org.broadinstitute.dsde.workbench.leonardo.{
   KubernetesClusterStatus,
   NodepoolStatus
 }
-import org.scalatest.FlatSpecLike
 
 import scala.concurrent.ExecutionContext.Implicits.global
+import org.scalatest.flatspec.AnyFlatSpecLike
 
-class KubernetesClusterComponentSpec extends FlatSpecLike with TestComponent {
+class KubernetesClusterComponentSpec extends AnyFlatSpecLike with TestComponent {
 
   it should "save, get, and delete" in isolatedDbTest {
     val cluster1 = makeKubeCluster(1)

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/LabelComponentSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/LabelComponentSpec.scala
@@ -6,11 +6,11 @@ import cats.effect.IO
 import org.broadinstitute.dsde.workbench.leonardo.CommonTestData._
 import org.broadinstitute.dsde.workbench.leonardo.KubernetesTestData._
 import org.broadinstitute.dsde.workbench.leonardo.db.{labelQuery, LabelResourceType, TestComponent}
-import org.scalatest.FlatSpecLike
 
 import scala.concurrent.ExecutionContext.Implicits.global
+import org.scalatest.flatspec.AnyFlatSpecLike
 
-class LabelComponentSpec extends FlatSpecLike with TestComponent with GcsPathUtils {
+class LabelComponentSpec extends AnyFlatSpecLike with TestComponent with GcsPathUtils {
 
   List(LabelResourceType.Runtime, LabelResourceType.PersistentDisk, LabelResourceType.App).foreach { resourceType =>
     it should s"save, get, update, and delete ${resourceType.asString} labels" in isolatedDbTest {

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/LeonardoServiceDbQueriesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/LeonardoServiceDbQueriesSpec.scala
@@ -4,13 +4,13 @@ package db
 import org.broadinstitute.dsde.workbench.leonardo.CommonTestData._
 import org.broadinstitute.dsde.workbench.leonardo.db.LeonardoServiceDbQueries._
 import org.broadinstitute.dsde.workbench.leonardo.http.service.ListRuntimeResponse
-import org.scalatest.FlatSpecLike
 import org.scalatest.concurrent.ScalaFutures
 
 import scala.concurrent.ExecutionContext.Implicits.global
+import org.scalatest.flatspec.AnyFlatSpecLike
 
 // TODO deprecated in favor of RuntimeServiceDbQueriesSpec
-class LeonardoServiceDbQueriesSpec extends FlatSpecLike with TestComponent with GcsPathUtils with ScalaFutures {
+class LeonardoServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent with GcsPathUtils with ScalaFutures {
   it should "get by labels" in isolatedDbTest {
 
     val savedCluster1 =

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/NamespaceComponentSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/NamespaceComponentSpec.scala
@@ -1,11 +1,11 @@
 package org.broadinstitute.dsde.workbench.leonardo.db
 
 import org.broadinstitute.dsde.workbench.leonardo.KubernetesTestData._
-import org.scalatest.FlatSpecLike
 
 import scala.concurrent.ExecutionContext.Implicits.global
+import org.scalatest.flatspec.AnyFlatSpecLike
 
-class NamespaceComponentSpec extends FlatSpecLike with TestComponent {
+class NamespaceComponentSpec extends AnyFlatSpecLike with TestComponent {
 
   "NamespaceComponent" should "save, getAll, delete" in isolatedDbTest {
     val savedCluster1 = makeKubeCluster(1).save()

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/NodepoolComponentSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/NodepoolComponentSpec.scala
@@ -5,11 +5,11 @@ import java.time.Instant
 import org.broadinstitute.dsde.workbench.leonardo.KubernetesTestData._
 import org.broadinstitute.dsde.workbench.leonardo.TestUtils._
 import org.broadinstitute.dsde.workbench.leonardo.{NodepoolStatus}
-import org.scalatest.FlatSpecLike
 
 import scala.concurrent.ExecutionContext.Implicits.global
+import org.scalatest.flatspec.AnyFlatSpecLike
 
-class NodepoolComponentSpec extends FlatSpecLike with TestComponent {
+class NodepoolComponentSpec extends AnyFlatSpecLike with TestComponent {
 
   it should "save, get, delete" in isolatedDbTest {
     val savedCluster1 = makeKubeCluster(1).save()

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/PersistentDiskComponentSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/PersistentDiskComponentSpec.scala
@@ -8,11 +8,11 @@ import org.broadinstitute.dsde.workbench.leonardo.CommonTestData._
 import org.broadinstitute.dsde.workbench.leonardo.DiskType.SSD
 import org.broadinstitute.dsde.workbench.leonardo.db.{persistentDiskQuery, TestComponent}
 import org.broadinstitute.dsde.workbench.leonardo.TestUtils.diskEq
-import org.scalatest.FlatSpecLike
 
 import scala.concurrent.ExecutionContext.Implicits.global
+import org.scalatest.flatspec.AnyFlatSpecLike
 
-class PersistentDiskComponentSpec extends FlatSpecLike with TestComponent {
+class PersistentDiskComponentSpec extends AnyFlatSpecLike with TestComponent {
 
   "PersistentDiskComponent" should "save and get records" in isolatedDbTest {
     val disk1 = makePersistentDisk(DiskId(1))

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/RuntimeConfigQueriesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/RuntimeConfigQueriesSpec.scala
@@ -6,11 +6,11 @@ import java.util.concurrent.TimeUnit
 import org.broadinstitute.dsde.workbench.google2.MachineTypeName
 import org.broadinstitute.dsde.workbench.leonardo.http.dbioToIO
 import org.broadinstitute.dsde.workbench.leonardo.{DiskSize, LeonardoTestSuite, RuntimeConfig}
-import org.scalatest.FlatSpecLike
 
 import scala.concurrent.ExecutionContext.Implicits.global
+import org.scalatest.flatspec.AnyFlatSpecLike
 
-class RuntimeConfigQueriesSpec extends FlatSpecLike with TestComponent with LeonardoTestSuite {
+class RuntimeConfigQueriesSpec extends AnyFlatSpecLike with TestComponent with LeonardoTestSuite {
   "RuntimeConfigQueries" should "save cluster with properties properly" in isolatedDbTest {
     val runtimeConfig = RuntimeConfig.DataprocConfig(
       numberOfWorkers = 0,

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/RuntimeServiceDbQueriesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/RuntimeServiceDbQueriesSpec.scala
@@ -17,13 +17,14 @@ import org.broadinstitute.dsde.workbench.leonardo.db.{
 }
 import org.broadinstitute.dsde.workbench.leonardo.http.api.ListRuntimeResponse2
 import org.broadinstitute.dsde.workbench.leonardo.http.service.GetRuntimeResponse
-import org.scalatest.FlatSpecLike
 import org.broadinstitute.dsde.workbench.leonardo.db.RuntimeServiceDbQueries._
+import org.scalatest.concurrent.ScalaFutures
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
+import org.scalatest.flatspec.AnyFlatSpecLike
 
-class RuntimeServiceDbQueriesSpec extends FlatSpecLike with TestComponent with GcsPathUtils {
+class RuntimeServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent with GcsPathUtils with ScalaFutures {
   val maxElapsed = 5.seconds
 
   it should "getStatusByName" in isolatedDbTest {

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dns/ClusterDnsCacheSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dns/ClusterDnsCacheSpec.scala
@@ -7,15 +7,16 @@ import org.broadinstitute.dsde.workbench.leonardo.CommonTestData._
 import org.broadinstitute.dsde.workbench.leonardo.db.TestComponent
 import org.broadinstitute.dsde.workbench.leonardo.dns.ClusterDnsCache._
 import org.scalatest.concurrent.{Eventually, ScalaFutures}
-import org.scalatest.{BeforeAndAfterAll, FlatSpecLike}
+import org.scalatest.BeforeAndAfterAll
 
 import scala.concurrent.ExecutionContext.Implicits.global
+import org.scalatest.flatspec.AnyFlatSpecLike
 
 /**
  * Created by rtitle on 9/1/17.
  */
 class ClusterDnsCacheSpec
-    extends FlatSpecLike
+    extends AnyFlatSpecLike
     with BeforeAndAfterAll
     with TestComponent
     with ScalaFutures

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeonardoModelSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeonardoModelSpec.scala
@@ -8,9 +8,9 @@ import org.broadinstitute.dsde.workbench.leonardo.CommonTestData._
 import org.broadinstitute.dsde.workbench.leonardo.http.api.LeoRoutesJsonCodec._
 import org.broadinstitute.dsde.workbench.leonardo.http.service.CreateRuntimeRequest
 import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GcsObjectName, GcsPath}
-import org.scalatest.FlatSpecLike
+import org.scalatest.flatspec.AnyFlatSpecLike
 
-class LeonardoModelSpec extends LeonardoTestSuite with FlatSpecLike {
+class LeonardoModelSpec extends LeonardoTestSuite with AnyFlatSpecLike {
 
   val exampleTime = Instant.parse("2018-08-07T10:12:35Z")
 

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/AutopauseMonitorSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/AutopauseMonitorSpec.scala
@@ -12,12 +12,12 @@ import org.broadinstitute.dsde.workbench.leonardo.dao.{JupyterDAO, MockJupyterDA
 import org.broadinstitute.dsde.workbench.leonardo.db.{clusterQuery, TestComponent}
 import org.broadinstitute.dsde.workbench.leonardo.http.{dbioToIO}
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
-import org.scalatest.FlatSpec
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
+import org.scalatest.flatspec.AnyFlatSpec
 
-class AutopauseMonitorSpec extends FlatSpec with LeonardoTestSuite with TestComponent {
+class AutopauseMonitorSpec extends AnyFlatSpec with LeonardoTestSuite with TestComponent {
 
   it should "auto freeze the cluster when kernel is idle" in isolatedDbTest {
     val jupyterDAO = new MockJupyterDAO {

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/BaseCloudServiceRuntimeMonitorSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/BaseCloudServiceRuntimeMonitorSpec.scala
@@ -27,7 +27,6 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
 class BaseCloudServiceRuntimeMonitorSpec extends AnyFlatSpec with Matchers with TestComponent with LeonardoTestSuite {
-  implicit val appContext = ApplicativeAsk.const[IO, AppContext](AppContext.generate[IO].unsafeRunSync())
   it should "terminate monitoring process if cluster status is changed in the middle of it" in isolatedDbTest {
     val runtimeMonitor = baseRuntimeMonitor(true)
 

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/BaseCloudServiceRuntimeMonitorSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/BaseCloudServiceRuntimeMonitorSpec.scala
@@ -17,15 +17,17 @@ import org.broadinstitute.dsde.workbench.leonardo.util._
 import org.broadinstitute.dsde.workbench.model.TraceId
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.broadinstitute.dsde.workbench.openTelemetry.OpenTelemetryMetrics
-import org.scalatest.{FlatSpec, Matchers}
 import fs2.Stream
 import org.broadinstitute.dsde.workbench.leonardo.monitor.MonitorState.CheckTools
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.ExecutionContext.global
 import scala.concurrent.duration._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class BaseCloudServiceRuntimeMonitorSpec extends FlatSpec with Matchers with TestComponent with LeonardoTestSuite {
+class BaseCloudServiceRuntimeMonitorSpec extends AnyFlatSpec with Matchers with TestComponent with LeonardoTestSuite {
+  implicit val appContext = ApplicativeAsk.const[IO, AppContext](AppContext.generate[IO].unsafeRunSync())
   it should "terminate monitoring process if cluster status is changed in the middle of it" in isolatedDbTest {
     val runtimeMonitor = baseRuntimeMonitor(true)
 

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterToolMonitorSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterToolMonitorSpec.scala
@@ -13,17 +13,18 @@ import cats.implicits._
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
 import org.scalatest.concurrent.Eventually.eventually
-import org.scalatest.{BeforeAndAfterAll, FlatSpecLike}
+import org.scalatest.BeforeAndAfterAll
 import org.scalatestplus.mockito.MockitoSugar
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 import scala.util.Try
+import org.scalatest.flatspec.AnyFlatSpecLike
 
 //TODO: running this spec results in lots of match `scala.MatchError: null`, investigate why that is
 class ClusterToolMonitorSpec
     extends TestKit(ActorSystem("leonardotest"))
-    with FlatSpecLike
+    with AnyFlatSpecLike
     with LazyLogging
     with BeforeAndAfterAll
     with TestComponent

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/DataprocRuntimeMonitorSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/DataprocRuntimeMonitorSpec.scala
@@ -35,8 +35,6 @@ import scala.collection.JavaConverters._
 import org.scalatest.flatspec.AnyFlatSpec
 
 class DataprocRuntimeMonitorSpec extends AnyFlatSpec with TestComponent with LeonardoTestSuite with EitherValues {
-  implicit val appContext = ApplicativeAsk.const[IO, AppContext](AppContext.generate[IO].unsafeRunSync())
-
   "creatingRuntime" should "check again if cluster doesn't exist yet" in isolatedDbTest {
     val runtime = makeCluster(1).copy(
       serviceAccount = clusterServiceAccountFromProject(project).get,

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/DataprocRuntimeMonitorSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/DataprocRuntimeMonitorSpec.scala
@@ -28,12 +28,15 @@ import org.broadinstitute.dsde.workbench.leonardo.util._
 import org.broadinstitute.dsde.workbench.model.TraceId
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import com.google.cloud.dataproc.v1.ClusterStatus.State
-import org.scalatest.{EitherValues, FlatSpec}
+import org.scalatest.EitherValues
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.collection.JavaConverters._
+import org.scalatest.flatspec.AnyFlatSpec
 
-class DataprocRuntimeMonitorSpec extends FlatSpec with TestComponent with LeonardoTestSuite with EitherValues {
+class DataprocRuntimeMonitorSpec extends AnyFlatSpec with TestComponent with LeonardoTestSuite with EitherValues {
+  implicit val appContext = ApplicativeAsk.const[IO, AppContext](AppContext.generate[IO].unsafeRunSync())
+
   "creatingRuntime" should "check again if cluster doesn't exist yet" in isolatedDbTest {
     val runtime = makeCluster(1).copy(
       serviceAccount = clusterServiceAccountFromProject(project).get,

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/DateAccessdUpdaterSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/DateAccessdUpdaterSpec.scala
@@ -11,15 +11,15 @@ import org.broadinstitute.dsde.workbench.leonardo.CommonTestData._
 import org.broadinstitute.dsde.workbench.leonardo.db.{clusterQuery, TestComponent}
 import org.broadinstitute.dsde.workbench.leonardo.monitor.DateAccessedUpdater._
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
-import org.scalatest.FlatSpec
 import fs2.Stream
 import org.broadinstitute.dsde.workbench.leonardo.config.Config
 
 import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext.Implicits.global
 import org.broadinstitute.dsde.workbench.leonardo.http.dbioToIO
+import org.scalatest.flatspec.AnyFlatSpec
 
-class DateAccessedUpdaterSpec extends FlatSpec with LeonardoTestSuite with TestComponent {
+class DateAccessedUpdaterSpec extends AnyFlatSpec with LeonardoTestSuite with TestComponent {
   it should "sort UpdateDateAccessMessage properly" in {
     val msg1 = UpdateDateAccessMessage(RuntimeName("r1"), GoogleProject("p1"), Instant.ofEpochMilli(1588264615480L))
     val msg2 = UpdateDateAccessMessage(RuntimeName("r1"), GoogleProject("p1"), Instant.ofEpochMilli(1588264615490L))

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/GceRuntimeMonitorSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/GceRuntimeMonitorSpec.scala
@@ -31,7 +31,6 @@ class GceRuntimeMonitorSpec
     with TestComponent
     with LeonardoTestSuite
     with EitherValues {
-  implicit val appContext = ApplicativeAsk.const[IO, AppContext](AppContext.generate[IO].unsafeRunSync())
   val readyInstance = Instance
     .newBuilder()
     .setStatus("Running")

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/GceRuntimeMonitorSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/GceRuntimeMonitorSpec.scala
@@ -17,13 +17,21 @@ import org.broadinstitute.dsde.workbench.leonardo.util._
 import org.broadinstitute.dsde.workbench.{model, DoneCheckable}
 import org.broadinstitute.dsde.workbench.model.TraceId
 import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GcsObjectName, GcsPath, GoogleProject}
-import org.scalatest.{EitherValues, FlatSpec, Matchers}
+import org.scalatest.EitherValues
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import org.broadinstitute.dsde.workbench.leonardo.CommonTestData._
 import scala.concurrent.duration._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class GceRuntimeMonitorSpec extends FlatSpec with Matchers with TestComponent with LeonardoTestSuite with EitherValues {
+class GceRuntimeMonitorSpec
+    extends AnyFlatSpec
+    with Matchers
+    with TestComponent
+    with LeonardoTestSuite
+    with EitherValues {
+  implicit val appContext = ApplicativeAsk.const[IO, AppContext](AppContext.generate[IO].unsafeRunSync())
   val readyInstance = Instance
     .newBuilder()
     .setStatus("Running")

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriberSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriberSpec.scala
@@ -37,15 +37,17 @@ import org.broadinstitute.dsde.workbench.leonardo.util._
 import org.broadinstitute.dsde.workbench.model.TraceId
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.scalatest.concurrent._
-import org.scalatest.{FlatSpecLike, Matchers}
 import org.scalatestplus.mockito.MockitoSugar
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
+import scala.util.Left
+import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.matchers.should.Matchers
 
 class LeoPubsubMessageSubscriberSpec
     extends TestKit(ActorSystem("leonardotest"))
-    with FlatSpecLike
+    with AnyFlatSpecLike
     with TestComponent
     with Matchers
     with MockitoSugar

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ZombieRuntimeMonitorSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ZombieRuntimeMonitorSpec.scala
@@ -33,14 +33,15 @@ import org.scalatest.time.{Seconds, Span}
 import org.scalatestplus.mockito.MockitoSugar
 import org.mockito.Mockito._
 import org.mockito.ArgumentMatchers.{eq => mockitoEq}
-import org.scalatest.{BeforeAndAfterAll, FlatSpec}
+import org.scalatest.BeforeAndAfterAll
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import scala.concurrent.duration._
+import org.scalatest.flatspec.AnyFlatSpec
 
 class ZombieRuntimeMonitorSpec
-    extends FlatSpec
+    extends AnyFlatSpec
     with BeforeAndAfterAll
     with LeonardoTestSuite
     with TestComponent

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/AuthProviderSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/AuthProviderSpec.scala
@@ -34,10 +34,12 @@ import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito
 import org.mockito.Mockito._
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{BeforeAndAfterAll, FreeSpec, Matchers, OptionValues}
+import org.scalatest.{BeforeAndAfterAll, OptionValues}
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
 class AuthProviderSpec
-    extends FreeSpec
+    extends AnyFreeSpec
     with ScalatestRouteTest
     with Matchers
     with TestComponent

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/DiskServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/DiskServiceInterpSpec.scala
@@ -19,11 +19,11 @@ import org.broadinstitute.dsde.workbench.leonardo.util.QueueFactory
 import org.broadinstitute.dsde.workbench.model
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.broadinstitute.dsde.workbench.model.{UserInfo, WorkbenchEmail, WorkbenchUserId}
-import org.scalatest.FlatSpec
 
 import scala.concurrent.ExecutionContext.Implicits.global
+import org.scalatest.flatspec.AnyFlatSpec
 
-class DiskServiceInterpSpec extends FlatSpec with LeonardoTestSuite with TestComponent {
+class DiskServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with TestComponent {
   val publisherQueue = QueueFactory.makePublisherQueue()
   val diskService = new DiskServiceInterp(
     Config.persistentDiskConfig,

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoServiceSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoServiceSpec.scala
@@ -38,10 +38,13 @@ import org.scalatest._
 import org.scalatest.concurrent.ScalaFutures
 
 import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration._
+import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.matchers.should.Matchers
 
 class LeonardoServiceSpec
     extends TestKit(ActorSystem("leonardotest"))
-    with FlatSpecLike
+    with AnyFlatSpecLike
     with Matchers
     with BeforeAndAfter
     with BeforeAndAfterAll

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoServiceSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoServiceSpec.scala
@@ -38,7 +38,6 @@ import org.scalatest._
 import org.scalatest.concurrent.ScalaFutures
 
 import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.duration._
 import org.scalatest.flatspec.AnyFlatSpecLike
 import org.scalatest.matchers.should.Matchers
 

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/RuntimeServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/RuntimeServiceInterpSpec.scala
@@ -24,13 +24,14 @@ import org.broadinstitute.dsde.workbench.leonardo.util.QueueFactory
 import org.broadinstitute.dsde.workbench.model
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.broadinstitute.dsde.workbench.model.{UserInfo, WorkbenchEmail, WorkbenchUserId}
-import org.scalatestplus.mockito.MockitoSugar
-import org.scalatest.{Assertion, FlatSpec}
+import org.scalatest.Assertion
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.mock.MockitoSugar
 
-class RuntimeServiceInterpSpec extends FlatSpec with LeonardoTestSuite with TestComponent with MockitoSugar {
+class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with TestComponent with MockitoSugar {
   val publisherQueue = QueueFactory.makePublisherQueue()
   def makeRuntimeService(publisherQueue: InspectableQueue[IO, LeoPubsubMessage]) =
     new RuntimeServiceInterp(

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/RuntimeServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/RuntimeServiceInterpSpec.scala
@@ -29,7 +29,7 @@ import org.scalatest.Assertion
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 import org.scalatest.flatspec.AnyFlatSpec
-import org.scalatest.mock.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with TestComponent with MockitoSugar {
   val publisherQueue = QueueFactory.makePublisherQueue()

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/DataprocInterpreterSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/DataprocInterpreterSpec.scala
@@ -22,15 +22,17 @@ import org.broadinstitute.dsde.workbench.leonardo.monitor.LeoPubsubMessage.Creat
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{BeforeAndAfterAll, FlatSpecLike, Matchers}
+import org.scalatest.BeforeAndAfterAll
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import scala.concurrent.duration._
+import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.matchers.should.Matchers
 
 class DataprocInterpreterSpec
     extends TestKit(ActorSystem("leonardotest"))
-    with FlatSpecLike
+    with AnyFlatSpecLike
     with TestComponent
     with Matchers
     with BeforeAndAfterAll

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/RuntimeTemplateValuesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/RuntimeTemplateValuesSpec.scala
@@ -3,9 +3,9 @@ package util
 
 import org.broadinstitute.dsde.workbench.leonardo.{CommonTestData, LeonardoTestSuite, RuntimeOperation, WelderAction}
 import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GcsObjectName, GcsPath}
-import org.scalatest.FlatSpecLike
+import org.scalatest.flatspec.AnyFlatSpecLike
 
-class RuntimeTemplateValuesSpec extends LeonardoTestSuite with FlatSpecLike {
+class RuntimeTemplateValuesSpec extends LeonardoTestSuite with AnyFlatSpecLike {
 
   "RuntimeTemplateValues" should "generate correct template values from a Runtime" in {
     val config = RuntimeTemplateValuesConfig.fromRuntime(

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/VPCInterpreterSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/VPCInterpreterSpec.scala
@@ -14,12 +14,12 @@ import org.broadinstitute.dsde.workbench.leonardo.config.Config
 import org.broadinstitute.dsde.workbench.leonardo.dao.google.MockGoogleComputeService
 import org.broadinstitute.dsde.workbench.model.TraceId
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
-import org.scalatest.FlatSpecLike
 
 import scala.collection.JavaConverters._
 import scala.concurrent.Future
+import org.scalatest.flatspec.AnyFlatSpecLike
 
-class VPCInterpreterSpec extends FlatSpecLike with LeonardoTestSuite {
+class VPCInterpreterSpec extends AnyFlatSpecLike with LeonardoTestSuite {
 
   "VPCInterpreter" should "get a subnet from a project label" in {
     val test = new VPCInterpreter(Config.vpcInterpreterConfig,

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/ValueBoxTest.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/ValueBoxTest.scala
@@ -1,11 +1,11 @@
 package org.broadinstitute.dsde.workbench.leonardo.util
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
 /**
  * Copied from https://github.com/broadinstitute/dig-loam-stream/blob/master/src/test/scala/loamstream/util/ValueBoxTest.scala
  */
-final class ValueBoxTest extends FunSuite {
+final class ValueBoxTest extends AnyFunSuite {
   test("mutateAndGet") {
     val v: ValueBox[Int] = ValueBox(42)
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,7 +10,7 @@ object Dependencies {
   val googleV = "1.23.0"
   val automationGoogleV = "1.30.5"
   val scalaLoggingV = "3.9.0"
-  val scalaTestV = "3.0.8"
+  val scalaTestV = "3.1.2"
   val slickV = "3.3.2"
   val http4sVersion = "0.21.0" //remove http4s related dependencies once workbench-libs are upgraded
   val guavaV = "28.2-jre"
@@ -81,6 +81,9 @@ object Dependencies {
 
   val scalaTest: ModuleID = "org.scalatest" %% "scalatest"    % scalaTestV  % "test"
   val mockito: ModuleID =   "org.mockito"   % "mockito-core"  % "3.2.4"    % "test"
+  val scalaTestScalaCheck = "org.scalatestplus" %% "scalatestplus-scalacheck" % "3.1.0.0-RC2" % Test //Since scalatest 3.1.0, scalacheck support is moved to `scalatestplus`
+  val scalaTestMockito = "org.scalatestplus" %% "scalatestplus-mockito" % "1.0.0-M2" % Test //Since scalatest 3.1.0, mockito support is moved to `scalatestplus`
+  val scalaTestSelenium =  "org.scalatestplus" %% "scalatestplus-selenium" % "1.0.0-M2" % Test //Since scalatest 3.1.0, selenium support is moved to `scalatestplus`
 
   // Exclude workbench-libs transitive dependencies so we can control the library versions individually.
   // workbench-google pulls in workbench-{util, model, metrics} and workbcan ench-metrics pulls in workbench-util.
@@ -133,9 +136,13 @@ object Dependencies {
     "org.scalacheck" %% "scalacheck" % "1.14.1" % "test",
     sealerate,
     enumeratum,
+<<<<<<< HEAD
     http4sCirce,
     http4sBlazeClient,
     http4sDsl
+=======
+    scalaTestScalaCheck
+>>>>>>> first attempt
   )
 
   val rootDependencies = Seq(
@@ -174,12 +181,17 @@ object Dependencies {
     "com.github.julien-truffaut" %%  "monocle-macro" % monocleV,
     mysql,
     liquibase,
+<<<<<<< HEAD
     "de.heikoseeberger" %% "akka-http-circe" % "1.31.0",
     "com.github.sebruck" %% "opencensus-scala-akka-http" % "0.7.2",
 
     // Dependent on the trace exporters you want to use add one or more of the following
     "io.opencensus" % "opencensus-exporter-trace-stackdriver" % opencensusV,
     "org.http4s" %% "http4s-blaze-server" % http4sVersion % Test
+=======
+    scalaTestSelenium,
+    scalaTestMockito
+>>>>>>> first attempt
   )
 
   val excludeGuavaJdk5 = ExclusionRule(organization = "com.google.guava", name = "guava-jdk5")
@@ -220,6 +232,8 @@ object Dependencies {
     workbenchServiceTest,
     googleCloudNio,
     akkaHttpSprayJson,
+    scalaTestSelenium,
+    scalaTestMockito,
     // required by workbenchGoogle
     "com.typesafe.akka" %% "akka-http-spray-json" % "10.0.6" % "provided"
   )

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -136,13 +136,10 @@ object Dependencies {
     "org.scalacheck" %% "scalacheck" % "1.14.1" % "test",
     sealerate,
     enumeratum,
-<<<<<<< HEAD
     http4sCirce,
     http4sBlazeClient,
-    http4sDsl
-=======
+    http4sDsl,
     scalaTestScalaCheck
->>>>>>> first attempt
   )
 
   val rootDependencies = Seq(
@@ -181,17 +178,14 @@ object Dependencies {
     "com.github.julien-truffaut" %%  "monocle-macro" % monocleV,
     mysql,
     liquibase,
-<<<<<<< HEAD
     "de.heikoseeberger" %% "akka-http-circe" % "1.31.0",
     "com.github.sebruck" %% "opencensus-scala-akka-http" % "0.7.2",
 
     // Dependent on the trace exporters you want to use add one or more of the following
     "io.opencensus" % "opencensus-exporter-trace-stackdriver" % opencensusV,
-    "org.http4s" %% "http4s-blaze-server" % http4sVersion % Test
-=======
+    "org.http4s" %% "http4s-blaze-server" % http4sVersion % Test,
     scalaTestSelenium,
     scalaTestMockito
->>>>>>> first attempt
   )
 
   val excludeGuavaJdk5 = ExclusionRule(organization = "com.google.guava", name = "guava-jdk5")

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -5,6 +5,8 @@ import Version._
 import sbt.Keys._
 import sbt._
 import sbtassembly.AssemblyPlugin.autoImport._
+import scalafix.sbt.ScalafixPlugin.autoImport.scalafixSemanticdb
+
 import scala.collection.JavaConverters._
 
 object Settings {
@@ -24,7 +26,8 @@ object Settings {
     scalacOptions in (Test, console) --= Seq("-Ywarn-unused:imports", "-Xfatal-warnings"), //disable unused fatal warning in `sbt test:console`
     scalacOptions in Test --= List("-Ywarn-dead-code", "-deprecation", "-Xfatal-warnings"),
     addCompilerPlugin("com.olegpy" %% "better-monadic-for" % "0.3.1"),
-    addCompilerPlugin("org.typelevel" % "kind-projector_2.12.11" % "0.11.0")
+    addCompilerPlugin("org.typelevel" % "kind-projector_2.12.11" % "0.11.0"),
+    addCompilerPlugin(scalafixSemanticdb)
   )
 
   val commonCompilerSettings = Seq(
@@ -38,7 +41,7 @@ object Settings {
     "-language:implicitConversions",     // Allow definition of implicit functions called views
     "-unchecked",                        // Enable additional warnings where generated code depends on assumptions.
     "-Xcheckinit",                       // Wrap field accessors to throw an exception on uninitialized access.
-    "-Xfatal-warnings",                  // Fail the compilation if there are any warnings.
+//    "-Xfatal-warnings",                  // Fail the compilation if there are any warnings.
     "-Xfuture",                          // Turn on future language features.
 //    "-Xlint:adapted-args",               // Warn if an argument list is modified to match the receiver.
     "-Xlint:by-name-right-associative",  // By-name parameter of right associative operator.

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -41,7 +41,7 @@ object Settings {
     "-language:implicitConversions",     // Allow definition of implicit functions called views
     "-unchecked",                        // Enable additional warnings where generated code depends on assumptions.
     "-Xcheckinit",                       // Wrap field accessors to throw an exception on uninitialized access.
-//    "-Xfatal-warnings",                  // Fail the compilation if there are any warnings.
+    "-Xfatal-warnings",                  // Fail the compilation if there are any warnings.
     "-Xfuture",                          // Turn on future language features.
 //    "-Xlint:adapted-args",               // Warn if an argument list is modified to match the receiver.
     "-Xlint:by-name-right-associative",  // By-name parameter of right associative operator.

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -10,4 +10,8 @@ addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.10.0-RC1")
 
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.3.4")
 
-addSbtPlugin("com.github.cb372" % "sbt-explicit-dependencies" % "0.2.11") // Use `unusedCompileDependencies` to see unused dependencies
+addSbtPlugin(
+  "com.github.cb372" % "sbt-explicit-dependencies" % "0.2.11"
+) // Use `unusedCompileDependencies` to see unused dependencies
+
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.15")


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-1828

Tried scalafix for upgrading scalatest, it's pretty convenient (https://github.com/scalatest/autofix/tree/master/3.1.x#autofix-for-scalatest-31x).


See if upgrading scalatest makes a difference


Main breaking changes are:
```
import org.scalatest.FlatSpec
import org.scalatest.Matchers
```
are now
```
import org.scalatest.flatspec.AnyFlatSpec
import org.scalatest.matchers.should.Matchers
```



---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
