### PR TITLE
[IA-2182] adding cleanup code for app creation failures

### DIFF
--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
@@ -547,7 +547,7 @@ class LeoPubsubMessageSubscriber[F[_]: Timer: ContextShift: Parallel](
         disk.samResource,
         disk.auditInfo.creator,
         disk.googleProject
-      ) >> logger.info(f"Completed disk deletion for ${diskId} | trace id: ${ctx.traceId}")
+      ) >> logger.info(s"Completed disk deletion for ${diskId} | trace id: ${ctx.traceId}")
       whenTimeout = F.raiseError[Unit](
         new TimeoutException(s"Fail to delete disk ${disk.name.value} in a timely manner")
       )

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/leoPubsubMessageSubscriberModels.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/leoPubsubMessageSubscriberModels.scala
@@ -210,7 +210,7 @@ object LeoPubsubMessage {
                                     appName: AppName,
                                     nodepoolId: Option[NodepoolLeoId],
                                     project: GoogleProject,
-                                    createDisk: Boolean,
+                                    createDisk: Option[DiskId],
                                     customEnvironmentVariables: Map[String, String],
                                     traceId: Option[TraceId])
       extends LeoPubsubMessage {

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/KubernetesServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/KubernetesServiceInterp.scala
@@ -157,7 +157,7 @@ class LeoKubernetesServiceInterp[F[_]: Parallel](
         //we don't want to create a nodepool if we already have claimed an existing one
         claimedNodepoolOpt.fold[Option[NodepoolLeoId]](Some(nodepool.id))(_ => None),
         saveClusterResult.minimalCluster.googleProject,
-        diskResultOpt.exists(_.creationNeeded),
+        if (diskResultOpt.exists(_.creationNeeded)) diskResultOpt.map(_.disk.id) else None,
         req.customEnvironmentVariables,
         Some(ctx.traceId)
       )

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEAlgebra.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEAlgebra.scala
@@ -65,4 +65,7 @@ final case class DeleteClusterParams(clusterId: KubernetesClusterLeoId, googlePr
 
 final case class DeleteNodepoolParams(nodepoolId: NodepoolLeoId, googleProject: GoogleProject)
 
-final case class DeleteAppParams(appId: AppId, googleProject: GoogleProject, appName: AppName)
+final case class DeleteAppParams(appId: AppId,
+                                 googleProject: GoogleProject,
+                                 appName: AppName,
+                                 errorAfterDelete: Boolean)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
@@ -431,7 +431,8 @@ class GKEInterpreter[F[_]: Parallel: ContextShift: Timer](
       _ <- logger.info(
         s"Delete app operation has finished for app ${app.appName.value} in cluster ${gkeClusterId.toString} | trace id: ${ctx.traceId}"
       )
-      _ <- appQuery.markAsDeleted(dbApp.app.id, ctx.now).transaction
+      _ <- if (!params.errorAfterDelete) appQuery.markAsDeleted(dbApp.app.id, ctx.now).transaction
+      else appQuery.updateStatus(dbApp.app.id, AppStatus.Error).transaction
     } yield ()
 
   private[util] def installNginx(dbCluster: KubernetesCluster,

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubCodecSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubCodecSpec.scala
@@ -105,7 +105,7 @@ class LeoPubsubCodecSpec extends AnyFlatSpec with Matchers {
       AppName("app1"),
       Some(NodepoolLeoId(2)),
       GoogleProject("project1"),
-      true,
+      Some(DiskId(1)),
       Map.empty,
       Some(traceId)
     )

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriberSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriberSpec.scala
@@ -47,10 +47,7 @@ import org.broadinstitute.dsde.workbench.leonardo.db._
 import org.broadinstitute.dsde.workbench.leonardo.http._
 import org.broadinstitute.dsde.workbench.leonardo.model.LeoAuthProvider
 import org.broadinstitute.dsde.workbench.leonardo.monitor.LeoPubsubMessage._
-import org.broadinstitute.dsde.workbench.leonardo.monitor.PubsubHandleMessageError.{
-  ClusterInvalidState,
-  DiskInvalidState
-}
+import org.broadinstitute.dsde.workbench.leonardo.monitor.PubsubHandleMessageError.ClusterInvalidState
 import org.broadinstitute.dsde.workbench.leonardo.util._
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.broadinstitute.dsde.workbench.model.{IP, TraceId, WorkbenchEmail}
@@ -566,7 +563,7 @@ class LeoPubsubMessageSubscriberSpec
     res.unsafeRunSync()
   }
 
-  it should "not handle DeleteDiskMessage when disk is not in Deleting status" in isolatedDbTest {
+  it should "handle DeleteDiskMessage when disk is not in Deleting status" in isolatedDbTest {
     val leoSubscriber = makeLeoSubscriber()
 
     val res = for {
@@ -575,7 +572,7 @@ class LeoPubsubMessageSubscriberSpec
       message = DeleteDiskMessage(disk.id, Some(tr))
       attempt <- leoSubscriber.messageResponder(message).attempt
     } yield {
-      attempt shouldBe Left(DiskInvalidState(disk.id, disk.projectNameString, disk))
+      attempt shouldBe Right(())
     }
 
     res.unsafeRunSync()
@@ -1408,7 +1405,7 @@ class LeoPubsubMessageSubscriberSpec
     assertions.unsafeRunSync()
   }
 
-  it should "clean-up google resources on error id1" in isolatedDbTest {
+  it should "clean-up google resources on error" in isolatedDbTest {
     val savedCluster1 = makeKubeCluster(1).save()
     val savedNodepool1 = makeNodepool(1, savedCluster1.id).save()
 

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriberSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriberSpec.scala
@@ -777,7 +777,7 @@ class LeoPubsubMessageSubscriberSpec
                               savedApp2.appName,
                               Some(savedNodepool2.id),
                               savedCluster1.googleProject,
-        None,
+                              None,
                               Map.empty,
                               Some(tr))
       queue <- InspectableQueue.bounded[IO, Task[IO]](10)
@@ -946,7 +946,7 @@ class LeoPubsubMessageSubscriberSpec
                              AppName("fakeapp"),
                              Some(savedNodepool1.id),
                              savedCluster1.googleProject,
-        None,
+                             None,
                              Map.empty,
                              Some(tr))
       queue <- InspectableQueue.bounded[IO, Task[IO]](10)
@@ -984,7 +984,7 @@ class LeoPubsubMessageSubscriberSpec
                              savedApp1.appName,
                              Some(savedNodepool1.id),
                              savedCluster1.googleProject,
-                            Some(DiskId(-1)),
+                             Some(DiskId(-1)),
                              Map.empty,
                              Some(tr))
       queue <- InspectableQueue.bounded[IO, Task[IO]](10)
@@ -1428,24 +1428,31 @@ class LeoPubsubMessageSubscriberSpec
     var deleteCalled = false
 
     val mockKubernetesService = new MockKubernetesService(PodStatus.Succeeded) {
-      override def createServiceAccount(clusterId: GKEModels.KubernetesClusterId, serviceAccount: KubernetesModels.KubernetesServiceAccount, namespaceName: KubernetesModels.KubernetesNamespace)(implicit ev: ApplicativeAsk[IO, TraceId]): IO[Unit] =
+      override def createServiceAccount(
+        clusterId: GKEModels.KubernetesClusterId,
+        serviceAccount: KubernetesModels.KubernetesServiceAccount,
+        namespaceName: KubernetesModels.KubernetesNamespace
+      )(implicit ev: ApplicativeAsk[IO, TraceId]): IO[Unit] =
         IO.raiseError(new Exception("this is an intentional test exception"))
 
-      override def deleteNamespace(clusterId: GKEModels.KubernetesClusterId, namespace: KubernetesModels.KubernetesNamespace)(implicit ev: ApplicativeAsk[IO, TraceId]): IO[Unit] =
-        IO({
+      override def deleteNamespace(
+        clusterId: GKEModels.KubernetesClusterId,
+        namespace: KubernetesModels.KubernetesNamespace
+      )(implicit ev: ApplicativeAsk[IO, TraceId]): IO[Unit] =
+        IO {
           deleteCalled = true
-        })
+        }
     }
 
     val gkeInterp =
       new GKEInterpreter[IO](Config.gkeInterpConfig,
-        vpcInterp,
-        MockGKEService,
-        mockKubernetesService,
-        MockHelm,
-        MockGalaxyDAO,
-        credentials,
-        blocker)
+                             vpcInterp,
+                             MockGKEService,
+                             mockKubernetesService,
+                             MockHelm,
+                             MockGalaxyDAO,
+                             credentials,
+                             blocker)
 
     val assertions = for {
       clusterOpt <- kubernetesClusterQuery.getMinimalClusterById(savedCluster1.id).transaction

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriberSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriberSpec.scala
@@ -654,7 +654,7 @@ class LeoPubsubMessageSubscriberSpec
         savedApp1.appName,
         Some(savedNodepool1.id),
         savedCluster1.googleProject,
-        true,
+        Some(disk.id),
         Map.empty,
         Some(tr)
       )
@@ -704,7 +704,7 @@ class LeoPubsubMessageSubscriberSpec
         savedApp1.appName,
         Some(savedNodepool1.id),
         savedCluster1.googleProject,
-        false,
+        None,
         Map.empty,
         Some(tr)
       )
