### PR TITLE
[IA-2246] Unable to delete Error'd apps in some cases

### DIFF
--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/KubernetesServiceDbQueries.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/KubernetesServiceDbQueries.scala
@@ -69,8 +69,8 @@ object KubernetesServiceDbQueries {
   def getActiveFullAppByName(googleProject: GoogleProject, appName: AppName, labelFilter: LabelMap = Map())(
     implicit ec: ExecutionContext
   ): DBIO[Option[GetAppResult]] =
-    getActiveFullApp(listClustersByProject(Some(googleProject)),
-                     nodepoolQuery.filter(_.destroyedDate === dummyDate),
+    getActiveFullApp(listClustersByProject(Some(googleProject), true),
+                     nodepoolQuery,
                      appQuery.findActiveByNameQuery(appName),
                      labelFilter)
 


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-2246

2 behavior changes:
1. In Back Leo, don't delete the Sam resource if the app goes into Error status and we're cleaning up GCP resources. Apps in `Error` status should still have records in Sam.
2. In Front Leo, don't send a `DeleteAppMessage` for deleting Error'd apps (we have the same behavior for runtimes)

Tested on a fiab. Will think about whether this can be unit tested.

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
