### PR TITLE
[IA-2060] Add custom environment variables to `CreateAppRequest`

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/kubernetesModels.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/kubernetesModels.scala
@@ -274,7 +274,8 @@ final case class App(id: AppId,
                      labels: LabelMap,
                      //this is populated async to app creation
                      appResources: AppResources,
-                     errors: List[KubernetesError])
+                     errors: List[KubernetesError],
+                     customEnvironmentVariables: Option[Map[String, String]])
 
 sealed abstract class AppStatus
 object AppStatus {

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/kubernetesModels.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/kubernetesModels.scala
@@ -275,7 +275,7 @@ final case class App(id: AppId,
                      //this is populated async to app creation
                      appResources: AppResources,
                      errors: List[KubernetesError],
-                     customEnvironmentVariables: Option[Map[String, String]])
+                     customEnvironmentVariables: Map[String, String])
 
 sealed abstract class AppStatus
 object AppStatus {

--- a/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changelog.xml
+++ b/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changelog.xml
@@ -58,4 +58,5 @@
     <include file="changesets/20200622_add_num_of_disks_to_runtime_config.xml" relativeToChangelogFile="true" />
     <include file="changesets/20200701_kubernetes_drop_port_table.xml" relativeToChangelogFile="true" />
     <include file="changesets/20200701_kubernetes_default_nodepool.xml" relativeToChangelogFile="true" />
+    <include file="changesets/20200719_add_app_Custom_env_vars.xml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changelog.xml
+++ b/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changelog.xml
@@ -58,5 +58,5 @@
     <include file="changesets/20200622_add_num_of_disks_to_runtime_config.xml" relativeToChangelogFile="true" />
     <include file="changesets/20200701_kubernetes_drop_port_table.xml" relativeToChangelogFile="true" />
     <include file="changesets/20200701_kubernetes_default_nodepool.xml" relativeToChangelogFile="true" />
-    <include file="changesets/20200719_add_app_Custom_env_vars.xml" relativeToChangelogFile="true" />
+    <include file="changesets/20200719_add_app_custom_env_vars.xml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/20200719_add_app_custom_env_vars.xml
+++ b/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/20200719_add_app_custom_env_vars.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog logicalFilePath="leonardo" xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+    <changeSet logicalFilePath="leonardo" author="gabriela" id="add_app_custom_env_vars">
+        <addColumn tableName="APP">
+            <column name="customEnvironmentVariables" type="varchar(2048)" >
+                <constraints nullable="true"/>
+            </column>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/KubernetesRoutes.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/KubernetesRoutes.scala
@@ -177,7 +177,8 @@ object KubernetesRoutes {
         a <- x.downField("appType").as[Option[AppType]]
         d <- x.downField("diskConfig").as[Option[PersistentDiskRequest]]
         l <- x.downField("labels").as[Option[LabelMap]]
-      } yield CreateAppRequest(c, a.getOrElse(AppType.Galaxy), d, l.getOrElse(Map.empty))
+        cv <- x.downField("customEnvironmentVariables").as[Option[LabelMap]]
+      } yield CreateAppRequest(c, a.getOrElse(AppType.Galaxy), d, l.getOrElse(Map.empty), cv.getOrElse(Map.empty))
     }
 
   implicit val nameKeyDecoder: KeyDecoder[ServiceName] = KeyDecoder.decodeKeyString.map(ServiceName.apply)
@@ -192,7 +193,7 @@ object KubernetesRoutes {
                                                                               "diskName")(ListAppResponse.apply)
 
   implicit val createAppEncoder: Encoder[CreateAppRequest] =
