### PR TITLE
[no ticket] Disable a few more

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoSuite.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoSuite.scala
@@ -104,10 +104,10 @@ final class LeonardoSuite
       new ClusterAutopauseSpec,
       new RuntimeAutopauseSpec,
       new RuntimePatchSpec,
-      new RuntimeStatusTransitionsSpec,
+      new RuntimeStatusTransitionsSpec
 //      new NotebookGCEClusterMonitoringSpec,
 //      new NotebookGCECustomizationSpec,
-      new NotebookGCEDataSyncingSpec
+//      new NotebookGCEDataSyncingSpec
     )
     with TestSuite
     with GPAllocBeforeAndAfterAll
@@ -115,9 +115,9 @@ final class LeonardoSuite
 
 final class LeonardoTerraDockerSuite
     extends Suites(
-      new NotebookAouSpec,
+//      new NotebookAouSpec,
       new NotebookBioconductorKernelSpec,
-      new NotebookGATKSpec,
+//      new NotebookGATKSpec,
       new NotebookHailSpec,
       new NotebookPyKernelSpec,
       new NotebookRKernelSpec,


### PR DESCRIPTION
Disable a few more tests until things are more stable.

Aou is not using new image yet, so it's probably okay to disable for now. We're not actively working on welder, hence disabling datasyncing as well...

These 2 specs cause fail sporadically

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
