### PR TITLE
IA-2096 fix delete disk flag

### DIFF
--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/GceRuntimeMonitor.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/GceRuntimeMonitor.scala
@@ -134,7 +134,7 @@ class GceRuntimeMonitor[F[_]: Parallel](
             .updateClusterStatus(runtimeAndRuntimeConfig.runtime.id, RuntimeStatus.PreDeleting, timeWhenInterrupted)
             .transaction >> publisherQueue
             .enqueue1(
-              DeleteRuntimeMessage(runtimeAndRuntimeConfig.runtime.id, false, Some(monitorContext.traceId))
+              DeleteRuntimeMessage(runtimeAndRuntimeConfig.runtime.id, None, Some(monitorContext.traceId))
               //Known limitation, we set deleteDisk is falsehere; but in reality, it could be `true`
             )
         case _ =>

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/leoPubsubMessageSubscriberModels.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/leoPubsubMessageSubscriberModels.scala
@@ -218,7 +218,9 @@ object LeoPubsubMessage {
     val messageType: LeoPubsubMessageType = LeoPubsubMessageType.DeleteApp
   }
 
-  final case class DeleteRuntimeMessage(runtimeId: Long, deleteDisk: Boolean, traceId: Option[TraceId])
+  final case class DeleteRuntimeMessage(runtimeId: Long,
+                                        persistentDiskToDelete: Option[DiskId],
+                                        traceId: Option[TraceId])
       extends LeoPubsubMessage {
     val messageType: LeoPubsubMessageType = LeoPubsubMessageType.DeleteRuntime
   }
@@ -261,8 +263,8 @@ object LeoPubsubCodec {
   implicit val runtimePatchDetailsDecoder: Decoder[RuntimePatchDetails] =
     Decoder.forProduct2("clusterId", "clusterStatus")(RuntimePatchDetails.apply)
 
-  implicit val deleteRuntimeDecoder: Decoder[DeleteRuntimeMessage] =
-    Decoder.forProduct3("runtimeId", "deleteDisk", "traceId")(DeleteRuntimeMessage.apply)
+  implicit val deleteRuntimeMessageDecoder: Decoder[DeleteRuntimeMessage] =
+    Decoder.forProduct3("runtimeId", "persistentDiskToDelete", "traceId")(DeleteRuntimeMessage.apply)
 
   implicit val stopRuntimeDecoder: Decoder[StopRuntimeMessage] =
     Decoder.forProduct2("runtimeId", "traceId")(StopRuntimeMessage.apply)
@@ -472,8 +474,8 @@ object LeoPubsubCodec {
     )(CreateRuntimeMessage.apply)
 
   implicit val deleteRuntimeMessageEncoder: Encoder[DeleteRuntimeMessage] =
-    Encoder.forProduct4("messageType", "runtimeId", "deleteDisk", "traceId")(x =>
-      (x.messageType, x.runtimeId, x.deleteDisk, x.traceId)
+    Encoder.forProduct4("messageType", "runtimeId", "persistentDiskToDelete", "traceId")(x =>
+      (x.messageType, x.runtimeId, x.persistentDiskToDelete, x.traceId)
     )
 
   implicit val stopRuntimeMessageEncoder: Encoder[StopRuntimeMessage] =

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoService.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoService.scala
@@ -435,7 +435,7 @@ class LeonardoService(
         _ <- if (hasDataprocInfo)
           clusterQuery.updateClusterStatus(cluster.id, RuntimeStatus.PreDeleting, now).transaction >> publisherQueue
             .enqueue1(
-              DeleteRuntimeMessage(cluster.id, false, Some(ctx))
+              DeleteRuntimeMessage(cluster.id, None, Some(ctx))
             )
         else clusterQuery.completeDeletion(cluster.id, now).transaction
         _ <- labelQuery

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GceInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GceInterpreter.scala
@@ -52,7 +52,6 @@ class GceInterpreter[F[_]: Parallel: ContextShift: Logger](
 )(implicit val executionContext: ExecutionContext, metrics: OpenTelemetryMetrics[F], dbRef: DbReference[F], F: Async[F])
     extends BaseRuntimeInterpreter[F](config, welderDao)
     with RuntimeAlgebra[F] {
-
   override def createRuntime(
     params: CreateRuntimeParams
   )(implicit ev: ApplicativeAsk[F, AppContext]): F[CreateRuntimeResponse] =

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/google/MockGoogleComputeService.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/google/MockGoogleComputeService.scala
@@ -101,7 +101,8 @@ class MockGoogleComputeService extends GoogleComputeService[IO] {
     zone: ZoneName,
     instanceName: InstanceName,
     autoDeleteDisks: Set[DiskName]
-  )(implicit ev: ApplicativeAsk[IO, TraceId], computePollOperation: ComputePollOperation[IO]): IO[Operation] = ???
+  )(implicit ev: ApplicativeAsk[IO, TraceId], computePollOperation: ComputePollOperation[IO]): IO[Operation] =
+    IO.pure(Operation.newBuilder().setId("op").setName("opName").setStatus("DONE").setTargetId("target").build())
 }
 
 object MockGoogleComputeService extends MockGoogleComputeService

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ZombieRuntimeMonitorSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ZombieRuntimeMonitorSpec.scala
@@ -442,7 +442,8 @@ class ZombieRuntimeMonitorSpec
   )(validations: () => A): A = {
     val dataprocInterp =
       new DataprocInterpreter(dataprocInterpreterConfig, null, null, gdDAO, gce, disk, null, null, null, null, blocker)
-    val gceInterp = new GceInterpreter(gceInterpreterConfig, null, null, gce, disk, null, blocker)
+    val gceInterp =
+      new GceInterpreter(gceInterpreterConfig, null, null, gce, disk, null, blocker)
 
     implicit val runtimeInstances = new RuntimeInstances[IO](dataprocInterp, gceInterp)
     val zombieClusterMonitor = ZombieRuntimeMonitor[IO](Config.zombieRuntimeMonitorConfig, googleProjectDAO)


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-2096

The bug is in frontend we've detached the persistent disk, hence in back leo, if we try to get the associated persistent disk, it won't be there to delete. Added automation test for deleteDisk flag

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
