### PR TITLE
IA-2232 remove "active-zombie" part of zombie monitor

### DIFF
--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/Boot.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/Boot.scala
@@ -172,9 +172,7 @@ object Boot extends IOApp {
       )
 
       val zombieClusterMonitor =
-        ZombieRuntimeMonitor[IO](zombieRuntimeMonitorConfig,
-                                 googleDependencies.googleProjectDAO,
-                                 googleDependencies.googleDataproc)
+        ZombieRuntimeMonitor[IO](zombieRuntimeMonitorConfig)
 
       val leoKubernetesService: LeoKubernetesServiceInterp[IO] =
         new LeoKubernetesServiceInterp(appDependencies.authProvider,

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ZombieRuntimeMonitorSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ZombieRuntimeMonitorSpec.scala
@@ -4,53 +4,39 @@ package monitor
 import cats.effect.IO
 import cats.effect.concurrent.Deferred
 import cats.mtl.ApplicativeAsk
-import com.google.api.client.googleapis.testing.json.GoogleJsonResponseExceptionFactoryTesting
-import com.google.api.client.testing.json.MockJsonFactory
 import com.google.cloud.compute.v1.{Instance, Operation}
-import com.google.cloud.dataproc.v1.{Cluster, ClusterStatus}
 import fs2.Stream
-import org.broadinstitute.dsde.workbench.google.GoogleProjectDAO
-import org.broadinstitute.dsde.workbench.google.mock.{MockGoogleDataprocDAO, MockGoogleProjectDAO}
-import org.broadinstitute.dsde.workbench.google2.mock.{BaseFakeGoogleDataprocService, FakeGoogleComputeService}
+import org.broadinstitute.dsde.workbench.google.mock.MockGoogleDataprocDAO
+import org.broadinstitute.dsde.workbench.google2.mock.FakeGoogleComputeService
 import org.broadinstitute.dsde.workbench.google2.{
-  DataprocClusterName,
   GoogleComputeService,
-  GoogleDataprocService,
   GoogleDiskService,
   InstanceName,
   MachineTypeName,
   MockGoogleDiskService,
-  RegionName,
   ZoneName
 }
-import org.broadinstitute.dsde.workbench.leonardo.TestUtils.clusterEq
 import org.broadinstitute.dsde.workbench.leonardo.CommonTestData._
+import org.broadinstitute.dsde.workbench.leonardo.TestUtils.clusterEq
 import org.broadinstitute.dsde.workbench.leonardo.config.Config
-import org.broadinstitute.dsde.workbench.leonardo.http.dbioToIO
 import org.broadinstitute.dsde.workbench.leonardo.config.Config.{dataprocInterpreterConfig, gceInterpreterConfig}
 import org.broadinstitute.dsde.workbench.leonardo.dao.google.GoogleDataprocDAO
 import org.broadinstitute.dsde.workbench.leonardo.db.{clusterQuery, TestComponent}
 import org.broadinstitute.dsde.workbench.leonardo.util.{
   DataprocInterpreter,
   GceInterpreter,
-  GetRuntimeStatusParams,
   RuntimeAlgebra,
   RuntimeInstances
 }
 import org.broadinstitute.dsde.workbench.model.TraceId
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
-import org.mockito.Mockito.verify
+import org.scalatest.BeforeAndAfterAll
 import org.scalatest.concurrent.Eventually.eventually
+import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.time.{Seconds, Span}
 import org.scalatestplus.mockito.MockitoSugar
-import org.mockito.Mockito._
-import org.mockito.ArgumentMatchers.{eq => mockitoEq}
-import org.scalatest.BeforeAndAfterAll
 
 import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
-import scala.concurrent.duration._
-import org.scalatest.flatspec.AnyFlatSpec
 
 class ZombieRuntimeMonitorSpec
     extends AnyFlatSpec
@@ -74,253 +60,6 @@ class ZombieRuntimeMonitorSpec
     auditInfo = olderRuntimeAuditInfo,
     labels = Map(Config.zombieRuntimeMonitorConfig.deletionConfirmationLabelKey -> "false")
   )
