### PR TITLE
IA-2202: Changing Extensions to remove failure

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
@@ -76,8 +76,8 @@ trait LeonardoTestUtils
   val getAfterCreatePatience = PatienceConfig(timeout = scaled(Span(5, Minutes)), interval = scaled(Span(2, Seconds)))
 
   val multiExtensionClusterRequest = UserJupyterExtensionConfig(
-    nbExtensions = Map("map" -> "gmaps"),
-    combinedExtensions = Map("pizza" -> "pizzabutton")
+    nbExtensions = Map("saturn-iframe-extension" -> "https://app.terra.bio/jupyter-iframe-extension.js")
+    //combinedExtensions = Map("pizza" -> "pizzabutton")
   )
   val jupyterLabExtensionClusterRequest = UserJupyterExtensionConfig(
     serverExtensions = Map("jupyterlab" -> "jupyterlab")

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
@@ -77,7 +77,6 @@ trait LeonardoTestUtils
 
   val multiExtensionClusterRequest = UserJupyterExtensionConfig(
     nbExtensions = Map("saturn-iframe-extension" -> "https://app.terra.bio/jupyter-iframe-extension.js")
-    //combinedExtensions = Map("pizza" -> "pizzabutton")
   )
   val jupyterLabExtensionClusterRequest = UserJupyterExtensionConfig(
     serverExtensions = Map("jupyterlab" -> "jupyterlab")

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookGCECustomizationSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookGCECustomizationSpec.scala
@@ -80,14 +80,12 @@ final class NotebookGCECustomizationSpec extends GPAllocFixtureSpec with Paralle
               withNewNotebook(runtime, Python3) { notebookPage =>
                 // Check the extensions were installed
                 val nbExt = notebookPage.executeCell("! jupyter nbextension list")
-                nbExt.get should include("jupyter-gmaps/extension  enabled")
-                nbExt.get should include("pizzabutton/index  enabled")
+                nbExt.get should include("jupyter-iframe-extension/mai enabled")
                 nbExt.get should include("translate_nbextension/main  enabled")
                 // should be installed by default
                 nbExt.get should include("toc2/main  enabled")
 
                 val serverExt = notebookPage.executeCell("! jupyter serverextension list")
-                serverExt.get should include("pizzabutton  enabled")
                 serverExt.get should include("jupyterlab  enabled")
                 // should be installed by default
                 serverExt.get should include("jupyter_nbextensions_configurator  enabled")

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookGCECustomizationSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookGCECustomizationSpec.scala
@@ -63,7 +63,7 @@ final class NotebookGCECustomizationSpec extends GPAllocFixtureSpec with Paralle
     // TODO: re-enable this test
     // Using nbtranslate extension from here:
     // https://github.com/ipython-contrib/jupyter_contrib_nbextensions/tree/master/src/jupyter_contrib_nbextensions/nbextensions/nbTranslate
-    "should install user specified notebook extensions" ignore { billingProject =>
+    "should install user specified notebook extensions" in { billingProject =>
       val translateExtensionFile = ResourceFile("bucket-tests/translate_nbextension.tar.gz")
       withResourceFileInBucket(billingProject, translateExtensionFile, "application/x-gzip") {
         translateExtensionBucketPath =>

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookGCECustomizationSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookGCECustomizationSpec.scala
@@ -149,7 +149,7 @@ final class NotebookGCECustomizationSpec extends GPAllocFixtureSpec with Paralle
     // TODO: This test has flaky selenium logic, ignoring for now. More details in:
     // https://broadworkbench.atlassian.net/browse/QA-1199
     // https://broadworkbench.atlassian.net/browse/IA-2050
-    "should execute user-specified start script" ignore { billingProject =>
+    "should execute user-specified start script" in { billingProject =>
       implicit val ronToken: AuthToken = ronAuthToken
 
       withNewGoogleBucket(billingProject) { bucketName =>

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookGCECustomizationSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookGCECustomizationSpec.scala
@@ -80,7 +80,7 @@ final class NotebookGCECustomizationSpec extends GPAllocFixtureSpec with Paralle
               withNewNotebook(runtime, Python3) { notebookPage =>
                 // Check the extensions were installed
                 val nbExt = notebookPage.executeCell("! jupyter nbextension list")
-                nbExt.get should include("jupyter-iframe-extension/main enabled")
+                nbExt.get should include("jupyter-iframe-extension/main  enabled")
                 nbExt.get should include("translate_nbextension/main  enabled")
                 // should be installed by default
                 nbExt.get should include("toc2/main  enabled")

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookGCECustomizationSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookGCECustomizationSpec.scala
@@ -80,7 +80,7 @@ final class NotebookGCECustomizationSpec extends GPAllocFixtureSpec with Paralle
               withNewNotebook(runtime, Python3) { notebookPage =>
                 // Check the extensions were installed
                 val nbExt = notebookPage.executeCell("! jupyter nbextension list")
-                nbExt.get should include("jupyter-iframe-extension/mai enabled")
+                nbExt.get should include("jupyter-iframe-extension/main enabled")
                 nbExt.get should include("translate_nbextension/main  enabled")
                 // should be installed by default
                 nbExt.get should include("toc2/main  enabled")

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookGCECustomizationSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookGCECustomizationSpec.scala
@@ -149,7 +149,7 @@ final class NotebookGCECustomizationSpec extends GPAllocFixtureSpec with Paralle
     // TODO: This test has flaky selenium logic, ignoring for now. More details in:
     // https://broadworkbench.atlassian.net/browse/QA-1199
     // https://broadworkbench.atlassian.net/browse/IA-2050
-    "should execute user-specified start script" in { billingProject =>
+    "should execute user-specified start script" ignore { billingProject =>
       implicit val ronToken: AuthToken = ronAuthToken
 
       withNewGoogleBucket(billingProject) { bucketName =>


### PR DESCRIPTION
The failure was due to the gmaps and pizzabuttons extensions not being compatible with the version of nbconvert.

Instead of bumping the version, we are opting to change the extension to one that is being used. Bumping the version has a possibility of breaking something else, so we are going to try this approach first
---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
