### PR TITLE
[IA-2088] [IA-2141] [IA-2089] [IA-2170] [IA-2140] Back Leo helm installs Galaxy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN mkdir /helm-go-lib-build && \
     cd /helm-go-lib-build && \
     git clone https://github.com/broadinstitute/helm-scala-sdk.git && \
     cd helm-scala-sdk && \
-    git checkout master && \
+    git checkout rt-uninstall && \
     cd helm-go-lib && \
     go build -o libhelm.so -buildmode=c-shared main.go
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN mkdir /helm-go-lib-build && \
     cd /helm-go-lib-build && \
     git clone https://github.com/broadinstitute/helm-scala-sdk.git && \
     cd helm-scala-sdk && \
-    git checkout rt-uninstall && \
+    git checkout master && \
     cd helm-go-lib && \
     go build -o libhelm.so -buildmode=c-shared main.go
 

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/appRoutesModels.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/appRoutesModels.scala
@@ -35,7 +35,8 @@ final case class GetAppResponse(kubernetesRuntimeConfig: KubernetesRuntimeConfig
                                 errors: List[AppError],
                                 status: AppStatus, //TODO: do we need some sort of aggregate status?
                                 proxyUrls: Map[ServiceName, URL],
-                                diskName: Option[DiskName])
+                                diskName: Option[DiskName],
+                                customEnvironmentVariables: Map[String, String])
 
 final case class ListAppResponse(googleProject: GoogleProject,
                                  kubernetesRuntimeConfig: KubernetesRuntimeConfig,
@@ -88,7 +89,8 @@ object GetAppResponse {
       appResult.app.errors,
       if (hasError) AppStatus.Error else appResult.app.status,
       appResult.app.getProxyUrls(appResult.cluster.googleProject, proxyUrlBase),
-      appResult.app.appResources.disk.map(_.name)
+      appResult.app.appResources.disk.map(_.name),
+      appResult.app.customEnvironmentVariables
     )
   }
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/kubernetesModels.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/kubernetesModels.scala
@@ -33,6 +33,8 @@ case class KubernetesCluster(id: KubernetesClusterLeoId,
                              namespaces: List[Namespace],
                              nodepools: List[Nodepool]) {
 
+  // TODO consider renaming this method and the KubernetesClusterId class
+  // to disambiguate a bit with KubernetesClusterLeoId which is a Leo-specific ID
   def getGkeClusterId: KubernetesClusterId = KubernetesClusterId(googleProject, location, clusterName)
 }
 

