### PR TITLE
[no ticket] small error message improvement

### DIFF
--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/LeoRoutesJsonCodec.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/LeoRoutesJsonCodec.scala
@@ -10,7 +10,8 @@ import org.broadinstitute.dsde.workbench.model.google.GcsPath
 
 // Shared routes specific codecs live in this file. When Routes file get too big, we can potentially move codec to this file too
 object LeoRoutesJsonCodec {
-  val invalidPropertiesError = DecodingFailure("invalid properties", List.empty)
+  val invalidPropertiesError =
+    DecodingFailure("invalid properties. An example of property is `spark:spark.executor.cores`", List.empty)
 
   implicit val dataprocConfigDecoder: Decoder[RuntimeConfigRequest.DataprocConfig] = Decoder.instance { c =>
     for {

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/LeoRoutesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/LeoRoutesSpec.scala
@@ -15,12 +15,17 @@ import io.circe.syntax._
 import org.broadinstitute.dsde.workbench.leonardo.CommonTestData._
 import org.broadinstitute.dsde.workbench.leonardo.db._
 import org.broadinstitute.dsde.workbench.leonardo.http.api.RoutesTestJsonSupport._
-import org.broadinstitute.dsde.workbench.leonardo.http.service.{CreateRuntimeRequest, ListRuntimeResponse}
+import org.broadinstitute.dsde.workbench.leonardo.http.service.{
+  CreateRuntimeRequest,
+  ListRuntimeResponse,
+  RuntimeConfigRequest
+}
 import org.broadinstitute.dsde.workbench.leonardo.monitor.LeoPubsubMessage
 import org.broadinstitute.dsde.workbench.model.google._
 import org.broadinstitute.dsde.workbench.model.{UserInfo, WorkbenchEmail, WorkbenchUserId}
 import org.scalatest.{Assertion, FlatSpec}
 import slick.dbio.DBIO
+import io.circe.parser.decode
 
 import scala.concurrent.duration._
 
@@ -344,6 +349,30 @@ class LeoRoutesSpec
       responseEntity.toStrict(5 seconds).futureValue.data.utf8String shouldBe expectedResponse
       status shouldEqual StatusCodes.BadRequest
     }
+  }
+
+  it should "decode RuntimeConfigRequest.DataprocConfig" in {
+    import org.broadinstitute.dsde.workbench.leonardo.http.api.LeoRoutesJsonCodec._
+    val jsonString =
+      """
+        |{
+        |   "cloudService": "dataproc",
+        |   "properties": {
+        |     "spark:spark.executor.cores": "4"
+        |   }
+        |}
+        |""".stripMargin
+    val expectedResult = RuntimeConfigRequest.DataprocConfig(
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      Map("spark:spark.executor.cores" -> "4")
+    )
+    decode[RuntimeConfigRequest.DataprocConfig](jsonString) shouldBe Right(expectedResult)
   }
 
   private def serviceAccountLabels: Map[String, String] =


### PR DESCRIPTION
Got a question from user liaison about how to set spark properties. And I had trouble myself figuring out the valid properties (altho later I realize we do have an example in swagger doc). Figured an example in error message would be nice

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
