### PR TITLE
[no ticket] Remove antiquated addGoogleRoleToBillingProjectUser call

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookPyKernelSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookPyKernelSpec.scala
@@ -1,7 +1,6 @@
 package org.broadinstitute.dsde.workbench.leonardo.notebooks
 
 import org.broadinstitute.dsde.workbench.leonardo.{Leonardo, LeonardoConfig, RuntimeFixtureSpec}
-import org.broadinstitute.dsde.workbench.service.Orchestration
 import org.scalatest.DoNotDiscover
 
 import scala.concurrent.duration.DurationLong
@@ -88,11 +87,6 @@ class NotebookPyKernelSpec extends RuntimeFixtureSpec with NotebookTestUtils {
     }
 
     "should allow BigQuerying via the command line" in { runtimeFixture =>
-      // project owners have the bigquery role automatically, so this also tests granting it to users
-      val ownerToken = hermioneAuthToken
-      Orchestration.billing.addGoogleRoleToBillingProjectUser(runtimeFixture.runtime.googleProject.value,
-                                                              ronEmail,
-                                                              "bigquery.jobUser")(ownerToken)
       withWebDriver { implicit driver =>
         withNewNotebook(runtimeFixture.runtime) { notebookPage =>
           val query =


### PR DESCRIPTION
@dvoet would like to remove this API, seeing if the test passes without it.

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
