### PR TITLE
[no ticket] Remove special k8s name validation in routes

### DIFF
--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/AppRoutes.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/AppRoutes.scala
@@ -62,7 +62,7 @@ class AppRoutes(kubernetesService: KubernetesService[IO], userInfoDirectives: Us
                 }
               } ~
               pathPrefix(Segment) { appNameString =>
-                RouteValidation.validateKubernetesName(appNameString, AppName.apply) { appName =>
+                RouteValidation.validateNameDirective(appNameString, AppName.apply) { appName =>
                   pathEndOrSingleSlash {
                     post {
                       entity(as[CreateAppRequest]) { req =>

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/RouteValidation.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/RouteValidation.scala
@@ -2,9 +2,8 @@ package org.broadinstitute.dsde.workbench.leonardo
 package http
 package api
 
-import akka.http.scaladsl.server.{Directive, Directive1}
 import akka.http.scaladsl.server.Directives.failWith
-import org.broadinstitute.dsde.workbench.google2.KubernetesName
+import akka.http.scaladsl.server.{Directive, Directive1}
 
 import scala.util.control.NoStackTrace
 
@@ -19,14 +18,6 @@ object RouteValidation {
       validateName(nameString) match {
         case Left(e)  => failWith(RequestValidationError(e))
         case Right(c) => inner(Tuple1(apply(c)))
-      }
-    }
-
-  def validateKubernetesName[A](nameString: String, apply: String => A): Directive1[A] =
-    Directive { inner =>
-      KubernetesName.withValidation(nameString, apply) match {
-        case Left(e)  => failWith(e)
-        case Right(c) => inner(Tuple1(c))
       }
     }
 }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/HttpRoutesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/HttpRoutesSpec.scala
@@ -409,7 +409,7 @@ class HttpRoutesSpec
 
   it should "validate app name" in {
     Get("/api/google/v1/apps/googleProject1/1badApp") ~> routes.route ~> check {
-      status.intValue shouldBe 500
+      status.intValue shouldBe 400
     }
   }
 


### PR DESCRIPTION
Missed this in my last PR -- since we're not using `appName` as k8s names anymore, we don't need to do custom k8s name validation in `AppRoutes`. Change `AppRoutes` to use the same Leo name validation logic as runtime names.

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
