### PR TITLE
[QA-1273] Rename KubernetesSpec and add context to log msgs

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoApiClient.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoApiClient.scala
@@ -3,39 +3,26 @@ package org.broadinstitute.dsde.workbench.leonardo
 import java.util.UUID
 import java.util.concurrent.TimeoutException
 
-import cats.implicits._
 import cats.effect.{IO, Resource, Timer}
+import cats.implicits._
 import org.broadinstitute.dsde.workbench.DoneCheckable
+import org.broadinstitute.dsde.workbench.DoneCheckableSyntax._
 import org.broadinstitute.dsde.workbench.google2.{streamFUntilDone, DiskName}
-import org.broadinstitute.dsde.workbench.leonardo.http.{
-  BatchNodepoolCreateRequest,
-  CreateAppRequest,
-  CreateDiskRequest,
-  CreateRuntime2Request,
-  GetAppResponse,
-  GetPersistentDiskResponse,
-  ListAppResponse,
-  ListPersistentDiskResponse,
-  UpdateRuntimeRequest
-}
+import org.broadinstitute.dsde.workbench.leonardo.ApiJsonDecoder._
+import org.broadinstitute.dsde.workbench.leonardo.http.AppRoutesTestJsonCodec._
+import org.broadinstitute.dsde.workbench.leonardo.http.DiskRoutesTestJsonCodec._
+import org.broadinstitute.dsde.workbench.leonardo.http.RuntimeRoutesTestJsonCodec._
+import org.broadinstitute.dsde.workbench.leonardo.http._
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.broadinstitute.dsde.workbench.util.ExecutionContexts
+import org.http4s._
+import org.http4s.circe.CirceEntityEncoder._
 import org.http4s.client.middleware.Logger
 import org.http4s.client.{blaze, Client}
 import org.http4s.headers._
-import org.http4s.circe.CirceEntityEncoder._
-import org.broadinstitute.dsde.workbench.leonardo.http.DiskRoutesTestJsonCodec._
-import org.broadinstitute.dsde.workbench.leonardo.http.RuntimeRoutesTestJsonCodec._
-import org.broadinstitute.dsde.workbench.leonardo.http.AppRoutesTestJsonCodec._
-
-import scala.concurrent.duration._
-import ApiJsonDecoder._
-import org.http4s._
 
 import scala.concurrent.ExecutionContext.global
-import org.broadinstitute.dsde.workbench.DoneCheckableSyntax._
-import org.broadinstitute.dsde.workbench.auth.AuthToken
-
+import scala.concurrent.duration._
 import scala.util.control.NoStackTrace
 
 object LeonardoApiClient {

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoSuite.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoSuite.scala
@@ -4,7 +4,7 @@ import cats.effect.IO
 import cats.implicits._
 import org.broadinstitute.dsde.workbench.fixture.BillingFixtures
 import org.broadinstitute.dsde.workbench.leonardo.GPAllocFixtureSpec.{shouldUnclaimProjectsKey, _}
-import org.broadinstitute.dsde.workbench.leonardo.apps.{BatchNodepoolCreationSpec, KubernetesSpec}
+import org.broadinstitute.dsde.workbench.leonardo.apps.{AppCreationSpec, BatchNodepoolCreationSpec}
 import org.broadinstitute.dsde.workbench.leonardo.lab.LabSpec
 import org.broadinstitute.dsde.workbench.leonardo.notebooks._
 import org.broadinstitute.dsde.workbench.leonardo.rstudio.RStudioSpec
@@ -195,7 +195,7 @@ final class LeonardoSuite
       new NotebookGCECustomizationSpec,
       new NotebookGCEDataSyncingSpec,
       new BatchNodepoolCreationSpec,
-      new KubernetesSpec
+      new AppCreationSpec
     )
     with TestSuite
     with GPAllocBeforeAndAfterAll

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/AppCreationSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/AppCreationSpec.scala
@@ -91,6 +91,10 @@ class AppCreationSpec extends GPAllocFixtureSpec with LeonardoTestUtils with GPA
 
           _ = app1DeletedDoneCheckable.isDone(monitorApp1DeletionResult) shouldBe true
 
