### PR TITLE
[IA-1937] URL encode emails in requests to Sam

### DIFF
--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpSamDAO.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpSamDAO.scala
@@ -4,6 +4,8 @@ package dao
 import java.io.ByteArrayInputStream
 import java.util.UUID
 import java.util.concurrent.TimeUnit
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets.UTF_8
 
 import _root_.io.circe.{Decoder, Json, KeyDecoder}
 import akka.http.scaladsl.model.{StatusCode, StatusCodes}
@@ -283,7 +285,7 @@ class HttpSamDAO[F[_]: Effect](httpClient: Client[F], config: HttpSamDaoConfig, 
       httpClient.expectOptionOr[WorkbenchEmail](
         Request[F](
           method = Method.GET,
-          uri = config.samUri.withPath(s"/api/google/v1/user/proxyGroup/${userEmail.value}"),
+          uri = config.samUri.withPath(s"/api/google/v1/user/proxyGroup/${URLEncoder.encode(userEmail.value, UTF_8.name)}"),
           headers = Headers.of(authHeader)
         )
       )(onError)
@@ -317,7 +319,7 @@ class HttpSamDAO[F[_]: Effect](httpClient: Client[F], config: HttpSamDaoConfig, 
         userPetKey <- httpClient.expectOptionOr[Json](
           Request[F](
             method = Method.GET,
-            uri = config.samUri.withPath(s"/api/google/v1/petServiceAccount/${googleProject.value}/${userEmail.value}"),
+            uri = config.samUri.withPath(s"/api/google/v1/petServiceAccount/${googleProject.value}/${URLEncoder.encode(userEmail.value, UTF_8.name)}"),
             headers = Headers.of(leoAuth)
           )
         )(onError)


### PR DESCRIPTION
This PR will URL encode emails when including them as path parameters in Sam requests. There's currently a user that is blocked because their email has a % in it, so this will help their requests get through to Sam.

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've documented my API changes in Swagger

In all cases:

- [x] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
