### PR TITLE
[IA-2226] Add app audit info to JSON response

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/appRoutesModels.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/appRoutesModels.scala
@@ -10,6 +10,7 @@ import org.broadinstitute.dsde.workbench.leonardo.{
   AppName,
   AppStatus,
   AppType,
+  AuditInfo,
   KubernetesCluster,
   KubernetesClusterStatus,
   KubernetesRuntimeConfig,
@@ -36,7 +37,8 @@ final case class GetAppResponse(kubernetesRuntimeConfig: KubernetesRuntimeConfig
                                 status: AppStatus, //TODO: do we need some sort of aggregate status?
                                 proxyUrls: Map[ServiceName, URL],
                                 diskName: Option[DiskName],
-                                customEnvironmentVariables: Map[String, String])
+                                customEnvironmentVariables: Map[String, String],
+                                auditInfo: AuditInfo)
 
 final case class ListAppResponse(googleProject: GoogleProject,
                                  kubernetesRuntimeConfig: KubernetesRuntimeConfig,
@@ -44,7 +46,8 @@ final case class ListAppResponse(googleProject: GoogleProject,
                                  status: AppStatus, //TODO: do we need some sort of aggregate status?
                                  proxyUrls: Map[ServiceName, URL],
                                  appName: AppName,
-                                 diskName: Option[DiskName])
+                                 diskName: Option[DiskName],
+                                 auditInfo: AuditInfo)
 
 final case class GetAppResult(cluster: KubernetesCluster, nodepool: Nodepool, app: App)
 
@@ -67,7 +70,8 @@ object ListAppResponse {
           if (hasError) AppStatus.Error else a.status,
           a.getProxyUrls(c.googleProject, proxyUrlBase),
           a.appName,
-          a.appResources.disk.map(_.name)
+          a.appResources.disk.map(_.name),
+          a.auditInfo
         )
       }
     )
