### PR TITLE
IA-1953 globally exclude guava from automation

### DIFF
--- a/http/src/main/resources/logback.xml
+++ b/http/src/main/resources/logback.xml
@@ -48,14 +48,14 @@
     </appender>
 
 
-    <logger name="org.broadinstitute.dsde" level="info" additivity="false">
+    <logger name="org.broadinstitute.dsde" level="debug" additivity="false">
         <appender-ref ref="file"/>
         <appender-ref ref="console"/>
         <appender-ref ref="SYSLOG"/>
         <appender-ref ref="Sentry" />
     </logger>
 
-    <logger name="akka" level="info" additivity="false">
+    <logger name="akka" level="debug" additivity="false">
         <appender-ref ref="file"/>
         <appender-ref ref="console"/>
         <appender-ref ref="SYSLOG"/>

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -115,6 +115,7 @@ object Settings {
 
   val automationSettings = commonSettings ++ List(
     libraryDependencies ++= automationDependencies,
+    excludeDependencies += excludeGuava,
     /**
       * sbt forking jvm -- sbt provides 2 testing modes: forked vs not forked.
       * -- forked: each task (test class) is executed in a forked JVM.


### PR DESCRIPTION
See https://broadworkbench.atlassian.net/browse/IA-1953

Globally exclude guava from all automation dependencies. It seems to fix it locally. Haven't run all tests yet.

(I just learned about this sbt feature, see https://www.scala-sbt.org/1.x/docs/Library-Management.html#Exclude+Transitive+Dependencies)


---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
