### PR TITLE
[IA-2251] Do not allow concurrent nodepool operations in front leo

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/BatchNodepoolCreationSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/BatchNodepoolCreationSpec.scala
@@ -162,6 +162,8 @@ class BatchNodepoolCreationSpec
             s"BatchNodepoolCreationSpec: app ${googleProject.value}/${appName1.value} delete result: $monitorApp1DeletionResult"
           )
 
+          _ = monitorApp1DeletionResult.map(_.status).toSet shouldBe Set(AppStatus.Deleted, AppStatus.Running)
+
           _ <- LeonardoApiClient.deleteApp(googleProject, appName2)
           monitorAppDeletionResult <- testTimer.sleep(30 seconds) >> streamFUntilDone(listApps, 120, 10 seconds)(
             testTimer,

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/kubernetesModels.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/kubernetesModels.scala
@@ -163,6 +163,9 @@ object NodepoolStatus {
 
   val deletableStatuses: Set[NodepoolStatus] =
     Set(Unspecified, Running, Reconciling, Unclaimed, Error, RunningWithError)
+
+  val nonParellizableStatuses: Set[NodepoolStatus] =
+    Set(Deleting, Provisioning)
 }
 
 final case class KubernetesClusterLeoId(id: Long) extends AnyVal

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/KubernetesServiceDbQueriesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/KubernetesServiceDbQueriesSpec.scala
@@ -376,4 +376,13 @@ class KubernetesServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent 
     getApp.app.errors should contain(error2)
   }
 
+  it should "correctly identify if theres an operation in progress" in isolatedDbTest {
+    val savedCluster1 = makeKubeCluster(1).copy(status = KubernetesClusterStatus.Running).save()
+    val savedNodepool1 = makeNodepool(1, savedCluster1.id).copy(status = NodepoolStatus.Provisioning).save()
+    val savedNodepool2 = makeNodepool(2, savedCluster1.id).copy(status = NodepoolStatus.Running).save()
+    val app2 = makeApp(1, savedNodepool2.id).copy(status = AppStatus.Running).save()
+
+    KubernetesServiceDbQueries.hasClusterOperationInProgress(savedCluster1.id).transaction.unsafeRunSync() shouldBe true
+  }
+
 }


### PR DESCRIPTION
This disallows concurrent nodepoool operations in front leo, and makes it so we do not mark the app as deleted in the db until both the app and nodepool have been deleted