### PR TITLE
IA-1953 QA-1197 Enable all tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ jdk:
 language: scala
 
 scala:
-  - 2.12.10
+  - 2.12.11
 
 sudo: required
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8
+FROM oracle/graalvm-ce:20.0.0-java8
 
 EXPOSE 8080
 EXPOSE 5050

--- a/Dockerfile-tests
+++ b/Dockerfile-tests
@@ -1,4 +1,4 @@
-FROM bigtruedata/sbt
+FROM hseeberger/scala-sbt:graalvm-ce-20.0.0-java8_1.3.13_2.12.11
 
 # This is only to make `sbt` work because `Version.scala` depends on `git` if this environment is not set
 ENV GIT_HASH="0.0.1"

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/ClusterFixtureSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/ClusterFixtureSpec.scala
@@ -6,14 +6,19 @@ import org.broadinstitute.dsde.workbench.auth.AuthToken
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.broadinstitute.dsde.workbench.leonardo.GPAllocFixtureSpec._
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
-import org.scalatest.{fixture, BeforeAndAfterAll, Outcome, Retries}
+import org.scalatest.{BeforeAndAfterAll, Outcome, Retries}
 import cats.implicits._
 import org.broadinstitute.dsde.workbench.google2.MachineTypeName
+import org.scalatest.freespec.FixtureAnyFreeSpec
 
 /**
  * trait BeforeAndAfterAll - One cluster per Scalatest Spec.
  */
