### PR TITLE
Switch to a standard enum ref for CreateDiskRequest.diskType

### DIFF
--- a/http/src/main/resources/swagger/api-docs.yaml
+++ b/http/src/main/resources/swagger/api-docs.yaml
@@ -2826,9 +2826,7 @@ components:
           type: integer
           description: The size of the persistent disk to be created in GB.
         diskType:
-          allOf:
-            - $ref: "#/components/schemas/DiskType"
-            - description: The type of the persistent disk to be created. Can be "Standard" or "SSD".
+          $ref: "#/components/schemas/DiskType"
         blockSize:
           type: integer
           description: The block size of the persistent disk to be created in bytes.


### PR DESCRIPTION
allOf is apparently legal here, but Java codegen fails on it, and this is consistent with other usages in the Leo spec.