### PR TITLE
[IA-2332] Enable gvisor

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/runtimeModels.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/runtimeModels.scala
@@ -404,19 +404,3 @@ final case class IpRange(value: String) extends AnyVal
 final case class NetworkTag(value: String) extends ValueObject
 final case class GoogleOperation(name: OperationName, id: GoogleId)
 final case class GoogleId(value: String) extends AnyVal
-
-sealed trait RuntimeOperation extends Product with Serializable {
-  def asString: String
-  final override def toString = asString
-}
-object RuntimeOperation {
-  final case object Creating extends RuntimeOperation {
-    val asString = "creating"
-  }
-  final case object Restarting extends RuntimeOperation {
-    val asString = "restarting"
-  }
-  final case object Stopping extends RuntimeOperation {
-    val asString = "stopping"
-  }
-}

--- a/http/src/main/resources/init-resources/gce-init.sh
+++ b/http/src/main/resources/init-resources/gce-init.sh
@@ -102,11 +102,11 @@ export PROXY_DOCKER_IMAGE=$(proxyDockerImage)
 export MEM_LIMIT=$(memLimit)
 export WELDER_MEM_LIMIT=$(welderMemLimit)
 export PROXY_SERVER_HOST_NAME=$(proxyServerHostName)
+export WELDER_ENABLED=$(welderEnabled)
 
 JUPYTER_START_USER_SCRIPT_URI=$(jupyterStartUserScriptUri)
 # Include a timestamp suffix to differentiate different startup logs across restarts.
 JUPYTER_START_USER_SCRIPT_OUTPUT_URI=$(jupyterStartUserScriptOutputUri)
-WELDER_ENABLED=$(welderEnabled)
 IS_GCE_FORMATTED=$(isGceFormatted)
 JUPYTER_HOME=/etc/jupyter
 JUPYTER_SCRIPTS=${JUPYTER_HOME}/scripts

--- a/http/src/main/resources/init-resources/gce-init.sh
+++ b/http/src/main/resources/init-resources/gce-init.sh
@@ -60,40 +60,31 @@ display_time() {
 }
 
 #####################################################################################################
-# Main starts here. It is composed of three sections:
-#   1. Set up that is NOT specific to RUNTIME_OPERATION
-#   2. Operations we want to perform only when we are 'creating' a VM
-#   3. Operations we want to perform only when we are 'restarting' a VM that was previously created
+# Main starts here.
 #####################################################################################################
+
+log "Running GCE VM init script..."
 
 # Array for instrumentation
 # UPDATE THIS IF YOU ADD MORE STEPS:
 # currently the steps are:
 # START init,
-# .. after env setup
-# .. after copying files from google and into docker
+# .. after persistent disk setup
+# .. after copying files from the GCS init bucket
+# .. after starting google-fluentd
 # .. after docker compose
 # .. after welder start
-# .. after hail and spark
-# .. after nbextension install
-# .. after server extension install
-# .. after combined extension install
+# .. after extension install
 # .. after user script
-# .. after lab extension install
-# .. after jupyter notebook start
+# .. after start user script
+# .. after start Jupyter
 # END
-
-# Note the start time so we can display the elapsed time at the end
 START_TIME=$(date +%s)
+STEP_TIMINGS=($(date +%s))
 
-#####################################################################################################
-# Set up that is NOT specific to RUNTIME_OPERATION
-#####################################################################################################
-RUNTIME_OPERATION=$(runtimeOperation)
-JUPYTER_HOME=/etc/jupyter
-
-log "Running GCE VM init script in $RUNTIME_OPERATION mode..."
-
+# Set variables
+# Values like $(..) are populated by Leo when a cluster is created.
+# Avoid exporting variables unless they are needed by external scripts or docker-compose files.
 export CLUSTER_NAME=$(clusterName)
 export RUNTIME_NAME=$(clusterName)
 export GOOGLE_PROJECT=$(googleProject)
@@ -101,89 +92,110 @@ export STAGING_BUCKET=$(stagingBucketName)
 export OWNER_EMAIL=$(loginHint)
 export JUPYTER_SERVER_NAME=$(jupyterServerName)
 export JUPYTER_DOCKER_IMAGE=$(jupyterDockerImage)
-export JUPYTER_START_USER_SCRIPT_URI=$(jupyterStartUserScriptUri)
-# Include a timestamp suffix to differentiate different startup logs across restarts.
-export JUPYTER_START_USER_SCRIPT_OUTPUT_URI=$(jupyterStartUserScriptOutputUri)
 export NOTEBOOKS_DIR=$(notebooksDir)
 export WELDER_SERVER_NAME=$(welderServerName)
 export WELDER_DOCKER_IMAGE=$(welderDockerImage)
-export WELDER_ENABLED=$(welderEnabled)
-export IS_GCE_FORMATTED=$(isGceFormatted)
+export RSTUDIO_SERVER_NAME=$(rstudioServerName)
+export PROXY_SERVER_NAME=$(proxyServerName)
+export RSTUDIO_DOCKER_IMAGE=$(rstudioDockerImage)
+export PROXY_DOCKER_IMAGE=$(proxyDockerImage)
+export MEM_LIMIT=$(memLimit)
+export WELDER_MEM_LIMIT=$(welderMemLimit)
+export PROXY_SERVER_HOST_NAME=$(proxyServerHostName)
 
-#####################################################################################################
-# Set up that IS specific to RUNTIME_OPERATION:
-#
-# We perform some of the operations based on whether we are 'creating' a GCE VM or 'restarting'
-# a VM that was previously created and stopped.
-#####################################################################################################
+JUPYTER_START_USER_SCRIPT_URI=$(jupyterStartUserScriptUri)
+# Include a timestamp suffix to differentiate different startup logs across restarts.
+JUPYTER_START_USER_SCRIPT_OUTPUT_URI=$(jupyterStartUserScriptOutputUri)
+WELDER_ENABLED=$(welderEnabled)
+IS_GCE_FORMATTED=$(isGceFormatted)
+JUPYTER_HOME=/etc/jupyter
+JUPYTER_SCRIPTS=${JUPYTER_HOME}/scripts
+JUPYTER_USER_HOME=/home/jupyter-user
+KERNELSPEC_HOME=/usr/local/share/jupyter/kernels
+SERVER_CRT=$(proxyServerCrt)
+SERVER_KEY=$(proxyServerKey)
+ROOT_CA=$(rootCaPem)
+JUPYTER_DOCKER_COMPOSE_GCE=$(jupyterDockerComposeGce)
+RSTUDIO_DOCKER_COMPOSE=$(rstudioDockerCompose)
+PROXY_DOCKER_COMPOSE=$(proxyDockerCompose)
+WELDER_DOCKER_COMPOSE=$(welderDockerCompose)
+PROXY_SITE_CONF=$(proxySiteConf)
+JUPYTER_SERVER_EXTENSIONS=$(jupyterServerExtensions)
+JUPYTER_NB_EXTENSIONS=$(jupyterNbExtensions)
+JUPYTER_COMBINED_EXTENSIONS=$(jupyterCombinedExtensions)
+JUPYTER_LAB_EXTENSIONS=$(jupyterLabExtensions)
+JUPYTER_USER_SCRIPT_URI=$(jupyterUserScriptUri)
+JUPYTER_USER_SCRIPT_OUTPUT_URI=$(jupyterUserScriptOutputUri)
+JUPYTER_NOTEBOOK_CONFIG_URI=$(jupyterNotebookConfigUri)
+JUPYTER_NOTEBOOK_FRONTEND_CONFIG_URI=$(jupyterNotebookFrontendConfigUri)
+CUSTOM_ENV_VARS_CONFIG_URI=$(customEnvVarsConfigUri)
+RSTUDIO_LICENSE_FILE=$(rstudioLicenseFile)
 
-if [[ "$RUNTIME_OPERATION" == 'creating' ]]; then
-    JUPYTER_SCRIPTS=${JUPYTER_HOME}/scripts
-    JUPYTER_USER_HOME=/home/jupyter-user
-    KERNELSPEC_HOME=/usr/local/share/jupyter/kernels
+mkdir -p /work
+mkdir -p /certs
 
-    # The following values are populated by Leo when a cluster is created.
-    export RSTUDIO_SERVER_NAME=$(rstudioServerName)
-    export PROXY_SERVER_NAME=$(proxyServerName)
-    export RSTUDIO_DOCKER_IMAGE=$(rstudioDockerImage)
-    export PROXY_DOCKER_IMAGE=$(proxyDockerImage)
-    export MEM_LIMIT=$(memLimit)
-    export WELDER_MEM_LIMIT=$(welderMemLimit)
-    export PROXY_SERVER_HOST_NAME=$(proxyServerHostName)
+log 'Formatting and mounting persistent disk...'
 
-    SERVER_CRT=$(proxyServerCrt)
-    SERVER_KEY=$(proxyServerKey)
-    ROOT_CA=$(rootCaPem)
-    JUPYTER_DOCKER_COMPOSE_GCE=$(jupyterDockerComposeGce)
-    RSTUDIO_DOCKER_COMPOSE=$(rstudioDockerCompose)
-    PROXY_DOCKER_COMPOSE=$(proxyDockerCompose)
-    WELDER_DOCKER_COMPOSE=$(welderDockerCompose)
-    PROXY_SITE_CONF=$(proxySiteConf)
-    JUPYTER_SERVER_EXTENSIONS=$(jupyterServerExtensions)
-    JUPYTER_NB_EXTENSIONS=$(jupyterNbExtensions)
-    JUPYTER_COMBINED_EXTENSIONS=$(jupyterCombinedExtensions)
-    JUPYTER_LAB_EXTENSIONS=$(jupyterLabExtensions)
-    JUPYTER_USER_SCRIPT_URI=$(jupyterUserScriptUri)
-    JUPYTER_USER_SCRIPT_OUTPUT_URI=$(jupyterUserScriptOutputUri)
-    JUPYTER_NOTEBOOK_CONFIG_URI=$(jupyterNotebookConfigUri)
-    JUPYTER_NOTEBOOK_FRONTEND_CONFIG_URI=$(jupyterNotebookFrontendConfigUri)
-    CUSTOM_ENV_VARS_CONFIG_URI=$(customEnvVarsConfigUri)
-    RSTUDIO_LICENSE_FILE=$(rstudioLicenseFile)
+# Format and mount persistent disk
+export DISK_DEVICE_ID=$(lsblk -o name,serial | grep 'user-disk' | awk '{print $1}')
+# Only format disk is it hasn't already been formatted
+if [ "$IS_GCE_FORMATTED" == "false" ] ; then
+  mkfs.ext4 -m 0 -E lazy_itable_init=0,lazy_journal_init=0,discard /dev/${DISK_DEVICE_ID}
+fi
+mount -o discard,defaults /dev/${DISK_DEVICE_ID} /work
+# Directory to store user installed packages so they persist
+mkdir -p /work/packages
+chmod a+rwx /work/packages
+# Ensure persistent disk re-mounts if runtime stops and restarts
+cp /etc/fstab /etc/fstab.backup
+echo UUID=`blkid -s UUID -o value /dev/${DISK_DEVICE_ID}` /work ext4 discard,defaults,nofail 0 2 | tee -a /etc/fstab
+chmod a+rwx /work
 