+          // TODO investigate why this is necessary - in theory the second app should be able
+          // to be created after the first is deleted.
+          _ <- testTimer.sleep(600 seconds)
+
           _ <- loggerIO.info(s"AppCreationSpec: About to create app ${googleProject}/${appName2}")
 
           _ <- LeonardoApiClient.createApp(googleProject, appName2, createAppRequest)

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/AppCreationSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/AppCreationSpec.scala
@@ -65,7 +65,7 @@ class AppCreationSpec extends GPAllocFixtureSpec with LeonardoTestUtils with GPA
 
           _ = getAppResponse.status should (be(AppStatus.Provisioning) or be(AppStatus.Precreating))
 
-          monitorStartingResult <- testTimer.sleep(120 seconds) >> streamFUntilDone(gar, 30, 30 seconds)(
+          monitorStartingResult <- testTimer.sleep(120 seconds) >> streamFUntilDone(gar, 120, 10 seconds)(
             testTimer,
             creatingDoneCheckable
           ).compile.lastOrError
@@ -101,7 +101,7 @@ class AppCreationSpec extends GPAllocFixtureSpec with LeonardoTestUtils with GPA
 
           _ = getAppResponse.status should (be(AppStatus.Provisioning) or be(AppStatus.Precreating))
 
-          monitorApp2CreationResult <- testTimer.sleep(180 seconds) >> streamFUntilDone(gar, 30, 30 seconds)(
+          monitorApp2CreationResult <- testTimer.sleep(180 seconds) >> streamFUntilDone(gar, 120, 10 seconds)(
             testTimer,
             creatingDoneCheckable
           ).compile.lastOrError

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/AppCreationSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/AppCreationSpec.scala
@@ -55,7 +55,7 @@ class AppCreationSpec extends GPAllocFixtureSpec with LeonardoTestUtils with GPA
 
         for {
 
-          _ <- loggerIO.info("AppCreationSpec: About to create app")
+          _ <- loggerIO.info(s"AppCreationSpec: About to create app ${googleProject}/${appName}")
 
           _ <- LeonardoApiClient.createApp(googleProject, appName, createAppRequest)
 
@@ -70,7 +70,9 @@ class AppCreationSpec extends GPAllocFixtureSpec with LeonardoTestUtils with GPA
             creatingDoneCheckable
           ).compile.lastOrError
 
-          _ <- loggerIO.info(s"AppCreationSpec: app 1 monitor result: ${monitorStartingResult}")
+          _ <- loggerIO.info(
+            s"AppCreationSpec: app ${googleProject}/${appName} monitor result: ${monitorStartingResult}"
+          )
 
           _ = monitorStartingResult.status shouldBe AppStatus.Running
 
@@ -83,11 +85,13 @@ class AppCreationSpec extends GPAllocFixtureSpec with LeonardoTestUtils with GPA
             app1DeletedDoneCheckable
           ).compile.lastOrError
 
-          _ <- loggerIO.info(s"AppCreationSpec: app1 delete result: $monitorApp1DeletionResult")
+          _ <- loggerIO.info(
+            s"AppCreationSpec: app ${googleProject}/${appName} delete result: $monitorApp1DeletionResult"
+          )
 
-          _ <- testTimer.sleep(480 seconds)
+          _ = app1DeletedDoneCheckable.isDone(monitorApp1DeletionResult) shouldBe true
 
-          _ <- loggerIO.info("AppCreationSpec: About to create app2")
+          _ <- loggerIO.info(s"AppCreationSpec: About to create app ${googleProject}/${appName2}")
 
           _ <- LeonardoApiClient.createApp(googleProject, appName2, createAppRequest)
 
@@ -102,7 +106,9 @@ class AppCreationSpec extends GPAllocFixtureSpec with LeonardoTestUtils with GPA
             creatingDoneCheckable
           ).compile.lastOrError
 
-          _ <- loggerIO.info(s"AppCreationSpec: app 2 monitor result: ${monitorApp2CreationResult}")
+          _ <- loggerIO.info(
+            s"AppCreationSpec: app ${googleProject}/${appName2} monitor result: ${monitorApp2CreationResult}"
+          )
 
           _ = monitorApp2CreationResult.status shouldBe AppStatus.Running
 
@@ -115,7 +121,9 @@ class AppCreationSpec extends GPAllocFixtureSpec with LeonardoTestUtils with GPA
             app2DeletedDoneCheckable
           ).compile.lastOrError
 
