### PR TITLE
[no ticket] Handle error during zombie detection

### DIFF
--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ZombieRuntimeMonitor.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ZombieRuntimeMonitor.scala
@@ -82,6 +82,7 @@ class ZombieRuntimeMonitor[F[_]: Parallel: ContextShift: Timer](
                         case Right(true) =>
                           F.pure(None)
                         case Right(false) =>
+                          // it's an active zombie if it's _inactive_ in Google
                           F.pure(zombieIfOlderThanCreationHangTolerance(candidate, startInstant))
                       }
                 }
@@ -113,6 +114,7 @@ class ZombieRuntimeMonitor[F[_]: Parallel: ContextShift: Timer](
                   )
                   .as(None)
               case Right(true) =>
+                // it's an inactive zombie if it's _active_ in Google
                 F.pure(Some(candidate))
               case Right(false) =>
                 updateRuntimeAsConfirmedDeleted(candidate.id).as(None)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ZombieRuntimeMonitor.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ZombieRuntimeMonitor.scala
@@ -41,7 +41,10 @@ class ZombieRuntimeMonitor[F[_]: Parallel: ContextShift: Timer](
   runtimes: RuntimeInstances[F]) {
 
   val process: Stream[F, Unit] =
-    (Stream.sleep[F](config.zombieCheckPeriod) ++ Stream.eval(zombieCheck)).repeat
+    (Stream.sleep[F](config.zombieCheckPeriod) ++ Stream.eval(
+      zombieCheck
+        .handleErrorWith(e => logger.error(e)("Unexpected error occurred during zombie monitoring"))
+    )).repeat
 
   private[monitor] val zombieCheck: F[Unit] =
     for {


### PR DESCRIPTION
I think this was causing issues in Back Leo on alpha. There are a couple of inactive dataproc clusters that were returning a 403 from Google for both `getClusterStatus` and `deleteCluster`. I think this error actually wasn't handled in the delete case and caused Back Leo to shut down [here](https://github.com/DataBiosphere/leonardo/blob/develop/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/Boot.scala#L252).

The fix: 
   * added error handling in `handleInactiveZombieRuntime`.
   * moved error handling _out_ of `isRuntimeActiveInGoogle` to the actual call site. Since this method is used in both active and inactive cases, we want different error handling behavior for each case.

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
