### PR TITLE
[IA-2291] use ol8 docker image to resolve trivy scan issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN mkdir /helm-go-lib-build && \
     cd helm-go-lib && \
     go build -o libhelm.so -buildmode=c-shared main.go
 
-FROM oracle/graalvm-ce:20.2.0-java8
+FROM oracle/graalvm-ce:20.2.0-java8-ol8
 
 EXPOSE 8080
 EXPOSE 5050

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -175,9 +175,8 @@ function docker_cmd()
 
         docker build -t "${DEFAULT_IMAGE}:${DOCKER_TAG}" .
 
-        # TODO add --exit-code 1 after after https://broadworkbench.atlassian.net/browse/IA-2291
         echo "scanning docker image..."
-        docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v "$HOME"/Library/Caches:/root/.cache/ aquasec/trivy --severity CRITICAL "${DEFAULT_IMAGE}":"${DOCKER_TAG}"
+        docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v "$HOME"/Library/Caches:/root/.cache/ aquasec/trivy --exit-code 1 --severity CRITICAL "${DEFAULT_IMAGE}":"${DOCKER_TAG}"
 
 
         echo "building $TESTS_IMAGE docker image..."


### PR DESCRIPTION
Have not tested yet. Letting auto tests run here to see if the docker file change is good. 

This change is a result of this slack discussion: https://broadinstitute.slack.com/archives/G01F2P32HC1/p1605299326041200