### PR TITLE
QA-1205

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookDataSyncingSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookDataSyncingSpec.scala
@@ -176,6 +176,8 @@ class NotebookDataSyncingSpec extends ClusterFixtureSpec with NotebookTestUtils 
                 notebookPage areElementsPresent (syncIssueElements) shouldBe true
 
                 notebookPage executeJavaScript ("window.onbeforeunload = null;") //disables pesky chrome modal to confirm navigation. we are not testing chrome's implementation and confirming the modal proves problematic
+                notebookPage executeJavaScript ("Jupyter.notebook.set_autosave_interval(0);") //removes Notebook changed modal
+
                 notebookPage makeACopyFromSyncIssue
               }
 

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookGCEClusterMonitoringSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookGCEClusterMonitoringSpec.scala
@@ -92,9 +92,8 @@ class NotebookGCEClusterMonitoringSpec extends GPAllocFixtureSpec with ParallelT
       }
     }
 
-    //TODO Re-enable this test once we fix the runtime error
-    // https://broadworkbench.atlassian.net/browse/QA-1204
-    "should update DockerHub welder on a cluster" taggedAs Retryable ignore { billingProject =>
+
+    "should update DockerHub welder on a cluster" taggedAs Retryable in { billingProject =>
       implicit val ronToken: AuthToken = ronAuthToken
       val deployWelderLabel = "saturnVersion" // matches deployWelderLabel in Leo reference.conf
 

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookGCEClusterMonitoringSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookGCEClusterMonitoringSpec.scala
@@ -92,7 +92,9 @@ class NotebookGCEClusterMonitoringSpec extends GPAllocFixtureSpec with ParallelT
       }
     }
 
-    "should update DockerHub welder on a cluster" taggedAs Retryable in { billingProject =>
+    //TODO Re-enable this test once we fix the runtime error
+    // https://broadworkbench.atlassian.net/browse/QA-1204
+    "should update DockerHub welder on a cluster" taggedAs Retryable ignore { billingProject =>
       implicit val ronToken: AuthToken = ronAuthToken
       val deployWelderLabel = "saturnVersion" // matches deployWelderLabel in Leo reference.conf
 

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookGCEClusterMonitoringSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookGCEClusterMonitoringSpec.scala
@@ -91,7 +91,7 @@ class NotebookGCEClusterMonitoringSpec extends GPAllocFixtureSpec with ParallelT
         newStatusResponse.toOption.get.gitHeadCommit should startWith(curWelderHash)
       }
     }
-    
+
     "should update DockerHub welder on a cluster" taggedAs Retryable in { billingProject =>
       implicit val ronToken: AuthToken = ronAuthToken
       val deployWelderLabel = "saturnVersion" // matches deployWelderLabel in Leo reference.conf

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookGCEClusterMonitoringSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookGCEClusterMonitoringSpec.scala
@@ -91,8 +91,7 @@ class NotebookGCEClusterMonitoringSpec extends GPAllocFixtureSpec with ParallelT
         newStatusResponse.toOption.get.gitHeadCommit should startWith(curWelderHash)
       }
     }
-
-
+    
     "should update DockerHub welder on a cluster" taggedAs Retryable in { billingProject =>
       implicit val ronToken: AuthToken = ronAuthToken
       val deployWelderLabel = "saturnVersion" // matches deployWelderLabel in Leo reference.conf


### PR DESCRIPTION
Currently we are running into a modal issue where a "Notebook Changed" Popup is interfering with the testing workflow. This popup seems to be caused by the timing for autosave. Have tested this change which disables autosave and haven't been running into this issue since. Also doesn't require any clicking so we should be fine if the pop up doesn't occur due to timing.

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
