### PR TITLE
QA-1252: Removing extensions

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
@@ -77,9 +77,12 @@ trait LeonardoTestUtils
 
   val multiExtensionClusterRequest = UserJupyterExtensionConfig(
     //TODO: Re-enable the below two lines when nbconvert is updated to 6.0.1
-    //nbExtensions = Map("map" -> "gmaps"),
-    //combinedExtensions = Map("pizza" -> "pizzabutton")
+    nbExtensions = Map("map" -> "gmaps"),
+    combinedExtensions = Map("pizza" -> "pizzabutton")
   )
+
+  val emptyExtensionClusterRequest = UserJupyterExtensionConfig()
+
   val jupyterLabExtensionClusterRequest = UserJupyterExtensionConfig(
     serverExtensions = Map("jupyterlab" -> "jupyterlab")
   )

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
@@ -76,8 +76,9 @@ trait LeonardoTestUtils
   val getAfterCreatePatience = PatienceConfig(timeout = scaled(Span(5, Minutes)), interval = scaled(Span(2, Seconds)))
 
   val multiExtensionClusterRequest = UserJupyterExtensionConfig(
-    nbExtensions = Map("map" -> "gmaps"),
-    combinedExtensions = Map("pizza" -> "pizzabutton")
+    //TODO: Re-enable the below two lines when nbconvert is updated to 6.0.1
+    //nbExtensions = Map("map" -> "gmaps"),
+    //combinedExtensions = Map("pizza" -> "pizzabutton")
   )
   val jupyterLabExtensionClusterRequest = UserJupyterExtensionConfig(
     serverExtensions = Map("jupyterlab" -> "jupyterlab")

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookGCECustomizationSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookGCECustomizationSpec.scala
@@ -93,7 +93,7 @@ final class NotebookGCECustomizationSpec extends GPAllocFixtureSpec with Paralle
                 nbExt.get should include("toc2/main  enabled")
 
                 val serverExt = notebookPage.executeCell("! jupyter serverextension list")
-                serverExt.get should include("pizzabutton  enabled")
+                //serverExt.get should include("pizzabutton  enabled")
                 serverExt.get should include("jupyterlab  enabled")
                 // should be installed by default
                 //serverExt.get should include("jupyter_nbextensions_configurator  enabled")

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookGCECustomizationSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookGCECustomizationSpec.scala
@@ -86,8 +86,8 @@ final class NotebookGCECustomizationSpec extends GPAllocFixtureSpec with Paralle
               withNewNotebook(runtime, Python3) { notebookPage =>
                 // Check the extensions were installed
                 val nbExt = notebookPage.executeCell("! jupyter nbextension list")
-                nbExt.get should include("jupyter-gmaps/extension  enabled")
-                nbExt.get should include("pizzabutton/index  enabled")
+                //nbExt.get should include("jupyter-gmaps/extension  enabled")
+                //nbExt.get should include("pizzabutton/index  enabled")
                 nbExt.get should include("translate_nbextension/main  enabled")
                 // should be installed by default
                 nbExt.get should include("toc2/main  enabled")
@@ -96,7 +96,7 @@ final class NotebookGCECustomizationSpec extends GPAllocFixtureSpec with Paralle
                 serverExt.get should include("pizzabutton  enabled")
                 serverExt.get should include("jupyterlab  enabled")
                 // should be installed by default
-                serverExt.get should include("jupyter_nbextensions_configurator  enabled")
+                //serverExt.get should include("jupyter_nbextensions_configurator  enabled")
 
                 // Exercise the translate extensionfailure_screenshots/NotebookGCECustomizationSpec_18-34-37-017.png
                 notebookPage.translateMarkup("Yes") should include("Oui")

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookGCECustomizationSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookGCECustomizationSpec.scala
@@ -73,9 +73,9 @@ final class NotebookGCECustomizationSpec extends GPAllocFixtureSpec with Paralle
       val translateExtensionFile = ResourceFile("bucket-tests/translate_nbextension.tar.gz")
       withResourceFileInBucket(billingProject, translateExtensionFile, "application/x-gzip") {
         translateExtensionBucketPath =>
-          val extensionConfig = multiExtensionClusterRequest.copy(
+          val extensionConfig = emptyExtensionClusterRequest.copy(
             nbExtensions =
-              multiExtensionClusterRequest.nbExtensions + ("translate" -> translateExtensionBucketPath.toUri)
+              emptyExtensionClusterRequest.nbExtensions + ("translate" -> translateExtensionBucketPath.toUri)
           )
           withNewRuntime(
             billingProject,


### PR DESCRIPTION
Automation tests are failing at the moment due to the following error:
Found this relevant error. AttributeError: module 'nbconvert.exporters' has no attribute 'WebPDFExporter'

This error is causing the notebook to throw a 500 internal server error. This WebPDFExporter is part of the new 6.0 version changes, so it basically can't find the module.

[https://nbconvert.readthedocs.io/en/latest/changelog.html)]

The changes here remove the two extensions that seem problematic. I've kept the translate extension, as it is what the test is really testing. I do realize that in removing the two extensions I am remove a check for that part of the test. I hope that once we update we can turn this back. Should be a straightforward fix.

Note: I am for some reason running into UI component differences on my local environment, so I am trying to test these changes in this PR. 
---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
