### PR TITLE
[IA-2279] Latest rstudio rocker versions don't launch

### DIFF
--- a/http/src/main/resources/init-resources/cluster-site.conf
+++ b/http/src/main/resources/init-resources/cluster-site.conf
@@ -29,9 +29,10 @@
     # Include a ProxyPassReverse so redirects by RStudio go to the correct server name (e.g. https://notebooks.firecloud.org)
     ProxyPassReverse /proxy/${GOOGLE_PROJECT}/${RUNTIME_NAME}/rstudio/ http://127.0.0.1:8001/
 
-    # Append SameSite=None to cookies set by RStudio. This is needed because we render RStudio in an iframe.
-    # There does not appear to be a way within RStudio to do this.
-    Header edit Set-Cookie ^(.*)$ $1;Secure;SameSite=None "expr=%{REQUEST_URI} ~ m#^/proxy/[^/]*/[^/]*/rstudio/.*#"
+    # Append SameSite=None to cookies set by RStudio. This is required by some browsers because we
+    # render RStudio in an iframe. There does not appear to be a way within RStudio to do this, hence
+    # doing it in the proxy.
+    Header edit Set-Cookie ^(.*)$ $1;Secure;SameSite=None "expr=%{REQUEST_URI} =~ m#/proxy/[^/]*/[^/]*/rstudio/.*#"
 
     ####################
     # Welder

--- a/http/src/main/resources/init-resources/cluster-site.conf
+++ b/http/src/main/resources/init-resources/cluster-site.conf
@@ -15,8 +15,9 @@
 
     RewriteEngine on
 
+    ################
     # RStudio
-
+    ################
     RewriteCond %{HTTP:Upgrade} =websocket
     RewriteCond %{REQUEST_URI} /proxy/[^/]*/[^/]*/rstudio/.* [NC]
     RewriteRule /proxy/[^/]*/[^/]*/rstudio/(.*) ws://127.0.0.1:8001/$1  [P,L]
@@ -28,12 +29,20 @@
     # Include a ProxyPassReverse so redirects by RStudio go to the correct server name (e.g. https://notebooks.firecloud.org)
     ProxyPassReverse /proxy/${GOOGLE_PROJECT}/${RUNTIME_NAME}/rstudio/ http://127.0.0.1:8001/
 
+    # Append SameSite=None to cookies set by RStudio. This is needed because we render RStudio in an iframe.
+    # There does not appear to be a way within RStudio to do this.
+    Header edit Set-Cookie ^(.*)$ $1;Secure;SameSite=None "expr=%{REQUEST_URI} ~ m#^/proxy/[^/]*/[^/]*/rstudio/.*#"
+
+    ####################
     # Welder
+    ####################
 
     RewriteCond %{REQUEST_URI} /proxy/[^/]*/[^/]*/welder/.* [NC]
     RewriteRule /proxy/[^/]*/[^/]*/welder/(.*) http://127.0.0.1:8080/$1 [P,L]
 
+    #####################################
     # Jupyter (legacy /notebooks path)
+    #####################################
 
     RewriteCond %{HTTP:Upgrade} =websocket
     RewriteCond %{REQUEST_URI} /notebooks/[^/]*/[^/]*/.* [NC]
@@ -45,7 +54,9 @@
 
     # Note Jupyter doesn't need ProxyPassReverse because the redirect URL is configured in jupyter_notebook_config.py
 
+    ################################
     # Jupyter (newer /proxy path)
+    ################################
 
     # This needs to be coordinated with a change in jupyter_notebooks_config.py
     # which is why we haven't yet enabled this.


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-2279

The root problem seems to be due to missing`SameSite=None` on RStudio cookies. RStudio sets some cookies to disable auth; without `SameSite=None` the browser rejects them (because RStudio is rendered within an iframe) causing it to go into an infinite-redirect loop and not load.

Originally I tried fixing this via an RStudio setting (https://github.com/anvilproject/anvil-docker/pull/18) but it didn't actually work, so doing this in the Apache proxy instead.

I tested the regular image (`us.gcr.io/anvil-gcr-public/anvil-rstudio-bioconductor:0.0.6`) and Nitesh's image based on the latest rocker version (`nitesh1989/anvil-rstudio-base:tidyverse_4.0.2`) and both loaded (the latter doesn't work without this change).

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
