### PR TITLE
IA-2066: Adding Trace Id to Leonardo routes header

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoApiClient.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoApiClient.scala
@@ -92,7 +92,7 @@ object LeonardoApiClient {
       .status(
         Request[IO](
           method = Method.POST,
-          headers = Headers.of(authHeader, defaultMediaType),
+          headers = Headers.of(authHeader, defaultMediaType, ),
           uri = rootUri.withPath(s"/api/google/v1/runtimes/${googleProject.value}/${runtimeName.asString}"),
           body = createRuntime2Request
         )
@@ -447,6 +447,9 @@ object LeonardoApiClient {
         else
           IO.unit
       }
+
+  private def genTraceIdHeader(): IO[Header] =
+    IO(UUID.randomUUID().toString).map(uuid => Header(traceIdHeaderString, uuid))
 }
 
 final case class RestError(message: String, statusCode: Status, body: Option[String]) extends NoStackTrace {

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookGCECustomizationSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookGCECustomizationSpec.scala
@@ -79,7 +79,9 @@ final class NotebookGCECustomizationSpec extends GPAllocFixtureSpec with Paralle
               withNewNotebook(runtime, Python3) { notebookPage =>
                 // Check the extensions were installed
                 val nbExt = notebookPage.executeCell("! jupyter nbextension list")
+
                 nbExt.get should include("jupyter-iframe-extension/main  enabled")
+
                 nbExt.get should include("translate_nbextension/main  enabled")
                 // should be installed by default
                 nbExt.get should include("toc2/main  enabled")

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeStatusTransitionsSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeStatusTransitionsSpec.scala
@@ -13,8 +13,12 @@ import org.scalatest.{DoNotDiscover, ParallelTestExecution}
  * Note these tests can take a long time so we don't test all edge cases, but these cases
  * should exercise the most commonly used paths through the system.
  */
-@DoNotDiscover
-class RuntimeStatusTransitionsSpec extends GPAllocFixtureSpec with ParallelTestExecution with LeonardoTestUtils {
+//@DoNotDiscover
+class RuntimeStatusTransitionsSpec
+    extends GPAllocFixtureSpec
+    with ParallelTestExecution
+    with LeonardoTestUtils
+    with GPAllocBeforeAndAfterAll {
 
   // these tests just hit the Leo APIs; they don't interact with notebooks via selenium
   "RuntimeStatusTransitionsSpec" - {

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeStatusTransitionsSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeStatusTransitionsSpec.scala
@@ -13,12 +13,8 @@ import org.scalatest.{DoNotDiscover, ParallelTestExecution}
  * Note these tests can take a long time so we don't test all edge cases, but these cases
  * should exercise the most commonly used paths through the system.
  */
-//@DoNotDiscover
-class RuntimeStatusTransitionsSpec
-    extends GPAllocFixtureSpec
-    with ParallelTestExecution
-    with LeonardoTestUtils
-    with GPAllocBeforeAndAfterAll {
+@DoNotDiscover
+class RuntimeStatusTransitionsSpec extends GPAllocFixtureSpec with ParallelTestExecution with LeonardoTestUtils {
 
   // these tests just hit the Leo APIs; they don't interact with notebooks via selenium
   "RuntimeStatusTransitionsSpec" - {

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/models.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/models.scala
@@ -29,12 +29,4 @@ object AppContext {
       context
     )
 
-  def withTraceId[F[_]: Sync: Timer](
-    span: Option[Span] = None
-  )(implicit traceId: TraceId): F[ApplicativeAsk[F, AppContext]] =
-    for {
-      now <- nowInstant[F]
-    } yield ApplicativeAsk.const[F, AppContext](
-      AppContext(traceId, now, span)
-    )
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/models.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/models.scala
@@ -28,4 +28,13 @@ object AppContext {
     } yield ApplicativeAsk.const[F, AppContext](
       context
     )
+
+  def withTraceId[F[_]: Sync: Timer](
+    span: Option[Span] = None
+  )(implicit traceId: TraceId): F[ApplicativeAsk[F, AppContext]] =
+    for {
+      now <- nowInstant[F]
+    } yield ApplicativeAsk.const[F, AppContext](
+      AppContext(traceId, now, span)
+    )
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/package.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/package.scala
@@ -12,7 +12,8 @@ import org.broadinstitute.dsde.workbench.model.TraceId
 package object leonardo {
   type LabelMap = Map[String, String]
   //this value is the default for autopause, if none is specified. An autopauseThreshold of 0 indicates no autopause
-  final val autoPauseOffValue = 0
+  val autoPauseOffValue = 0
+  val traceIdHeaderString = "X-Cloud-Trace-Context"
 
   // convenience to get now as a F[Instant] using a Timer
   def nowInstant[F[_]: Timer: Functor]: F[Instant] =

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/AppRoutes.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/AppRoutes.scala
@@ -7,7 +7,7 @@ import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.server
 import JsonCodec._
 import akka.http.scaladsl.server.Directives.pathEndOrSingleSlash
-import cats.effect.{IO, Timer}
+import cats.effect.IO
 import cats.mtl.ApplicativeAsk
 import org.broadinstitute.dsde.workbench.leonardo.api.CookieSupport
 import org.broadinstitute.dsde.workbench.model.UserInfo

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/AppRoutes.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/AppRoutes.scala
@@ -18,154 +18,156 @@ import org.broadinstitute.dsde.workbench.leonardo.http.api.AppRoutes._
 import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
 import org.broadinstitute.dsde.workbench.google2.KubernetesSerializableName.ServiceName
 import org.broadinstitute.dsde.workbench.leonardo.service.KubernetesService
+import io.opencensus.scala.akka.http.TracingDirective.traceRequestForService
 
-class AppRoutes(kubernetesService: KubernetesService[IO], userInfoDirectives: UserInfoDirectives)(
-  implicit timer: Timer[IO]
-) {
+class AppRoutes(kubernetesService: KubernetesService[IO], userInfoDirectives: UserInfoDirectives) {
 
-  val routes: server.Route = userInfoDirectives.requireUserInfo { userInfo =>
-    CookieSupport.setTokenCookie(userInfo, CookieSupport.tokenCookieName) {
-      pathPrefix("google" / "v1" / "apps") {
-        pathEndOrSingleSlash {
-          parameterMap { params =>
-            get {
-              complete(
-                listAppHandler(userInfo, None, params)
-              )
-            }
-          }
-        } ~
-          pathPrefix(googleProjectSegment) { googleProject =>
+  val routes: server.Route = traceRequestForService(serviceData) { span =>
+    extractAppContext(Some(span)) { implicit ctx =>
+      userInfoDirectives.requireUserInfo { userInfo =>
+        CookieSupport.setTokenCookie(userInfo, CookieSupport.tokenCookieName) {
+          pathPrefix("google" / "v1" / "apps") {
             pathEndOrSingleSlash {
               parameterMap { params =>
                 get {
                   complete(
-                    listAppHandler(
-                      userInfo,
-                      Some(googleProject),
-                      params
-                    )
+                    listAppHandler(userInfo, None, params)
                   )
                 }
               }
             } ~
-              path("batchNodepoolCreate") {
+              pathPrefix(googleProjectSegment) { googleProject =>
                 pathEndOrSingleSlash {
-                  post {
-                    entity(as[BatchNodepoolCreateRequest]) { req =>
+                  parameterMap { params =>
+                    get {
                       complete(
-                        batchNodepoolCreateHandler(userInfo, googleProject, req)
+                        listAppHandler(
+                          userInfo,
+                          Some(googleProject),
+                          params
+                        )
                       )
                     }
                   }
-                }
-              } ~
-              pathPrefix(Segment) { appNameString =>
-                RouteValidation.validateNameDirective(appNameString, AppName.apply) { appName =>
-                  pathEndOrSingleSlash {
-                    post {
-                      entity(as[CreateAppRequest]) { req =>
-                        complete(
-                          createAppHandler(userInfo, googleProject, appName, req)
-                        )
-                      }
-                    } ~
-                      get {
-                        complete(
-                          getAppHandler(
-                            userInfo,
-                            googleProject,
-                            appName
-                          )
-                        )
-                      } ~
-                      delete {
-                        parameterMap { params =>
+                } ~
+                  path("batchNodepoolCreate") {
+                    pathEndOrSingleSlash {
+                      post {
+                        entity(as[BatchNodepoolCreateRequest]) { req =>
                           complete(
-                            deleteAppHandler(
-                              userInfo,
-                              googleProject,
-                              appName,
-                              params
-                            )
+                            batchNodepoolCreateHandler(userInfo, googleProject, req)
                           )
                         }
                       }
+                    }
+                  } ~
+                  pathPrefix(Segment) { appNameString =>
+                    RouteValidation.validateNameDirective(appNameString, AppName.apply) { appName =>
+                      pathEndOrSingleSlash {
+                        post {
+                          entity(as[CreateAppRequest]) { req =>
+                            complete(
+                              createAppHandler(userInfo, googleProject, appName, req)
+                            )
+                          }
+                        } ~
+                          get {
+                            complete(
+                              getAppHandler(
+                                userInfo,
+                                googleProject,
+                                appName
+                              )
+                            )
+                          } ~
+                          delete {
+                            parameterMap { params =>
+                              complete(
+                                deleteAppHandler(
+                                  userInfo,
+                                  googleProject,
+                                  appName,
+                                  params
+                                )
+                              )
+                            }
+                          }
+                      }
+                    }
                   }
-                }
               }
           }
+        }
       }
     }
   }
-
   private[api] def batchNodepoolCreateHandler(userInfo: UserInfo,
                                               googleProject: GoogleProject,
-                                              req: BatchNodepoolCreateRequest): IO[ToResponseMarshallable] =
+                                              req: BatchNodepoolCreateRequest)(
+    implicit ev: ApplicativeAsk[IO, AppContext]
+  ): IO[ToResponseMarshallable] =
     for {
-      context <- AppContext.generate[IO]()
-      implicit0(ctx: ApplicativeAsk[IO, AppContext]) = ApplicativeAsk.const[IO, AppContext](
-        context
-      )
-      _ <- kubernetesService.batchNodepoolCreate(userInfo, googleProject, req)
+      ctx <- ev.ask
+      apiCall = kubernetesService.batchNodepoolCreate(userInfo, googleProject, req)
+      _ <- ctx.span.fold(apiCall)(span => spanResource[IO](span, "batchNodepoolCreate").use(_ => apiCall))
     } yield StatusCodes.Accepted
 
   private[api] def createAppHandler(userInfo: UserInfo,
                                     googleProject: GoogleProject,
                                     appName: AppName,
-                                    req: CreateAppRequest): IO[ToResponseMarshallable] =
+                                    req: CreateAppRequest)(
+    implicit ev: ApplicativeAsk[IO, AppContext]
+  ): IO[ToResponseMarshallable] =
     for {
-      context <- AppContext.generate[IO]()
-      implicit0(ctx: ApplicativeAsk[IO, AppContext]) = ApplicativeAsk.const[IO, AppContext](
-        context
-      )
-      _ <- kubernetesService.createApp(
+      ctx <- ev.ask
+      apiCall = kubernetesService.createApp(
         userInfo,
         googleProject,
         appName,
         req
       )
+      _ <- ctx.span.fold(apiCall)(span => spanResource[IO](span, "createApp").use(_ => apiCall))
+
     } yield StatusCodes.Accepted
 
-  private[api] def getAppHandler(userInfo: UserInfo,
-                                 googleProject: GoogleProject,
-                                 appName: AppName): IO[ToResponseMarshallable] =
+  private[api] def getAppHandler(userInfo: UserInfo, googleProject: GoogleProject, appName: AppName)(
+    implicit ev: ApplicativeAsk[IO, AppContext]
+  ): IO[ToResponseMarshallable] =
     for {
-      context <- AppContext.generate[IO]()
-      implicit0(ctx: ApplicativeAsk[IO, AppContext]) = ApplicativeAsk.const[IO, AppContext](
-        context
-      )
-      resp <- kubernetesService.getApp(
+      ctx <- ev.ask
+      apiCall = kubernetesService.getApp(
         userInfo,
         googleProject,
         appName
       )
+      resp <- ctx.span.fold(apiCall)(span => spanResource[IO](span, "getApp").use(_ => apiCall))
+
     } yield StatusCodes.OK -> resp
 
   private[api] def listAppHandler(userInfo: UserInfo,
                                   googleProject: Option[GoogleProject],
-                                  params: Map[String, String]): IO[ToResponseMarshallable] =
+                                  params: Map[String, String])(
+    implicit ev: ApplicativeAsk[IO, AppContext]
+  ): IO[ToResponseMarshallable] =
     for {
-      context <- AppContext.generate[IO]()
-      implicit0(ctx: ApplicativeAsk[IO, AppContext]) = ApplicativeAsk.const[IO, AppContext](
-        context
-      )
-      resp <- kubernetesService.listApp(
+      ctx <- ev.ask
+      apiCall = kubernetesService.listApp(
         userInfo,
         googleProject,
         params
       )
+      resp <- ctx.span.fold(apiCall)(span => spanResource[IO](span, "listApp").use(_ => apiCall))
     } yield StatusCodes.OK -> resp
 
   private[api] def deleteAppHandler(userInfo: UserInfo,
                                     googleProject: GoogleProject,
                                     appName: AppName,
-                                    params: Map[String, String]): IO[ToResponseMarshallable] =
+                                    params: Map[String, String])(
+    implicit ev: ApplicativeAsk[IO, AppContext]
+  ): IO[ToResponseMarshallable] =
     for {
-      context <- AppContext.generate[IO]()
-      implicit0(ctx: ApplicativeAsk[IO, AppContext]) = ApplicativeAsk.const[IO, AppContext](
-        context
-      )
+      ctx <- ev.ask
+
       deleteDisk = params
         .get("deleteDisk")
         .map(s => s == "true")
@@ -176,9 +178,10 @@ class AppRoutes(kubernetesService: KubernetesService[IO], userInfoDirectives: Us
         appName,
         deleteDisk
       )
-      _ <- kubernetesService.deleteApp(
+      apiCall = kubernetesService.deleteApp(
         deleteParams
       )
+      _ <- ctx.span.fold(apiCall)(span => spanResource[IO](span, "deleteApp").use(_ => apiCall))
     } yield StatusCodes.Accepted
 
 }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/DiskRoutes.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/DiskRoutes.scala
@@ -33,7 +33,7 @@ class DiskRoutes(diskService: DiskService[IO], userInfoDirectives: UserInfoDirec
                   complete(
                     listDisksHandler(
                       userInfo,
-                      Some(googleProject),
+                      None,
                       params
                     )
                   )

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/DiskRoutes.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/DiskRoutes.scala
@@ -8,7 +8,7 @@ import akka.http.scaladsl.marshalling.ToResponseMarshallable
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.server
 import akka.http.scaladsl.server.Directives._
-import cats.effect.{IO, Timer}
+import cats.effect.IO
 import cats.mtl.ApplicativeAsk
 import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
 import io.circe.{Decoder, Encoder}

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/RuntimeRoutes.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/RuntimeRoutes.scala
@@ -163,20 +163,6 @@ class RuntimeRoutes(runtimeService: RuntimeService[IO], userInfoDirectives: User
       )
     } yield StatusCodes.Accepted: ToResponseMarshallable
 
-//    val res = for {
-//      implicit0(ctx: ApplicativeAsk[IO, AppContext]) <- AppContext.lift[IO](Some(span))
-//      _ <- runtimeService.createRuntime(
-//        userInfo,
-//        googleProject,
-//        runtimeName,
-//        req
-//      )
-//      _ <- IO(span.end())
-//    } yield StatusCodes.Accepted: ToResponseMarshallable
-//
-//    spanResource[IO](span, "createRuntime")
-//      .use(_ => res)
-
   private[api] def getRuntimeHandler(userInfo: UserInfo, googleProject: GoogleProject, runtimeName: RuntimeName)(
     implicit ev: ApplicativeAsk[IO, AppContext]
   ): IO[ToResponseMarshallable] =
@@ -188,14 +174,6 @@ class RuntimeRoutes(runtimeService: RuntimeService[IO], userInfoDirectives: User
           .use(_ => apiCall)
       )
     } yield StatusCodes.OK -> resp: ToResponseMarshallable
-//
-//    val res = for {
-//      ctx <- ev.ask
-//      resp <- runtimeService.getRuntime(userInfo, googleProject, runtimeName)
-//    } yield StatusCodes.OK -> resp: ToResponseMarshallable
-//
-//    spanResource[IO](span, "getRuntime")
-//      .use(_ => res)
 
   private[api] def listRuntimesHandler(userInfo: UserInfo,
                                        googleProject: Option[GoogleProject],
@@ -210,14 +188,6 @@ class RuntimeRoutes(runtimeService: RuntimeService[IO], userInfoDirectives: User
           .use(_ => apiCall)
       )
     } yield StatusCodes.OK -> resp: ToResponseMarshallable
-
-//    val res = for {
-//      implicit0(ctx: ApplicativeAsk[IO, AppContext]) <- AppContext.lift[IO](Some(span))
-//      resp <- runtimeService.listRuntimes(userInfo, googleProject, params)
-//    } yield StatusCodes.OK -> resp: ToResponseMarshallable
-//
-//    spanResource[IO](span, "listRuntime")
-//      .use(_ => res)
 
   private[api] def deleteRuntimeHandler(userInfo: UserInfo,
                                         googleProject: GoogleProject,
@@ -239,19 +209,6 @@ class RuntimeRoutes(runtimeService: RuntimeService[IO], userInfoDirectives: User
       )
     } yield StatusCodes.Accepted: ToResponseMarshallable
 
-//    val res = for {
-//      implicit0(ctx: ApplicativeAsk[IO, AppContext]) <- AppContext.lift[IO](Some(span))
-//      deleteDisk = params
-//        .get("deleteDisk")
-//        .map(s => if (s == "true") true else false)
-//        .getOrElse(false) //if `deleteDisk` is explicitly set to true, then we delete disk; otherwise, we don't
-//      request = DeleteRuntimeRequest(userInfo, googleProject, runtimeName, deleteDisk)
-//      _ <- runtimeService.deleteRuntime(request)
-//    } yield StatusCodes.Accepted: ToResponseMarshallable
-//
-//    spanResource[IO](span, "deleteRuntime")
-//      .use(_ => res)
-
   private[api] def stopRuntimeHandler(userInfo: UserInfo, googleProject: GoogleProject, runtimeName: RuntimeName)(
     implicit ev: ApplicativeAsk[IO, AppContext]
   ): IO[ToResponseMarshallable] =
@@ -263,13 +220,6 @@ class RuntimeRoutes(runtimeService: RuntimeService[IO], userInfoDirectives: User
           .use(_ => apiCall)
       )
     } yield StatusCodes.Accepted: ToResponseMarshallable
-//    val res = for {
-//      implicit0(ctx: ApplicativeAsk[IO, AppContext]) <- AppContext.lift[IO](Some(span))
-//      _ <- runtimeService.stopRuntime(userInfo, googleProject, runtimeName)
-//    } yield StatusCodes.Accepted: ToResponseMarshallable
-//
-//    spanResource[IO](span, "stopRuntime")
-//      .use(_ => res)
 
   private[api] def startRuntimeHandler(userInfo: UserInfo, googleProject: GoogleProject, runtimeName: RuntimeName)(
     implicit ev: ApplicativeAsk[IO, AppContext]
@@ -282,14 +232,6 @@ class RuntimeRoutes(runtimeService: RuntimeService[IO], userInfoDirectives: User
           .use(_ => apiCall)
       )
     } yield StatusCodes.Accepted: ToResponseMarshallable
-//    val res = for {
-//      implicit0(ctx: ApplicativeAsk[IO, AppContext]) <- AppContext.lift[IO](Some(span))
-//      _ <- runtimeService.startRuntime(userInfo, googleProject, runtimeName)
-//      _ <- IO(span.end())
-//    } yield StatusCodes.Accepted: ToResponseMarshallable
-//
-//    spanResource[IO](span, "startRuntime")
-//      .use(_ => res)
 
   private[api] def updateRuntimeHandler(userInfo: UserInfo,
                                         googleProject: GoogleProject,
@@ -306,13 +248,6 @@ class RuntimeRoutes(runtimeService: RuntimeService[IO], userInfoDirectives: User
       )
     } yield StatusCodes.Accepted: ToResponseMarshallable
 
-//    val res = for {
-//      implicit0(ctx: ApplicativeAsk[IO, AppContext]) <- AppContext.lift[IO](Some(span))
-//      _ <- runtimeService.updateRuntime(userInfo, googleProject, runtimeName, req)
-//    } yield StatusCodes.Accepted: ToResponseMarshallable
-//
-//    spanResource[IO](span, "updateRuntime")
-//      .use(_ => res)
 }
 
 object RuntimeRoutes {

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/package.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/package.scala
@@ -6,11 +6,8 @@ import java.util.UUID
 
 import akka.http.scaladsl.marshalling.Marshaller
 import akka.http.scaladsl.server.Directive1
-<<<<<<< HEAD
 import akka.http.scaladsl.server.Directives.provide
-=======
 import akka.http.scaladsl.server.Directives.optionalHeaderValueByName
->>>>>>> updating runtime routes
 import akka.http.scaladsl.server.directives.OnSuccessMagnet
 import akka.http.scaladsl.server.util.Tupler
 import cats.effect.IO


### PR DESCRIPTION
Adding some tracing to our logs. With a trace id, it should be easier to determine which routes have produced which log entries. It looks like Rob is also doing updates in https://github.com/DataBiosphere/leonardo/pull/1685
---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
