### PR TITLE
[QA-1221] Retry getDisk() in RuntimeCreationDiskSpec

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeCreationDiskSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeCreationDiskSpec.scala
@@ -187,8 +187,9 @@ class RuntimeCreationDiskSpec
           }
         })
         _ <- deleteRuntimeWithWait(googleProject, runtimeWithDataName, deleteDisk = true)
-        ioa = getDisk(googleProject, diskName).attempt
-        diskResp <- streamFUntilDone(ioa, 5, 10 seconds).compile.lastOrError
+        getDiskAttempt = getDisk(googleProject, diskName).attempt
+        // Disk deletion may take some time so we're retrying to reduce flaky test failures
+        diskResp <- streamFUntilDone(getDiskAttempt, 5, 10 seconds).compile.lastOrError
       } yield {
         runtime.diskConfig.map(_.name) shouldBe Some(diskName)
         runtime.diskConfig.map(_.size) shouldBe Some(diskSize)

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeCreationDiskSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeCreationDiskSpec.scala
@@ -189,7 +189,7 @@ class RuntimeCreationDiskSpec
         _ <- deleteRuntimeWithWait(googleProject, runtimeWithDataName, deleteDisk = true)
         getDiskAttempt = getDisk(googleProject, diskName).attempt
         // Disk deletion may take some time so we're retrying to reduce flaky test failures
-        diskResp <- streamFUntilDone(getDiskAttempt, 5, 10 seconds).compile.lastOrError
+        diskResp <- streamFUntilDone(getDiskAttempt, 5, 5 seconds).compile.lastOrError
       } yield {
         runtime.diskConfig.map(_.name) shouldBe Some(diskName)
         runtime.diskConfig.map(_.size) shouldBe Some(diskSize)

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeCreationDiskSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeCreationDiskSpec.scala
@@ -121,7 +121,7 @@ class RuntimeCreationDiskSpec
     res.unsafeRunSync()
   }
 
-  "create runtime and attach an existing a persistent disk" in { googleProject =>
+  "create runtime and attach an existing persistent disk" in { googleProject =>
     val randomeName = randomClusterName
     val runtimeName = randomeName.copy(asString = randomeName.asString + "pd-spec") // just to make sure the test runtime name is unique
     val runtimeWithDataName = randomeName.copy(asString = randomeName.asString + "pd-spec-data-persist")

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeCreationDiskSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeCreationDiskSpec.scala
@@ -186,9 +186,9 @@ class RuntimeCreationDiskSpec
             notebookPage.executeCell(persistedPackage).get should include("/home/jupyter-user/notebooks/packages")
           }
         })
-        _ <- testTimer.sleep(5 seconds) //runtime status updates to Deleted before disk status change, hence add a sleep
         _ <- deleteRuntimeWithWait(googleProject, runtimeWithDataName, deleteDisk = true)
-        diskResp <- getDisk(googleProject, diskName).attempt
+        ioa = getDisk(googleProject, diskName).attempt
+        diskResp <- streamFUntilDone(ioa, 5, 10 seconds).compile.lastOrError
       } yield {
         runtime.diskConfig.map(_.name) shouldBe Some(diskName)
         runtime.diskConfig.map(_.size) shouldBe Some(diskSize)

--- a/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestSuite.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestSuite.scala
@@ -31,7 +31,7 @@ trait LeonardoTestSuite extends Matchers {
       val signal = Stream.unfoldEval(accumulator) { acc =>
         if (acc.maxRetry < 0)
           signalToStop
-            .complete(Assertions.fail(s"time out after retries", acc.throwable.getOrElse(null)))
+            .complete(Assertions.fail(s"time out after retries", acc.throwable.orNull))
             .as(None)
         else
           testTimer.sleep(1 seconds) >> validations.attempt.flatMap {


### PR DESCRIPTION
[JIRA ticket](https://broadworkbench.atlassian.net/browse/QA-1221)

At the end of a [RuntimeCreationDiskSpec test](https://github.com/DataBiosphere/leonardo/blob/2034bb8260dad82fae7250207a3d203a185d162e/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeCreationDiskSpec.scala#L124), we’re deleting a runtime as well as the attached disk. Once we find out that the runtime is deleted, we check if the disk is deleted. The flakiness appears to be due to that sometimes the disk isn’t yet deleted right then. Therefore, we’ve added a retry for a few more times. From a user experience perspective, it shouldn’t be a big deal if the deletion of their disk takes another 5-10 seconds.