### PR TITLE
[IA-2105] add label to gke clusters for clean up script

### DIFF
--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
@@ -98,6 +98,7 @@ class GKEInterpreter[F[_]: Parallel: ContextShift: Timer](
         .addAllNodePools(
           nodepools.asJava
         )
+        .putResourceLabels("leonardo", "true")
         // all the below code corresponds to security recommendations
         .setLegacyAbac(LegacyAbac.newBuilder().setEnabled(false))
         .setNetwork(kubeNetwork.idString)


### PR DESCRIPTION
gke clusters are now created with label `leonardo: true` so we know which ones to delete when running our cleanup script
<img width="1053" alt="Screen Shot 2020-09-02 at 4 37 19 PM" src="https://user-images.githubusercontent.com/23626109/92034192-e68b5b00-ed3a-11ea-8236-2b01f3e018a2.png">


---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
