### PR TITLE
[no ticket] fix a bug where when host is down leonardo thinks kernel is still active

### DIFF
--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpJupyterDAO.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpJupyterDAO.scala
@@ -48,7 +48,7 @@ class HttpJupyterDAO[F[_]: Timer: ContextShift: Concurrent](val clusterDnsCache:
               )
             )
           } yield res.forall(k => k.kernel.executionState == Idle)
-        case _ => Concurrent[F].pure(false)
+        case _ => Concurrent[F].pure(true)
       }
     } yield resp
 }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/FakeHttpClient.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/FakeHttpClient.scala
@@ -1,0 +1,13 @@
+package org.broadinstitute.dsde.workbench.leonardo
+
+import cats.effect.IO
+import org.http4s.HttpApp
+import org.http4s.client.Client
+import org.http4s.dsl.Http4sDsl
+
+object FakeHttpClient extends Http4sDsl[IO] {
+  val client = Client
+    .fromHttpApp[IO](
+      HttpApp.liftF[IO](Ok(""))
+    )
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -175,7 +175,8 @@ object Dependencies {
     "com.github.sebruck" %% "opencensus-scala-akka-http" % "0.7.2",
 
     // Dependent on the trace exporters you want to use add one or more of the following
-    "io.opencensus" % "opencensus-exporter-trace-stackdriver" % opencensusV
+    "io.opencensus" % "opencensus-exporter-trace-stackdriver" % opencensusV,
+    "org.http4s" %% "http4s-blaze-server" % http4sVersion % Test
   )
 
   val serviceTestV = "0.16-e6493d5"


### PR DESCRIPTION
Autopause works for usual cases, but then we can't get the host IP, Leonardo mistakenly thinks that indicates the kernel is not idle, which prevents it from autopausing the cluster (not sure how this ends up happening, but I saw one case from user liaison today, where master node is stopped, but Leo thinks the cluster still has active kernel.)

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