-    log 'Copying secrets from GCS...'
+# done persistent disk setup
+STEP_TIMINGS+=($(date +%s))
 
-    mkdir -p /work
-    mkdir -p /certs
-    # Format and mount persisent disk
-    export DISK_DEVICE_ID=$(lsblk -o name,serial | grep 'user-disk' | awk '{print $1}')
-    # Only format disk is it hasn't already been formatted
-    if [ "$IS_GCE_FORMATTED" == "false" ] ; then
-      mkfs.ext4 -m 0 -E lazy_itable_init=0,lazy_journal_init=0,discard /dev/${DISK_DEVICE_ID}
-    fi
-    mount -o discard,defaults /dev/${DISK_DEVICE_ID} /work
-    # Directory to store user installed packages so they persist
-    mkdir -p /work/packages
-    chmod a+rwx /work/packages
-    # Ensure peristent disk re-mounts if runtime stops and restarts
-    cp /etc/fstab /etc/fstab.backup
-    echo UUID=`blkid -s UUID -o value /dev/${DISK_DEVICE_ID}` /work ext4 discard,defaults,nofail 0 2 | tee -a /etc/fstab
-    chmod a+rwx /work
+log 'Copying secrets from GCS...'
 
-    # Add the certificates from the bucket to the VM. They are used by the docker-compose file
-    gsutil cp ${SERVER_CRT} /certs
-    gsutil cp ${SERVER_KEY} /certs
-    gsutil cp ${ROOT_CA} /certs
-    gsutil cp ${PROXY_SITE_CONF} /etc
-    gsutil cp ${JUPYTER_DOCKER_COMPOSE_GCE} /etc
-    gsutil cp ${RSTUDIO_DOCKER_COMPOSE} /etc
-    gsutil cp ${PROXY_DOCKER_COMPOSE} /etc
-    gsutil cp ${WELDER_DOCKER_COMPOSE} /etc
+# Add the certificates from the bucket to the VM. They are used by the docker-compose file
+gsutil cp ${SERVER_CRT} /certs
+gsutil cp ${SERVER_KEY} /certs
+gsutil cp ${ROOT_CA} /certs
+gsutil cp ${PROXY_SITE_CONF} /etc
+gsutil cp ${JUPYTER_DOCKER_COMPOSE_GCE} /etc
+gsutil cp ${RSTUDIO_DOCKER_COMPOSE} /etc
+gsutil cp ${PROXY_DOCKER_COMPOSE} /etc
+gsutil cp ${WELDER_DOCKER_COMPOSE} /etc
 
-    # Not all images have the directory used for Stackdriver configs. If so, create it
-    mkdir -p /etc/google-fluentd/config.d
+echo "" > /etc/google_application_credentials.env
 
-    # Add stack driver configuration for welder
-    tee /etc/google-fluentd/config.d/welder.conf << END
+# Install env var config
+if [ ! -z "$CUSTOM_ENV_VARS_CONFIG_URI" ] ; then
+  log 'Copy custom env vars config...'
+  gsutil cp ${CUSTOM_ENV_VARS_CONFIG_URI} /etc
+fi
+
+# Install RStudio license file, if specified
+if [ ! -z "$RSTUDIO_DOCKER_IMAGE" ] ; then
+  STAT_EXIT_CODE=0
+  gsutil -q stat ${RSTUDIO_LICENSE_FILE} || STAT_EXIT_CODE=$?
+  if [ $STAT_EXIT_CODE -eq 0 ] ; then
+    echo "Using RStudio license file $RSTUDIO_LICENSE_FILE"
+    gsutil cp ${RSTUDIO_LICENSE_FILE} /etc/rstudio-license-file.lic
+  else
+    echo "" > /etc/rstudio-license-file.lic
+  fi
+fi
+
+# done GCS copy
+STEP_TIMINGS+=($(date +%s))
+
+log 'Setting up google-fluentd...'
+
+# Not all images have the directory used for Stackdriver configs. If so, create it
+mkdir -p /etc/google-fluentd/config.d
+
+# Add stack driver configuration for welder
+tee /etc/google-fluentd/config.d/welder.conf << END
 <source>
  @type tail
  format json
@@ -194,8 +206,8 @@ if [[ "$RUNTIME_OPERATION" == 'creating' ]]; then
 </source>
 END
 
-    # Add stack driver configuration for jupyter
-    tee /etc/google-fluentd/config.d/jupyter.conf << END
+# Add stack driver configuration for jupyter
+tee /etc/google-fluentd/config.d/jupyter.conf << END
 <source>
  @type tail
  format none
@@ -206,8 +218,8 @@ END
 </source>
 END
 
-    # Add stack driver configuration for user startup and shutdown scripts
-    tee /etc/google-fluentd/config.d/daemon.conf << END
+# Add stack driver configuration for user startup and shutdown scripts
+tee /etc/google-fluentd/config.d/daemon.conf << END
 <source>
  @type tail
  format none
@@ -218,265 +230,213 @@ END
 </source>
 END
 
-    # restarting instead of `service google-fluentd-reload` because of bug:
-    # https://github.com/GoogleCloudPlatform/google-fluentd/issues/232
-    service google-fluentd restart
+# restarting instead of `service google-fluentd-reload` because of bug:
+# https://github.com/GoogleCloudPlatform/google-fluentd/issues/232
+service google-fluentd restart
 
-    echo "" > /etc/google_application_credentials.env
+# done google-fluentd setup
+STEP_TIMINGS+=($(date +%s))
 
-    # Install env var config
-    if [ ! -z "$CUSTOM_ENV_VARS_CONFIG_URI" ] ; then
-      log 'Copy custom env vars config...'
-      gsutil cp ${CUSTOM_ENV_VARS_CONFIG_URI} /etc
-    fi
+# If any image is hosted in a GCR registry (detected by regex) then
+# authorize docker to interact with gcr.io.
+if grep -qF "gcr.io" <<< "${JUPYTER_DOCKER_IMAGE}${RSTUDIO_DOCKER_IMAGE}${PROXY_DOCKER_IMAGE}${WELDER_DOCKER_IMAGE}" ; then
+  log 'Authorizing GCR...'
+  gcloud --quiet auth configure-docker
+fi
 
-    # Install RStudio license file, if specified
-    if [ ! -z "$RSTUDIO_DOCKER_IMAGE" ] ; then
-      # TODO: remove the gsutil stat command when https://github.com/broadinstitute/firecloud-develop/pull/2105
-      # is merged because then we'll expect the license file to always be present.
-      STAT_EXIT_CODE=0
-      gsutil -q stat ${RSTUDIO_LICENSE_FILE} || STAT_EXIT_CODE=$?
-      if [ $STAT_EXIT_CODE -eq 0 ] ; then
-        echo "Using RStudio license file $RSTUDIO_LICENSE_FILE"
-        gsutil cp ${RSTUDIO_LICENSE_FILE} /etc/rstudio-license-file.lic
-      else
-        echo "" > /etc/rstudio-license-file.lic
-      fi
-    fi
+log 'Starting up the Jupydocker...'
 
-    # If any image is hosted in a GCR registry (detected by regex) then
-    # authorize docker to interact with gcr.io.
-    if grep -qF "gcr.io" <<< "${JUPYTER_DOCKER_IMAGE}${RSTUDIO_DOCKER_IMAGE}${PROXY_DOCKER_IMAGE}${WELDER_DOCKER_IMAGE}" ; then
-      log 'Authorizing GCR...'
-      gcloud --quiet auth configure-docker
-    fi
+# Run docker-compose for each specified compose file.
+# Note the `docker-compose pull` is retried to avoid intermittent network errors, but
+# `docker-compose up` is not retried since if that fails, something is probably broken
+# and wouldn't be remedied by retrying
+COMPOSE_FILES=(-f /etc/`basename ${PROXY_DOCKER_COMPOSE}`)
+cat /etc/`basename ${PROXY_DOCKER_COMPOSE}`
+if [ ! -z "$JUPYTER_DOCKER_IMAGE" ] ; then
+  COMPOSE_FILES+=(-f /etc/`basename ${JUPYTER_DOCKER_COMPOSE_GCE}`)
+  cat /etc/`basename ${JUPYTER_DOCKER_COMPOSE_GCE}`
+fi
+if [ ! -z "$RSTUDIO_DOCKER_IMAGE" ] ; then
+  COMPOSE_FILES+=(-f /etc/`basename ${RSTUDIO_DOCKER_COMPOSE}`)
+  cat /etc/`basename ${RSTUDIO_DOCKER_COMPOSE}`
+fi
+if [ ! -z "$WELDER_DOCKER_IMAGE" ] && [ "$WELDER_ENABLED" == "true" ] ; then
+  COMPOSE_FILES+=(-f /etc/`basename ${WELDER_DOCKER_COMPOSE}`)
+  cat /etc/`basename ${WELDER_DOCKER_COMPOSE}`
+fi
 
