### PR TITLE
[no ticket] Add spans and counters to all Leo http routes

### DIFF
--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/HttpRoutes.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/HttpRoutes.scala
@@ -26,6 +26,7 @@ import org.broadinstitute.dsde.workbench.leonardo.model.LeoException
 import org.broadinstitute.dsde.workbench.leonardo.service.KubernetesService
 import org.broadinstitute.dsde.workbench.model.ErrorReportJsonSupport._
 import org.broadinstitute.dsde.workbench.model.ErrorReport
+import org.broadinstitute.dsde.workbench.openTelemetry.OpenTelemetryMetrics
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -39,7 +40,11 @@ class HttpRoutes(
   kubernetesService: KubernetesService[IO],
   userInfoDirectives: UserInfoDirectives,
   contentSecurityPolicy: String
-)(implicit timer: Timer[IO], ec: ExecutionContext, ac: ActorSystem, cs: ContextShift[IO])
+)(implicit timer: Timer[IO],
+  ec: ExecutionContext,
+  ac: ActorSystem,
+  cs: ContextShift[IO],
+  metrics: OpenTelemetryMetrics[IO])
     extends LazyLogging {
   private val swaggerRoutes = new SwaggerRoutes(swaggerConfig)
   private val statusRoutes = new StatusRoutes(statusService)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/ProxyRoutes.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/ProxyRoutes.scala
@@ -11,111 +11,113 @@ import akka.http.scaladsl.server.RouteResult.Complete
 import akka.http.scaladsl.server.directives.{DebuggingDirectives, LogEntry, LoggingMagnet}
 import akka.http.scaladsl.server.{Directive0, Directive1, Route}
 import akka.stream.Materializer
-import cats.effect.{ContextShift, IO, Timer}
+import cats.effect.{ContextShift, IO}
 import cats.implicits._
 import cats.mtl.ApplicativeAsk
 import com.typesafe.scalalogging.LazyLogging
+import io.opencensus.scala.akka.http.TracingDirective.traceRequestForService
 import org.broadinstitute.dsde.workbench.google2.KubernetesSerializableName.ServiceName
 import org.broadinstitute.dsde.workbench.leonardo.api.CookieSupport
 import org.broadinstitute.dsde.workbench.leonardo.dao.TerminalName
 import org.broadinstitute.dsde.workbench.leonardo.http.service.ProxyService
 import org.broadinstitute.dsde.workbench.model.UserInfo
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
+import org.broadinstitute.dsde.workbench.openTelemetry.OpenTelemetryMetrics
 
 class ProxyRoutes(proxyService: ProxyService, corsSupport: CorsSupport)(
   implicit materializer: Materializer,
   cs: ContextShift[IO],
-  timer: Timer[IO]
+  metrics: OpenTelemetryMetrics[IO]
 ) extends LazyLogging {
   val route: Route =
-    // Note that the "notebooks" path prefix is deprecated
-    pathPrefix("proxy" | "notebooks") {
+    traceRequestForService(serviceData) { span =>
+      extractAppContext(Some(span)) { implicit ctx =>
+        // Note that the "notebooks" path prefix is deprecated
+        pathPrefix("proxy" | "notebooks") {
 
-      corsSupport.corsHandler {
+          corsSupport.corsHandler {
 
-        // "apps" proxy routes
-        pathPrefix("google" / "v1" / "apps") {
-          pathPrefix(googleProjectSegment / appNameSegment / serviceNameSegment) {
-            (googleProject, appName, serviceName) =>
-              (extractRequest & extractUserInfo) { (request, userInfo) =>
-                logRequestResultForMetrics(userInfo) {
-                  complete {
-                    proxyAppHandler(userInfo, googleProject, appName, serviceName, request)
-                  }
-                }
-              }
-          }
-        } ~
-          // "runtimes" proxy routes
-          pathPrefix(googleProjectSegment / runtimeNameSegment) { (googleProject, runtimeName) =>
-            // Note the setCookie route exists at the top-level /proxy/setCookie as well
-            path("setCookie") {
-              extractUserInfoFromHeader { userInfoOpt =>
-                get {
-                  val cookieDirective = userInfoOpt match {
-                    case Some(userInfo) => CookieSupport.setTokenCookie(userInfo, CookieSupport.tokenCookieName)
-                    case None           => CookieSupport.unsetTokenCookie(CookieSupport.tokenCookieName)
-                  }
-                  cookieDirective {
-                    complete {
-                      IO(logger.debug(s"Successfully set cookie for user $userInfoOpt"))
-                        .as(StatusCodes.NoContent)
-                    }
-                  }
-                }
-              }
-            } ~
-              pathPrefix("jupyter" / "terminals") {
-                pathSuffix(terminalNameSegment) { terminalName =>
+            // "apps" proxy routes
+            pathPrefix("google" / "v1" / "apps") {
+              pathPrefix(googleProjectSegment / appNameSegment / serviceNameSegment) {
+                (googleProject, appName, serviceName) =>
                   (extractRequest & extractUserInfo) { (request, userInfo) =>
                     logRequestResultForMetrics(userInfo) {
                       complete {
-                        openTerminalHandler(userInfo, googleProject, runtimeName, terminalName, request)
+                        proxyAppHandler(userInfo, googleProject, appName, serviceName, request)
+                      }
+                    }
+                  }
+              }
+            } ~
+              // "runtimes" proxy routes
+              pathPrefix(googleProjectSegment / runtimeNameSegment) { (googleProject, runtimeName) =>
+                // Note the setCookie route exists at the top-level /proxy/setCookie as well
+                path("setCookie") {
+                  extractUserInfoFromHeader { userInfoOpt =>
+                    get {
+                      val cookieDirective = userInfoOpt match {
+                        case Some(userInfo) => CookieSupport.setTokenCookie(userInfo, CookieSupport.tokenCookieName)
+                        case None           => CookieSupport.unsetTokenCookie(CookieSupport.tokenCookieName)
+                      }
+                      cookieDirective {
+                        complete {
+                          setCookieHandler(userInfoOpt)
+                        }
+                      }
+                    }
+                  }
+                } ~
+                  pathPrefix("jupyter" / "terminals") {
+                    pathSuffix(terminalNameSegment) { terminalName =>
+                      (extractRequest & extractUserInfo) { (request, userInfo) =>
+                        logRequestResultForMetrics(userInfo) {
+                          complete {
+                            openTerminalHandler(userInfo, googleProject, runtimeName, terminalName, request)
+                          }
+                        }
+                      }
+                    }
+                  } ~
+                  (extractRequest & extractUserInfo) { (request, userInfo) =>
+                    logRequestResultForMetrics(userInfo) {
+                      // Proxy logic handled by the ProxyService class
+                      // Note ProxyService calls the LeoAuthProvider internally
+                      complete {
+                        proxyRuntimeHandler(userInfo, googleProject, runtimeName, request)
+                      }
+                    }
+                  }
+              } ~
+              // Top-level routes
+              path("invalidateToken") {
+                get {
+                  extractUserInfoOpt { userInfoOpt =>
+                    CookieSupport.unsetTokenCookie(CookieSupport.tokenCookieName) {
+                      complete {
+                        invalidateTokenHandler(userInfoOpt)
                       }
                     }
                   }
                 }
               } ~
-              (extractRequest & extractUserInfo) { (request, userInfo) =>
-                logRequestResultForMetrics(userInfo) {
-                  // Proxy logic handled by the ProxyService class
-                  // Note ProxyService calls the LeoAuthProvider internally
-                  complete {
-                    proxyRuntimeHandler(userInfo, googleProject, runtimeName, request)
+              path("setCookie") {
+                extractUserInfoFromHeader { userInfoOpt =>
+                  get {
+                    val cookieDirective = userInfoOpt match {
+                      case Some(userInfo) => CookieSupport.setTokenCookie(userInfo, CookieSupport.tokenCookieName)
+                      case None           => CookieSupport.unsetTokenCookie(CookieSupport.tokenCookieName)
+                    }
+                    cookieDirective {
+                      complete {
+                        setCookieHandler(userInfoOpt)
+                      }
+                    }
                   }
                 }
               }
-          } ~
-          // Top-level routes
-          path("invalidateToken") {
-            get {
-              extractUserInfoOpt { userInfoOpt =>
-                CookieSupport.unsetTokenCookie(CookieSupport.tokenCookieName) {
-                  complete {
-                    userInfoOpt.traverse(userInfo => proxyService.invalidateAccessToken(userInfo.accessToken.token)) >>
-                      IO(logger.debug(s"Invalidated access token"))
-                        .as(StatusCodes.NoContent)
-                  }
-                }
-              }
-            }
-          } ~
-          path("setCookie") {
-            extractUserInfoFromHeader { userInfoOpt =>
-              get {
-                val cookieDirective = userInfoOpt match {
-                  case Some(userInfo) => CookieSupport.setTokenCookie(userInfo, CookieSupport.tokenCookieName)
-                  case None           => CookieSupport.unsetTokenCookie(CookieSupport.tokenCookieName)
-                }
-                cookieDirective {
-                  complete {
-                    IO(logger.debug(s"Successfully set cookie for user $userInfoOpt"))
-                      .as(StatusCodes.NoContent)
-                  }
-                }
-              }
-            }
           }
+        }
       }
     }
 
@@ -184,44 +186,66 @@ class ProxyRoutes(proxyService: ProxyService, corsSupport: CorsSupport)(
     DebuggingDirectives.logRequestResult(LoggingMagnet(myMetricsLogger))
   }
 
-  private[api] def proxyAppHandler(userInfo: UserInfo,
-                                   googleProject: GoogleProject,
-                                   appName: AppName,
-                                   serviceName: ServiceName,
-                                   request: HttpRequest): IO[ToResponseMarshallable] =
+  private[api] def proxyAppHandler(
+    userInfo: UserInfo,
+    googleProject: GoogleProject,
+    appName: AppName,
+    serviceName: ServiceName,
+    request: HttpRequest
+  )(implicit ev: ApplicativeAsk[IO, AppContext]): IO[ToResponseMarshallable] =
     for {
-      implicit0(ctx: ApplicativeAsk[IO, AppContext]) <- AppContext.lift[IO]()
-      t <- ctx.ask
-      res <- proxyService
+      ctx <- ev.ask
+      apiCall = proxyService
         .proxyAppRequest(userInfo, googleProject, appName, serviceName, request)
         .onError {
           case e =>
             IO(
               logger.warn(
-                s"${t.traceId} | proxy request failed for ${userInfo.userEmail.value} ${googleProject.value} ${appName.value} ${serviceName.value}",
+                s"${ctx.traceId} | proxy request failed for ${userInfo.userEmail.value} ${googleProject.value} ${appName.value} ${serviceName.value}",
                 e
               )
             ) <* IO
               .fromFuture(IO(request.entity.discardBytes().future))
         }
-    } yield res
+      _ <- metrics.incrementCounter("proxyApp")
+      resp <- ctx.span.fold(apiCall)(span => spanResource[IO](span, "proxyApp").use(_ => apiCall))
+    } yield resp
 
-  private[api] def openTerminalHandler(userInfo: UserInfo,
-                                       googleProject: GoogleProject,
-                                       runtimeName: RuntimeName,
-                                       terminalName: TerminalName,
-                                       request: HttpRequest): IO[ToResponseMarshallable] =
+  private[api] def openTerminalHandler(
+    userInfo: UserInfo,
+    googleProject: GoogleProject,
+    runtimeName: RuntimeName,
+    terminalName: TerminalName,
+    request: HttpRequest
+  )(implicit ev: ApplicativeAsk[IO, AppContext]): IO[ToResponseMarshallable] =
     for {
-      implicit0(ctx: ApplicativeAsk[IO, AppContext]) <- AppContext.lift[IO]()
-      res <- proxyService.openTerminal(userInfo, googleProject, runtimeName, terminalName, request)
-    } yield res
+      ctx <- ev.ask
+      apiCall = proxyService.openTerminal(userInfo, googleProject, runtimeName, terminalName, request)
+      _ <- metrics.incrementCounter("openTerminal")
+      resp <- ctx.span.fold(apiCall)(span => spanResource[IO](span, "openTerminal").use(_ => apiCall))
+    } yield resp
 
-  private[api] def proxyRuntimeHandler(userInfo: UserInfo,
-                                       googleProject: GoogleProject,
-                                       runtimeName: RuntimeName,
-                                       request: HttpRequest): IO[ToResponseMarshallable] =
+  private[api] def proxyRuntimeHandler(
+    userInfo: UserInfo,
+    googleProject: GoogleProject,
+    runtimeName: RuntimeName,
+    request: HttpRequest
+  )(implicit ev: ApplicativeAsk[IO, AppContext]): IO[ToResponseMarshallable] =
     for {
-      implicit0(ctx: ApplicativeAsk[IO, AppContext]) <- AppContext.lift[IO]()
-      res <- proxyService.proxyRequest(userInfo, googleProject, runtimeName, request)
-    } yield res
+      ctx <- ev.ask
+      apiCall = proxyService.proxyRequest(userInfo, googleProject, runtimeName, request)
+      _ <- metrics.incrementCounter("proxyRuntime")
+      resp <- ctx.span.fold(apiCall)(span => spanResource[IO](span, "proxyRuntime").use(_ => apiCall))
+    } yield resp
+
+  private[api] def setCookieHandler(userInfoOpt: Option[UserInfo]): IO[ToResponseMarshallable] =
+    metrics.incrementCounter("setCookie") >>
+      IO(logger.debug(s"Successfully set cookie for user $userInfoOpt"))
+        .as(StatusCodes.NoContent)
+
+  private[api] def invalidateTokenHandler(userInfoOpt: Option[UserInfo]): IO[ToResponseMarshallable] =
+    metrics.incrementCounter("invalidateToken") >>
+      userInfoOpt.traverse(userInfo => proxyService.invalidateAccessToken(userInfo.accessToken.token)) >>
+      IO(logger.debug(s"Invalidated access token"))
+        .as(StatusCodes.NoContent)
 }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/package.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/package.scala
@@ -54,10 +54,8 @@ package object api {
   }
 
   def extractAppContext(span: Option[Span]): Directive1[ApplicativeAsk[IO, AppContext]] =
-    //val traceIdFromHeader = req.headers.get(CaseInsensitiveString("X-Cloud-Trace-Context")).map(x => TraceId(x.value))
-    //traceIdFromHeader.fold(IO(TraceId(UUID.randomUUID().toString)))(IO.pure)
     optionalHeaderValueByName(traceIdHeaderString).map {
-      case (uuidOpt) =>
+      case uuidOpt =>
         val traceId = uuidOpt.getOrElse(UUID.randomUUID().toString)
         val now = Instant.now()
         val appContext = AppContext(TraceId(traceId), now, span)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/package.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/package.scala
@@ -5,14 +5,15 @@ import java.sql.SQLDataException
 import java.util.Objects
 
 import akka.http.scaladsl.model.Uri.Host
-import io.opencensus.trace.{AttributeValue, Span}
-import io.opencensus.scala.http.ServiceData
 import cats.effect.{Blocker, ContextShift, Resource, Sync}
 import cats.implicits._
 import cats.mtl.ApplicativeAsk
+import io.opencensus.scala.http.ServiceData
+import io.opencensus.trace.{AttributeValue, Span}
 import fs2._
 import org.broadinstitute.dsde.workbench.errorReporting.ReportWorthy
 import org.broadinstitute.dsde.workbench.leonardo.db.DBIOOps
+import org.broadinstitute.dsde.workbench.leonardo.http.api.BuildTimeVersion
 import org.broadinstitute.dsde.workbench.leonardo.monitor.{
   InvalidMonitorRequest,
   RuntimeConfigInCreateRuntimeMessage,
@@ -21,9 +22,8 @@ import org.broadinstitute.dsde.workbench.leonardo.monitor.{
 import org.broadinstitute.dsde.workbench.leonardo.util.CloudServiceOps
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.broadinstitute.dsde.workbench.model.{ErrorReportSource, TraceId}
-import org.broadinstitute.dsde.workbench.leonardo.http.api.BuildTimeVersion
-import slick.dbio.DBIO
 import shapeless._
+import slick.dbio.DBIO
 
 package object http {
   implicit val errorReportSource = ErrorReportSource("leonardo")


### PR DESCRIPTION
Just something I did in my spare time. Added OpenCensus tracing and counters to all http routes:
- `RuntimeRoutes`
- `DiskRoutes`
- `AppRoutes`
- `ProxyRoutes`

Will verify tests.

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
