### PR TITLE
IA-2130 get rid of customizable submodule versions

### DIFF
--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -141,10 +141,6 @@ pipeline {
             description: "The path for the bucket where the custom GCE images will be stored")
         string(name: "DATAPROC_VERSIONS", defaultValue: "1.2.79-debian9 1.4.15-debian9",
             description: "A custom image will be build for each of these dataproc versions")
-        string(name: "IMAGE_HARDENING_LIB_VERSION", defaultValue: "100d620",
-            description: "The branch or hash of the 'broadinstitute/dsp-appsec-base-image-hardening' repo that contains libraries for CIS-hardening GCE images")
-        string(name: "CRYPTOMINING_LIB_VERSION", defaultValue: "master",
-            description: "The branch or hash of the 'broadinstitute/terra-cryptomining-security-alerts' repo that contains libraries for detecting cryptomining processes")
         booleanParam(name: "USE_CUSTOM_DOCKER_IMAGE_VERSIONS", defaultValue: false,
             description: "Check if you want to specify custom image versions below")
         string(name: "terra_jupyter_base", defaultValue: "0.0.9")
@@ -378,8 +374,6 @@ pipeline {
                             sshagent(['jenkins-ssh-github']) {
                                 sh """
                                     cd ${WORKSPACE}/jenkins/gce-custom-images/terra-cryptomining-security-alerts
-                                    git fetch && git checkout $CRYPTOMINING_LIB_VERSION
-
                                     gsutil cp install_falco.sh $DATAPROC_IMAGE_BUCKET/terra-cryptomining-security-alerts/install_falco.sh
                                     gsutil cp falco.yaml $DATAPROC_IMAGE_BUCKET/terra-cryptomining-security-alerts/falco.yaml
                                     gsutil cp terra-cryptomining-rules.yaml $DATAPROC_IMAGE_BUCKET/terra-cryptomining-security-alerts/terra-cryptomining-rules.yaml
@@ -425,12 +419,6 @@ pipeline {
                                 String daisyImage = "gcr.io/compute-image-tools/daisy:release"
                                 sshagent(['jenkins-ssh-github']) {
                                     sh """
-                                        cd ${WORKSPACE}/jenkins/gce-custom-images/cis-harden-images
-                                        git fetch && git checkout $IMAGE_HARDENING_LIB_VERSION
-
-                                        cd ${WORKSPACE}/jenkins/gce-custom-images/terra-cryptomining-security-alerts
-                                        git fetch && git checkout $CRYPTOMINING_LIB_VERSION
-
                                         # Create the Daisy scratch bucket if it doesn't exist. The Daisy workflow will clean it up at the end.
                                         gsutil ls $GCE_IMAGE_BUCKET || gsutil mb -p $GOOGLE_PROJECT -l $REGION $GCE_IMAGE_BUCKET
 

--- a/jenkins/dataproc-custom-images/prepare-custom-leonardo-jupyter-dataproc-image.sh
+++ b/jenkins/dataproc-custom-images/prepare-custom-leonardo-jupyter-dataproc-image.sh
@@ -105,6 +105,8 @@ log 'Installing prerequisites...'
 retry 5 curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
 retry 5 apt-key update
 
+retry 5 apt-get update
+
 # install Docker
 # https://docs.docker.com/install/linux/docker-ce/debian/
 # export DOCKER_CE_VERSION="19.03.2~ce~3-0~debian"
@@ -157,8 +159,8 @@ add-apt-repository \
 
 log 'Installing Docker...'
 
-retry 5 apt-get update
 retry 5 add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/debian $(lsb_release -cs) stable"
+retry 5 apt-get update
 
 dpkg --configure -a
 # This line fails consistently, but it does not fail in a fatal way so we add `|| true` to prevent the script from halting execution

--- a/jenkins/dataproc-custom-images/prepare-custom-leonardo-jupyter-dataproc-image.sh
+++ b/jenkins/dataproc-custom-images/prepare-custom-leonardo-jupyter-dataproc-image.sh
@@ -24,7 +24,7 @@ terra_jupyter_bioconductor="us.gcr.io/broad-dsp-gcr-public/terra-jupyter-biocond
 terra_jupyter_hail="us.gcr.io/broad-dsp-gcr-public/terra-jupyter-hail:0.0.9"
 terra_jupyter_gatk="us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:0.0.13"
 terra_jupyter_aou_old="us.gcr.io/broad-dsp-gcr-public/terra-jupyter-aou:0.0.1"
-terra_jupyter_aou="us.gcr.io/broad-dsp-gcr-public/terra-jupyter-aou:1.0.4"
+terra_jupyter_aou="us.gcr.io/broad-dsp-gcr-public/terra-jupyter-aou:1.0.5"
 
 # leonardo_jupyter will be discontinued soon
 welder_server="us.gcr.io/broad-dsp-gcr-public/welder-server:59be71a"

--- a/jenkins/gce-custom-images/prepare_custom_leonardo_gce_image.sh
+++ b/jenkins/gce-custom-images/prepare_custom_leonardo_gce_image.sh
@@ -25,7 +25,7 @@ terra_jupyter_python="us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.10
 terra_jupyter_r="us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:0.0.11"
 terra_jupyter_bioconductor="us.gcr.io/broad-dsp-gcr-public/terra-jupyter-bioconductor:0.0.12"
 terra_jupyter_gatk="us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:0.0.13"
-terra_jupyter_aou="us.gcr.io/broad-dsp-gcr-public/terra-jupyter-aou:1.0.4"
+terra_jupyter_aou="us.gcr.io/broad-dsp-gcr-public/terra-jupyter-aou:1.0.5"
 
 # leonardo_jupyter will be discontinued soon
 welder_server="us.gcr.io/broad-dsp-gcr-public/welder-server:59be71a"

--- a/jenkins/gce-custom-images/prepare_custom_leonardo_gce_image.sh
+++ b/jenkins/gce-custom-images/prepare_custom_leonardo_gce_image.sh
@@ -110,6 +110,8 @@ log 'Installing prerequisites...'
 retry 5 curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
 retry 5 apt-key update
 
+retry 5 apt-get update
+
 retry 5 apt-get install -y -q \
     apt-transport-https \
     ca-certificates \
@@ -142,6 +144,8 @@ add-apt-repository \
   "deb [arch=${os_dist_arch:?}] ${docker_apt_repo_url:?} \
   ${os_dist_code_name:?} \
   ${os_dist_release_channel:?}"
+
+retry 5 apt-get update
 
 # Do some set-up in preparation for image hardening
 
@@ -178,8 +182,8 @@ service falco restart
 
 log 'Installing Docker...'
 
-retry 5 apt-get update
 retry 5 add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/debian $(lsb_release -cs) stable"
+retry 5 apt-get update
 
 dpkg --configure -a
 # This line fails consistently, but it does not fail in a fatal way so we add `|| true` to prevent the script from halting execution


### PR DESCRIPTION
Leo has submodules for `cis-harden-images` and `terra-cryptomining-security-alerts`. Previously the Jenkins job also took parameters to specify the versions of these libraries. I think this caused https://broadworkbench.atlassian.net/browse/IA-2130 because the submodule was the right version, but the job checked out an out-of-date `master` branch after running `git submodule init` and `git fetch`.

To simplify things I think we can just rely on the submodule versions for these tools and remove the extra params passed to the Jenkins job. If we want to update the version we should just need to update the submodule hash.

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
