### PR TITLE
[IA-2146] Add GSA and KSA to App table and remove GSA from cluster table

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/kubernetesModels.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/kubernetesModels.scala
@@ -28,7 +28,6 @@ case class KubernetesCluster(id: KubernetesClusterLeoId,
                              location: Location,
                              region: RegionName,
                              status: KubernetesClusterStatus,
-                             serviceAccount: WorkbenchEmail,
                              auditInfo: AuditInfo,
                              asyncFields: Option[KubernetesClusterAsyncFields],
                              namespaces: List[Namespace],
@@ -159,6 +158,7 @@ object NodepoolStatus {
 final case class KubernetesClusterLeoId(id: Long) extends AnyVal
 final case class NamespaceId(id: Long) extends AnyVal
 final case class Namespace(id: NamespaceId, name: NamespaceName)
+final case class KubernetesServiceAccount(value: String) extends AnyVal
 
 final case class Nodepool(id: NodepoolLeoId,
                           clusterId: KubernetesClusterLeoId,
@@ -291,7 +291,10 @@ final case class RemoteUserName(value: String) extends AnyVal
 final case class AppId(id: Long) extends AnyVal
 final case class AppName(value: String) extends AnyVal
 //These are async from the perspective of Front Leo saving the app record, but both must exist before the helm command is executed
-final case class AppResources(namespace: Namespace, disk: Option[PersistentDisk], services: List[KubernetesService])
+final case class AppResources(namespace: Namespace,
+                              disk: Option[PersistentDisk],
+                              services: List[KubernetesService],
+                              kubernetesServiceAccount: Option[KubernetesServiceAccount])
 
 final case class App(id: AppId,
                      nodepoolId: NodepoolLeoId,
@@ -299,6 +302,7 @@ final case class App(id: AppId,
                      appName: AppName,
                      status: AppStatus,
                      samResourceId: AppSamResourceId,
+                     googleServiceAccount: WorkbenchEmail,
                      auditInfo: AuditInfo,
                      labels: LabelMap,
                      //this is populated async to app creation

--- a/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changelog.xml
+++ b/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changelog.xml
@@ -60,5 +60,5 @@
     <include file="changesets/20200701_kubernetes_default_nodepool.xml" relativeToChangelogFile="true" />
     <include file="changesets/20200719_add_app_custom_env_vars.xml" relativeToChangelogFile="true" />
     <include file="changesets/20200708_kubernetes_add_errors_and_region.xml" relativeToChangelogFile="true" />
-    <include file="changesets/20200817_add_ksa_and_gsa_to_app_tabl.xml" relativeToChangelogFile="true" />
+    <include file="changesets/20200817_add_ksa_and_gsa_to_app_table.xml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changelog.xml
+++ b/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changelog.xml
@@ -60,4 +60,5 @@
     <include file="changesets/20200701_kubernetes_default_nodepool.xml" relativeToChangelogFile="true" />
     <include file="changesets/20200719_add_app_custom_env_vars.xml" relativeToChangelogFile="true" />
     <include file="changesets/20200708_kubernetes_add_errors_and_region.xml" relativeToChangelogFile="true" />
+    <include file="changesets/20200817_add_ksa_and_gsa_to_app_tabl.xml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/20200817_add_ksa_and_gsa_to_app_table.xml
+++ b/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/20200817_add_ksa_and_gsa_to_app_table.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog logicalFilePath="leonardo" xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+    <changeSet logicalFilePath="leonardo" author="gabriela" id="add_ksa_and_gsa_to_app_table">
+        <addColumn tableName="APP">
+            <column name="googleServiceAccount" type="VARCHAR(254)">
+                <constraints nullable="false"/>
+            </column>
+        </addColumn>
+        <addColumn tableName="APP">
+            <column name="kubernetesServiceAccount" type="VARCHAR(254)">
+                <constraints nullable="true"/>
+            </column>
+        </addColumn>
+        <dropColumn tableName="KUBERNETES_CLUSTER" columnName="serviceAccount"/>
+    </changeSet>
+</databaseChangeLog>

--- a/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/20200817_add_ksa_and_gsa_to_app_table.xml
+++ b/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/20200817_add_ksa_and_gsa_to_app_table.xml
@@ -2,7 +2,7 @@
 <databaseChangeLog logicalFilePath="leonardo" xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
     <changeSet logicalFilePath="leonardo" author="gabriela" id="add_ksa_and_gsa_to_app_table">
         <addColumn tableName="APP">
-            <column name="googleServiceAccount" type="VARCHAR(254)">
+            <column name="googleServiceAccount" type="VARCHAR(254)" defaultValue="dummy_gsa">
                 <constraints nullable="false"/>
             </column>
         </addColumn>

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/KubernetesClusterComponent.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/KubernetesClusterComponent.scala
@@ -22,7 +22,6 @@ final case class KubernetesClusterRecord(id: KubernetesClusterLeoId,
                                          location: Location,
                                          region: RegionName,
                                          status: KubernetesClusterStatus,
-                                         serviceAccount: WorkbenchEmail,
                                          creator: WorkbenchEmail,
                                          createdDate: Instant,
                                          destroyedDate: Instant,
@@ -39,7 +38,6 @@ case class KubernetesClusterTable(tag: Tag) extends Table[KubernetesClusterRecor
   def location = column[Location]("location", O.Length(254))
   def region = column[RegionName]("region", O.Length(254))
   def status = column[KubernetesClusterStatus]("status", O.Length(254))
-  def serviceAccount = column[WorkbenchEmail]("serviceAccount", O.Length(254))
   def creator = column[WorkbenchEmail]("creator", O.Length(254))
   def createdDate = column[Instant]("createdDate", O.SqlType("TIMESTAMP(6)"))
   def destroyedDate = column[Instant]("destroyedDate", O.SqlType("TIMESTAMP(6)"))
@@ -58,7 +56,6 @@ case class KubernetesClusterTable(tag: Tag) extends Table[KubernetesClusterRecor
      location,
      region,
      status,
-     serviceAccount,
      creator,
      createdDate,
      destroyedDate,
@@ -174,7 +171,6 @@ object kubernetesClusterQuery extends TableQuery(new KubernetesClusterTable(_)) 
       cr.location,
       cr.region,
       cr.status,
-      cr.serviceAccount,
       AuditInfo(
         cr.creator,
         cr.createdDate,
@@ -217,7 +213,6 @@ case class SaveKubernetesCluster(googleProject: GoogleProject,
                                  location: Location,
                                  region: RegionName,
                                  status: KubernetesClusterStatus,
-                                 serviceAccount: WorkbenchEmail,
                                  auditInfo: AuditInfo,
                                  defaultNodepool: DefaultNodepool) {
   def toClusterRecord(): KubernetesClusterRecord =
@@ -228,7 +223,6 @@ case class SaveKubernetesCluster(googleProject: GoogleProject,
       location,
       region,
       status,
-      serviceAccount,
       auditInfo.creator,
       auditInfo.createdDate,
       dummyDate,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/LeoProfile.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/LeoProfile.scala
@@ -153,6 +153,8 @@ private[leonardo] object LeoProfile extends MySQLProfile {
       MappedColumnType.base[NamespaceId, Long](_.id, NamespaceId.apply)
     implicit val namespaceNameColumnType: BaseColumnType[NamespaceName] =
       MappedColumnType.base[NamespaceName, String](_.value, NamespaceName.apply)
+    implicit val kubernetesServiceAccountColumnType: BaseColumnType[KubernetesServiceAccount] =
+      MappedColumnType.base[KubernetesServiceAccount, String](_.value, KubernetesServiceAccount.apply)
 
     implicit val nodepoolIdColumnType: BaseColumnType[NodepoolLeoId] =
       MappedColumnType.base[NodepoolLeoId, Long](_.id, NodepoolLeoId.apply)

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/KubernetesTestData.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/KubernetesTestData.scala
@@ -93,7 +93,6 @@ object KubernetesTestData {
       location,
       region,
       KubernetesClusterStatus.Unspecified,
-      serviceAccountEmail,
       auditInfo,
       None,
       List(),
@@ -109,21 +108,25 @@ object KubernetesTestData {
   def makeApp(index: Int, nodepoolId: NodepoolLeoId): App = {
     val name = AppName("app" + index)
     val namespace = makeNamespace(index, "app")
-    App(AppId(-1),
-        nodepoolId,
-        galaxyApp,
-        name,
-        AppStatus.Unspecified,
-        appSamId,
-        auditInfo,
-        Map.empty,
-        AppResources(
-          namespace,
-          None,
-          List.empty
-        ),
+    App(
+      AppId(-1),
+      nodepoolId,
+      galaxyApp,
+      name,
+      AppStatus.Unspecified,
+      appSamId,
+      serviceAccountEmail,
+      auditInfo,
+      Map.empty,
+      AppResources(
+        namespace,
+        None,
         List.empty,
-        Map.empty)
+        Option.empty
+      ),
+      List.empty,
+      Map.empty
+    )
   }
 
   def makeService(index: Int): KubernetesService = {

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/KubernetesServiceDbQueriesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/KubernetesServiceDbQueriesSpec.scala
@@ -234,7 +234,6 @@ class KubernetesServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent 
                               c.location,
                               c.region,
                               c.status,
-                              c.serviceAccount,
                               c.auditInfo,
                               DefaultNodepool.fromNodepool(c.nodepools.headOption.get))
       )
@@ -264,7 +263,6 @@ class KubernetesServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent 
                               c.location,
                               c.region,
                               c.status,
-                              c.serviceAccount,
                               c.auditInfo,
                               DefaultNodepool.fromNodepool(c.nodepools.headOption.get))
       )
@@ -276,7 +274,6 @@ class KubernetesServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent 
                               c.location,
                               c.region,
                               c.status,
-                              c.serviceAccount,
                               c.auditInfo,
                               DefaultNodepool.fromNodepool(c.nodepools.headOption.get))
       )
@@ -306,7 +303,6 @@ class KubernetesServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent 
                               c.location,
                               c.region,
                               c.status,
-                              c.serviceAccount,
                               c.auditInfo,
                               DefaultNodepool.fromNodepool(c.nodepools.headOption.get))
       )

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/TestComponent.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/TestComponent.scala
@@ -133,7 +133,6 @@ trait TestComponent extends LeonardoTestSuite with ScalaFutures with GcsPathUtil
             c.location,
             c.region,
             c.status,
-            c.serviceAccount,
             c.auditInfo,
             DefaultNodepool.fromNodepool(
               c.nodepools.headOption


### PR DESCRIPTION
Currently we store the Leo dev SA as the service account for the kubernetes cluster. When it comes to workload identity, this won't work. We need the google service account of the user who created the app in order to link it to a kubernetes service account. we get the google service account from the create app request in front leo then back leo will create the kubernetes service account and update the db. 

This PR also removes `serviceAccount` from the kubernetes cluster table entirely because there are multiple users per cluster. Also, we were saving the leo dev SA which is not helpful in workload identity and not needed since leo will always be creating the cluster and we know what the leo dev SA is. 

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