-    log 'Starting up the Jupydocker...'
+docker-compose "${COMPOSE_FILES[@]}" config
+retry 5 docker-compose "${COMPOSE_FILES[@]}" pull
+docker-compose "${COMPOSE_FILES[@]}" up -d
 
-    # Run docker-compose for each specified compose file.
-    # Note the `docker-compose pull` is retried to avoid intermittent network errors, but
-    # `docker-compose up` is not retried since if that fails, something is probably broken
-    # and wouldn't be remedied by retrying
-    COMPOSE_FILES=(-f /etc/`basename ${PROXY_DOCKER_COMPOSE}`)
-    cat /etc/`basename ${PROXY_DOCKER_COMPOSE}`
-    if [ ! -z "$JUPYTER_DOCKER_IMAGE" ] ; then
-      COMPOSE_FILES+=(-f /etc/`basename ${JUPYTER_DOCKER_COMPOSE_GCE}`)
-      cat /etc/`basename ${JUPYTER_DOCKER_COMPOSE_GCE}`
-    fi
-    if [ ! -z "$RSTUDIO_DOCKER_IMAGE" ] ; then
-      COMPOSE_FILES+=(-f /etc/`basename ${RSTUDIO_DOCKER_COMPOSE}`)
-      cat /etc/`basename ${RSTUDIO_DOCKER_COMPOSE}`
-    fi
-    if [ ! -z "$WELDER_DOCKER_IMAGE" ] && [ "$WELDER_ENABLED" == "true" ] ; then
-      COMPOSE_FILES+=(-f /etc/`basename ${WELDER_DOCKER_COMPOSE}`)
-      cat /etc/`basename ${WELDER_DOCKER_COMPOSE}`
-    fi
+# done docker-compose
+STEP_TIMINGS+=($(date +%s))
 
-    docker-compose "${COMPOSE_FILES[@]}" config
-    retry 5 docker-compose "${COMPOSE_FILES[@]}" pull
-    docker-compose "${COMPOSE_FILES[@]}" up -d
+# If Welder is installed, start the service.
+# See https://broadworkbench.atlassian.net/browse/IA-1026
+if [ ! -z "$WELDER_DOCKER_IMAGE" ] && [ "$WELDER_ENABLED" == "true" ] ; then
+  log 'Starting Welder (file synchronization service)...'
+  retry 3 docker exec -d ${WELDER_SERVER_NAME} /opt/docker/bin/entrypoint.sh
+fi
 
-    # If Welder is installed, start the service.
-    # See https://broadworkbench.atlassian.net/browse/IA-1026
-    if [ ! -z "$WELDER_DOCKER_IMAGE" ] && [ "$WELDER_ENABLED" == "true" ] ; then
-      log 'Starting Welder (file synchronization service)...'
-      retry 3 docker exec -d ${WELDER_SERVER_NAME} /opt/docker/bin/entrypoint.sh
-    fi
+# done welder start
+STEP_TIMINGS+=($(date +%s))
 
-    # Jupyter-specific setup, only do if Jupyter is installed
-    if [ ! -z "$JUPYTER_DOCKER_IMAGE" ] ; then
-      log 'Installing Jupydocker kernelspecs...'
+# Jupyter-specific setup, only do if Jupyter is installed
+if [ ! -z "$JUPYTER_DOCKER_IMAGE" ] ; then
+  log 'Installing Jupydocker kernelspecs...'
 
-      # Used to pip install packacges
-      # TODO: update this if we upgrade python version
-      ROOT_USER_PIP_DIR=/usr/local/lib/python3.7/dist-packages
-      JUPYTER_USER_PIP_DIR=/home/jupyter-user/.local/lib/python3.7/site-packages
+  # Used to pip install packacges
+  # TODO: update this if we upgrade python version
+  ROOT_USER_PIP_DIR=/usr/local/lib/python3.7/dist-packages
+  JUPYTER_USER_PIP_DIR=/home/jupyter-user/.local/lib/python3.7/site-packages
 
-      # Install kernelspecs inside the Jupyter container
-      # TODO This is baked into terra-jupyter-base as of version 0.0.6. Keeping it here for now to support prior image versions.
-      retry 3 docker exec -u root ${JUPYTER_SERVER_NAME} ${JUPYTER_SCRIPTS}/kernel/kernelspec.sh ${JUPYTER_SCRIPTS}/kernel ${KERNELSPEC_HOME}
+  # Install kernelspecs inside the Jupyter container
+  # TODO This is baked into terra-jupyter-base as of version 0.0.6. Keeping it here for now to support prior image versions.
+  retry 3 docker exec -u root ${JUPYTER_SERVER_NAME} ${JUPYTER_SCRIPTS}/kernel/kernelspec.sh ${JUPYTER_SCRIPTS}/kernel ${KERNELSPEC_HOME}
 
