### PR TITLE
IA-2422: Recover when detachDisk returns 400 error

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -21,7 +21,7 @@ object Dependencies {
   val workbenchUtilV = "0.5-4c7acd5"
   val workbenchModelV = "0.14-2e155f0"
   val workbenchGoogleV = "0.21-64a7b29"
-  val workbenchGoogle2V = "0.13-39c1b35"
+  val workbenchGoogle2V = "0.13-6f4d8f1"
   val workbenchMetricsV = "0.3-c5b80d2"
   val workbenchOpenTelemetryV = "0.1-e66171c"
   val workbenchErrorReportingV = "0.1-92fcd96"


### PR DESCRIPTION
After updating workbench libs, we updated the deleteRuntime function to check the type of error that pollZoneOperation returns and it will continue if the error status code is 400. It will return an message indicating that the disk is in error, but the deletion should still continue.

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