-          _ <- loggerIO.info(s"AppCreationSpec: app 2 delete result: $monitorApp2DeletionResult")
+          _ <- loggerIO.info(
+            s"AppCreationSpec: app ${googleProject}/${appName2} delete result: $monitorApp2DeletionResult"
+          )
 
         } yield ()
       }

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/AppCreationSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/AppCreationSpec.scala
@@ -15,7 +15,7 @@ import org.scalatest.{DoNotDiscover, ParallelTestExecution}
 import scala.concurrent.duration._
 
 @DoNotDiscover
-class KubernetesSpec extends GPAllocFixtureSpec with LeonardoTestUtils with GPAllocUtils with ParallelTestExecution {
+class AppCreationSpec extends GPAllocFixtureSpec with LeonardoTestUtils with GPAllocUtils with ParallelTestExecution {
 
   implicit val authTokenForOldApiClient = ronAuthToken
   implicit val auth: Authorization =
@@ -36,7 +36,7 @@ class KubernetesSpec extends GPAllocFixtureSpec with LeonardoTestUtils with GPAl
       val app2DeletedDoneCheckable: DoneCheckable[List[ListAppResponse]] =
         x => x.filter(_.appName == appName2).map(_.status).distinct == List(AppStatus.Deleted)
 
-      logger.info(s"Google Project 1 " + googleProject.value)
+      logger.info(s"AppCreationSpec: Google Project 1 " + googleProject.value)
 
       val createAppRequest = defaultCreateAppRequest.copy(
         diskConfig = Some(
@@ -55,7 +55,7 @@ class KubernetesSpec extends GPAllocFixtureSpec with LeonardoTestUtils with GPAl
 
         for {
 
-          _ <- loggerIO.info("About to create app")
+          _ <- loggerIO.info("AppCreationSpec: About to create app")
 
           _ <- LeonardoApiClient.createApp(googleProject, appName, createAppRequest)
 
@@ -70,7 +70,7 @@ class KubernetesSpec extends GPAllocFixtureSpec with LeonardoTestUtils with GPAl
             creatingDoneCheckable
           ).compile.lastOrError
 
-          _ <- loggerIO.info(s"app 1 monitor result: ${monitorStartingResult}")
+          _ <- loggerIO.info(s"AppCreationSpec: app 1 monitor result: ${monitorStartingResult}")
 
           _ = monitorStartingResult.status shouldBe AppStatus.Running
 
@@ -83,11 +83,11 @@ class KubernetesSpec extends GPAllocFixtureSpec with LeonardoTestUtils with GPAl
             app1DeletedDoneCheckable
           ).compile.lastOrError
 
-          _ <- loggerIO.info(s"app1 delete result: $monitorApp1DeletionResult")
+          _ <- loggerIO.info(s"AppCreationSpec: app1 delete result: $monitorApp1DeletionResult")
 
           _ <- testTimer.sleep(480 seconds)
 
-          _ <- loggerIO.info("About to create app2")
+          _ <- loggerIO.info("AppCreationSpec: About to create app2")
 
           _ <- LeonardoApiClient.createApp(googleProject, appName2, createAppRequest)
 
@@ -102,7 +102,7 @@ class KubernetesSpec extends GPAllocFixtureSpec with LeonardoTestUtils with GPAl
             creatingDoneCheckable
           ).compile.lastOrError
 
-          _ <- loggerIO.info(s"app 2 monitor result: ${monitorApp2CreationResult}")
+          _ <- loggerIO.info(s"AppCreationSpec: app 2 monitor result: ${monitorApp2CreationResult}")
 
           _ = monitorApp2CreationResult.status shouldBe AppStatus.Running
 
@@ -115,7 +115,7 @@ class KubernetesSpec extends GPAllocFixtureSpec with LeonardoTestUtils with GPAl
             app2DeletedDoneCheckable
           ).compile.lastOrError
 
-          _ <- loggerIO.info(s"app 2 delete result: $monitorApp2DeletionResult")
+          _ <- loggerIO.info(s"AppCreationSpec: app 2 delete result: $monitorApp2DeletionResult")
 
         } yield ()
       }

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/AppCreationSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/AppCreationSpec.scala
@@ -55,7 +55,7 @@ class AppCreationSpec extends GPAllocFixtureSpec with LeonardoTestUtils with GPA
 
         for {
 
-          _ <- loggerIO.info(s"AppCreationSpec: About to create app ${googleProject}/${appName}")
+          _ <- loggerIO.info(s"AppCreationSpec: About to create app ${googleProject.value}/${appName.value}")
 
           _ <- LeonardoApiClient.createApp(googleProject, appName, createAppRequest)
 
@@ -71,7 +71,7 @@ class AppCreationSpec extends GPAllocFixtureSpec with LeonardoTestUtils with GPA
           ).compile.lastOrError
 
           _ <- loggerIO.info(
-            s"AppCreationSpec: app ${googleProject}/${appName} monitor result: ${monitorStartingResult}"
+            s"AppCreationSpec: app ${googleProject.value}/${appName.value} monitor result: ${monitorStartingResult}"
           )
 
           _ = monitorStartingResult.status shouldBe AppStatus.Running
