### PR TITLE
[IA-2171] Galaxy disk attachment

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/AppCreationSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/AppCreationSpec.scala
@@ -42,7 +42,7 @@ class AppCreationSpec extends GPAllocFixtureSpec with LeonardoTestUtils with GPA
         diskConfig = Some(
           PersistentDiskRequest(
             randomDiskName,
-            Some(DiskSize(30)),
+            Some(DiskSize(500)),
             None,
             Map.empty
           )

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -261,6 +261,14 @@ gke {
       }
     ]
   }
+  galaxyDisk {
+    nfsPersistenceName = "nfs-disk"
+    postgresPersistenceName = "postgres-disk"
+    # TODO: remove post-alpha once persistence is in place for Galaxy
+    postgresDiskNameSuffix = "gxy-postres-disk"
+    postgresDiskSizeGB = 10
+    postgresDiskBlockSize = 4096
+  }
 }
 
 image {
@@ -540,6 +548,7 @@ persistentDisk {
   defaultDiskType = "pd-standard"
   defaultBlockSizeBytes = 4096
   zone = "us-central1-a"
+  defaultGalaxyNFSDiskSizeGB = 500
 }
 
 clusterToolMonitor {

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
@@ -290,7 +290,8 @@ object Config {
       config.as[DiskSize]("defaultDiskSizeGB"),
       config.as[DiskType]("defaultDiskType"),
       config.as[BlockSize]("defaultBlockSizeBytes"),
-      config.as[ZoneName]("zone")
+      config.as[ZoneName]("zone"),
+      config.as[DiskSize]("defaultGalaxyNFSDiskSizeGB")
     )
   }
 
@@ -596,6 +597,16 @@ object Config {
     )
   }
 
+  implicit private val appDiskConfigReader: ValueReader[GalaxyDiskConfig] = ValueReader.relative { config =>
+    GalaxyDiskConfig(
+      config.as[String]("nfsPersistenceName"),
+      config.as[String]("postgresPersistenceName"),
+      config.as[String]("postgresDiskNameSuffix"),
+      config.as[DiskSize]("postgresDiskSizeGB"),
+      config.as[BlockSize]("postgresDiskBlockSize")
+    )
+  }
+
   implicit private val releaseNameReader: ValueReader[Release] = stringValueReader.map(Release)
   implicit private val namespaceNameReader: ValueReader[NamespaceName] = stringValueReader.map(NamespaceName)
   implicit private val chartNameReader: ValueReader[ChartName] = stringValueReader.map(ChartName)
@@ -629,6 +640,7 @@ object Config {
   val gkeIngressConfig = config.as[KubernetesIngressConfig]("gke.ingress")
   val gkeGalaxyAppConfig = config.as[GalaxyAppConfig]("gke.galaxyApp")
   val gkeNodepoolConfig = NodepoolConfig(gkeDefaultNodepoolConfig, gkeGalaxyNodepoolConfig)
+  val gkeGalaxyDiskConfig = config.as[GalaxyDiskConfig]("gke.galaxyDisk")
   val leoKubernetesConfig = LeoKubernetesConfig(kubeServiceAccountProviderConfig,
                                                 gkeClusterConfig,
                                                 gkeNodepoolConfig,
@@ -699,5 +711,6 @@ object Config {
                          gkeGalaxyAppConfig,
                          gkeMonitorConfig,
                          gkeClusterConfig,
-                         proxyConfig)
+                         proxyConfig,
+                         gkeGalaxyDiskConfig)
 }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/GalaxyDiskConfig.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/GalaxyDiskConfig.scala
