### PR TITLE
[IA-2259] Peg GKE version at 1.15.x

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/kubernetesModels.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/kubernetesModels.scala
@@ -51,6 +51,8 @@ final case class NetworkFields(networkName: NetworkName, subNetworkName: Subnetw
 //should be in the format 0.0.0.0/0
 final case class CidrIP(value: String) extends AnyVal
 
+final case class KubernetesClusterVersion(value: String) extends AnyVal
+
 /** Google Container Cluster statuses
  *  see: https://cloud.google.com/kubernetes-engine/docs/reference/rest/v1/projects.locations.clusters#Cluster.Status
  */

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -187,6 +187,9 @@ gke {
                           "69.173.127.240/28",
                           "69.173.112.0/21"
     ]
+    # See https://cloud.google.com/kubernetes-engine/docs/release-notes
+    # As of 2020-10-09, 1.16.x is the default but it does not work with the Galaxy chart.
+    version = "1.15.12-gke.4000"
   }
   defaultNodepool {
     machineType = "n1-standard-1"

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
@@ -519,9 +519,12 @@ object Config {
   implicit private val cidrIPReader: ValueReader[CidrIP] = stringValueReader.map(CidrIP)
 
   implicit private val kubeClusterConfigReader: ValueReader[KubernetesClusterConfig] = ValueReader.relative { config =>
-    KubernetesClusterConfig(config.as[Location]("location"),
-                            config.as[RegionName]("region"),
-                            config.as[List[CidrIP]]("authorizedNetworks"))
+    KubernetesClusterConfig(
+      config.as[Location]("location"),
+      config.as[RegionName]("region"),
+      config.as[List[CidrIP]]("authorizedNetworks"),
+      config.as[KubernetesClusterVersion]("version")
+    )
   }
 
   implicit private val maxNodepoolsPerDefaultNodeReader: ValueReader[MaxNodepoolsPerDefaultNode] =
@@ -622,6 +625,8 @@ object Config {
   )
   implicit private val serviceKindValueReader: ValueReader[KubernetesServiceKindName] =
     stringValueReader.map(KubernetesServiceKindName)
+  implicit private val kubernetesClusterVersionReader: ValueReader[KubernetesClusterVersion] =
+    stringValueReader.map(KubernetesClusterVersion)
 
   val gkeClusterConfig = config.as[KubernetesClusterConfig]("gke.cluster")
   val gkeDefaultNodepoolConfig = config.as[DefaultNodepoolConfig]("gke.defaultNodepool")

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/KubernetesClusterConfig.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/KubernetesClusterConfig.scala
@@ -1,10 +1,11 @@
 package org.broadinstitute.dsde.workbench.leonardo.config
 
 import org.broadinstitute.dsde.workbench.google2.{Location, RegionName}
-import org.broadinstitute.dsde.workbench.leonardo.CidrIP
+import org.broadinstitute.dsde.workbench.leonardo.{CidrIP, KubernetesClusterVersion}
 
 case class KubernetesClusterConfig(
   location: Location,
   region: RegionName,
-  authorizedNetworks: List[CidrIP]
+  authorizedNetworks: List[CidrIP],
+  version: KubernetesClusterVersion
 )

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
@@ -111,6 +111,7 @@ class GKEInterpreter[F[_]: Parallel: ContextShift: Timer](
 
       legacyCreateClusterRec = new com.google.api.services.container.model.Cluster()
         .setName(dbCluster.clusterName.value)
+        .setInitialClusterVersion(config.clusterConfig.version.value)
         .setNodePools(nodepools.asJava)
         .setLegacyAbac(new com.google.api.services.container.model.LegacyAbac().setEnabled(false))
         .setNetwork(kubeNetwork.idString)

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/config/ConfigSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/config/ConfigSpec.scala
@@ -80,7 +80,8 @@ final class ConfigSpec extends AnyFlatSpec with Matchers {
         "69.173.96.0/20",
         "69.173.127.240/28",
         "69.173.112.0/21"
-      ).map(CidrIP)
+      ).map(CidrIP),
+      KubernetesClusterVersion("1.15.12-gke.4000")
     )
     Config.gkeClusterConfig shouldBe expectedResult
   }


### PR DESCRIPTION
I hope this fixes the error which started today: 

```
err is %!(EXTRA *errors.withStack=unable to build kubernetes objects from release manifest: [unable to recognize "": no matches for kind "DaemonSet" in version "apps/v1beta2", unable to recognize "": no matches for kind "StatefulSet" in version "apps/v1beta1"], string=
```

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