-      # Install jupyter_notebook_config.py
-      # TODO This is baked into terra-jupyter-base as of version 0.0.6. Keeping it here for now to support prior image versions.
-      if [ ! -z "$JUPYTER_NOTEBOOK_CONFIG_URI" ] ; then
-        log 'Copy Jupyter notebook config...'
-        gsutil cp ${JUPYTER_NOTEBOOK_CONFIG_URI} /etc
-        JUPYTER_NOTEBOOK_CONFIG=`basename ${JUPYTER_NOTEBOOK_CONFIG_URI}`
-        docker cp /etc/${JUPYTER_NOTEBOOK_CONFIG} ${JUPYTER_SERVER_NAME}:${JUPYTER_HOME}/
-      fi
-
-      # Install notebook.json
-      if [ ! -z "$JUPYTER_NOTEBOOK_FRONTEND_CONFIG_URI" ] ; then
-        log 'Copy Jupyter frontend notebook config...'
-        gsutil cp ${JUPYTER_NOTEBOOK_FRONTEND_CONFIG_URI} /etc
-        JUPYTER_NOTEBOOK_FRONTEND_CONFIG=`basename ${JUPYTER_NOTEBOOK_FRONTEND_CONFIG_URI}`
-        docker cp /etc/${JUPYTER_NOTEBOOK_FRONTEND_CONFIG} ${JUPYTER_SERVER_NAME}:${JUPYTER_HOME}/nbconfig/
-      fi
-
-      # Install NbExtensions
-      if [ ! -z "$JUPYTER_NB_EXTENSIONS" ] ; then
-        for ext in ${JUPYTER_NB_EXTENSIONS}
-        do
-          log 'Installing Jupyter NB extension [$ext]...'
-          if [[ $ext == 'gs://'* ]]; then
-            gsutil cp $ext /etc
-            JUPYTER_EXTENSION_ARCHIVE=`basename $ext`
-            docker cp /etc/${JUPYTER_EXTENSION_ARCHIVE} ${JUPYTER_SERVER_NAME}:${JUPYTER_HOME}/${JUPYTER_EXTENSION_ARCHIVE}
-            retry 3 docker exec -u root -e PIP_TARGET=${ROOT_USER_PIP_DIR} ${JUPYTER_SERVER_NAME} ${JUPYTER_SCRIPTS}/extension/jupyter_install_notebook_extension.sh ${JUPYTER_HOME}/${JUPYTER_EXTENSION_ARCHIVE}
-          elif [[ $ext == 'http://'* || $ext == 'https://'* ]]; then
-            JUPYTER_EXTENSION_FILE=`basename $ext`
-            curl $ext -o /etc/${JUPYTER_EXTENSION_FILE}
-            docker cp /etc/${JUPYTER_EXTENSION_FILE} ${JUPYTER_SERVER_NAME}:${JUPYTER_HOME}/${JUPYTER_EXTENSION_FILE}
-            retry 3 docker exec -u root -e PIP_TARGET=${ROOT_USER_PIP_DIR} ${JUPYTER_SERVER_NAME} ${JUPYTER_SCRIPTS}/extension/jupyter_install_notebook_extension.sh ${JUPYTER_HOME}/${JUPYTER_EXTENSION_FILE}
-          else
-            retry 3 docker exec -u root -e PIP_TARGET=${ROOT_USER_PIP_DIR} ${JUPYTER_SERVER_NAME} ${JUPYTER_SCRIPTS}/extension/jupyter_pip_install_notebook_extension.sh $ext
-          fi
-        done
-      fi
-
-      # Install serverExtensions
-      if [ ! -z "$JUPYTER_SERVER_EXTENSIONS" ] ; then
-        for ext in ${JUPYTER_SERVER_EXTENSIONS}
-        do
-          log 'Installing Jupyter server extension [$ext]...'
-          if [[ $ext == 'gs://'* ]]; then
-            gsutil cp $ext /etc
-            JUPYTER_EXTENSION_ARCHIVE=`basename $ext`
-            docker cp /etc/${JUPYTER_EXTENSION_ARCHIVE} ${JUPYTER_SERVER_NAME}:${JUPYTER_HOME}/${JUPYTER_EXTENSION_ARCHIVE}
-            retry 3 docker exec -u root -e PIP_TARGET=${ROOT_USER_PIP_DIR} ${JUPYTER_SERVER_NAME} ${JUPYTER_SCRIPTS}/extension/jupyter_install_server_extension.sh ${JUPYTER_HOME}/${JUPYTER_EXTENSION_ARCHIVE}
-          else
-            retry 3 docker exec -u root -e PIP_TARGET=${ROOT_USER_PIP_DIR} ${JUPYTER_SERVER_NAME} ${JUPYTER_SCRIPTS}/extension/jupyter_pip_install_server_extension.sh $ext
-          fi
-        done
-      fi
-
-      # Install combined extensions
-      if [ ! -z "$JUPYTER_COMBINED_EXTENSIONS"  ] ; then
-        for ext in ${JUPYTER_COMBINED_EXTENSIONS}
-        do
-          log 'Installing Jupyter combined extension [$ext]...'
-          log $ext
-          if [[ $ext == 'gs://'* ]]; then
-            gsutil cp $ext /etc
-            JUPYTER_EXTENSION_ARCHIVE=`basename $ext`
-            docker cp /etc/${JUPYTER_EXTENSION_ARCHIVE} ${JUPYTER_SERVER_NAME}:${JUPYTER_HOME}/${JUPYTER_EXTENSION_ARCHIVE}
-            retry 3 docker exec -u root -e PIP_TARGET=${ROOT_USER_PIP_DIR} ${JUPYTER_SERVER_NAME} ${JUPYTER_SCRIPTS}/extension/jupyter_install_combined_extension.sh ${JUPYTER_EXTENSION_ARCHIVE}
-          else
-            retry 3 docker exec -u root -e PIP_TARGET=${ROOT_USER_PIP_DIR} ${JUPYTER_SERVER_NAME} ${JUPYTER_SCRIPTS}/extension/jupyter_pip_install_combined_extension.sh $ext
-          fi
-        done
-      fi
-
-      # If a Jupyter user script was specified, copy it into the jupyter docker container and execute it.
-      if [ ! -z "$JUPYTER_USER_SCRIPT_URI" ] ; then
-        log 'Running Jupyter user script [$JUPYTER_USER_SCRIPT_URI]...'
-        JUPYTER_USER_SCRIPT=`basename ${JUPYTER_USER_SCRIPT_URI}`
-        if [[ "$JUPYTER_USER_SCRIPT_URI" == 'gs://'* ]]; then
-          gsutil cp ${JUPYTER_USER_SCRIPT_URI} /etc
-        else
-          curl $JUPYTER_USER_SCRIPT_URI -o /etc/${JUPYTER_USER_SCRIPT}
-        fi
-        docker cp /etc/${JUPYTER_USER_SCRIPT} ${JUPYTER_SERVER_NAME}:${JUPYTER_HOME}/${JUPYTER_USER_SCRIPT}
-        retry 3 docker exec -u root ${JUPYTER_SERVER_NAME} chmod +x ${JUPYTER_HOME}/${JUPYTER_USER_SCRIPT}
-        # Execute the user script as privileged to allow for deeper customization of VM behavior, e.g. installing
-        # network egress throttling. As docker is not a security layer, it is assumed that a determined attacker
-        # can gain full access to the VM already, so using this flag is not a significant escalation.
-        EXIT_CODE=0
-        docker exec --privileged -u root -e PIP_TARGET=${ROOT_USER_PIP_DIR} ${JUPYTER_SERVER_NAME} ${JUPYTER_HOME}/${JUPYTER_USER_SCRIPT} &> us_output.txt || EXIT_CODE=$?
-
-        if [ $EXIT_CODE -ne 0 ]; then
-            log "User script failed with exit code $EXIT_CODE. Output is saved to $JUPYTER_USER_SCRIPT_OUTPUT_URI."
-            retry 3 gsutil -h "x-goog-meta-passed":"false" cp us_output.txt ${JUPYTER_USER_SCRIPT_OUTPUT_URI}
-            exit $EXIT_CODE
-        else
-            retry 3 gsutil -h "x-goog-meta-passed":"true" cp us_output.txt ${JUPYTER_USER_SCRIPT_OUTPUT_URI}
-        fi
-      fi
-
-      # If a Jupyter start user script was specified, copy it into the jupyter docker container for consumption during startups.
-      if [ ! -z "$JUPYTER_START_USER_SCRIPT_URI" ] ; then
-        log 'Copying Jupyter start user script [$JUPYTER_START_USER_SCRIPT_URI]...'
-        JUPYTER_START_USER_SCRIPT=`basename ${JUPYTER_START_USER_SCRIPT_URI}`
-        if [[ "$JUPYTER_START_USER_SCRIPT_URI" == 'gs://'* ]]; then
-          gsutil cp ${JUPYTER_START_USER_SCRIPT_URI} /etc
-        else
-          curl $JUPYTER_START_USER_SCRIPT_URI -o /etc/${JUPYTER_START_USER_SCRIPT}
-        fi
-        docker cp /etc/${JUPYTER_START_USER_SCRIPT} ${JUPYTER_SERVER_NAME}:${JUPYTER_HOME}/${JUPYTER_START_USER_SCRIPT}
-        retry 3 docker exec -u root ${JUPYTER_SERVER_NAME} chmod +x ${JUPYTER_HOME}/${JUPYTER_START_USER_SCRIPT}
-
-        # Keep in sync with startup.sh
-        log 'Executing Jupyter user start script [$JUPYTER_START_USER_SCRIPT]...'
-        EXIT_CODE=0
-        docker exec --privileged -u root -e PIP_TARGET=${ROOT_USER_PIP_DIR} ${JUPYTER_SERVER_NAME} ${JUPYTER_HOME}/${JUPYTER_START_USER_SCRIPT} &> start_output.txt || EXIT_CODE=$?
-        if [ $EXIT_CODE -ne 0 ]; then
-          echo "User start script failed with exit code ${EXIT_CODE}. Output is saved to ${JUPYTER_START_USER_SCRIPT_OUTPUT_URI}"
-          retry 3 gsutil -h "x-goog-meta-passed":"false" cp start_output.txt ${JUPYTER_START_USER_SCRIPT_OUTPUT_URI}
-          exit $EXIT_CODE
-        else
-          retry 3 gsutil -h "x-goog-meta-passed":"true" cp start_output.txt ${JUPYTER_START_USER_SCRIPT_OUTPUT_URI}
-        fi
-      fi
-
-      # Install lab extensions
-      # Note: lab extensions need to installed as jupyter user, not root
-      if [ ! -z "$JUPYTER_LAB_EXTENSIONS" ] ; then
-        for ext in ${JUPYTER_LAB_EXTENSIONS}
-        do
-          log 'Installing JupyterLab extension [$ext]...'
-          pwd
-          if [[ $ext == 'gs://'* ]]; then
-            gsutil cp -r $ext /etc
-            JUPYTER_EXTENSION_ARCHIVE=`basename $ext`
-            docker cp /etc/${JUPYTER_EXTENSION_ARCHIVE} ${JUPYTER_SERVER_NAME}:${JUPYTER_HOME}/${JUPYTER_EXTENSION_ARCHIVE}
-            retry 3 docker exec -e PIP_TARGET=${JUPYTER_USER_PIP_DIR} ${JUPYTER_SERVER_NAME} ${JUPYTER_SCRIPTS}/extension/jupyter_install_lab_extension.sh ${JUPYTER_HOME}/${JUPYTER_EXTENSION_ARCHIVE}
-          elif [[ $ext == 'http://'* || $ext == 'https://'* ]]; then
-            JUPYTER_EXTENSION_FILE=`basename $ext`
-            curl $ext -o /etc/${JUPYTER_EXTENSION_FILE}
-            docker cp /etc/${JUPYTER_EXTENSION_FILE} ${JUPYTER_SERVER_NAME}:${JUPYTER_HOME}/${JUPYTER_EXTENSION_FILE}
-            retry 3 docker exec -e PIP_TARGET=${JUPYTER_USER_PIP_DIR} ${JUPYTER_SERVER_NAME} ${JUPYTER_SCRIPTS}/extension/jupyter_install_lab_extension.sh ${JUPYTER_HOME}/${JUPYTER_EXTENSION_FILE}
-          else
-            retry 3 docker exec -e PIP_TARGET=${JUPYTER_USER_PIP_DIR} ${JUPYTER_SERVER_NAME} ${JUPYTER_SCRIPTS}/extension/jupyter_install_lab_extension.sh $ext
-          fi
-        done
-      fi
-
-      # See IA-1901: Jupyter UI stalls indefinitely on initial R kernel connection after cluster create/resume
-      # The intent of this is to "warm up" R at VM creation time to hopefully prevent issues when the Jupyter
-      # kernel tries to connect to it.
-      docker exec $JUPYTER_SERVER_NAME /bin/bash -c "R -e '1+1'" || true
-
-      log 'Starting Jupyter Notebook...'
-      retry 3 docker exec -d ${JUPYTER_SERVER_NAME} ${JUPYTER_SCRIPTS}/run-jupyter.sh ${NOTEBOOKS_DIR}
-    fi
-
-    # Remove any unneeded cached images to save disk space.
-    # Do this asynchronously so it doesn't hold up cluster creation
-    log 'Pruning docker images...'
-    docker image prune -a -f &
-
-# TODO (RT): I'm pretty sure this block is never used because we have a dedicated startup.sh script
-# used for starting runtimes. We could confirm this and remove this block.
-elif [[ "$RUNTIME_OPERATION" == 'restarting' ]]; then
-  export UPDATE_WELDER=$(updateWelder)
-  export DISABLE_DELOCALIZATION=$(disableDelocalization)
-
-  # Sometimes we want to update Welder without having to delete and recreate a cluster
-  if [ "$UPDATE_WELDER" == "true" ] ; then
-      gcloud auth configure-docker
-      docker-compose -f /etc/welder-docker-compose.yaml stop
-      docker-compose -f /etc/welder-docker-compose.yaml rm -f
-      retry 5 docker-compose -f /etc/welder-docker-compose.yaml pull
-      docker-compose -f /etc/welder-docker-compose.yaml up -d
+  # Install jupyter_notebook_config.py
+  # TODO This is baked into terra-jupyter-base as of version 0.0.6. Keeping it here for now to support prior image versions.
+  if [ ! -z "$JUPYTER_NOTEBOOK_CONFIG_URI" ] ; then
+    log 'Copy Jupyter notebook config...'
+    gsutil cp ${JUPYTER_NOTEBOOK_CONFIG_URI} /etc
+    JUPYTER_NOTEBOOK_CONFIG=`basename ${JUPYTER_NOTEBOOK_CONFIG_URI}`
+    docker cp /etc/${JUPYTER_NOTEBOOK_CONFIG} ${JUPYTER_SERVER_NAME}:${JUPYTER_HOME}/
   fi
 