--- a/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/AppRoutesTestJsonCodec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/AppRoutesTestJsonCodec.scala
@@ -28,7 +28,12 @@ object AppRoutesTestJsonCodec {
     Decoder.decodeMap[ServiceName, URL](KeyDecoder.decodeKeyString.map(ServiceName), urlDecoder)
 
   implicit val getAppResponseDecoder: Decoder[GetAppResponse] =
-    Decoder.forProduct5("kubernetesRuntimeConfig", "errors", "status", "proxyUrls", "diskName")(GetAppResponse.apply)
+    Decoder.forProduct6("kubernetesRuntimeConfig",
+                        "errors",
+                        "status",
+                        "proxyUrls",
+                        "diskName",
+                        "customEnvironmentVariables")(GetAppResponse.apply)
 
   implicit val listAppResponseDecoder: Decoder[ListAppResponse] = Decoder.forProduct7("googleProject",
                                                                                       "kubernetesRuntimeConfig",

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -242,6 +242,10 @@ gke {
     chart = "galaxy/galaxykubeman"
     namespaceNameSuffix = "galaxy-ns"
     serviceAccountSuffix = "galaxy-ksa"
+    # Setting uninstallKeepHistory will cause the `helm uninstall` command to keep a record of
+    # the deleted release, which can make debugging and auditing easier. It should be safe for
+    # our use case because we generate unique release names anyway.
+    # See https://helm.sh/docs/intro/using_helm/#helm-uninstall-uninstalling-a-release
     uninstallKeepHistory = true
     services = [
       {

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -242,6 +242,7 @@ gke {
     chart = "galaxy/galaxykubeman"
     namespaceNameSuffix = "galaxy-ns"
     serviceAccountSuffix = "galaxy-ksa"
+    uninstallKeepHistory = true
     services = [
       {
         name = "galaxy"
@@ -487,6 +488,7 @@ pubsub {
     persistent-disk-monitor {
       create {
         max-attempts = 5
+
         interval = 3 seconds
       }
       delete {

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -469,6 +469,10 @@ pubsub {
       max-attempts = 100 # 3 seconds * 100 is 5 min
       interval = 3 seconds
     }
+    createApp {
+      interval = 10 seconds
+      max-attempts = 120 # 10 seconds * 120 = 20 min
+    }
   }
 
   subscriber {

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -238,7 +238,7 @@ gke {
     ]
   }
   galaxyApp {
-    releaseName = "galaxy-rls"
+    releaseNameSuffix = "galaxy-rls"
     chart = "galaxy/galaxykubeman"
     namespaceNameSuffix = "galaxy-ns"
     services = [

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -240,6 +240,12 @@ gke {
   galaxyApp {
     releaseName = "galaxy1"
     namespaceNameSuffix = "galaxy-ns"
+    services = [
+      {
+        name = "galaxy"
+        kind = "ClusterIP"
+      }
+    ]
     values = [
       "nfs.storageClass.name=nfs-galaxy1",
       "cvmfs.repositories.cvmfs-gxy-data-galaxy1=data.galaxyproject.org"

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -241,6 +241,7 @@ gke {
     releaseNameSuffix = "galaxy-rls"
     chart = "galaxy/galaxykubeman"
     namespaceNameSuffix = "galaxy-ns"
+    serviceAccountSuffix = "galaxy-ksa"
     services = [
       {
         name = "galaxy"

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -238,13 +238,23 @@ gke {
     ]
   }
   galaxyApp {
-    releaseName = "release1"
-    namespaceNameSuffix = "namespace"
-    services = [
-      {
-        name = "galaxy"
-        kind = "ClusterIP"
-      }
+    releaseName = "galaxy1"
+    namespaceNameSuffix = "galaxy-ns"
+    values = [
+      "nfs.storageClass.name=nfs-galaxy1",
+      "cvmfs.repositories.cvmfs-gxy-data-galaxy1=data.galaxyproject.org"
+      "cvmfs.repositories.cvmfs-gxy-main-galaxy1=main.galaxyproject.org"
+      "cvmfs.cache.alienCache.storageClass=nfs-galaxy1"
+      "galaxy.persistence.storageClass=nfs-galaxy1"
+      "galaxy.cvmfs.data.pvc.storageClassName=cvmfs-gxy-data-galaxy1"
+      "galaxy.cvmfs.main.pvc.storageClassName=cvmfs-gxy-main-galaxy1"
+      "nodeSelector.\"beta\\.kubernetes\\.io/nodeName=ron-pool"
+      "galaxy.ingress.path=/proxy/google/v1/apps/galaxy-dev-env/galaxy1/galaxy"
+      "galaxy.ingress.annotations.\"nginx\\.ingress\\.kubernetes\\.io/proxy-redirect-from=https://863027343.jupyter-dev.firecloud.org"
+      "galaxy.ingress.annotations.\"nginx\\.ingress\\.kubernetes\\.io/proxy-redirect-to=https://leonardo-anvil.dsde-dev.broadinstitute.org:30443"
+      "galaxy.ingress.hosts[0]=863027343.jupyter-dev.firecloud.org"
+      "galaxy.configs.\"galaxy\\.yml\".galaxy.single_user=ron.weasley@test.firecloud.org"
+      "galaxy.configs.\"galaxy\\.yml\".galaxy.admin_users=ron.weasley@test.firecloud.org"
     ]
   }
 }

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -474,8 +474,8 @@ pubsub {
       max-attempts = 120 # 10 seconds * 120 = 20 min
     }
     deleteApp {
-      interval = 30 seconds
-      max-attempts = 40 # 30 seconds * 40 = 20 min
+      interval = 10 seconds
+      max-attempts = 120 # 10 seconds * 120 = 20 min
     }
   }
 

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -473,6 +473,10 @@ pubsub {
       interval = 10 seconds
       max-attempts = 120 # 10 seconds * 120 = 20 min
     }
+    deleteApp {
+      interval = 30 seconds
+      max-attempts = 40 # 30 seconds * 40 = 20 min
+    }
   }
 
   subscriber {

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -238,29 +238,14 @@ gke {
     ]
   }
   galaxyApp {
-    releaseName = "galaxy1"
+    releaseName = "galaxy-rls"
+    chart = "galaxy/galaxykubeman"
     namespaceNameSuffix = "galaxy-ns"
     services = [
       {
         name = "galaxy"
         kind = "ClusterIP"
       }
-    ]
-    values = [
-      "nfs.storageClass.name=nfs-galaxy1",
-      "cvmfs.repositories.cvmfs-gxy-data-galaxy1=data.galaxyproject.org"
-      "cvmfs.repositories.cvmfs-gxy-main-galaxy1=main.galaxyproject.org"
-      "cvmfs.cache.alienCache.storageClass=nfs-galaxy1"
-      "galaxy.persistence.storageClass=nfs-galaxy1"
-      "galaxy.cvmfs.data.pvc.storageClassName=cvmfs-gxy-data-galaxy1"
-      "galaxy.cvmfs.main.pvc.storageClassName=cvmfs-gxy-main-galaxy1"
-      "nodeSelector.\"beta\\.kubernetes\\.io/nodeName=ron-pool"
-      "galaxy.ingress.path=/proxy/google/v1/apps/galaxy-dev-env/galaxy1/galaxy"
-      "galaxy.ingress.annotations.\"nginx\\.ingress\\.kubernetes\\.io/proxy-redirect-from=https://863027343.jupyter-dev.firecloud.org"
-      "galaxy.ingress.annotations.\"nginx\\.ingress\\.kubernetes\\.io/proxy-redirect-to=https://leonardo-anvil.dsde-dev.broadinstitute.org:30443"
-      "galaxy.ingress.hosts[0]=863027343.jupyter-dev.firecloud.org"
-      "galaxy.configs.\"galaxy\\.yml\".galaxy.single_user=ron.weasley@test.firecloud.org"
-      "galaxy.configs.\"galaxy\\.yml\".galaxy.admin_users=ron.weasley@test.firecloud.org"
     ]
   }
 }

--- a/http/src/main/resources/swagger/api-docs.yaml
+++ b/http/src/main/resources/swagger/api-docs.yaml
@@ -1999,6 +1999,7 @@ components:
           example:
             diskConfig:
               name: "disk1"
+            appType: "GALAXY"
     BatchNodepoolCreateRequest:
       content:
         application/json:
@@ -3120,6 +3121,9 @@ components:
         labels:
           type: object
           description: The labels to be placed on the cluster. Of type Map[String,String]
+        customEnvironmentVariables:
+          type: object
+          description: Optional environment variables to be set on the app
 
     BatchNodepoolCreateRequest:
       description: The configuration for a pool of nodepools, used to create a cluster with pre-created nodepools
@@ -3152,6 +3156,9 @@ components:
         diskName:
           type: string
           description: the name of the disk associated with this app
+        customEnvironmentVariables:
+          type: object
+          description: Optional environment variables to be set on the app
 
     ListAppResponse:
       description: the configuration of an app

--- a/http/src/main/resources/swagger/api-docs.yaml
+++ b/http/src/main/resources/swagger/api-docs.yaml
@@ -1300,7 +1300,7 @@ paths:
         $ref: "#/components/requestBodies/CreateAppRequest"
       responses:
         "202":
-          description: App creation successful
+          description: App creation request has been received
         "400":
           description: Bad Request
           content:

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/Boot.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/Boot.scala
@@ -248,6 +248,7 @@ object Boot extends IOApp {
                                                  googleDependencies.gkeService,
                                                  googleDependencies.kubeService,
                                                  appDependencies.helmClient,
+                                                 appDependencies.galaxyDAO,
                                                  googleDependencies.credentials,
                                                  appDependencies.blocker)
 
@@ -366,6 +367,7 @@ object Boot extends IOApp {
       kubeService <- org.broadinstitute.dsde.workbench.google2.KubernetesService
         .resource(Paths.get(pathToCredentialJson), gkeService, blocker, semaphore)
       helmClient = new HelmInterpreter[F](blocker, semaphore)
+      galaxyDAO = new HttpGalaxyDAO(kubernetesDnsCache, clientWithRetryAndLogging)
 
       leoPublisher = new LeoPublisher(publisherQueue, googlePublisher)
 
@@ -431,7 +433,8 @@ object Boot extends IOApp {
       dataAccessedUpdater,
       subscriber,
       asyncTasksQueue,
-      helmClient
+      helmClient,
+      galaxyDAO
     )
 
   override def run(args: List[String]): IO[ExitCode] = startup().as(ExitCode.Success)
@@ -474,5 +477,6 @@ final case class AppDependencies[F[_]](
   dateAccessedUpdaterQueue: fs2.concurrent.InspectableQueue[F, UpdateDateAccessMessage],
   subscriber: GoogleSubscriber[F, LeoPubsubMessage],
   asyncTasksQueue: InspectableQueue[F, Task[F]],
-  helmClient: HelmAlgebra[F]
+  helmClient: HelmAlgebra[F],
+  galaxyDAO: GalaxyDAO[F]
 )

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/Boot.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/Boot.scala
@@ -244,6 +244,7 @@ object Boot extends IOApp {
           val asyncTasks = AsyncTaskProcessor(asyncTaskProcessorConfig, appDependencies.asyncTasksQueue)
 
           val gkeInterp = new GKEInterpreter[IO](gkeInterpConfig,
+                                                 proxyConfig,
                                                  vpcInterp,
                                                  googleDependencies.gkeService,
                                                  googleDependencies.kubeService,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/Boot.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/Boot.scala
@@ -244,7 +244,6 @@ object Boot extends IOApp {
           val asyncTasks = AsyncTaskProcessor(asyncTaskProcessorConfig, appDependencies.asyncTasksQueue)
 
           val gkeInterp = new GKEInterpreter[IO](gkeInterpConfig,
-                                                 proxyConfig,
                                                  vpcInterp,
                                                  googleDependencies.gkeService,
                                                  googleDependencies.kubeService,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/AppRoutes.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/AppRoutes.scala
@@ -199,7 +199,12 @@ object AppRoutes {
 
   implicit val nameKeyDecoder: KeyDecoder[ServiceName] = KeyDecoder.decodeKeyString.map(ServiceName.apply)
   implicit val getAppDecoder: Decoder[GetAppResponse] =
-    Decoder.forProduct5("kubernetesRuntimeConfig", "errors", "status", "proxyUrls", "diskName")(GetAppResponse.apply)
+    Decoder.forProduct6("kubernetesRuntimeConfig",
+                        "errors",
+                        "status",
+                        "proxyUrls",
+                        "diskName",
+                        "customEnvironmentVariables")(GetAppResponse.apply)
 
   implicit val numNodepoolsDecoder: Decoder[NumNodepools] = Decoder.decodeInt.emap(n =>
     n match {
@@ -241,7 +246,10 @@ object AppRoutes {
                         "diskName")(x => ListAppResponse.unapply(x).get)
 
   implicit val getAppResponseEncoder: Encoder[GetAppResponse] =
-    Encoder.forProduct5("kubernetesRuntimeConfig", "errors", "status", "proxyUrls", "diskName")(x =>
-      GetAppResponse.unapply(x).get
-    )
+    Encoder.forProduct6("kubernetesRuntimeConfig",
+                        "errors",
+                        "status",
+                        "proxyUrls",
+                        "diskName",
+                        "customEnvironmentVariables")(x => GetAppResponse.unapply(x).get)
 }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/AppMonitorConfig.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/AppMonitorConfig.scala
@@ -6,4 +6,5 @@ case class AppMonitorConfig(nodepoolCreate: PollMonitorConfig,
                             clusterCreate: PollMonitorConfig,
                             nodepoolDelete: PollMonitorConfig,
                             clusterDelete: PollMonitorConfig,
-                            createIngress: PollMonitorConfig)
+                            createIngress: PollMonitorConfig,
+                            createApp: PollMonitorConfig)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/AppMonitorConfig.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/AppMonitorConfig.scala
@@ -7,4 +7,5 @@ case class AppMonitorConfig(nodepoolCreate: PollMonitorConfig,
                             nodepoolDelete: PollMonitorConfig,
                             clusterDelete: PollMonitorConfig,
                             createIngress: PollMonitorConfig,
-                            createApp: PollMonitorConfig)
+                            createApp: PollMonitorConfig,
+                            deleteApp: PollMonitorConfig)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
@@ -591,6 +591,7 @@ object Config {
   implicit private val appConfigReader: ValueReader[GalaxyAppConfig] = ValueReader.relative { config =>
     GalaxyAppConfig(
       config.as[ReleaseName]("releaseName"),
+      config.as[ChartName]("chart"),
       config.as[NamespaceName]("namespaceNameSuffix"),
       config.as[List[ServiceConfig]]("services")
     )
@@ -656,8 +657,7 @@ object Config {
     clusterResourcesConfig,
     securityFilesConfig,
     dataprocMonitorConfig.monitorStatusTimeouts
-      .get(RuntimeStatus.Creating)
-      .getOrElse(throw new Exception("Missing dataproc.monitor.statusTimeouts.creating"))
+      .getOrElse(RuntimeStatus.Creating, throw new Exception("Missing dataproc.monitor.statusTimeouts.creating"))
   )
 
   val gceInterpreterConfig = GceInterpreterConfig(
@@ -668,9 +668,8 @@ object Config {
     vpcConfig,
     clusterResourcesConfig,
     securityFilesConfig,
-    gceMonitorConfig.monitorStatusTimeouts
-      .get(RuntimeStatus.Creating)
-      .getOrElse(throw new Exception("Missing gce.monitor.statusTimeouts.creating"))
+    gceMonitorConfig.monitorStatusTimeouts.getOrElse(RuntimeStatus.Creating,
+                                                     throw new Exception("Missing gce.monitor.statusTimeouts.creating"))
   )
   val vpcInterpreterConfig = VPCInterpreterConfig(vpcConfig)
 
@@ -689,5 +688,11 @@ object Config {
 
   val gkeMonitorConfig = config.as[AppMonitorConfig]("pubsub.kubernetes-monitor")
 
-  val gkeInterpConfig = GKEInterpreterConfig(securityFilesConfig, gkeIngressConfig, gkeMonitorConfig, gkeClusterConfig)
+  val gkeInterpConfig =
+    GKEInterpreterConfig(securityFilesConfig,
+                         gkeIngressConfig,
+                         gkeGalaxyAppConfig,
+                         gkeMonitorConfig,
+                         gkeClusterConfig,
+                         proxyConfig)
 }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
@@ -29,26 +29,18 @@ import org.broadinstitute.dsde.workbench.google2.{
   ZoneName
 }
 import org.broadinstitute.dsde.workbench.leonardo.CustomImage.{DataprocCustomImage, GceCustomImage}
-import org.broadinstitute.dsde.workbench.leonardo.KubernetesServiceAccount
 import org.broadinstitute.dsde.workbench.leonardo.auth.sam.SamAuthProviderConfig
-import org.broadinstitute.dsde.workbench.leonardo.config.ContentSecurityPolicyComponent.{
-  ConnectSrc,
-  FrameAncestors,
-  ObjectSrc,
-  ReportUri,
-  ScriptSrc,
-  StyleSrc
-}
+import org.broadinstitute.dsde.workbench.leonardo.config.ContentSecurityPolicyComponent._
 import org.broadinstitute.dsde.workbench.leonardo.dao.HttpSamDaoConfig
 import org.broadinstitute.dsde.workbench.leonardo.http.service.LeoKubernetesServiceInterp.LeoKubernetesConfig
 import org.broadinstitute.dsde.workbench.leonardo.model.ServiceAccountProviderConfig
+import org.broadinstitute.dsde.workbench.leonardo.monitor.MonitorConfig.{DataprocMonitorConfig, GceMonitorConfig}
 import org.broadinstitute.dsde.workbench.leonardo.monitor.{
   DateAccessedUpdaterConfig,
   LeoPubsubMessageSubscriberConfig,
   PersistentDiskMonitorConfig,
   PollMonitorConfig
 }
-import org.broadinstitute.dsde.workbench.leonardo.monitor.MonitorConfig.{DataprocMonitorConfig, GceMonitorConfig}
 import org.broadinstitute.dsde.workbench.leonardo.util.RuntimeInterpreterConfig.{
   DataprocInterpreterConfig,
   GceInterpreterConfig
@@ -591,11 +583,11 @@ object Config {
 
   implicit private val appConfigReader: ValueReader[GalaxyAppConfig] = ValueReader.relative { config =>
     GalaxyAppConfig(
-      config.as[ReleaseName]("releaseNameSuffix"),
+      config.as[String]("releaseNameSuffix"),
       config.as[ChartName]("chart"),
-      config.as[NamespaceName]("namespaceNameSuffix"),
+      config.as[String]("namespaceNameSuffix"),
       config.as[List[ServiceConfig]]("services"),
-      config.as[KubernetesServiceAccount]("serviceAccountSuffix"),
+      config.as[String]("serviceAccountSuffix"),
       config.as[Boolean]("uninstallKeepHistory")
     )
   }
@@ -603,8 +595,6 @@ object Config {
   implicit private val releaseNameReader: ValueReader[ReleaseName] = stringValueReader.map(ReleaseName)
   implicit private val namespaceNameReader: ValueReader[NamespaceName] = stringValueReader.map(NamespaceName)
   implicit private val chartNameReader: ValueReader[ChartName] = stringValueReader.map(ChartName)
-  implicit private val ksaReader: ValueReader[KubernetesServiceAccount] =
-    stringValueReader.map(KubernetesServiceAccount)
   implicit private val valueConfigReader: ValueReader[ValueConfig] = stringValueReader.map(ValueConfig)
 
   implicit private val serviceReader: ValueReader[ServiceConfig] = ValueReader.relative { config =>

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
@@ -595,7 +595,8 @@ object Config {
       config.as[ChartName]("chart"),
       config.as[NamespaceName]("namespaceNameSuffix"),
       config.as[List[ServiceConfig]]("services"),
-      config.as[KubernetesServiceAccount]("serviceAccountSuffix")
+      config.as[KubernetesServiceAccount]("serviceAccountSuffix"),
+      config.as[Boolean]("uninstallKeepHistory")
     )
   }
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
@@ -682,7 +682,8 @@ object Config {
       config.as[PollMonitorConfig]("deleteNodepool"),
       config.as[PollMonitorConfig]("createCluster"),
       config.as[PollMonitorConfig]("deleteCluster"),
-      config.as[PollMonitorConfig]("createIngress")
+      config.as[PollMonitorConfig]("createIngress"),
+      config.as[PollMonitorConfig]("createApp")
     )
   }
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
@@ -683,7 +683,8 @@ object Config {
       config.as[PollMonitorConfig]("createCluster"),
       config.as[PollMonitorConfig]("deleteCluster"),
       config.as[PollMonitorConfig]("createIngress"),
-      config.as[PollMonitorConfig]("createApp")
+      config.as[PollMonitorConfig]("createApp"),
+      config.as[PollMonitorConfig]("deleteApp")
     )
   }
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
@@ -29,6 +29,7 @@ import org.broadinstitute.dsde.workbench.google2.{
   ZoneName
 }
 import org.broadinstitute.dsde.workbench.leonardo.CustomImage.{DataprocCustomImage, GceCustomImage}
+import org.broadinstitute.dsde.workbench.leonardo.KubernetesServiceAccount
 import org.broadinstitute.dsde.workbench.leonardo.auth.sam.SamAuthProviderConfig
 import org.broadinstitute.dsde.workbench.leonardo.config.ContentSecurityPolicyComponent.{
   ConnectSrc,
@@ -593,13 +594,16 @@ object Config {
       config.as[ReleaseName]("releaseNameSuffix"),
       config.as[ChartName]("chart"),
       config.as[NamespaceName]("namespaceNameSuffix"),
-      config.as[List[ServiceConfig]]("services")
+      config.as[List[ServiceConfig]]("services"),
+      config.as[KubernetesServiceAccount]("serviceAccountSuffix")
     )
   }
 
   implicit private val releaseNameReader: ValueReader[ReleaseName] = stringValueReader.map(ReleaseName)
   implicit private val namespaceNameReader: ValueReader[NamespaceName] = stringValueReader.map(NamespaceName)
   implicit private val chartNameReader: ValueReader[ChartName] = stringValueReader.map(ChartName)
+  implicit private val ksaReader: ValueReader[KubernetesServiceAccount] =
+    stringValueReader.map(KubernetesServiceAccount)
   implicit private val valueConfigReader: ValueReader[ValueConfig] = stringValueReader.map(ValueConfig)
 
   implicit private val serviceReader: ValueReader[ServiceConfig] = ValueReader.relative { config =>

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
@@ -590,7 +590,7 @@ object Config {
 
   implicit private val appConfigReader: ValueReader[GalaxyAppConfig] = ValueReader.relative { config =>
     GalaxyAppConfig(
-      config.as[ReleaseName]("releaseName"),
+      config.as[ReleaseName]("releaseNameSuffix"),
       config.as[ChartName]("chart"),
       config.as[NamespaceName]("namespaceNameSuffix"),
       config.as[List[ServiceConfig]]("services")

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/GalaxyAppConfig.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/GalaxyAppConfig.scala
@@ -3,7 +3,7 @@ package org.broadinstitute.dsde.workbench.leonardo.config
 import org.broadinstitute.dsde.workbench.google2.KubernetesSerializableName.NamespaceName
 import org.broadinstitute.dsde.workbench.leonardo.{ChartName, ReleaseName, ServiceConfig}
 
-case class GalaxyAppConfig(releaseName: ReleaseName,
+case class GalaxyAppConfig(releaseNameSuffix: ReleaseName,
                            chart: ChartName,
                            namespaceNameSuffix: NamespaceName,
                            services: List[ServiceConfig])

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/GalaxyAppConfig.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/GalaxyAppConfig.scala
@@ -1,9 +1,10 @@
 package org.broadinstitute.dsde.workbench.leonardo.config
 
 import org.broadinstitute.dsde.workbench.google2.KubernetesSerializableName.NamespaceName
-import org.broadinstitute.dsde.workbench.leonardo.{ChartName, ReleaseName, ServiceConfig}
+import org.broadinstitute.dsde.workbench.leonardo.{ChartName, KubernetesServiceAccount, ReleaseName, ServiceConfig}
 
 case class GalaxyAppConfig(releaseNameSuffix: ReleaseName,
                            chart: ChartName,
                            namespaceNameSuffix: NamespaceName,
-                           services: List[ServiceConfig])
+                           services: List[ServiceConfig],
+                           serviceAccountSuffix: KubernetesServiceAccount)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/GalaxyAppConfig.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/GalaxyAppConfig.scala
@@ -1,11 +1,10 @@
 package org.broadinstitute.dsde.workbench.leonardo.config
 
-import org.broadinstitute.dsde.workbench.google2.KubernetesSerializableName.NamespaceName
-import org.broadinstitute.dsde.workbench.leonardo.{ChartName, KubernetesServiceAccount, ReleaseName, ServiceConfig}
+import org.broadinstitute.dsde.workbench.leonardo.{ChartName, ServiceConfig}
 
-case class GalaxyAppConfig(releaseNameSuffix: ReleaseName,
+case class GalaxyAppConfig(releaseNameSuffix: String,
                            chart: ChartName,
-                           namespaceNameSuffix: NamespaceName,
+                           namespaceNameSuffix: String,
                            services: List[ServiceConfig],
-                           serviceAccountSuffix: KubernetesServiceAccount,
+                           serviceAccountSuffix: String,
                            uninstallKeepHistory: Boolean)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/GalaxyAppConfig.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/GalaxyAppConfig.scala
@@ -1,6 +1,9 @@
 package org.broadinstitute.dsde.workbench.leonardo.config
 
 import org.broadinstitute.dsde.workbench.google2.KubernetesSerializableName.NamespaceName
-import org.broadinstitute.dsde.workbench.leonardo.{ReleaseName, ServiceConfig}
+import org.broadinstitute.dsde.workbench.leonardo.{ChartName, ReleaseName, ServiceConfig}
 
-case class GalaxyAppConfig(releaseName: ReleaseName, namespaceNameSuffix: NamespaceName, services: List[ServiceConfig])
+case class GalaxyAppConfig(releaseName: ReleaseName,
+                           chart: ChartName,
+                           namespaceNameSuffix: NamespaceName,
+                           services: List[ServiceConfig])

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/GalaxyAppConfig.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/GalaxyAppConfig.scala
@@ -7,4 +7,5 @@ case class GalaxyAppConfig(releaseNameSuffix: ReleaseName,
                            chart: ChartName,
                            namespaceNameSuffix: NamespaceName,
                            services: List[ServiceConfig],
-                           serviceAccountSuffix: KubernetesServiceAccount)
+                           serviceAccountSuffix: KubernetesServiceAccount,
+                           uninstallKeepHistory: Boolean)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpGalaxyDAO.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpGalaxyDAO.scala
@@ -1,0 +1,36 @@
+package org.broadinstitute.dsde.workbench.leonardo.dao
+
+import cats.effect.{Concurrent, ContextShift, Timer}
+import cats.implicits._
+import org.broadinstitute.dsde.workbench.leonardo.AppName
+import org.broadinstitute.dsde.workbench.leonardo.dao.HostStatus.HostReady
+import org.broadinstitute.dsde.workbench.leonardo.dns.KubernetesDnsCache
+import org.broadinstitute.dsde.workbench.model.google.GoogleProject
+import org.http4s.client.Client
+import org.http4s.{Method, Request, Uri}
+
+class HttpGalaxyDAO[F[_]: Timer: ContextShift: Concurrent](val kubernetesDnsCache: KubernetesDnsCache[F],
+                                                           client: Client[F])
+    extends GalaxyDAO[F] {
+
+  // TODO potentially add other Galaxy-specific checks
+  def isProxyAvailable(googleProject: GoogleProject, appName: AppName): F[Boolean] =
+    Proxy.getAppTargetHost[F](kubernetesDnsCache, googleProject, appName) flatMap {
+      case HostReady(targetHost) =>
+        client
+          .successful(
+            Request[F](
+              method = Method.GET,
+              uri = Uri.unsafeFromString(
+                s"https://${targetHost.toString}/proxy/google/v1/apps/${googleProject.value}/${appName.value}/galaxy"
+              )
+            )
+          )
+          .handleError(_ => false)
+      case _ => Concurrent[F].pure(false)
+    }
+}
+
+trait GalaxyDAO[F[_]] {
+  def isProxyAvailable(googleProject: GoogleProject, appName: AppName): F[Boolean]
+}

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpGalaxyDAO.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpGalaxyDAO.scala
@@ -13,7 +13,6 @@ class HttpGalaxyDAO[F[_]: Timer: ContextShift: Concurrent](val kubernetesDnsCach
                                                            client: Client[F])
     extends GalaxyDAO[F] {
 
-  // TODO potentially add other Galaxy-specific checks
   def isProxyAvailable(googleProject: GoogleProject, appName: AppName): F[Boolean] =
     Proxy.getAppTargetHost[F](kubernetesDnsCache, googleProject, appName) flatMap {
       case HostReady(targetHost) =>
@@ -22,7 +21,7 @@ class HttpGalaxyDAO[F[_]: Timer: ContextShift: Concurrent](val kubernetesDnsCach
             Request[F](
               method = Method.GET,
               uri = Uri.unsafeFromString(
-                s"https://${targetHost.toString}/proxy/google/v1/apps/${googleProject.value}/${appName.value}/galaxy"
+                s"https://${targetHost.toString}/proxy/google/v1/apps/${googleProject.value}/${appName.value}/galaxy/"
               )
             )
           )

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/AppComponent.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/AppComponent.scala
@@ -168,6 +168,11 @@ object appQuery extends TableQuery(new AppTable(_)) {
       .map(_.status)
       .update(status)
 
+  def updateKubernetesServiceAccount(id: AppId, ksa: KubernetesServiceAccount): DBIO[Int] =
+    getByIdQuery(id)
+      .map(_.kubernetesServiceAccount)
+      .update(Some(ksa))
+
   def markPendingDeletion(id: AppId): DBIO[Int] =
     updateStatus(id, AppStatus.Deleting)
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dns/KubernetesDnsCache.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dns/KubernetesDnsCache.scala
@@ -11,7 +11,7 @@ import org.broadinstitute.dsde.workbench.leonardo.config.{CacheConfig, ProxyConf
 import org.broadinstitute.dsde.workbench.leonardo.dao.HostStatus
 import org.broadinstitute.dsde.workbench.leonardo.dao.HostStatus.{HostNotFound, HostNotReady, HostReady}
 import org.broadinstitute.dsde.workbench.leonardo.db.{DbReference, KubernetesServiceDbQueries}
-import org.broadinstitute.dsde.workbench.leonardo.http.{host, GetAppResult}
+import org.broadinstitute.dsde.workbench.leonardo.http.{kubernetesProxyHost, GetAppResult}
 import org.broadinstitute.dsde.workbench.leonardo.AppName
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 
@@ -62,7 +62,7 @@ final class KubernetesDnsCache[F[_]: Effect: ContextShift: Logger](proxyConfig: 
     appResult.cluster.asyncFields.map(_.loadBalancerIp) match {
       case None => Effect[F].pure(HostNotReady)
       case Some(ip) =>
-        val h = host(appResult.cluster, proxyConfig.proxyDomain)
+        val h = kubernetesProxyHost(appResult.cluster, proxyConfig.proxyDomain)
         HostToIpMapping.hostToIpMapping.getAndUpdate(_ + (h -> ip)).as[HostStatus](HostReady(h)).to[F]
     }
 }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/DateAccessedUpdater.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/DateAccessedUpdater.scala
@@ -32,7 +32,7 @@ class DateAccessedUpdater[F[_]: ContextShift: Timer](
     (Stream.sleep[F](config.interval) ++ Stream.eval(check)).repeat
 
   private[monitor] val check: F[Unit] =
-    logger.info(s"Going to update dateAccessed") >> queue.tryDequeueChunk1(config.maxUpdate).flatMap { chunks =>
+    logger.debug(s"Going to update dateAccessed") >> queue.tryDequeueChunk1(config.maxUpdate).flatMap { chunks =>
       chunks
         .traverse(c =>
           messagesToUpdate(c.toChain)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/DateAccessedUpdater.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/DateAccessedUpdater.scala
@@ -3,6 +3,7 @@ package org.broadinstitute.dsde.workbench.leonardo.monitor
 import java.time.Instant
 
 import cats.Order
+import cats.data.Chain
 import cats.effect.{Concurrent, ContextShift, Timer}
 import cats.implicits._
 import fs2.Stream
@@ -10,11 +11,9 @@ import fs2.concurrent.InspectableQueue
 import org.broadinstitute.dsde.workbench.leonardo.RuntimeName
 import org.broadinstitute.dsde.workbench.leonardo.db._
 import org.broadinstitute.dsde.workbench.leonardo.http._
+import org.broadinstitute.dsde.workbench.leonardo.monitor.DateAccessedUpdater._
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.broadinstitute.dsde.workbench.openTelemetry.OpenTelemetryMetrics
-import DateAccessedUpdater._
-import cats.data.Chain
-import io.chrisdavenport.log4cats.Logger
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration.FiniteDuration
@@ -22,17 +21,13 @@ import scala.concurrent.duration.FiniteDuration
 class DateAccessedUpdater[F[_]: ContextShift: Timer](
   config: DateAccessedUpdaterConfig,
   queue: InspectableQueue[F, UpdateDateAccessMessage]
-)(implicit F: Concurrent[F],
-  metrics: OpenTelemetryMetrics[F],
-  dbRef: DbReference[F],
-  ec: ExecutionContext,
-  logger: Logger[F]) {
+)(implicit F: Concurrent[F], metrics: OpenTelemetryMetrics[F], dbRef: DbReference[F], ec: ExecutionContext) {
 
   val process: Stream[F, Unit] =
     (Stream.sleep[F](config.interval) ++ Stream.eval(check)).repeat
 
   private[monitor] val check: F[Unit] =
-    logger.debug(s"Going to update dateAccessed") >> queue.tryDequeueChunk1(config.maxUpdate).flatMap { chunks =>
+    queue.tryDequeueChunk1(config.maxUpdate).flatMap { chunks =>
       chunks
         .traverse(c =>
           messagesToUpdate(c.toChain)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/package.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/package.scala
@@ -54,10 +54,8 @@ package object http {
       _ <- Stream.emits(data).through(io.file.writeAll(path, blocker)).compile.drain
     } yield path
 
-  // TODO Move to kubernetesModels.KubernetesCluster?
-  def host(cluster: KubernetesCluster, proxyDomain: String): Host = {
-    // TODO is there a better strategy than Objects.hashCode?
-    // This hostname also needs to be specified in the ingress resource
+  // This hostname is used by the ProxyService and also needs to be specified in the Galaxy ingress resource
+  def kubernetesProxyHost(cluster: KubernetesCluster, proxyDomain: String): Host = {
     val prefix = Math.abs(Objects.hashCode(cluster.getGkeClusterId)).toString
     Host(prefix + proxyDomain)
   }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/package.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/package.scala
@@ -2,7 +2,9 @@ package org.broadinstitute.dsde.workbench.leonardo
 
 import java.nio.file.{Files, Path}
 import java.sql.SQLDataException
+import java.util.Objects
 
+import akka.http.scaladsl.model.Uri.Host
 import io.opencensus.trace.{AttributeValue, Span}
 import io.opencensus.scala.http.ServiceData
 import cats.effect.{Blocker, ContextShift, Resource, Sync}
@@ -51,6 +53,14 @@ package object http {
       _ <- Sync[F].delay(path.toFile.deleteOnExit())
       _ <- Stream.emits(data).through(io.file.writeAll(path, blocker)).compile.drain
     } yield path
+
+  // TODO Move to kubernetesModels.KubernetesCluster?
+  def host(cluster: KubernetesCluster, proxyDomain: String): Host = {
+    // TODO is there a better strategy than Objects.hashCode?
+    // This hostname also needs to be specified in the ingress resource
+    val prefix = Math.abs(Objects.hashCode(cluster.getGkeClusterId)).toString
+    Host(prefix + proxyDomain)
+  }
 
   val userScriptStartupOutputUriMetadataKey = "user-startup-script-output-url"
   implicit def cloudServiceSyntax[F[_], A](

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/KubernetesServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/KubernetesServiceInterp.scala
@@ -157,7 +157,7 @@ class LeoKubernetesServiceInterp[F[_]: Parallel](
         //we don't want to create a nodepool if we already have claimed an existing one
         claimedNodepoolOpt.fold[Option[NodepoolLeoId]](Some(nodepool.id))(_ => None),
         saveClusterResult.minimalCluster.googleProject,
-        diskResultOpt.map(_.creationNeeded).getOrElse(false),
+        diskResultOpt.exists(_.creationNeeded),
         req.customEnvironmentVariables,
         Some(ctx.traceId)
       )

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/KubernetesServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/KubernetesServiceInterp.scala
@@ -396,7 +396,7 @@ class LeoKubernetesServiceInterp[F[_]: Parallel](
         Left(AppRequiresDiskException(googleProject, appName, req.appType, ctx.traceId))
       else Right(diskOpt)
       namespaceName <- KubernetesName.withValidation(
-        s"${appName.value}-${leoKubernetesConfig.galaxyAppConfig.namespaceNameSuffix.value}",
+        s"${appName.value}-${leoKubernetesConfig.galaxyAppConfig.namespaceNameSuffix}",
         NamespaceName.apply
       )
     } yield SaveApp(

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
@@ -551,7 +551,7 @@ class GKEInterpreter[F[_]: Parallel: ContextShift: Timer](
             )
             (succeeded, failed) = terminated.partition(_.podStatus == PodStatus.Succeeded)
             _ <- logger.info(
-              s"Monitoring app ${appName.value} in cluster ${dbCluster.getGkeClusterId.toString} for deletion. Pending pods: ['${pending
+              s"Monitoring app ${appName.value} in cluster ${dbCluster.getGkeClusterId.toString} for deletion. Pending pods: [${pending
                 .mkString(", ")}]. Succeeded pods: [${succeeded.mkString(", ")}]. Failed pods: [${failed.mkString(", ")}]"
             )
           } yield pending.isEmpty

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
@@ -551,15 +551,15 @@ class GKEInterpreter[F[_]: Parallel: ContextShift: Timer](
       raw"""galaxy.persistence.storageClass=nfs-${release.value}""",
       raw"""galaxy.cvmfs.data.pvc.storageClassName=cvmfs-gxy-data-${release.value}""",
       raw"""galaxy.cvmfs.main.pvc.storageClassName=cvmfs-gxy-main-${release.value}""",
-      raw"""galaxy.nodeSelector."cloud\.google\.com/gke-nodepool"=${nodepoolName.value}""",
-      raw"""nfs.nodeSelector."cloud\.google\.com/gke-nodepool"=${nodepoolName.value}""",
+      raw"""galaxy.nodeSelector.cloud\.google\.com/gke-nodepool=${nodepoolName.value}""",
+      raw"""nfs.nodeSelector.cloud\.google\.com/gke-nodepool=${nodepoolName.value}""",
       raw"""galaxy.ingress.path=${ingressPath}""",
-      raw"""galaxy.ingress.annotations."nginx\.ingress\.kubernetes\.io/proxy-redirect-from"=${proxyUrl}""",
-      raw"""galaxy.ingress.annotations."nginx\.ingress\.kubernetes\.io/proxy-redirect-to"=${hostUrl}""",
-      raw"""galaxy.ingress.hosts[0]=${hostUrl}""",
-      raw"""galaxy.configs."galaxy\.yml".galaxy.single_user=${userEmail}""",
+      raw"""galaxy.ingress.annotations.nginx\.ingress\.kubernetes\.io/proxy-redirect-from=https://${proxyUrl}""",
+      raw"""galaxy.ingress.annotations.nginx\.ingress\.kubernetes\.io/proxy-redirect-to=${hostUrl}""",
+      raw"""galaxy.ingress.hosts[0]=${proxyUrl}""",
+      raw"""galaxy.configs.galaxy\.yml.galaxy.single_user=${userEmail}""",
       // a user is also the admin on their app
-      raw"""galaxy.configs."galaxy\.yml".galaxy.admin_users=${userEmail}"""
+      raw"""galaxy.configs.galaxy\.yml.galaxy.admin_users=${userEmail}"""
     ).mkString(",")
   }
 }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
@@ -537,7 +537,8 @@ class GKEInterpreter[F[_]: Parallel: ContextShift: Timer](
     val release = config.galaxyAppConfig.releaseName
     val proxyUrl = host(cluster, config.proxyConfig.proxyDomain).toString
     val hostUrl = config.proxyConfig.getProxyServerHostName
-    val ingressPath = s"/proxy/google/v1/apps/${cluster.googleProject.value}/${release}/galaxy"
+    // TODO Is the path below set in any config? If not, add
+    val ingressPath = s"/proxy/google/v1/apps/${cluster.googleProject.value}/${release.value}/galaxy"
 
     // Using the string interpolator raw""" since the chart keys include quotes to escape Helm
     // value override special characters such as '.'

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
@@ -318,7 +318,7 @@ class GKEInterpreter[F[_]: Parallel: ContextShift: Timer](
       _ <- kubeService.createServiceAccount(gkeClusterId, ksa, KubernetesNamespace(namespaceName))
 
       // update KSA in DB
-      _ = appQuery.updateKubernetesServiceAccount(app.id, ksaName).transaction
+      _ <- appQuery.updateKubernetesServiceAccount(app.id, ksaName).transaction
 
       // TODO add workload identity IAM roles
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
@@ -498,7 +498,7 @@ class GKEInterpreter[F[_]: Parallel: ContextShift: Timer](
 
       helmAuthContext <- getHelmAuthContext(googleCluster, dbCluster.id, namespaceName)
 
-      releaseName = ReleaseName(s"${appName.value}-${config.galaxyAppConfig.releaseNameSuffix}")
+      releaseName = buildReleaseName(appName)
       chartValues = buildGalaxyChartOverrideValuesString(appName,
                                                          releaseName,
                                                          dbCluster,
@@ -550,7 +550,7 @@ class GKEInterpreter[F[_]: Parallel: ContextShift: Timer](
 
       helmAuthContext <- getHelmAuthContext(googleCluster, dbCluster.id, namespaceName)
 
-      releaseName = ReleaseName(s"${appName.value}-${config.galaxyAppConfig.releaseNameSuffix}")
+      releaseName = buildReleaseName(appName)
 
       // Invoke helm
       _ <- helmClient
@@ -700,6 +700,12 @@ class GKEInterpreter[F[_]: Parallel: ContextShift: Timer](
       raw"""rbac.serviceAccount=${ksa.value}"""
     ) ++ configs).mkString(",")
   }
+
+  // TODO: should we append a timestamp to the release name?
+  // If we do then we should probably persist it to the database since we need it
+  // at install and uninstall time.
+  private[util] def buildReleaseName(appName: AppName): ReleaseName =
+    ReleaseName(s"${appName.value}-${config.galaxyAppConfig.releaseNameSuffix}")
 
   private[util] def isPodDone(pod: KubernetesPodStatus): Boolean =
     pod.podStatus == PodStatus.Failed || pod.podStatus == PodStatus.Succeeded

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
@@ -562,7 +562,7 @@ class GKEInterpreter[F[_]: Parallel: ContextShift: Timer](
 
       // Invoke helm
       _ <- helmClient
-        .uninstall(org.broadinstitute.dsp.Release(releaseName.value))
+        .uninstall(org.broadinstitute.dsp.Release(releaseName.value), config.galaxyAppConfig.uninstallKeepHistory)
         .run(helmAuthContext)
 
       isDone <- (Stream.sleep_(config.monitorConfig.deleteApp.interval) ++

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
@@ -457,6 +457,11 @@ class GKEInterpreter[F[_]: Parallel: ContextShift: Timer](
         s"Installing GalaxyKubeMan helm chart: ${config.galaxyAppConfig.chart} in cluster ${dbCluster.id} | trace id: ${ctx.traceId}"
       )
 
+      // TODO log as debug message
+      _ <- logger.info(
+        s"Chart override values are: ${chartValues} | trace id: ${ctx.traceId}"
+      )
+
       // The helm client requires a Google access token
       _ <- F.delay(credentials.refreshIfExpired())
 

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/config/ConfigSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/config/ConfigSpec.scala
@@ -100,8 +100,9 @@ class ConfigSpec extends AnyFlatSpec with Matchers {
 
   it should "read GalaxyAppConfig properly" in {
     val expectedResult = GalaxyAppConfig(
-      ReleaseName("release1"),
-      NamespaceName("namespace"),
+      ReleaseName("galaxy-rls"),
+      ChartName("galaxy/galaxykubeman"),
+      NamespaceName("galaxy-ns"),
       List(ServiceConfig(ServiceName("galaxy"), KubernetesServiceKindName("ClusterIP")))
     )
     Config.gkeGalaxyAppConfig shouldBe expectedResult

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/config/ConfigSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/config/ConfigSpec.scala
@@ -1,9 +1,9 @@
 package org.broadinstitute.dsde.workbench.leonardo
 package config
 
-import org.broadinstitute.dsde.workbench.google2.KubernetesSerializableName.{NamespaceName, ServiceName}
-import org.broadinstitute.dsde.workbench.leonardo.monitor.MonitorConfig.GceMonitorConfig
+import org.broadinstitute.dsde.workbench.google2.KubernetesSerializableName.ServiceName
 import org.broadinstitute.dsde.workbench.google2.{Location, MachineTypeName, RegionName, ZoneName}
+import org.broadinstitute.dsde.workbench.leonardo.monitor.MonitorConfig.GceMonitorConfig
 import org.broadinstitute.dsde.workbench.leonardo.monitor.{
   LeoPubsubMessageSubscriberConfig,
   PersistentDiskMonitorConfig,
@@ -100,11 +100,11 @@ class ConfigSpec extends AnyFlatSpec with Matchers {
 
   it should "read GalaxyAppConfig properly" in {
     val expectedResult = GalaxyAppConfig(
-      ReleaseName("galaxy-rls"),
+      "galaxy-rls",
       ChartName("galaxy/galaxykubeman"),
-      NamespaceName("galaxy-ns"),
+      "galaxy-ns",
       List(ServiceConfig(ServiceName("galaxy"), KubernetesServiceKindName("ClusterIP"))),
-      KubernetesServiceAccount("galaxy-ksa"),
+      "galaxy-ksa",
       true
     )
     Config.gkeGalaxyAppConfig shouldBe expectedResult

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/config/ConfigSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/config/ConfigSpec.scala
@@ -104,7 +104,8 @@ class ConfigSpec extends AnyFlatSpec with Matchers {
       ChartName("galaxy/galaxykubeman"),
       NamespaceName("galaxy-ns"),
       List(ServiceConfig(ServiceName("galaxy"), KubernetesServiceKindName("ClusterIP"))),
-      KubernetesServiceAccount("galaxy-ksa")
+      KubernetesServiceAccount("galaxy-ksa"),
+      true
     )
     Config.gkeGalaxyAppConfig shouldBe expectedResult
   }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/config/ConfigSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/config/ConfigSpec.scala
@@ -103,7 +103,8 @@ class ConfigSpec extends AnyFlatSpec with Matchers {
       ReleaseName("galaxy-rls"),
       ChartName("galaxy/galaxykubeman"),
       NamespaceName("galaxy-ns"),
-      List(ServiceConfig(ServiceName("galaxy"), KubernetesServiceKindName("ClusterIP")))
+      List(ServiceConfig(ServiceName("galaxy"), KubernetesServiceKindName("ClusterIP"))),
+      KubernetesServiceAccount("galaxy-ksa")
     )
     Config.gkeGalaxyAppConfig shouldBe expectedResult
   }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/MockGalaxyDAO.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/MockGalaxyDAO.scala
@@ -1,0 +1,11 @@
+package org.broadinstitute.dsde.workbench.leonardo.dao
+
+import cats.effect.IO
+import org.broadinstitute.dsde.workbench.leonardo.AppName
+import org.broadinstitute.dsde.workbench.model.google.GoogleProject
+
+class MockGalaxyDAO(isUp: Boolean = true) extends GalaxyDAO[IO] {
+  override def isProxyAvailable(googleProject: GoogleProject, appName: AppName): IO[Boolean] = IO.pure(isUp)
+}
+
+object MockGalaxyDAO extends MockGalaxyDAO(isUp = true)

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriberSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriberSpec.scala
@@ -630,6 +630,9 @@ class LeoPubsubMessageSubscriberSpec
       getCluster.nodepools.filter(_.isDefault).head.status shouldBe NodepoolStatus.Running
       getApp.app.errors shouldBe List()
       getApp.app.status shouldBe AppStatus.Running
+      getApp.app.appResources.kubernetesServiceAccount shouldBe Some(
+        KubernetesServiceAccount(s"${getApp.app.appName.value}-galaxy-ksa")
+      )
       getApp.cluster.status shouldBe KubernetesClusterStatus.Running
       getApp.nodepool.status shouldBe NodepoolStatus.Running
       getApp.cluster.asyncFields shouldBe Some(
@@ -687,6 +690,9 @@ class LeoPubsubMessageSubscriberSpec
       )
       getApp.app.appResources.disk shouldBe None
       getApp.app.status shouldBe AppStatus.Running
+      getApp.app.appResources.kubernetesServiceAccount shouldBe Some(
+        KubernetesServiceAccount(s"${getApp.app.appName.value}-galaxy-ksa")
+      )
     }
 
     val res = for {
@@ -736,6 +742,9 @@ class LeoPubsubMessageSubscriberSpec
       getApp2.nodepool.status shouldBe NodepoolStatus.Running
       getApp1.app.errors shouldBe List()
       getApp1.app.status shouldBe AppStatus.Running
+      getApp1.app.appResources.kubernetesServiceAccount shouldBe Some(
+        KubernetesServiceAccount(s"${getApp1.app.appName.value}-galaxy-ksa")
+      )
       getApp1.cluster.asyncFields shouldBe Some(
         KubernetesClusterAsyncFields(IP("1.2.3.4"),
                                      IP("0.0.0.0"),
@@ -745,6 +754,9 @@ class LeoPubsubMessageSubscriberSpec
       )
       getApp2.app.errors shouldBe List()
       getApp2.app.status shouldBe AppStatus.Running
+      getApp2.app.appResources.kubernetesServiceAccount shouldBe Some(
+        KubernetesServiceAccount(s"${getApp2.app.appName.value}-galaxy-ksa")
+      )
     }
 
     val res = for {
@@ -1323,6 +1335,9 @@ class LeoPubsubMessageSubscriberSpec
       getCluster.nodepools.filter(_.isDefault).head.status shouldBe NodepoolStatus.Unspecified
       getApp.app.errors shouldBe List()
       getApp.app.status shouldBe AppStatus.Running
+      getApp.app.appResources.kubernetesServiceAccount shouldBe Some(
+        KubernetesServiceAccount(s"${getApp.app.appName.value}-galaxy-ksa")
+      )
       getApp.cluster.status shouldBe KubernetesClusterStatus.Running
       getApp.nodepool.status shouldBe NodepoolStatus.Running
       getDisk.status shouldBe DiskStatus.Ready

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriberSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriberSpec.scala
@@ -41,7 +41,7 @@ import org.broadinstitute.dsde.workbench.leonardo.KubernetesTestData.{
 }
 import org.broadinstitute.dsde.workbench.leonardo.RuntimeImageType.VM
 import org.broadinstitute.dsde.workbench.leonardo.config.Config
-import org.broadinstitute.dsde.workbench.leonardo.dao.WelderDAO
+import org.broadinstitute.dsde.workbench.leonardo.dao.{MockGalaxyDAO, WelderDAO}
 import org.broadinstitute.dsde.workbench.leonardo.db.{
   clusterErrorQuery,
   clusterQuery,
@@ -119,6 +119,7 @@ class LeoPubsubMessageSubscriberSpec
                            MockGKEService,
                            MockKubernetesService,
                            MockHelm,
+                           MockGalaxyDAO,
                            credentials,
                            blocker)
 
@@ -1138,6 +1139,7 @@ class LeoPubsubMessageSubscriberSpec
                              MockGKEService,
                              mockKubernetesService,
                              MockHelm,
+                             MockGalaxyDAO,
                              credentials,
                              blocker)
 
@@ -1189,6 +1191,7 @@ class LeoPubsubMessageSubscriberSpec
                              mockGKEService,
                              MockKubernetesService,
                              MockHelm,
+                             MockGalaxyDAO,
                              credentials,
                              blocker)
 

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreterSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreterSpec.scala
@@ -71,19 +71,4 @@ class GKEInterpreterSpec extends AnyFlatSpecLike with TestComponent with Leonard
     emptyFileSecrets should contain((SecretName("tls-secret"), savedApp1.appResources.namespace.name))
     secrets.flatMap(_.secrets.values).map(s => s.isEmpty shouldBe false)
   }
-
-//  it should "string together galaxy chart override values" in isolatedDbTest {
-//    val savedCluster = makeKubeCluster(1).save()
-//    val savedNodepool = makeNodepool(1, savedCluster.id).save()
-//    val savedApp = makeApp(1, savedNodepool.id).save()
-//
-//    val chartValues =
-//      gkeInterp
-//        .buildGalaxyChartOverrideValuesString(Config.gkeInterpConfig.galaxyAppConfig.releaseName,
-//                                              savedNodepool.nodepoolName,
-//                                              proxyUrl,
-//                                              hostUrl,
-//                                              userEmail)
-//
-//  }
 }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreterSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreterSpec.scala
@@ -12,6 +12,7 @@ import org.broadinstitute.dsde.workbench.google2.mock.{
 import org.broadinstitute.dsde.workbench.leonardo.CommonTestData._
 import org.broadinstitute.dsde.workbench.leonardo.KubernetesTestData.{makeApp, makeKubeCluster, makeNodepool}
 import org.broadinstitute.dsde.workbench.leonardo.config.Config
+import org.broadinstitute.dsde.workbench.leonardo.dao.MockGalaxyDAO
 import org.broadinstitute.dsde.workbench.leonardo.db.TestComponent
 import org.broadinstitute.dsde.workbench.leonardo.{AutoscalingConfig, AutoscalingMax, AutoscalingMin, LeonardoTestSuite}
 import org.broadinstitute.dsp.mocks._
@@ -35,6 +36,7 @@ class GKEInterpreterSpec extends AnyFlatSpecLike with TestComponent with Leonard
                            MockGKEService,
                            MockKubernetesService,
                            MockHelm,
+                           MockGalaxyDAO,
                            credentials,
                            blocker)
 

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreterSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreterSpec.scala
@@ -1,8 +1,18 @@
 package org.broadinstitute.dsde.workbench.leonardo.util
 
+import java.nio.file.Files
+import java.util.Base64
+
 import cats.effect.IO
 import org.broadinstitute.dsde.workbench.google.mock.MockGoogleProjectDAO
-import org.broadinstitute.dsde.workbench.google2.KubernetesSerializableName.{SecretKey, SecretName}
+import org.broadinstitute.dsde.workbench.google2.GKEModels.NodepoolName
+import org.broadinstitute.dsde.workbench.google2.KubernetesModels.{KubernetesPodStatus, PodStatus}
+import org.broadinstitute.dsde.workbench.google2.KubernetesSerializableName.{
+  NamespaceName,
+  PodName,
+  SecretKey,
+  SecretName
+}
 import org.broadinstitute.dsde.workbench.google2.mock.{
   FakeGoogleComputeService,
   MockComputePollOperation,
@@ -14,10 +24,20 @@ import org.broadinstitute.dsde.workbench.leonardo.KubernetesTestData.{makeApp, m
 import org.broadinstitute.dsde.workbench.leonardo.config.Config
 import org.broadinstitute.dsde.workbench.leonardo.dao.MockGalaxyDAO
 import org.broadinstitute.dsde.workbench.leonardo.db.TestComponent
-import org.broadinstitute.dsde.workbench.leonardo.{AutoscalingConfig, AutoscalingMax, AutoscalingMin, LeonardoTestSuite}
+import org.broadinstitute.dsde.workbench.leonardo.{
+  AppName,
+  AutoscalingConfig,
+  AutoscalingMax,
+  AutoscalingMin,
+  KubernetesClusterLeoId,
+  KubernetesServiceAccount,
+  LeonardoTestSuite,
+  ReleaseName
+}
 import org.broadinstitute.dsp.mocks._
 import org.scalatest.flatspec.AnyFlatSpecLike
 
+import scala.collection.JavaConverters._
 import scala.concurrent.ExecutionContext.Implicits.global
 
 class GKEInterpreterSpec extends AnyFlatSpecLike with TestComponent with LeonardoTestSuite {
@@ -40,7 +60,7 @@ class GKEInterpreterSpec extends AnyFlatSpecLike with TestComponent with Leonard
                            credentials,
                            blocker)
 
-  it should "create a nodepool with autoscaling" in isolatedDbTest {
+  "GKEInterpreter" should "create a nodepool with autoscaling" in isolatedDbTest {
     val savedCluster1 = makeKubeCluster(1).save()
     val minNodes = 0
     val maxNodes = 2
@@ -72,5 +92,54 @@ class GKEInterpreterSpec extends AnyFlatSpecLike with TestComponent with Leonard
     emptyFileSecrets should contain((SecretName("ca-secret"), savedApp1.appResources.namespace.name))
     emptyFileSecrets should contain((SecretName("tls-secret"), savedApp1.appResources.namespace.name))
     secrets.flatMap(_.secrets.values).map(s => s.isEmpty shouldBe false)
+  }
+
+  it should "get a helm auth context" in {
+    val googleCluster = com.google.container.v1.Cluster
+      .newBuilder()
+      .setEndpoint("1.2.3.4")
+      .setMasterAuth(
+        com.google.container.v1.MasterAuth
+          .newBuilder()
+          .setClusterCaCertificate(Base64.getEncoder.encodeToString("ca_cert".getBytes()))
+      )
+      .build
+
+    val authContext =
+      gkeInterp.getHelmAuthContext(googleCluster, KubernetesClusterLeoId(1), NamespaceName("ns")).unsafeRunSync()
+
+    authContext.namespace.asString shouldBe "ns"
+    authContext.kubeApiServer.asString shouldBe "https://1.2.3.4"
+    authContext.kubeToken.asString shouldBe "accessToken"
+    Files.exists(authContext.caCertFile.path) shouldBe true
+    Files.readAllLines(authContext.caCertFile.path).asScala.mkString shouldBe "ca_cert"
+  }
+
+  it should "build Galaxy override values string" in {
+    val savedCluster1 = makeKubeCluster(1).save()
+    val result = gkeInterp.buildGalaxyChartOverrideValuesString(
+      AppName("app1"),
+      ReleaseName("app1-galaxy-rls"),
+      savedCluster1,
+      NodepoolName("pool1"),
+      userEmail,
+      Map.empty,
+      KubernetesServiceAccount("app1-galaxy-ksa")
+    )
+
+    result shouldBe """nfs.storageClass.name=nfs-app1-galaxy-rls,cvmfs.repositories.cvmfs-gxy-data-app1-galaxy-rls=data.galaxyproject.org,cvmfs.repositories.cvmfs-gxy-main-app1-galaxy-rls=main.galaxyproject.org,cvmfs.cache.alienCache.storageClass=nfs-app1-galaxy-rls,galaxy.persistence.storageClass=nfs-app1-galaxy-rls,galaxy.cvmfs.data.pvc.storageClassName=cvmfs-gxy-data-app1-galaxy-rls,galaxy.cvmfs.main.pvc.storageClassName=cvmfs-gxy-main-app1-galaxy-rls,galaxy.nodeSelector.cloud\.google\.com/gke-nodepool=pool1,nfs.nodeSelector.cloud\.google\.com/gke-nodepool=pool1,galaxy.ingress.path=/proxy/google/v1/apps/dsp-leo-test1/app1/galaxy,galaxy.ingress.annotations.nginx\.ingress\.kubernetes\.io/proxy-redirect-from=https://1211904326.jupyter.firecloud.org,galaxy.ingress.annotations.nginx\.ingress\.kubernetes\.io/proxy-redirect-to=https://leo,galaxy.ingress.hosts[0]=1211904326.jupyter.firecloud.org,galaxy.configs.galaxy\.yml.galaxy.single_user=user1@example.com,galaxy.configs.galaxy\.yml.galaxy.admin_users=user1@example.com,rbac.serviceAccount=app1-galaxy-ksa"""
+  }
+
+  it should "build a release name" in {
+    val releaseName = gkeInterp.buildReleaseName(AppName("app1"))
+    releaseName shouldBe ReleaseName("app1-galaxy-rls")
+  }
+
+  it should "check if a pod is done" in {
+    gkeInterp.isPodDone(KubernetesPodStatus(PodName("pod1"), PodStatus.Succeeded)) shouldBe true
+    gkeInterp.isPodDone(KubernetesPodStatus(PodName("pod2"), PodStatus.Pending)) shouldBe false
+    gkeInterp.isPodDone(KubernetesPodStatus(PodName("pod3"), PodStatus.Failed)) shouldBe true
+    gkeInterp.isPodDone(KubernetesPodStatus(PodName("pod4"), PodStatus.Unknown)) shouldBe false
+    gkeInterp.isPodDone(KubernetesPodStatus(PodName("pod5"), PodStatus.Running)) shouldBe false
   }
 }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreterSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreterSpec.scala
@@ -71,4 +71,19 @@ class GKEInterpreterSpec extends AnyFlatSpecLike with TestComponent with Leonard
     emptyFileSecrets should contain((SecretName("tls-secret"), savedApp1.appResources.namespace.name))
     secrets.flatMap(_.secrets.values).map(s => s.isEmpty shouldBe false)
   }
+
+//  it should "string together galaxy chart override values" in isolatedDbTest {
+//    val savedCluster = makeKubeCluster(1).save()
+//    val savedNodepool = makeNodepool(1, savedCluster.id).save()
+//    val savedApp = makeApp(1, savedNodepool.id).save()
+//
+//    val chartValues =
+//      gkeInterp
+//        .buildGalaxyChartOverrideValuesString(Config.gkeInterpConfig.galaxyAppConfig.releaseName,
+//                                              savedNodepool.nodepoolName,
+//                                              proxyUrl,
+//                                              hostUrl,
+//                                              userEmail)
+//
+//  }
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -26,7 +26,7 @@ object Dependencies {
   val workbenchOpenTelemetryV = "0.1-e66171c"
   val workbenchErrorReportingV = "0.1-92fcd96"
 
-  val helmScalaSdkV = "0.0.1-RC1"
+  val helmScalaSdkV = "0.0.1-rt-uninstall-SNAPSHOT"
 
   val excludeAkkaHttp = ExclusionRule(organization = "com.typesafe.akka", name = "akka-http_2.12")
   val excludeAkkaStream = ExclusionRule(organization = "com.typesafe.akka", name = "akka-stream_2.12")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -26,7 +26,7 @@ object Dependencies {
   val workbenchOpenTelemetryV = "0.1-e66171c"
   val workbenchErrorReportingV = "0.1-92fcd96"
 
-  val helmScalaSdkV = "0.0.1-rt-uninstall-SNAPSHOT"
+  val helmScalaSdkV = "0.0.1-RC1"
 
   val excludeAkkaHttp = ExclusionRule(organization = "com.typesafe.akka", name = "akka-http_2.12")
   val excludeAkkaStream = ExclusionRule(organization = "com.typesafe.akka", name = "akka-stream_2.12")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -26,7 +26,7 @@ object Dependencies {
   val workbenchOpenTelemetryV = "0.1-e66171c"
   val workbenchErrorReportingV = "0.1-92fcd96"
 
-  val helmScalaSdkV = "0.0.1-RC1"
+  val helmScalaSdkV = "0.0.1-RC2"
 
   val excludeAkkaHttp = ExclusionRule(organization = "com.typesafe.akka", name = "akka-http_2.12")
   val excludeAkkaStream = ExclusionRule(organization = "com.typesafe.akka", name = "akka-stream_2.12")


### PR DESCRIPTION
This PR covers the following tickets:

* [IA-2088](https://broadworkbench.atlassian.net/browse/IA-2088) Back Leo installs Galaxy via Helm client lib
* [IA-2141](https://broadworkbench.atlassian.net/browse/IA-2141) Build string of override values
   * All known `--set` flags to the Galaxy install should now be present
* [IA-2089](https://broadworkbench.atlassian.net/browse/IA-2089) Update back Leo to uninstall charts
   * See https://github.com/broadinstitute/helm-scala-sdk/pull/5. 
   * The helm uninstall seems to work, but there is a known Galaxy issue with pods not terminating (Alex is looking into it)
* [IA-2170](https://broadworkbench.atlassian.net/browse/IA-2170) Add Role and Role Binding to helm install galaxy
   * This PR creates a KSA and passes it to `rbac` in the `galaxykubeman` chart
   * Note it does NOT set up Workload Identity yet (that will be a separate PR)
* [IA-2140](https://broadworkbench.atlassian.net/browse/IA-2140) Add code for monitoring waiting for app to come up
   * Added basic monitoring based on http polling. It works for now, but we can add k8s job polling in a future iteration.

Tested create/delete app flows in a fiab, and all seems to work.