### PR TITLE
Experiment: exclude guava from opencensus deps

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -172,10 +172,10 @@ object Dependencies {
     mysql,
     liquibase,
     "de.heikoseeberger" %% "akka-http-circe" % "1.31.0",
-    "com.github.sebruck" %% "opencensus-scala-akka-http" % "0.7.2",
+    "com.github.sebruck" %% "opencensus-scala-akka-http" % "0.7.2" excludeAll (excludeGuava),
 
     // Dependent on the trace exporters you want to use add one or more of the following
-    "io.opencensus" % "opencensus-exporter-trace-stackdriver" % opencensusV
+    "io.opencensus" % "opencensus-exporter-trace-stackdriver" % opencensusV excludeAll (excludeGuava)
   )
 
   val serviceTestV = "0.16-e6493d5"


### PR DESCRIPTION
Wondering if the global exclusion here is causing issues: https://github.com/DataBiosphere/leonardo/pull/1432

Trying this instead

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
