### PR TITLE
QA-1205 :  Creating more responsive ways to deal with second modal

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookDataSyncingSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookDataSyncingSpec.scala
@@ -172,13 +172,12 @@ class NotebookDataSyncingSpec extends ClusterFixtureSpec with NotebookTestUtils 
               val syncIssueElements =
                 List(notebookPage.syncCopyButton, notebookPage.syncReloadButton, notebookPage.modalId)
 
-              Thread.sleep(300000)
-              eventually(timeout(Span(2, Minutes)), interval(Span(30, Seconds))) { //wait for checkMeta tick
+              eventually(timeout(Span(10, Minutes)), interval(Span(30, Seconds))) { //wait for checkMeta tick
                 notebookPage areElementsPresent (syncIssueElements) shouldBe true
 
                 notebookPage executeJavaScript ("window.onbeforeunload = null;") //disables pesky chrome modal to confirm navigation. we are not testing chrome's implementation and confirming the modal proves problematic
 
-                notebookPage clickOverrideNotebookChanged
+                notebookPage validateOverrideModal
 
                 notebookPage makeACopyFromSyncIssue
               }

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookGCEClusterMonitoringSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookGCEClusterMonitoringSpec.scala
@@ -92,7 +92,9 @@ class NotebookGCEClusterMonitoringSpec extends GPAllocFixtureSpec with ParallelT
       }
     }
 
-    "should update DockerHub welder on a cluster" taggedAs Retryable in { billingProject =>
+    //TODO Re-enable this test once we fix the runtime error
+    // https://broadworkbench.atlassian.net/browse/QA-1204
+    "should update DockerHub welder on a cluster" taggedAs Retryable ignore { billingProject =>
       implicit val ronToken: AuthToken = ronAuthToken
       val deployWelderLabel = "saturnVersion" // matches deployWelderLabel in Leo reference.conf
 

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookPage.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookPage.scala
@@ -114,6 +114,8 @@ class NotebookPage(val url: String)(implicit override val authToken: AuthToken,
 
   lazy val jupyterModal: Query = cssSelector("[class='modal-title']")
 
+  lazy val secondJupyterModal: Query = cssSelector("[class='modal-title']:nth-child(2)")
+
   lazy val confirmNotebookSaveButton: Query = cssSelector(
     "[class='btn btn-default btn-sm btn-danger save-confirm-btn']"
   )
@@ -328,6 +330,9 @@ class NotebookPage(val url: String)(implicit override val authToken: AuthToken,
   def modeExists(): Boolean =
     find(modeBanner).size > 0
 
+  def secondModalExists(): Boolean =
+    find(secondJupyterModal).size > 0
+
   def getMode(): NotebookMode =
     if (modeExists()) {
       NotebookMode.getModeFromString(find(modeBanner).head.text)
@@ -376,11 +381,18 @@ class NotebookPage(val url: String)(implicit override val authToken: AuthToken,
 
   //will cause an exception if no modal exists - check existence of below ID before calling
   def makeACopyFromSyncIssue(): Unit =
-    click on getSelectorFrom(syncCopyButton)
+    if (find(syncCopyButton).size > 0) {
+      click on getSelectorFrom(syncCopyButton)
+    }
 
   //will cause an exception if expected modal does not exist - check existence of below ID before calling
   def goToPlaygroundModeFromLockIssue(): Unit =
     click on getSelectorFrom(lockPlaygroundButton)
+
+  def validateOverrideModal(): Unit = {
+    await condition (secondModalExists, 7.minutes.toSeconds)
+    clickOverrideNotebookChanged()
+  }
 
   /**
    * In some situations Jupyter UI will display a "Notebook changed" modal if it detects


### PR DESCRIPTION
We are still running into issues with having the second modal appear. I'm not super certain if this is because we are clicking before the modal shows up, or if there's another issue.

Going to try this new approach which will wait until a second modal appears. Once it appears, it'll perform a click. I don't think we should ever run into having 3 modals at the same time.

This fix might not work for GCE, so leaving that to be fixed with Qi's PR
---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