-abstract class ClusterFixtureSpec extends fixture.FreeSpec with BeforeAndAfterAll with LeonardoTestUtils with Retries {
+abstract class ClusterFixtureSpec
+    extends FixtureAnyFreeSpec
+    with BeforeAndAfterAll
+    with LeonardoTestUtils
+    with Retries {
 
   implicit val ronToken: AuthToken = ronAuthToken
 

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeoPubsubSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeoPubsubSpec.scala
@@ -4,10 +4,11 @@ import cats.effect.IO
 import fs2.concurrent.InspectableQueue
 import org.broadinstitute.dsde.workbench.google2.GooglePublisher
 import org.scalatest.time.{Minutes, Span}
-import org.scalatest.{DoNotDiscover, FlatSpec}
+import org.scalatest.DoNotDiscover
+import org.scalatest.flatspec.AnyFlatSpec
 
 @DoNotDiscover
-class LeoPubsubSpec extends FlatSpec with LeonardoTestUtils {
+class LeoPubsubSpec extends AnyFlatSpec with LeonardoTestUtils {
 
   "Google publisher" should "be able to auth" in {
     logger.info(s"publisher config is: ${LeonardoConfig.Leonardo.publisherConfig}")

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoSuite.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoSuite.scala
@@ -107,7 +107,7 @@ final class LeonardoSuite
       new RuntimePatchSpec,
       new RuntimeStatusTransitionsSpec,
 //      new NotebookGCEClusterMonitoringSpec,
-      new NotebookGCECustomizationSpec,
+//      new NotebookGCECustomizationSpec,
       new NotebookGCEDataSyncingSpec
     )
     with TestSuite

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoSuite.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoSuite.scala
@@ -98,7 +98,7 @@ final class LeonardoSuite
       new RuntimeCreationDiskSpec,
       new ClusterStatusTransitionsSpec,
       new LabSpec,
-      new NotebookClusterMonitoringSpec,
+//      new NotebookClusterMonitoringSpec,
       new NotebookCustomizationSpec,
       new NotebookDataSyncingSpec,
       new LeoPubsubSpec,
@@ -106,7 +106,7 @@ final class LeonardoSuite
       new RuntimeAutopauseSpec,
       new RuntimePatchSpec,
       new RuntimeStatusTransitionsSpec,
-      new NotebookGCEClusterMonitoringSpec,
+//      new NotebookGCEClusterMonitoringSpec,
       new NotebookGCECustomizationSpec,
       new NotebookGCEDataSyncingSpec
     )

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoSuite.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoSuite.scala
@@ -16,8 +16,9 @@ import org.broadinstitute.dsde.workbench.leonardo.runtimes.{
   RuntimePatchSpec,
   RuntimeStatusTransitionsSpec
 }
+import org.scalatest.freespec.FixtureAnyFreeSpecLike
 
-trait GPAllocFixtureSpec extends fixture.FreeSpecLike with Retries {
+trait GPAllocFixtureSpec extends FixtureAnyFreeSpecLike with Retries {
   override type FixtureParam = GoogleProject
   override def withFixture(test: OneArgTest): Outcome = {
     def runTestAndCheckOutcome(project: GoogleProject) = {
@@ -97,17 +98,17 @@ final class LeonardoSuite
       new RuntimeCreationDiskSpec,
       new ClusterStatusTransitionsSpec,
       new LabSpec,
-//      new NotebookClusterMonitoringSpec,
-//      new NotebookCustomizationSpec,
-//      new NotebookDataSyncingSpec,
+      new NotebookClusterMonitoringSpec,
+      new NotebookCustomizationSpec,
+      new NotebookDataSyncingSpec,
       new LeoPubsubSpec,
       new ClusterAutopauseSpec,
       new RuntimeAutopauseSpec,
       new RuntimePatchSpec,
-      new RuntimeStatusTransitionsSpec
-//      new NotebookGCEClusterMonitoringSpec,
-//      new NotebookGCECustomizationSpec,
-//      new NotebookGCEDataSyncingSpec
+      new RuntimeStatusTransitionsSpec,
+      new NotebookGCEClusterMonitoringSpec,
+      new NotebookGCECustomizationSpec,
+      new NotebookGCEDataSyncingSpec
     )
     with TestSuite
     with GPAllocBeforeAndAfterAll
@@ -115,9 +116,9 @@ final class LeonardoSuite
 
 final class LeonardoTerraDockerSuite
     extends Suites(
-//      new NotebookAouSpec,
+      new NotebookAouSpec,
       new NotebookBioconductorKernelSpec,
-//      new NotebookGATKSpec,
+      new NotebookGATKSpec,
       new NotebookHailSpec,
       new NotebookPyKernelSpec,
       new NotebookRKernelSpec,

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
@@ -514,7 +514,7 @@ trait LeonardoTestUtils
 
       caught.message should include("\"statusCode\":422")
       caught.message should include(
-        s"""Runtime ${googleProject.value}/${clusterName.asString} is stopped. Start your runtime before proceeding."""
+        s"""Proxy host ${googleProject.value}/${clusterName.asString} is stopped. Start your runtime before proceeding."""
       )
     }
   }
@@ -544,7 +544,7 @@ trait LeonardoTestUtils
 
       caught.message should include("\"statusCode\":422")
       caught.message should include(
-        s"""Runtime ${googleProject.value}/${runtimeName.asString} is stopped. Start your runtime before proceeding."""
+        s"""Proxy host ${googleProject.value}/${runtimeName.asString} is stopped. Start your runtime before proceeding."""
       )
     }
   }

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/RuntimeFixtureSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/RuntimeFixtureSpec.scala
@@ -4,7 +4,7 @@ import cats.implicits._
 import org.broadinstitute.dsde.workbench.auth.AuthToken
 import org.broadinstitute.dsde.workbench.leonardo.GPAllocFixtureSpec._
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
-import org.scalatest.{fixture, BeforeAndAfterAll, Outcome, Retries}
+import org.scalatest.{BeforeAndAfterAll, Outcome, Retries}
 import RuntimeFixtureSpec._
 import cats.effect.IO
 import org.broadinstitute.dsde.workbench.google2.MachineTypeName
@@ -12,11 +12,16 @@ import org.broadinstitute.dsde.workbench.leonardo.http.{CreateRuntime2Request, R
 import org.http4s.{AuthScheme, Credentials}
 import org.http4s.client.Client
 import org.http4s.headers.Authorization
+import org.scalatest.freespec.FixtureAnyFreeSpec
 
 /**
  * trait BeforeAndAfterAll - One cluster per Scalatest Spec.
  */
-abstract class RuntimeFixtureSpec extends fixture.FreeSpec with BeforeAndAfterAll with LeonardoTestUtils with Retries {
+abstract class RuntimeFixtureSpec
+    extends FixtureAnyFreeSpec
+    with BeforeAndAfterAll
+    with LeonardoTestUtils
+    with Retries {
 
   implicit val ronToken: AuthToken = ronAuthToken
 

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookBioconductorKernelSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookBioconductorKernelSpec.scala
@@ -30,34 +30,17 @@ import scala.concurrent.duration._
 class NotebookBioconductorKernelSpec extends RuntimeFixtureSpec with NotebookTestUtils {
   override val toolDockerImage: Option[String] = Some(LeonardoConfig.Leonardo.bioconductorImageUrl)
   "NotebookBioconductorKernelSpec" - {
-
-//    "should use Bioconductor version 3.10" in { runtimeFixture =>
-//      withWebDriver { implicit driver =>
-//        withNewNotebook(runtimeFixture.runtime, RKernel) { notebookPage =>
-//          // Make sure BiocManager has the correct version of Bioconductor
-//          notebookPage.executeCell("""BiocManager::version() == "3.10"""")
-//        }
-//      }
-//    }
-
-    "should create a notebook with a working R kernel and install package rsbml" ignore { runtimeFixture =>
+    "should create a notebook with a working R kernel and install package rsbml, RCurl" ignore { runtimeFixture =>
       withWebDriver { implicit driver =>
         withNewNotebook(runtimeFixture.runtime, RKernel) { notebookPage =>
+//          notebookPage.executeCell("""BiocManager::version() == "3.10"""")
+
           // Make sure unicode characters display correctly
           notebookPage.executeCell("""BiocManager::install("rsbml")""")
           notebookPage.executeCell("library(rsbml)")
 
-        }
-      }
-    }
-
-    "should create a notebook with a working R kernel and install package RCurl" ignore { runtimeFixture =>
-      withWebDriver { implicit driver =>
-        withNewNotebook(runtimeFixture.runtime, RKernel) { notebookPage =>
-          // Make sure unicode characters display correctly
           notebookPage.executeCell("""BiocManager::install("RCurl")""")
           notebookPage.executeCell("library(RCurl)")
-
         }
       }
     }
@@ -80,36 +63,16 @@ class NotebookBioconductorKernelSpec extends RuntimeFixtureSpec with NotebookTes
       }
     }
 
-    "should have GenomicFeatures automatically installed" in { runtimeFixture =>
-      withWebDriver { implicit driver =>
-        withNewNotebook(runtimeFixture.runtime, RKernel) { notebookPage =>
-          notebookPage.executeCell(""""GenomicFeatures" %in% installed.packages()""") shouldBe Some("TRUE")
+    "should have GenomicFeatures, SingleCellExperiment, GenomicAlignments, ShortRead automatically installed" in {
+      runtimeFixture =>
+        withWebDriver { implicit driver =>
+          withNewNotebook(runtimeFixture.runtime, RKernel) { notebookPage =>
+            notebookPage.executeCell(""""GenomicFeatures" %in% installed.packages()""") shouldBe Some("TRUE")
+            notebookPage.executeCell(""""SingleCellExperiment" %in% installed.packages()""") shouldBe Some("TRUE")
+            notebookPage.executeCell(""""GenomicAlignments" %in% installed.packages()""") shouldBe Some("TRUE")
+            notebookPage.executeCell(""""ShortRead" %in% installed.packages()""") shouldBe Some("TRUE")
+          }
         }
-      }
-    }
-
-    "should have SingleCellExperiment automatically installed" in { runtimeFixture =>
-      withWebDriver { implicit driver =>
-        withNewNotebook(runtimeFixture.runtime, RKernel) { notebookPage =>
-          notebookPage.executeCell(""""SingleCellExperiment" %in% installed.packages()""") shouldBe Some("TRUE")
-        }
-      }
-    }
-
-    "should have GenomicAlignments automatically installed" in { runtimeFixture =>
-      withWebDriver { implicit driver =>
-        withNewNotebook(runtimeFixture.runtime, RKernel) { notebookPage =>
-          notebookPage.executeCell(""""GenomicAlignments" %in% installed.packages()""") shouldBe Some("TRUE")
-        }
-      }
-    }
-
-    "should have ShortRead automatically installed" in { runtimeFixture =>
-      withWebDriver { implicit driver =>
-        withNewNotebook(runtimeFixture.runtime, RKernel) { notebookPage =>
-          notebookPage.executeCell(""""ShortRead" %in% installed.packages()""") shouldBe Some("TRUE")
-        }
-      }
     }
 
     // TODO: this is fixed in the new bioc (R 4.0) image
@@ -121,132 +84,59 @@ class NotebookBioconductorKernelSpec extends RuntimeFixtureSpec with NotebookTes
       }
     }
 
-    "should be able to install packages that depend on libXML" in { runtimeFixture =>
+    "should be able to install packages that depend on libXML, graphviz" in { runtimeFixture =>
       withWebDriver { implicit driver =>
         withNewNotebook(runtimeFixture.runtime, RKernel) { notebookPage =>
           val installTimeout = 5.minutes
 
-          val installOutput = notebookPage.executeCell("""BiocManager::install('XML')""", installTimeout)
+          notebookPage.executeCell("""BiocManager::install('XML')""", installTimeout)
           notebookPage.executeCell("library(XML)")
 
-        }
-      }
-    }
-
-    "should be able to install packages that depend on graphviz" in { runtimeFixture =>
-      withWebDriver { implicit driver =>
-        withNewNotebook(runtimeFixture.runtime, RKernel) { notebookPage =>
-          val installTimeout = 5.minutes
-
-          val installOutput = notebookPage.executeCell("""BiocManager::install('Rgraphviz')""", installTimeout)
+          notebookPage.executeCell("""BiocManager::install('Rgraphviz')""", installTimeout)
           notebookPage.executeCell("library('Rgraphviz')")
         }
       }
     }
 
-    "should be able to install packages that depend on scikit-learn python package" in { runtimeFixture =>
-      withWebDriver { implicit driver =>
-        withNewNotebook(runtimeFixture.runtime, RKernel) { notebookPage =>
-          val installTimeout = 5.minutes
+    "should be able to install packages that depend on scikit-learn, hdf5, openbabel, gsl, magick++, database package" in {
+      runtimeFixture =>
+        withWebDriver { implicit driver =>
+          withNewNotebook(runtimeFixture.runtime, RKernel) { notebookPage =>
+            val installTimeout = 20 minutes
 
-          val installOutput = notebookPage.executeCell("""BiocManager::install('BiocSklearn')""", installTimeout)
-          notebookPage.executeCell("library('BiocSklearn')")
+            notebookPage.executeCell("""BiocManager::install('BiocSklearn')""", installTimeout)
+            notebookPage.executeCell("library('BiocSklearn')")
 
-        }
-      }
-    }
+            notebookPage.executeCell("""BiocManager::install('rhdf5')""", installTimeout)
+            notebookPage.executeCell("library(rhdf5)")
 
-    "should be able to install packages that depend on hdf5" in { runtimeFixture =>
-      withWebDriver { implicit driver =>
-        withNewNotebook(runtimeFixture.runtime, RKernel) { notebookPage =>
-          val installTimeout = 5.minutes
+            notebookPage.executeCell("""BiocManager::install('ChemmineOB')""", installTimeout)
+            notebookPage.executeCell("library(ChemmineOB)")
 
-          val installOutput = notebookPage.executeCell("""BiocManager::install('rhdf5')""", installTimeout)
-          notebookPage.executeCell("library(rhdf5)")
+            notebookPage.executeCell("""BiocManager::install('EBImage')""", installTimeout)
+            notebookPage.executeCell("library(EBImage)")
 
-        }
-      }
-    }
+            notebookPage.executeCell("""BiocManager::install('RMySQL')""", installTimeout)
+            notebookPage.executeCell("library(RMySQL)")
 
-    "should be able to install packages that depend on openbabel" in { runtimeFixture =>
-      withWebDriver { implicit driver =>
-        withNewNotebook(runtimeFixture.runtime, RKernel) { notebookPage =>
-          val installTimeout = 5.minutes
-
-          val installOutput = notebookPage.executeCell("""BiocManager::install('ChemmineOB')""", installTimeout)
-          notebookPage.executeCell("library(ChemmineOB)")
-
-        }
-      }
-    }
-
-    "should be able to install packages that depend on gsl" in { runtimeFixture =>
-      withWebDriver { implicit driver =>
-        withNewNotebook(runtimeFixture.runtime, RKernel) { notebookPage =>
-          val installTimeout = 5.minutes
-
-          val installOutput =
             notebookPage.executeCell("""BiocManager::install('DirichletMultinomial')""", installTimeout)
-          notebookPage.executeCell("library(DirichletMultinomial)")
-
+            notebookPage.executeCell("library(DirichletMultinomial)")
+          }
         }
-      }
     }
 
-    "should be able to install packages that depend on magick++" in { runtimeFixture =>
+    "should be able to install packages that depend on jags, protobuf, Cairo and gtk" in { runtimeFixture =>
       withWebDriver { implicit driver =>
         withNewNotebook(runtimeFixture.runtime, RKernel) { notebookPage =>
-          val installTimeout = 5.minutes
+          val installTimeout = 15 minutes
 
-          val installOutput = notebookPage.executeCell("""BiocManager::install('EBImage')""", installTimeout)
-          notebookPage.executeCell("library(EBImage)")
-
-        }
-      }
-    }
-
-    "should be able to install packages that depend on database packages" in { runtimeFixture =>
-      withWebDriver { implicit driver =>
-        withNewNotebook(runtimeFixture.runtime, RKernel) { notebookPage =>
-          val installTimeout = 5.minutes
-
-          val installOutput = notebookPage.executeCell("""BiocManager::install('RMySQL')""", installTimeout)
-          notebookPage.executeCell("library(RMySQL)")
-
-        }
-      }
-    }
-
-    "should be able to install packages that depend on jags" in { runtimeFixture =>
-      withWebDriver { implicit driver =>
-        withNewNotebook(runtimeFixture.runtime, RKernel) { notebookPage =>
-          val installTimeout = 5.minutes
-
-          val installOutput = notebookPage.executeCell("""BiocManager::install('rjags')""", installTimeout)
+          notebookPage.executeCell("""BiocManager::install('rjags')""", installTimeout)
           notebookPage.executeCell("library('rjags')")
 
-        }
-      }
-    }
-
-    "should be able to install packages that depend on protobuf" in { runtimeFixture =>
-      withWebDriver { implicit driver =>
-        withNewNotebook(runtimeFixture.runtime, RKernel) { notebookPage =>
-          val installTimeout = 5.minutes
-
-          val installOutput = notebookPage.executeCell("""BiocManager::install('protolite')""", installTimeout)
+          notebookPage.executeCell("""BiocManager::install('protolite')""", installTimeout)
           notebookPage.executeCell("library(protolite)")
 
-        }
-      }
-    }
-
-    "should be able to install packages that depend on Cairo and gtk" in { runtimeFixture =>
-      withWebDriver { implicit driver =>
-        withNewNotebook(runtimeFixture.runtime, RKernel) { notebookPage =>
-          val installTimeout = 5.minutes
-
-          val installOutput = notebookPage.executeCell("""BiocManager::install('RGtk2')""", installTimeout)
+          notebookPage.executeCell("""BiocManager::install('RGtk2')""", installTimeout)
           notebookPage.executeCell("library(RGtk2)")
           // new packages should install to directory where PD is mounted
           notebookPage.executeCell("find.package('RGtk2')").get should include("/home/jupyter-user/notebooks/packages")

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookCustomizationSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookCustomizationSpec.scala
@@ -182,6 +182,8 @@ final class NotebookCustomizationSpec extends GPAllocFixtureSpec with ParallelTe
                 // Start the cluster
                 startAndMonitor(cluster.googleProject, cluster.clusterName)
 
+                // To remediate errors like https://fc-jenkins.dsp-techops.broadinstitute.org/job/leonardo-fiab-test-runner/25553/artifact/failure_screenshots/NotebookCustomizationSpec_21-00-50-419.png
+                // We cache cluster's IP, so we might get old IP after restart
                 withNewNotebook(cluster, Python3) { notebookPage =>
                   notebookPage.executeCell("!cat $JUPYTER_HOME/leo_test_start_count.txt").get shouldBe "2"
                 }

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookPyKernelSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookPyKernelSpec.scala
@@ -143,69 +143,68 @@ class NotebookPyKernelSpec extends RuntimeFixtureSpec with NotebookTestUtils {
           val secondApiCall =
             Leonardo.cluster.getRuntime(runtimeFixture.runtime.googleProject, runtimeFixture.runtime.clusterName)
           firstApiCall.auditInfo.dateAccessed should be < secondApiCall.auditInfo.dateAccessed
-          Leonardo.cluster.stopRuntime(runtimeFixture.runtime.googleProject, runtimeFixture.runtime.clusterName)
         }
       }
     }
 
     //TODO: uncomment this
 
-//    Seq(Python3).foreach { kernel =>
-//      s"should preinstall google cloud subpackages for ${kernel.string}" in { runtimeFixture =>
-//        withWebDriver { implicit driver =>
-//          withNewNotebook(runtimeFixture.runtime, kernel) { notebookPage =>
-//            //all other packages cannot be tested for their versions in this manner
-//            //warnings are ignored because they are benign warnings that show up for python2 because of compilation against an older numpy
-//            notebookPage.executeCell(
-//              "import warnings; warnings.simplefilter('ignore')\nfrom google.cloud import bigquery\nprint(bigquery.__version__)"
-//            ) shouldBe Some("1.23.1")
-//            notebookPage.executeCell("from google.cloud import datastore\nprint(datastore.__version__)") shouldBe Some(
-//              "1.10.0"
-//            )
-//            notebookPage.executeCell("from google.cloud import storage\nprint(storage.__version__)") shouldBe Some(
-//              "1.23.0"
-//            )
-//          }
-//        }
-//      }
-//    }
-//
-//    // https://github.com/DataBiosphere/leonardo/issues/797
-//    s"should be able to import ggplot for ${Python3.toString}" in { runtimeFixture =>
-//      withWebDriver { implicit driver =>
-//        withNewNotebook(runtimeFixture.runtime, Python3) { notebookPage =>
-//          notebookPage.executeCell("from ggplot import *").get should not include ("ImportError")
-//          notebookPage.executeCell("ggplot") shouldBe Some("ggplot.ggplot.ggplot")
-//        }
-//      }
-//    }
-//
-//    s"should have the workspace-related environment variables set in ${Python3.toString} kernel" in { runtimeFixture =>
-//      withWebDriver { implicit driver =>
-//        withNewNotebookInSubfolder(runtimeFixture.runtime, Python3) { notebookPage =>
-//          notebookPage.executeCell("import os")
-//          notebookPage
-//            .executeCell("os.getenv('GOOGLE_PROJECT')")
-//            .get shouldBe s"'${runtimeFixture.runtime.googleProject.value}'"
-//          notebookPage
-//            .executeCell("os.getenv('WORKSPACE_NAMESPACE')")
-//            .get shouldBe s"'${runtimeFixture.runtime.googleProject.value}'"
-//          notebookPage.executeCell("os.getenv('WORKSPACE_NAME')").get shouldBe "'Untitled Folder'"
-//          notebookPage.executeCell("os.getenv('OWNER_EMAIL')").get shouldBe s"'${ronEmail}'"
-//          // workspace bucket is not wired up in tests
-//          notebookPage.executeCell("os.getenv('WORKSPACE_BUCKET')") shouldBe None
-//        }
-//      }
-//    }
-//
-//    // https://github.com/DataBiosphere/leonardo/issues/891
-//    "should be able to install python libraries with C bindings" in { runtimeFixture =>
-//      withWebDriver { implicit driver =>
-//        withNewNotebook(runtimeFixture.runtime, Python3) { notebookPage =>
-//          notebookPage.executeCell("! pip show Cython").get should include("Name: Cython")
-//          notebookPage.executeCell("! pip install POT").get should include("Successfully installed POT")
-//        }
-//      }
-//    }
+    Seq(Python3).foreach { kernel =>
+      s"should preinstall google cloud subpackages for ${kernel.string}" in { runtimeFixture =>
+        withWebDriver { implicit driver =>
+          withNewNotebook(runtimeFixture.runtime, kernel) { notebookPage =>
+            //all other packages cannot be tested for their versions in this manner
+            //warnings are ignored because they are benign warnings that show up for python2 because of compilation against an older numpy
+            notebookPage.executeCell(
+              "import warnings; warnings.simplefilter('ignore')\nfrom google.cloud import bigquery\nprint(bigquery.__version__)"
+            ) shouldBe Some("1.23.1")
+            notebookPage.executeCell("from google.cloud import datastore\nprint(datastore.__version__)") shouldBe Some(
+              "1.10.0"
+            )
+            notebookPage.executeCell("from google.cloud import storage\nprint(storage.__version__)") shouldBe Some(
+              "1.23.0"
+            )
+          }
+        }
+      }
+    }
+
+    // https://github.com/DataBiosphere/leonardo/issues/797
+    s"should be able to import ggplot for ${Python3.toString}" in { runtimeFixture =>
+      withWebDriver { implicit driver =>
+        withNewNotebook(runtimeFixture.runtime, Python3) { notebookPage =>
+          notebookPage.executeCell("from ggplot import *").get should not include ("ImportError")
+          notebookPage.executeCell("ggplot") shouldBe Some("ggplot.ggplot.ggplot")
+        }
+      }
+    }
+
+    s"should have the workspace-related environment variables set in ${Python3.toString} kernel" in { runtimeFixture =>
+      withWebDriver { implicit driver =>
+        withNewNotebookInSubfolder(runtimeFixture.runtime, Python3) { notebookPage =>
+          notebookPage.executeCell("import os")
+          notebookPage
+            .executeCell("os.getenv('GOOGLE_PROJECT')")
+            .get shouldBe s"'${runtimeFixture.runtime.googleProject.value}'"
+          notebookPage
+            .executeCell("os.getenv('WORKSPACE_NAMESPACE')")
+            .get shouldBe s"'${runtimeFixture.runtime.googleProject.value}'"
+          notebookPage.executeCell("os.getenv('WORKSPACE_NAME')").get shouldBe "'Untitled Folder'"
+          notebookPage.executeCell("os.getenv('OWNER_EMAIL')").get shouldBe s"'${ronEmail}'"
+          // workspace bucket is not wired up in tests
+          notebookPage.executeCell("os.getenv('WORKSPACE_BUCKET')") shouldBe None
+        }
+      }
+    }
+
+    // https://github.com/DataBiosphere/leonardo/issues/891
+    "should be able to install python libraries with C bindings" in { runtimeFixture =>
+      withWebDriver { implicit driver =>
+        withNewNotebook(runtimeFixture.runtime, Python3) { notebookPage =>
+          notebookPage.executeCell("! pip show Cython").get should include("Name: Cython")
+          notebookPage.executeCell("! pip install POT").get should include("Successfully installed POT")
+        }
+      }
+    }
   }
 }

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimePatchSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimePatchSpec.scala
@@ -13,13 +13,13 @@ import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.broadinstitute.dsde.workbench.service.util.Tags
 import org.http4s.headers.Authorization
 import org.http4s.{AuthScheme, Credentials}
-import org.scalatest.{fixture, DoNotDiscover, Outcome}
-
+import org.scalatest.{DoNotDiscover, Outcome}
+import org.scalatest.freespec.FixtureAnyFreeSpec
 import scala.concurrent.duration._
 
 // extending fixture.Freespec just so we can use `taggedAs`. Not really need fixture for anything
 @DoNotDiscover
-class RuntimePatchSpec extends fixture.FreeSpec with LeonardoTestUtils with LeonardoTestSuite {
+class RuntimePatchSpec extends FixtureAnyFreeSpec with LeonardoTestUtils with LeonardoTestSuite {
   implicit val ronToken: AuthToken = ronAuthToken
   implicit val auth: Authorization = Authorization(Credentials.Token(AuthScheme.Bearer, ronCreds.makeAuthToken().value))
 

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/page/CookieAuthedPage.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/page/CookieAuthedPage.scala
@@ -14,6 +14,7 @@ trait CookieAuthedPage[P <: Page] extends Page with PageUtil[P] with WebBrowserU
   // always use open() to access a CookieAuthedPage - `go to` will not set the cookie
   override def open(implicit webDriver: WebDriver): P = {
     go.to(this)
+
     addCookie("LeoToken", authToken.value)
     Try(super.open) match {
       case Success(page) => page

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -64,9 +64,6 @@ while [ "$1" != "" ]; do
         jar)
             MAKE_JAR=true
             ;;
-        -ui | --user-interface)
-            BUILD_UI=true
-            ;;
         -d | --docker)
             shift
             echo "docker command = $1"

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/CloudTraceSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/CloudTraceSpec.scala
@@ -9,11 +9,12 @@ import cats.effect.IO
 import io.opencensus.scala.akka.http.TracingDirective.traceRequestForService
 import org.broadinstitute.dsde.workbench.leonardo.http.serviceData
 import org.broadinstitute.dsde.workbench.openTelemetry.OpenTelemetryMetrics
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 // This test is useful if we try to manually test cloud tracing. But it's ignored in CI
 class CloudTraceSpec
-    extends FlatSpec
+    extends AnyFlatSpec
     with ScalatestRouteTest
     with RequestBuilding
     with Matchers

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/RuntimeRoutesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/RuntimeRoutesSpec.scala
@@ -5,9 +5,10 @@ package api
 import io.circe.parser.decode
 import org.broadinstitute.dsde.workbench.google2.{DiskName, MachineTypeName}
 import org.broadinstitute.dsde.workbench.leonardo.http.api.RuntimeRoutes._
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class RuntimeRoutesSpec extends FlatSpec with Matchers with LeonardoTestSuite {
+class RuntimeRoutesSpec extends AnyFlatSpec with Matchers with LeonardoTestSuite {
   it should "decode RuntimeConfigRequest.GceWithPdConfig correctly" in {
     val jsonString =
       """

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/config/ConfigSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/config/ConfigSpec.scala
@@ -7,11 +7,12 @@ import org.broadinstitute.dsde.workbench.leonardo.monitor.{
   PersistentDiskMonitorConfig
 }
 import org.broadinstitute.dsde.workbench.leonardo.{BlockSize, DiskSize, DiskType}
-import org.scalatest.{FlatSpec, Matchers}
 
 import scala.concurrent.duration._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class ConfigSpec extends FlatSpec with Matchers {
+class ConfigSpec extends AnyFlatSpec with Matchers {
   it should "read PersistentDiskConfig properly" in {
     val expectedResult = PersistentDiskConfig(
       DiskSize(30),

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/AppComponentSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/AppComponentSpec.scala
@@ -2,15 +2,15 @@ package org.broadinstitute.dsde.workbench.leonardo.db
 
 import java.sql.SQLIntegrityConstraintViolationException
 
-import org.scalatest.FlatSpecLike
 import org.broadinstitute.dsde.workbench.leonardo.KubernetesTestData._
 import org.broadinstitute.dsde.workbench.leonardo.CommonTestData._
 import org.broadinstitute.dsde.workbench.leonardo.{AppName, AppStatus, DiskId, NodepoolLeoId}
 import org.broadinstitute.dsde.workbench.leonardo.TestUtils._
 
 import scala.concurrent.ExecutionContext.Implicits.global
+import org.scalatest.flatspec.AnyFlatSpecLike
 
-class AppComponentSpec extends FlatSpecLike with TestComponent {
+class AppComponentSpec extends AnyFlatSpecLike with TestComponent {
 
   it should "save basic app" in isolatedDbTest {
     val savedCluster1 = makeKubeCluster(1).save()

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/KubernetesServiceDbQueriesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/KubernetesServiceDbQueriesSpec.scala
@@ -15,14 +15,14 @@ import org.broadinstitute.dsde.workbench.leonardo.db.{
   SaveKubernetesCluster,
   TestComponent
 }
-import org.scalatest.FlatSpecLike
 import CommonTestData._
 import KubernetesTestData._
 import TestUtils._
 
 import scala.concurrent.ExecutionContext.Implicits.global
+import org.scalatest.flatspec.AnyFlatSpecLike
 
-class KubernetesServiceDbQueriesSpec extends FlatSpecLike with TestComponent {
+class KubernetesServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent {
 
   it should "return None when there is no matching app" in isolatedDbTest {
     val cluster1 = makeKubeCluster(1).save()

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/ServiceComponentSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/ServiceComponentSpec.scala
@@ -1,12 +1,12 @@
 package org.broadinstitute.dsde.workbench.leonardo.db
 
-import org.scalatest.FlatSpecLike
 import org.broadinstitute.dsde.workbench.leonardo.KubernetesTestData._
 import org.broadinstitute.dsde.workbench.leonardo.TestUtils._
 
 import scala.concurrent.ExecutionContext.Implicits.global
+import org.scalatest.flatspec.AnyFlatSpecLike
 
-class ServiceComponentSpec extends FlatSpecLike with TestComponent {
+class ServiceComponentSpec extends AnyFlatSpecLike with TestComponent {
 
   it should "save a record" in isolatedDbTest {
     val savedCluster1 = makeKubeCluster(1).save()

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubCodecSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubCodecSpec.scala
@@ -13,13 +13,14 @@ import org.broadinstitute.dsde.workbench.leonardo.{
 import org.broadinstitute.dsde.workbench.leonardo.monitor.LeoPubsubMessage.CreateRuntimeMessage
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
-import org.scalatest.{FlatSpec, Matchers}
 import _root_.io.circe.syntax._
 import _root_.io.circe.parser.decode
 import LeoPubsubCodec._
 import io.circe.Printer
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class LeoPubsubCodecSpec extends FlatSpec with Matchers {
+class LeoPubsubCodecSpec extends AnyFlatSpec with Matchers {
   it should "encode/decode CreateRuntimeMessage properly" in {
     val now = Instant.now()
     val originalMessage = CreateRuntimeMessage(

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/KubernetesServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/KubernetesServiceInterpSpec.scala
@@ -37,11 +37,11 @@ import org.broadinstitute.dsde.workbench.leonardo.http.PersistentDiskRequest
 import org.broadinstitute.dsde.workbench.leonardo.monitor.LeoPubsubMessage.{CreateAppMessage, DeleteAppMessage}
 import org.broadinstitute.dsde.workbench.leonardo.monitor.{LeoPubsubMessage, LeoPubsubMessageType}
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
-import org.scalatest.FlatSpec
 
 import scala.concurrent.ExecutionContext.Implicits.global
+import org.scalatest.flatspec.AnyFlatSpec
 
-class KubernetesServiceInterpSpec extends FlatSpec with LeonardoTestSuite with TestComponent {
+class KubernetesServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with TestComponent {
 
   //used when we care about queue state
   def makeInterp(queue: InspectableQueue[IO, LeoPubsubMessage]) =

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,13 +10,13 @@ object Dependencies {
   val googleV = "1.23.0"
   val automationGoogleV = "1.30.5"
   val scalaLoggingV = "3.9.0"
-  val scalaTestV = "3.1.2"
+  val scalaTestV = "3.2.0"
   val slickV = "3.3.2"
   val http4sVersion = "0.21.0" //remove http4s related dependencies once workbench-libs are upgraded
   val guavaV = "28.2-jre"
   val monocleV = "2.0.0"
   val opencensusV = "0.26.0"
-  val serviceTestV = "0.18-d57f8a6"
+  val serviceTestV = "0.18-61887ce"
 
   val workbenchUtilV = "0.5-4c7acd5"
   val workbenchModelV = "0.13-31cacc4"
@@ -79,11 +79,10 @@ object Dependencies {
   val googleRpc: ModuleID =                 "io.grpc"         % "grpc-core"                       % "1.28.0" excludeAll (excludeGuava, excludeGson, excludeFindbugsJsr, excludeAutoValueAnnotation, excludeAutoValue)
   val googleOAuth2: ModuleID =              "com.google.auth" % "google-auth-library-oauth2-http" % "0.9.1" excludeAll (excludeGuava, excludeFindbugsJsr, excludeGoogleApiClient, excludeGoogleApiClientJackson2, excludeGoogleHttpClient, excludeHttpComponent)
 
-  val scalaTest: ModuleID = "org.scalatest" %% "scalatest"    % scalaTestV  % "test"
-  val mockito: ModuleID =   "org.mockito"   % "mockito-core"  % "3.2.4"    % "test"
-  val scalaTestScalaCheck = "org.scalatestplus" %% "scalatestplus-scalacheck" % "3.1.0.0-RC2" % Test //Since scalatest 3.1.0, scalacheck support is moved to `scalatestplus`
-  val scalaTestMockito = "org.scalatestplus" %% "scalatestplus-mockito" % "1.0.0-M2" % Test //Since scalatest 3.1.0, mockito support is moved to `scalatestplus`
-  val scalaTestSelenium =  "org.scalatestplus" %% "scalatestplus-selenium" % "1.0.0-M2" % Test //Since scalatest 3.1.0, selenium support is moved to `scalatestplus`
+  val scalaTest: ModuleID = "org.scalatest"                 %% "scalatest"     % scalaTestV  % "test"
+  val scalaTestScalaCheck = "org.scalatestplus" %% "scalacheck-1-14" % "3.2.0.0" % Test // https://github.com/scalatest/scalatestplus-scalacheck
+  val scalaTestMockito = "org.scalatestplus" %% "mockito-3-3" % "3.2.0.0" % Test // https://github.com/scalatest/scalatestplus-selenium
+  val scalaTestSelenium =  "org.scalatestplus" %% "selenium-3-141" % "3.2.0.0" % Test // https://github.com/scalatest/scalatestplus-selenium
 
   // Exclude workbench-libs transitive dependencies so we can control the library versions individually.
   // workbench-google pulls in workbench-{util, model, metrics} and workbcan ench-metrics pulls in workbench-util.
@@ -165,7 +164,6 @@ object Dependencies {
     googleDataproc,
     googleRpc,
     googleOAuth2,
-    mockito,
     hikariCP,
     workbenchUtil,
     workbenchGoogle,
@@ -214,7 +212,6 @@ object Dependencies {
     "com.typesafe.akka" %% "akka-testkit" % akkaV % "test",
     "com.typesafe.akka" %% "akka-slf4j" % akkaV,
     scalaTest,
-    "org.seleniumhq.selenium" % "selenium-java" % "4.0.0-alpha-6" % "test",
     "com.typesafe.scala-logging" %% "scala-logging" % "3.8.0",
     "org.apache.commons" % "commons-text" % "1.2",
     googleRpc,

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -132,7 +132,7 @@ object Settings {
       * Specify that all tests will be executed in a single external JVM.
       * By default, tests executed in a forked JVM are executed sequentially.
       */
-    Test / fork := false,
+    Test / fork := true,
 
     /**
       * forked tests can optionally be run in parallel.
@@ -161,7 +161,7 @@ object Settings {
       *  setting the limit on Tags.ForkedTestGroup tag, 1 is default.
       *  Warning: can't set too high (set at 10 would crashes OS)
       */
-    Global / concurrentRestrictions := Seq(Tags.limit(Tags.ForkedTestGroup, 2)),
+    Global / concurrentRestrictions := Seq(Tags.limit(Tags.ForkedTestGroup, 4)),
 
     /**
       * Forked JVM options

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -132,7 +132,7 @@ object Settings {
       * Specify that all tests will be executed in a single external JVM.
       * By default, tests executed in a forked JVM are executed sequentially.
       */
-    Test / fork := true,
+    Test / fork := false,
 
     /**
       * forked tests can optionally be run in parallel.
@@ -161,7 +161,7 @@ object Settings {
       *  setting the limit on Tags.ForkedTestGroup tag, 1 is default.
       *  Warning: can't set too high (set at 10 would crashes OS)
       */
-    Global / concurrentRestrictions := Seq(Tags.limit(Tags.ForkedTestGroup, 4)),
+    Global / concurrentRestrictions := Seq(Tags.limit(Tags.ForkedTestGroup, 2)),
 
     /**
       * Forked JVM options

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.9
+sbt.version=1.3.13


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-1953
https://broadworkbench.atlassian.net/browse/QA-1197

Root cause of the flakiness is recent privacy change in chrome incognito mode blocks all third parties cookies. We turned this off in https://github.com/broadinstitute/workbench-libs/pull/326

1. consoliate tests in biocondutorSpec a bit so that we're opening less webdrivers at the same time
2. Update the sbt container that we've been using for building automation test container image so that the sbt version available on the image matches up with leonardo.
3. Update scalatest to 3.2.0
4. Looks like `NotebookClusterMonitoringSpec` and `NotebookGCEClusterMonitoringSpec` are failing due to real bug introduced lately. I haven't had time to look yet..but will do after this PR

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
