### PR TITLE
[IA-1986] Update attached PD when updating runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ sbt "testOnly *LeoAuthProviderHelperSpec"
 ```
 or a particular test within a suite, e.g.
 ```
-sbt "testOnly *LeoAuthProviderHelperSpec -- -z map"
+sbt "testOnly org.broadinstitute.dsde.workbench.leonardo.runtimes.RuntimeCreationDiskSpec -- -t "create runtime and attach a persistent disk""
 ```
 where `map` is a substring within the test name.
 

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/Leonardo.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/Leonardo.scala
@@ -170,16 +170,6 @@ object Leonardo extends RestClient with LazyLogging {
       logger.info(s"Update cluster: PATCH /$path")
       handleClusterResponse(patchRequest(url + path, clusterRequest))
     }
-
-    def updateRuntime(googleProject: GoogleProject, runtimeName: RuntimeName, request: UpdateRuntimeRequestCopy)(
-      implicit token: AuthToken
-    ): Unit = {
-      val path = runtimePath(googleProject, runtimeName, Some(ApiVersion.V1))
-      logger.info(s"Update runtime: PATCH /$path")
-      patchRequest(url + path, request)
-
-    }
-
   }
 }
 

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoModelCopy.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoModelCopy.scala
@@ -8,7 +8,6 @@ import org.broadinstitute.dsde.workbench.leonardo.http.DiskConfig
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
 import org.broadinstitute.dsde.workbench.model.google._
 
-import scala.concurrent.duration.FiniteDuration
 import scala.language.implicitConversions
 
 sealed trait StringValueClass extends Any
@@ -175,26 +174,3 @@ final case class ListRuntimeResponseCopy(id: Long,
                                          status: ClusterStatus,
                                          labels: LabelMap,
                                          patchInProgress: Boolean)
-
-final case class UpdateRuntimeRequestCopy(runtimeConfig: Option[UpdateRuntimeConfigRequestCopy],
-                                          allowStop: Boolean,
-                                          autopauseEnabled: Option[Boolean],
-                                          autopauseThreshold: Option[FiniteDuration])
-
-sealed trait UpdateRuntimeConfigRequestCopy extends Product with Serializable {
-  def cloudService: String
-}
-object UpdateRuntimeConfigRequestCopy {
-  final case class GceConfig(machineType: Option[String], diskSize: Option[Int])
-      extends UpdateRuntimeConfigRequestCopy {
-    val cloudService: String = CloudService.GCE.asString
-  }
-
-  final case class DataprocConfig(masterMachineType: Option[String],
-                                  masterDiskSize: Option[Int],
-                                  numberOfWorkers: Option[Int],
-                                  numberOfPreemptibleWorkers: Option[Int])
-      extends UpdateRuntimeConfigRequestCopy {
-    val cloudService: String = CloudService.Dataproc.asString
-  }
-}

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeCreationDiskSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeCreationDiskSpec.scala
@@ -108,11 +108,11 @@ class RuntimeCreationDiskSpec
         _ <- if (res.isDone) IO.unit
         else IO.raiseError(new TimeoutException(s"delete runtime ${googleProject.value}/${runtimeName.asString}"))
         disk <- LeonardoApiClient.getDisk(googleProject, diskName)
+        _ <- IO(disk.status shouldBe DiskStatus.Ready)
+        _ <- IO(disk.size shouldBe diskSize)
         _ <- LeonardoApiClient.deleteDiskWithWait(googleProject, diskName)
         listofDisks <- LeonardoApiClient.listDisk(googleProject, true)
       } yield {
-        disk.status shouldBe DiskStatus.Ready
-        disk.size shouldBe diskSize
         listofDisks.collect { case resp if resp.name == diskName => resp.status } shouldBe List(
           DiskStatus.Deleted
         ) //assume we won't have multiple disks with same name in the same project in tests

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimePatchSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimePatchSpec.scala
@@ -5,21 +5,28 @@ import cats.effect.IO
 import cats.implicits._
 import org.broadinstitute.dsde.workbench.DoneCheckable
 import org.broadinstitute.dsde.workbench.auth.AuthToken
-import org.broadinstitute.dsde.workbench.google2.{streamFUntilDone, MachineTypeName}
+import org.broadinstitute.dsde.workbench.google2.{streamFUntilDone, DiskName, MachineTypeName}
 import org.broadinstitute.dsde.workbench.leonardo.GPAllocFixtureSpec.gpallocProjectKey
 import org.broadinstitute.dsde.workbench.leonardo.LeonardoApiClient._
-import org.broadinstitute.dsde.workbench.leonardo.http.RuntimeConfigRequest
+import org.broadinstitute.dsde.workbench.leonardo.http.{
+  PersistentDiskRequest,
+  RuntimeConfigRequest,
+  UpdateRuntimeConfigRequest,
+  UpdateRuntimeRequest
+}
+import org.broadinstitute.dsde.workbench.leonardo.notebooks.{NotebookTestUtils, Python3}
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.broadinstitute.dsde.workbench.service.util.Tags
 import org.http4s.headers.Authorization
 import org.http4s.{AuthScheme, Credentials}
 import org.scalatest.{DoNotDiscover, Outcome}
 import org.scalatest.freespec.FixtureAnyFreeSpec
+
 import scala.concurrent.duration._
 
 // extending fixture.Freespec just so we can use `taggedAs`. Not really need fixture for anything
 @DoNotDiscover
-class RuntimePatchSpec extends FixtureAnyFreeSpec with LeonardoTestUtils with LeonardoTestSuite {
+class RuntimePatchSpec extends FixtureAnyFreeSpec with LeonardoTestUtils with LeonardoTestSuite with NotebookTestUtils {
   implicit val ronToken: AuthToken = ronAuthToken
   implicit val auth: Authorization = Authorization(Credentials.Token(AuthScheme.Bearer, ronCreds.makeAuthToken().value))
 
@@ -31,16 +38,22 @@ class RuntimePatchSpec extends FixtureAnyFreeSpec with LeonardoTestUtils with Le
     // create a new GCE runtime
     val runtimeName = randomClusterName
 
-    val newMasterMachineType = "n1-standard-2"
-    val newRuntimeConfig = UpdateRuntimeConfigRequestCopy.GceConfig(
-      Some(newMasterMachineType),
-      None
-    )
+    val newMasterMachineType = MachineTypeName("n1-standard-2")
+    val newDiskSize = DiskSize(20)
+    val updateRuntimeRequest = UpdateRuntimeRequest(Some(
+                                                      UpdateRuntimeConfigRequest.GceConfig(
+                                                        Some(newMasterMachineType),
+                                                        Some(newDiskSize)
+                                                      )
+                                                    ),
+                                                    true,
+                                                    None,
+                                                    None)
     val createRuntimeRequest = defaultCreateRuntime2Request.copy(
       runtimeConfig = Some(
         RuntimeConfigRequest.GceConfig(
           Some(MachineTypeName("n1-standard-4")),
-          None
+          Some(DiskSize(10))
         )
       )
     )
@@ -54,13 +67,7 @@ class RuntimePatchSpec extends FixtureAnyFreeSpec with LeonardoTestUtils with Le
 
       for {
         _ <- createRuntimeWithWait(googleProject, runtimeName, createRuntimeRequest)
-        _ <- IO {
-          Leonardo.cluster.updateRuntime(
-            googleProject,
-            runtimeName,
-            request = UpdateRuntimeRequestCopy(Some(newRuntimeConfig), true, None, None)
-          )
-        }
+        _ <- updateRuntime(googleProject, runtimeName, updateRuntimeRequest)
         _ <- testTimer.sleep(30 seconds) //We need this because DB update happens in subscriber for update API.
         ioa = LeonardoApiClient.getRuntime(googleProject, runtimeName)
         getRuntimeResult <- ioa
@@ -70,15 +77,103 @@ class RuntimePatchSpec extends FixtureAnyFreeSpec with LeonardoTestUtils with Le
           stoppingDoneCheckable
         ).compile.lastOrError
         _ = monitorStoppingResult.status shouldBe ClusterStatus.Starting
-        monitringStartingResult <- testTimer.sleep(50 seconds) >> streamFUntilDone(ioa, 30, 10 seconds)(
+        monitoringStartingResult <- testTimer.sleep(50 seconds) >> streamFUntilDone(ioa, 30, 10 seconds)(
           testTimer,
           startingDoneCheckable
         ).compile.lastOrError
+        clusterCopy = ClusterCopy.fromGetRuntimeResponseCopy(getRuntimeResult)
+        _ <- IO(
+          withWebDriver { implicit driver =>
+            withNewNotebook(clusterCopy, Python3) { notebookPage =>
+              //all other packages cannot be tested for their versions in this manner
+              //warnings are ignored because they are benign warnings that show up for python2 because of compilation against an older numpy
+              val res = notebookPage
+                .executeCell(
+                  "! df -H |grep sdb"
+                )
+                .get
+              res should include("22G") //disk output is always a few more gb than what's specified
+            }
+          }
+        )
       } yield {
-        monitringStartingResult.status shouldBe ClusterStatus.Running
-        monitringStartingResult.runtimeConfig
+        monitoringStartingResult.status shouldBe ClusterStatus.Running
+        val res = monitoringStartingResult.runtimeConfig
           .asInstanceOf[RuntimeConfig.GceConfig]
-          .machineType shouldBe MachineTypeName(newMasterMachineType)
+        res.machineType shouldBe newMasterMachineType
+        res.diskSize shouldBe newDiskSize
+      }
+    }
+    res.unsafeRunSync
+  }
+
+  //this is an end to end test of the pub/sub infrastructure
+  "Patch endpoint should perform a stop/start tranition for GCE VM with PD" taggedAs Tags.SmokeTest in { _ =>
+    val billingProjectString =
+      sys.props.get(gpallocProjectKey).getOrElse(throw new Exception("Billing project is not set"))
+    val googleProject = GoogleProject(billingProjectString)
+    // create a new GCE runtime
+    val runtimeName = randomClusterName
+
+    val newMasterMachineType = MachineTypeName("n1-standard-2")
+    val newDiskSize = DiskSize(20)
+    val updateRuntimeRequest = UpdateRuntimeRequest(Some(
+                                                      UpdateRuntimeConfigRequest.GceConfig(
+                                                        Some(newMasterMachineType),
+                                                        Some(newDiskSize)
+                                                      )
+                                                    ),
+                                                    true,
+                                                    None,
+                                                    None)
+    val createRuntimeRequest = defaultCreateRuntime2Request.copy(
+      runtimeConfig = Some(
+        RuntimeConfigRequest.GceWithPdConfig(
+          Some(MachineTypeName("n1-standard-4")),
+          PersistentDiskRequest(
+            DiskName("pd-test"),
+            Some(DiskSize(10)),
+            None,
+            Map.empty
+          )
+        )
+      )
+    )
+
+    val res = LeonardoApiClient.client.use { implicit c =>
+      val startingDoneCheckable: DoneCheckable[GetRuntimeResponseCopy] =
+        x => x.status == ClusterStatus.Running
+
+      for {
+        _ <- createRuntimeWithWait(googleProject, runtimeName, createRuntimeRequest)
+        _ <- updateRuntime(googleProject, runtimeName, updateRuntimeRequest)
+        _ <- testTimer.sleep(70 seconds) //We need this because DB update happens in subscriber for update API.
+        ioa = LeonardoApiClient.getRuntime(googleProject, runtimeName)
+        getRuntimeResult <- ioa
+        monitoringStartingResult <- testTimer.sleep(50 seconds) >> streamFUntilDone(ioa, 30, 10 seconds)(
+          testTimer,
+          startingDoneCheckable
+        ).compile.lastOrError
+        clusterCopy = ClusterCopy.fromGetRuntimeResponseCopy(getRuntimeResult)
+        _ <- IO(
+          withWebDriver { implicit driver =>
+            withNewNotebook(clusterCopy, Python3) { notebookPage =>
+              //all other packages cannot be tested for their versions in this manner
+              //warnings are ignored because they are benign warnings that show up for python2 because of compilation against an older numpy
+              val res = notebookPage
+                .executeCell(
+                  "! df -H |grep sdb"
+                )
+                .get
+              res should include("22G") //disk output is always a few more gb than what's specified
+            }
+          }
+        )
+      } yield {
+        monitoringStartingResult.status shouldBe ClusterStatus.Running
+        val res = monitoringStartingResult.runtimeConfig
+          .asInstanceOf[RuntimeConfig.GceWithPdConfig]
+        res.machineType shouldBe newMasterMachineType
       }
     }
     res.unsafeRunSync
@@ -88,21 +183,26 @@ class RuntimePatchSpec extends FixtureAnyFreeSpec with LeonardoTestUtils with Le
     val billingProjectString =
       sys.props.get(gpallocProjectKey).getOrElse(throw new Exception("Billing project is not set"))
     val googleProject = GoogleProject(billingProjectString)
-    val newMasterMachineType = "n1-standard-2"
-    val newRuntimeConfig = UpdateRuntimeConfigRequestCopy.DataprocConfig(
-      Some(newMasterMachineType),
-      None,
-      None,
-      None
-    )
-
+    val newMasterMachineType = MachineTypeName("n1-standard-2")
+    val newDiskSize = DiskSize(60)
+    val updateRuntimeRequest = UpdateRuntimeRequest(Some(
+                                                      UpdateRuntimeConfigRequest.DataprocConfig(
+                                                        Some(newMasterMachineType),
+                                                        Some(newDiskSize),
+                                                        None,
+                                                        None
+                                                      )
+                                                    ),
+                                                    true,
+                                                    None,
+                                                    None)
     val runtimeName = randomClusterName
     val createRuntimeRequest = defaultCreateRuntime2Request.copy(
       runtimeConfig = Some(
         RuntimeConfigRequest.DataprocConfig(
           None,
           Some(MachineTypeName("n1-standard-4")),
-          None,
+          Some(DiskSize(50)),
           None,
           None,
           None,
@@ -120,13 +220,7 @@ class RuntimePatchSpec extends FixtureAnyFreeSpec with LeonardoTestUtils with Le
 
       for {
         _ <- createRuntimeWithWait(googleProject, runtimeName, createRuntimeRequest)
-        _ <- IO {
-          Leonardo.cluster.updateRuntime(
-            googleProject,
-            runtimeName,
-            request = UpdateRuntimeRequestCopy(Some(newRuntimeConfig), true, None, None)
-          )
-        }
+        _ <- updateRuntime(googleProject, runtimeName, updateRuntimeRequest)
         _ <- testTimer.sleep(30 seconds) //We need this because DB update happens in subscriber for update API.
         ioa = LeonardoApiClient.getRuntime(googleProject, runtimeName)
         getRuntimeResult <- ioa
@@ -140,11 +234,27 @@ class RuntimePatchSpec extends FixtureAnyFreeSpec with LeonardoTestUtils with Le
           testTimer,
           startingDoneCheckable
         ).compile.lastOrError
+        clusterCopy = ClusterCopy.fromGetRuntimeResponseCopy(getRuntimeResult)
+        _ <- IO(
+          withWebDriver { implicit driver =>
+            withNewNotebook(clusterCopy, Python3) { notebookPage =>
+              //all other packages cannot be tested for their versions in this manner
+              //warnings are ignored because they are benign warnings that show up for python2 because of compilation against an older numpy
+              val res = notebookPage
+                .executeCell(
+                  "! df -H |grep sda1"
+                )
+                .get
+              res should include("64G") //disk output is always a few more gb than what's specified
+            }
+          }
+        )
       } yield {
         monitringStartingResult.status shouldBe ClusterStatus.Running
-        monitringStartingResult.runtimeConfig
+        val res = monitringStartingResult.runtimeConfig
           .asInstanceOf[RuntimeConfig.DataprocConfig]
-          .masterMachineType shouldBe MachineTypeName(newMasterMachineType)
+        res.masterMachineType shouldBe newMasterMachineType
+        res.diskSize shouldBe newDiskSize
       }
     }
     res.unsafeRunSync

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/runtimeRoutesModels.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/runtimeRoutesModels.scala
@@ -60,3 +60,25 @@ final case class CreateRuntime2Request(
   scopes: Set[String],
   customEnvironmentVariables: Map[String, String]
 )
+
+sealed trait UpdateRuntimeConfigRequest extends Product with Serializable {
+  def cloudService: CloudService
+}
+object UpdateRuntimeConfigRequest {
+  final case class GceConfig(updatedMachineType: Option[MachineTypeName], updatedDiskSize: Option[DiskSize])
+      extends UpdateRuntimeConfigRequest {
+    val cloudService: CloudService = CloudService.GCE
+  }
+  final case class DataprocConfig(updatedMasterMachineType: Option[MachineTypeName],
+                                  updatedMasterDiskSize: Option[DiskSize],
+                                  updatedNumberOfWorkers: Option[Int],
+                                  updatedNumberOfPreemptibleWorkers: Option[Int])
+      extends UpdateRuntimeConfigRequest {
+    val cloudService: CloudService = CloudService.Dataproc
+  }
+}
+
+final case class UpdateRuntimeRequest(updatedRuntimeConfig: Option[UpdateRuntimeConfigRequest],
+                                      allowStop: Boolean,
+                                      updateAutopauseEnabled: Option[Boolean],
+                                      updateAutopauseThreshold: Option[FiniteDuration])

--- a/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/RuntimeRoutesTestJsonCodec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/RuntimeRoutesTestJsonCodec.scala
@@ -74,4 +74,46 @@ object RuntimeRoutesTestJsonCodec {
       x.customEnvironmentVariables
     )
   )
+
+  implicit val updateGceConfigRequestEncoder: Encoder[UpdateRuntimeConfigRequest.GceConfig] = Encoder.forProduct3(
+    "cloudService",
+    "machineType",
+    "diskSize"
+  )(x => (x.cloudService, x.updatedMachineType, x.updatedDiskSize))
+
+  implicit val updateDataprocConfigRequestEncoder: Encoder[UpdateRuntimeConfigRequest.DataprocConfig] =
+    Encoder.forProduct5(
+      "cloudService",
+      "masterMachineType",
+      "masterDiskSize",
+      "numberOfWorkers",
+      "numberOfPreemptibleWorkers"
+    )(x =>
+      (x.cloudService,
+       x.updatedMasterMachineType,
+       x.updatedMasterDiskSize,
+       x.updatedNumberOfWorkers,
+       x.updatedNumberOfPreemptibleWorkers)
+    )
+
+  implicit val updateRuntimeConfigRequestEncoder: Encoder[UpdateRuntimeConfigRequest] = Encoder.instance { x =>
+    x match {
+      case x: UpdateRuntimeConfigRequest.DataprocConfig => x.asJson
+      case x: UpdateRuntimeConfigRequest.GceConfig      => x.asJson
+    }
+  }
+
+  implicit val updateRuntimeRequestEncoder: Encoder[UpdateRuntimeRequest] = Encoder.forProduct4(
+    "runtimeConfig",
+    "allowStop",
+    "autopause",
+    "autopauseThreshold"
+  )(x =>
+    (
+      x.updatedRuntimeConfig,
+      x.allowStop,
+      x.updateAutopauseEnabled,
+      x.updateAutopauseThreshold.map(_.toMinutes)
+    )
+  )
 }

--- a/http/src/main/resources/init-resources/gce-init.sh
+++ b/http/src/main/resources/init-resources/gce-init.sh
@@ -223,7 +223,7 @@ END
     service google-fluentd restart
 
     echo "" > /etc/google_application_credentials.env
-    
+
     # Install env var config
     if [ ! -z "$CUSTOM_ENV_VARS_CONFIG_URI" ] ; then
       log 'Copy custom env vars config...'
@@ -454,7 +454,7 @@ END
     # Do this asynchronously so it doesn't hold up cluster creation
     log 'Pruning docker images...'
     docker image prune -a -f &
-    
+
 # TODO (RT): I'm pretty sure this block is never used because we have a dedicated startup.sh script
 # used for starting runtimes. We could confirm this and remove this block.
 elif [[ "$RUNTIME_OPERATION" == 'restarting' ]]; then

--- a/http/src/main/resources/init-resources/startup.sh
+++ b/http/src/main/resources/init-resources/startup.sh
@@ -154,3 +154,7 @@ if [ "$WELDER_ENABLED" == "true" ] ; then
     echo "Starting Welder on cluster $GOOGLE_PROJECT / $CLUSTER_NAME..."
     docker exec -d $WELDER_SERVER_NAME /bin/bash -c "export STAGING_BUCKET=$STAGING_BUCKET && /opt/docker/bin/entrypoint.sh"
 fi
+
+# Resize persistent disk if needed.
+echo "Resizing persistent disk attached to runtime $GOOGLE_PROJECT / $CLUSTER_NAME if disk size changed..."
+resize2fs /dev/sdb

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/LeoLenses.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/LeoLenses.scala
@@ -6,7 +6,7 @@ import monocle.{Lens, Optional, Prism}
 import monocle.macros.GenLens
 import org.broadinstitute.dsde.workbench.leonardo.db.GetClusterKey
 import org.broadinstitute.dsde.workbench.leonardo.http.service.{CreateRuntimeResponse, ListRuntimeResponse}
-import org.broadinstitute.dsde.workbench.leonardo.monitor.RuntimeConfigInCreateRuntimeMessage
+import org.broadinstitute.dsde.workbench.leonardo.monitor.{DiskUpdate, RuntimeConfigInCreateRuntimeMessage}
 import org.broadinstitute.dsde.workbench.leonardo.http.dataprocInCreateRuntimeMsgToDataprocRuntime
 import org.broadinstitute.dsde.workbench.leonardo.http.dataprocRuntimeToDataprocInCreateRuntimeMsg
 
@@ -137,5 +137,10 @@ object LeoLenses {
   val dataprocPrism = Prism[RuntimeConfig, RuntimeConfig.DataprocConfig] {
     case x: RuntimeConfig.DataprocConfig => Some(x)
     case _                               => None
+  }(identity)
+
+  val pdSizeUpdatePrism = Prism[DiskUpdate, DiskUpdate.PdSizeUpdate] {
+    case x: DiskUpdate.PdSizeUpdate => Some(x)
+    case _                          => None
   }(identity)
 }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/RuntimeRoutes.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/RuntimeRoutes.scala
@@ -489,28 +489,6 @@ object RuntimeRoutes {
 
 }
 
-sealed trait UpdateRuntimeConfigRequest extends Product with Serializable {
-  def cloudService: CloudService
-}
-object UpdateRuntimeConfigRequest {
-  final case class GceConfig(updatedMachineType: Option[MachineTypeName], updatedDiskSize: Option[DiskSize])
-      extends UpdateRuntimeConfigRequest {
-    val cloudService: CloudService = CloudService.GCE
-  }
-  final case class DataprocConfig(updatedMasterMachineType: Option[MachineTypeName],
-                                  updatedMasterDiskSize: Option[DiskSize],
-                                  updatedNumberOfWorkers: Option[Int],
-                                  updatedNumberOfPreemptibleWorkers: Option[Int])
-      extends UpdateRuntimeConfigRequest {
-    val cloudService: CloudService = CloudService.Dataproc
-  }
-}
-
-final case class UpdateRuntimeRequest(updatedRuntimeConfig: Option[UpdateRuntimeConfigRequest],
-                                      allowStop: Boolean,
-                                      updateAutopauseEnabled: Option[Boolean],
-                                      updateAutopauseThreshold: Option[FiniteDuration])
-
 final case class ListRuntimeResponse2(id: Long,
                                       samResource: RuntimeSamResourceId,
                                       clusterName: RuntimeName,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/LeonardoServiceDbQueries.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/LeonardoServiceDbQueries.scala
@@ -31,7 +31,7 @@ object LeonardoServiceDbQueries {
     implicit ec: ExecutionContext
   ): DBIO[List[ListRuntimeResponse]] = {
     val clusterQueryFilteredByDeletion =
-      if (includeDeleted) clusterQuery else clusterQuery.filterNot(_.status === "Deleted")
+      if (includeDeleted) clusterQuery else clusterQuery.filterNot(_.status === (RuntimeStatus.Deleted: RuntimeStatus))
     val clusterQueryFilteredByProject = googleProjectOpt.fold(clusterQueryFilteredByDeletion)(p =>
       clusterQueryFilteredByDeletion.filter(_.googleProject === p)
     )
@@ -85,7 +85,7 @@ object LeonardoServiceDbQueries {
           ListRuntimeResponse(
             clusterRec.id,
             RuntimeSamResourceId(clusterRec.internalId),
-            clusterRec.clusterName,
+            clusterRec.runtimeName,
             clusterRec.googleProject,
             clusterRec.serviceAccountInfo,
             dataprocInfo,
@@ -94,10 +94,10 @@ object LeonardoServiceDbQueries {
             runTimeConfigRecOpt,
             Runtime.getProxyUrl(Config.proxyConfig.proxyUrlBase,
                                 clusterRec.googleProject,
-                                clusterRec.clusterName,
+                                clusterRec.runtimeName,
                                 Set.empty,
                                 lmp), //TODO: remove clusterImages field
-            RuntimeStatus.withName(clusterRec.status),
+            clusterRec.status,
             lmp,
             clusterRec.jupyterUserScriptUri,
             Set.empty, //TODO: remove instances from ListResponse

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/DiskServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/DiskServiceInterp.scala
@@ -276,6 +276,9 @@ case class DiskNotFoundException(googleProject: GoogleProject, diskName: DiskNam
     extends LeoException(s"${traceId} | Persistent disk ${googleProject.value}/${diskName.value} not found",
                          StatusCodes.NotFound)
 
+case class DiskNotFoundByIdException(diskId: DiskId, traceId: TraceId)
+    extends LeoException(s"${traceId} | Persistent disk ${diskId.value} not found", StatusCodes.NotFound)
+
 case class DiskCannotBeUpdatedException(projectNameString: String,
                                         status: DiskStatus,
                                         userHint: String = "",

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/RuntimeService.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/RuntimeService.scala
@@ -3,7 +3,7 @@ package http
 package service
 
 import cats.mtl.ApplicativeAsk
-import org.broadinstitute.dsde.workbench.leonardo.http.api.{ListRuntimeResponse2, UpdateRuntimeRequest}
+import org.broadinstitute.dsde.workbench.leonardo.http.api.ListRuntimeResponse2
 import org.broadinstitute.dsde.workbench.model.UserInfo
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/RuntimeTemplateValues.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/RuntimeTemplateValues.scala
@@ -82,17 +82,19 @@ case class RuntimeTemplateValuesConfig private (runtimeProjectAndName: RuntimePr
                                                 isGceFormatted: Boolean,
                                                 useGceStartupScript: Boolean)
 object RuntimeTemplateValuesConfig {
-  def fromCreateRuntimeParams(params: CreateRuntimeParams,
-                              initBucketName: Option[GcsBucketName],
-                              stagingBucketName: Option[GcsBucketName],
-                              serviceAccountKey: Option[ServiceAccountKey],
-                              imageConfig: ImageConfig,
-                              welderConfig: WelderConfig,
-                              proxyConfig: ProxyConfig,
-                              clusterFilesConfig: ClusterFilesConfig,
-                              clusterResourcesConfig: ClusterResourcesConfig,
-                              clusterResourceConstraints: Option[RuntimeResourceConstraints],
-                              isFormatted: Boolean): RuntimeTemplateValuesConfig =
+  def fromCreateRuntimeParams(
+    params: CreateRuntimeParams,
+    initBucketName: Option[GcsBucketName],
+    stagingBucketName: Option[GcsBucketName],
+    serviceAccountKey: Option[ServiceAccountKey],
+    imageConfig: ImageConfig,
+    welderConfig: WelderConfig,
+    proxyConfig: ProxyConfig,
+    clusterFilesConfig: ClusterFilesConfig,
+    clusterResourcesConfig: ClusterResourcesConfig,
+    clusterResourceConstraints: Option[RuntimeResourceConstraints],
+    isFormatted: Boolean
+  ): RuntimeTemplateValuesConfig =
     RuntimeTemplateValuesConfig(
       params.runtimeProjectAndName,
       stagingBucketName,

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/HttpRoutesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/HttpRoutesSpec.scala
@@ -451,48 +451,6 @@ class HttpRoutesSpec
 }
 
 object HttpRoutesSpec {
-  implicit val updateGceConfigRequestEncoder: Encoder[UpdateRuntimeConfigRequest.GceConfig] = Encoder.forProduct3(
-    "cloudService",
-    "machineType",
-    "diskSize"
-  )(x => (x.cloudService, x.updatedMachineType, x.updatedDiskSize))
-
-  implicit val updateDataprocConfigRequestEncoder: Encoder[UpdateRuntimeConfigRequest.DataprocConfig] =
-    Encoder.forProduct5(
-      "cloudService",
-      "masterMachineType",
-      "masterDiskSize",
-      "numberOfWorkers",
-      "numberOfPreemptibleWorkers"
-    )(x =>
-      (x.cloudService,
-       x.updatedMasterMachineType,
-       x.updatedMasterDiskSize,
-       x.updatedNumberOfWorkers,
-       x.updatedNumberOfPreemptibleWorkers)
-    )
-
-  implicit val updateRuntimeConfigRequestEncoder: Encoder[UpdateRuntimeConfigRequest] = Encoder.instance { x =>
-    x match {
-      case x: UpdateRuntimeConfigRequest.DataprocConfig => x.asJson
-      case x: UpdateRuntimeConfigRequest.GceConfig      => x.asJson
-    }
-  }
-
-  implicit val updateRuntimeRequestEncoder: Encoder[UpdateRuntimeRequest] = Encoder.forProduct4(
-    "runtimeConfig",
-    "allowStop",
-    "autopause",
-    "autopauseThreshold"
-  )(x =>
-    (
-      x.updatedRuntimeConfig,
-      x.allowStop,
-      x.updateAutopauseEnabled,
-      x.updateAutopauseThreshold.map(_.toMinutes)
-    )
-  )
-
   implicit val updateDiskRequestEncoder: Encoder[UpdateDiskRequest] = Encoder.forProduct2(
     "labels",
     "size"

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/AppComponentSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/AppComponentSpec.scala
@@ -4,7 +4,7 @@ import java.sql.SQLIntegrityConstraintViolationException
 
 import org.broadinstitute.dsde.workbench.leonardo.KubernetesTestData._
 import org.broadinstitute.dsde.workbench.leonardo.CommonTestData._
-import org.broadinstitute.dsde.workbench.leonardo.{AppName, AppStatus, DiskId, NodepoolLeoId}
+import org.broadinstitute.dsde.workbench.leonardo.{AppName, AppStatus, NodepoolLeoId}
 import org.broadinstitute.dsde.workbench.leonardo.TestUtils._
 
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -39,7 +39,7 @@ class AppComponentSpec extends AnyFlatSpecLike with TestComponent {
     val savedCluster1 = makeKubeCluster(1).save()
     val savedNodepool1 = makeNodepool(1, savedCluster1.id).save()
 
-    val disk = makePersistentDisk(DiskId(1)).save().unsafeRunSync()
+    val disk = makePersistentDisk(None).save().unsafeRunSync()
     val basicApp = makeApp(1, savedNodepool1.id)
     val complexApp = basicApp.copy(appResources =
       basicApp.appResources.copy(

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponentSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponentSpec.scala
@@ -321,7 +321,7 @@ class ClusterComponentSpec extends AnyFlatSpecLike with TestComponent with GcsPa
 
   it should "persist persistentDiskId foreign key" in isolatedDbTest {
     val res = for {
-      savedDisk <- makePersistentDisk(DiskId(1)).save()
+      savedDisk <- makePersistentDisk(None).save()
       savedRuntime <- IO(
         makeCluster(1).saveWithRuntimeConfig(
           RuntimeConfig.GceWithPdConfig(defaultMachineType, Some(savedDisk.id), bootDiskSize = DiskSize(50))

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/KubernetesServiceDbQueriesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/KubernetesServiceDbQueriesSpec.scala
@@ -84,7 +84,7 @@ class KubernetesServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent 
     val savedCluster1 = makeKubeCluster(1).save()
     val savedNodepool1 = makeNodepool(1, savedCluster1.id).save()
 
-    val disk = makePersistentDisk(DiskId(1)).save().unsafeRunSync()
+    val disk = makePersistentDisk(None).save().unsafeRunSync()
     val basicApp = makeApp(1, savedNodepool1.id)
     val complexApp = basicApp.copy(appResources =
       basicApp.appResources.copy(

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/LabelComponentSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/LabelComponentSpec.scala
@@ -64,7 +64,7 @@ class LabelComponentSpec extends AnyFlatSpecLike with TestComponent with GcsPath
   private def makeResource(index: Int, lblType: LabelResourceType): IO[Long] =
     lblType match {
       case LabelResourceType.Runtime        => IO(makeCluster(index).save()).map(_.id)
-      case LabelResourceType.PersistentDisk => makePersistentDisk(DiskId(index)).save().map(_.id.value)
+      case LabelResourceType.PersistentDisk => makePersistentDisk(None).save().map(_.id.value)
       case LabelResourceType.App =>
         for {
           clusterId <- IO(makeKubeCluster(index).save()).map(_.id)

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/RuntimeConfigQueriesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/RuntimeConfigQueriesSpec.scala
@@ -6,7 +6,7 @@ import java.util.concurrent.TimeUnit
 import org.broadinstitute.dsde.workbench.google2.MachineTypeName
 import org.broadinstitute.dsde.workbench.leonardo.CommonTestData.makePersistentDisk
 import org.broadinstitute.dsde.workbench.leonardo.http.dbioToIO
-import org.broadinstitute.dsde.workbench.leonardo.{DiskId, DiskSize, LeonardoTestSuite, RuntimeConfig}
+import org.broadinstitute.dsde.workbench.leonardo.{DiskSize, LeonardoTestSuite, RuntimeConfig}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import org.scalatest.flatspec.AnyFlatSpecLike
@@ -59,10 +59,9 @@ class RuntimeConfigQueriesSpec extends AnyFlatSpecLike with TestComponent with L
   }
 
   it should "save gceWithPdConfig properly" in isolatedDbTest {
-    val persistentDiskId = DiskId(1)
     val res = for {
       now <- testTimer.clock.realTime(TimeUnit.MILLISECONDS)
-      savedDisk <- makePersistentDisk(persistentDiskId).save()
+      savedDisk <- makePersistentDisk(None).save()
       runtimeConfig = RuntimeConfig.GceWithPdConfig(
         MachineTypeName("n1-standard-4"),
         Some(savedDisk.id),

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubCodecSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubCodecSpec.scala
@@ -2,7 +2,7 @@ package org.broadinstitute.dsde.workbench.leonardo.monitor
 
 import java.time.Instant
 
-import org.broadinstitute.dsde.workbench.google2.MachineTypeName
+import org.broadinstitute.dsde.workbench.google2.{DiskName, MachineTypeName}
 import org.broadinstitute.dsde.workbench.leonardo.{AuditInfo, DiskId, DiskSize, RuntimeName, RuntimeProjectAndName}
 import org.broadinstitute.dsde.workbench.leonardo.monitor.LeoPubsubMessage.CreateRuntimeMessage
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
@@ -69,5 +69,19 @@ class LeoPubsubCodecSpec extends AnyFlatSpec with Matchers {
     val res = decode[CreateRuntimeMessage](originalMessage.asJson.printWith(Printer.noSpaces))
 
     res shouldBe Right(originalMessage)
+  }
+
+  it should "encode/decode DiskUpdate.PdSizeUpdate properly" in {
+    val diskUpdate = DiskUpdate.PdSizeUpdate(DiskId(1), DiskName("name"), DiskSize(10))
+    val res = decode[DiskUpdate](diskUpdate.asJson.printWith(Printer.noSpaces))
+
+    res shouldBe Right(diskUpdate)
+  }
+
+  it should "encode/decode DiskUpdate.NoPdSizeUpdate properly" in {
+    val diskUpdate = DiskUpdate.NoPdSizeUpdate(DiskSize(10))
+    val res = decode[DiskUpdate](diskUpdate.asJson.printWith(Printer.noSpaces))
+
+    res shouldBe Right(diskUpdate)
   }
 }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/DiskServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/DiskServiceInterpSpec.scala
@@ -94,7 +94,7 @@ class DiskServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with Test
 
     val res = for {
       samResource <- IO(PersistentDiskSamResourceId(UUID.randomUUID.toString))
-      disk <- makePersistentDisk(DiskId(1)).copy(samResource = samResource).save()
+      disk <- makePersistentDisk(None).copy(samResource = samResource).save()
       _ <- labelQuery.save(disk.id.value, LabelResourceType.PersistentDisk, "label1", "value1").transaction
       _ <- labelQuery.save(disk.id.value, LabelResourceType.PersistentDisk, "label2", "value2").transaction
       labelResp <- labelQuery.getAllForResource(disk.id.value, LabelResourceType.PersistentDisk).transaction
@@ -110,8 +110,8 @@ class DiskServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with Test
     val userInfo = UserInfo(OAuth2BearerToken(""), WorkbenchUserId("userId"), WorkbenchEmail("user1@example.com"), 0) // this email is white listed
 
     val res = for {
-      disk1 <- makePersistentDisk(DiskId(1)).save()
-      disk2 <- makePersistentDisk(DiskId(2)).save()
+      disk1 <- makePersistentDisk(Some(DiskName("d1"))).save()
+      disk2 <- makePersistentDisk(Some(DiskName("d2"))).save()
       listResponse <- diskService.listDisks(userInfo, None, Map.empty)
     } yield {
       listResponse.map(_.id).toSet shouldBe Set(disk1.id, disk2.id)
@@ -124,9 +124,9 @@ class DiskServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with Test
     val userInfo = UserInfo(OAuth2BearerToken(""), WorkbenchUserId("userId"), WorkbenchEmail("user1@example.com"), 0) // this email is white listed
 
     val res = for {
-      disk1 <- makePersistentDisk(DiskId(1)).save()
-      disk2 <- makePersistentDisk(DiskId(2)).save()
-      _ <- makePersistentDisk(DiskId(3)).copy(googleProject = project2).save()
+      disk1 <- makePersistentDisk(Some(DiskName("d1"))).save()
+      disk2 <- makePersistentDisk(Some(DiskName("d2"))).save()
+      _ <- makePersistentDisk(None).copy(googleProject = project2).save()
       listResponse <- diskService.listDisks(userInfo, Some(project), Map.empty)
     } yield {
       listResponse.map(_.id).toSet shouldBe Set(disk1.id, disk2.id)
@@ -139,8 +139,8 @@ class DiskServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with Test
     val userInfo = UserInfo(OAuth2BearerToken(""), WorkbenchUserId("userId"), WorkbenchEmail("user1@example.com"), 0) // this email is white listed
 
     val res = for {
-      disk1 <- makePersistentDisk(DiskId(1)).save()
-      _ <- makePersistentDisk(DiskId(2)).save()
+      disk1 <- makePersistentDisk(Some(DiskName("d1"))).save()
+      _ <- makePersistentDisk(Some(DiskName("d2"))).save()
       _ <- labelQuery.save(disk1.id.value, LabelResourceType.PersistentDisk, "foo", "bar").transaction
       listResponse <- diskService.listDisks(userInfo, None, Map("foo" -> "bar"))
     } yield {
@@ -156,7 +156,7 @@ class DiskServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with Test
     val res = for {
       context <- ctx.ask
       diskSamResource <- IO(PersistentDiskSamResourceId(UUID.randomUUID.toString))
-      disk <- makePersistentDisk(DiskId(1)).copy(samResource = diskSamResource).save()
+      disk <- makePersistentDisk(None).copy(samResource = diskSamResource).save()
 
       _ <- diskService.deleteDisk(userInfo, disk.googleProject, disk.name)
       dbDiskOpt <- persistentDiskQuery
@@ -179,7 +179,7 @@ class DiskServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with Test
     val res = for {
       t <- ctx.ask
       diskSamResource <- IO(PersistentDiskSamResourceId(UUID.randomUUID.toString))
-      disk <- makePersistentDisk(DiskId(1)).copy(samResource = diskSamResource).save()
+      disk <- makePersistentDisk(None).copy(samResource = diskSamResource).save()
       _ <- IO(
         makeCluster(1).saveWithRuntimeConfig(
           RuntimeConfig.GceWithPdConfig(MachineTypeName("n1-standard-4"), Some(disk.id), bootDiskSize = DiskSize(50))
@@ -200,7 +200,7 @@ class DiskServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with Test
         val res = for {
           t <- ctx.ask
           diskSamResource <- IO(PersistentDiskSamResourceId(UUID.randomUUID.toString))
-          disk <- makePersistentDisk(DiskId(1)).copy(samResource = diskSamResource, status = status).save()
+          disk <- makePersistentDisk(None).copy(samResource = diskSamResource, status = status).save()
           req = UpdateDiskRequest(Map.empty, DiskSize(600))
           fail <- diskService
             .updateDisk(userInfo, disk.googleProject, disk.name, req)
@@ -218,7 +218,7 @@ class DiskServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with Test
     val res = for {
       context <- ctx.ask
       diskSamResource <- IO(PersistentDiskSamResourceId(UUID.randomUUID.toString))
-      disk <- makePersistentDisk(DiskId(1)).copy(samResource = diskSamResource).save()
+      disk <- makePersistentDisk(None).copy(samResource = diskSamResource).save()
       req = UpdateDiskRequest(Map.empty, DiskSize(600))
       _ <- diskService.updateDisk(userInfo, disk.googleProject, disk.name, req)
       message <- publisherQueue.dequeue1

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/KubernetesServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/KubernetesServiceInterpSpec.scala
@@ -20,7 +20,6 @@ import org.broadinstitute.dsde.workbench.leonardo.{
   AppStatus,
   AppType,
   CreateCluster,
-  DiskId,
   KubernetesClusterStatus,
   LabelMap,
   LeonardoTestSuite,
@@ -126,7 +125,7 @@ class KubernetesServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite wit
   }
 
   it should "create an app with an existing disk" in isolatedDbTest {
-    val disk = makePersistentDisk(DiskId(1)).copy(googleProject = project).save().unsafeRunSync()
+    val disk = makePersistentDisk(None).copy(googleProject = project).save().unsafeRunSync()
 
     val appName = AppName("app1")
     val createDiskConfig = PersistentDiskRequest(disk.name, None, None, Map.empty)
@@ -158,8 +157,7 @@ class KubernetesServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite wit
   }
 
   it should "error on creation if a disk is attached to another app" in isolatedDbTest {
-    val id = DiskId(1)
-    val disk = makePersistentDisk(id).copy(googleProject = project).save().unsafeRunSync()
+    val disk = makePersistentDisk(None).copy(googleProject = project).save().unsafeRunSync()
     val appName1 = AppName("app1")
     val appName2 = AppName("app2")
 

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/MockRuntimeServiceInterp.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/MockRuntimeServiceInterp.scala
@@ -3,8 +3,8 @@ package service
 
 import cats.effect.IO
 import cats.mtl.ApplicativeAsk
-import org.broadinstitute.dsde.workbench.leonardo.http.CreateRuntime2Request
-import org.broadinstitute.dsde.workbench.leonardo.http.api.{ListRuntimeResponse2, UpdateRuntimeRequest}
+import org.broadinstitute.dsde.workbench.leonardo.http.{CreateRuntime2Request, UpdateRuntimeRequest}
+import org.broadinstitute.dsde.workbench.leonardo.http.api.ListRuntimeResponse2
 import org.broadinstitute.dsde.workbench.leonardo.http.service.{
   DeleteRuntimeRequest,
   GetRuntimeResponse,


### PR DESCRIPTION
1. Fix a bug in existing update disk size where we're updating boot disk size
2. Fix a bug where update disk size doesn't work because runtime is not restarted.
3. Add automation tests to validate update disk size works for gce, gce with pd, dataproc

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