@@ -86,7 +86,7 @@ class AppCreationSpec extends GPAllocFixtureSpec with LeonardoTestUtils with GPA
           ).compile.lastOrError
 
           _ <- loggerIO.info(
-            s"AppCreationSpec: app ${googleProject}/${appName} delete result: $monitorApp1DeletionResult"
+            s"AppCreationSpec: app ${googleProject.value}/${appName.value} delete result: $monitorApp1DeletionResult"
           )
 
           _ = app1DeletedDoneCheckable.isDone(monitorApp1DeletionResult) shouldBe true
@@ -95,7 +95,7 @@ class AppCreationSpec extends GPAllocFixtureSpec with LeonardoTestUtils with GPA
           // to be created after the first is deleted.
           _ <- testTimer.sleep(600 seconds)
 
-          _ <- loggerIO.info(s"AppCreationSpec: About to create app ${googleProject}/${appName2}")
+          _ <- loggerIO.info(s"AppCreationSpec: About to create app ${googleProject.value}/${appName2.value}")
 
           _ <- LeonardoApiClient.createApp(googleProject, appName2, createAppRequest)
 
@@ -111,7 +111,7 @@ class AppCreationSpec extends GPAllocFixtureSpec with LeonardoTestUtils with GPA
           ).compile.lastOrError
 
           _ <- loggerIO.info(
-            s"AppCreationSpec: app ${googleProject}/${appName2} monitor result: ${monitorApp2CreationResult}"
+            s"AppCreationSpec: app ${googleProject.value}/${appName2.value} monitor result: ${monitorApp2CreationResult}"
           )
 
           _ = monitorApp2CreationResult.status shouldBe AppStatus.Running