@@ -90,7 +94,8 @@ object GetAppResponse {
       if (hasError) AppStatus.Error else appResult.app.status,
       appResult.app.getProxyUrls(appResult.cluster.googleProject, proxyUrlBase),
       appResult.app.appResources.disk.map(_.name),
-      appResult.app.customEnvironmentVariables
+      appResult.app.customEnvironmentVariables,
+      appResult.app.auditInfo
     )
   }
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/appRoutesModels.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/appRoutesModels.scala
@@ -16,7 +16,8 @@ import org.broadinstitute.dsde.workbench.leonardo.{
   KubernetesRuntimeConfig,
   LabelMap,
   Nodepool,
-  NodepoolStatus
+  NodepoolStatus,
+  NumNodepools
 }
 import org.broadinstitute.dsde.workbench.model.UserInfo
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
@@ -26,6 +27,9 @@ final case class CreateAppRequest(kubernetesRuntimeConfig: Option[KubernetesRunt
                                   diskConfig: Option[PersistentDiskRequest],
                                   labels: LabelMap = Map.empty,
                                   customEnvironmentVariables: Map[String, String])
+
+final case class BatchNodepoolCreateRequest(numNodepools: NumNodepools,
+                                            kubernetesRuntimeConfig: Option[KubernetesRuntimeConfig])
 
 final case class DeleteAppRequest(userInfo: UserInfo,
                                   googleProject: GoogleProject,

--- a/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/AppRoutesTestJsonCodec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/AppRoutesTestJsonCodec.scala
@@ -5,9 +5,9 @@ import java.net.URL
 import io.circe.{Decoder, Encoder, KeyDecoder}
 import org.broadinstitute.dsde.workbench.google2.KubernetesSerializableName.ServiceName
 import org.broadinstitute.dsde.workbench.leonardo.JsonCodec._
+import org.broadinstitute.dsde.workbench.leonardo.NumNodepools
 
 object AppRoutesTestJsonCodec {
-
   implicit val createAppEncoder: Encoder[CreateAppRequest] = Encoder.forProduct5(
     "kubernetesRuntimeConfig",
     "appType",
@@ -23,6 +23,11 @@ object AppRoutesTestJsonCodec {
       x.customEnvironmentVariables
     )
   )
+
+  implicit val numNodepoolsEncoder: Encoder[NumNodepools] = Encoder.encodeInt.contramap(_.value)
+
+  implicit val batchNodepoolCreateEncoder: Encoder[BatchNodepoolCreateRequest] =
+    Encoder.forProduct2("numNodepools", "kubernetesRuntimeConfig")(x => BatchNodepoolCreateRequest.unapply(x).get)
 
   implicit val proxyUrlDecoder: Decoder[Map[ServiceName, URL]] =
     Decoder.decodeMap[ServiceName, URL](KeyDecoder.decodeKeyString.map(ServiceName), urlDecoder)

--- a/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/AppRoutesTestJsonCodec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/AppRoutesTestJsonCodec.scala
@@ -28,18 +28,21 @@ object AppRoutesTestJsonCodec {
     Decoder.decodeMap[ServiceName, URL](KeyDecoder.decodeKeyString.map(ServiceName), urlDecoder)
 
   implicit val getAppResponseDecoder: Decoder[GetAppResponse] =
-    Decoder.forProduct6("kubernetesRuntimeConfig",
+    Decoder.forProduct7("kubernetesRuntimeConfig",
                         "errors",
                         "status",
                         "proxyUrls",
                         "diskName",
-                        "customEnvironmentVariables")(GetAppResponse.apply)
+                        "customEnvironmentVariables",
+                        "auditInfo")(GetAppResponse.apply)
 
-  implicit val listAppResponseDecoder: Decoder[ListAppResponse] = Decoder.forProduct7("googleProject",
-                                                                                      "kubernetesRuntimeConfig",
-                                                                                      "errors",
-                                                                                      "status",
-                                                                                      "proxyUrls",
-                                                                                      "appName",
-                                                                                      "diskName")(ListAppResponse.apply)
+  implicit val listAppResponseDecoder: Decoder[ListAppResponse] =
+    Decoder.forProduct8("googleProject",
+                        "kubernetesRuntimeConfig",
+                        "errors",
+                        "status",
+                        "proxyUrls",
+                        "appName",
+                        "diskName",
+                        "auditInfo")(ListAppResponse.apply)
 }

--- a/http/src/main/resources/swagger/api-docs.yaml
+++ b/http/src/main/resources/swagger/api-docs.yaml
@@ -2428,7 +2428,7 @@ components:
         runtimeName:
           type: string
           description: The user-supplied name for the runtime
-        auditoInfo:
+        auditInfo:
           type: object
           $ref: "#/components/schemas/AuditInfo"
         googleProject:

--- a/http/src/main/resources/swagger/api-docs.yaml
+++ b/http/src/main/resources/swagger/api-docs.yaml
@@ -1394,6 +1394,13 @@ paths:
           required: true
           schema:
             type: string
+        - in: query
+          name: deleteDisk
+          description: Whether or not the disk associated with the app should be deleted. Default to false if not specified.
+          required: false
+          schema:
+            type: boolean
+            default: false
       responses:
         "202":
           description: App deletion request accepted
@@ -3171,6 +3178,10 @@ components:
 
     GetAppResponse:
       description: the configuration of an app
+      required:
+        - kubernetesRuntimeConfig
+        - status
+        - auditInfo
       type: object
       properties:
         kubernetesRuntimeConfig:
@@ -3191,9 +3202,15 @@ components:
         customEnvironmentVariables:
           type: object
           description: Optional environment variables to be set on the app
+        auditInfo:
+          $ref: "#/components/schemas/AuditInfo"
 
     ListAppResponse:
       description: the configuration of an app
+      required:
+        - kubernetesRuntimeConfig
+        - status
+        - auditInfo
       type: object
       properties:
         googleProject:
@@ -3217,6 +3234,8 @@ components:
         appName:
           type: string
           description: the name of the app
+        auditInfo:
+          $ref: "#/components/schemas/AuditInfo"
 
     KubernetesRuntimeConfig:
       description: configuration for a kubernetes app runtime

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/AppRoutes.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/AppRoutes.scala
@@ -196,16 +196,6 @@ object AppRoutes {
       } yield CreateAppRequest(c, a.getOrElse(AppType.Galaxy), d, l.getOrElse(Map.empty), cv.getOrElse(Map.empty))
     }
 
-//  implicit val nameKeyDecoder: KeyDecoder[ServiceName] = KeyDecoder.decodeKeyString.map(ServiceName.apply)
-//  implicit val getAppDecoder: Decoder[GetAppResponse] =
-//    Decoder.forProduct7("kubernetesRuntimeConfig",
-//                        "errors",
-//                        "status",
-//                        "proxyUrls",
-//                        "diskName",
-//                        "customEnvironmentVariables",
-//                        "auditInfo")(GetAppResponse.apply)
-
   implicit val numNodepoolsDecoder: Decoder[NumNodepools] = Decoder.decodeInt.emap(n =>
     n match {
       case n if n < 1   => Left("Minimum number of nodepools is 1")
@@ -214,27 +204,8 @@ object AppRoutes {
     }
   )
 
-//  implicit val numNodepoolsEncoder: Encoder[NumNodepools] = Encoder.encodeInt.contramap(_.value)
-
   implicit val batchNodepoolCreateRequestDecoder: Decoder[BatchNodepoolCreateRequest] =
     Decoder.forProduct2("numNodepools", "kubernetesRuntimeConfig")(BatchNodepoolCreateRequest.apply)
-
-//  implicit val listAppDecoder: Decoder[ListAppResponse] = Decoder.forProduct8("googleProject",
-//                                                                              "kubernetesRuntimeConfig",
-//                                                                              "errors",
-//                                                                              "status",
-//                                                                              "proxyUrls",
-//                                                                              "appName",
-//                                                                              "diskName",
-//                                                                              "auditInfo")(ListAppResponse.apply)
-
-//  implicit val createAppEncoder: Encoder[CreateAppRequest] =
-//    Encoder.forProduct5("kubernetesRuntimeConfig", "appType", "diskConfig", "labels", "customEnvironmentVariables")(x =>
-//      CreateAppRequest.unapply(x).get
-//    )
-
-//  implicit val batchNodepoolCreateEncoder: Encoder[BatchNodepoolCreateRequest] =
-//    Encoder.forProduct2("numNodepools", "kubernetesRuntimeConfig")(x => BatchNodepoolCreateRequest.unapply(x).get)
 
   implicit val nameKeyEncoder: KeyEncoder[ServiceName] = KeyEncoder.encodeKeyString.contramap(_.value)
   implicit val listAppResponseEncoder: Encoder[ListAppResponse] =

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/AppRoutes.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/AppRoutes.scala
@@ -198,13 +198,14 @@ object AppRoutes {
     }
 
   implicit val nameKeyDecoder: KeyDecoder[ServiceName] = KeyDecoder.decodeKeyString.map(ServiceName.apply)
-  implicit val getAppDecoder: Decoder[GetAppResponse] =
-    Decoder.forProduct6("kubernetesRuntimeConfig",
-                        "errors",
-                        "status",
-                        "proxyUrls",
-                        "diskName",
-                        "customEnvironmentVariables")(GetAppResponse.apply)
+//  implicit val getAppDecoder: Decoder[GetAppResponse] =
+//    Decoder.forProduct7("kubernetesRuntimeConfig",
+//                        "errors",
+//                        "status",
+//                        "proxyUrls",
+//                        "diskName",
+//                        "customEnvironmentVariables",
+//                        "auditInfo")(GetAppResponse.apply)
 
   implicit val numNodepoolsDecoder: Decoder[NumNodepools] = Decoder.decodeInt.emap(n =>
     n match {
@@ -219,13 +220,14 @@ object AppRoutes {
   implicit val batchNodepoolCreateRequestDecoder: Decoder[BatchNodepoolCreateRequest] =
     Decoder.forProduct2("numNodepools", "kubernetesRuntimeConfig")(BatchNodepoolCreateRequest.apply)
 
-  implicit val listAppDecoder: Decoder[ListAppResponse] = Decoder.forProduct7("googleProject",
-                                                                              "kubernetesRuntimeConfig",
-                                                                              "errors",
-                                                                              "status",
-                                                                              "proxyUrls",
-                                                                              "appName",
-                                                                              "diskName")(ListAppResponse.apply)
+//  implicit val listAppDecoder: Decoder[ListAppResponse] = Decoder.forProduct8("googleProject",
+//                                                                              "kubernetesRuntimeConfig",
+//                                                                              "errors",
+//                                                                              "status",
+//                                                                              "proxyUrls",
+//                                                                              "appName",
+//                                                                              "diskName",
+//                                                                              "auditInfo")(ListAppResponse.apply)
 
   implicit val createAppEncoder: Encoder[CreateAppRequest] =
     Encoder.forProduct5("kubernetesRuntimeConfig", "appType", "diskConfig", "labels", "customEnvironmentVariables")(x =>
@@ -237,19 +239,21 @@ object AppRoutes {
 
   implicit val nameKeyEncoder: KeyEncoder[ServiceName] = KeyEncoder.encodeKeyString.contramap(_.value)
   implicit val listAppResponseEncoder: Encoder[ListAppResponse] =
-    Encoder.forProduct7("googleProject",
+    Encoder.forProduct8("googleProject",
                         "kubernetesRuntimeConfig",
                         "errors",
                         "status",
                         "proxyUrls",
                         "appName",
-                        "diskName")(x => ListAppResponse.unapply(x).get)
+                        "diskName",
+                        "auditInfo")(x => ListAppResponse.unapply(x).get)
 
   implicit val getAppResponseEncoder: Encoder[GetAppResponse] =
-    Encoder.forProduct6("kubernetesRuntimeConfig",
+    Encoder.forProduct7("kubernetesRuntimeConfig",
                         "errors",
                         "status",
                         "proxyUrls",
                         "diskName",
-                        "customEnvironmentVariables")(x => GetAppResponse.unapply(x).get)
+                        "customEnvironmentVariables",
+                        "auditInfo")(x => GetAppResponse.unapply(x).get)
 }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/AppRoutes.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/AppRoutes.scala
@@ -13,8 +13,7 @@ import org.broadinstitute.dsde.workbench.leonardo.api.CookieSupport
 import org.broadinstitute.dsde.workbench.model.UserInfo
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import akka.http.scaladsl.server.Directives._
-import io.circe.{Decoder, Encoder, KeyDecoder, KeyEncoder}
-import org.broadinstitute.dsde.workbench.leonardo.http.service.{BatchNodepoolCreateRequest}
+import io.circe.{Decoder, Encoder, KeyEncoder}
 import org.broadinstitute.dsde.workbench.leonardo.http.api.AppRoutes._
 import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
 import org.broadinstitute.dsde.workbench.google2.KubernetesSerializableName.ServiceName
@@ -197,7 +196,7 @@ object AppRoutes {
       } yield CreateAppRequest(c, a.getOrElse(AppType.Galaxy), d, l.getOrElse(Map.empty), cv.getOrElse(Map.empty))
     }
 
-  implicit val nameKeyDecoder: KeyDecoder[ServiceName] = KeyDecoder.decodeKeyString.map(ServiceName.apply)
+//  implicit val nameKeyDecoder: KeyDecoder[ServiceName] = KeyDecoder.decodeKeyString.map(ServiceName.apply)
 //  implicit val getAppDecoder: Decoder[GetAppResponse] =
 //    Decoder.forProduct7("kubernetesRuntimeConfig",
 //                        "errors",
@@ -215,7 +214,7 @@ object AppRoutes {
     }
   )
 
-  implicit val numNodepoolsEncoder: Encoder[NumNodepools] = Encoder.encodeInt.contramap(_.value)
+//  implicit val numNodepoolsEncoder: Encoder[NumNodepools] = Encoder.encodeInt.contramap(_.value)
 
   implicit val batchNodepoolCreateRequestDecoder: Decoder[BatchNodepoolCreateRequest] =
     Decoder.forProduct2("numNodepools", "kubernetesRuntimeConfig")(BatchNodepoolCreateRequest.apply)
@@ -229,13 +228,13 @@ object AppRoutes {
 //                                                                              "diskName",
 //                                                                              "auditInfo")(ListAppResponse.apply)
 
-  implicit val createAppEncoder: Encoder[CreateAppRequest] =
-    Encoder.forProduct5("kubernetesRuntimeConfig", "appType", "diskConfig", "labels", "customEnvironmentVariables")(x =>
-      CreateAppRequest.unapply(x).get
-    )
+//  implicit val createAppEncoder: Encoder[CreateAppRequest] =
+//    Encoder.forProduct5("kubernetesRuntimeConfig", "appType", "diskConfig", "labels", "customEnvironmentVariables")(x =>
+//      CreateAppRequest.unapply(x).get
+//    )
 
-  implicit val batchNodepoolCreateEncoder: Encoder[BatchNodepoolCreateRequest] =
-    Encoder.forProduct2("numNodepools", "kubernetesRuntimeConfig")(x => BatchNodepoolCreateRequest.unapply(x).get)
+//  implicit val batchNodepoolCreateEncoder: Encoder[BatchNodepoolCreateRequest] =
+//    Encoder.forProduct2("numNodepools", "kubernetesRuntimeConfig")(x => BatchNodepoolCreateRequest.unapply(x).get)
 
   implicit val nameKeyEncoder: KeyEncoder[ServiceName] = KeyEncoder.encodeKeyString.contramap(_.value)
   implicit val listAppResponseEncoder: Encoder[ListAppResponse] =

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/KubernetesService.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/KubernetesService.scala
@@ -2,8 +2,8 @@ package org.broadinstitute.dsde.workbench.leonardo.service
 
 import cats.mtl.ApplicativeAsk
 import org.broadinstitute.dsde.workbench.leonardo.{AppContext, AppName}
-import org.broadinstitute.dsde.workbench.leonardo.http.service.BatchNodepoolCreateRequest
 import org.broadinstitute.dsde.workbench.leonardo.http.{
+  BatchNodepoolCreateRequest,
   CreateAppRequest,
   DeleteAppRequest,
   GetAppResponse,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/leonardoServiceContractModel.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/leonardoServiceContractModel.scala
@@ -231,6 +231,3 @@ object GetRuntimeResponse {
     diskConfig
   )
 }
-
-final case class BatchNodepoolCreateRequest(numNodepools: NumNodepools,
-                                            kubernetesRuntimeConfig: Option[KubernetesRuntimeConfig])

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/KubernetesTestData.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/KubernetesTestData.scala
@@ -5,8 +5,13 @@ import org.broadinstitute.dsde.workbench.google2.KubernetesModels.Protocol
 import org.broadinstitute.dsde.workbench.google2.KubernetesSerializableName.{NamespaceName, ServiceName}
 import org.broadinstitute.dsde.workbench.google2.{Location, MachineTypeName, RegionName}
 import org.broadinstitute.dsde.workbench.leonardo.CommonTestData._
-import org.broadinstitute.dsde.workbench.leonardo.http.service.BatchNodepoolCreateRequest
-import org.broadinstitute.dsde.workbench.leonardo.http.{CreateAppRequest, GetAppResponse, GetAppResult, ListAppResponse}
+import org.broadinstitute.dsde.workbench.leonardo.http.{
+  BatchNodepoolCreateRequest,
+  CreateAppRequest,
+  GetAppResponse,
+  GetAppResult,
+  ListAppResponse
+}
 import org.broadinstitute.dsde.workbench.model.IP
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.broadinstitute.dsp.{ChartName, ChartVersion, Release}

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/HttpRoutesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/HttpRoutesSpec.scala
@@ -20,7 +20,6 @@ import org.broadinstitute.dsde.workbench.leonardo.KubernetesTestData._
 import org.broadinstitute.dsde.workbench.google2.MachineTypeName
 import org.broadinstitute.dsde.workbench.leonardo.CommonTestData.{contentSecurityPolicy, swaggerConfig}
 import org.broadinstitute.dsde.workbench.leonardo.JsonCodec._
-import org.broadinstitute.dsde.workbench.leonardo.http.api.AppRoutes._
 import org.broadinstitute.dsde.workbench.leonardo.ContainerRegistry.DockerHub
 import org.broadinstitute.dsde.workbench.leonardo.db.TestComponent
 import org.broadinstitute.dsde.workbench.leonardo.http.service.{

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/HttpRoutesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/HttpRoutesSpec.scala
@@ -12,6 +12,7 @@ import cats.mtl.ApplicativeAsk
 import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
 import io.circe.syntax._
 import io.circe.{Decoder, Encoder}
+import org.broadinstitute.dsde.workbench.leonardo.http.AppRoutesTestJsonCodec._
 import org.broadinstitute.dsde.workbench.leonardo.http.DiskRoutesTestJsonCodec._
 import org.broadinstitute.dsde.workbench.leonardo.http.RuntimeRoutesTestJsonCodec._
 import org.broadinstitute.dsde.workbench.leonardo.http.api.HttpRoutesSpec._

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/MockKubernetesServiceInterp.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/MockKubernetesServiceInterp.scala
@@ -4,8 +4,8 @@ package service
 import cats.effect.IO
 import cats.mtl.ApplicativeAsk
 import KubernetesTestData._
-import org.broadinstitute.dsde.workbench.leonardo.http.service.BatchNodepoolCreateRequest
 import org.broadinstitute.dsde.workbench.leonardo.http.{
+  BatchNodepoolCreateRequest,
   CreateAppRequest,
   DeleteAppRequest,
   GetAppResponse,


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-2226

* Adds app `auditInfo` to `GetAppResponse` and `ListAppResponse` and updates Swagger
* Update swagger to include `?deleteDisk=[true|false]` in `deleteApp` docs
* Moved some codecs that are only needed for tests out of `AppRoutes.scala` and into `AppRoutesTestJsonCodec.scala`

Testing on a fiab..

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