@@ -768,7 +768,7 @@ class LeoPubsubMessageSubscriberSpec
         savedApp1.appName,
         Some(savedNodepool1.id),
         savedCluster1.googleProject,
-        false,
+        None,
         Map.empty,
         Some(tr)
       )
@@ -777,7 +777,7 @@ class LeoPubsubMessageSubscriberSpec
                               savedApp2.appName,
                               Some(savedNodepool2.id),
                               savedCluster1.googleProject,
-                              false,
+        None,
                               Map.empty,
                               Some(tr))
       queue <- InspectableQueue.bounded[IO, Task[IO]](10)
@@ -820,7 +820,7 @@ class LeoPubsubMessageSubscriberSpec
         savedApp1.appName,
         Some(NodepoolLeoId(-1)),
         project,
-        false,
+        None,
         Map.empty,
         Some(tr)
       )
@@ -863,7 +863,7 @@ class LeoPubsubMessageSubscriberSpec
         savedApp1.appName,
         Some(NodepoolLeoId(-2)),
         savedCluster1.googleProject,
-        false,
+        None,
         Map.empty,
         Some(tr)
       )
@@ -906,7 +906,7 @@ class LeoPubsubMessageSubscriberSpec
         savedApp1.appName,
         Some(NodepoolLeoId(-2)),
         savedCluster1.googleProject,