@@ -126,7 +126,7 @@ class AppCreationSpec extends GPAllocFixtureSpec with LeonardoTestUtils with GPA
           ).compile.lastOrError
 
           _ <- loggerIO.info(
-            s"AppCreationSpec: app ${googleProject}/${appName2} delete result: $monitorApp2DeletionResult"
+            s"AppCreationSpec: app ${googleProject.value}/${appName2.value} delete result: $monitorApp2DeletionResult"
           )
 
         } yield ()

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/AppCreationSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/AppCreationSpec.scala
@@ -51,7 +51,7 @@ class AppCreationSpec extends GPAllocFixtureSpec with LeonardoTestUtils with GPA
       val res = dependencies.use { dep =>
         implicit val client = dep.httpClient
         val creatingDoneCheckable: DoneCheckable[GetAppResponse] =
-          x => x.status == AppStatus.Running
+          x => x.status == AppStatus.Running || x.status == AppStatus.Error
 
         for {
 

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/BatchNodepoolCreationSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/BatchNodepoolCreationSpec.scala
@@ -9,7 +9,7 @@ import com.google.container.v1.{Cluster, NodePool}
 import org.broadinstitute.dsde.workbench.DoneCheckable
 import org.broadinstitute.dsde.workbench.auth.AuthToken
 import org.broadinstitute.dsde.workbench.google2.GKEModels.{KubernetesClusterId, KubernetesClusterName}
-import org.broadinstitute.dsde.workbench.google2.{streamFUntilDone, DiskName, GKEService}
+import org.broadinstitute.dsde.workbench.google2.{streamFUntilDone, GKEService}
 import org.broadinstitute.dsde.workbench.leonardo.LeonardoApiClient._
 import org.broadinstitute.dsde.workbench.leonardo.http.{GetAppResponse, ListAppResponse, PersistentDiskRequest}
 import org.http4s.headers.Authorization
@@ -48,10 +48,11 @@ class BatchNodepoolCreationSpec
             val id = KubernetesClusterId(googleProject, LeonardoConfig.Leonardo.location, clusterName)
             gkeClient.getCluster(id)
           }
-          monitorCreationResult <- testTimer.sleep(30 seconds) >> streamFUntilDone(getCluster, 60, 10 seconds)(
-            testTimer,
-            clusterDoneCheckable
-          ).compile.lastOrError
+          monitorCreationResult <- testTimer.sleep(30 seconds) >>
+            (getCluster, 60, 10 seconds)(
+              testTimer,
+              clusterDoneCheckable
+            ).compile.lastOrError
 
           _ = monitorCreationResult.map(_.getNodePoolsList().size()) shouldBe Some(
             defaultBatchNodepoolRequest.numNodepools.value + 1
@@ -152,7 +153,7 @@ class BatchNodepoolCreationSpec
 
           listApps = LeonardoApiClient.listApps(googleProject, true)
 
-          monitorApp1DeletionResult <- testTimer.sleep(30 seconds) >> streamFUntilDone(listApps, 60, 10 seconds)(
+          monitorApp1DeletionResult <- testTimer.sleep(30 seconds) >> streamFUntilDone(listApps, 120, 10 seconds)(
             testTimer,
             app1DeletedDoneCheckable
           ).compile.lastOrError
@@ -162,7 +163,7 @@ class BatchNodepoolCreationSpec
           )
 
           _ <- LeonardoApiClient.deleteApp(googleProject, appName2)
-          monitorAppDeletionResult <- testTimer.sleep(30 seconds) >> streamFUntilDone(listApps, 60, 10 seconds)(
+          monitorAppDeletionResult <- testTimer.sleep(30 seconds) >> streamFUntilDone(listApps, 120, 10 seconds)(
             testTimer,
             appDeletedDoneCheckable
           ).compile.lastOrError

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/BatchNodepoolCreationSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/BatchNodepoolCreationSpec.scala
@@ -102,13 +102,13 @@ class BatchNodepoolCreationSpec
 
           diskConfig1 = Some(PersistentDiskRequest(DiskName("disk1"), None, None, Map.empty))
 
-          _ <- loggerIO.info("About to create app1")
+          _ <- loggerIO.info("BatchNodepoolCreationSpec: About to create app1")
 
           _ <- LeonardoApiClient.createApp(googleProject,
                                            appName1,
                                            createAppRequest = defaultCreateAppRequest.copy(diskConfig = diskConfig1))
 
-          _ <- loggerIO.info("About to get app1")
+          _ <- loggerIO.info("BatchNodepoolCreationSpec: About to get app1")
 
           getApp1 = LeonardoApiClient.getApp(googleProject, appName1)
           monitorApp1CreationResult <- testTimer.sleep(30 seconds) >> streamFUntilDone(getApp1, 120, 10 seconds)(
@@ -116,7 +116,7 @@ class BatchNodepoolCreationSpec
             appDoneCheckable
           ).compile.lastOrError
 
-          _ <- loggerIO.info(s"app1 monitor result: ${monitorApp1CreationResult}")
+          _ <- loggerIO.info(s"BatchNodepoolCreationSpec: app1 monitor result: ${monitorApp1CreationResult}")
           _ = monitorApp1CreationResult.status shouldBe AppStatus.Running
 
           clusterAfterApp1 <- getCluster
@@ -125,7 +125,7 @@ class BatchNodepoolCreationSpec
           appName2 = AppName("app2")
           diskConfig2 = Some(PersistentDiskRequest(DiskName("disk2"), None, None, Map.empty))
 
-          _ <- loggerIO.info("About to create app2")
+          _ <- loggerIO.info("BatchNodepoolCreationSpec: About to create app2")
 
           _ <- LeonardoApiClient.createApp(googleProject,
                                            appName2,
@@ -138,7 +138,7 @@ class BatchNodepoolCreationSpec
             appDoneCheckable
           ).compile.lastOrError
 
-          _ <- loggerIO.info(s"app2 monitor result: ${monitorApp2CreationResult}")
+          _ <- loggerIO.info(s"BatchNodepoolCreationSpec: app2 monitor result: ${monitorApp2CreationResult}")
           _ = monitorApp2CreationResult.status shouldBe AppStatus.Running
 
           clusterAfterApp2 <- getCluster
@@ -154,7 +154,7 @@ class BatchNodepoolCreationSpec
             app1DeletedDoneCheckable
           ).compile.lastOrError
 
-          _ <- loggerIO.info(s"app1 delete result: $monitorApp1DeletionResult")
+          _ <- loggerIO.info(s"BatchNodepoolCreationSpec: app1 delete result: $monitorApp1DeletionResult")
 
           _ <- LeonardoApiClient.deleteApp(googleProject, appName2)
           monitorAppDeletionResult <- testTimer.sleep(30 seconds) >> streamFUntilDone(listApps, 60, 10 seconds)(
@@ -162,7 +162,7 @@ class BatchNodepoolCreationSpec
             appDeletedDoneCheckable
           ).compile.lastOrError
 
-          _ <- loggerIO.info(s"all app delete result: $monitorAppDeletionResult")
+          _ <- loggerIO.info(s"BatchNodepoolCreationSpec: all app delete result: $monitorAppDeletionResult")
 
         } yield ()
       }

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/BatchNodepoolCreationSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/BatchNodepoolCreationSpec.scala
@@ -103,13 +103,13 @@ class BatchNodepoolCreationSpec
 
           diskConfig1 = Some(PersistentDiskRequest(randomDiskName, None, None, Map.empty))
 
