### PR TITLE
[IA-1973] Fix jupyter extension installs

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoSuite.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoSuite.scala
@@ -99,7 +99,7 @@ final class LeonardoSuite
       new ClusterStatusTransitionsSpec,
       new LabSpec,
       new NotebookClusterMonitoringSpec,
-//      new NotebookCustomizationSpec,
+      new NotebookCustomizationSpec,
       new NotebookDataSyncingSpec,
       new LeoPubsubSpec,
       new ClusterAutopauseSpec,

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoSuite.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoSuite.scala
@@ -107,7 +107,7 @@ final class LeonardoSuite
       new RuntimePatchSpec,
       new RuntimeStatusTransitionsSpec,
       new NotebookGCEClusterMonitoringSpec,
-//      new NotebookGCECustomizationSpec,
+      new NotebookGCECustomizationSpec,
       new NotebookGCEDataSyncingSpec
     )
     with TestSuite

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookCustomizationSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookCustomizationSpec.scala
@@ -158,7 +158,8 @@ final class NotebookCustomizationSpec extends GPAllocFixtureSpec with ParallelTe
         // tracking the number of times it has been invoked.
         val startScriptString = "#!/usr/bin/env bash\n\n" +
           "count=$(cat $JUPYTER_HOME/leo_test_start_count.txt || echo 0)\n" +
-          "echo $(($count + 1)) > $JUPYTER_HOME/leo_test_start_count.txt"
+          "echo $(($count + 1)) > $JUPYTER_HOME/leo_test_start_count.txt\n" +
+          "pip install mock"
         val startScriptObjectName = GcsObjectName("start-script.sh")
         val startScriptUri = s"gs://${bucketName.value}/${startScriptObjectName.value}"
 
@@ -174,6 +175,9 @@ final class NotebookCustomizationSpec extends GPAllocFixtureSpec with ParallelTe
               withWebDriver { implicit driver =>
                 withNewNotebook(cluster, Python3) { notebookPage =>
                   notebookPage.executeCell("!cat $JUPYTER_HOME/leo_test_start_count.txt").get shouldBe "1"
+                  notebookPage.executeCell("! pip show mock").get should include(
+                    "/usr/local/lib/python3.7/dist-packages"
+                  )
                 }
 
                 // Stop the cluster
@@ -186,6 +190,10 @@ final class NotebookCustomizationSpec extends GPAllocFixtureSpec with ParallelTe
                 // We cache cluster's IP, so we might get old IP after restart
                 withNewNotebook(cluster, Python3) { notebookPage =>
                   notebookPage.executeCell("!cat $JUPYTER_HOME/leo_test_start_count.txt").get shouldBe "2"
+                  notebookPage.executeCell("! pip show mock").get should include(
+                    "/usr/local/lib/python3.7/dist-packages"
+                  )
+                  notebookPage.executeCell("""import mock""") shouldBe None
                 }
               }
           }

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookGCECustomizationSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookGCECustomizationSpec.scala
@@ -168,7 +168,8 @@ final class NotebookGCECustomizationSpec extends GPAllocFixtureSpec with Paralle
         // tracking the number of times it has been invoked.
         val startScriptString = "#!/usr/bin/env bash\n\n" +
           "count=$(cat $JUPYTER_HOME/leo_test_start_count.txt || echo 0)\n" +
-          "echo $(($count + 1)) > $JUPYTER_HOME/leo_test_start_count.txt"
+          "echo $(($count + 1)) > $JUPYTER_HOME/leo_test_start_count.txt\n" +
+          "pip install mock"
         val startScriptObjectName = GcsObjectName("start-script.sh")
         val startScriptUri = UserScriptPath.Gcs(GcsPath(bucketName, startScriptObjectName))
 
@@ -186,6 +187,7 @@ final class NotebookGCECustomizationSpec extends GPAllocFixtureSpec with Paralle
             withWebDriver { implicit driver =>
               withNewNotebook(runtime, Python3) { notebookPage =>
                 notebookPage.executeCell("!cat $JUPYTER_HOME/leo_test_start_count.txt").get shouldBe "1"
+                notebookPage.executeCell("! pip show mock").get should include("/usr/local/lib/python3.7/dist-packages")
               }
 
               // Stop the cluster
@@ -196,6 +198,8 @@ final class NotebookGCECustomizationSpec extends GPAllocFixtureSpec with Paralle
 
               withNewNotebook(runtime, Python3) { notebookPage =>
                 notebookPage.executeCell("!cat $JUPYTER_HOME/leo_test_start_count.txt").get shouldBe "2"
+                notebookPage.executeCell("! pip show mock").get should include("/usr/local/lib/python3.7/dist-packages")
+                notebookPage.executeCell("""import mock""") shouldBe None
               }
             }
           }

