### PR TITLE
[IA-2222] Streamline cluster+nodepool creation

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/JsonCodec.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/JsonCodec.scala
@@ -198,8 +198,6 @@ object JsonCodec {
       KubernetesClusterAsyncFields.unapply(x).get
     )
 
-  implicit val createClusterEncoder: Encoder[CreateCluster] =
-    Encoder.forProduct2("clusterId", "nodepoolId")(x => (x.clusterId, x.defaultNodepoolId))
   implicit val instanceNameEncoder: Encoder[InstanceName] = Encoder.encodeString.contramap(_.value)
   implicit val dataprocRoleEncoder: Encoder[DataprocRole] =
     Encoder.encodeString.contramap(_.toString) // We've been using `.toString` in db
@@ -402,9 +400,6 @@ object JsonCodec {
     Decoder.forProduct3("networkName", "subNetworkName", "subNetworkIpRange")(NetworkFields)
   implicit val kubeAsyncFieldDecoder: Decoder[KubernetesClusterAsyncFields] =
     Decoder.forProduct3("loadBalancerIp", "apiServerIp", "networkInfo")(KubernetesClusterAsyncFields)
-
-  implicit val createClusterDecoder: Decoder[CreateCluster] =
-    Decoder.forProduct2("clusterId", "nodepoolId")(CreateCluster.apply)
 
   implicit val dataprocInstanceKeyDecoder: Decoder[DataprocInstanceKey] = Decoder.forProduct3(
     "project",

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/kubernetesModels.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/kubernetesModels.scala
@@ -389,9 +389,6 @@ final case class KubernetesServiceKindName(value: String) extends AnyVal
 final case class KubernetesRuntimeConfig(numNodes: NumNodes, machineType: MachineTypeName, autoscalingEnabled: Boolean)
 final case class NumNodepools(value: Int) extends AnyVal
 
-//used in pubsub messaging to indicate the cluster and dummy nodepool to be created
-final case class CreateCluster(clusterId: KubernetesClusterLeoId, defaultNodepoolId: NodepoolLeoId)
-
 final case class NodepoolNotFoundException(nodepoolLeoId: NodepoolLeoId) extends Exception {
   override def getMessage: String = s"nodepool with id ${nodepoolLeoId} not found"
 }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/NodepoolComponent.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/NodepoolComponent.scala
@@ -102,14 +102,6 @@ object nodepoolQuery extends TableQuery(new NodepoolTable(_)) {
         fromNodepool(n)
     } yield n.copy(id = nodepoolId)
 
-  def markAsUnclaimed(ids: List[NodepoolLeoId])(implicit ec: ExecutionContext): DBIO[Unit] =
-    for {
-      _ <- nodepoolQuery
-        .filter(_.id inSetBind ids.toSet)
-        .map(_.status)
-        .update(NodepoolStatus.Unclaimed)
-    } yield ()
-
   private def fromNodepool(n: Nodepool) = NodepoolRecord(
     NodepoolLeoId(0),
     n.clusterId,
@@ -141,6 +133,14 @@ object nodepoolQuery extends TableQuery(new NodepoolTable(_)) {
     findByNodepoolIdQuery(id)
       .map(_.status)
       .update(status)
+
+  def updateStatuses(ids: List[NodepoolLeoId], status: NodepoolStatus)(implicit ec: ExecutionContext): DBIO[Unit] =
+    for {
+      _ <- nodepoolQuery
+        .filter(_.id inSetBind ids.toSet)
+        .map(_.status)
+        .update(status)
+    } yield ()
 
   def markActiveAsDeletedForCluster(clusterId: KubernetesClusterLeoId, destroyedDate: Instant): DBIO[Int] =
     deleteFromQuery(findActiveByClusterIdQuery(clusterId), destroyedDate)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
@@ -630,7 +630,8 @@ class LeoPubsubMessageSubscriber[F[_]: Timer: ContextShift: Parallel](
       // we can nack the message on errors. Monitoring all creations will be asynchronous,
       // and (3) and (4) will always be asynchronous.
 
-      // Create the cluster or nodepool synchronously if necessary
+      // Create the cluster or nodepool synchronously if necessary.
+      // The monitor operation is returned so it can be run asynchronously.
       monitorClusterOrNodepool <- msg.clusterNodepoolAction match {
         case Some(ClusterNodepoolAction.CreateClusterAndNodepool(clusterId, defaultNodepoolId, nodepoolId)) =>
           for {

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
@@ -643,7 +643,7 @@ class LeoPubsubMessageSubscriber[F[_]: Timer: ContextShift: Parallel](
                   PubsubKubernetesError(
                     AppError(e.getMessage, ctx.now, ErrorAction.CreateGalaxyApp, ErrorSource.Cluster, None),
                     Some(msg.appId),
-                    true,
+                    false,
                     None,
                     Some(clusterId)
                   )
@@ -659,7 +659,7 @@ class LeoPubsubMessageSubscriber[F[_]: Timer: ContextShift: Parallel](
                   PubsubKubernetesError(
                     AppError(e.getMessage, ctx.now, ErrorAction.CreateGalaxyApp, ErrorSource.Nodepool, None),
                     Some(msg.appId),
-                    true,
+                    false,
                     Some(nodepoolId),
                     None
                   )

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/leoPubsubMessageSubscriberModels.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/leoPubsubMessageSubscriberModels.scala
@@ -205,6 +205,18 @@ object LeoPubsubMessage {
       )
   }
 
+  // cases:
+  // - Some(cluster), Some(nodepool)  [ cluster does not exist  ]
+  // - None, Some(nodepool)   [ cluster already exists ]
+  // - None, None  [ claimed nodepool ]
+  sealed trait ClusterNodepoolState extends Product with Serializable
+  object ClusterNodepoolState {
+    final case object Exists extends ClusterNodepoolState
+    final case class CreateNodepool(nodepoolId: NodepoolLeoId) extends ClusterNodepoolState
+    final case class CreateClusterAndNodepool(cluster: CreateCluster, nodepoolLeoId: NodepoolLeoId)
+        extends ClusterNodepoolState
+  }
+
   final case class CreateAppMessage(cluster: Option[CreateCluster],
                                     appId: AppId,
                                     appName: AppName,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/leoPubsubMessageSubscriberModels.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/leoPubsubMessageSubscriberModels.scala
@@ -290,7 +290,7 @@ object ClusterNodepoolActionType {
     val asString: String = "createNodepool"
   }
   def values: Set[ClusterNodepoolActionType] = sealerate.values[ClusterNodepoolActionType]
-  def stringToObject: Map[String, ClusterNodepoolActionType] = values.map(v => v.toString -> v).toMap
+  def stringToObject: Map[String, ClusterNodepoolActionType] = values.map(v => v.asString -> v).toMap
 }
 
 sealed trait ClusterNodepoolAction extends Product with Serializable {

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/KubernetesServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/KubernetesServiceInterp.scala
@@ -40,7 +40,7 @@ import org.broadinstitute.dsde.workbench.leonardo.http.service.LeoKubernetesServ
 import org.broadinstitute.dsde.workbench.leonardo.http.service.LeonardoService.includeDeletedKey
 import org.broadinstitute.dsde.workbench.leonardo.model.SamResourceAction._
 import org.broadinstitute.dsde.workbench.leonardo.model.{LeoAuthProvider, ServiceAccountProviderConfig, _}
-import org.broadinstitute.dsde.workbench.leonardo.monitor.LeoPubsubMessage
+import org.broadinstitute.dsde.workbench.leonardo.monitor.{ClusterNodepoolAction, LeoPubsubMessage}
 import org.broadinstitute.dsde.workbench.leonardo.monitor.LeoPubsubMessage.{
   BatchNodepoolCreateMessage,
   CreateAppMessage,
@@ -95,7 +95,7 @@ final class LeoKubernetesServiceInterp[F[_]: Parallel](
         }
 
       saveCluster <- F.fromEither(getSavableCluster(userInfo, googleProject, ctx.now, None))
-      saveClusterResult <- KubernetesServiceDbQueries.saveOrGetForApp(saveCluster).transaction
+      saveClusterResult <- KubernetesServiceDbQueries.saveOrGetClusterForApp(saveCluster).transaction
       _ <- if (saveClusterResult.minimalCluster.status == KubernetesClusterStatus.Error)
         F.raiseError[Unit](
           KubernetesAppCreationException(
@@ -150,17 +150,17 @@ final class LeoKubernetesServiceInterp[F[_]: Parallel](
       )
       app <- appQuery.save(saveApp).transaction
 
+      clusterNodepoolAction = saveClusterResult match {
+        case ClusterExists(_) =>
+          if (claimedNodepoolOpt.isDefined) None else Some(ClusterNodepoolAction.CreateNodepool(nodepool.id))
+        case ClusterDoesNotExist(c, n) => Some(ClusterNodepoolAction.CreateClusterAndNodepool(c.id, n.id, nodepool.id))
+      }
       createAppMessage = CreateAppMessage(
-        saveClusterResult match {
-          case _: ClusterExists         => None
-          case res: ClusterDoesNotExist => Some(CreateCluster(res.minimalCluster.id, res.defaultNodepool.id))
-        },
+        googleProject,
+        clusterNodepoolAction,
         app.id,
         app.appName,
-        //we don't want to create a nodepool if we already have claimed an existing one
-        claimedNodepoolOpt.fold[Option[NodepoolLeoId]](Some(nodepool.id))(_ => None),
-        saveClusterResult.minimalCluster.googleProject,
-        if (diskResultOpt.exists(_.creationNeeded)) diskResultOpt.map(_.disk.id) else None,
+        diskResultOpt.flatMap(d => if (d.creationNeeded) Some(d.disk.id) else None),
         req.customEnvironmentVariables,
         Some(ctx.traceId)
       )
@@ -274,22 +274,22 @@ final class LeoKubernetesServiceInterp[F[_]: Parallel](
 
       // create default nodepool with size dependant on number of nodes requested
       saveCluster <- F.fromEither(getSavableCluster(userInfo, googleProject, ctx.now, Some(req.numNodepools)))
-      saveClusterResult <- KubernetesServiceDbQueries.saveOrGetForApp(saveCluster).transaction
+      saveClusterResult <- KubernetesServiceDbQueries.saveOrGetClusterForApp(saveCluster).transaction
 
       // check if the cluster exists (we reject this request if it does)
-      createCluster <- saveClusterResult match {
-        case _: ClusterExists         => F.raiseError[CreateCluster](ClusterExistsException(googleProject))
-        case res: ClusterDoesNotExist => F.pure(CreateCluster(res.minimalCluster.id, res.defaultNodepool.id))
+      clusterId <- saveClusterResult match {
+        case _: ClusterExists         => F.raiseError[KubernetesClusterLeoId](ClusterExistsException(googleProject))
+        case res: ClusterDoesNotExist => F.pure(res.minimalCluster.id)
       }
       // create list of Precreating nodepools
       eitherNodepoolsOrError = List.tabulate(req.numNodepools.value) { _ =>
-        getUserNodepool(createCluster.clusterId, userInfo, req.kubernetesRuntimeConfig, ctx.now)
+        getUserNodepool(clusterId, userInfo, req.kubernetesRuntimeConfig, ctx.now)
       }
       nodepools <- eitherNodepoolsOrError.traverse(n => F.fromEither(n))
       _ <- nodepoolQuery.saveAllForCluster(nodepools).transaction
-      dbNodepools <- KubernetesServiceDbQueries.getAllNodepoolsForCluster(createCluster.clusterId).transaction
+      dbNodepools <- KubernetesServiceDbQueries.getAllNodepoolsForCluster(clusterId).transaction
       allNodepoolIds = dbNodepools.map(_.id)
-      msg = BatchNodepoolCreateMessage(createCluster.clusterId, allNodepoolIds, googleProject, Some(ctx.traceId))
+      msg = BatchNodepoolCreateMessage(clusterId, allNodepoolIds, googleProject, Some(ctx.traceId))
       _ <- publisherQueue.enqueue1(msg)
     } yield ()
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/KubernetesServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/KubernetesServiceInterp.scala
@@ -152,6 +152,7 @@ final class LeoKubernetesServiceInterp[F[_]: Parallel](
 
       clusterNodepoolAction = saveClusterResult match {
         case ClusterExists(_) =>
+          // If we're claiming a pre-existing nodepool then don't specify CreateNodepool in the pubsub message
           if (claimedNodepoolOpt.isDefined) None else Some(ClusterNodepoolAction.CreateNodepool(nodepool.id))
         case ClusterDoesNotExist(c, n) => Some(ClusterNodepoolAction.CreateClusterAndNodepool(c.id, n.id, nodepool.id))
       }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
@@ -222,10 +222,12 @@ class GKEInterpreter[F[_]: Parallel: ContextShift: Timer](
         )
         .transaction
       _ <- kubernetesClusterQuery.updateStatus(dbCluster.id, KubernetesClusterStatus.Running).transaction
-      _ <- nodepoolQuery.updateStatus(defaultNodepool.id, NodepoolStatus.Running).transaction
-      _ <- if (params.isNodepoolPrecreate)
-        nodepoolQuery.markAsUnclaimed(dbCluster.nodepools.filterNot(_.isDefault).map(_.id)).transaction
-      else F.unit
+      _ <- if (params.isNodepoolPrecreate) {
+        (nodepoolQuery.updateStatus(defaultNodepool.id, NodepoolStatus.Running) >>
+          nodepoolQuery.updateStatuses(dbCluster.nodepools.filterNot(_.isDefault).map(_.id), NodepoolStatus.Unclaimed)).transaction
+      } else {
+        nodepoolQuery.updateStatuses(dbCluster.nodepools.map(_.id), NodepoolStatus.Running).transaction
+      }
 
     } yield ()
 

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/KubernetesServiceDbQueriesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/KubernetesServiceDbQueriesSpec.scala
@@ -240,7 +240,7 @@ class KubernetesServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent 
       )
       .get
 
-    val saveResult = dbFutureValue(KubernetesServiceDbQueries.saveOrGetForApp(saveCluster1))
+    val saveResult = dbFutureValue(KubernetesServiceDbQueries.saveOrGetClusterForApp(saveCluster1))
 
     val x = saveResult match {
       case _: ClusterExists       => false
@@ -282,8 +282,8 @@ class KubernetesServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent 
       )
       .get
 
-    val saveResult1IO = KubernetesServiceDbQueries.saveOrGetForApp(saveCluster1).transaction
-    val saveResult2IO = KubernetesServiceDbQueries.saveOrGetForApp(saveCluster2).transaction
+    val saveResult1IO = KubernetesServiceDbQueries.saveOrGetClusterForApp(saveCluster1).transaction
+    val saveResult2IO = KubernetesServiceDbQueries.saveOrGetClusterForApp(saveCluster2).transaction
 
     the[KubernetesAppCreationException] thrownBy {
       saveResult1IO.unsafeRunSync()
@@ -311,7 +311,7 @@ class KubernetesServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent 
                               DefaultNodepool.fromNodepool(c.nodepools.headOption.get))
       )
       .get
-    val saveClusterResult = dbFutureValue(KubernetesServiceDbQueries.saveOrGetForApp(saveCluster2))
+    val saveClusterResult = dbFutureValue(KubernetesServiceDbQueries.saveOrGetClusterForApp(saveCluster2))
 
     val x = saveClusterResult match {
       case _: ClusterExists       => true

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubCodecSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubCodecSpec.scala
@@ -8,7 +8,6 @@ import org.broadinstitute.dsde.workbench.leonardo.{
   AppId,
   AppName,
   AuditInfo,
-  CreateCluster,
   DiskId,
   DiskSize,
   KubernetesClusterLeoId,
@@ -100,11 +99,12 @@ class LeoPubsubCodecSpec extends AnyFlatSpec with Matchers {
   it should "encode/decode CreateAppMessage properly" in {
     val traceId = TraceId(UUID.randomUUID().toString)
     val originalMessage = CreateAppMessage(
-      Some(CreateCluster(KubernetesClusterLeoId(1), NodepoolLeoId(1))),
+      GoogleProject("project1"),
+      Some(
+        ClusterNodepoolAction.CreateClusterAndNodepool(KubernetesClusterLeoId(1), NodepoolLeoId(1), NodepoolLeoId(2))
+      ),
       AppId(1),
       AppName("app1"),
-      Some(NodepoolLeoId(2)),
-      GoogleProject("project1"),
       Some(DiskId(1)),
       Map.empty,
       Some(traceId)

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriberSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriberSpec.scala
@@ -898,7 +898,7 @@ class LeoPubsubMessageSubscriberSpec
     } yield {
       getApp.app.errors.size shouldBe 1
       getApp.app.errors.map(_.action) should contain(ErrorAction.CreateGalaxyApp)
-      getApp.app.errors.map(_.source) should contain(ErrorSource.Nodepool)
+      getApp.app.errors.map(_.source) should contain(ErrorSource.Cluster)
       //the nodepool does not exist, so we should not have updated its status
       getApp.nodepool.status shouldBe NodepoolStatus.Unspecified
     }


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-2222

This saves some time on app creation by passing in both the default nodepool and the user nodepool to the createCluster request, instead of creating the cluster and user nodepool serially.

I also refactored some of the models for the `createApp` pubsub message. Previously we determined behavior based on a few optional parameters in the message. I found this confusing, and not all permutations were actually valid states for the system to be in. So I added a sum type:
```
sealed trait ClusterNodepoolAction extends Product with Serializable {
  def actionType: ClusterNodepoolActionType
}
object ClusterNodepoolAction {
  final case class CreateClusterAndNodepool(clusterId: KubernetesClusterLeoId,
                                            defaultNodepoolId: NodepoolLeoId,
                                            nodepoolId: NodepoolLeoId)
      extends ClusterNodepoolAction {
    val actionType: ClusterNodepoolActionType = ClusterNodepoolActionType.CreateClusterAndNodepool

  }
  final case class CreateNodepool(nodepoolId: NodepoolLeoId) extends ClusterNodepoolAction {
    val actionType: ClusterNodepoolActionType = ClusterNodepoolActionType.CreateNodepool
  }
}
```
I think this is simpler as the cluster/nodepool action is now explicitly defined in the pubsub message.

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