-    Encoder.forProduct4("kubernetesRuntimeConfig", "appType", "diskConfig", "labels")(x =>
+    Encoder.forProduct5("kubernetesRuntimeConfig", "appType", "diskConfig", "labels", "customEnvironmentVariables")(x =>
       CreateAppRequest.unapply(x).get
     )
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/AppComponent.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/AppComponent.scala
@@ -45,7 +45,7 @@ final case class AppRecord(id: AppId,
                            dateAccessed: Instant,
                            namespaceId: NamespaceId,
                            diskId: Option[DiskId],
-                           customEnvironmentVariables: Option[Map[String, String]])
+                           customEnvironmentVariables: Map[String, String])
 
 class AppTable(tag: Tag) extends Table[AppRecord](tag, "APP") {
   //unique (appName, destroyedDate)
@@ -61,7 +61,7 @@ class AppTable(tag: Tag) extends Table[AppRecord](tag, "APP") {
   def dateAccessed = column[Instant]("dateAccessed", O.SqlType("TIMESTAMP(6)"))
   def namespaceId = column[NamespaceId]("namespaceId", O.Length(254))
   def diskId = column[Option[DiskId]]("diskId", O.Length(254))
-  def customEnvironmentVariables = column[Option[Map[String, String]]]("customEnvironmentVariables")
+  def customEnvironmentVariables = column[Map[String, String]]("customEnvironmentVariables")
 
   def * =
     (

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/leoPubsubMessageSubscriberModels.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/leoPubsubMessageSubscriberModels.scala
@@ -203,6 +203,7 @@ object LeoPubsubMessage {
                                     nodepoolId: NodepoolLeoId,
                                     project: GoogleProject,
                                     createDisk: Boolean,
+                                    customEnvironmentVariables: Map[String, String],
                                     traceId: Option[TraceId])
       extends LeoPubsubMessage {
     val messageType: LeoPubsubMessageType = LeoPubsubMessageType.CreateApp
@@ -293,7 +294,13 @@ object LeoPubsubCodec {
 
   implicit val appIdDecoder: Decoder[AppId] = Decoder.decodeLong.map(AppId)
   implicit val createAppDecoder: Decoder[CreateAppMessage] =
-    Decoder.forProduct6("cluster", "appId", "nodepoolId", "project", "createDisk", "traceId")(CreateAppMessage.apply)
+    Decoder.forProduct7("cluster",
+                        "appId",
+                        "nodepoolId",
+                        "project",
+                        "createDisk",
+                        "customEnvironmentVariables",
+                        "traceId")(CreateAppMessage.apply)
 
   implicit val deleteAppDecoder: Decoder[DeleteAppMessage] =
     Decoder.forProduct5("appId", "nodepoolId", "project", "deleteDisk", "traceId")(DeleteAppMessage.apply)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/KubernetesServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/KubernetesServiceInterp.scala
@@ -119,6 +119,7 @@ class LeoKubernetesServiceInterp[F[_]: Parallel](
         nodepool.id,
         saveClusterResult.minimalCluster.googleProject,
         diskResultOpt.map(_.creationNeeded).getOrElse(false),
+        req.customEnvironmentVariables,
         Some(ctx.traceId)
       )
       _ <- publisherQueue.enqueue1(createAppMessage)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/KubernetesServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/KubernetesServiceInterp.scala
@@ -322,7 +322,8 @@ class LeoKubernetesServiceInterp[F[_]: Parallel](
               leoKubernetesConfig.galaxyAppConfig.services.map(config => KubernetesService(ServiceId(-1), config))
           }
         ),
-        List.empty
+        List.empty,
+        req.customEnvironmentVariables
       )
     )
   }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/leonardoServiceContractModel.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/leonardoServiceContractModel.scala
@@ -239,7 +239,8 @@ object GetRuntimeResponse {
 final case class CreateAppRequest(kubernetesRuntimeConfig: Option[KubernetesRuntimeConfig],
                                   appType: AppType,
                                   diskConfig: Option[PersistentDiskRequest],
-                                  labels: LabelMap = Map.empty)
+                                  labels: LabelMap = Map.empty,
+                                  customEnvironmentVariables: Map[String, String])
 
 final case class DeleteAppParams(userInfo: UserInfo,
                                  googleProject: GoogleProject,

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/KubernetesTestData.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/KubernetesTestData.scala
@@ -41,6 +41,7 @@ object KubernetesTestData {
     Some(kubernetesRuntimeConfig),
     AppType.Galaxy,
     None,
+    Map.empty,
     Map.empty
   )
 
@@ -117,7 +118,8 @@ object KubernetesTestData {
           None,
           List.empty
         ),
-        List.empty)
+        List.empty,
+        Map.empty)
   }
 
   def makeService(index: Int): KubernetesService = {

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/KubernetesServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/KubernetesServiceInterpSpec.scala
@@ -89,7 +89,8 @@ class KubernetesServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite wit
 
     val appName = AppName("app1")
     val createDiskConfig = PersistentDiskRequest(diskName, None, None, Map.empty)
-    val appReq = createAppRequest.copy(diskConfig = Some(createDiskConfig))
+    val customEnvVars = Map("WORKSPACE_NAME" -> "testWorkspace")
+    val appReq = createAppRequest.copy(diskConfig = Some(createDiskConfig), customEnvironmentVariables = customEnvVars)
 
     val publisherQueue = QueueFactory.makePublisherQueue()
     val kubeServiceInterp = makeInterp(publisherQueue)
@@ -121,6 +122,7 @@ class KubernetesServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite wit
         defaultNodepool.id
       )
     )
+    createAppMessage.customEnvironmentVariables shouldBe customEnvVars
   }
 
   it should "create an app with an existing disk" in isolatedDbTest {

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/KubernetesServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/KubernetesServiceInterpSpec.scala
@@ -54,7 +54,8 @@ class KubernetesServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite wit
   it should "create an app and a new disk" in isolatedDbTest {
     val appName = AppName("app1")
     val createDiskConfig = PersistentDiskRequest(diskName, None, None, Map.empty)
-    val appReq = createAppRequest.copy(diskConfig = Some(createDiskConfig))
+    val customEnvVars = Map("WORKSPACE_NAME" -> "testWorkspace")
+    val appReq = createAppRequest.copy(diskConfig = Some(createDiskConfig), customEnvironmentVariables = customEnvVars)
 
     kubeServiceInterp.createApp(userInfo, project, appName, appReq).unsafeRunSync()
 
@@ -76,6 +77,7 @@ class KubernetesServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite wit
     val app = clusters.flatMap(_.nodepools).flatMap(_.apps).head
     app.appName shouldEqual appName
     app.auditInfo.creator shouldEqual userInfo.userEmail
+    app.customEnvironmentVariables shouldEqual customEnvVars
 
     val savedDisk = dbFutureValue {
       persistentDiskQuery.getById(app.appResources.disk.get.id)


### PR DESCRIPTION
This PR adds `customEnvironmentVariables` to `CreateAppRequest` and to `CreateAppMessage` and saves them to the db (`App` table) in front leo. 
---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
