### PR TITLE
IA-2041 Investigate restricting ICMP traffic on Leo user VMs

### DIFF
--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -154,7 +154,7 @@ vpc {
     }
   ]
   # Remove RDP and SSH rules in the default network. Also remove legacy leonardo-notebooks-rule if it exists.
-  firewallsToRemove = ["default-allow-rdp"]
+  firewallsToRemove = ["default-allow-rdp", "default-allow-icmp", "allow-icmp"]
   pollPeriod = 5 seconds
   maxAttempts = 24 # 2 minutes
 }


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-2041

Removes open-to-the-world ICMP firewall rule. Also adds a retry in `VPCInterpreter` to attempt to fix failing tests.

Will open a corresponding PR in https://github.com/broadinstitute/gcp-dm-templates to make it not create the ICMP rule in the first place.

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