-        false,
+        None,
         Map.empty,
         Some(tr)
       )
@@ -946,7 +946,7 @@ class LeoPubsubMessageSubscriberSpec
                              AppName("fakeapp"),
                              Some(savedNodepool1.id),
                              savedCluster1.googleProject,
-                             false,
+        None,
                              Map.empty,
                              Some(tr))
       queue <- InspectableQueue.bounded[IO, Task[IO]](10)
@@ -984,7 +984,7 @@ class LeoPubsubMessageSubscriberSpec
                              savedApp1.appName,
                              Some(savedNodepool1.id),
                              savedCluster1.googleProject,
-                             true,
+                            Some(DiskId(-1)),
                              Map.empty,
                              Some(tr))
       queue <- InspectableQueue.bounded[IO, Task[IO]](10)
@@ -1351,7 +1351,7 @@ class LeoPubsubMessageSubscriberSpec
         savedApp1.appName,
         None,
         savedCluster1.googleProject,
-        true,
+        Some(disk.id),
         Map.empty,
         Some(tr)
       )
@@ -1406,6 +1406,89 @@ class LeoPubsubMessageSubscriberSpec
 
     res.unsafeRunSync()
     assertions.unsafeRunSync()
+  }
+
+  it should "clean-up google resources on error id1" in isolatedDbTest {
+    val savedCluster1 = makeKubeCluster(1).save()
+    val savedNodepool1 = makeNodepool(1, savedCluster1.id).save()
+
+    val disk = makePersistentDisk(None).save().unsafeRunSync()
+    val makeApp1 = makeApp(1, savedNodepool1.id)
+    val savedApp1 = makeApp1
+      .copy(appResources =
+        makeApp1.appResources.copy(
+          disk = Some(disk),
+          services = List(makeService(1), makeService(2))
+        )
+      )
+      .save()
+
+    //using a var here to simplify test code
+    //we could use mockito for this functionality, but it would be overly complicated since we wish to override other functionality of the mock as well
+    var deleteCalled = false
+
+    val mockKubernetesService = new MockKubernetesService(PodStatus.Succeeded) {
+      override def createServiceAccount(clusterId: GKEModels.KubernetesClusterId, serviceAccount: KubernetesModels.KubernetesServiceAccount, namespaceName: KubernetesModels.KubernetesNamespace)(implicit ev: ApplicativeAsk[IO, TraceId]): IO[Unit] =
+        IO.raiseError(new Exception("this is an intentional test exception"))
+
+      override def deleteNamespace(clusterId: GKEModels.KubernetesClusterId, namespace: KubernetesModels.KubernetesNamespace)(implicit ev: ApplicativeAsk[IO, TraceId]): IO[Unit] =
+        IO({
+          deleteCalled = true
+        })
+    }
+
+    val gkeInterp =
+      new GKEInterpreter[IO](Config.gkeInterpConfig,
+        vpcInterp,
+        MockGKEService,
+        mockKubernetesService,
+        MockHelm,
+        MockGalaxyDAO,
+        credentials,
+        blocker)
+
+    val assertions = for {
+      clusterOpt <- kubernetesClusterQuery.getMinimalClusterById(savedCluster1.id).transaction
+      getCluster = clusterOpt.get
+      getAppOpt <- KubernetesServiceDbQueries
+        .getFullAppByName(savedCluster1.googleProject, savedApp1.id)
+        .transaction
+      getApp = getAppOpt.get
+      getDiskOpt <- persistentDiskQuery.getById(savedApp1.appResources.disk.get.id).transaction
+      getDisk = getDiskOpt.get
+    } yield {
+      getCluster.status shouldBe KubernetesClusterStatus.Running
+      //only the default should be left, the other has been deleted
+      getCluster.nodepools.size shouldBe 1
+      getCluster.nodepools.filter(_.isDefault).head.status shouldBe NodepoolStatus.Running
+      getApp.app.errors.size shouldBe 1
+      getApp.app.status shouldBe AppStatus.Error
+      getApp.nodepool.status shouldBe NodepoolStatus.Deleted
+      getDisk.status shouldBe DiskStatus.Deleted
+      deleteCalled shouldBe true
+    }
+
+    val res = for {
+      tr <- traceId.ask
+      dummyNodepool = savedCluster1.nodepools.filter(_.isDefault).head
+      msg = CreateAppMessage(
+        Some(CreateCluster(savedCluster1.id, dummyNodepool.id)),
+        savedApp1.id,
+        savedApp1.appName,
+        Some(savedNodepool1.id),
+        savedCluster1.googleProject,
+        Some(disk.id),
+        Map.empty,
+        Some(tr)
+      )
+      queue <- InspectableQueue.bounded[IO, Task[IO]](10)
+      leoSubscriber = makeLeoSubscriber(asyncTaskQueue = queue, gkeInterp = gkeInterp)
+      asyncTaskProcessor = AsyncTaskProcessor(AsyncTaskProcessor.Config(10, 10), queue)
+      _ <- leoSubscriber.handleCreateAppMessage(msg)
+      _ <- withInfiniteStream(asyncTaskProcessor.process, assertions, maxRetry = 50)
+    } yield ()
+
+    res.unsafeRunSync()
   }
 
   def makeLeoSubscriber(runtimeMonitor: RuntimeMonitor[IO, CloudService] = MockRuntimeMonitor,

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriberSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriberSpec.scala
@@ -1468,6 +1468,7 @@ class LeoPubsubMessageSubscriberSpec
       getApp.app.errors.size shouldBe 1
       getApp.app.status shouldBe AppStatus.Error
       getApp.nodepool.status shouldBe NodepoolStatus.Deleted
+      getApp.app.auditInfo.destroyedDate shouldBe None
       getDisk.status shouldBe DiskStatus.Deleted
       deleteCalled shouldBe true
     }
