### PR TITLE
IA-2236 add ability to unset a Leo token cookie

### DIFF
--- a/http/src/main/resources/swagger/api-docs.yaml
+++ b/http/src/main/resources/swagger/api-docs.yaml
@@ -1586,11 +1586,12 @@ paths:
         Jupyter notebook
       description: >
         If using Google token-based authorization to a Jupyter notebook, the Leo
-        proxy accepts a
-
-        Google token passed as a cookie value. This endpoint facilitates setting that cookie.
+        proxy accepts a Google token passed as a cookie value. This endpoint facilitates setting that cookie.
 
         It accepts a bearer token in an Authorization header and responds with a Set-Cookie header.
+
+        If no bearer token is present, it unsets the cookie by returning a Set-Cookie header with a null
+        value and expiration date in the past.
       operationId: setCookieApi
       tags:
         - notebooks
@@ -1632,17 +1633,16 @@ paths:
       deprecated: true
       summary: (Deprecated) Invalidates a token
       description: >
-        If using Google token-based auth, call this endpoint when a user's
-        Google token is invalidated
+        If using Google token-based auth, clients can call this endpoint when a user's
+        Google token should be invalidated (e.g. when logging out of the application).
 
-        (e.g. when logging out of the application). This ensures that the token is also invalidated in Leo
-
-        and that the user's proxied notebook connections stop working.
+        This endpoint will unset the Leo token cookie and invalidate caches to ensure
+        the user's proxied notebook connections stop working.
       operationId: invalidateTokenApi
       tags:
         - notebooks
       responses:
-        "200":
+        "204":
           description: Successfully invalidated a token
         "500":
           description: Internal Error
@@ -1895,6 +1895,9 @@ paths:
         accepts a Google token passed as a cookie value. This endpoint facilitates setting that cookie.
 
         It accepts a bearer token in an Authorization header and responds with a Set-Cookie header.
+
+        If no bearer token is present, it unsets the cookie by returning a Set-Cookie header with a null
+        value and expiration date in the past.
       operationId: setCookie
       tags:
         - proxy
@@ -1917,15 +1920,16 @@ paths:
     get:
       summary: Invalidates a token
       description: >
-        If using Google token-based auth, call this endpoint when a user's
-        Google token is invalidated (e.g. when logging out of the application).
-        This ensures that the token is also invalidated in Leo and that the user's
-        proxied connections stop working.
+        If using Google token-based auth, clients can call this endpoint when a user's
+        Google token should be invalidated (e.g. when logging out of the application).
+
+        This endpoint will unset the Leo token cookie and invalidate caches to ensure
+        the user's proxied connections stop working.
       operationId: invalidateToken
       tags:
         - proxy
       responses:
-        "200":
+        "204":
           description: Successfully invalidated a token
         "500":
           description: Internal Error
@@ -1942,6 +1946,9 @@ paths:
         accepts a Google token passed as a cookie value. This endpoint facilitates setting that cookie.
 
         It accepts a bearer token in an Authorization header and responds with a Set-Cookie header.
