### PR TITLE
[no ticket] Reduce tokenInfo log verbosity

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN mkdir /helm-go-lib-build && \
     cd helm-go-lib && \
     go build -o libhelm.so -buildmode=c-shared main.go
 
-FROM oracle/graalvm-ce:20.2.0-java8
+FROM oracle/graalvm-ce:20.0.0-java8
 
 EXPOSE 8080
 EXPOSE 5050
@@ -34,9 +34,6 @@ RUN curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/master
 RUN helm repo add stable https://kubernetes-charts.storage.googleapis.com/ && \
     helm repo add galaxy https://raw.githubusercontent.com/cloudve/helm-charts/anvil/ && \
     helm repo update
-
-# Fix CVE-2019-12450 and CVE-2017-12652
-RUN yum update -y -q libpng glib2
 
 # Add Leonardo as a service (it will start when the container starts)
 CMD java $JAVA_OPTS -jar $(find /leonardo -name 'leonardo*.jar')

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN mkdir /helm-go-lib-build && \
     cd helm-go-lib && \
     go build -o libhelm.so -buildmode=c-shared main.go
 
-FROM oracle/graalvm-ce:20.0.0-java8
+FROM oracle/graalvm-ce:20.2.0-java8
 
 EXPOSE 8080
 EXPOSE 5050

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN mkdir /helm-go-lib-build && \
     cd helm-go-lib && \
     go build -o libhelm.so -buildmode=c-shared main.go
 
-FROM oracle/graalvm-ce:20.0.0-java8
+FROM oracle/graalvm-ce:20.2.0-java8
 
 EXPOSE 8080
 EXPOSE 5050
@@ -34,6 +34,9 @@ RUN curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/master
 RUN helm repo add stable https://kubernetes-charts.storage.googleapis.com/ && \
     helm repo add galaxy https://raw.githubusercontent.com/cloudve/helm-charts/anvil/ && \
     helm repo update
+
+# Fix CVE-2019-12450 and CVE-2017-12652
+RUN yum update -y -q libpng glib2
 
 # Add Leonardo as a service (it will start when the container starts)
 CMD java $JAVA_OPTS -jar $(find /leonardo -name 'leonardo*.jar')

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -175,6 +175,7 @@ function docker_cmd()
 
         docker build -t "${DEFAULT_IMAGE}:${DOCKER_TAG}" .
 
+        # TODO add --exit-code 1 after after https://broadworkbench.atlassian.net/browse/IA-2291
         echo "scanning docker image..."
         docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v "$HOME"/Library/Caches:/root/.cache/ aquasec/trivy --severity CRITICAL "${DEFAULT_IMAGE}":"${DOCKER_TAG}"
 

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -176,7 +176,7 @@ function docker_cmd()
         docker build -t "${DEFAULT_IMAGE}:${DOCKER_TAG}" .
 
         echo "scanning docker image..."
-        docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v "$HOME"/Library/Caches:/root/.cache/ aquasec/trivy --exit-code 1 --severity CRITICAL "${DEFAULT_IMAGE}":"${DOCKER_TAG}"
+        docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v "$HOME"/Library/Caches:/root/.cache/ aquasec/trivy --severity CRITICAL "${DEFAULT_IMAGE}":"${DOCKER_TAG}"
 
 
         echo "building $TESTS_IMAGE docker image..."

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/LeoRoutes.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/LeoRoutes.scala
@@ -19,14 +19,16 @@ import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
 import org.broadinstitute.dsde.workbench.leonardo.http.api.RouteValidation._
 import org.broadinstitute.dsde.workbench.leonardo.api.CookieSupport
 import org.broadinstitute.dsde.workbench.leonardo.http.service.{CreateRuntimeRequest, LeonardoService}
-import org.broadinstitute.dsde.workbench.leonardo.model.{LeoException}
+import org.broadinstitute.dsde.workbench.leonardo.model.LeoException
 import org.broadinstitute.dsde.workbench.model._
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 
 import scala.concurrent.ExecutionContext
+import scala.util.control.NoStackTrace
 case class AuthenticationError(email: Option[WorkbenchEmail] = None)
     extends LeoException(s"${email.map(e => s"'${e.value}'").getOrElse("Your account")} is not authenticated",
                          StatusCodes.Unauthorized)
+    with NoStackTrace
 
 // TODO: This can probably renamed to legacyRuntimeRoutes
 // Future runtime related APIs should be added to `RuntimeRoutes`

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpSamDAO.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpSamDAO.scala
@@ -429,3 +429,4 @@ final case class UserEmailAndProject(userEmail: WorkbenchEmail, googleProject: G
 final case object NotFoundException extends NoStackTrace
 final case class AuthProviderException(traceId: TraceId, msg: String, code: StatusCode)
     extends LeoException(message = s"${traceId} | AuthProvider error: $msg", statusCode = code)
+    with NoStackTrace


### PR DESCRIPTION
Avoid logging really long stack traces when `tokenInfo` fails

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
