### PR TITLE
IA-2086 Galaxy proxy error when importing a workflow

### DIFF
--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/ProxyService.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/ProxyService.scala
@@ -284,7 +284,7 @@ class ProxyService(
     // 1. filter out headers not needed for the backend server
     val newHeaders = filterHeaders(request.headers)
     // 2. strip out Uri.Authority:
-    val newUri = Uri(path = rewrittenPath, queryString = request.uri.queryString())
+    val newUri = Uri(path = rewrittenPath, queryString = request.uri.rawQueryString)
     // 3. build a new HttpRequest
     val newRequest = request.copy(headers = newHeaders, uri = newUri)
 

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/ProxyRoutesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/ProxyRoutesSpec.scala
@@ -161,6 +161,13 @@ class ProxyRoutesSpec
     }
   }
 
+  it should "pass through encoded query string params in runtime proxy requests" in {
+    Get(s"/proxy/$googleProject/$clusterName?foo=This%20is%20an%20encoded%20param.&baz=biz")
+      .addHeader(Cookie(tokenCookie)) ~> httpRoutes.route ~> check {
+      responseAs[Data].qs shouldEqual Some("foo=This is an encoded param.&baz=biz")
+    }
+  }
+
   it should "pass through http methods in runtime proxy requests" in {
     Get(s"/proxy/$googleProject/$clusterName").addHeader(Cookie(tokenCookie)) ~> httpRoutes.route ~> check {
       responseAs[Data].method shouldBe "GET"
@@ -287,6 +294,13 @@ class ProxyRoutesSpec
     Get(s"/proxy/google/v1/apps/$googleProject/$appName/$serviceName?foo=bar&baz=biz")
       .addHeader(Cookie(tokenCookie)) ~> httpRoutes.route ~> check {
       responseAs[Data].qs shouldEqual Some("foo=bar&baz=biz")
+    }
+  }
+
+  it should "pass through encoded query string params in app proxy requests" in {
+    Get(s"/proxy/google/v1/apps/$googleProject/$appName/$serviceName?foo=This%20is%20an%20encoded%20param.&baz=biz")
+      .addHeader(Cookie(tokenCookie)) ~> httpRoutes.route ~> check {
+      responseAs[Data].qs shouldEqual Some("foo=This is an encoded param.&baz=biz")
     }
   }
 


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-2086

I think the Leo proxy was not handling encoded query string parameters correctly, like: 
```
?message=Imported,%20but%20some%20steps%20in%20this%20workflow%20have%20validation%20errors.&status=success
```
Interestingly I think this bug has existed in Leo for a long time, but Galaxy is the first thing to expose it.

I manually deployed this to the `galaxy-dev-env` fiab, and it seems to work.

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