-
-  it should "detect zombie clusters when the project is inactive" in isolatedDbTest {
-    // create 2 running clusters in the same project
-    val savedTestCluster1 = testCluster1.save()
-    savedTestCluster1.copy(runtimeConfigId = RuntimeConfigId(-1)) shouldEqual testCluster1
-
-    val savedTestCluster2 = testCluster2.save()
-    savedTestCluster2.copy(runtimeConfigId = RuntimeConfigId(-1)) shouldEqual testCluster2
-
-    // stub GoogleProjectDAO to make the project inactive
-    val googleProjectDAO = new MockGoogleProjectDAO {
-      override def isProjectActive(projectName: String): Future[Boolean] = Future.successful(false)
-    }
-
-    // zombie actor should flag both clusters as inactive
-    withZombieMonitor(googleProjectDAO = googleProjectDAO) { () =>
-      eventually(timeout(Span(10, Seconds))) {
-        val c1 = dbFutureValue(clusterQuery.getClusterById(savedTestCluster1.id)).get
-        val c2 = dbFutureValue(clusterQuery.getClusterById(savedTestCluster2.id)).get
-
-        List(c1, c2).foreach { c =>
-          c.status shouldBe RuntimeStatus.Deleted
-          c.auditInfo.destroyedDate shouldBe 'defined
-          c.errors.size shouldBe 1
-          c.errors.head.errorCode shouldBe None
-          c.errors.head.errorMessage should include("An underlying resource was removed in Google")
-        }
-      }
-    }
-  }
-
-  it should "detect zombie clusters when we get a 403 from google" in isolatedDbTest {
-    // create a running cluster
-    val savedTestCluster1 = testCluster1.save()
-    savedTestCluster1.copy(runtimeConfigId = RuntimeConfigId(-1)) shouldEqual testCluster1
-
-    // stub GoogleProjectDAO to make the project throw an error
-    val googleProjectDAO = new MockGoogleProjectDAO {
-      val jsonFactory = new MockJsonFactory
-      val testException = GoogleJsonResponseExceptionFactoryTesting.newMock(jsonFactory, 403, "you shall not pass")
-
-      override def isProjectActive(projectName: String): Future[Boolean] =
-        Future.failed(testException)
-    }
-
-    // zombie actor should flag the cluster as inactive
-    withZombieMonitor(googleProjectDAO = googleProjectDAO) { () =>
-      eventually(timeout(Span(10, Seconds))) {
-        val c1 = dbFutureValue(clusterQuery.getClusterById(savedTestCluster1.id)).get
-
-        c1.status shouldBe RuntimeStatus.Deleted
-        c1.auditInfo.destroyedDate shouldBe 'defined
-        c1.errors.size shouldBe 1
-        c1.errors.head.errorCode shouldBe None
-        c1.errors.head.errorMessage should include("An underlying resource was removed in Google")
-      }
-    }
-  }
-
-  it should "detect zombie clusters when the project's billing is inactive" in isolatedDbTest {
-    // create 2 running clusters in the same project
-    val savedTestCluster1 = testCluster1.save()
-    savedTestCluster1.copy(runtimeConfigId = RuntimeConfigId(-1)) shouldEqual testCluster1
-
-    val savedTestCluster2 = testCluster2.save()
-    savedTestCluster2.copy(runtimeConfigId = RuntimeConfigId(-1)) shouldEqual testCluster2
-
-    // stub GoogleProjectDAO to make the project inactive
-    val googleProjectDAO = new MockGoogleProjectDAO {
-      override def isBillingActive(projectName: String): Future[Boolean] = Future.successful(false)
-    }
-
-    // zombie actor should flag both clusters as inactive
-    withZombieMonitor(googleProjectDAO = googleProjectDAO) { () =>
-      eventually(timeout(Span(10, Seconds))) {
-        val c1 = dbFutureValue(clusterQuery.getClusterById(savedTestCluster1.id)).get
-        val c2 = dbFutureValue(clusterQuery.getClusterById(savedTestCluster2.id)).get
-
-        List(c1, c2).foreach { c =>
-          c.status shouldBe RuntimeStatus.Deleted
-          c.auditInfo.destroyedDate shouldBe 'defined
-          c.errors.size shouldBe 1
-          c.errors.head.errorCode shouldBe None
-          c.errors.head.errorMessage should include("An underlying resource was removed in Google")
-        }
-      }
-    }
-  }
-
-  it should "delete a dataproc cluster if it's in ERROR state in GCP" in isolatedDbTest {
-    val savedTestCluster1 = testCluster1.saveWithRuntimeConfig(defaultDataprocRuntimeConfig)
-
-    // stub GoogleProjectDAO to make the project inactive
-    val googleProjectDAO = new MockGoogleProjectDAO {
-      override def isBillingActive(projectName: String): Future[Boolean] = Future.successful(true)
-    }
-
-    val dataprocInterp = new BaseFakeDataproInterp {
-      override def getRuntimeStatus(
-        params: GetRuntimeStatusParams
-      )(implicit ev: ApplicativeAsk[IO, TraceId]): IO[RuntimeStatus] =
-        IO(println("getting runtime status 2222")).flatMap(_ => IO.pure(RuntimeStatus.Error))
-    }
-
-    val dataprocService = new BaseFakeGoogleDataprocService {
-      override def getCluster(project: GoogleProject, region: RegionName, clusterName: DataprocClusterName)(
-        implicit ev: ApplicativeAsk[IO, TraceId]
-      ): IO[Option[Cluster]] = {
-        val cluster =
-          Cluster.newBuilder().setStatus(ClusterStatus.newBuilder().setDetail("error happened").build()).build()
-        IO.pure(Some(cluster))
-      }
-    }
-    // zombie actor should flag both clusters as inactive
-    withZombieMonitor(googleProjectDAO = googleProjectDAO,
-                      dataprocInterp = Some(dataprocInterp),
-                      dataprocService = dataprocService) { () =>
-      eventually(timeout(Span(10, Seconds))) {
-        val c = clusterQuery.getClusterById(savedTestCluster1.id).transaction.unsafeRunSync().get
-        c.status shouldBe RuntimeStatus.Error
-        c.errors.head.errorMessage shouldBe
-          """
-            |Unrecoverable ERROR state for Spark Cloud Environment: error happened
-            |
-            |Please Delete and Recreate your Cloud environment. If you have important data you’d like to retrieve 
-            |from your Cloud environment prior to deleting, try to access the machine via notebook or terminal. 
-            |If you can't connect to the cluster, please contact customer support and we can help you move your data.
-            |""".stripMargin
-      }
-    }
-  }
-
-  it should "detect active zombie dataproc cluster" in isolatedDbTest {
-    // create 2 running clusters in the same project
-    val savedTestCluster1 = testCluster1.save()
-    savedTestCluster1.copy(runtimeConfigId = RuntimeConfigId(-1)) shouldEqual testCluster1
-
-    val savedTestCluster2 = testCluster2.save()
-    savedTestCluster2.copy(runtimeConfigId = RuntimeConfigId(-1)) shouldEqual testCluster2
-
-    // stub GoogleDataprocDAO to flag cluster2 as deleted
-    val gdDAO = new MockGoogleDataprocDAO {
-      override def getClusterStatus(googleProject: GoogleProject,
-                                    clusterName: RuntimeName): Future[Option[DataprocClusterStatus]] =
-        Future.successful {
-          if (clusterName == savedTestCluster2.runtimeName) {
-            None
-          } else {
-            Some(DataprocClusterStatus.Running)
-          }
-        }
-    }
-
-    // c2 should be flagged as a zombie but not c1
-    withZombieMonitor(gdDAO = gdDAO) { () =>
-      eventually(timeout(Span(10, Seconds))) {
-        val c1 = dbFutureValue(clusterQuery.getClusterById(savedTestCluster1.id)).get
-        val c2 = dbFutureValue(clusterQuery.getClusterById(savedTestCluster2.id)).get
-
-        c2.status shouldBe RuntimeStatus.Deleted
-        c2.auditInfo.destroyedDate shouldBe 'defined
-        c2.labels.get(Config.zombieRuntimeMonitorConfig.deletionConfirmationLabelKey) shouldBe Some("false")
-        c2.errors.size shouldBe 1
-        c2.errors.head.errorCode shouldBe None
-        c2.errors.head.errorMessage should include("An underlying resource was removed in Google")
-
-        c1.status shouldBe RuntimeStatus.Running
-        c1.errors shouldBe 'empty
-      }
-    }
-  }
-
-  it should "detect inactive zombie dataproc cluster" ignore isolatedDbTest {
-    // create 2 running clusters in the same project
-    val savedDeletedRuntime1 = deletedRuntime1.save()
-    savedDeletedRuntime1.copy(runtimeConfigId = RuntimeConfigId(-1)) shouldEqual deletedRuntime1
-
-    val savedDeletedRuntime2 = deletedRuntime2.save()
-    savedDeletedRuntime2.copy(runtimeConfigId = RuntimeConfigId(-1)) shouldEqual deletedRuntime2
-
-    // stub GoogleDataprocDAO to flag deletedRuntime2 as running
-    val gdDAO = mock[GoogleDataprocDAO]
-    when {
-      gdDAO.getClusterStatus(mockitoEq(deletedRuntime1.googleProject),
-                             RuntimeName(mockitoEq(deletedRuntime1.runtimeName.asString)))
-    } thenReturn {
-      Future.successful(None)
-    }
-
-    when {
-      gdDAO.getClusterStatus(mockitoEq(deletedRuntime2.googleProject),
-                             RuntimeName(mockitoEq(deletedRuntime2.runtimeName.asString)))
-    } thenReturn {
-      Future.successful(Some(DataprocClusterStatus.Running))
-    }
-
-    when {
-      gdDAO.deleteCluster(mockitoEq(deletedRuntime2.googleProject),
-                          RuntimeName(mockitoEq(deletedRuntime2.runtimeName.asString)))
-    } thenReturn {
-      Future.unit
-    }
-
-    // c2 should be flagged as a zombie but not c1
-    withZombieMonitor(gdDAO = gdDAO) { () =>
-      eventually(timeout(Span(10, Seconds))) {
-        val c1 = dbFutureValue(clusterQuery.getClusterById(savedDeletedRuntime1.id)).get
-        val c2 = dbFutureValue(clusterQuery.getClusterById(savedDeletedRuntime2.id)).get
-
-        c1.labels.get(Config.zombieRuntimeMonitorConfig.deletionConfirmationLabelKey) shouldBe Some("true")
-        c2.labels.get(Config.zombieRuntimeMonitorConfig.deletionConfirmationLabelKey) shouldBe Some("false")
-      }
-      verify(gdDAO, times(1)).deleteCluster(mockitoEq(deletedRuntime2.googleProject),
-                                            RuntimeName(mockitoEq(deletedRuntime2.runtimeName.asString)))
-    }
-  }
-
-  it should "detect active zombie gce instance" in isolatedDbTest {
-    val runtimeConfig = RuntimeConfig.GceConfig(
-      MachineTypeName("n1-standard-4"),
-      DiskSize(50),
-      bootDiskSize = Some(DiskSize(50))
-    )
-    val savedTestRuntime = testCluster1.saveWithRuntimeConfig(runtimeConfig)
-    savedTestRuntime.copy(runtimeConfigId = RuntimeConfigId(-1)) shouldEqual testCluster1
-
-    // stub GoogleComputeService to flag runtime as deleted
-    val gce = new FakeGoogleComputeService {
-      override def getInstance(project: GoogleProject, zone: ZoneName, instanceName: InstanceName)(
-        implicit ev: ApplicativeAsk[IO, TraceId]
-      ): IO[Option[Instance]] =
-        IO.pure(None)
-    }
-
-    withZombieMonitor(gce = gce) { () =>
-      eventually(timeout(Span(10, Seconds))) {
-        val c1 = dbFutureValue(clusterQuery.getClusterById(savedTestRuntime.id)).get
-
-        c1.status shouldBe RuntimeStatus.Deleted
-        c1.auditInfo.destroyedDate shouldBe 'defined
-        c1.labels.get(Config.zombieRuntimeMonitorConfig.deletionConfirmationLabelKey) shouldBe Some("false")
-        c1.errors.size shouldBe 1
-        c1.errors.head.errorCode shouldBe None
-        c1.errors.head.errorMessage should include("An underlying resource was removed in Google")
-      }
-    }
-  }
 
   it should "detect inactive zombie gce instance" in isolatedDbTest {
     // create a running gce instance
@@ -365,137 +104,11 @@ class ZombieRuntimeMonitorSpec
     }
   }
 