@@ -1,0 +1,10 @@
+package org.broadinstitute.dsde.workbench.leonardo.config
+
+import org.broadinstitute.dsde.workbench.leonardo.{BlockSize, DiskSize}
+
+final case class GalaxyDiskConfig(nfsPersistenceName: String,
+                                  postgresPersistenceName: String,
+                                  // TODO: remove post-alpha once persistence is in place
+                                  postgresDiskNameSuffix: String,
+                                  postgresDiskSizeGB: DiskSize,
+                                  postgresDiskBlockSize: BlockSize) {}

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/PersistentDiskConfig.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/PersistentDiskConfig.scala
@@ -7,5 +7,6 @@ final case class PersistentDiskConfig(
   defaultDiskSizeGB: DiskSize,
   defaultDiskType: DiskType,
   defaultBlockSizeBytes: BlockSize,
-  zone: ZoneName
+  zone: ZoneName,
+  defaultGalaxyNFSDiskSizeGB: DiskSize
 )

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/leoPubsubMessageSubscriberModels.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/leoPubsubMessageSubscriberModels.scala
@@ -801,13 +801,6 @@ object PubsubHandleMessageError {
       s"${diskId}, ${projectName} | Unable to process disk because not in correct state. Disk details: ${disk}"
     val isRetryable: Boolean = false
   }
-
-  final case class PostgresDiskError(project: GoogleProject, appName: AppName, diskName: DiskName, errorMessage: String)
-      extends PubsubHandleMessageError {
-    override def getMessage: String =
-      s"An error occurred with Postres Disk ${diskName.value} in app ${appName.value}. Project: ${project.value} \nOriginal message: ${errorMessage}"
-    val isRetryable: Boolean = false
-  }
 }
 
 final case class PersistentDiskMonitor(maxAttempts: Int, interval: FiniteDuration)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/KubernetesServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/KubernetesServiceInterp.scala
@@ -164,6 +164,7 @@ final class LeoKubernetesServiceInterp[F[_]: Parallel](
         app.appName,
         diskResultOpt.flatMap(d => if (d.creationNeeded) Some(d.disk.id) else None),
         req.customEnvironmentVariables,
+        req.appType,
         Some(ctx.traceId)
       )
       _ <- publisherQueue.enqueue1(createAppMessage)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/RuntimeServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/RuntimeServiceInterp.scala
@@ -901,14 +901,17 @@ object RuntimeServiceInterp {
             _ <- if (hasPermission) F.unit else F.raiseError[Unit](AuthorizationError(userInfo.userEmail))
             samResource <- F.delay(PersistentDiskSamResourceId(UUID.randomUUID().toString))
             diskBeforeSave <- F.fromEither(
-              DiskServiceInterp.convertToDisk(userInfo,
-                                              serviceAccount,
-                                              googleProject,
-                                              req.name,
-                                              samResource,
-                                              diskConfig,
-                                              CreateDiskRequest.fromDiskConfigRequest(req),
-                                              ctx.now)
+              DiskServiceInterp.convertToDisk(
+                userInfo,
+                serviceAccount,
+                googleProject,
+                req.name,
+                samResource,
+                diskConfig,
+                CreateDiskRequest.fromDiskConfigRequest(req),
+                ctx.now,
+                if (willBeUsedBy == FormattedBy.Galaxy) true else false
+              )
             )
             _ <- authProvider
               .notifyResourceCreated(samResource, userInfo.userEmail, googleProject)

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/config/ConfigSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/config/ConfigSpec.scala
@@ -21,7 +21,8 @@ final class ConfigSpec extends AnyFlatSpec with Matchers {
       DiskSize(30),
       DiskType.Standard,
       BlockSize(4096),
-      ZoneName("us-central1-a")
+      ZoneName("us-central1-a"),
+      DiskSize(300)
     )
 
     Config.persistentDiskConfig shouldBe expectedResult
@@ -110,5 +111,11 @@ final class ConfigSpec extends AnyFlatSpec with Matchers {
       true
     )
     Config.gkeGalaxyAppConfig shouldBe expectedResult
+  }
+
+  it should "read GalaxyDiskConfig properly" in {
+    val expectedResult =
+      GalaxyDiskConfig("nfs-persistence", "postgres-persistence", "gxy-postres-disk", DiskSize(10), BlockSize(4096))
+    Config.gkeGalaxyDiskConfig shouldBe expectedResult
   }
 }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/config/ConfigSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/config/ConfigSpec.scala
