### PR TITLE
[IA-2280] A few Sam-related performance fixes

### DIFF
--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/Boot.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/Boot.scala
@@ -333,7 +333,9 @@ object Boot extends IOApp {
       implicit0(openTelemetry: OpenTelemetryMetrics[F]) <- OpenTelemetryMetrics
         .resource[F](applicationConfig.leoServiceAccountJsonFile, applicationConfig.applicationName, blocker)
 
-      samDao = HttpSamDAO[F](clientWithRetryAndLogging, httpSamDaoConfig, blocker)
+      // Note the Sam client intentionally doesn't use clientWithRetryAndLogging because the logs are
+      // too verbose. We send OpenTelemetry metrics instead for instrumenting Sam calls.
+      samDao = HttpSamDAO[F](clientWithRetryWithCustomSSL, httpSamDaoConfig, blocker)
       concurrentDbAccessPermits <- Resource.liftF(Semaphore[F](dbConcurrency))
       implicit0(dbRef: DbReference[F]) <- DbReference.init(liquibaseConfig, concurrentDbAccessPermits, blocker)
       runtimeDnsCache = new RuntimeDnsCache(proxyConfig, dbRef, runtimeDnsCacheConfig, blocker)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/auth/sam/SamAuthProvider.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/auth/sam/SamAuthProvider.scala
@@ -145,14 +145,17 @@ class SamAuthProvider[F[_]: Effect: Logger: Timer: OpenTelemetryMetrics](samDao:
     implicit sr: SamResource[R],
     decoder: Decoder[R],
     ev: ApplicativeAsk[F, TraceId]
-  ): F[List[R]] = {
-    val authHeader = Authorization(Credentials.Token(AuthScheme.Bearer, userInfo.accessToken.token))
-    for {
-      resourcePolicies <- samDao
-        .getResourcePolicies[R](authHeader)
-      res = resourcePolicies.filter { case (_, pn) => sr.policyNames.contains(pn) }
-    } yield resources.filter(r => res.exists(_._1 == r))
-  }
+  ): F[List[R]] =
+    if (resources.isEmpty) {
+      Effect[F].pure(List.empty)
+    } else {
+      val authHeader = Authorization(Credentials.Token(AuthScheme.Bearer, userInfo.accessToken.token))
+      for {
+        resourcePolicies <- samDao
+          .getResourcePolicies[R](authHeader)
+        res = resourcePolicies.filter { case (_, pn) => sr.policyNames.contains(pn) }
+      } yield resources.filter(r => res.exists(_._1 == r))
+    }
 
   def filterUserVisibleWithProjectFallback[R](
     resources: List[(GoogleProject, R)],
@@ -161,21 +164,24 @@ class SamAuthProvider[F[_]: Effect: Logger: Timer: OpenTelemetryMetrics](samDao:
     implicit sr: SamResource[R],
     decoder: Decoder[R],
     ev: ApplicativeAsk[F, TraceId]
-  ): F[List[(GoogleProject, R)]] = {
-    val authHeader = Authorization(Credentials.Token(AuthScheme.Bearer, userInfo.accessToken.token))
-    for {
-      projectPolicies <- samDao.getResourcePolicies[ProjectSamResourceId](authHeader)
-      owningProjects = projectPolicies.collect {
-        case (r, SamPolicyName.Owner) => r.googleProject
+  ): F[List[(GoogleProject, R)]] =
+    if (resources.isEmpty) {
+      Effect[F].pure(List.empty)
+    } else {
+      val authHeader = Authorization(Credentials.Token(AuthScheme.Bearer, userInfo.accessToken.token))
+      for {
+        projectPolicies <- samDao.getResourcePolicies[ProjectSamResourceId](authHeader)
+        owningProjects = projectPolicies.collect {
+          case (r, SamPolicyName.Owner) => r.googleProject
+        }
+        resourcePolicies <- samDao
+          .getResourcePolicies[R](authHeader)
+        res = resourcePolicies.filter { case (_, pn) => sr.policyNames.contains(pn) }
+      } yield resources.filter {
+        case (project, r) =>
+          owningProjects.contains(project) || res.exists(_._1 == r)
       }
-      resourcePolicies <- samDao
-        .getResourcePolicies[R](authHeader)
-      res = resourcePolicies.filter { case (_, pn) => sr.policyNames.contains(pn) }
-    } yield resources.filter {
-      case (project, r) =>
-        owningProjects.contains(project) || res.exists(_._1 == r)
     }
-  }
 
   override def notifyResourceCreated[R](
     samResource: R,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpSamDAO.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpSamDAO.scala
@@ -322,6 +322,7 @@ class HttpSamDAO[F[_]: Effect](httpClient: Client[F], config: HttpSamDaoConfig, 
       traceId <- ev.ask
       body <- response.bodyText.compile.foldMonoid
       _ <- logger.error(s"${traceId} | Sam call failed: $body")
+      _ <- metrics.incrementCounter("sam/errorResponse")
     } yield AuthProviderException(traceId, body, response.status.code)
 
   private def getProjectOwnerPolicyEmail(authorization: Authorization, googleProject: GoogleProject)(

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeoAuthProvider.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeoAuthProvider.scala
@@ -1,6 +1,7 @@
 package org.broadinstitute.dsde.workbench.leonardo
 package model
 
+import cats.data.NonEmptyList
 import cats.mtl.ApplicativeAsk
 import io.circe.{Decoder, Encoder}
 import org.broadinstitute.dsde.workbench.leonardo.model.SamResource.{
@@ -120,14 +121,14 @@ trait LeoAuthProvider[F[_]] {
     ev: ApplicativeAsk[F, TraceId]
   ): F[(List[sr.ActionCategory], List[ProjectAction])]
 
-  def filterUserVisible[R](resources: List[R], userInfo: UserInfo)(
+  def filterUserVisible[R](resources: NonEmptyList[R], userInfo: UserInfo)(
     implicit sr: SamResource[R],
     decoder: Decoder[R],
     ev: ApplicativeAsk[F, TraceId]
   ): F[List[R]]
 
   def filterUserVisibleWithProjectFallback[R](
-    resources: List[(GoogleProject, R)],
+    resources: NonEmptyList[(GoogleProject, R)],
     userInfo: UserInfo
   )(
     implicit sr: SamResource[R],

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/auth/WhitelistAuthProvider.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/auth/WhitelistAuthProvider.scala
@@ -1,5 +1,6 @@
 package org.broadinstitute.dsde.workbench.leonardo.auth
 
+import cats.data.NonEmptyList
 import cats.effect.IO
 import cats.implicits._
 import cats.mtl.ApplicativeAsk
@@ -49,12 +50,12 @@ class WhitelistAuthProvider(config: Config, saProvider: ServiceAccountProvider[I
       case false => (List.empty, List.empty)
     }
 
-  def filterUserVisible[R](resources: List[R], userInfo: UserInfo)(
+  def filterUserVisible[R](resources: NonEmptyList[R], userInfo: UserInfo)(
     implicit sr: SamResource[R],
     decoder: Decoder[R],
     ev: ApplicativeAsk[IO, TraceId]
   ): IO[List[R]] =
-    resources.traverseFilter { a =>
+    resources.toList.traverseFilter { a =>
       checkWhitelist(userInfo).map {
         case true  => Some(a)
         case false => None
@@ -62,14 +63,14 @@ class WhitelistAuthProvider(config: Config, saProvider: ServiceAccountProvider[I
     }
 
   def filterUserVisibleWithProjectFallback[R](
-    resources: List[(GoogleProject, R)],
+    resources: NonEmptyList[(GoogleProject, R)],
     userInfo: UserInfo
   )(
     implicit sr: SamResource[R],
     decoder: Decoder[R],
     ev: ApplicativeAsk[IO, TraceId]
   ): IO[List[(GoogleProject, R)]] =
-    resources.traverseFilter { a =>
+    resources.toList.traverseFilter { a =>
       checkWhitelist(userInfo).map {
         case true  => Some(a)
         case false => None

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/mocks.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/mocks.scala
@@ -1,5 +1,6 @@
 package org.broadinstitute.dsde.workbench.leonardo
 
+import cats.data.NonEmptyList
 import cats.effect.IO
 import cats.mtl.ApplicativeAsk
 import com.google.auth.Credentials
@@ -100,12 +101,12 @@ object MockAuthProvider extends LeoAuthProvider[IO] {
   ): IO[(List[sr.ActionCategory], List[ProjectAction])] = ???
 
   override def filterUserVisible[R](
-    resources: List[R],
+    resources: NonEmptyList[R],
     userInfo: UserInfo
   )(implicit sr: SamResource[R], decoder: Decoder[R], ev: ApplicativeAsk[IO, TraceId]): IO[List[R]] = ???
 
   override def filterUserVisibleWithProjectFallback[R](
-    resources: List[(GoogleProject, R)],
+    resources: NonEmptyList[(GoogleProject, R)],
     userInfo: UserInfo
   )(implicit sr: SamResource[R], decoder: Decoder[R], ev: ApplicativeAsk[IO, TraceId]): IO[List[(GoogleProject, R)]] =
     ???


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-2280

I was looking at the prod front Leo logs, and we call Sam a LOT. Basically the UI is polling `listRuntimes`, `listDisks`, and `listApps` for each user logged into Terra, and Leo is making 1-2 Sam calls for each `list*` request it receives. We also log every Sam request/response, and it looks like syslog is getting overwhelmed with the log volume.

This PR makes a few changes:

1. Don't call Sam `getResourcePolicies` if the result from the Leo DB is empty -- just return an empty list. 🤦  I think this should save a lot of Sam calls since many users don't have active runtimes/disks/apps.
2. Don't log every Sam request/response. It seems desirable but most requests just look like `GET https://sam.dsde-prod.broadinstitute.org:443/api/resources/v1/billing-project` so it doesn't really add much value. (We will still log error responses from Sam.)
3. Since we're not logging Sam calls anymore, add an OpenTelemetry counter metric for each type of Sam request (and error). This should hopefully give us some insight into our Sam calls (and may even be better than logging). 

Will test on a fiab tomorrow, would like to try and merge this for next release.

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
