### PR TITLE
IA-2227 drop_on_update_pd_table

### DIFF
--- a/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changelog.xml
+++ b/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changelog.xml
@@ -64,4 +64,5 @@
     <include file="changesets/20200817_kubernetes_cluster_api_server.xml" relativeToChangelogFile="true" />
     <include file="changesets/20200915_add_chart_to_app_and_cluster_tables.xml" relativeToChangelogFile="true" />
     <include file="changesets/20200917_add_release_to_app_table.xml" relativeToChangelogFile="true" />
+    <include file="changesets/20200921_drop_on_update_pd_table.xml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/20200921_drop_on_update_pd_table.xml
+++ b/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/20200921_drop_on_update_pd_table.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <databaseChangeLog logicalFilePath="leonardo" xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
     <changeSet logicalFilePath="leonardo" author="qi" id="drop_on_update_pd_table">
-        <sql>ALTER TABLE PERSISTENT_DISK CHANGE createdDate createdDate TIMESTAMP NOT NULL</sql>
+        <sql>ALTER TABLE PERSISTENT_DISK CHANGE createdDate createdDate TIMESTAMP(6) DEFAULT CURRENT_TIMESTAMP(6) NOT NULL</sql>
+        <dropDefaultValue  columnDataType="TIMESTAMP(6)"
+                           columnName="createdDate"
+                           tableName="PERSISTENT_DISK"/>
     </changeSet>
 </databaseChangeLog>

--- a/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/20200921_drop_on_update_pd_table.xml
+++ b/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/20200921_drop_on_update_pd_table.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog logicalFilePath="leonardo" xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+    <changeSet logicalFilePath="leonardo" author="qi" id="drop_on_update_pd_table">
+        <sql>ALTER TABLE PERSISTENT_DISK CHANGE createdDate createdDate TIMESTAMP NOT NULL</sql>
+    </changeSet>
+</databaseChangeLog>

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -21,7 +21,7 @@ object Dependencies {
   val workbenchUtilV = "0.5-4c7acd5"
   val workbenchModelV = "0.14-2e155f0"
   val workbenchGoogleV = "0.21-64a7b29"
-  val workbenchGoogle2V = "0.13-4a533e2"
+  val workbenchGoogle2V = "0.13-39c1b35"
   val workbenchMetricsV = "0.3-c5b80d2"
   val workbenchOpenTelemetryV = "0.1-e66171c"
   val workbenchErrorReportingV = "0.1-92fcd96"


### PR DESCRIPTION
Currently `createdDate` in pd table has the following definition
```
`createdDate` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6)
```

This makes `createdDate` updated every time the record is updated, which is not what we want.

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