-  # If a Jupyter start user script was specified, execute it now. It should already be in the docker container
-  # via initialization at VM creation time. We do not want to recopy it from GCS on every cluster restart.
+  # Install notebook.json
+  if [ ! -z "$JUPYTER_NOTEBOOK_FRONTEND_CONFIG_URI" ] ; then
+    log 'Copy Jupyter frontend notebook config...'
+    gsutil cp ${JUPYTER_NOTEBOOK_FRONTEND_CONFIG_URI} /etc
+    JUPYTER_NOTEBOOK_FRONTEND_CONFIG=`basename ${JUPYTER_NOTEBOOK_FRONTEND_CONFIG_URI}`
+    docker cp /etc/${JUPYTER_NOTEBOOK_FRONTEND_CONFIG} ${JUPYTER_SERVER_NAME}:${JUPYTER_HOME}/nbconfig/
+  fi
+
+  # Install NbExtensions
+  if [ ! -z "$JUPYTER_NB_EXTENSIONS" ] ; then
+    for ext in ${JUPYTER_NB_EXTENSIONS}
+    do
+      log 'Installing Jupyter NB extension [$ext]...'
+      if [[ $ext == 'gs://'* ]]; then
+        gsutil cp $ext /etc
+        JUPYTER_EXTENSION_ARCHIVE=`basename $ext`
+        docker cp /etc/${JUPYTER_EXTENSION_ARCHIVE} ${JUPYTER_SERVER_NAME}:${JUPYTER_HOME}/${JUPYTER_EXTENSION_ARCHIVE}
+        retry 3 docker exec -e PIP_TARGET=${ROOT_USER_PIP_DIR} ${JUPYTER_SERVER_NAME} ${JUPYTER_SCRIPTS}/extension/jupyter_install_notebook_extension.sh ${JUPYTER_HOME}/${JUPYTER_EXTENSION_ARCHIVE}
+      elif [[ $ext == 'http://'* || $ext == 'https://'* ]]; then
+        JUPYTER_EXTENSION_FILE=`basename $ext`
+        curl $ext -o /etc/${JUPYTER_EXTENSION_FILE}
+        docker cp /etc/${JUPYTER_EXTENSION_FILE} ${JUPYTER_SERVER_NAME}:${JUPYTER_HOME}/${JUPYTER_EXTENSION_FILE}
+        retry 3 docker exec -e PIP_TARGET=${ROOT_USER_PIP_DIR} ${JUPYTER_SERVER_NAME} ${JUPYTER_SCRIPTS}/extension/jupyter_install_notebook_extension.sh ${JUPYTER_HOME}/${JUPYTER_EXTENSION_FILE}
+      else
+        retry 3 docker exec -e PIP_TARGET=${ROOT_USER_PIP_DIR} ${JUPYTER_SERVER_NAME} ${JUPYTER_SCRIPTS}/extension/jupyter_pip_install_notebook_extension.sh $ext
+      fi
+    done
+  fi
+
+  # Install serverExtensions
+  if [ ! -z "$JUPYTER_SERVER_EXTENSIONS" ] ; then
+    for ext in ${JUPYTER_SERVER_EXTENSIONS}
+    do
+      log 'Installing Jupyter server extension [$ext]...'
+      if [[ $ext == 'gs://'* ]]; then
+        gsutil cp $ext /etc
+        JUPYTER_EXTENSION_ARCHIVE=`basename $ext`
+        docker cp /etc/${JUPYTER_EXTENSION_ARCHIVE} ${JUPYTER_SERVER_NAME}:${JUPYTER_HOME}/${JUPYTER_EXTENSION_ARCHIVE}
+        retry 3 docker exec -e PIP_TARGET=${ROOT_USER_PIP_DIR} ${JUPYTER_SERVER_NAME} ${JUPYTER_SCRIPTS}/extension/jupyter_install_server_extension.sh ${JUPYTER_HOME}/${JUPYTER_EXTENSION_ARCHIVE}
+      else
+        retry 3 docker exec -e PIP_TARGET=${ROOT_USER_PIP_DIR} ${JUPYTER_SERVER_NAME} ${JUPYTER_SCRIPTS}/extension/jupyter_pip_install_server_extension.sh $ext
+      fi
+    done
+  fi
+
+  # Install combined extensions
+  if [ ! -z "$JUPYTER_COMBINED_EXTENSIONS"  ] ; then
+    for ext in ${JUPYTER_COMBINED_EXTENSIONS}
+    do
+      log 'Installing Jupyter combined extension [$ext]...'
+      log $ext
+      if [[ $ext == 'gs://'* ]]; then
+        gsutil cp $ext /etc
+        JUPYTER_EXTENSION_ARCHIVE=`basename $ext`
+        docker cp /etc/${JUPYTER_EXTENSION_ARCHIVE} ${JUPYTER_SERVER_NAME}:${JUPYTER_HOME}/${JUPYTER_EXTENSION_ARCHIVE}
+        retry 3 docker exec -e PIP_TARGET=${ROOT_USER_PIP_DIR} ${JUPYTER_SERVER_NAME} ${JUPYTER_SCRIPTS}/extension/jupyter_install_combined_extension.sh ${JUPYTER_EXTENSION_ARCHIVE}
+      else
+        retry 3 docker exec -e PIP_TARGET=${ROOT_USER_PIP_DIR} ${JUPYTER_SERVER_NAME} ${JUPYTER_SCRIPTS}/extension/jupyter_pip_install_combined_extension.sh $ext
+      fi
+    done
+  fi
+
+  # Install lab extensions
+  # Note: lab extensions need to installed as jupyter user, not root
+  if [ ! -z "$JUPYTER_LAB_EXTENSIONS" ] ; then
+    for ext in ${JUPYTER_LAB_EXTENSIONS}
+    do
+      log 'Installing JupyterLab extension [$ext]...'
+      pwd
+      if [[ $ext == 'gs://'* ]]; then
+        gsutil cp -r $ext /etc
+        JUPYTER_EXTENSION_ARCHIVE=`basename $ext`
+        docker cp /etc/${JUPYTER_EXTENSION_ARCHIVE} ${JUPYTER_SERVER_NAME}:${JUPYTER_HOME}/${JUPYTER_EXTENSION_ARCHIVE}
+        retry 3 docker exec -e PIP_TARGET=${JUPYTER_USER_PIP_DIR} ${JUPYTER_SERVER_NAME} ${JUPYTER_SCRIPTS}/extension/jupyter_install_lab_extension.sh ${JUPYTER_HOME}/${JUPYTER_EXTENSION_ARCHIVE}
+      elif [[ $ext == 'http://'* || $ext == 'https://'* ]]; then
+        JUPYTER_EXTENSION_FILE=`basename $ext`
+        curl $ext -o /etc/${JUPYTER_EXTENSION_FILE}
+        docker cp /etc/${JUPYTER_EXTENSION_FILE} ${JUPYTER_SERVER_NAME}:${JUPYTER_HOME}/${JUPYTER_EXTENSION_FILE}
+        retry 3 docker exec -e PIP_TARGET=${JUPYTER_USER_PIP_DIR} ${JUPYTER_SERVER_NAME} ${JUPYTER_SCRIPTS}/extension/jupyter_install_lab_extension.sh ${JUPYTER_HOME}/${JUPYTER_EXTENSION_FILE}
+      else
+        retry 3 docker exec -e PIP_TARGET=${JUPYTER_USER_PIP_DIR} ${JUPYTER_SERVER_NAME} ${JUPYTER_SCRIPTS}/extension/jupyter_install_lab_extension.sh $ext
+      fi
+    done
+  fi
+
+  # done extension setup
+  STEP_TIMINGS+=($(date +%s))
+
+  # If a Jupyter user script was specified, copy it into the jupyter docker container and execute it.
+  if [ ! -z "$JUPYTER_USER_SCRIPT_URI" ] ; then
+    log 'Running Jupyter user script [$JUPYTER_USER_SCRIPT_URI]...'
+    JUPYTER_USER_SCRIPT=`basename ${JUPYTER_USER_SCRIPT_URI}`
+    if [[ "$JUPYTER_USER_SCRIPT_URI" == 'gs://'* ]]; then
+      gsutil cp ${JUPYTER_USER_SCRIPT_URI} /etc
+    else
+      curl $JUPYTER_USER_SCRIPT_URI -o /etc/${JUPYTER_USER_SCRIPT}
+    fi
+    docker cp /etc/${JUPYTER_USER_SCRIPT} ${JUPYTER_SERVER_NAME}:${JUPYTER_HOME}/${JUPYTER_USER_SCRIPT}
+    retry 3 docker exec -u root ${JUPYTER_SERVER_NAME} chmod +x ${JUPYTER_HOME}/${JUPYTER_USER_SCRIPT}
+    # Execute the user script as privileged to allow for deeper customization of VM behavior, e.g. installing
+    # network egress throttling. As docker is not a security layer, it is assumed that a determined attacker
+    # can gain full access to the VM already, so using this flag is not a significant escalation.
+    EXIT_CODE=0
+    docker exec --privileged -u root -e PIP_TARGET=${ROOT_USER_PIP_DIR} ${JUPYTER_SERVER_NAME} ${JUPYTER_HOME}/${JUPYTER_USER_SCRIPT} &> us_output.txt || EXIT_CODE=$?
+
+    if [ $EXIT_CODE -ne 0 ]; then
+      log "User script failed with exit code $EXIT_CODE. Output is saved to $JUPYTER_USER_SCRIPT_OUTPUT_URI."
+      retry 3 gsutil -h "x-goog-meta-passed":"false" cp us_output.txt ${JUPYTER_USER_SCRIPT_OUTPUT_URI}
+      exit $EXIT_CODE
+    else
+      retry 3 gsutil -h "x-goog-meta-passed":"true" cp us_output.txt ${JUPYTER_USER_SCRIPT_OUTPUT_URI}
+    fi
+  fi
+
+  # done user script
+  STEP_TIMINGS+=($(date +%s))
+
+  # If a Jupyter start user script was specified, copy it into the jupyter docker container for consumption during startups.
   if [ ! -z "$JUPYTER_START_USER_SCRIPT_URI" ] ; then
+    log 'Copying Jupyter start user script [$JUPYTER_START_USER_SCRIPT_URI]...'
     JUPYTER_START_USER_SCRIPT=`basename ${JUPYTER_START_USER_SCRIPT_URI}`
