### PR TITLE
Fix for PROD-440: listRuntimes returns 0 runtimes for AoU prod service account

### DIFF
--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/LeoLenses.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/LeoLenses.scala
@@ -9,12 +9,14 @@ import org.broadinstitute.dsde.workbench.leonardo.http.service.{CreateRuntimeRes
 import org.broadinstitute.dsde.workbench.leonardo.monitor.{DiskUpdate, RuntimeConfigInCreateRuntimeMessage}
 import org.broadinstitute.dsde.workbench.leonardo.http.dataprocInCreateRuntimeMsgToDataprocRuntime
 import org.broadinstitute.dsde.workbench.leonardo.http.dataprocRuntimeToDataprocInCreateRuntimeMsg
-import org.broadinstitute.dsde.workbench.model.IP
+import org.broadinstitute.dsde.workbench.model.{IP, WorkbenchEmail}
 
 object LeoLenses {
   val runtimeToRuntimeImages: Lens[Runtime, Set[RuntimeImage]] = GenLens[Runtime](_.runtimeImages)
 
   val runtimeToAuditInfo: Lens[Runtime, AuditInfo] = GenLens[Runtime](_.auditInfo)
+
+  val runtimeToCreator: Lens[Runtime, WorkbenchEmail] = GenLens[Runtime](_.auditInfo.creator)
 
   val runtimeToRuntimeConfigId: Lens[Runtime, RuntimeConfigId] = GenLens[Runtime](_.runtimeConfigId)
 
@@ -90,6 +92,8 @@ object LeoLenses {
 
   val diskToDestroyedDate: Lens[PersistentDisk, Option[Instant]] = GenLens[PersistentDisk](_.auditInfo.destroyedDate)
 
+  val diskToCreator: Lens[PersistentDisk, WorkbenchEmail] = GenLens[PersistentDisk](_.auditInfo.creator)
+
   val runtimeConfigPrism = Prism[RuntimeConfig, RuntimeConfigInCreateRuntimeMessage] {
     case x: RuntimeConfig.GceConfig =>
       Some(
@@ -146,4 +150,6 @@ object LeoLenses {
   }(identity)
 
   val appToServices: Lens[App, List[KubernetesService]] = GenLens[App](_.appResources.services)
+
+  val appToCreator: Lens[App, WorkbenchEmail] = GenLens[App](_.auditInfo.creator)
 }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/DiskServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/DiskServiceInterpSpec.scala
@@ -150,6 +150,27 @@ class DiskServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with Test
     res.unsafeRunSync()
   }
 
+  it should "list disks belonging to other users" in isolatedDbTest {
+    val userInfo = UserInfo(OAuth2BearerToken(""), WorkbenchUserId("userId"), WorkbenchEmail("user1@example.com"), 0) // this email is white listed
+
+    // Make disks belonging to different users than the calling user
+    val res = for {
+      disk1 <- LeoLenses.diskToCreator
+        .set(WorkbenchEmail("a_different_user@example.com"))(makePersistentDisk(Some(DiskName("d1"))))
+        .save()
+      disk2 <- LeoLenses.diskToCreator
+        .set(WorkbenchEmail("a_different_user2@example.com"))(makePersistentDisk(Some(DiskName("d2"))))
+        .save()
+      listResponse <- diskService.listDisks(userInfo, None, Map.empty)
+    } yield {
+      // Since the calling user is whitelisted in the auth provider, it should return
+      // the disks belonging to other users.
+      listResponse.map(_.id).toSet shouldBe Set(disk1.id, disk2.id)
+    }
+
+    res.unsafeRunSync()
+  }
+
   it should "delete a disk" in isolatedDbTest {
     val userInfo = UserInfo(OAuth2BearerToken(""), WorkbenchUserId("userId"), WorkbenchEmail("user1@example.com"), 0) // this email is white listed
 


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/PROD-440

Scala unchecked `.contains()` strikes again. :(

Root cause of this bug was it was doing `samVisibleRuntimes.contains(a)` where `samVisibleRuntimes` is a `Option[List[A]]`. It's optional because it comes from `NonEmptyList.fromList` (introduced in https://github.com/DataBiosphere/leonardo/pull/1651).

This PR fixes the issue for runtimes, disks, and apps and also adds a unit test for each case. I confirmed that each test fails before the fix, and passes after the fix.

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