-          _ <- loggerIO.info(s"BatchNodepoolCreationSpec: About to create app ${googleProject}/${appName1}")
+          _ <- loggerIO.info(s"BatchNodepoolCreationSpec: About to create app ${googleProject.value}/${appName1.value}")
 
           _ <- LeonardoApiClient.createApp(googleProject,
                                            appName1,
                                            createAppRequest = defaultCreateAppRequest.copy(diskConfig = diskConfig1))
 
-          _ <- loggerIO.info(s"BatchNodepoolCreationSpec: About to get app ${googleProject}/${appName1}")
+          _ <- loggerIO.info(s"BatchNodepoolCreationSpec: About to get app ${googleProject.value}/${appName1.value}")
 
           getApp1 = LeonardoApiClient.getApp(googleProject, appName1)
           monitorApp1CreationResult <- testTimer.sleep(30 seconds) >> streamFUntilDone(getApp1, 120, 10 seconds)(
@@ -118,7 +118,7 @@ class BatchNodepoolCreationSpec
           ).compile.lastOrError
 
           _ <- loggerIO.info(
-            s"BatchNodepoolCreationSpec: app ${googleProject}/${appName1} monitor result: ${monitorApp1CreationResult}"
+            s"BatchNodepoolCreationSpec: app ${googleProject.value}/${appName1.value} monitor result: ${monitorApp1CreationResult}"
           )
           _ = monitorApp1CreationResult.status shouldBe AppStatus.Running
 
@@ -127,7 +127,7 @@ class BatchNodepoolCreationSpec
 
           diskConfig2 = Some(PersistentDiskRequest(randomDiskName, None, None, Map.empty))
 
-          _ <- loggerIO.info(s"BatchNodepoolCreationSpec: About to create app ${googleProject}/${appName2}")
+          _ <- loggerIO.info(s"BatchNodepoolCreationSpec: About to create app ${googleProject.value}/${appName2.value}")
 
           _ <- LeonardoApiClient.createApp(googleProject,
                                            appName2,
@@ -141,7 +141,7 @@ class BatchNodepoolCreationSpec
           ).compile.lastOrError
 
           _ <- loggerIO.info(
-            s"BatchNodepoolCreationSpec: app ${googleProject}/${appName2} monitor result: ${monitorApp2CreationResult}"
+            s"BatchNodepoolCreationSpec: app ${googleProject.value}/${appName2.value} monitor result: ${monitorApp2CreationResult}"
           )
           _ = monitorApp2CreationResult.status shouldBe AppStatus.Running
 
@@ -159,7 +159,7 @@ class BatchNodepoolCreationSpec
           ).compile.lastOrError
 
           _ <- loggerIO.info(
-            s"BatchNodepoolCreationSpec: app ${googleProject}/${appName1} delete result: $monitorApp1DeletionResult"
+            s"BatchNodepoolCreationSpec: app ${googleProject.value}/${appName1.value} delete result: $monitorApp1DeletionResult"
           )
 
           _ <- LeonardoApiClient.deleteApp(googleProject, appName2)

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/BatchNodepoolCreationSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/BatchNodepoolCreationSpec.scala
@@ -71,7 +71,7 @@ class BatchNodepoolCreationSpec
         val appName2 = randomAppName
 
         val appDoneCheckable: DoneCheckable[GetAppResponse] =
