### PR TITLE
Add one more test

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoModelCopy.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoModelCopy.scala
@@ -30,6 +30,25 @@ case class ClusterCopy(clusterName: RuntimeName,
   def projectNameString: String = s"${googleProject.value}/${clusterName.asString}"
 }
 
+object ClusterCopy {
+  def fromGetRuntimeResponseCopy(getRuntimeResponse: GetRuntimeResponseCopy) =
+    ClusterCopy(
+      getRuntimeResponse.runtimeName,
+      getRuntimeResponse.googleProject,
+      getRuntimeResponse.serviceAccount,
+      getRuntimeResponse.runtimeConfig,
+      getRuntimeResponse.status,
+      getRuntimeResponse.auditInfo.creator,
+      getRuntimeResponse.labels,
+      getRuntimeResponse.asyncRuntimeFields.map(_.stagingBucket),
+      getRuntimeResponse.errors,
+      getRuntimeResponse.auditInfo.dateAccessed,
+      false,
+      getRuntimeResponse.autopauseThreshold,
+      false
+    )
+}
+
 sealed trait RuntimeConfigRequestCopy extends Product with Serializable {
   def typedCloudService: CloudService
 }

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoSuite.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoSuite.scala
@@ -11,7 +11,7 @@ import cats.implicits._
 import org.broadinstitute.dsde.workbench.leonardo.lab.LabSpec
 import org.broadinstitute.dsde.workbench.leonardo.runtimes.{
   RuntimeAutopauseSpec,
-  RuntimeCreationPdSpec,
+  RuntimeCreationDiskSpec,
   RuntimePatchSpec,
   RuntimeStatusTransitionsSpec
 }
@@ -93,7 +93,7 @@ trait GPAllocBeforeAndAfterAll extends BeforeAndAfterAll with BillingFixtures wi
 
 final class LeonardoSuite
     extends Suites(
-      new RuntimeCreationPdSpec,
+      new RuntimeCreationDiskSpec,
       new ClusterStatusTransitionsSpec,
       new LabSpec,
 //      new NotebookClusterMonitoringSpec, TODO: enabled this...This spec pass locally

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeCreationDiskSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeCreationDiskSpec.scala
@@ -7,17 +7,19 @@ import org.broadinstitute.dsde.workbench.google2.{GoogleDiskService, ZoneName}
 import org.broadinstitute.dsde.workbench.leonardo.DiskModelGenerators._
 import org.broadinstitute.dsde.workbench.leonardo.LeonardoApiClient._
 import org.broadinstitute.dsde.workbench.leonardo.http.{PersistentDiskRequest, RuntimeConfigRequest}
+import org.broadinstitute.dsde.workbench.leonardo.notebooks.{NotebookTestUtils, Python3}
 import org.http4s.client.Client
 import org.http4s.headers.Authorization
 import org.http4s.{AuthScheme, Credentials}
 import org.scalatest.{DoNotDiscover, ParallelTestExecution}
 
-@DoNotDiscover
-class RuntimeCreationPdSpec
+//@DoNotDiscover
+class RuntimeCreationDiskSpec
     extends GPAllocFixtureSpec
     with ParallelTestExecution
     with LeonardoTestUtils
-    with PropertyBasedTesting {
+    with NotebookTestUtils
+    with GPAllocBeforeAndAfterAll {
   implicit val authTokenForOldApiClient = ronAuthToken
   implicit val auth: Authorization = Authorization(Credentials.Token(AuthScheme.Bearer, ronCreds.makeAuthToken().value))
 
@@ -27,6 +29,58 @@ class RuntimeCreationPdSpec
     diskService <- googleDiskService
     httpClient <- LeonardoApiClient.client
   } yield RuntimeCreationPdSpecDependencies(httpClient, diskService)
+
+  "create runtime and mount disk correctly" in { googleProject =>
+    val runtimeName = randomClusterName
+    val createRuntimeRequest = defaultCreateRuntime2Request.copy(
+      runtimeConfig = Some(
+        RuntimeConfigRequest.GceConfig(
+          None,
+          Some(DiskSize(20))
+        )
+      )
+    )
+
+    // validate disk still exists after runtime is deleted
+    val res = dependencies.use { dep =>
+      implicit val client = dep.httpClient
+      for {
+        getRuntimeResponse <- LeonardoApiClient.createRuntimeWithWait(googleProject, runtimeName, createRuntimeRequest)
+        clusterCopy = ClusterCopy(
+          getRuntimeResponse.runtimeName,
+          getRuntimeResponse.googleProject,
+          getRuntimeResponse.serviceAccount,
+          getRuntimeResponse.runtimeConfig,
+          getRuntimeResponse.status,
+          getRuntimeResponse.auditInfo.creator,
+          getRuntimeResponse.labels,
+          getRuntimeResponse.asyncRuntimeFields.map(_.stagingBucket),
+          getRuntimeResponse.errors,
+          getRuntimeResponse.auditInfo.dateAccessed,
+          false,
+          getRuntimeResponse.autopauseThreshold,
+          false
+        )
+        _ <- IO(
+          withWebDriver { implicit driver =>
+            withNewNotebook(clusterCopy, Python3) { notebookPage =>
+              //all other packages cannot be tested for their versions in this manner
+              //warnings are ignored because they are benign warnings that show up for python2 because of compilation against an older numpy
+              val res = notebookPage
+                .executeCell(
+                  "! df -H"
+                )
+                .get
+              res should include("/dev/sdb")
+              res should include("/home/jupyter-user/notebooks")
+            }
+          }
+        )
+        _ <- LeonardoApiClient.deleteRuntimeWithWait(googleProject, runtimeName)
+      } yield ()
+    }
+    res.unsafeRunSync()
+  }
 
   "create runtime and attach a persistent disk" in { googleProject =>
     val diskName = genDiskName.sample.get


### PR DESCRIPTION
Before Gabriella's mount PR...df output looks like this:
```
Filesystem      Size  Used Avail Use% Mounted on
overlay          53G   14G   38G  27% /
tmpfs            68M     0   68M   0% /dev
tmpfs           7.9G     0  7.9G   0% /sys/fs/cgroup
/dev/sda1        53G   14G   38G  27% /etc/hosts
shm              68M     0   68M   0% /dev/shm
tmpfs           7.9G     0  7.9G   0% /proc/acpi
tmpfs           7.9G     0  7.9G   0% /sys/firmware
```

After her PR, inside VM, we can see
```
root@saturn-f628e8fb-f7cd-48b8-93b6-67d28b0fa0d2:/home/qi# lsblk -o name,serial,mountpoint
NAME   SERIAL            MOUNTPOINT
sda    persistent-disk-0
└─sda1                   /
sdb    user-disk         /work
```
But we won't be able to get to this host VM from container directly, hence just checking inside the container, that the directory is mapped to `sdb`

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
