### PR TITLE
IA-2045 fix runtimes stuck in Stopping, Deleting

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/cluster/ClusterStatusTransitionsSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/cluster/ClusterStatusTransitionsSpec.scala
@@ -12,8 +12,12 @@ import org.scalatest.{DoNotDiscover, ParallelTestExecution}
  * Note these tests can take a long time so we don't test all edge cases, but these cases
  * should exercise the most commonly used paths through the system.
  */
-@DoNotDiscover
-class ClusterStatusTransitionsSpec extends GPAllocFixtureSpec with ParallelTestExecution with LeonardoTestUtils {
+//@DoNotDiscover
+class ClusterStatusTransitionsSpec
+    extends GPAllocFixtureSpec
+    with ParallelTestExecution
+    with LeonardoTestUtils
+    with GPAllocBeforeAndAfterAll {
 
   // these tests just hit the Leo APIs; they don't interact with notebooks via selenium
   "ClusterStatusTransitionsSpec" - {

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/cluster/ClusterStatusTransitionsSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/cluster/ClusterStatusTransitionsSpec.scala
@@ -12,12 +12,8 @@ import org.scalatest.{DoNotDiscover, ParallelTestExecution}
  * Note these tests can take a long time so we don't test all edge cases, but these cases
  * should exercise the most commonly used paths through the system.
  */
-//@DoNotDiscover
-class ClusterStatusTransitionsSpec
-    extends GPAllocFixtureSpec
-    with ParallelTestExecution
-    with LeonardoTestUtils
-    with GPAllocBeforeAndAfterAll {
+@DoNotDiscover
+class ClusterStatusTransitionsSpec extends GPAllocFixtureSpec with ParallelTestExecution with LeonardoTestUtils {
 
   // these tests just hit the Leo APIs; they don't interact with notebooks via selenium
   "ClusterStatusTransitionsSpec" - {

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/Boot.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/Boot.scala
@@ -10,10 +10,12 @@ import cats.effect.concurrent.Semaphore
 import cats.effect._
 import cats.implicits._
 import com.google.api.services.compute.ComputeScopes
+import com.google.devtools.clouderrorreporting.v1beta1.ProjectName
 import fs2.Stream
 import fs2.concurrent.InspectableQueue
 import io.chrisdavenport.log4cats.StructuredLogger
 import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
+import org.broadinstitute.dsde.workbench.errorReporting.ErrorReporting
 import org.broadinstitute.dsde.workbench.google.GoogleCredentialModes.{Json, Token}
 import org.broadinstitute.dsde.workbench.google2.{
   credentialResource,
@@ -69,10 +71,11 @@ object Boot extends IOApp {
     implicit val logger = Slf4jLogger.getLogger[IO]
 
     createDependencies[IO](applicationConfig.leoServiceAccountJsonFile.toString).use { appDependencies =>
-      implicit val openTelemetry = appDependencies.openTelemetryMetrics
-      implicit val dbRef = appDependencies.dbReference
-
       val googleDependencies = appDependencies.googleDependencies
+
+      implicit val dbRef = appDependencies.dbReference
+      implicit val openTelemetry = googleDependencies.openTelemetryMetrics
+
       val bucketHelperConfig = BucketHelperConfig(
         imageConfig,
         welderConfig,
@@ -228,7 +231,7 @@ object Boot extends IOApp {
           implicit val cloudServiceRuntimeMonitor: RuntimeMonitor[IO, CloudService] =
             new CloudServiceRuntimeMonitor(gceRuntimeMonitor, dataprocRuntimeMonitor)
 
-          val monitorAtBoot = new MonitorAtBoot[IO]()
+          val monitorAtBoot = new MonitorAtBoot[IO](appDependencies.publisherQueue)
 
           val googleDiskService = googleDependencies.googleDiskService
 
@@ -248,7 +251,8 @@ object Boot extends IOApp {
                                                googleDiskService,
                                                googleDependencies.computePollOperation,
                                                appDependencies.authProvider,
-                                               gkeInterp)
+                                               gkeInterp,
+                                               googleDependencies.errorReporting)
 
           val autopauseMonitor = AutopauseMonitor(
             autoFreezeConfig,
@@ -321,6 +325,8 @@ object Boot extends IOApp {
       serviceAccountProvider = new PetClusterServiceAccountProvider(samDao)
       authProvider = new SamAuthProvider(samDao, samAuthConfig, serviceAccountProvider, blocker)
 
+      credential <- credentialResource(pathToCredentialJson)
+      scopedCredential = credential.createScoped(Seq(ComputeScopes.COMPUTE).asJava)
       credentialJson <- Resource.liftF(
         readFileToString(applicationConfig.leoServiceAccountJsonFile, blocker)
       )
@@ -376,9 +382,10 @@ object Boot extends IOApp {
       asyncTasksQueue <- Resource.liftF(InspectableQueue.bounded[F, Task[F]](asyncTaskProcessorConfig.queueBound))
       _ <- OpenTelemetryMetrics.registerTracing[F](Paths.get(pathToCredentialJson), blocker)
       googleDiskService <- GoogleDiskService.resource(pathToCredentialJson, blocker, semaphore)
-      credential <- credentialResource(pathToCredentialJson)
-      scopedCredential = credential.createScoped(Seq(ComputeScopes.COMPUTE).asJava)
       computePollOperation <- ComputePollOperation.resourceFromCredential(scopedCredential, blocker, semaphore)
+      errorReporting <- ErrorReporting.fromCredential(scopedCredential,
+                                                      applicationConfig.applicationName,
+                                                      ProjectName.of(applicationConfig.leoGoogleProject.value))
       googleDependencies = GoogleDependencies(
         petGoogleStorageDAO,
         googleComputeService,
@@ -391,7 +398,9 @@ object Boot extends IOApp {
         dataprocService,
         kubernetesDnsCache,
         gkeService,
-        kubeService
+        kubeService,
+        openTelemetry,
+        errorReporting
       )
     } yield AppDependencies(
       storage,
@@ -405,7 +414,6 @@ object Boot extends IOApp {
       rstudioDAO,
       serviceAccountProvider,
       authProvider,
-      openTelemetry,
       blocker,
       semaphore,
       leoPublisher,
@@ -430,7 +438,9 @@ final case class GoogleDependencies[F[_]](
   googleDataproc: GoogleDataprocService[F],
   kubernetesDnsCache: KubernetesDnsCache[F],
   gkeService: GKEService[F],
-  kubeService: org.broadinstitute.dsde.workbench.google2.KubernetesService[F]
+  kubeService: org.broadinstitute.dsde.workbench.google2.KubernetesService[F],
+  openTelemetryMetrics: OpenTelemetryMetrics[F],
+  errorReporting: ErrorReporting[F]
 )
 
 final case class AppDependencies[F[_]](
@@ -445,7 +455,6 @@ final case class AppDependencies[F[_]](
   rStudioDAO: RStudioDAO[F],
   serviceAccountProvider: ServiceAccountProvider[F],
   authProvider: LeoAuthProvider[F],
-  openTelemetryMetrics: OpenTelemetryMetrics[F],
   blocker: Blocker,
   semaphore: Semaphore[F],
   leoPublisher: LeoPublisher[F],

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/Boot.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/Boot.scala
@@ -369,10 +369,10 @@ object Boot extends IOApp {
         RetryPredicates.standardRetryPredicate,
         RetryPredicates.whenStatusCode(400)
       )
-      googleComputeService <- GoogleComputeService.resource(pathToCredentialJson,
-                                                            blocker,
-                                                            semaphore,
-                                                            googleComputeRetryPolicy)
+      googleComputeService <- GoogleComputeService.fromCredential(scopedCredential,
+                                                                  blocker,
+                                                                  semaphore,
+                                                                  googleComputeRetryPolicy)
       dataprocService <- GoogleDataprocService.resource(
         pathToCredentialJson,
         blocker,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
@@ -20,6 +20,7 @@ import org.broadinstitute.dsde.workbench.google2.{
   KubernetesName,
   Location,
   MachineTypeName,
+  MaxRetries,
   NetworkName,
   PublisherConfig,
   RegionName,
@@ -603,6 +604,7 @@ object Config {
   val subscriberConfig: SubscriberConfig = SubscriberConfig(applicationConfig.leoServiceAccountJsonFile.toString,
                                                             topic,
                                                             config.as[FiniteDuration]("pubsub.ackDeadLine"),
+                                                            MaxRetries(10),
                                                             None)
 
   private val retryConfig = GoogleTopicAdminInterpreter.defaultRetryConfig

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/BaseCloudServiceRuntimeMonitor.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/BaseCloudServiceRuntimeMonitor.scala
@@ -392,3 +392,7 @@ abstract class BaseCloudServiceRuntimeMonitor[F[_]] {
         }.void
     }
 }
+
+final case class InvalidMonitorRequest(msg: String) extends RuntimeException {
+  override def getMessage: String = msg
+}

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/DataprocRuntimeMonitor.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/DataprocRuntimeMonitor.scala
@@ -17,7 +17,6 @@ import org.broadinstitute.dsde.workbench.google2.{
   GoogleStorageService,
   ZoneName
 }
-import org.broadinstitute.dsde.workbench.leonardo._
 import org.broadinstitute.dsde.workbench.leonardo.dao.ToolDAO
 import org.broadinstitute.dsde.workbench.leonardo.dao.google.{getInstanceIP, parseGoogleTimestamp}
 import org.broadinstitute.dsde.workbench.leonardo.db._
@@ -214,16 +213,15 @@ class DataprocRuntimeMonitor[F[_]: Parallel](
     runtimeAndRuntimeConfig: RuntimeAndRuntimeConfig
   )(implicit ev: ApplicativeAsk[F, AppContext]): F[CheckResult] = cluster match {
     case None =>
-      for {
-        _ <- logger
-          .error(s"${monitorContext} | Can't stop an instance that hasn't been initialized yet or doesn't exist")
-        _ <- failedRuntime(
-          monitorContext,
-          runtimeAndRuntimeConfig,
-          Some(RuntimeErrorDetails("Can't stop an instance that hasn't been initialized yet or doesn't exist")),
-          Set.empty
-        )
-      } yield ((), None) //TODO: Ideally we should have sentry report this case
+      val e = InvalidMonitorRequest(
+        s"${monitorContext} | Can't stop an instance that hasn't been initialized yet or doesn't exist"
+      )
+      failedRuntime(
+        monitorContext,
+        runtimeAndRuntimeConfig,
+        Some(RuntimeErrorDetails(e.getMessage)),
+        Set.empty
+      ) >> F.raiseError[CheckResult](e)
     case Some(c) =>
       for {
         instances <- getDataprocInstances(c, runtimeAndRuntimeConfig.runtime.googleProject)
@@ -247,16 +245,15 @@ class DataprocRuntimeMonitor[F[_]: Parallel](
     runtimeAndRuntimeConfig: RuntimeAndRuntimeConfig
   )(implicit ev: ApplicativeAsk[F, AppContext]): F[CheckResult] = cluster match {
     case None =>
-      for {
-        _ <- logger
-          .error(s"${monitorContext} | Can't update an instance that hasn't been initialized yet or doesn't exist")
-        _ <- failedRuntime(
-          monitorContext,
-          runtimeAndRuntimeConfig,
-          Some(RuntimeErrorDetails("Can't update an instance that hasn't been initialized yet or doesn't exist")),
-          Set.empty
-        )
-      } yield ((), None) //TODO: Ideally we should have sentry report this case
+      val e = InvalidMonitorRequest(
+        s"${monitorContext} | Can't update an instance that hasn't been initialized yet or doesn't exist"
+      )
+      failedRuntime(
+        monitorContext,
+        runtimeAndRuntimeConfig,
+        Some(RuntimeErrorDetails(e.getMessage)),
+        Set.empty
+      ) >> F.raiseError[CheckResult](e)
     case Some(c) =>
       for {
         instances <- getDataprocInstances(c, runtimeAndRuntimeConfig.runtime.googleProject)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/DataprocRuntimeMonitor.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/DataprocRuntimeMonitor.scala
@@ -486,5 +486,3 @@ class DataprocRuntimeMonitor[F[_]: Parallel](
     }
   }
 }
-
-object DataprocRuntimeMonitor {}

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/DataprocRuntimeMonitor.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/DataprocRuntimeMonitor.scala
@@ -140,7 +140,7 @@ class DataprocRuntimeMonitor[F[_]: Parallel](
                 monitorContext,
                 runtimeAndRuntimeConfig,
                 error
-                  .map(e => RuntimeErrorDetails(e.message, Some(e.code), Some(e.message))),
+                  .map(e => RuntimeErrorDetails(e.message, Some(e.code), Some("dataproc_creation_error"))),
                 instances
               )
             } yield res

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
@@ -13,6 +13,7 @@ import cats.mtl.ApplicativeAsk
 import com.google.cloud.compute.v1.Disk
 import fs2.Stream
 import fs2.concurrent.InspectableQueue
+import org.broadinstitute.dsde.workbench.errorReporting.ErrorReporting
 import org.broadinstitute.dsde.workbench.leonardo.AsyncTaskProcessor.Task
 import org.broadinstitute.dsde.workbench.google2.{
   ComputePollOperation,
@@ -23,6 +24,7 @@ import org.broadinstitute.dsde.workbench.google2.{
   MachineTypeName,
   OperationName
 }
+import org.broadinstitute.dsde.workbench.errorReporting.ReportWorthySyntax._
 import org.broadinstitute.dsde.workbench.leonardo.db._
 import org.broadinstitute.dsde.workbench.leonardo.http.{cloudServiceSyntax, _}
 import org.broadinstitute.dsde.workbench.leonardo.model.{LeoAuthProvider, LeoException}
@@ -42,7 +44,8 @@ class LeoPubsubMessageSubscriber[F[_]: Timer: ContextShift](
   googleDiskService: GoogleDiskService[F],
   computePollOperation: ComputePollOperation[F],
   authProvider: LeoAuthProvider[F],
-  gkeInterp: GKEInterpreter[F]
+  gkeInterp: GKEInterpreter[F],
+  errorReporting: ErrorReporting[F]
 )(implicit executionContext: ExecutionContext,
   F: ConcurrentEffect[F],
   parallel: Parallel[F],
@@ -168,30 +171,16 @@ class LeoPubsubMessageSubscriber[F[_]: Timer: ContextShift](
         } else F.unit
       } yield ()
       _ <- asyncTasks.enqueue1(
-        Task(ctx.traceId, taskToRun, Some(logError(msg.runtimeProjectAndName.toString, "creating runtime")), ctx.now)
+        Task(
+          ctx.traceId,
+          taskToRun,
+          Some(createRuntimeErrorHandler(msg, ctx.now)),
+          ctx.now
+        )
       )
     } yield ()
 
-    createCluster.handleErrorWith {
-      case e =>
-        for {
-          ctx <- ev.ask
-          _ <- logger.error(e)(s"Failed to create runtime ${msg.runtimeProjectAndName} in Google")
-          errorMessage = e match {
-            case leoEx: LeoException =>
-              Some(ErrorReport.loggableString(leoEx.toErrorReport))
-            case ee: com.google.api.gax.rpc.AbortedException
-                if ee.getStatusCode().getCode == 409 && ee.getMessage().contains("already exists") =>
-              None //this could happen when pubsub redelivers an event unexpectedly
-            case _ =>
-              Some(s"Failed to create cluster ${msg.runtimeProjectAndName} due to ${e.getMessage}")
-          }
-          _ <- errorMessage.traverse(m =>
-            (clusterErrorQuery.save(msg.runtimeId, RuntimeError(m, -1, ctx.now)) >>
-              clusterQuery.updateClusterStatus(msg.runtimeId, RuntimeStatus.Error, ctx.now)).transaction[F]
-          )
-        } yield ()
-    }
+    createCluster.handleErrorWith(e => ev.ask.flatMap(ctx => createRuntimeErrorHandler(msg, ctx.now)(e)))
   }
 
   private[monitor] def handleDeleteRuntimeMessage(msg: DeleteRuntimeMessage)(
@@ -254,7 +243,12 @@ class LeoPubsubMessageSubscriber[F[_]: Timer: ContextShift](
         )
       }
       _ <- asyncTasks.enqueue1(
-        Task(ctx.traceId, fa, Some(logError(runtime.projectNameString, "deleting runtime")), ctx.now)
+        Task(
+          ctx.traceId,
+          fa,
+          Some(handleRuntimeMessageError(runtime.id, ctx.now, s"deleting runtime ${runtime.projectNameString} failed")),
+          ctx.now
+        )
       )
     } yield ()
 
@@ -286,7 +280,14 @@ class LeoPubsubMessageSubscriber[F[_]: Timer: ContextShift](
           runtimeConfig.cloudService.process(runtime.id, RuntimeStatus.Stopping).compile.drain
       }
       _ <- asyncTasks.enqueue1(
-        Task(ctx.traceId, poll, Some(logError(runtime.projectNameString, "stopping runtime")), ctx.now)
+        Task(
+          ctx.traceId,
+          poll,
+          Some(
+            handleRuntimeMessageError(msg.runtimeId, ctx.now, s"stopping runtime ${runtime.projectNameString} failed")
+          ),
+          ctx.now
+        )
       )
     } yield ()
 
@@ -313,7 +314,9 @@ class LeoPubsubMessageSubscriber[F[_]: Timer: ContextShift](
         Task(
           ctx.traceId,
           runtimeConfig.cloudService.process(msg.runtimeId, RuntimeStatus.Starting).compile.drain,
-          Some(logError(runtime.projectNameString, "starting runtime")),
+          Some(
+            handleRuntimeMessageError(msg.runtimeId, ctx.now, s"starting runtime ${runtime.projectNameString} failed")
+          ),
           ctx.now
         )
       )
@@ -402,7 +405,14 @@ class LeoPubsubMessageSubscriber[F[_]: Timer: ContextShift](
             _ <- startAndUpdateRuntime(runtime, msg.newMachineType)(ctxStarting)
           } yield ()
           _ <- asyncTasks.enqueue1(
-            Task(ctx.traceId, task, Some(logError(runtime.projectNameString, "updating runtime")), ctx.now)
+            Task(ctx.traceId,
+                 task,
+                 Some(
+                   handleRuntimeMessageError(msg.runtimeId,
+                                             ctx.now,
+                                             s"updating runtime ${runtime.projectNameString} failed")
+                 ),
+                 ctx.now)
           )
         } yield ()
       } else
@@ -802,6 +812,84 @@ class LeoPubsubMessageSubscriber[F[_]: Timer: ContextShift](
         Task(ctx.traceId, task, Some(handleKubernetesError), ctx.now)
       )
     } yield ()
+
+  private def deleteDiskForApp(diskId: DiskId)(
+    implicit ev: ApplicativeAsk[F, AppContext]
+  ): F[Unit] =
+    deleteDisk(diskId, true)
+
+  private def createDiskForApp(msg: CreateAppMessage)(
+    implicit ev: ApplicativeAsk[F, AppContext]
+  ): F[Unit] =
+    msg.createDisk match {
+      case true =>
+        for {
+          _ <- logger.info(s"Beginning disk creation for app ${msg.appId}")
+          ctx <- ev.ask
+          getAppOpt <- KubernetesServiceDbQueries.getActiveFullAppByName(msg.project, msg.appName).transaction
+          getApp <- F.fromOption(getAppOpt, AppNotFoundException(msg.project, msg.appName, ctx.traceId))
+          disk <- F.fromOption(
+            getApp.app.appResources.disk,
+            AppCreationException(
+              s"create disk was true for create app message, but app ${getApp.app.id} does not have a disk id saved"
+            )
+          )
+          _ <- createDisk(CreateDiskMessage.fromDisk(disk, Some(ctx.traceId)), true)
+        } yield ()
+      case false => F.unit
+    }
+
+  private def handleKubernetesError(e: Throwable): F[Unit] =
+    e match {
+      case e: PubsubKubernetesError =>
+        for {
+          _ <- appErrorQuery.save(e.appId, e.dbError).transaction
+          _ <- appQuery.updateStatus(e.appId, AppStatus.Error).transaction
+          _ <- e.clusterId.traverse(clusterId =>
+            kubernetesClusterQuery.updateStatus(clusterId, KubernetesClusterStatus.Error).transaction
+          )
+          _ <- e.nodepoolId.traverse(nodepoolId =>
+            nodepoolQuery.updateStatus(nodepoolId, NodepoolStatus.Error).transaction
+          )
+          _ <- logger.error(e)(s"updating db state for an async error for app ${e.appId}")
+        } yield ()
+      case _ =>
+        F.raiseError(
+          new RuntimeException(s"handleKubernetesError should not be used with a non kubernetes error. Error: ${e}")
+        )
+    }
+
+  private def createRuntimeErrorHandler(msg: CreateRuntimeMessage, now: Instant)(e: Throwable): F[Unit] =
+    for {
+      _ <- logger.error(e)(s"Failed to create runtime ${msg.runtimeProjectAndName} in Google")
+      errorMessage = e match {
+        case leoEx: LeoException =>
+          Some(ErrorReport.loggableString(leoEx.toErrorReport))
+        case ee: com.google.api.gax.rpc.AbortedException
+            if ee.getStatusCode().getCode == 409 && ee.getMessage().contains("already exists") =>
+          None //this could happen when pubsub redelivers an event unexpectedly
+        case _ =>
+          Some(s"Failed to create cluster ${msg.runtimeProjectAndName} due to ${e.getMessage}")
+      }
+      _ <- errorMessage.traverse(m =>
+        (clusterErrorQuery.save(msg.runtimeId, RuntimeError(m, -1, now)) >>
+          clusterQuery.updateClusterStatus(msg.runtimeId, RuntimeStatus.Error, now)).transaction[F]
+      )
+      _ <- if (e.isReportWorthy)
+        errorReporting.reportError(e)
+      else F.unit
+    } yield ()
+
+  private def handleRuntimeMessageError(runtimeId: Long, now: Instant, msg: String)(e: Throwable): F[Unit] = {
+    val m = s"${msg} due to ${e.getMessage}"
+    for {
+      _ <- clusterErrorQuery.save(runtimeId, RuntimeError(m, -1, now)).transaction
+      _ <- logger.error(e)(m)
+      _ <- if (e.isReportWorthy)
+        errorReporting.reportError(e)
+      else F.unit
+    } yield ()
+  }
 
   private def logError(projectAndName: String, action: String): Throwable => F[Unit] =
     t => logger.error(t)(s"Fail to monitor ${projectAndName} for ${action}")

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/MonitorAtBoot.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/MonitorAtBoot.scala
@@ -6,20 +6,20 @@ import cats.implicits._
 import cats.mtl.ApplicativeAsk
 import fs2.Stream
 import io.chrisdavenport.log4cats.Logger
-import org.broadinstitute.dsde.workbench.leonardo.db.{clusterQuery, patchQuery, DbReference}
+import org.broadinstitute.dsde.workbench.leonardo.db.{clusterQuery, patchQuery, DbReference, RuntimeConfigQueries}
 import org.broadinstitute.dsde.workbench.leonardo.http.dbioToIO
 import org.broadinstitute.dsde.workbench.model.TraceId
-import org.broadinstitute.dsde.workbench.leonardo.http.cloudServiceSyntax
 import org.broadinstitute.dsde.workbench.openTelemetry.OpenTelemetryMetrics
 
 import scala.concurrent.ExecutionContext
 
-class MonitorAtBoot[F[_]: Timer](implicit F: Async[F],
-                                 dbRef: DbReference[F],
-                                 logger: Logger[F],
-                                 ec: ExecutionContext,
-                                 monitor: RuntimeMonitor[F, CloudService],
-                                 metrics: OpenTelemetryMetrics[F]) {
+class MonitorAtBoot[F[_]: Timer](publisherQueue: fs2.concurrent.Queue[F, LeoPubsubMessage])(
+  implicit F: Async[F],
+  dbRef: DbReference[F],
+  logger: Logger[F],
+  ec: ExecutionContext,
+  metrics: OpenTelemetryMetrics[F]
+) {
   val process: Stream[F, Unit] = {
     implicit val traceId = ApplicativeAsk.const[F, TraceId](TraceId("BootMonitoring"))
     val res = clusterQuery.listMonitored
@@ -30,12 +30,14 @@ class MonitorAtBoot[F[_]: Timer](implicit F: Async[F],
           clusters.toList.traverse_ {
             case c if c.status.isMonitored && c.status != RuntimeStatus.Unknown =>
               val r = for {
-                _ <- c.cloudService.process(c.id, c.status).compile.drain
+                tid <- traceId.ask
+                message <- runtimeStatusToMessage(c, tid)
+                // If a runtime is in transition status (Creating, Starting etc), then we're enqueue a pubsub message again
+                _ <- message.traverse(m => publisherQueue.enqueue1(m))
                 patchInProgress <- patchQuery.isInprogress(c.id).transaction
                 _ <- if (patchInProgress) {
                   for {
                     statusOpt <- clusterQuery.getClusterStatus(c.id).transaction
-                    tid <- traceId.ask
                     s <- F.fromEither(
                       statusOpt
                         .toRight(new Exception(s"${tid} | ${c.id} not found after transition. This is very weird!"))
@@ -63,6 +65,73 @@ class MonitorAtBoot[F[_]: Timer](implicit F: Async[F],
 
     Stream.eval(res)
   }
+
+  private def runtimeStatusToMessage(runtime: RuntimeToMonitor, traceId: TraceId): F[Option[LeoPubsubMessage]] =
+    runtime.status match {
+      case RuntimeStatus.Stopping =>
+        F.pure(Some(LeoPubsubMessage.StopRuntimeMessage(runtime.id, Some(traceId))))
+      case RuntimeStatus.Deleting =>
+        F.pure(
+          Some(
+            LeoPubsubMessage.DeleteRuntimeMessage(
+              runtime.id,
+              None,
+              Some(traceId)
+            )
+          )
+        ) //If user specified `deleteDisk` being true in the original request, then we can't really recover; User will have to explicitly delete disk in UI again
+      case RuntimeStatus.Starting =>
+        F.pure(
+          Some(
+            LeoPubsubMessage.StartRuntimeMessage(
+              runtime.id,
+              Some(traceId)
+            )
+          )
+        )
+      case RuntimeStatus.Creating =>
+        for {
+          fullRuntime <- clusterQuery.getClusterById(runtime.id).transaction
+          rt <- F.fromOption(fullRuntime, new Exception(s"can't find ${runtime.id} in DB"))
+          rtConfig <- RuntimeConfigQueries.getRuntimeConfig(rt.runtimeConfigId).transaction
+          r = rtConfig match {
+            case x: RuntimeConfig.GceConfig =>
+              for {
+                bootDiskSize <- x.bootDiskSize.toRight(
+                  s"disk Size field not found for ${rt.id}. This should never happen"
+                ) //TODO: report error
+              } yield RuntimeConfigInCreateRuntimeMessage.GceConfig(
+                x.machineType,
+                x.diskSize,
+                bootDiskSize
+              ): RuntimeConfigInCreateRuntimeMessage
+            case x: RuntimeConfig.GceWithPdConfig =>
+              for {
+                diskId <- x.persistentDiskId.toRight(
+                  s"disk id field not found for ${rt.id}. This should never happen"
+                ) //TODO: report error
+              } yield RuntimeConfigInCreateRuntimeMessage.GceWithPdConfig(
+                x.machineType,
+                diskId,
+                x.bootDiskSize
+              ): RuntimeConfigInCreateRuntimeMessage
+            case _: RuntimeConfig.DataprocConfig =>
+              Right(
+                LeoLenses.runtimeConfigPrism.getOption(rtConfig).get: RuntimeConfigInCreateRuntimeMessage
+              )
+          }
+          rtConfigInMessage <- F.fromEither(r.leftMap(s => new RuntimeException(s)))
+        } yield {
+          Some(
+            LeoPubsubMessage.CreateRuntimeMessage.fromRuntime(
+              rt,
+              rtConfigInMessage,
+              Some(traceId)
+            )
+          )
+        }
+      case x => logger.info(s"${runtime.id} is in ${x} status. Do nothing").as(none[LeoPubsubMessage])
+    }
 }
 
 final case class RuntimeToMonitor(

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/RuntimeServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/RuntimeServiceInterp.scala
@@ -620,7 +620,7 @@ class RuntimeServiceInterp[F[_]: Parallel](config: RuntimeServiceConfig,
         if (m.stopToUpdateMachineType) {
           val patchDetails = RuntimePatchDetails(runtime.id, RuntimeStatus.Stopped)
           patchQuery.save(patchDetails, m.newMachineType).transaction.void >> metrics.incrementCounter(
-            "patchStopToUpdateMachineType"
+            "patchStopToUpdate"
           )
         } else F.unit
       }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriberSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriberSpec.scala
@@ -1344,7 +1344,8 @@ class LeoPubsubMessageSubscriberSpec
       MockGoogleDiskService,
       computePollOperation,
       MockAuthProvider,
-      gkeInterp
+      gkeInterp,
+      org.broadinstitute.dsde.workbench.errorReporting.FakeErrorReporting
     )
   }
 }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/MonitorAtBootSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/MonitorAtBootSpec.scala
@@ -1,0 +1,95 @@
+package org.broadinstitute.dsde.workbench.leonardo.monitor
+
+import cats.effect.IO
+import cats.Eq
+import cats.implicits._
+import fs2.concurrent.InspectableQueue
+import org.broadinstitute.dsde.workbench.leonardo.{LeoLenses, LeonardoTestSuite, RuntimeStatus}
+import org.broadinstitute.dsde.workbench.leonardo.db.TestComponent
+import org.scalatest.flatspec.AnyFlatSpec
+import org.broadinstitute.dsde.workbench.leonardo.CommonTestData._
+import org.scalatest.Assertions
+
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class MonitorAtBootSpec extends AnyFlatSpec with TestComponent with LeonardoTestSuite {
+  implicit val msgEq: Eq[LeoPubsubMessage] =
+    Eq.instance[LeoPubsubMessage]((x, y) =>
+      (x, y) match {
+        case (xx: LeoPubsubMessage.StopRuntimeMessage, yy: LeoPubsubMessage.StopRuntimeMessage) =>
+          xx.copy(traceId = None) == yy.copy(traceId = None)
+        case (xx: LeoPubsubMessage.DeleteRuntimeMessage, yy: LeoPubsubMessage.DeleteRuntimeMessage) =>
+          xx.copy(traceId = None) == yy.copy(traceId = None)
+        case (xx: LeoPubsubMessage.CreateRuntimeMessage, yy: LeoPubsubMessage.CreateRuntimeMessage) =>
+          xx.copy(traceId = None) == yy.copy(traceId = None)
+        case (xx: LeoPubsubMessage.StartRuntimeMessage, yy: LeoPubsubMessage.StartRuntimeMessage) =>
+          xx.copy(traceId = None) == yy.copy(traceId = None)
+        case (xx, yy) =>
+          Assertions.fail(s"unexpected messages ${xx}, ${yy}", null)
+      }
+    )
+
+  it should "recover RuntimeStatus.Stopping properly" in isolatedDbTest {
+    val res = for {
+      queue <- InspectableQueue.bounded[IO, LeoPubsubMessage](10)
+      monitorAtBoot = createMonitorAtBoot(queue)
+      runtime <- IO(makeCluster(0).copy(status = RuntimeStatus.Stopping).save())
+      _ <- monitorAtBoot.process.take(1).compile.drain
+      msg <- queue.tryDequeue1
+    } yield {
+      (msg eqv Some(LeoPubsubMessage.StopRuntimeMessage(runtime.id, None))) shouldBe (true)
+    }
+    res.unsafeRunSync()
+  }
+
+  it should "recover RuntimeStatus.Deleting properly" in isolatedDbTest {
+    val res = for {
+      queue <- InspectableQueue.bounded[IO, LeoPubsubMessage](10)
+      monitorAtBoot = createMonitorAtBoot(queue)
+      runtime <- IO(makeCluster(0).copy(status = RuntimeStatus.Deleting).save())
+      _ <- monitorAtBoot.process.take(1).compile.drain
+      msg <- queue.tryDequeue1
+    } yield {
+      (msg eqv Some(LeoPubsubMessage.DeleteRuntimeMessage(runtime.id, None, None))) shouldBe (true)
+    }
+    res.unsafeRunSync()
+  }
+
+  it should "recover RuntimeStatus.Starting properly" in isolatedDbTest {
+    val res = for {
+      queue <- InspectableQueue.bounded[IO, LeoPubsubMessage](10)
+      monitorAtBoot = createMonitorAtBoot(queue)
+      runtime <- IO(makeCluster(0).copy(status = RuntimeStatus.Starting).save())
+      _ <- monitorAtBoot.process.take(1).compile.drain
+      msg <- queue.tryDequeue1
+    } yield {
+      (msg eqv Some(LeoPubsubMessage.StartRuntimeMessage(runtime.id, None))) shouldBe (true)
+    }
+    res.unsafeRunSync()
+  }
+
+  it should "recover RuntimeStatus.Creating properly" in isolatedDbTest {
+    val res = for {
+      queue <- InspectableQueue.bounded[IO, LeoPubsubMessage](10)
+      monitorAtBoot = createMonitorAtBoot(queue)
+      runtime <- IO(makeCluster(0).copy(status = RuntimeStatus.Creating).save())
+      _ <- monitorAtBoot.process.take(1).compile.drain
+      msg <- queue.tryDequeue1
+    } yield {
+      val runtimeConfigInCreateRuntimeMessage = LeoLenses.runtimeConfigPrism.getOption(defaultDataprocRuntimeConfig).get
+      (msg eqv Some(
+        LeoPubsubMessage.CreateRuntimeMessage.fromRuntime(
+          runtime,
+          runtimeConfigInCreateRuntimeMessage,
+          None
+        )
+      )) shouldBe (true)
+    }
+    res.unsafeRunSync()
+  }
+
+  def createMonitorAtBoot(
+    queue: InspectableQueue[IO, LeoPubsubMessage] = InspectableQueue.bounded[IO, LeoPubsubMessage](10).unsafeRunSync
+  ): MonitorAtBoot[IO] =
+    new MonitorAtBoot[IO](queue)
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -21,7 +21,7 @@ object Dependencies {
   val workbenchUtilV = "0.5-4c7acd5"
   val workbenchModelV = "0.13-31cacc4"
   val workbenchGoogleV = "0.21-2a218f3"
-  val workbenchGoogle2V = "0.11-59c8c5da-SNAP"
+  val workbenchGoogle2V = "0.11-966c4cc"
   val workbenchMetricsV = "0.3-c5b80d2"
   val workbenchOpenTelemetryV = "0.1-e66171c"
   val workbenchErrorReportingV = "0.1-92fcd96"
@@ -168,7 +168,6 @@ object Dependencies {
     googleDataproc,
     googleRpc,
     googleOAuth2,
-//    googleGaxGrpc,
     googleErrorReporting, // forcing an older versin of google-cloud-errorreporting because latest version brings in higher version of gax-grpc, which isn't compatible with other google dependencies
 
     hikariCP,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -21,7 +21,7 @@ object Dependencies {
   val workbenchUtilV = "0.5-4c7acd5"
   val workbenchModelV = "0.13-31cacc4"
   val workbenchGoogleV = "0.21-2a218f3"
-  val workbenchGoogle2V = "0.11-966c4cc"
+  val workbenchGoogle2V = "0.11-02ef6de8-SNAP"
   val workbenchMetricsV = "0.3-c5b80d2"
   val workbenchOpenTelemetryV = "0.1-e66171c"
   val workbenchErrorReportingV = "0.1-92fcd96"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -21,9 +21,10 @@ object Dependencies {
   val workbenchUtilV = "0.5-4c7acd5"
   val workbenchModelV = "0.13-31cacc4"
   val workbenchGoogleV = "0.21-2a218f3"
-  val workbenchGoogle2V = "0.11-c0e6762"
+  val workbenchGoogle2V = "0.11-59c8c5da-SNAP"
   val workbenchMetricsV = "0.3-c5b80d2"
   val workbenchOpenTelemetryV = "0.1-e66171c"
+  val workbenchErrorReportingV = "0.1-92fcd96"
 
   val excludeAkkaHttp = ExclusionRule(organization = "com.typesafe.akka", name = "akka-http_2.12")
   val excludeAkkaStream = ExclusionRule(organization = "com.typesafe.akka", name = "akka-stream_2.12")
@@ -37,6 +38,7 @@ object Dependencies {
   val excludeFindbugsJsr = ExclusionRule(organization = "com.google.code.findbugs", name = "jsr305")
   val excludeGson = ExclusionRule(organization = "com.google.code.gson", name = "gson")
   val excludeGoogleApiClient = ExclusionRule(organization = "com.google.api-client", name = "google-api-client")
+  val excludeGoogleErrorReporting = ExclusionRule(organization = "com.google.cloud", name = "google-cloud-errorreporting")
   val excludeGoogleApiClientJackson2 = ExclusionRule(organization = "com.google.http-client", name = "google-http-client-jackson2")
   val excludeGoogleHttpClient = ExclusionRule(organization = "com.google.http-client", name = "google-http-client")
   val excludeJacksonCore = ExclusionRule(organization = "com.fasterxml.jackson.core", name = "jackson-core")
@@ -61,7 +63,6 @@ object Dependencies {
   val jacksonCore: ModuleID =         "com.fasterxml.jackson.core" % "jackson-core"         % jacksonV
 
   val logbackClassic: ModuleID =  "ch.qos.logback"              % "logback-classic" % "1.2.3"
-  val ravenLogback: ModuleID =    "com.getsentry.raven"         % "raven-logback"   % "8.0.3" excludeAll (excludeJacksonCore, excludeSlf4j, excludeLogbackCore, excludeLogbackClassic)
   val scalaLogging: ModuleID =    "com.typesafe.scala-logging"  %% "scala-logging"  % scalaLoggingV
   val swaggerUi: ModuleID =       "org.webjars"                 % "swagger-ui"      % "3.25.0"
   val ficus: ModuleID =           "com.iheart"                  %% "ficus"          % "1.4.7"
@@ -76,8 +77,10 @@ object Dependencies {
   val akkaHttpTestKit: ModuleID =   "com.typesafe.akka" %% "akka-http-testkit"    % akkaHttpV % "test"
 
   val googleDataproc: ModuleID =            "com.google.apis" % "google-api-services-dataproc"    % s"v1-rev91-$googleV" excludeAll (excludeGuavaJDK5, excludeJacksonCore, excludeFindbugsJsr, excludeHttpComponent, excludeFirestore)
-  val googleRpc: ModuleID =                 "io.grpc"         % "grpc-core"                       % "1.28.0" excludeAll (excludeGuava, excludeGson, excludeFindbugsJsr, excludeAutoValueAnnotation, excludeAutoValue)
+  val googleRpc: ModuleID =                 "io.grpc"         % "grpc-core"                       % "1.28.1" excludeAll (excludeGuava, excludeGson, excludeFindbugsJsr, excludeAutoValueAnnotation, excludeAutoValue)
   val googleOAuth2: ModuleID =              "com.google.auth" % "google-auth-library-oauth2-http" % "0.9.1" excludeAll (excludeGuava, excludeFindbugsJsr, excludeGoogleApiClient, excludeGoogleApiClientJackson2, excludeGoogleHttpClient, excludeHttpComponent)
+  val googleGaxGrpc: ModuleID = "com.google.api" % "gax-grpc" % "1.57.0"  excludeAll (excludeGuava, excludeFindbugsJsr, excludeGoogleApiClient, excludeGoogleApiClientJackson2, excludeGoogleHttpClient, excludeHttpComponent)
+  val googleErrorReporting: ModuleID = "com.google.cloud" % "google-cloud-errorreporting" % "0.119.2-beta"
 
   val scalaTest: ModuleID = "org.scalatest"                 %% "scalatest"     % scalaTestV  % "test"
   val scalaTestScalaCheck = "org.scalatestplus" %% "scalacheck-1-14" % "3.2.0.0" % Test // https://github.com/scalatest/scalatestplus-scalacheck
@@ -89,7 +92,7 @@ object Dependencies {
   val workbenchUtil: ModuleID =         "org.broadinstitute.dsde.workbench" %% "workbench-util"     % workbenchUtilV excludeAll (excludeWorkbenchModel, excludeGoogleError, excludeGuava)
   val workbenchModel: ModuleID =        "org.broadinstitute.dsde.workbench" %% "workbench-model"    % workbenchModelV excludeAll (excludeGoogleError, excludeGuava)
   val workbenchGoogle: ModuleID =       "org.broadinstitute.dsde.workbench" %% "workbench-google"   % workbenchGoogleV excludeAll (excludeWorkbenchUtil, excludeWorkbenchModel, excludeIoGrpc, excludeFindbugsJsr, excludeGoogleApiClient, excludeGoogleError, excludeHttpComponent, excludeAutoValue, excludeAutoValueAnnotation, excludeGuava)
-  val workbenchGoogle2: ModuleID =      "org.broadinstitute.dsde.workbench" %% "workbench-google2"  % workbenchGoogle2V excludeAll (excludeWorkbenchUtil,
+ val workbenchGoogle2: ModuleID =      "org.broadinstitute.dsde.workbench" %% "workbench-google2"  % workbenchGoogle2V excludeAll (excludeWorkbenchUtil,
     excludeWorkbenchModel,
     excludeWorkbenchMetrics,
     excludeIoGrpc,
@@ -107,13 +110,15 @@ object Dependencies {
   val workbenchGoogleTest: ModuleID =   "org.broadinstitute.dsde.workbench" %% "workbench-google"   % workbenchGoogleV  % "test" classifier "tests" excludeAll (excludeWorkbenchUtil, excludeWorkbenchModel, excludeGuava)
   val workbenchGoogle2Test: ModuleID =  "org.broadinstitute.dsde.workbench" %% "workbench-google2"  % workbenchGoogle2V % "test" classifier "tests" excludeAll (excludeGuava) //for generators
   val workbenchOpenTelemetry: ModuleID =     "org.broadinstitute.dsde.workbench" %% "workbench-opentelemetry" % workbenchOpenTelemetryV excludeAll (excludeGuava)
-  val workbenchOpenTelemetryTest: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-opentelemetry" % workbenchOpenTelemetryV % "test" classifier "tests" excludeAll (excludeGuava)
+  val workbenchOpenTelemetryTest: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-opentelemetry" % workbenchOpenTelemetryV % Test classifier "tests" excludeAll (excludeGuava)
+  val workbenchErrorReporting: ModuleID =      "org.broadinstitute.dsde.workbench" %% "workbench-error-reporting"  % workbenchErrorReportingV excludeAll(excludeGoogleErrorReporting)
+  val workbenchErrorReportingTest: ModuleID =      "org.broadinstitute.dsde.workbench" %% "workbench-error-reporting"  % workbenchErrorReportingV % Test classifier "tests" excludeAll(excludeGoogleErrorReporting)
 
   val slick: ModuleID =           "com.typesafe.slick"  %% "slick"                % slickV excludeAll (excludeTypesafeConfig, excludeReactiveStream)
   val hikariCP: ModuleID =        "com.typesafe.slick"  %% "slick-hikaricp"       % slickV excludeAll (excludeSlf4j)
   val mysql: ModuleID =           "mysql"               % "mysql-connector-java"  % "8.0.18"
   val liquibase: ModuleID =       "org.liquibase"       % "liquibase-core"        % "3.8.8"
-  val sealerate: ModuleID =       "ca.mrvisser"         %% "sealerate"            % "0.0.5"
+  val sealerate: ModuleID =       "ca.mrvisser"         %% "sealerate"            % "0.0.6"
   val googleCloudNio: ModuleID =  "com.google.cloud"    % "google-cloud-nio"      % "0.107.0-alpha" % "test" // brought in for FakeStorageInterpreter
 
   val http4sCirce =       "org.http4s"        %% "http4s-circe"         % http4sVersion
@@ -131,7 +136,7 @@ object Dependencies {
     workbenchGoogle2Test,
     workbenchOpenTelemetry,
     workbenchOpenTelemetryTest,
-    "net.logstash.logback" % "logstash-logback-encoder" % "6.2", // for structured logging in logback
+//    "net.logstash.logback" % "logstash-logback-encoder" % "6.2", // for structured logging in logback
     "org.scalacheck" %% "scalacheck" % "1.14.1" % "test",
     sealerate,
     enumeratum,
@@ -149,7 +154,6 @@ object Dependencies {
     jacksonCore,
     fs2Io,
     logbackClassic,
-    ravenLogback,
     scalaLogging,
     swaggerUi,
     ficus,
@@ -164,10 +168,15 @@ object Dependencies {
     googleDataproc,
     googleRpc,
     googleOAuth2,
+//    googleGaxGrpc,
+    googleErrorReporting, // forcing an older versin of google-cloud-errorreporting because latest version brings in higher version of gax-grpc, which isn't compatible with other google dependencies
+
     hikariCP,
     workbenchUtil,
     workbenchGoogle,
     workbenchGoogleTest,
+    workbenchErrorReporting,
+    workbenchErrorReportingTest,
     "org.typelevel" %% "cats-mtl-core"  % "0.7.0",
     "org.typelevel" %% "cats-effect"    % "2.0.0", //forcing cats 2.0.0
     "com.rms.miu" %% "slick-cats" % "0.10.1",

--- a/project/Merging.scala
+++ b/project/Merging.scala
@@ -7,7 +7,9 @@ object Merging {
     //[error] java.lang.RuntimeException: deduplicate: different file contents found in the following:
     //[error] /root/.cache/coursier/v1/https/repo1.maven.org/maven2/com/google/protobuf/protobuf-java/3.11.4/protobuf-java-3.11.4.jar:google/protobuf/field_mask.proto
     //[error] /root/.cache/coursier/v1/https/repo1.maven.org/maven2/com/typesafe/akka/akka-protobuf-v3_2.12/2.6.5/akka-protobuf-v3_2.12-2.6.5.jar:google/protobuf/field_mask.proto
-    case PathList("google", "protobuf", "field_mask.proto") => MergeStrategy.first
+    case PathList("google", "protobuf", "field_mask.proto")         => MergeStrategy.first
+    case PathList("google", "protobuf", "descriptor.proto")         => MergeStrategy.first
+    case PathList("google", "protobuf", "compiler", "plugin.proto") => MergeStrategy.first
     case "module-info.class" =>
       MergeStrategy.discard // JDK 8 does not use the file module-info.class so it is safe to discard the file.
     case "reference.conf" => MergeStrategy.concat


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-2045. 

* My theory on the bug is error occurred before we update DB, but after google Delete/Stop completed. Hence we never updated DB status properly (altho the chance seems to me pretty low)
* Made `MonitorAtBoot` to resend a message, if a runtime is in `Stopping`, `Deleting`, `Creating`, `Starting`. This should make things more robust.
* Updated error handle in subscriber for runtime messages so that errors happen in async task will be persisted in DB


---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