-          x => x.status == AppStatus.Running
+          x => x.status == AppStatus.Running || x.status == AppStatus.Error
 
         val appDeletedDoneCheckable: DoneCheckable[List[ListAppResponse]] =
           x => x.map(_.status).distinct == List(AppStatus.Deleted)

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/BatchNodepoolCreationSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/BatchNodepoolCreationSpec.scala
@@ -49,7 +49,7 @@ class BatchNodepoolCreationSpec
             gkeClient.getCluster(id)
           }
           monitorCreationResult <- testTimer.sleep(30 seconds) >>
-            (getCluster, 60, 10 seconds)(
+            streamFUntilDone(getCluster, 60, 10 seconds)(
               testTimer,
               clusterDoneCheckable
             ).compile.lastOrError

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -1,3 +1,4 @@
+
 # NOTE: commented fields are overridden in firecloud-develop with templated values
 # Fields with "replace_me" are also expected to be overridden, but need to be in
 # this file to allow referential integrity.

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -1,4 +1,3 @@
-leo
 # NOTE: commented fields are overridden in firecloud-develop with templated values
 # Fields with "replace_me" are also expected to be overridden, but need to be in
 # this file to allow referential integrity.

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -1,4 +1,4 @@
-
+leo
 # NOTE: commented fields are overridden in firecloud-develop with templated values
 # Fields with "replace_me" are also expected to be overridden, but need to be in
 # this file to allow referential integrity.

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
@@ -648,8 +648,8 @@ class GKEInterpreter[F[_]: Parallel: ContextShift: Timer](
       // The helm client requires a Google access token
       _ <- F.delay(credentials.refreshIfExpired())
 
-      // Don't use AppContext.now for the tmp file namebecause we want this to be unique
-      //for each helm invocation
+      // Don't use AppContext.now for the tmp file name because we want it to be unique
+      // for each helm invocation
       now <- nowInstant
 
       // The helm client requires the ca cert passed as a file - hence writing a temp file before helm invocation.

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreterSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreterSpec.scala
@@ -4,16 +4,10 @@ import java.nio.file.Files
 import java.util.Base64
 
 import cats.effect.IO
+import org.broadinstitute.dsde.workbench.google.mock.{MockGoogleIamDAO, MockGoogleProjectDAO}
 import org.broadinstitute.dsde.workbench.google2.GKEModels.NodepoolName
 import org.broadinstitute.dsde.workbench.google2.KubernetesModels.{KubernetesPodStatus, PodStatus}
-import org.broadinstitute.dsde.workbench.google2.KubernetesSerializableName.{
-  NamespaceName,
-  PodName,
-  SecretKey,
-  SecretName,
-  ServiceAccountName
-}
-import org.broadinstitute.dsde.workbench.google.mock.{MockGoogleIamDAO, MockGoogleProjectDAO}
+import org.broadinstitute.dsde.workbench.google2.KubernetesSerializableName._
 import org.broadinstitute.dsde.workbench.google2.mock.{
   FakeGoogleComputeService,
   MockComputePollOperation,
@@ -30,7 +24,6 @@ import org.broadinstitute.dsde.workbench.leonardo.{
   AutoscalingConfig,
   AutoscalingMax,
   AutoscalingMin,
-  KubernetesClusterLeoId,
   LeonardoTestSuite
 }
 import org.broadinstitute.dsp.Release
@@ -110,7 +103,7 @@ class GKEInterpreterSpec extends AnyFlatSpecLike with TestComponent with Leonard
       .build
 
     val authContext =
-      gkeInterp.getHelmAuthContext(googleCluster, KubernetesClusterLeoId(1), NamespaceName("ns")).unsafeRunSync()
+      gkeInterp.getHelmAuthContext(googleCluster, makeKubeCluster(1), NamespaceName("ns")).unsafeRunSync()
 
     authContext.namespace.asString shouldBe "ns"
     authContext.kubeApiServer.asString shouldBe "https://1.2.3.4"


### PR DESCRIPTION
The new `KubernetesSpec` test failed a few times, see https://broadworkbench.atlassian.net/browse/QA-1273

This PR:
* renames `KubernetesSpec` to `AppCreationSpec`
* use random names instead of `app1` and `app2` -- the current names make it hard to distinguish the test case by looking at test logs
* add more context to test `logger` messages
* adds a missing assertion after `streamFUntilDone` instead of using a sleep
* use 20 minute wait times for app create/delete calls

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
