### PR TITLE
add bootDiskSize

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/Leonardo.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/Leonardo.scala
@@ -40,7 +40,6 @@ object Leonardo extends RestClient with LazyLogging {
     def handleClusterSeqResponse(response: String): List[ClusterCopy] = {
       val res = for {
         json <- io.circe.parser.parse(response)
-        _ = println(s"11111: list response ${json}")
         r <- json.as[List[ClusterCopy]]
       } yield r
 

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/Leonardo.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/Leonardo.scala
@@ -40,6 +40,7 @@ object Leonardo extends RestClient with LazyLogging {
     def handleClusterSeqResponse(response: String): List[ClusterCopy] = {
       val res = for {
         json <- io.circe.parser.parse(response)
+        _ = println(s"11111: list response ${json}")
         r <- json.as[List[ClusterCopy]]
       } yield r
 

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
@@ -634,7 +634,7 @@ trait LeonardoTestUtils
     val cluster = createCluster(googleProject, name, request, monitor)
 
     if (monitor) {
-      withClue(s"Monitoring ClusterCopy status: $name") {
+      withClue(s"Monitoring ClusterCopy status: $name...Creating ${request}") {
         val clusterShouldBeStopped = request.stopAfterCreation.getOrElse(false)
         val expectedStatus = if (clusterShouldBeStopped) ClusterStatus.Stopped else ClusterStatus.Running
 

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/JsonCodec.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/JsonCodec.scala
@@ -89,11 +89,12 @@ object JsonCodec {
      x.numberOfPreemptibleWorkers,
      x.cloudService)
   )
-  implicit val gceRuntimeConfigEncoder: Encoder[RuntimeConfig.GceConfig] = Encoder.forProduct3(
+  implicit val gceRuntimeConfigEncoder: Encoder[RuntimeConfig.GceConfig] = Encoder.forProduct4(
     "machineType",
     "diskSize",
-    "cloudService"
-  )(x => (x.machineType, x.diskSize, x.cloudService))
+    "cloudService",
+    "bootDiskSize"
+  )(x => (x.machineType, x.diskSize, x.cloudService, x.bootDiskSize))
   implicit val userJupyterExtensionConfigEncoder: Encoder[UserJupyterExtensionConfig] = Encoder.forProduct4(
     "nbExtensions",
     "serverExtensions",
@@ -121,11 +122,12 @@ object JsonCodec {
     "size",
     "diskType"
   )(x => PersistentDiskInRuntimeConfig.unapply(x).get)
-  implicit val gceWithPdConfigEncoder: Encoder[RuntimeConfig.GceWithPdConfig] = Encoder.forProduct3(
+  implicit val gceWithPdConfigEncoder: Encoder[RuntimeConfig.GceWithPdConfig] = Encoder.forProduct4(
     "machineType",
     "persistentDiskId",
-    "cloudService"
-  )(x => (x.machineType, x.persistentDiskId, x.cloudService))
+    "cloudService",
+    "bootDiskSize"
+  )(x => (x.machineType, x.persistentDiskId, x.cloudService, x.bootDiskSize))
 
   implicit val runtimeConfigEncoder: Encoder[RuntimeConfig] = Encoder.instance(x =>
     x match {
@@ -300,14 +302,16 @@ object JsonCodec {
   implicit val diskTypeDecoder: Decoder[DiskType] =
     Decoder.decodeString.emap(x => DiskType.stringToObject.get(x).toRight(s"Invalid disk type: $x"))
 
-  implicit val gceWithPdConfigDecoder: Decoder[RuntimeConfig.GceWithPdConfig] = Decoder.forProduct2(
+  implicit val gceWithPdConfigDecoder: Decoder[RuntimeConfig.GceWithPdConfig] = Decoder.forProduct3(
     "machineType",
-    "persistentDiskId"
+    "persistentDiskId",
+    "bootDiskSize"
   )(RuntimeConfig.GceWithPdConfig.apply)
-  implicit val gceConfigDecoder: Decoder[RuntimeConfig.GceConfig] = Decoder.forProduct2(
+  implicit val gceConfigDecoder: Decoder[RuntimeConfig.GceConfig] = Decoder.forProduct3(
     "machineType",
-    "diskSize"
-  )((mt, ds) => RuntimeConfig.GceConfig(mt, ds))
+    "diskSize",
+    "bootDiskSize"
+  )((mt, ds, bds) => RuntimeConfig.GceConfig(mt, ds, bds))
   implicit val persistentDiskDecoder: Decoder[PersistentDiskInRuntimeConfig] = Decoder.forProduct6(
     "id",
     "zone",

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/runtimeModels.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/runtimeModels.scala
@@ -204,7 +204,9 @@ object RuntimeConfig {
   final case class GceConfig(
     machineType: MachineTypeName,
     diskSize: DiskSize,
-    bootDiskSize: Option[DiskSize]
+    bootDiskSize: Option[
+      DiskSize
+    ] //This is optional for supporting old runtimes which only have 1 disk. All new runtime will have a boot disk
   ) extends RuntimeConfig {
     val cloudService: CloudService = CloudService.GCE
   }

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/runtimeModels.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/runtimeModels.scala
@@ -203,13 +203,16 @@ sealed trait RuntimeConfig extends Product with Serializable {
 object RuntimeConfig {
   final case class GceConfig(
     machineType: MachineTypeName,
-    diskSize: DiskSize
+    diskSize: DiskSize,
+    bootDiskSize: Option[DiskSize]
   ) extends RuntimeConfig {
     val cloudService: CloudService = CloudService.GCE
   }
 
   // When persistentDiskId is None, then we don't have any disk attached to the runtime
-  final case class GceWithPdConfig(machineType: MachineTypeName, persistentDiskId: Option[DiskId])
+  final case class GceWithPdConfig(machineType: MachineTypeName,
+                                   persistentDiskId: Option[DiskId],
+                                   bootDiskSize: DiskSize)
       extends RuntimeConfig {
     val cloudService: CloudService = CloudService.GCE
   }

--- a/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/JsonCodecSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/JsonCodecSpec.scala
@@ -49,7 +49,8 @@ class JsonCodecSpec extends LeonardoTestSuite with Matchers with AnyFlatSpecLike
     val res = decode[RuntimeConfig](inputString)
     val expected = RuntimeConfig.GceConfig(
       MachineTypeName("n1-standard-8"),
-      DiskSize(500)
+      DiskSize(500),
+      None
     )
     res shouldBe (Right(expected))
   }
@@ -67,7 +68,8 @@ class JsonCodecSpec extends LeonardoTestSuite with Matchers with AnyFlatSpecLike
     val res = decode[RuntimeConfig](inputString)
     val expected = RuntimeConfig.GceWithPdConfig(
       MachineTypeName("n1-standard-8"),
-      None
+      None,
+      DiskSize(50)
     )
     res shouldBe (Right(expected))
   }
@@ -97,12 +99,13 @@ class JsonCodecSpec extends LeonardoTestSuite with Matchers with AnyFlatSpecLike
         |{
         |   "cloudService": "gce",
         |   "machineType": "n1-standard-8",
-        |   "persistentDiskId": 50
+        |   "persistentDiskId": 50,
+        |   "bootDiskSize": 50
         |}
         |""".stripMargin
 
     val res = decode[RuntimeConfig](inputString)
-    res shouldBe Right(RuntimeConfig.GceWithPdConfig(MachineTypeName("n1-standard-8"), Some(DiskId(50))))
+    res shouldBe Right(RuntimeConfig.GceWithPdConfig(MachineTypeName("n1-standard-8"), Some(DiskId(50)), DiskSize(50)))
   }
 
   it should "fail decoding if diskName has upper case" in {

--- a/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/JsonCodecSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/JsonCodecSpec.scala
@@ -61,7 +61,8 @@ class JsonCodecSpec extends LeonardoTestSuite with Matchers with AnyFlatSpecLike
       """
         |{
         |   "machineType": "n1-standard-8",
-        |   "cloudService": "GCE"
+        |   "cloudService": "GCE",
+        |   "bootDiskSize": 50
         |}
         |""".stripMargin
 

--- a/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changelog.xml
+++ b/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changelog.xml
@@ -55,4 +55,5 @@
     <include file="changesets/20200609_add_runtime_disk_foreign_key_to_runtime_config.xml" relativeToChangelogFile="true" />
     <include file="changesets/20200520_kubernetes_refactor.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20200609_add_persistent_disk_formattedBy.xml" relativeToChangelogFile="true" />
+    <include file="changesets/20200622_add_num_of_disks_to_runtime_config.xml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/20200622_add_num_of_disks_to_runtime_config.xml
+++ b/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/20200622_add_num_of_disks_to_runtime_config.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog logicalFilePath="leonardo" xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+    <changeSet logicalFilePath="leonardo" author="qi" id="add_num_of_disks_to_runtime_config">
+        <addColumn tableName="RUNTIME_CONFIG">
+            <column name="bootDiskSize" type="INT">
+            </column>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -67,9 +67,9 @@ gce {
   runtimeDefaults {
     machineType = "n1-standard-4"
     diskSize = 30 # This is default size for just user disk
+    bootDiskSize = 50
   }
   gceReservedMemory = 1g
-  bootDiskSize = 50
 
   monitor {
     initialDelay = 20 seconds

--- a/http/src/main/resources/swagger/api-docs.yaml
+++ b/http/src/main/resources/swagger/api-docs.yaml
@@ -2547,6 +2547,9 @@ components:
               description: >
                 Optional, the size in gigabytes of the disk on the GCE VM.
                 Minimum size is 50GB. If unspecified, default size is 100GB.
+            bootDiskSize:
+              type: integer
+              description: size for boot disk. For old runtimes (prior 6/22/2020, gce runtimes don't have a separate boot disk)
             machineType:
               type: string
               description: >
@@ -2564,6 +2567,9 @@ components:
           properties:
             persistentDisk:
               $ref: "#/components/schemas/PersistentDiskConfig"
+            bootDiskSize:
+              type: integer
+              description: size for boot disk
             machineType:
               type: string
               description: >

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/LeoRoutesSprayJsonCodec.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/LeoRoutesSprayJsonCodec.scala
@@ -17,11 +17,12 @@ object LeoRoutesSprayJsonCodec extends DefaultJsonProtocol {
   implicit val runtimeConfigWriter: RootJsonWriter[RuntimeConfig] = (obj: RuntimeConfig) => {
     val allFields = obj match {
       case x: RuntimeConfig.GceConfig =>
+        val bootDiskSize = x.bootDiskSize.fold(Map.empty)(s => Map("bootDiskSize" -> s.gb.toJson))
         Map(
           "machineType" -> x.machineType.value.toJson,
           "diskSize" -> x.diskSize.gb.toJson,
           "cloudService" -> x.cloudService.asString.toJson
-        )
+        ) ++ bootDiskSize
       case x: RuntimeConfig.DataprocConfig =>
         Map(
           "numberOfWorkers" -> x.numberOfWorkers.toJson,
@@ -37,7 +38,8 @@ object LeoRoutesSprayJsonCodec extends DefaultJsonProtocol {
         val diskId = x.persistentDiskId.map(id => Map("diskId" -> id.value.toJson)).getOrElse(Map.empty)
         Map(
           "machineType" -> x.machineType.value.toJson,
-          "cloudService" -> x.cloudService.asString.toJson
+          "cloudService" -> x.cloudService.asString.toJson,
+          "bootDiskSize" -> x.bootDiskSize.gb.toJson
         ) ++ diskId
     }
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/LeoRoutesSprayJsonCodec.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/LeoRoutesSprayJsonCodec.scala
@@ -17,7 +17,7 @@ object LeoRoutesSprayJsonCodec extends DefaultJsonProtocol {
   implicit val runtimeConfigWriter: RootJsonWriter[RuntimeConfig] = (obj: RuntimeConfig) => {
     val allFields = obj match {
       case x: RuntimeConfig.GceConfig =>
-        val bootDiskSize = x.bootDiskSize.fold(Map.empty)(s => Map("bootDiskSize" -> s.gb.toJson))
+        val bootDiskSize = x.bootDiskSize.fold(Map.empty[String, JsValue])(s => Map("bootDiskSize" -> s.gb.toJson))
         Map(
           "machineType" -> x.machineType.value.toJson,
           "diskSize" -> x.diskSize.gb.toJson,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
@@ -82,8 +82,9 @@ object Config {
 
   implicit private val gceRuntimeConfigReader: ValueReader[RuntimeConfig.GceConfig] = ValueReader.relative { config =>
     RuntimeConfig.GceConfig(
-      config.as[MachineTypeName]("machineType"),
-      config.as[DiskSize]("diskSize")
+      machineType = config.as[MachineTypeName]("machineType"),
+      diskSize = config.as[DiskSize]("diskSize"),
+      bootDiskSize = Some(config.as[DiskSize]("bootDiskSize"))
     )
   }
 
@@ -101,7 +102,6 @@ object Config {
 
   implicit private val gceConfigReader: ValueReader[GceConfig] = ValueReader.relative { config =>
     GceConfig(
-      config.as[DiskSize]("bootDiskSize"),
       config.as[GceCustomImage]("customGceImage"),
       config.as[RegionName]("region"),
       config.as[ZoneName]("zone"),

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/GceConfig.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/GceConfig.scala
@@ -2,10 +2,9 @@ package org.broadinstitute.dsde.workbench.leonardo.config
 
 import org.broadinstitute.dsde.workbench.google2.{RegionName, ZoneName}
 import org.broadinstitute.dsde.workbench.leonardo.CustomImage.GceCustomImage
-import org.broadinstitute.dsde.workbench.leonardo.{DiskSize, MemorySize, RuntimeConfig}
+import org.broadinstitute.dsde.workbench.leonardo.{MemorySize, RuntimeConfig}
 
-case class GceConfig(bootDiskSize: DiskSize,
-                     customGceImage: GceCustomImage,
+case class GceConfig(customGceImage: GceCustomImage,
                      regionName: RegionName,
                      zoneName: ZoneName,
                      defaultScopes: Set[String],

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GceInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GceInterpreter.scala
@@ -136,7 +136,7 @@ class GceInterpreter[F[_]: Parallel: ContextShift: Logger](
             .setDescription("Leonardo Managed Boot Disk")
             .setSourceImage(config.gceConfig.customGceImage.asString)
             .setDiskSizeGb(
-              config.gceConfig.bootDiskSize.gb.toString
+              config.gceConfig.runtimeConfigDefaults.bootDiskSize.get.gb.toString //Using `.get` here is okay since `bootDiskSize` always exists in config
             )
             .putAllLabels(Map("leonardo" -> "true").asJava)
             .build()

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/CommonTestData.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/CommonTestData.scala
@@ -186,7 +186,7 @@ object CommonTestData {
     RuntimeConfig.DataprocConfig(0, MachineTypeName("n1-standard-4"), DiskSize(500), None, None, None, None, Map.empty)
 
   val defaultGceRuntimeConfig =
-    RuntimeConfig.GceConfig(MachineTypeName("n1-standard-4"), DiskSize(500))
+    RuntimeConfig.GceConfig(MachineTypeName("n1-standard-4"), DiskSize(500), bootDiskSize = Some(DiskSize(50)))
   val defaultRuntimeConfigRequest =
     RuntimeConfigRequest.DataprocConfig(Some(0),
                                         Some(MachineTypeName("n1-standard-4")),
@@ -197,7 +197,7 @@ object CommonTestData {
                                         None,
                                         Map.empty[String, String])
   val gceRuntimeConfig =
-    RuntimeConfig.GceConfig(MachineTypeName("n1-standard-4"), DiskSize(500))
+    RuntimeConfig.GceConfig(MachineTypeName("n1-standard-4"), DiskSize(500), bootDiskSize = Some(DiskSize(50)))
 
   def makeCluster(index: Int): Runtime = {
     val clusterName = RuntimeName("clustername" + index.toString)

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/HttpRoutesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/HttpRoutesSpec.scala
@@ -106,7 +106,11 @@ class HttpRoutesSpec
   it should "list runtimes without a project" in {
     Get("/api/google/v1/runtimes") ~> routes.route ~> check {
       status shouldEqual StatusCodes.OK
-      responseAs[Vector[ListRuntimeResponse2]].map(_.id) shouldBe Vector(CommonTestData.testCluster.id)
+      val response = responseAs[Vector[ListRuntimeResponse2]]
+      response.map(_.id) shouldBe Vector(CommonTestData.testCluster.id)
+      response.map(_.runtimeConfig.asInstanceOf[RuntimeConfig.GceConfig]) shouldBe Vector(
+        CommonTestData.defaultGceRuntimeConfig
+      )
       validateRawCookie(header("Set-Cookie"))
     }
   }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/MockSamDAO.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/MockSamDAO.scala
@@ -8,6 +8,7 @@ import cats.mtl.ApplicativeAsk
 import org.broadinstitute.dsde.workbench.leonardo.SamResource.{
   AppSamResource,
   PersistentDiskSamResource,
+  ProjectSamResource,
   RuntimeSamResource
 }
 import org.broadinstitute.dsde.workbench.leonardo.dao.MockSamDAO._
@@ -82,7 +83,8 @@ class MockSamDAO extends SamDAO[IO] {
         IO(runtimes += (r, userEmailToAuthorization(creatorEmail)) -> runtimeActions)
       case r: PersistentDiskSamResource =>
         IO(persistentDisks += (r, userEmailToAuthorization(creatorEmail)) -> diskActions)
-      case _: AppSamResource => IO.unit //TODO
+      case _: ProjectSamResource => IO.unit //TODO: this may need to be stubbed out more correctly
+      case _: AppSamResource     => IO.unit //TODO
     }
 
   override def deleteResource(resource: SamResource,
@@ -94,7 +96,8 @@ class MockSamDAO extends SamDAO[IO] {
         IO(runtimes.remove((r, userEmailToAuthorization(userEmail))))
       case r: PersistentDiskSamResource =>
         IO(persistentDisks.remove((r, userEmailToAuthorization(userEmail))))
-      case _: AppSamResource => IO.unit //TODO
+      case _: ProjectSamResource => IO.unit //TODO: this may need to be stubbed out more correctly
+      case _: AppSamResource     => IO.unit //TODO
     }
 
   override def getPetServiceAccount(authorization: Authorization, googleProject: GoogleProject)(

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/MockSamDAO.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/MockSamDAO.scala
@@ -82,7 +82,7 @@ class MockSamDAO extends SamDAO[IO] {
         IO(runtimes += (r, userEmailToAuthorization(creatorEmail)) -> runtimeActions)
       case r: PersistentDiskSamResource =>
         IO(persistentDisks += (r, userEmailToAuthorization(creatorEmail)) -> diskActions)
-      case r: AppSamResource => IO.unit //TODO
+      case _: AppSamResource => IO.unit //TODO
     }
 
   override def deleteResource(resource: SamResource,
@@ -94,7 +94,7 @@ class MockSamDAO extends SamDAO[IO] {
         IO(runtimes.remove((r, userEmailToAuthorization(userEmail))))
       case r: PersistentDiskSamResource =>
         IO(persistentDisks.remove((r, userEmailToAuthorization(userEmail))))
-      case r: AppSamResource => IO.unit //TODO
+      case _: AppSamResource => IO.unit //TODO
     }
 
   override def getPetServiceAccount(authorization: Authorization, googleProject: GoogleProject)(

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponentSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponentSpec.scala
@@ -323,12 +323,16 @@ class ClusterComponentSpec extends AnyFlatSpecLike with TestComponent with GcsPa
     val res = for {
       savedDisk <- makePersistentDisk(DiskId(1)).save()
       savedRuntime <- IO(
-        makeCluster(1).saveWithRuntimeConfig(RuntimeConfig.GceWithPdConfig(defaultMachineType, Some(savedDisk.id)))
+        makeCluster(1).saveWithRuntimeConfig(
+          RuntimeConfig.GceWithPdConfig(defaultMachineType, Some(savedDisk.id), bootDiskSize = DiskSize(50))
+        )
       )
       retrievedRuntime <- clusterQuery.getClusterById(savedRuntime.id).transaction
       runtimeConfig <- RuntimeConfigQueries.getRuntimeConfig(retrievedRuntime.get.runtimeConfigId).transaction
       error <- IO(
-        makeCluster(2).saveWithRuntimeConfig(RuntimeConfig.GceWithPdConfig(defaultMachineType, Some(DiskId(-1))))
+        makeCluster(2).saveWithRuntimeConfig(
+          RuntimeConfig.GceWithPdConfig(defaultMachineType, Some(DiskId(-1)), bootDiskSize = DiskSize(50))
+        )
       ).attempt
     } yield {
       retrievedRuntime shouldBe 'defined

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/RuntimeConfigQueriesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/RuntimeConfigQueriesSpec.scala
@@ -4,6 +4,7 @@ import java.time.Instant
 import java.util.concurrent.TimeUnit
 
 import org.broadinstitute.dsde.workbench.google2.MachineTypeName
+import org.broadinstitute.dsde.workbench.leonardo.CommonTestData.makePersistentDisk
 import org.broadinstitute.dsde.workbench.leonardo.http.dbioToIO
 import org.broadinstitute.dsde.workbench.leonardo.{DiskId, DiskSize, LeonardoTestSuite, RuntimeConfig}
 
@@ -49,7 +50,7 @@ class RuntimeConfigQueriesSpec extends AnyFlatSpecLike with TestComponent with L
       rc <- RuntimeConfigQueries.getRuntimeConfig(id).transaction
 
       id2 <- RuntimeConfigQueries.insertRuntimeConfig(runtimeConfig2, Instant.ofEpochMilli(now)).transaction
-      rc2 <- RuntimeConfigQueries.getRuntimeConfig(id).transaction
+      rc2 <- RuntimeConfigQueries.getRuntimeConfig(id2).transaction
     } yield {
       rc shouldBe runtimeConfig1
       rc2 shouldBe runtimeConfig2
@@ -58,13 +59,15 @@ class RuntimeConfigQueriesSpec extends AnyFlatSpecLike with TestComponent with L
   }
 
   it should "save gceWithPdConfig properly" in isolatedDbTest {
-    val runtimeConfig = RuntimeConfig.GceWithPdConfig(
-      MachineTypeName("n1-standard-4"),
-      Some(DiskId(0)),
-      DiskSize(50)
-    )
+    val persistentDiskId = DiskId(1)
     val res = for {
       now <- testTimer.clock.realTime(TimeUnit.MILLISECONDS)
+      savedDisk <- makePersistentDisk(persistentDiskId).save()
+      runtimeConfig = RuntimeConfig.GceWithPdConfig(
+        MachineTypeName("n1-standard-4"),
+        Some(savedDisk.id),
+        DiskSize(50)
+      )
       id <- RuntimeConfigQueries.insertRuntimeConfig(runtimeConfig, Instant.ofEpochMilli(now)).transaction
       rc <- RuntimeConfigQueries.getRuntimeConfig(id).transaction
     } yield {

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/RuntimeServiceDbQueriesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/RuntimeServiceDbQueriesSpec.scala
@@ -49,13 +49,13 @@ class RuntimeServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent wit
       start <- testTimer.clock.monotonic(TimeUnit.MILLISECONDS)
       list1 <- RuntimeServiceDbQueries.listRuntimes(Map.empty, false, None).transaction
       d1 <- makePersistentDisk(DiskId(1)).save()
-      d1RuntimeConfig = RuntimeConfig.GceWithPdConfig(defaultMachineType, Some(d1.id))
+      d1RuntimeConfig = RuntimeConfig.GceWithPdConfig(defaultMachineType, Some(d1.id), bootDiskSize = DiskSize(50))
       c1 <- IO(
         makeCluster(1).saveWithRuntimeConfig(d1RuntimeConfig)
       )
       list2 <- RuntimeServiceDbQueries.listRuntimes(Map.empty, false, None).transaction
       d2 <- makePersistentDisk(DiskId(2)).save()
-      d2RuntimeConfig = RuntimeConfig.GceWithPdConfig(defaultMachineType, Some(d2.id))
+      d2RuntimeConfig = RuntimeConfig.GceWithPdConfig(defaultMachineType, Some(d2.id), bootDiskSize = DiskSize(50))
       c2 <- IO(
         makeCluster(2).saveWithRuntimeConfig(d2RuntimeConfig)
       )
@@ -79,10 +79,10 @@ class RuntimeServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent wit
     val res = for {
       start <- testTimer.clock.monotonic(TimeUnit.MILLISECONDS)
       d1 <- makePersistentDisk(DiskId(1)).save()
-      c1RuntimeConfig = RuntimeConfig.GceWithPdConfig(defaultMachineType, Some(d1.id))
+      c1RuntimeConfig = RuntimeConfig.GceWithPdConfig(defaultMachineType, Some(d1.id), bootDiskSize = DiskSize(50))
       c1 <- IO(makeCluster(1).saveWithRuntimeConfig(c1RuntimeConfig))
       d2 <- makePersistentDisk(DiskId(2)).save()
-      c2RuntimeConfig = RuntimeConfig.GceWithPdConfig(defaultMachineType, Some(d2.id))
+      c2RuntimeConfig = RuntimeConfig.GceWithPdConfig(defaultMachineType, Some(d2.id), bootDiskSize = DiskSize(50))
       c2 <- IO(makeCluster(2).saveWithRuntimeConfig(c2RuntimeConfig))
       labels1 = Map("googleProject" -> c1.googleProject.value,
                     "clusterName" -> c1.runtimeName.asString,
@@ -120,12 +120,12 @@ class RuntimeServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent wit
     val res = for {
       start <- testTimer.clock.monotonic(TimeUnit.MILLISECONDS)
       d1 <- makePersistentDisk(DiskId(1)).save()
-      c1RuntimeConfig = RuntimeConfig.GceWithPdConfig(defaultMachineType, Some(d1.id))
+      c1RuntimeConfig = RuntimeConfig.GceWithPdConfig(defaultMachineType, Some(d1.id), bootDiskSize = DiskSize(50))
       c1 <- IO(
         makeCluster(1).saveWithRuntimeConfig(c1RuntimeConfig)
       )
       d2 <- makePersistentDisk(DiskId(2)).save()
-      c2RuntimeConfig = RuntimeConfig.GceWithPdConfig(defaultMachineType, Some(d2.id))
+      c2RuntimeConfig = RuntimeConfig.GceWithPdConfig(defaultMachineType, Some(d2.id), bootDiskSize = DiskSize(50))
       c2 <- IO(
         makeCluster(2).saveWithRuntimeConfig(c2RuntimeConfig)
       )
@@ -149,23 +149,25 @@ class RuntimeServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent wit
     val res = for {
       start <- testTimer.clock.monotonic(TimeUnit.MILLISECONDS)
       d1 <- makePersistentDisk(DiskId(1)).save()
-      c1RuntimeConfig = RuntimeConfig.GceWithPdConfig(defaultMachineType, Some(d1.id))
+      c1RuntimeConfig = RuntimeConfig.GceWithPdConfig(defaultMachineType, Some(d1.id), bootDiskSize = DiskSize(50))
       c1 <- IO(
         makeCluster(1)
           .copy(status = RuntimeStatus.Deleted)
           .saveWithRuntimeConfig(c1RuntimeConfig)
       )
       d2 <- makePersistentDisk(DiskId(2)).save()
-      c2RuntimeConfig = RuntimeConfig.GceWithPdConfig(defaultMachineType, Some(d2.id))
+      c2RuntimeConfig = RuntimeConfig.GceWithPdConfig(defaultMachineType, Some(d2.id), bootDiskSize = DiskSize(50))
       c2 <- IO(
         makeCluster(2)
           .copy(status = RuntimeStatus.Deleted)
           .saveWithRuntimeConfig(c2RuntimeConfig)
       )
       d3 <- makePersistentDisk(DiskId(3)).save()
-      c3RuntimeConfig = RuntimeConfig.GceWithPdConfig(defaultMachineType, Some(d3.id))
+      c3RuntimeConfig = RuntimeConfig.GceWithPdConfig(defaultMachineType, Some(d3.id), bootDiskSize = DiskSize(50))
       c3 <- IO(
-        makeCluster(3).saveWithRuntimeConfig(RuntimeConfig.GceWithPdConfig(defaultMachineType, Some(d3.id)))
+        makeCluster(3).saveWithRuntimeConfig(
+          RuntimeConfig.GceWithPdConfig(defaultMachineType, Some(d3.id), bootDiskSize = DiskSize(50))
+        )
       )
       list1 <- RuntimeServiceDbQueries.listRuntimes(Map.empty, true, None).transaction
       list2 <- RuntimeServiceDbQueries.listRuntimes(Map.empty, false, None).transaction
@@ -187,7 +189,7 @@ class RuntimeServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent wit
   it should "get a runtime" in isolatedDbTest {
     val res = for {
       disk <- makePersistentDisk(DiskId(1)).save()
-      c1RuntimeConfig = RuntimeConfig.GceWithPdConfig(defaultMachineType, Some(disk.id))
+      c1RuntimeConfig = RuntimeConfig.GceWithPdConfig(defaultMachineType, Some(disk.id), bootDiskSize = DiskSize(50))
       c1 <- IO(makeCluster(1).saveWithRuntimeConfig(c1RuntimeConfig))
       get1 <- RuntimeServiceDbQueries.getRuntime(c1.googleProject, c1.runtimeName).transaction
       get2 <- RuntimeServiceDbQueries.getRuntime(c1.googleProject, RuntimeName("does-not-exist")).transaction.attempt

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/TestComponent.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/TestComponent.scala
@@ -78,7 +78,7 @@ trait TestComponent extends LeonardoTestSuite with ScalaFutures with GcsPathUtil
     } catch {
       case t: Throwable => t.printStackTrace(); throw t
     } finally {
-//      dbFutureValue(testDbRef.dataAccess.truncateAll)
+      dbFutureValue(testDbRef.dataAccess.truncateAll)
     }
 
   protected def getClusterId(getClusterIdRequest: GetClusterKey): Long =

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/TestComponent.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/TestComponent.scala
@@ -78,7 +78,7 @@ trait TestComponent extends LeonardoTestSuite with ScalaFutures with GcsPathUtil
     } catch {
       case t: Throwable => t.printStackTrace(); throw t
     } finally {
-      dbFutureValue(testDbRef.dataAccess.truncateAll)
+//      dbFutureValue(testDbRef.dataAccess.truncateAll)
     }
 
   protected def getClusterId(getClusterIdRequest: GetClusterKey): Long =

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubCodecSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubCodecSpec.scala
@@ -36,7 +36,7 @@ class LeoPubsubCodecSpec extends FlatSpec with Matchers {
       Set.empty,
       false,
       Map.empty,
-      RuntimeConfig.GceConfig(MachineTypeName("n1-standard-4"), DiskSize(50)),
+      RuntimeConfig.GceConfig(MachineTypeName("n1-standard-4"), DiskSize(50), bootDiskSize = Some(DiskSize(50))),
       false,
       None
     )

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ZombieRuntimeMonitorSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ZombieRuntimeMonitorSpec.scala
@@ -239,7 +239,8 @@ class ZombieRuntimeMonitorSpec
   it should "detect active zombie gce instance" in isolatedDbTest {
     val runtimeConfig = RuntimeConfig.GceConfig(
       MachineTypeName("n1-standard-4"),
-      DiskSize(50)
+      DiskSize(50),
+      bootDiskSize = Some(DiskSize(50))
     )
     val savedTestRuntime = testCluster1.saveWithRuntimeConfig(runtimeConfig)
     savedTestRuntime.copy(runtimeConfigId = RuntimeConfigId(-1)) shouldEqual testCluster1
@@ -270,7 +271,8 @@ class ZombieRuntimeMonitorSpec
     // create a running gce instance
     val runtimeConfig = RuntimeConfig.GceConfig(
       MachineTypeName("n1-standard-4"),
-      DiskSize(50)
+      DiskSize(50),
+      bootDiskSize = Some(DiskSize(50))
     )
     val savedTestInstance1 = deletedRuntime1.saveWithRuntimeConfig(runtimeConfig)
     savedTestInstance1.copy(runtimeConfigId = RuntimeConfigId(-1)) shouldEqual deletedRuntime1

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/AuthProviderSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/AuthProviderSpec.scala
@@ -200,7 +200,7 @@ class AuthProviderSpec
       )(any[ApplicativeAsk[IO, TraceId]])
     }
 
-    "should not let you do things if the auth provider says no" in {
+    "should not let you do things if the auth provider says no" in isolatedDbTest {
       val spyProvider = spy(alwaysNoProvider)
       val leo = leoWithAuthProvider(spyProvider)
       val proxy = proxyWithAuthProvider(spyProvider)

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/DiskServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/DiskServiceInterpSpec.scala
@@ -183,7 +183,7 @@ class DiskServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with Test
       disk <- makePersistentDisk(DiskId(1)).copy(samResource = diskSamResource).save()
       _ <- IO(
         makeCluster(1).saveWithRuntimeConfig(
-          RuntimeConfig.GceWithPdConfig(MachineTypeName("n1-standard-4"), Some(disk.id))
+          RuntimeConfig.GceWithPdConfig(MachineTypeName("n1-standard-4"), Some(disk.id), bootDiskSize = DiskSize(50))
         )
       )
       err <- diskService.deleteDisk(userInfo, disk.googleProject, disk.name).attempt

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/MockRuntimeServiceInterp.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/MockRuntimeServiceInterp.scala
@@ -36,7 +36,7 @@ object MockRuntimeServiceInterp extends RuntimeService[IO] {
           CommonTestData.testCluster.runtimeName,
           CommonTestData.testCluster.googleProject,
           CommonTestData.testCluster.auditInfo,
-          CommonTestData.defaultDataprocRuntimeConfig,
+          CommonTestData.defaultGceRuntimeConfig,
           CommonTestData.testCluster.proxyUrl,
           CommonTestData.testCluster.status,
           CommonTestData.testCluster.labels,

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/RuntimeServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/RuntimeServiceInterpSpec.scala
@@ -273,7 +273,8 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
       disk.size shouldBe DiskSize(500)
       runtimeConfig shouldBe RuntimeConfig.GceWithPdConfig(
         MachineTypeName("n1-standard-4"),
-        Some(disk.id)
+        Some(disk.id),
+        bootDiskSize = DiskSize(50)
       ) //TODO: this is a problem in terms of inconsistency
       val expectedMessage = CreateRuntimeMessage
         .fromRuntime(runtime, runtimeConfig, Some(context.traceId))
@@ -284,7 +285,8 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
             RuntimeImage(RuntimeImageType.Proxy, Config.imageConfig.proxyImage.imageUrl, context.now)
           ),
           scopes = Config.gceConfig.defaultScopes,
-          runtimeConfig = RuntimeConfig.GceWithPdConfig(runtimeConfig.machineType, Some(disk.id))
+          runtimeConfig =
+            RuntimeConfig.GceWithPdConfig(runtimeConfig.machineType, Some(disk.id), bootDiskSize = DiskSize(50))
         )
       message shouldBe expectedMessage
     }
@@ -831,7 +833,9 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
       t <- ctx.ask
       savedDisk <- makePersistentDisk(DiskId(1)).save()
       _ <- IO(
-        makeCluster(1).saveWithRuntimeConfig(RuntimeConfig.GceWithPdConfig(defaultMachineType, Some(savedDisk.id)))
+        makeCluster(1).saveWithRuntimeConfig(
+          RuntimeConfig.GceWithPdConfig(defaultMachineType, Some(savedDisk.id), bootDiskSize = DiskSize(50))
+        )
       )
       req = PersistentDiskRequest(savedDisk.name, Some(savedDisk.size), Some(savedDisk.diskType), savedDisk.labels)
       err <- RuntimeServiceInterp


### PR DESCRIPTION
UI is displaying disk cost as well. They need a way to differentiate older runtimes with one disk vs new runtimes with 2 disks...Exposing `bootDiskSize` is useful going forward as well if we optimize custom VM image size to lower than 50G, then we'll be able to use smaller size boot disk

Tested in fiab
```
[
  {
    "id": 62,
    "runtimeName": "rt-no-pd",
    "googleProject": "qi-billing1",
    "auditInfo": {
      "creator": "hermione.owner@test.firecloud.org",
      "createdDate": "2020-06-22T21:55:02.051Z",
      "destroyedDate": null,
      "dateAccessed": "2020-06-22T21:55:47.516Z"
    },
    "runtimeConfig": {
      "machineType": "n1-standard-4",
      "diskSize": 100,
      "cloudService": "GCE",
      "bootDiskSize": 50
    },
    "proxyUrl": "https://leonardo-fiab.dsde-dev.broadinstitute.org:30443/proxy/qi-billing1/rt-no-pd/jupyter",
    "status": "Creating",
    "labels": {
      "tool": "Jupyter",
      "creator": "hermione.owner@test.firecloud.org",
      "runtimeName": "rt-no-pd",
      "googleProject": "qi-billing1",
      "clusterServiceAccount": "b272pet-110530393451290928813@qi-billing1.iam.gserviceaccount.com",
      "clusterName": "rt-no-pd"
    },
    "patchInProgress": false
  },
  {
    "id": 63,
    "runtimeName": "rt-pd",
    "googleProject": "qi-billing1",
    "auditInfo": {
      "creator": "hermione.owner@test.firecloud.org",
      "createdDate": "2020-06-22T21:57:13.454Z",
      "destroyedDate": null,
      "dateAccessed": "2020-06-22T21:57:16.127Z"
    },
    "runtimeConfig": {
      "machineType": "n1-standard-4",
      "persistentDiskId": 33,
      "cloudService": "GCE",
      "bootDiskSize": 50
    },
    "proxyUrl": "https://leonardo-fiab.dsde-dev.broadinstitute.org:30443/proxy/qi-billing1/rt-pd/jupyter",
    "status": "Creating",
    "labels": {
      "tool": "Jupyter",
      "creator": "hermione.owner@test.firecloud.org",
      "runtimeName": "rt-pd",
      "googleProject": "qi-billing1",
      "clusterServiceAccount": "b272pet-110530393451290928813@qi-billing1.iam.gserviceaccount.com",
      "clusterName": "rt-pd"
    },
    "patchInProgress": false
  }
]
```

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