--- a/http/src/main/resources/init-resources/jupyter-docker-compose-gce.yaml
+++ b/http/src/main/resources/init-resources/jupyter-docker-compose-gce.yaml
@@ -28,6 +28,7 @@ services:
       PIP_USER: "false"
       PIP_TARGET: "${NOTEBOOKS_DIR}/packages"
       R_LIBS: "${NOTEBOOKS_DIR}/packages"
+      PYTHONPATH: "${PYTHONPATH:+$PYTHONPATH:}${NOTEBOOKS_DIR}/packages"
     env_file:
       - /etc/google_application_credentials.env
       - /etc/custom_env_vars.env

--- a/http/src/main/resources/init-resources/jupyter-docker-compose-gce.yaml
+++ b/http/src/main/resources/init-resources/jupyter-docker-compose-gce.yaml
@@ -28,7 +28,6 @@ services:
       PIP_USER: "false"
       PIP_TARGET: "${NOTEBOOKS_DIR}/packages"
       R_LIBS: "${NOTEBOOKS_DIR}/packages"
-      PYTHONPATH: "${PYTHONPATH:+$PYTHONPATH:}${NOTEBOOKS_DIR}/packages"
     env_file:
       - /etc/google_application_credentials.env
       - /etc/custom_env_vars.env

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/BaseRuntimeInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/BaseRuntimeInterpreter.scala
@@ -164,7 +164,8 @@ abstract private[util] class BaseRuntimeInterpreter[F[_]: Async: ContextShift: L
                                  welderAction: Option[WelderAction],
                                  now: Instant,
                                  blocker: Blocker,
-                                 runtimeResourceConstraints: RuntimeResourceConstraints)(
+                                 runtimeResourceConstraints: RuntimeResourceConstraints,
+                                 useGceStartupScript: Boolean)(
     implicit ev: ApplicativeAsk[F, AppContext]
   ): F[Map[String, String]] = {
     val googleKey = "startup-script" // required; see https://cloud.google.com/compute/docs/startupscript
@@ -180,7 +181,8 @@ abstract private[util] class BaseRuntimeInterpreter[F[_]: Async: ContextShift: L
       config.clusterResourcesConfig,
       Some(runtimeResourceConstraints),
       RuntimeOperation.Restarting,
-      welderAction
+      welderAction,
+      useGceStartupScript
     )
 
     for {
@@ -215,7 +217,8 @@ abstract private[util] class BaseRuntimeInterpreter[F[_]: Async: ContextShift: L
       config.clusterResourcesConfig,
       None,
       RuntimeOperation.Stopping,
-      None
+      None,
+      false
     )
     val replacements = RuntimeTemplateValues(templateConfig, None).toMap
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/DataprocInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/DataprocInterpreter.scala
@@ -269,7 +269,7 @@ class DataprocInterpreter[F[_]: Timer: Async: Parallel: ContextShift: Logger](
         RuntimeProjectAndName(runtime.googleProject, runtime.runtimeName),
         runtimeConfig.machineType
       )
-      metadata <- getStartupScript(runtime, welderAction, ctx.now, blocker, resourceConstraints)
+      metadata <- getStartupScript(runtime, welderAction, ctx.now, blocker, resourceConstraints, false)
 
       // Add back the preemptible instances, if any
       _ <- runtimeConfig match {

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GceInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GceInterpreter.scala
@@ -278,7 +278,7 @@ class GceInterpreter[F[_]: Parallel: ContextShift: Logger](
       resourceConstraints <- getResourceConstraints(runtime.googleProject,
                                                     config.gceConfig.zoneName,
                                                     runtimeConfig.machineType)
-      metadata <- getStartupScript(runtime, welderAction, ctx.now, blocker, resourceConstraints)
+      metadata <- getStartupScript(runtime, welderAction, ctx.now, blocker, resourceConstraints, true)
       // remove the startup-script-url metadata entry if present which is only used at creation time
       _ <- googleComputeService.modifyInstanceMetadata(
         runtime.googleProject,

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/RuntimeTemplateValuesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/RuntimeTemplateValuesSpec.scala
@@ -18,7 +18,8 @@ class RuntimeTemplateValuesSpec extends LeonardoTestSuite with AnyFlatSpecLike {
       CommonTestData.clusterResourcesConfig,
       Some(CommonTestData.clusterResourceConstraints),
       RuntimeOperation.Restarting,
-      Some(WelderAction.UpdateWelder)
+      Some(WelderAction.UpdateWelder),
+      false
     )
 
     val test = for {


### PR DESCRIPTION
Now that we docker compose with env var `PIP_TARGET` we need to update the `gce-init` script to use `PIP_TARGET` instead of `PIP_USER` when installing packages

Tested the following:
- `NotebookGCECustomizationSpec` now passes
- `NotebookPyKernelSpec` still passes
- determined `ROOT_USER_PIP_DIR` and `JUPYTER_USER_PIP_DIR` by reverting my FIAB to before I updated user package installation persistence and seeing where `userJupyterExtensionConfig` get installed to


---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
