### PR TITLE
[no ticket] A bit more logging for helping debugging

### DIFF
--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/GceRuntimeMonitor.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/GceRuntimeMonitor.scala
@@ -217,7 +217,13 @@ class GceRuntimeMonitor[F[_]: Parallel](
                 case UserScriptsValidationResult.CheckAgain(msg) =>
                   checkAgain(monitorContext, runtimeAndRuntimeConfig, Set.empty, Some(msg))
                 case UserScriptsValidationResult.Error(msg) =>
-                  failedRuntime(monitorContext, runtimeAndRuntimeConfig, Some(RuntimeErrorDetails(msg)), Set.empty)
+                  logger
+                    .info(s"${runtimeAndRuntimeConfig.runtime.projectNameString} user script failed ${msg}") >> failedRuntime(
+                    monitorContext,
+                    runtimeAndRuntimeConfig,
+                    Some(RuntimeErrorDetails(msg)),
+                    Set.empty
+                  )
                 case UserScriptsValidationResult.Success =>
                   getInstanceIP(i) match {
                     case Some(ip) =>
@@ -233,7 +239,9 @@ class GceRuntimeMonitor[F[_]: Parallel](
               }
             } yield r
           case ss =>
-            logger.info(s"Going to delete runtime due to unexpected status ${ss}") >> failedRuntime(
+            logger.info(
+              s"Going to delete runtime ${runtimeAndRuntimeConfig.runtime.projectNameString} due to unexpected status ${ss}"
+            ) >> failedRuntime(
               monitorContext,
               runtimeAndRuntimeConfig,
               Some(RuntimeErrorDetails(s"unexpected GCE instance status ${ss} when trying to creating an instance")),

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/GceRuntimeMonitor.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/GceRuntimeMonitor.scala
@@ -233,7 +233,7 @@ class GceRuntimeMonitor[F[_]: Parallel](
               }
             } yield r
           case ss =>
-            failedRuntime(
+            logger.info(s"Going to delete runtime due to unexpected status ${ss}") >> failedRuntime(
               monitorContext,
               runtimeAndRuntimeConfig,
               Some(RuntimeErrorDetails(s"unexpected GCE instance status ${ss} when trying to creating an instance")),

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/config/ConfigSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/config/ConfigSpec.scala
@@ -3,6 +3,7 @@ package config
 
 import org.broadinstitute.dsde.workbench.google2.KubernetesSerializableName.{NamespaceName, ServiceName}
 import org.broadinstitute.dsde.workbench.google2.{Location, MachineTypeName, ZoneName}
+import org.broadinstitute.dsde.workbench.leonardo.monitor.MonitorConfig.GceMonitorConfig
 import org.broadinstitute.dsde.workbench.leonardo.monitor.{
   LeoPubsubMessageSubscriberConfig,
   PersistentDiskMonitor,
@@ -37,6 +38,25 @@ class ConfigSpec extends AnyFlatSpec with Matchers {
     )
 
     Config.leoPubsubMessageSubscriberConfig shouldBe expectedResult
+  }
+
+  it should "read gce.monitor properly" in {
+    val expected = GceMonitorConfig(
+      20 seconds,
+      15 seconds,
+      120,
+      8 seconds,
+      Config.clusterBucketConfig,
+      Map(
+        RuntimeStatus.Creating -> 30.minutes,
+        RuntimeStatus.Starting -> 20.minutes,
+        RuntimeStatus.Deleting -> 30.minutes
+      ),
+      ZoneName("us-central1-a"),
+      Config.imageConfig
+    )
+
+    Config.gceMonitorConfig shouldBe (expected)
   }
 
   "GKE config" should "read ClusterConfig properly" in {


### PR DESCRIPTION
Not sure if there's a way to see the error message persisted to DB from automation tests, hence adding a bit extra logging

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