+    if [[ "$JUPYTER_START_USER_SCRIPT_URI" == 'gs://'* ]]; then
+      gsutil cp ${JUPYTER_START_USER_SCRIPT_URI} /etc
+    else
+      curl $JUPYTER_START_USER_SCRIPT_URI -o /etc/${JUPYTER_START_USER_SCRIPT}
+    fi
+    docker cp /etc/${JUPYTER_START_USER_SCRIPT} ${JUPYTER_SERVER_NAME}:${JUPYTER_HOME}/${JUPYTER_START_USER_SCRIPT}
+    retry 3 docker exec -u root ${JUPYTER_SERVER_NAME} chmod +x ${JUPYTER_HOME}/${JUPYTER_START_USER_SCRIPT}
+
+    # Keep in sync with startup.sh
     log 'Executing Jupyter user start script [$JUPYTER_START_USER_SCRIPT]...'
     EXIT_CODE=0
-    docker exec --privileged -u root -e PIP_USER=false ${JUPYTER_SERVER_NAME} ${JUPYTER_HOME}/${JUPYTER_START_USER_SCRIPT} &> start_output.txt || EXIT_CODE=$?
+    docker exec --privileged -u root -e PIP_TARGET=${ROOT_USER_PIP_DIR} ${JUPYTER_SERVER_NAME} ${JUPYTER_HOME}/${JUPYTER_START_USER_SCRIPT} &> start_output.txt || EXIT_CODE=$?
     if [ $EXIT_CODE -ne 0 ]; then
       echo "User start script failed with exit code ${EXIT_CODE}. Output is saved to ${JUPYTER_START_USER_SCRIPT_OUTPUT_URI}"
       retry 3 gsutil -h "x-goog-meta-passed":"false" cp start_output.txt ${JUPYTER_START_USER_SCRIPT_OUTPUT_URI}
@@ -486,39 +446,28 @@ elif [[ "$RUNTIME_OPERATION" == 'restarting' ]]; then
     fi
   fi
 
-  # By default GCE restarts containers on exit so we're not explicitly starting them below
+  # done start user script
+  STEP_TIMINGS+=($(date +%s))
 
-  # Configuring Jupyter
-  if [ ! -z "$JUPYTER_DOCKER_IMAGE" ] ; then
-      # See IA-1901: Jupyter UI stalls indefinitely on initial R kernel connection after cluster create/resume
-      # The intent of this is to "warm up" R at VM creation time to hopefully prevent issues when the Jupyter
-      # kernel tries to connect to it.
-      docker exec $JUPYTER_SERVER_NAME /bin/bash -c "R -e '1+1'" || true
+  # See IA-1901: Jupyter UI stalls indefinitely on initial R kernel connection after cluster create/resume
+  # The intent of this is to "warm up" R at VM creation time to hopefully prevent issues when the Jupyter
+  # kernel tries to connect to it.
+  docker exec $JUPYTER_SERVER_NAME /bin/bash -c "R -e '1+1'" || true
 
-      echo "Starting Jupyter on cluster $GOOGLE_PROJECT / $CLUSTER_NAME..."
-      docker exec -d $JUPYTER_SERVER_NAME /bin/bash -c "export WELDER_ENABLED=$WELDER_ENABLED && export NOTEBOOKS_DIR=$NOTEBOOKS_DIR && (/etc/jupyter/scripts/run-jupyter.sh $NOTEBOOKS_DIR || /usr/local/bin/jupyter notebook)"
+  log 'Starting Jupyter Notebook...'
+  retry 3 docker exec -d ${JUPYTER_SERVER_NAME} ${JUPYTER_SCRIPTS}/run-jupyter.sh ${NOTEBOOKS_DIR}
 
-      # TODO: Do we still need this for GCE?
-      if [ "$WELDER_ENABLED" == "true" ] ; then
-          # fix for https://broadworkbench.atlassian.net/browse/IA-1453
-          # TODO: remove this when we stop supporting the legacy docker image
-          docker exec -u root jupyter-server sed -i -e 's/export WORKSPACE_NAME=.*/export WORKSPACE_NAME="$(basename "$(dirname "$(pwd)")")"/' /etc/jupyter/scripts/kernel/kernel_bootstrap.sh
-      fi
-  fi
-
-  # Configuring Welder, if enabled
-  if [ "$WELDER_ENABLED" == "true" ] ; then
-      echo "Starting Welder on cluster $GOOGLE_PROJECT / $CLUSTER_NAME..."
-      docker exec -d $WELDER_SERVER_NAME /bin/bash -c "export STAGING_BUCKET=$STAGING_BUCKET && /opt/docker/bin/entrypoint.sh"
-  fi
-else
-  log "Invalid RUNTIME_OPERATION: $RUNTIME_OPERATION. Expected it to be either 'creating' or 'restarting'."
-  exit 1
+  # done start Jupyter
+  STEP_TIMINGS+=($(date +%s))
 fi
+
+# Remove any unneeded cached images to save disk space.
+# Do this asynchronously so it doesn't hold up cluster creation
+log 'Pruning docker images...'
+docker image prune -a -f &
 
 log 'All done!'
 
-END_TIME=$(date +%s)
 ELAPSED_TIME=$(($END_TIME - $START_TIME))
-log "gce-init.sh took "
-display_time $ELAPSED_TIME
+log "gce-init.sh took $(display_time $ELAPSED_TIME)"
+log "Step timings: ${STEP_TIMINGS[@]}"

--- a/http/src/main/resources/init-resources/gce-init.sh
+++ b/http/src/main/resources/init-resources/gce-init.sh
@@ -312,6 +312,16 @@ if [ ! -z "$JUPYTER_DOCKER_IMAGE" ] ; then
     docker cp /etc/${JUPYTER_NOTEBOOK_FRONTEND_CONFIG} ${JUPYTER_SERVER_NAME}:${JUPYTER_HOME}/nbconfig/
   fi
 
+  # Ugly hack alert!
+  #
+  # Prior to terra-jupyter-base:0.0.16, the jupyter_install_*_extension.sh scripts expect to be run
+  # as root and contain `sudo -E -u jupyter-user` commands. This is no longer possible with gvisor (IA-2315)
+  # so we are instead running them as jupyter-user and stripping out the sudo commands.
+  #
+  # Though terra-jupyter-base has been updated, we include this sed command here for backwards
+  # compatibility, so older image versions can still be used.
+  retry 3 docker exec ${JUPYTER_SERVER_NAME} /bin/bash -c "find /etc/jupyter/scripts/extension -name *.sh | xargs sed -i 's/sudo -E -u jupyter-user //g'"
+
   # Install NbExtensions
   if [ ! -z "$JUPYTER_NB_EXTENSIONS" ] ; then
     for ext in ${JUPYTER_NB_EXTENSIONS}

--- a/http/src/main/resources/init-resources/init-actions.sh
+++ b/http/src/main/resources/init-resources/init-actions.sh
@@ -215,8 +215,6 @@ END
 
     # Install RStudio license file, if specified
     if [ ! -z "$RSTUDIO_DOCKER_IMAGE" ] ; then
-      # TODO: remove the gsutil stat command when https://github.com/broadinstitute/firecloud-develop/pull/2105
-      # is merged because then we'll expect the license file to always be present.
       STAT_EXIT_CODE=0
       gsutil -q stat ${RSTUDIO_LICENSE_FILE} || STAT_EXIT_CODE=$?
       if [ $STAT_EXIT_CODE -eq 0 ] ; then
@@ -333,14 +331,14 @@ END
             gsutil cp $ext /etc
             JUPYTER_EXTENSION_ARCHIVE=`basename $ext`
             docker cp /etc/${JUPYTER_EXTENSION_ARCHIVE} ${JUPYTER_SERVER_NAME}:${JUPYTER_HOME}/${JUPYTER_EXTENSION_ARCHIVE}
-            retry 3 docker exec -u root -e PIP_USER=false ${JUPYTER_SERVER_NAME} ${JUPYTER_SCRIPTS}/extension/jupyter_install_notebook_extension.sh ${JUPYTER_HOME}/${JUPYTER_EXTENSION_ARCHIVE}
+            retry 3 docker exec -e PIP_USER=false ${JUPYTER_SERVER_NAME} ${JUPYTER_SCRIPTS}/extension/jupyter_install_notebook_extension.sh ${JUPYTER_HOME}/${JUPYTER_EXTENSION_ARCHIVE}
           elif [[ $ext == 'http://'* || $ext == 'https://'* ]]; then
             JUPYTER_EXTENSION_FILE=`basename $ext`
             curl $ext -o /etc/${JUPYTER_EXTENSION_FILE}
             docker cp /etc/${JUPYTER_EXTENSION_FILE} ${JUPYTER_SERVER_NAME}:${JUPYTER_HOME}/${JUPYTER_EXTENSION_FILE}
-            retry 3 docker exec -u root -e PIP_USER=false ${JUPYTER_SERVER_NAME} ${JUPYTER_SCRIPTS}/extension/jupyter_install_notebook_extension.sh ${JUPYTER_HOME}/${JUPYTER_EXTENSION_FILE}
+            retry 3 docker exec -e PIP_USER=false ${JUPYTER_SERVER_NAME} ${JUPYTER_SCRIPTS}/extension/jupyter_install_notebook_extension.sh ${JUPYTER_HOME}/${JUPYTER_EXTENSION_FILE}
           else
-            retry 3 docker exec -u root -e PIP_USER=false ${JUPYTER_SERVER_NAME} ${JUPYTER_SCRIPTS}/extension/jupyter_pip_install_notebook_extension.sh $ext
+            retry 3 docker exec -e PIP_USER=false ${JUPYTER_SERVER_NAME} ${JUPYTER_SCRIPTS}/extension/jupyter_pip_install_notebook_extension.sh $ext
           fi
         done
       fi
@@ -356,9 +354,9 @@ END
             gsutil cp $ext /etc
             JUPYTER_EXTENSION_ARCHIVE=`basename $ext`
             docker cp /etc/${JUPYTER_EXTENSION_ARCHIVE} ${JUPYTER_SERVER_NAME}:${JUPYTER_HOME}/${JUPYTER_EXTENSION_ARCHIVE}
-            retry 3 docker exec -u root -e PIP_USER=false ${JUPYTER_SERVER_NAME} ${JUPYTER_SCRIPTS}/extension/jupyter_install_server_extension.sh ${JUPYTER_HOME}/${JUPYTER_EXTENSION_ARCHIVE}
+            retry 3 docker exec -e PIP_USER=false ${JUPYTER_SERVER_NAME} ${JUPYTER_SCRIPTS}/extension/jupyter_install_server_extension.sh ${JUPYTER_HOME}/${JUPYTER_EXTENSION_ARCHIVE}
           else
