### PR TITLE
[no ticket] make persistent disk default size to 30G

### DIFF
--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -66,7 +66,7 @@ gce {
   ]
   runtimeDefaults {
     machineType = "n1-standard-4"
-    diskSize = 20 # This is default size for just user disk
+    diskSize = 30 # This is default size for just user disk
   }
   gceReservedMemory = 1g
   bootDiskSize = 50
@@ -427,7 +427,7 @@ zombieRuntimeMonitor {
 }
 
 persistentDisk {
-  defaultDiskSizeGB = 20
+  defaultDiskSizeGB = 30
   defaultDiskType = "pd-standard"
   defaultBlockSizeBytes = 4096
   zone = "us-central1-a"

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -66,7 +66,7 @@ gce {
   ]
   runtimeDefaults {
     machineType = "n1-standard-4"
-    diskSize = 50
+    diskSize = 20 # This is default size for just user disk
   }
   gceReservedMemory = 1g
   bootDiskSize = 50
@@ -427,7 +427,7 @@ zombieRuntimeMonitor {
 }
 
 persistentDisk {
-  defaultDiskSizeGB = 500
+  defaultDiskSizeGB = 20
   defaultDiskType = "pd-standard"
   defaultBlockSizeBytes = 4096
   zone = "us-central1-a"

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/config/ConfigSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/config/ConfigSpec.scala
@@ -14,7 +14,7 @@ import scala.concurrent.duration._
 class ConfigSpec extends FlatSpec with Matchers {
   it should "read PersistentDiskConfig properly" in {
     val expectedResult = PersistentDiskConfig(
-      DiskSize(500),
+      DiskSize(20),
       DiskType.Standard,
       BlockSize(4096),
       ZoneName("us-central1-a")

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/config/ConfigSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/config/ConfigSpec.scala
@@ -14,7 +14,7 @@ import scala.concurrent.duration._
 class ConfigSpec extends FlatSpec with Matchers {
   it should "read PersistentDiskConfig properly" in {
     val expectedResult = PersistentDiskConfig(
-      DiskSize(20),
+      DiskSize(30),
       DiskType.Standard,
       BlockSize(4096),
       ZoneName("us-central1-a")


### PR DESCRIPTION
Set default user disk size to 20G instead of 500G....Old default is 50G in total for the one disk...

Tested in fiab

Per https://broadinstitute.slack.com/archives/GB1VAM14J/p1592423352248900

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