@@ -22,7 +22,7 @@ final class ConfigSpec extends AnyFlatSpec with Matchers {
       DiskType.Standard,
       BlockSize(4096),
       ZoneName("us-central1-a"),
-      DiskSize(300)
+      DiskSize(500)
     )
 
     Config.persistentDiskConfig shouldBe expectedResult
@@ -115,7 +115,7 @@ final class ConfigSpec extends AnyFlatSpec with Matchers {
 
   it should "read GalaxyDiskConfig properly" in {
     val expectedResult =
-      GalaxyDiskConfig("nfs-persistence", "postgres-persistence", "gxy-postres-disk", DiskSize(10), BlockSize(4096))
+      GalaxyDiskConfig("nfs-disk", "postgres-disk", "gxy-postres-disk", DiskSize(10), BlockSize(4096))
     Config.gkeGalaxyDiskConfig shouldBe expectedResult
   }
 }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubCodecSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubCodecSpec.scala
@@ -23,6 +23,7 @@ import _root_.io.circe.syntax._
 import _root_.io.circe.parser.decode
 import LeoPubsubCodec._
 import io.circe.Printer
+import org.broadinstitute.dsde.workbench.leonardo.AppType.Galaxy
 import org.scalatest.flatspec.AnyFlatSpec
 
 class LeoPubsubCodecSpec extends AnyFlatSpec with Matchers {
@@ -107,6 +108,7 @@ class LeoPubsubCodecSpec extends AnyFlatSpec with Matchers {
       AppName("app1"),
       Some(DiskId(1)),
       Map.empty,
+      Galaxy, // TODO: should this be an Option?
       Some(traceId)
     )
 

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriberSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriberSpec.scala
@@ -681,12 +681,14 @@ class LeoPubsubMessageSubscriberSpec
     val savedCluster1 = makeKubeCluster(1).save()
     val savedNodepool1 = makeNodepool(1, savedCluster1.id).save()
     val savedNodepool2 = makeNodepool(2, savedCluster1.id).save()
+    val disk1 = makePersistentDisk(Some(DiskName("disk1"))).save().unsafeRunSync()
+    val disk2 = makePersistentDisk(Some(DiskName("disk2"))).save().unsafeRunSync()
 
     val makeApp1 = makeApp(1, savedNodepool1.id)
     val savedApp1 = makeApp1
       .copy(appResources =
         makeApp1.appResources.copy(
-          disk = None,
+          disk = Some(disk1),
           services = List(makeService(1), makeService(2))
         )
       )
@@ -695,7 +697,7 @@ class LeoPubsubMessageSubscriberSpec
     val savedApp2 = makeApp2
       .copy(appResources =
         makeApp2.appResources.copy(
-          disk = None,
+          disk = Some(disk2),
           services = List(makeService(1), makeService(2))
         )
       )
@@ -742,7 +744,7 @@ class LeoPubsubMessageSubscriberSpec
         Some(ClusterNodepoolAction.CreateClusterAndNodepool(savedCluster1.id, dummyNodepool.id, savedNodepool1.id)),
         savedApp1.id,
         savedApp1.appName,
-        Some(DiskId(1)),
+        Some(disk1.id),
         Map.empty,
         AppType.Galaxy,
         Some(tr)
@@ -752,7 +754,7 @@ class LeoPubsubMessageSubscriberSpec
         Some(ClusterNodepoolAction.CreateNodepool(savedNodepool2.id)),
         savedApp2.id,
         savedApp2.appName,
-        Some(DiskId(2)),
+        Some(disk2.id),
         Map.empty,
         AppType.Galaxy,
         Some(tr)


### PR DESCRIPTION
Tested by creating an app using the `createApp` endpoint and verifying that the correct PV/PVC (both for the NFS disk and the postgres disk) pairs get created and that Galaxy successfully transitions to `RUNNING` 

We're defaulting the NFS disk to 500Gb because currently, Galaxy requests 300Gb in storage from the NFS provisioner and CVMFS cache requests 10Gb so the size of the NFS disk needs to be at least 310Gb. 500Gb was a suggestion from the Galaxy team -  if we want to lower this then we can but we just need to also lower the amount of storage Galaxy requests. 

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