-            retry 3 docker exec -u root -e PIP_USER=false ${JUPYTER_SERVER_NAME} ${JUPYTER_SCRIPTS}/extension/jupyter_pip_install_server_extension.sh $ext
+            retry 3 docker exec -e PIP_USER=false ${JUPYTER_SERVER_NAME} ${JUPYTER_SCRIPTS}/extension/jupyter_pip_install_server_extension.sh $ext
           fi
         done
       fi
@@ -375,9 +373,9 @@ END
             gsutil cp $ext /etc
             JUPYTER_EXTENSION_ARCHIVE=`basename $ext`
             docker cp /etc/${JUPYTER_EXTENSION_ARCHIVE} ${JUPYTER_SERVER_NAME}:${JUPYTER_HOME}/${JUPYTER_EXTENSION_ARCHIVE}
-            retry 3 docker exec -u root -e PIP_USER=false ${JUPYTER_SERVER_NAME} ${JUPYTER_SCRIPTS}/extension/jupyter_install_combined_extension.sh ${JUPYTER_EXTENSION_ARCHIVE}
+            retry 3 docker exec -e PIP_USER=false ${JUPYTER_SERVER_NAME} ${JUPYTER_SCRIPTS}/extension/jupyter_install_combined_extension.sh ${JUPYTER_EXTENSION_ARCHIVE}
           else
-            retry 3 docker exec -u root -e PIP_USER=false ${JUPYTER_SERVER_NAME} ${JUPYTER_SCRIPTS}/extension/jupyter_pip_install_combined_extension.sh $ext
+            retry 3 docker exec -e PIP_USER=false ${JUPYTER_SERVER_NAME} ${JUPYTER_SCRIPTS}/extension/jupyter_pip_install_combined_extension.sh $ext
           fi
         done
       fi
@@ -458,14 +456,6 @@ END
             retry 3 docker exec ${JUPYTER_SERVER_NAME} ${JUPYTER_SCRIPTS}/extension/jupyter_install_lab_extension.sh $ext
           fi
         done
-      fi
-
-      STEP_TIMINGS+=($(date +%s))
-
-      # fix for https://broadworkbench.atlassian.net/browse/IA-1453
-      # TODO: remove this when we stop supporting the legacy docker image
-      if [ ! -z ${WELDER_DOCKER_IMAGE} ] && [ "${WELDER_ENABLED}" == "true" ] ; then
-        retry 3 docker exec -u root ${JUPYTER_SERVER_NAME} sed -i -e 's/export WORKSPACE_NAME=.*/export WORKSPACE_NAME="$(basename "$(dirname "$(pwd)")")"/' ${JUPYTER_HOME}/scripts/kernel/kernel_bootstrap.sh
       fi
 
       STEP_TIMINGS+=($(date +%s))

--- a/http/src/main/resources/init-resources/init-actions.sh
+++ b/http/src/main/resources/init-resources/init-actions.sh
@@ -322,6 +322,16 @@ END
 
       STEP_TIMINGS+=($(date +%s))
 
+      # Ugly hack alert!
+      #
+      # Prior to terra-jupyter-base:0.0.16, the jupyter_install_*_extension.sh scripts expect to be run
+      # as root and contain `sudo -E -u jupyter-user` commands. This is no longer possible with gvisor (IA-2315)
+      # so we are instead running them as jupyter-user and stripping out the sudo commands.
+      #
+      # Though terra-jupyter-base has been updated, we include this sed command here for backwards
+      # compatibility, so older image versions can still be used.
+      retry 3 docker exec ${JUPYTER_SERVER_NAME} /bin/bash -c "find /etc/jupyter/scripts/extension -name *.sh | xargs sed -i 's/sudo -E -u jupyter-user //g'"
+
       # Install NbExtensions
       if [ ! -z "${JUPYTER_NB_EXTENSIONS}" ] ; then
         for ext in ${JUPYTER_NB_EXTENSIONS}

--- a/http/src/main/resources/init-resources/jupyter-docker-compose-gce.yaml
+++ b/http/src/main/resources/init-resources/jupyter-docker-compose-gce.yaml
@@ -11,6 +11,7 @@ services:
     # The cluster init script will run some scripts as root and then start pyspark as
     # jupyter-user via docker exec.
     entrypoint: "tail -f /dev/null"
+    runtime: runsc
     network_mode: host
     volumes:
       # shared with welder

--- a/http/src/main/resources/init-resources/jupyter-docker-compose-gce.yaml
+++ b/http/src/main/resources/init-resources/jupyter-docker-compose-gce.yaml
@@ -2,7 +2,7 @@
 # configuring memory options in container mode. See discussion in:
 # https://docs.docker.com/compose/compose-file/#resources
 # https://github.com/docker/compose/issues/4513
-version: '2'
+version: '2.4'
 services:
   jupyter:
     container_name: "${JUPYTER_SERVER_NAME}"

--- a/http/src/main/resources/init-resources/jupyter-docker-compose.yaml
+++ b/http/src/main/resources/init-resources/jupyter-docker-compose.yaml
@@ -11,6 +11,7 @@ services:
     # The cluster init script will run some scripts as root and then start pyspark as
     # jupyter-user via docker exec.
     entrypoint: "tail -f /dev/null"
+    runtime: runsc
     network_mode: host
     volumes:
       # shared with welder

--- a/http/src/main/resources/init-resources/proxy-docker-compose.yaml
+++ b/http/src/main/resources/init-resources/proxy-docker-compose.yaml
@@ -1,4 +1,4 @@
-version: '2'
+version: '2.4'
 services:
   proxy:
     container_name: "${PROXY_SERVER_NAME}"

--- a/http/src/main/resources/init-resources/proxy-docker-compose.yaml
+++ b/http/src/main/resources/init-resources/proxy-docker-compose.yaml
@@ -3,6 +3,7 @@ services:
   proxy:
     container_name: "${PROXY_SERVER_NAME}"
     image: "${PROXY_DOCKER_IMAGE}"
+    runtime: runsc
     network_mode: host
     volumes:
     - /certs/jupyter-server.crt:/etc/ssl/certs/server.crt:ro

--- a/http/src/main/resources/init-resources/proxy-docker-compose.yaml
+++ b/http/src/main/resources/init-resources/proxy-docker-compose.yaml
@@ -3,7 +3,8 @@ services:
   proxy:
     container_name: "${PROXY_SERVER_NAME}"
     image: "${PROXY_DOCKER_IMAGE}"
-    runtime: runsc
+    # TODO gvisor doesn't work with apache for some reason
+    #runtime: runsc
     network_mode: host
     volumes:
     - /certs/jupyter-server.crt:/etc/ssl/certs/server.crt:ro

--- a/http/src/main/resources/init-resources/rstudio-docker-compose.yaml
+++ b/http/src/main/resources/init-resources/rstudio-docker-compose.yaml
@@ -2,7 +2,7 @@
 # configuring memory options in container mode. See discussion in:
 # https://docs.docker.com/compose/compose-file/#resources
 # https://github.com/docker/compose/issues/4513
-version: '2'
+version: '2.4'
 services:
   rstudio:
     container_name: "${RSTUDIO_SERVER_NAME}"

--- a/http/src/main/resources/init-resources/rstudio-docker-compose.yaml
+++ b/http/src/main/resources/init-resources/rstudio-docker-compose.yaml
@@ -7,6 +7,7 @@ services:
   rstudio:
     container_name: "${RSTUDIO_SERVER_NAME}"
     image: "${RSTUDIO_DOCKER_IMAGE}"
+    runtime: runsc
     network_mode: host
     restart: always
     environment:

--- a/http/src/main/resources/init-resources/welder-docker-compose.yaml
+++ b/http/src/main/resources/init-resources/welder-docker-compose.yaml
@@ -12,7 +12,7 @@ services:
     # when Application Default Credentials are available.
     # See https://broadworkbench.atlassian.net/browse/IA-1026
     entrypoint: "tail -f /dev/null"
-    #TODO doesn't work for some reason
+    # TODO gvisor doesn't work on welder for some reason
     #runtime: runsc
     network_mode: host
     restart: always

--- a/http/src/main/resources/init-resources/welder-docker-compose.yaml
+++ b/http/src/main/resources/init-resources/welder-docker-compose.yaml
@@ -12,6 +12,8 @@ services:
     # when Application Default Credentials are available.
     # See https://broadworkbench.atlassian.net/browse/IA-1026
     entrypoint: "tail -f /dev/null"
+    #TODO doesn't work for some reason
+    #runtime: runsc
     network_mode: host
     restart: always
     environment:

--- a/http/src/main/resources/init-resources/welder-docker-compose.yaml
+++ b/http/src/main/resources/init-resources/welder-docker-compose.yaml
@@ -2,7 +2,7 @@
 # configuring memory options in container mode. See discussion in:
 # https://docs.docker.com/compose/compose-file/#resources
 # https://github.com/docker/compose/issues/4513
-version: '2'
+version: '2.4'
 services:
   welder:
     container_name: "${WELDER_SERVER_NAME}"

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -33,8 +33,8 @@ dataproc {
     numberOfPreemptibleWorkers = 0
   }
   # This image is used for legacy jupyter image where hail is compatible with earlier version of spark
-  legacyCustomDataprocImage = "projects/broad-dsp-gcr-public/global/images/custom-leo-image-dataproc-1-2-79-debian9-rt-gvisor"
-  customDataprocImage = "projects/broad-dsp-gcr-public/global/images/custom-leo-image-dataproc-1-4-15-debian9-rt-gvisor"
+  legacyCustomDataprocImage = "projects/broad-dsp-gcr-public/global/images/custom-leo-image-dataproc-1-2-79-debian9-gvisor-20-11-2"
+  customDataprocImage = "projects/broad-dsp-gcr-public/global/images/custom-leo-image-dataproc-1-4-15-debian9-gvisor-20-11-2"
 
   dataprocReservedMemory = 6g
 
