### PR TITLE
[no ticket] bake aou 1.0.4 version

### DIFF
--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -258,7 +258,9 @@ pipeline {
                                 if (GENERATE_DATAPROC_IMAGE == "true" && dataprocImages.contains(image)) {
                                     println("Using version $version for $image in this build of custom Dataproc images")
                                     sh """
-                                        sed -i "s/$image.*/$image:$version\\"/" jenkins/dataproc-custom-images/prepare-custom-leonardo-jupyter-dataproc-image.sh
+                                       if [ $image != 'terra-jupyter-aou' ]; then
+                                          sed -i "s/$image.*/$image:$version\\"/" jenkins/dataproc-custom-images/prepare-custom-leonardo-jupyter-dataproc-image.sh
+                                       fi
                                     """
                                 }
 
@@ -266,9 +268,7 @@ pipeline {
                                     println("Using version $version for $image in this build of custom GCE images")
                                     // Not replace aou version because we want to fix bake 2 aou versions until aou migrate to new version
                                     sh """
-                                        if [ $image != 'terra-jupyter-aou' ]; then
-                                            sed -i "s/$image.*/$image:$version\\"/" jenkins/gce-custom-images/prepare_custom_leonardo_gce_image.sh
-                                        fi
+                                       sed -i "s/$image.*/$image:$version\\"/" jenkins/gce-custom-images/prepare_custom_leonardo_gce_image.sh
                                     """
                                 }
                             }

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -155,8 +155,6 @@ pipeline {
         string(name: "terra_jupyter_aou", defaultValue: "0.0.1")
         string(name: "anvil_rstudio_base", defaultValue: "0.0.2")
         string(name: "anvil_rstudio_bioconductor", defaultValue: "0.0.3")
-        string(name: "leonardo_jupyter", defaultValue: "5c51ce6935da",
-            description: "The tag of the jupyter image to pull in docker image build. Used in the prepare script.")
         string(name: "welder_server", defaultValue: "59be71a",
             description: "The tag of the welder image to pull in docker image build. Used in the prepare script. Please note this default is possibly an old hash.")
         string(name: "openidc_proxy", defaultValue: "2.3.1_2",
@@ -171,7 +169,7 @@ pipeline {
                     customDataprocImageBaseName = "${IMAGE_BASE_NAME}-dataproc"
                     customGceImageBaseName = "${IMAGE_BASE_NAME}-gce-debian9"
                     ArrayList<String> nonTerraDockerImages = [
-                        'leonardo-jupyter', 'welder-server', 'openidc-proxy', 'anvil-rstudio-base', 'anvil-rstudio-bioconductor'
+                        'welder-server', 'openidc-proxy', 'anvil-rstudio-base', 'anvil-rstudio-bioconductor'
                     ]
 
                     String selectBuildableTerraDockerImagesQuery = "cat config/conf.json | jq -r '.image_data | .[] | select(.automated_flags.build == true)"

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -264,8 +264,11 @@ pipeline {
 
                                 if (GENERATE_GCE_IMAGE == "true" && gceImages.contains(image)) {
                                     println("Using version $version for $image in this build of custom GCE images")
+                                    // Not replace aou version because we want to fix bake 2 aou versions until aou migrate to new version
                                     sh """
-                                        sed -i "s/$image.*/$image:$version\\"/" jenkins/gce-custom-images/prepare_custom_leonardo_gce_image.sh
+                                        if [ $image != 'terra-jupyter-aou' ]; then
+                                            sed -i "s/$image.*/$image:$version\\"/" jenkins/gce-custom-images/prepare_custom_leonardo_gce_image.sh
+                                        fi
                                     """
                                 }
                             }

--- a/jenkins/dataproc-custom-images/prepare-custom-leonardo-jupyter-dataproc-image.sh
+++ b/jenkins/dataproc-custom-images/prepare-custom-leonardo-jupyter-dataproc-image.sh
@@ -23,10 +23,10 @@ terra_jupyter_r="us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:0.0.11"
 terra_jupyter_bioconductor="us.gcr.io/broad-dsp-gcr-public/terra-jupyter-bioconductor:0.0.12"
 terra_jupyter_hail="us.gcr.io/broad-dsp-gcr-public/terra-jupyter-hail:0.0.9"
 terra_jupyter_gatk="us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:0.0.13"
-terra_jupyter_aou="us.gcr.io/broad-dsp-gcr-public/terra-jupyter-aou:0.0.1"
+terra_jupyter_aou_old="us.gcr.io/broad-dsp-gcr-public/terra-jupyter-aou:0.0.1"
+terra_jupyter_aou="us.gcr.io/broad-dsp-gcr-public/terra-jupyter-aou:1.0.4"
 
 # leonardo_jupyter will be discontinued soon
-leonardo_jupyter="us.gcr.io/broad-dsp-gcr-public/leonardo-jupyter:5c51ce6935da"
 welder_server="us.gcr.io/broad-dsp-gcr-public/welder-server:59be71a"
 openidc_proxy="broadinstitute/openidc-proxy:2.3.1_2"
 anvil_rstudio_base="us.gcr.io/anvil-gcr-public/anvil-rstudio-base:0.0.2"
@@ -34,7 +34,7 @@ anvil_rstudio_bioconductor="us.gcr.io/anvil-gcr-public/anvil-rstudio-bioconducto
 
 # this array determines which of the above images are baked into the custom image
 # the entry must match the var name above, which must correspond to a valid docker URI
-docker_image_var_names="welder_server leonardo_jupyter terra_jupyter_base terra_jupyter_python terra_jupyter_r terra_jupyter_bioconductor terra_jupyter_hail terra_jupyter_gatk terra_jupyter_aou openidc_proxy anvil_rstudio_base anvil_rstudio_bioconductor"
+docker_image_var_names="welder_server terra_jupyter_base terra_jupyter_python terra_jupyter_r terra_jupyter_bioconductor terra_jupyter_hail terra_jupyter_gatk terra_jupyter_aou terra_jupyter_aou_old openidc_proxy anvil_rstudio_base anvil_rstudio_bioconductor"
 
 # The version of python to install
 python_version="3.7.4"

--- a/jenkins/gce-custom-images/prepare_custom_leonardo_gce_image.sh
+++ b/jenkins/gce-custom-images/prepare_custom_leonardo_gce_image.sh
@@ -25,7 +25,8 @@ terra_jupyter_python="us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.10
 terra_jupyter_r="us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:0.0.11"
 terra_jupyter_bioconductor="us.gcr.io/broad-dsp-gcr-public/terra-jupyter-bioconductor:0.0.12"
 terra_jupyter_gatk="us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:0.0.13"
-terra_jupyter_aou="us.gcr.io/broad-dsp-gcr-public/terra-jupyter-aou:0.0.1"
+terra_jupyter_aou_old="us.gcr.io/broad-dsp-gcr-public/terra-jupyter-aou:0.0.1" #TODO: remove this once aou has migrated to new image
+terra_jupyter_aou="us.gcr.io/broad-dsp-gcr-public/terra-jupyter-aou:1.0.4"
 
 # leonardo_jupyter will be discontinued soon
 welder_server="us.gcr.io/broad-dsp-gcr-public/welder-server:59be71a"
@@ -35,7 +36,7 @@ anvil_rstudio_bioconductor="us.gcr.io/anvil-gcr-public/anvil-rstudio-bioconducto
 
 # This array determines which of the above images are baked into the custom image
 # the entry must match the var name above, which must correspond to a valid docker URI
-docker_image_var_names="welder_server terra_jupyter_base terra_jupyter_python terra_jupyter_r terra_jupyter_bioconductor terra_jupyter_gatk terra_jupyter_aou openidc_proxy anvil_rstudio_base anvil_rstudio_bioconductor"
+docker_image_var_names="welder_server terra_jupyter_base terra_jupyter_python terra_jupyter_r terra_jupyter_bioconductor terra_jupyter_gatk terra_jupyter_aou terra_jupyter_aou_old openidc_proxy anvil_rstudio_base anvil_rstudio_bioconductor"
 
 # Variables for downloading the Ansible playbook files for hardening
 cis_hardening_dir="cis-harden-images/debian9"

--- a/jenkins/gce-custom-images/prepare_custom_leonardo_gce_image.sh
+++ b/jenkins/gce-custom-images/prepare_custom_leonardo_gce_image.sh
@@ -25,7 +25,6 @@ terra_jupyter_python="us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.10
 terra_jupyter_r="us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:0.0.11"
 terra_jupyter_bioconductor="us.gcr.io/broad-dsp-gcr-public/terra-jupyter-bioconductor:0.0.12"
 terra_jupyter_gatk="us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:0.0.13"
-terra_jupyter_aou_old="us.gcr.io/broad-dsp-gcr-public/terra-jupyter-aou:0.0.1" #TODO: remove this once aou has migrated to new image
 terra_jupyter_aou="us.gcr.io/broad-dsp-gcr-public/terra-jupyter-aou:1.0.4"
 
 # leonardo_jupyter will be discontinued soon
@@ -36,7 +35,7 @@ anvil_rstudio_bioconductor="us.gcr.io/anvil-gcr-public/anvil-rstudio-bioconducto
 
 # This array determines which of the above images are baked into the custom image
 # the entry must match the var name above, which must correspond to a valid docker URI
-docker_image_var_names="welder_server terra_jupyter_base terra_jupyter_python terra_jupyter_r terra_jupyter_bioconductor terra_jupyter_gatk terra_jupyter_aou terra_jupyter_aou_old openidc_proxy anvil_rstudio_base anvil_rstudio_bioconductor"
+docker_image_var_names="welder_server terra_jupyter_base terra_jupyter_python terra_jupyter_r terra_jupyter_bioconductor terra_jupyter_gatk terra_jupyter_aou openidc_proxy anvil_rstudio_base anvil_rstudio_bioconductor"
 
 # Variables for downloading the Ansible playbook files for hardening
 cis_hardening_dir="cis-harden-images/debian9"


### PR DESCRIPTION
need to check image size after this PR to see actually custom image and update bootDiskSize if necessary

This PR will
1. cache aou 0.0.1 and 1.0.4 for dataproc image
2. cache latest aou for gce image

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
