### PR TITLE
[IA-2277] [IA-2331] add deletedFrom

### DIFF
--- a/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changelog.xml
+++ b/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changelog.xml
@@ -66,4 +66,5 @@
     <include file="changesets/20200917_add_release_to_app_table.xml" relativeToChangelogFile="true" />
     <include file="changesets/20200921_drop_on_update_pd_table.xml" relativeToChangelogFile="true" />
     <include file="changesets/20201026_drop_not_null_constraint_on_error_code_table.xml" relativeToChangelogFile="true" />
+    <include file="changesets/20201104_add_deletedFrom.xml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/20201104_add_deletedFrom.xml
+++ b/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/20201104_add_deletedFrom.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog logicalFilePath="leonardo" xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+    <changeSet logicalFilePath="leonardo" author="rtitle" id="add-deletedFrom">
+        <addColumn tableName="CLUSTER">
+            <column name="deletedFrom" type="varchar(1024)">
+                <constraints nullable="true"/>
+            </column>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/CommonTestData.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/CommonTestData.scala
@@ -292,7 +292,8 @@ object CommonTestData {
     stagingBucket = Some(stagingBucketName.value),
     welderEnabled = true,
     customClusterEnvironmentVariables = Map.empty,
-    runtimeConfigId = RuntimeConfigId(-1)
+    runtimeConfigId = RuntimeConfigId(-1),
+    deletedFrom = None
   )
 
   val readyInstance = Instance

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponentSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponentSpec.scala
@@ -342,4 +342,18 @@ class ClusterComponentSpec extends AnyFlatSpecLike with TestComponent with GcsPa
 
     res.unsafeRunSync()
   }
+
+  it should "save and get deletedFrom" in isolatedDbTest {
+    val res = for {
+      savedRuntime <- IO(
+        makeCluster(1).save()
+      )
+      _ <- clusterQuery.updateDeletedFrom(savedRuntime.id, "zombieMonitor").transaction
+      deletedFrom <- clusterQuery.getDeletedFrom(savedRuntime.id).transaction
+    } yield {
+      deletedFrom shouldBe Some("zombieMonitor")
+    }
+
+    res.unsafeRunSync()
+  }
 }


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-2277

Add `deletedFrom` field to distinguish reason why a runtime is marked as `Deleted`, such as from zombie monitor, or crypto mining...default to `None` if it's from normal user action

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