+
+        If no bearer token is present, it unsets the cookie by returning a Set-Cookie header with a null
+        value and expiration date in the past.
       operationId: setCookieDeprecated
       tags:
         - proxy

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/CookieSupport.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/CookieSupport.scala
@@ -8,19 +8,25 @@ import org.broadinstitute.dsde.workbench.model.UserInfo
 object CookieSupport {
   val tokenCookieName = "LeoToken"
 
+  // TODO: in the below 2 methods we set a cookie by building a RawHeader because the cookie
+  // SameSite attribute is not natively supported in akka-http. Support is tentatively
+  // slated for version 10.2.0, after which we can switch back to using HttpCookie.
+  // See https://github.com/akka/akka-http/issues/1354
+
   /**
    * Sets a token cookie in the HTTP response.
    */
   def setTokenCookie(userInfo: UserInfo, cookieName: String): Directive0 =
-    // TODO: we set a cookie by building a RawHeader because the cookie SameSite
-    // attribute is not natively supported in akka-http. Support is tentatively
-    // slated for version 10.2.0, after which we can switch back to using HttpCookie.
-    // See https://github.com/akka/akka-http/issues/1354
-
     //setCookie(buildCookie(userInfo, cookieName))
     respondWithHeaders(buildRawCookie(userInfo, cookieName))
 
-  def buildCookie(userInfo: UserInfo, cookieName: String): HttpCookie =
+  /**
+   * Unsets a token cookie in the HTTP response.
+   */
+  def unsetTokenCookie(cookieName: String): Directive0 =
+    respondWithHeaders(buildRawUnsetCookie(cookieName))
+
+  private def buildCookie(userInfo: UserInfo, cookieName: String): HttpCookie =
     HttpCookie(
       name = cookieName,
       value = userInfo.accessToken.token,
@@ -30,11 +36,17 @@ object CookieSupport {
       path = Some("/") // needed so it works for AJAX requests
     )
 
-  def buildRawCookie(userInfo: UserInfo, cookieName: String): RawHeader =
+  private def buildRawCookie(userInfo: UserInfo, cookieName: String): RawHeader =
     RawHeader(
       name = "Set-Cookie",
       value =
         s"$tokenCookieName=${userInfo.accessToken.token}; Max-Age=${userInfo.tokenExpiresIn.toString}; Path=/; Secure; SameSite=None"
+    )
+
+  private def buildRawUnsetCookie(cookieName: String): RawHeader =
+    RawHeader(
+      name = "Set-Cookie",
+      value = s"$tokenCookieName=unset; expires=Thu, 01 Jan 1970 00:00:00 GMT; Path=/; Secure; SameSite=None"
     )
 
 }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/ProxyRoutes.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/ProxyRoutes.scala
@@ -48,29 +48,34 @@ class ProxyRoutes(proxyService: ProxyService, corsSupport: CorsSupport)(
         } ~
           // "runtimes" proxy routes
           pathPrefix(googleProjectSegment / runtimeNameSegment) { (googleProject, runtimeName) =>
-            // Note this endpoint exists at the top-level /proxy/setCookie as well
+            // Note the setCookie route exists at the top-level /proxy/setCookie as well
             path("setCookie") {
-              extractUserInfo { userInfo =>
+              extractUserInfoOpt { userInfoOpt =>
                 get {
-                  CookieSupport.setTokenCookie(userInfo, CookieSupport.tokenCookieName) {
+                  val cookieDirective = userInfoOpt match {
+                    case Some(userInfo) => CookieSupport.setTokenCookie(userInfo, CookieSupport.tokenCookieName)
+                    case None           => CookieSupport.unsetTokenCookie(CookieSupport.tokenCookieName)
+                  }
+                  cookieDirective {
                     complete {
-                      IO(logger.debug(s"Successfully set cookie for user $userInfo"))
+                      IO(logger.debug(s"Successfully set cookie for user $userInfoOpt"))
                         .as(StatusCodes.NoContent)
                     }
                   }
                 }
               }
-            } ~ pathPrefix("jupyter" / "terminals") {
-              pathSuffix(terminalNameSegment) { terminalName =>
-                (extractRequest & extractUserInfo) { (request, userInfo) =>
-                  logRequestResultForMetrics(userInfo) {
-                    complete {
-                      openTerminalHandler(userInfo, googleProject, runtimeName, terminalName, request)
+            } ~
+              pathPrefix("jupyter" / "terminals") {
+                pathSuffix(terminalNameSegment) { terminalName =>
+                  (extractRequest & extractUserInfo) { (request, userInfo) =>
+                    logRequestResultForMetrics(userInfo) {
+                      complete {
+                        openTerminalHandler(userInfo, googleProject, runtimeName, terminalName, request)
+                      }
                     }
                   }
                 }
-              }
-            } ~
+              } ~
               (extractRequest & extractUserInfo) { (request, userInfo) =>
                 logRequestResultForMetrics(userInfo) {
                   // Proxy logic handled by the ProxyService class
@@ -84,22 +89,27 @@ class ProxyRoutes(proxyService: ProxyService, corsSupport: CorsSupport)(
           // Top-level routes
           path("invalidateToken") {
             get {
-              extractToken { token =>
-                complete {
-                  proxyService.invalidateAccessToken(token).map { _ =>
-                    IO(logger.debug(s"Invalidated access token $token"))
-                      .as(StatusCodes.OK)
+              extractUserInfoOpt { userInfoOpt =>
+                CookieSupport.unsetTokenCookie(CookieSupport.tokenCookieName) {
+                  complete {
+                    userInfoOpt.traverse(userInfo => proxyService.invalidateAccessToken(userInfo.accessToken.token)) >>
+                      IO(logger.debug(s"Invalidated access token"))
+                        .as(StatusCodes.OK)
                   }
                 }
               }
             }
           } ~
           path("setCookie") {
-            extractUserInfo { userInfo =>
+            extractUserInfoOpt { userInfoOpt =>
               get {
-                CookieSupport.setTokenCookie(userInfo, CookieSupport.tokenCookieName) {
+                val cookieDirective = userInfoOpt match {
+                  case Some(userInfo) => CookieSupport.setTokenCookie(userInfo, CookieSupport.tokenCookieName)
+                  case None           => CookieSupport.unsetTokenCookie(CookieSupport.tokenCookieName)
+                }
+                cookieDirective {
                   complete {
-                    IO(logger.debug(s"Successfully set cookie for user $userInfo"))
+                    IO(logger.debug(s"Successfully set cookie for user $userInfoOpt"))
                       .as(StatusCodes.NoContent)
                   }
                 }
@@ -112,30 +122,43 @@ class ProxyRoutes(proxyService: ProxyService, corsSupport: CorsSupport)(
   /**
    * Extracts the user token from either a cookie or Authorization header.
    */
-  private def extractToken: Directive1[String] =
+  private def extractTokenOpt: Directive1[Option[String]] =
     optionalHeaderValueByType[`Authorization`](()) flatMap {
 
       // We have an Authorization header, extract the token
       // Note the Authorization header overrides the cookie
-      case Some(header) => provide(header.credentials.token)
+      case Some(header) => provide(Some(header.credentials.token))
 
       // We don't have an Authorization header; check the cookie
       case None =>
         optionalCookie(CookieSupport.tokenCookieName) flatMap {
 
           // We have a cookie, extract the token
-          case Some(cookie) => provide(cookie.value)
+          case Some(cookie) => provide(Some(cookie.value))
 
-          // Not found in cookie or Authorization header, fail
-          case None => failWith(AuthenticationError())
+          // Not found in cookie or Authorization header
+          case None => provide(None)
         }
     }
 
   /**
    * Extracts the user token from the request, and looks up the cached UserInfo.
+   * Fails with AuthenticationError if a token cannot be retrieved.
    */
   private def extractUserInfo: Directive1[UserInfo] =
-    extractToken.flatMap(token => onSuccess(proxyService.getCachedUserInfoFromToken(token).unsafeToFuture()))
+    extractTokenOpt.flatMap {
+      case Some(token) => onSuccess(proxyService.getCachedUserInfoFromToken(token).unsafeToFuture())
+      case None        => failWith(AuthenticationError())
+    }
+
+  /**
+   * Like extractUserInfo, but returns None if a token cannot be retrieved.
+   */
+  private def extractUserInfoOpt: Directive1[Option[UserInfo]] =
+    extractTokenOpt.flatMap {
+      case Some(token) => onSuccess(proxyService.getCachedUserInfoFromToken(token).unsafeToFuture()).map(_.some)
+      case None        => provide(None)
+    }
 
   // basis for logRequestResult lifted from http://stackoverflow.com/questions/32475471/how-does-one-log-akka-http-client-requests
   private def logRequestResultForMetrics(userInfo: UserInfo): Directive0 = {

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/ProxyRoutes.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/ProxyRoutes.scala
@@ -94,7 +94,7 @@ class ProxyRoutes(proxyService: ProxyService, corsSupport: CorsSupport)(
                   complete {
                     userInfoOpt.traverse(userInfo => proxyService.invalidateAccessToken(userInfo.accessToken.token)) >>
                       IO(logger.debug(s"Invalidated access token"))
-                        .as(StatusCodes.OK)
+                        .as(StatusCodes.NoContent)
                   }
                 }
               }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/package.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/package.scala
@@ -2,6 +2,8 @@ package org.broadinstitute.dsde.workbench.leonardo
 package http
 
 import akka.http.scaladsl.marshalling.Marshaller
+import akka.http.scaladsl.server.Directive1
+import akka.http.scaladsl.server.Directives.provide
 import akka.http.scaladsl.server.directives.OnSuccessMagnet
 import akka.http.scaladsl.server.util.Tupler
 import cats.effect.IO
@@ -34,6 +36,15 @@ package object api {
   val appNameSegment = Segment.map(AppName)
   val serviceNameSegment = Segment.map(ServiceName)
   val terminalNameSegment = Segment.map(TerminalName)
+
+  // Adds `orElse` to Directive1[Option[A]]
+  implicit private[api] class Directive1Support[A](d1: Directive1[Option[A]]) {
+    def orElse(d2: => Directive1[Option[A]]): Directive1[Option[A]] =
+      d1.flatMap {
+        case Some(a) => provide(Some(a))
+        case None    => d2
+      }
+  }
 }
 
 object ImplicitConversions {

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/ProxyRoutesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/ProxyRoutesSpec.scala
@@ -246,7 +246,7 @@ class ProxyRoutesSpec
     result.futureValue shouldBe "Hello Leonardo!"
   }
 
-  it should "create terminal trying to access a terminal not created yet" in {
+  it should "create a new terminal when trying to access a terminal that was not created yet" in {
     val jupyterDAO = mock[JupyterDAO[IO]]
     when {
       jupyterDAO.terminalExists(GoogleProject(googleProject), RuntimeName(clusterName), TerminalName("1"))

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/TestLeoRoutes.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/TestLeoRoutes.scala
@@ -235,4 +235,11 @@ trait TestLeoRoutes {
 
     replaced shouldBe s"${expectedCookie.name}=${expectedCookie.value}; Max-Age=${age.toString}; Path=/; Secure; SameSite=None"
   }
+
+  protected def validateUnsetRawCookie(setCookie: Option[HttpHeader],
+                                       expectedCookie: HttpCookiePair = tokenCookie): Unit = {
+    setCookie shouldBe 'defined
+    setCookie.get.name shouldBe "Set-Cookie"
+    setCookie.get.value shouldBe s"${tokenName}=unset; expires=Thu, 01 Jan 1970 00:00:00 GMT; Path=/; Secure; SameSite=None"
+  }
 }


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-2236

Changes the following 2 routes:
* `invalidateToken` will now unset the LeoToken cookie (in addition to invalidating caches as it did before)
* `setCookie` will now unset the LeoToken cookie if no auth information is passed to the request. Previously it would fail with a 401.

Either of the above routes can be called upon UI signout to prevent access to proxied apps running in different tabs.

cc @breilly2 @panentheos 

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
