### PR TITLE
[no ticket] handle https redirects by RStudio

### DIFF
--- a/http/src/main/resources/init-resources/cluster-site.conf
+++ b/http/src/main/resources/init-resources/cluster-site.conf
@@ -27,7 +27,9 @@
     RewriteRule /proxy/[^/]*/[^/]*/rstudio/(.*) http://127.0.0.1:8001/$1 [P,L]
 
     # Include a ProxyPassReverse so redirects by RStudio go to the correct server name (e.g. https://notebooks.firecloud.org)
+    # Need to include both http and https, as RStudio redirects to https in some cases.
     ProxyPassReverse /proxy/${GOOGLE_PROJECT}/${RUNTIME_NAME}/rstudio/ http://127.0.0.1:8001/
+    ProxyPassReverse /proxy/${GOOGLE_PROJECT}/${RUNTIME_NAME}/rstudio/ https://127.0.0.1:8001/
 
     # Append SameSite=None to cookies set by RStudio. This is required by some browsers because we
     # render RStudio in an iframe. There does not appear to be a way within RStudio to do this, hence


### PR DESCRIPTION
I think this fixes the issue reported in https://github.com/anvilproject/anvil-docker/pull/21. I had thought [this PR](https://github.com/DataBiosphere/leonardo/pull/1673) fixed it but it turns out this version of RStudio redirects to `https` so we need a `ProxyPassReverse` directive to handle `https` redirects. 

I tested by:
1. Launched an RStudio with this image: `nitesh1989/anvil-rstudio-bioconductor:0.0.8`
2. It failed in the same way as Nitesh reported
3. ssh'd into the runtime, made this change, restarted the apache container
4. It works now
5. reverted the change, restarted apache again
6. it fails again

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