@@ -1495,7 +1496,7 @@ class LeoPubsubMessageSubscriberSpec
     res.unsafeRunSync()
   }
 
-  it should "not delete a disk that already existing on error id1" in isolatedDbTest {
+  it should "not delete a disk that already existing on error" in isolatedDbTest {
     val savedCluster1 = makeKubeCluster(1).save()
     val savedNodepool1 = makeNodepool(1, savedCluster1.id).save()
 

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/KubernetesServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/KubernetesServiceInterpSpec.scala
@@ -120,7 +120,7 @@ class KubernetesServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite wit
     createAppMessage.appId shouldBe getApp.app.id
     createAppMessage.nodepoolId shouldBe Some(getApp.nodepool.id)
     createAppMessage.project shouldBe project
-    createAppMessage.createDisk shouldBe true
+    createAppMessage.createDisk shouldBe getApp.app.appResources.disk.map(_.id)
     createAppMessage.cluster shouldBe Some(
       CreateCluster(getMinimalCluster.id, defaultNodepool.id)
     )
@@ -140,7 +140,7 @@ class KubernetesServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite wit
 
     val message = publisherQueue.dequeue1.unsafeRunSync()
     message.messageType shouldBe LeoPubsubMessageType.CreateApp
-    message.asInstanceOf[CreateAppMessage].createDisk shouldBe false
+    message.asInstanceOf[CreateAppMessage].createDisk shouldBe None
 
     val appResult = dbFutureValue {
       KubernetesServiceDbQueries.getActiveFullAppByName(project, appName)


### PR DESCRIPTION
This PR adds cleanup for nodepools, disks, and app-related kubernetes entities when app creation fails.