### PR TITLE
[IA-2197] Delete cluster on cluster error

### DIFF
--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/KubernetesServiceDbQueries.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/KubernetesServiceDbQueries.scala
@@ -74,10 +74,13 @@ object KubernetesServiceDbQueries {
                      appQuery.findActiveByNameQuery(appName),
                      labelFilter)
 
-  def getFullAppByName(googleProject: GoogleProject, appId: AppId, labelFilter: LabelMap = Map())(
+  def getFullAppByName(googleProject: GoogleProject,
+                       appId: AppId,
+                       labelFilter: LabelMap = Map(),
+                       includeDeletedClusterApps: Boolean = false)(
     implicit ec: ExecutionContext
   ): DBIO[Option[GetAppResult]] =
-    getActiveFullApp(listClustersByProject(Some(googleProject)),
+    getActiveFullApp(listClustersByProject(Some(googleProject), includeDeletedClusterApps),
                      nodepoolQuery,
                      appQuery.getByIdQuery(appId),
                      labelFilter)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
@@ -642,6 +642,9 @@ class LeoPubsubMessageSubscriber[F[_]: Timer: ContextShift: Parallel](
               .onError {
                 case _ =>
                   for {
+                    _ <- logger.info(
+                      s"Beginning clean up for cluster $clusterId due to an error during cluster creation"
+                    )
                     _ <- kubernetesClusterQuery.markPendingDeletion(clusterId).transaction
                     _ <- gkeInterp.deleteAndPollCluster(DeleteClusterParams(clusterId, msg.project)).handleErrorWith {
                       e =>

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/KubernetesServiceDbQueriesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/KubernetesServiceDbQueriesSpec.scala
@@ -294,6 +294,29 @@ class KubernetesServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent 
     }
   }
 
+  it should "allow creation of a cluster if a deleted one exists in the same project" in isolatedDbTest {
+    val savedCluster1 = makeKubeCluster(1).copy(status = KubernetesClusterStatus.Deleted).save
+    val makeCluster2 = makeKubeCluster(2).copy(status = KubernetesClusterStatus.Precreating)
+
+    val saveCluster2 = Some(makeCluster2)
+      .map(c =>
+        SaveKubernetesCluster(c.googleProject,
+                              c.clusterName,
+                              c.location,
+                              c.region,
+                              c.status,
+                              c.ingressChart,
+                              c.auditInfo,
+                              DefaultNodepool.fromNodepool(c.nodepools.headOption.get))
+      )
+      .get
+
+    val saveResult = KubernetesServiceDbQueries.saveOrGetForApp(saveCluster2).transaction.unsafeRunSync()
+    // We are verifying it saved a new cluster here.
+    // We don't know the ID, but the method not returning the original DELETED cluster is sufficient
+    saveResult.minimalCluster.id should not be savedCluster1.id
+  }
+
   it should "get cluster if exists for project" in isolatedDbTest {
     val makeCluster1 = makeKubeCluster(1).copy()
     val makeCluster2 = makeCluster1.copy(clusterName = kubeName0)

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/KubernetesServiceDbQueriesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/KubernetesServiceDbQueriesSpec.scala
@@ -311,7 +311,7 @@ class KubernetesServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent 
       )
       .get
 
-    val saveResult = KubernetesServiceDbQueries.saveOrGetForApp(saveCluster2).transaction.unsafeRunSync()
+    val saveResult = KubernetesServiceDbQueries.saveOrGetClusterForApp(saveCluster2).transaction.unsafeRunSync()
     // We are verifying it saved a new cluster here.
     // We don't know the ID, but the method not returning the original DELETED cluster is sufficient
     saveResult.minimalCluster.id should not be savedCluster1.id

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriberSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriberSpec.scala
@@ -851,15 +851,14 @@ class LeoPubsubMessageSubscriberSpec
 
     val assertions = for {
       getAppOpt <- KubernetesServiceDbQueries
-        .getActiveFullAppByName(savedCluster1.googleProject, savedApp1.appName)
+        .getFullAppByName(savedCluster1.googleProject, savedApp1.id, includeDeletedClusterApps = true)
         .transaction
       getApp = getAppOpt.get
     } yield {
       getApp.app.errors.size shouldBe 1
       getApp.app.errors.map(_.action) should contain(ErrorAction.CreateGalaxyApp)
       getApp.app.errors.map(_.source) should contain(ErrorSource.Cluster)
-      //the nodepool does not exist, so we should not have updated its status
-      getApp.nodepool.status shouldBe NodepoolStatus.Unspecified
+      getApp.nodepool.status shouldBe NodepoolStatus.Deleted
     }
 
     val res = for {
@@ -892,15 +891,14 @@ class LeoPubsubMessageSubscriberSpec
 
     val assertions = for {
       getAppOpt <- KubernetesServiceDbQueries
-        .getActiveFullAppByName(savedCluster1.googleProject, savedApp1.appName)
+        .getFullAppByName(savedCluster1.googleProject, savedApp1.id, includeDeletedClusterApps = true)
         .transaction
       getApp = getAppOpt.get
     } yield {
       getApp.app.errors.size shouldBe 1
       getApp.app.errors.map(_.action) should contain(ErrorAction.CreateGalaxyApp)
       getApp.app.errors.map(_.source) should contain(ErrorSource.Cluster)
-      //the nodepool does not exist, so we should not have updated its status
-      getApp.nodepool.status shouldBe NodepoolStatus.Unspecified
+      getApp.nodepool.status shouldBe NodepoolStatus.Deleted
     }
 
     val res = for {

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriberSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriberSpec.scala
@@ -1602,7 +1602,7 @@ class LeoPubsubMessageSubscriberSpec
     val mockGKEService = new MockGKEService {
       override def createCluster(request: GKEModels.KubernetesCreateClusterRequest)(
         implicit ev: ApplicativeAsk[IO, TraceId]
-      ): IO[com.google.container.v1.Operation] = IO.raiseError(new Exception("test exception"))
+      ): IO[com.google.api.services.container.model.Operation] = IO.raiseError(new Exception("test exception"))
     }
 
     val gkeInterp =
@@ -1634,11 +1634,10 @@ class LeoPubsubMessageSubscriberSpec
       tr <- traceId.ask
       dummyNodepool = savedCluster1.nodepools.filter(_.isDefault).head
       msg = CreateAppMessage(
-        Some(CreateCluster(savedCluster1.id, dummyNodepool.id)),
+        savedCluster1.googleProject,
+        Some(ClusterNodepoolAction.CreateClusterAndNodepool(savedCluster1.id, dummyNodepool.id, savedNodepool1.id)),
         savedApp1.id,
         savedApp1.appName,
-        Some(savedNodepool1.id),
-        savedCluster1.googleProject,
         None,
         Map.empty,
         Some(tr)

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriberSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriberSpec.scala
@@ -1583,6 +1583,75 @@ class LeoPubsubMessageSubscriberSpec
     res.unsafeRunSync()
   }
 
+  it should "delete a cluster and put that app in error status on cluster error" in isolatedDbTest {
+    val savedCluster1 = makeKubeCluster(1).save()
+    val savedNodepool1 = makeNodepool(1, savedCluster1.id).save()
+
+    val disk = makePersistentDisk(None).save().unsafeRunSync()
+    val makeApp1 = makeApp(1, savedNodepool1.id)
+    val savedApp1 = makeApp1
+      .copy(appResources =
+        makeApp1.appResources.copy(
+          disk = Some(disk),
+          services = List(makeService(1), makeService(2))
+        )
+      )
+      .save()
+    val mockAckConsumer = mock[AckReplyConsumer]
+
+    val mockGKEService = new MockGKEService {
+      override def createCluster(request: GKEModels.KubernetesCreateClusterRequest)(
+        implicit ev: ApplicativeAsk[IO, TraceId]
+      ): IO[com.google.container.v1.Operation] = IO.raiseError(new Exception("test exception"))
+    }
+
+    val gkeInterp =
+      new GKEInterpreter[IO](Config.gkeInterpConfig,
+                             vpcInterp,
+                             mockGKEService,
+                             new MockKubernetesService(PodStatus.Succeeded),
+                             MockHelm,
+                             MockGalaxyDAO,
+                             credentials,
+                             iamDAO,
+                             blocker)
+
+    val assertions = for {
+      clusterOpt <- kubernetesClusterQuery.getMinimalClusterById(savedCluster1.id, true).transaction
+      getCluster = clusterOpt.get
+      getAppOpt <- KubernetesServiceDbQueries
+        .getFullAppByName(savedCluster1.googleProject, savedApp1.id, includeDeletedClusterApps = true)
+        .transaction
+      getApp = getAppOpt.get
+    } yield {
+      getCluster.status shouldBe KubernetesClusterStatus.Deleted
+      getCluster.nodepools.map(_.status).distinct shouldBe List(NodepoolStatus.Deleted)
+      getApp.app.status shouldBe AppStatus.Error
+      getApp.app.errors.size shouldBe 1
+    }
+
+    val res = for {
+      tr <- traceId.ask
+      dummyNodepool = savedCluster1.nodepools.filter(_.isDefault).head
+      msg = CreateAppMessage(
+        Some(CreateCluster(savedCluster1.id, dummyNodepool.id)),
+        savedApp1.id,
+        savedApp1.appName,
+        Some(savedNodepool1.id),
+        savedCluster1.googleProject,
+        None,
+        Map.empty,
+        Some(tr)
+      )
+      queue <- InspectableQueue.bounded[IO, Task[IO]](10)
+      leoSubscriber = makeLeoSubscriber(asyncTaskQueue = queue, gkeInterp = gkeInterp)
+      _ <- leoSubscriber.messageHandler(Event(msg, None, timestamp, mockAckConsumer))
+    } yield ()
+
+    res.unsafeRunSync()
+    assertions.unsafeRunSync()
+  }
+
   def makeLeoSubscriber(runtimeMonitor: RuntimeMonitor[IO, CloudService] = MockRuntimeMonitor,
                         asyncTaskQueue: InspectableQueue[IO, Task[IO]] =
                           InspectableQueue.bounded[IO, Task[IO]](10).unsafeRunSync,


### PR DESCRIPTION
This PR allows users to attempt to create an app again if a create app requests results in a failed cluster creation attempt.

Previously, if the cluster errored out, users would not be able to create apps without manual intervention.
