### PR TITLE
try break specs into 2 suites

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoSuite.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoSuite.scala
@@ -96,17 +96,10 @@ final class LeonardoSuite
     extends Suites(
       new RuntimeCreationPdSpec,
       new ClusterStatusTransitionsSpec,
-//      new LabSpec, TODO: comment out this for now since we seem to reach the limit of number of specs we can mix in for `Suite`
-      new NotebookAouSpec,
-      new NotebookBioconductorKernelSpec,
+      new LabSpec,
       new NotebookClusterMonitoringSpec,
       new NotebookCustomizationSpec,
       new NotebookDataSyncingSpec,
-      new NotebookGATKSpec,
-      new NotebookHailSpec,
-      new NotebookPyKernelSpec,
-      new NotebookRKernelSpec,
-      new RStudioSpec,
       new LeoPubsubSpec,
       new ClusterAutopauseSpec,
       new RuntimeAutopauseSpec,
@@ -115,6 +108,21 @@ final class LeonardoSuite
       new NotebookGCEClusterMonitoringSpec,
       new NotebookGCECustomizationSpec,
       new NotebookGCEDataSyncingSpec
+    )
+    with TestSuite
+    with GPAllocBeforeAndAfterAll
+    with ParallelTestExecution
+
+final class LeonardoTerraDockerSuite
+    extends Suites(
+      new NotebookAouSpec,
+      new NotebookBioconductorKernelSpec,
+      new NotebookClusterMonitoringSpec,
+      new NotebookGATKSpec,
+      new NotebookHailSpec,
+      new NotebookPyKernelSpec,
+      new NotebookRKernelSpec,
+      new RStudioSpec
     )
     with TestSuite
     with GPAllocBeforeAndAfterAll

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -20,7 +20,7 @@ object Dependencies {
   val workbenchUtilV = "0.5-4c7acd5"
   val workbenchModelV = "0.13-31cacc4"
   val workbenchGoogleV = "0.21-2a218f3"
-  val workbenchGoogle2V = "0.10-7ef36a6"
+  val workbenchGoogle2V = "0.10-85d499a"
   val workbenchMetricsV = "0.3-c5b80d2"
   val workbenchOpenTelemetryV = "0.1-e66171c"
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -20,7 +20,7 @@ object Dependencies {
   val workbenchUtilV = "0.5-4c7acd5"
   val workbenchModelV = "0.13-31cacc4"
   val workbenchGoogleV = "0.21-2a218f3"
-  val workbenchGoogle2V = "0.10-bd284e7"
+  val workbenchGoogle2V = "0.10-7ef36a6"
   val workbenchMetricsV = "0.3-c5b80d2"
   val workbenchOpenTelemetryV = "0.1-e66171c"
 


### PR DESCRIPTION
In last PR, I commented out `LabSpec` (See https://github.com/DataBiosphere/leonardo/pull/1430/files#diff-172f2665109e4c94cbb04d245fd9c696R99) since the tests were running correctly (project gets claimed by gpalloc when running PatchSpec). This PR is to try break out tests into 2 Suites, and see if things will run properly

 
---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