-  it should "zombify creating cluster after hang period" in isolatedDbTest {
-    // create a Running and a Creating cluster in the same project
-    val savedTestCluster1 = testCluster1.save()
-    savedTestCluster1.copy(runtimeConfigId = RuntimeConfigId(-1)) shouldEqual testCluster1
-
-    val creatingTestCluster = testCluster2.copy(status = RuntimeStatus.Creating)
-    val savedTestCluster2 = creatingTestCluster.save()
-    savedTestCluster2.copy(runtimeConfigId = RuntimeConfigId(-1)) shouldEqual creatingTestCluster
-
-    // stub GoogleDataprocDAO to flag both clusters as deleted
-    val gdDAO = new MockGoogleDataprocDAO {
-      override def getClusterStatus(googleProject: GoogleProject,
-                                    clusterName: RuntimeName): Future[Option[DataprocClusterStatus]] =
-        Future.successful(None)
-    }
-
-    val shouldHangAfter: Span =
-      Config.zombieRuntimeMonitorConfig.creationHangTolerance.plus(Config.zombieRuntimeMonitorConfig.zombieCheckPeriod)
-
-    // cluster2 should be active when it's still within hang tolerance
-    withZombieMonitor(gdDAO = gdDAO) { () =>
-      eventually(timeout(3 seconds)) { //This timeout can be anything smaller than hang tolerance
-        val c2 = dbFutureValue(clusterQuery.getClusterById(savedTestCluster2.id)).get
-
-        c2.status shouldBe RuntimeStatus.Creating
-        c2.auditInfo.destroyedDate shouldBe None
-      }
-    }
-
-    // the Running cluster should be a zombie but the Creating one shouldn't
-    withZombieMonitor(gdDAO = gdDAO) { () =>
-      eventually(timeout(shouldHangAfter)) {
-        val c1 = dbFutureValue(clusterQuery.getClusterById(savedTestCluster1.id)).get
-        val c2 = dbFutureValue(clusterQuery.getClusterById(savedTestCluster2.id)).get
-
-        c1.status shouldBe RuntimeStatus.Deleted
-        c1.auditInfo.destroyedDate shouldBe 'defined
-        c1.errors.size shouldBe 1
-        c1.errors.head.errorCode shouldBe None
-        c1.errors.head.errorMessage should include("An underlying resource was removed in Google")
-
-        c2.status shouldBe RuntimeStatus.Deleted
-        c2.auditInfo.destroyedDate shouldBe 'defined
-        c2.errors.size shouldBe 1
-        c2.errors.head.errorCode shouldBe None
-        c2.errors.head.errorMessage should include("An underlying resource was removed in Google")
-      }
-    }
-  }
-
-  it should "not zombify cluster before hang period" in isolatedDbTest {
-    val creatingTestCluster = testCluster2.copy(status = RuntimeStatus.Creating)
-    val savedTestCluster2 = creatingTestCluster.save()
-    savedTestCluster2.copy(runtimeConfigId = RuntimeConfigId(-1)) shouldEqual creatingTestCluster
-
-    val shouldNotHangBefore =
-      Config.zombieRuntimeMonitorConfig.creationHangTolerance.minus(Config.zombieRuntimeMonitorConfig.zombieCheckPeriod)
-    // stub GoogleDataprocDAO to flag both clusters as deleted
-    val gdDAO = new MockGoogleDataprocDAO {
-      override def getClusterStatus(googleProject: GoogleProject,
-                                    clusterName: RuntimeName): Future[Option[DataprocClusterStatus]] =
-        Future.successful(None)
-    }
-
-    // the Running cluster should be a zombie but the Creating one shouldn't
-    withZombieMonitor(gdDAO = gdDAO) { () =>
-      Thread.sleep(shouldNotHangBefore.toSeconds)
-      val c1 = dbFutureValue(clusterQuery.getClusterById(savedTestCluster2.id)).get
-      c1.status shouldBe RuntimeStatus.Creating
-      c1.errors.size shouldBe 0
-    }
-  }
-
-  it should "not zombify upon non-403 errors from Google" in isolatedDbTest {
-    // running cluster in "bad" project - should not get zombified
-    val clusterBadProject = testCluster1.copy(googleProject = GoogleProject("bad-project"))
-    val savedClusterBadProject = clusterBadProject.save()
-    savedClusterBadProject.copy(runtimeConfigId = RuntimeConfigId(-1)) shouldEqual clusterBadProject
-
-    // running "bad" cluster - should not get zombified
-    val badCluster = testCluster2.copy(runtimeName = RuntimeName("bad-cluster"))
-    val savedBadCluster = badCluster.save()
-    savedBadCluster.copy(runtimeConfigId = RuntimeConfigId(-1)) shouldEqual badCluster
-
-    // running "good" cluster - should get zombified
-    val goodCluster = testCluster3.copy(runtimeName = RuntimeName("good-cluster"))
-    val savedGoodCluster = goodCluster.save()
-    savedGoodCluster.copy(runtimeConfigId = RuntimeConfigId(-1)) shouldEqual goodCluster
-
-    // stub GoogleDataprocDAO to return an error for the bad cluster
-    val gdDAO = new MockGoogleDataprocDAO {
-      override def getClusterStatus(googleProject: GoogleProject,
-                                    clusterName: RuntimeName): Future[Option[DataprocClusterStatus]] =
-        if (googleProject == clusterBadProject.googleProject && clusterName == clusterBadProject.runtimeName) {
-          Future.successful(Some(DataprocClusterStatus.Running))
-        } else if (googleProject == badCluster.googleProject && clusterName == badCluster.runtimeName) {
-          Future.failed(new Exception("boom"))
-        } else {
-          Future.successful(None)
-        }
-    }
-
-    // only the "good" cluster should be zombified
-    withZombieMonitor(gdDAO = gdDAO) { () =>
-      eventually(timeout(Span(10, Seconds))) {
-        val c1 = dbFutureValue(clusterQuery.getClusterById(savedClusterBadProject.id)).get
-        val c2 = dbFutureValue(clusterQuery.getClusterById(savedBadCluster.id)).get
-        val c3 = dbFutureValue(clusterQuery.getClusterById(savedGoodCluster.id)).get
-
-        c1.status shouldBe RuntimeStatus.Running
-        c1.errors shouldBe 'empty
-
-        c2.status shouldBe RuntimeStatus.Running
-        c2.errors shouldBe 'empty
-
-        c3.status shouldBe RuntimeStatus.Deleted
-        c3.auditInfo.destroyedDate shouldBe 'defined
-        c3.errors.size shouldBe 1
-        c3.errors.head.errorCode shouldBe None
-        c3.errors.head.errorMessage should include("An underlying resource was removed in Google")
-      }
-    }
-  }
-
   private def withZombieMonitor[A](
     gdDAO: GoogleDataprocDAO = new MockGoogleDataprocDAO,
     gce: GoogleComputeService[IO] = new FakeGoogleComputeService,
     disk: GoogleDiskService[IO] = new MockGoogleDiskService,
-    googleProjectDAO: GoogleProjectDAO = new MockGoogleProjectDAO,
-    dataprocInterp: Option[RuntimeAlgebra[IO]] = None,
-    dataprocService: GoogleDataprocService[IO] = new BaseFakeGoogleDataprocService()
+    dataprocInterp: Option[RuntimeAlgebra[IO]] = None
   )(validations: () => A): A = {
     val dataproc = dataprocInterp.getOrElse(
       new DataprocInterpreter[IO](dataprocInterpreterConfig,
@@ -515,7 +128,7 @@ class ZombieRuntimeMonitorSpec
 
     implicit val runtimeInstances = new RuntimeInstances[IO](dataproc, gceInterp)
     val zombieClusterMonitor =
-      ZombieRuntimeMonitor[IO](Config.zombieRuntimeMonitorConfig, googleProjectDAO, dataprocService)
+      ZombieRuntimeMonitor[IO](Config.zombieRuntimeMonitorConfig)
     val process = Stream.eval(Deferred[IO, A]).flatMap { signalToStop =>
       val signal = Stream.eval(IO(validations())).evalMap(r => signalToStop.complete(r))
       val p = Stream(zombieClusterMonitor.process.interruptWhen(signalToStop.get.attempt.map(_.map(_ => ()))), signal)


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-2232

The removed part of the code is mostly covered by zombie-monitor-cron-job now, there're a few differences between this code vs what's in cron job today
1. Leo's zombie monitor sends metrics to SD. https://github.com/broadinstitute/leonardo-cron-jobs/pull/24 should address this
2. Leo's zombie monitor adds a row in CLUSTER_ERROR table to indicate that a runtime was removed in Google. Cron job today doesn't do that, it'll be covered by https://github.com/broadinstitute/leonardo-cron-jobs/pull/22

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
