### PR TITLE
IA-2319 Make error message less confusing

### DIFF
--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoService.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoService.scala
@@ -70,9 +70,13 @@ case class RuntimeCannotBeStoppedException(googleProject: GoogleProject,
       StatusCodes.Conflict
     )
 
-case class RuntimeCannotBeDeletedException(googleProject: GoogleProject, runtimeName: RuntimeName)
-    extends LeoException(s"Runtime ${googleProject.value}/${runtimeName.asString} cannot be deleted in Creating status",
-                         StatusCodes.Conflict)
+case class RuntimeCannotBeDeletedException(googleProject: GoogleProject,
+                                           runtimeName: RuntimeName,
+                                           status: RuntimeStatus = RuntimeStatus.Creating)
+    extends LeoException(
+      s"Runtime ${googleProject.value}/${runtimeName.asString} cannot be deleted in ${status} status",
+      StatusCodes.Conflict
+    )
 
 case class RuntimeCannotBeStartedException(googleProject: GoogleProject,
                                            runtimeName: RuntimeName,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/RuntimeServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/RuntimeServiceInterp.scala
@@ -285,7 +285,8 @@ class RuntimeServiceInterp[F[_]: Parallel](config: RuntimeServiceConfig,
       _ <- if (hasDeletePermission) F.unit else F.raiseError[Unit](AuthorizationError(req.userInfo.userEmail))
       // throw 409 if the cluster is not deletable
       _ <- if (runtime.status.isDeletable) F.unit
-      else F.raiseError[Unit](RuntimeCannotBeDeletedException(runtime.googleProject, runtime.runtimeName))
+      else
+        F.raiseError[Unit](RuntimeCannotBeDeletedException(runtime.googleProject, runtime.runtimeName, runtime.status))
       // delete the runtime
       runtimeConfig <- RuntimeConfigQueries.getRuntimeConfig(runtime.runtimeConfigId).transaction
       persistentDiskToDelete <- runtimeConfig match {


### PR DESCRIPTION
"deletable" statuses are more than just `Creating`. The behavior looks like we're throwing `RuntimeCannotBeDeletedException` when runtime status is `Error`, but looking at code, it seems it's doing the right thing except the error message says it's in `Creating` because the status in exception is hardcoded. 

Make the status in `RuntimeCannotBeDeletedException` non hard coded, and if we run into similar issue, we should have a better idea what went wrong 

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
