### PR TITLE
IA-2050: Enabling test

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookGCECustomizationSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookGCECustomizationSpec.scala
@@ -149,7 +149,7 @@ final class NotebookGCECustomizationSpec extends GPAllocFixtureSpec with Paralle
     // TODO: This test has flaky selenium logic, ignoring for now. More details in:
     // https://broadworkbench.atlassian.net/browse/QA-1199
     // https://broadworkbench.atlassian.net/browse/IA-2050
-    "should execute user-specified start script" ignore { billingProject =>
+    "should execute user-specified start script" in { billingProject =>
       implicit val ronToken: AuthToken = ronAuthToken
 
       withNewGoogleBucket(billingProject) { bucketName =>

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookGCECustomizationSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookGCECustomizationSpec.scala
@@ -60,7 +60,6 @@ final class NotebookGCECustomizationSpec extends GPAllocFixtureSpec with Paralle
       }
     }
 
-    // TODO: re-enable this test
     // Using nbtranslate extension from here:
     // https://github.com/ipython-contrib/jupyter_contrib_nbextensions/tree/master/src/jupyter_contrib_nbextensions/nbextensions/nbTranslate
     "should install user specified notebook extensions" in { billingProject =>

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookGCEDataSyncingSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookGCEDataSyncingSpec.scala
@@ -176,7 +176,6 @@ class NotebookGCEDataSyncingSpec extends RuntimeFixtureSpec with NotebookTestUti
 
               eventually(timeout(Span(2, Minutes)), interval(Span(30, Seconds))) { //wait for checkMeta tick
                 notebookPage areElementsPresent (syncIssueElements) shouldBe true
-
                 notebookPage executeJavaScript ("window.onbeforeunload = null;") //disables pesky chrome modal to confirm navigation. we are not testing chrome's implementation and confirming the modal proves problematic
 
                 notebookPage makeACopyFromSyncIssue


### PR DESCRIPTION
Enabling test for the "should execute user-specified start script" to see if the same errors are persisting
---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