@@ -59,7 +59,7 @@ gce {
   region = "us-central1"
   # TODO we could think about balancing between zones a-f instead of always using -a
   zone = "us-central1-a"
-  customGceImage = "projects/broad-dsp-gcr-public/global/images/custom-leo-image-gce-debian9-rt-gvisor"
+  customGceImage = "projects/broad-dsp-gcr-public/global/images/custom-leo-image-gce-debian9-gvisor-20-11-2"
   userDiskDeviceName = "user-disk"
   defaultScopes = [
     "https://www.googleapis.com/auth/userinfo.email",

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -33,8 +33,8 @@ dataproc {
     numberOfPreemptibleWorkers = 0
   }
   # This image is used for legacy jupyter image where hail is compatible with earlier version of spark
-  legacyCustomDataprocImage = "projects/broad-dsp-gcr-public/global/images/custom-leo-image-dataproc-1-2-79-debian9-7ee8bf4"
-  customDataprocImage = "projects/broad-dsp-gcr-public/global/images/custom-leo-image-dataproc-1-4-15-debian9-7ee8bf4"
+  legacyCustomDataprocImage = "projects/broad-dsp-gcr-public/global/images/custom-leo-image-dataproc-1-2-79-debian9-rt-gvisor"
+  customDataprocImage = "projects/broad-dsp-gcr-public/global/images/custom-leo-image-dataproc-1-4-15-debian9-rt-gvisor"
 
   dataprocReservedMemory = 6g
 
@@ -57,9 +57,9 @@ dataproc {
 
 gce {
   region = "us-central1"
-  # TODO is it safe to use this zone for all GCE VMs?
+  # TODO we could think about balancing between zones a-f instead of always using -a
   zone = "us-central1-a"
-  customGceImage = "projects/broad-dsp-gcr-public/global/images/custom-leo-image-gce-debian9-7ee8bf4"
+  customGceImage = "projects/broad-dsp-gcr-public/global/images/custom-leo-image-gce-debian9-rt-gvisor"
   userDiskDeviceName = "user-disk"
   defaultScopes = [
     "https://www.googleapis.com/auth/userinfo.email",

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/BaseRuntimeInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/BaseRuntimeInterpreter.scala
@@ -176,7 +176,6 @@ abstract private[util] class BaseRuntimeInterpreter[F[_]: Async: ContextShift: L
       config.clusterFilesConfig,
       config.clusterResourcesConfig,
       Some(runtimeResourceConstraints),
-      RuntimeOperation.Restarting,
       welderAction,
       useGceStartupScript
     )
@@ -212,7 +211,6 @@ abstract private[util] class BaseRuntimeInterpreter[F[_]: Async: ContextShift: L
       config.clusterFilesConfig,
       config.clusterResourcesConfig,
       None,
-      RuntimeOperation.Stopping,
       None,
       false
     )

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/RuntimeTemplateValues.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/RuntimeTemplateValues.scala
@@ -47,7 +47,6 @@ case class RuntimeTemplateValues private (googleProject: String,
                                           customEnvVarsConfigUri: String,
                                           memLimit: String,
                                           welderMemLimit: String,
-                                          runtimeOperation: String,
                                           updateWelder: String,
                                           disableDelocalization: String,
                                           rstudioLicenseFile: String,
@@ -77,7 +76,6 @@ case class RuntimeTemplateValuesConfig private (runtimeProjectAndName: RuntimePr
                                                 clusterFilesConfig: SecurityFilesConfig,
                                                 clusterResourcesConfig: ClusterResourcesConfig,
                                                 clusterResourceConstraints: Option[RuntimeResourceConstraints],
-                                                runtimeOperation: RuntimeOperation,
                                                 welderAction: Option[WelderAction],
                                                 isGceFormatted: Boolean,
                                                 useGceStartupScript: Boolean)
@@ -113,7 +111,6 @@ object RuntimeTemplateValuesConfig {
       clusterFilesConfig,
       clusterResourcesConfig,
       clusterResourceConstraints,
-      RuntimeOperation.Creating,
       None,
       isFormatted,
       false
@@ -128,7 +125,6 @@ object RuntimeTemplateValuesConfig {
                   clusterFilesConfig: SecurityFilesConfig,
                   clusterResourcesConfig: ClusterResourcesConfig,
                   clusterResourceConstraints: Option[RuntimeResourceConstraints],
-                  runtimeOperation: RuntimeOperation,
                   welderAction: Option[WelderAction],
                   useGceStartupScript: Boolean): RuntimeTemplateValuesConfig =
     RuntimeTemplateValuesConfig(
@@ -149,7 +145,6 @@ object RuntimeTemplateValuesConfig {
       clusterFilesConfig,
       clusterResourcesConfig,
       clusterResourceConstraints,
-      runtimeOperation,
       welderAction,
       false,
       useGceStartupScript
@@ -232,7 +227,6 @@ object RuntimeTemplateValues {
         .getOrElse(""),
       config.clusterResourceConstraints.map(_.memoryLimit.toString).getOrElse(""),
       config.welderConfig.welderReservedMemory.map(_.toString).getOrElse(""),
-      config.runtimeOperation.asString,
       (config.welderAction == Some(UpdateWelder)).toString,
       (config.welderAction == Some(DisableDelocalization)).toString,
       config.initBucketName

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/RuntimeTemplateValuesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/RuntimeTemplateValuesSpec.scala
@@ -17,7 +17,6 @@ class RuntimeTemplateValuesSpec extends LeonardoTestSuite with AnyFlatSpecLike {
       CommonTestData.clusterFilesConfig,
       CommonTestData.clusterResourcesConfig,
       Some(CommonTestData.clusterResourceConstraints),
-      RuntimeOperation.Restarting,
       Some(WelderAction.UpdateWelder),
       false
     )
@@ -73,7 +72,6 @@ class RuntimeTemplateValuesSpec extends LeonardoTestSuite with AnyFlatSpecLike {
       result.rstudioLicenseFile shouldBe GcsPath(CommonTestData.initBucketName,
                                                  GcsObjectName("rstudio-license-file.lic")).toUri
       result.rstudioServerName shouldBe "rstudio-server"
-      result.runtimeOperation shouldBe RuntimeOperation.Restarting.asString
       result.stagingBucketName shouldBe CommonTestData.stagingBucketName.value
       result.updateWelder shouldBe "true"
       result.welderDockerCompose shouldBe GcsPath(CommonTestData.initBucketName,

--- a/jenkins/dataproc-custom-images/prepare-custom-leonardo-jupyter-dataproc-image.sh
+++ b/jenkins/dataproc-custom-images/prepare-custom-leonardo-jupyter-dataproc-image.sh
@@ -189,8 +189,6 @@ log 'Installing gvisor...'
 curl -fsSL https://gvisor.dev/archive.key | sudo apt-key add -
 add-apt-repository "deb https://storage.googleapis.com/gvisor/releases release main"
 retry 5 apt-get update
-# the apt-get install automatically configures docker, no need for additional steps
-# https://gvisor.dev/docs/user_guide/quick_start/docker/
 retry 5 apt-get install -y -q runsc
 runsc install
 jq '.runtimes.runsc += {"runtimeArgs":["--network=host"]}' /etc/docker/daemon.json > /etc/docker/daemon.json.tmp \

--- a/jenkins/gce-custom-images/prepare_custom_leonardo_gce_image.sh
+++ b/jenkins/gce-custom-images/prepare_custom_leonardo_gce_image.sh
@@ -120,7 +120,8 @@ retry 5 apt-get install -y -q \
     gnupg2 \
     software-properties-common \
     libffi-dev \
-    python3-pip
+    python3-pip \
+    jq
 
 # Install google-fluent-d
 # https://cloud.google.com/logging/docs/agent/installation
@@ -208,6 +209,21 @@ docker_compose_binary_download_target_filename="/usr/local/bin/docker-compose"
 
 retry 5 curl -L "${docker_compose_binary_download_url:?}" -o "${docker_compose_binary_download_target_filename:?}"
 chmod +x "${docker_compose_binary_download_target_filename:?}"
+
+# Install gvisor. See:
+# https://gvisor.dev/docs/user_guide/install/#install-from-an-apt-repository
+# https://gvisor.dev/docs/user_guide/quick_start/docker/
+log 'Installing gvisor...'
+curl -fsSL https://gvisor.dev/archive.key | sudo apt-key add -
+add-apt-repository "deb https://storage.googleapis.com/gvisor/releases release main"
+retry 5 apt-get update
+# the apt-get install automatically configures docker, no need for additional steps
+# https://gvisor.dev/docs/user_guide/quick_start/docker/
+retry 5 apt-get install -y -q runsc
+runsc install
+jq '.runtimes.runsc += {"runtimeArgs":["--network=host"]}' /etc/docker/daemon.json > /etc/docker/daemon.json.tmp \
+  && mv /etc/docker/daemon.json.tmp /etc/docker/daemon.json
+systemctl restart docker
 
 # Pull docker image versions as of the time this script ran; this caches them in the
 # GCE custom instance image.

--- a/jenkins/gce-custom-images/prepare_custom_leonardo_gce_image.sh
+++ b/jenkins/gce-custom-images/prepare_custom_leonardo_gce_image.sh
@@ -217,8 +217,6 @@ log 'Installing gvisor...'
 curl -fsSL https://gvisor.dev/archive.key | sudo apt-key add -
 add-apt-repository "deb https://storage.googleapis.com/gvisor/releases release main"
 retry 5 apt-get update
-# the apt-get install automatically configures docker, no need for additional steps
-# https://gvisor.dev/docs/user_guide/quick_start/docker/
 retry 5 apt-get install -y -q runsc
 runsc install
 jq '.runtimes.runsc += {"runtimeArgs":["--network=host"]}' /etc/docker/daemon.json > /etc/docker/daemon.json.tmp \


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-2332

This PR enables the [gvisor](https://gvisor.dev/) docker runtime, which is a requirement for adding user `sudo` support (will be in a separate PR).

Also refactored `gce-init.sh` a little bit, and removed some dead code.

I am testing via automation tests and manually in a fiab.

Need to confirm with AoU as well.

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
