### PR TITLE
[no ticket] Fix nginx install causing auto test failures

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/master
     rm get_helm.sh
 
 # Add the repos containing nginx and galaxy charts
-RUN helm repo add stable https://kubernetes-charts.storage.googleapis.com/ && \
+RUN helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx && \
     helm repo add galaxy https://raw.githubusercontent.com/cloudve/helm-charts/anvil/ && \
     helm repo update
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/master
     rm get_helm.sh
 
 # Add the repos containing nginx and galaxy charts
-RUN helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx && \
+RUN helm repo add center https://repo.chartcenter.io && \
     helm repo add galaxy https://raw.githubusercontent.com/cloudve/helm-charts/anvil/ && \
     helm repo update
 

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -209,8 +209,6 @@ gke {
   ingress {
     namespace = "nginx"
     release = "nginx"
-    # TODO Switch to ingress-nginx because of:
-    # https://artifacthub.io/packages/helm/helm-stable/nginx-ingress
     chartName = "ingress-nginx/ingress-nginx"
     chartVersion = "3.10.1"
     loadBalancerService = "nginx-nginx-ingress-controller"

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -211,8 +211,8 @@ gke {
     release = "nginx"
     # TODO Switch to ingress-nginx because of:
     # https://artifacthub.io/packages/helm/helm-stable/nginx-ingress
-    chartName = "stable/nginx-ingress"
-    chartVersion = "1.41.3"
+    chartName = "ingress-nginx/ingress-nginx"
+    chartVersion = "3.10.1"
     loadBalancerService = "nginx-nginx-ingress-controller"
     values = [
       "rbac.create=true",

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -210,8 +210,10 @@ gke {
     namespace = "nginx"
     release = "nginx"
     chartName = "ingress-nginx/ingress-nginx"
-    chartVersion = "3.10.1"
-    loadBalancerService = "nginx-nginx-ingress-controller"
+    # ingress-nginx >= 3.0.0 requires Kubernetes >= 1.16.0
+    # see https://github.com/kubernetes/ingress-nginx/blob/master/charts/ingress-nginx/CHANGELOG.md
+    chartVersion = "2.16.0"
+    loadBalancerService = "nginx-ingress-nginx-controller"
     values = [
       "rbac.create=true",
       "controller.publishService.enabled=true"

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -209,8 +209,9 @@ gke {
   ingress {
     namespace = "nginx"
     release = "nginx"
-    # TODO this chart is deprecated, switch to ingress-nginx.
-    # See: https://github.com/helm/charts/tree/master/stable/nginx-ingress
+    # TODO this chart is deprecated, switch to ingress-nginx. See:
+    #  https://broadworkbench.atlassian.net/browse/IA-2358
+    #  https://github.com/helm/charts/tree/master/stable/nginx-ingress
     chartName = "center/stable/nginx-ingress"
     chartVersion = "1.41.3"
     loadBalancerService = "nginx-nginx-ingress-controller"

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -209,11 +209,11 @@ gke {
   ingress {
     namespace = "nginx"
     release = "nginx"
-    chartName = "ingress-nginx/ingress-nginx"
-    # ingress-nginx >= 3.0.0 requires Kubernetes >= 1.16.0
-    # see https://github.com/kubernetes/ingress-nginx/blob/master/charts/ingress-nginx/CHANGELOG.md
-    chartVersion = "2.16.0"
-    loadBalancerService = "nginx-ingress-nginx-controller"
+    # TODO this chart is deprecated, switch to ingress-nginx.
+    # See: https://github.com/helm/charts/tree/master/stable/nginx-ingress
+    chartName = "center/stable/nginx-ingress"
+    chartVersion = "1.41.3"
+    loadBalancerService = "nginx-nginx-ingress-controller"
     values = [
       "rbac.create=true",
       "controller.publishService.enabled=true"


### PR DESCRIPTION
I was looking at Leo [logs](https://fc-jenkins.dsp-techops.broadinstitute.org/view/FIAB/job/fiab-stop/56747/artifact/logs/logs-20201116_191415/firecloud_leonardo-app_1.log) for a failed auto-test run, and I have a theory as to what's going on.

The logs look fine, up until this point when it tries to launch a Galaxy:

```
[INFO] [00:03:26.781] [ioapp-compute-2] o.h.client.middleware.RequestLogger - HTTP/1.1 GET https://3665325303026068971.jupyter-qa.firecloud.org/proxy/gpalloc-qa-master-ckgexq6/automation-test-aiwe0wm3z/welder/status Headers()
2020/11/17 00:03:27 failed to download "stable/nginx-ingress" (hint: running `helm repo update` may help)
helm.sh/helm/v3/pkg/action.(*ChartPathOptions).LocateChart
	/go/pkg/mod/helm.sh/helm/v3@v3.2.0/pkg/action/install.go:674
main.installChart
	/helm-go-lib-build/helm-scala-sdk/helm-go-lib/main.go:111
main._cgoexpwrap_30cb615677c7_installChart
	_cgo_gotypes.go:80
runtime.cgocallbackg1
	/usr/local/go/src/runtime/cgocall.go:332
runtime.cgocallbackg
	/usr/local/go/src/runtime/cgocall.go:207
runtime.cgocallback_gofunc
	/usr/local/go/src/runtime/asm_amd64.s:793
runtime.goexit
	/usr/local/go/src/runtime/asm_amd64.s:1373
[INFO] [00:03:27.397] [ioapp-compute-4] o.b.d.workbench.leonardo.http.Boot - The command 'helm installChart' failed with result failed to download "stable/nginx-ingress" (hint: running `helm repo update` may help)
[ERROR] [00:03:27.417] [ioapp-compute-1] o.b.d.workbench.leonardo.http.Boot - Failed to start leonardo
java.lang.RuntimeException: handleKubernetesError should not be used with a non kubernetes error. Error: org.broadinstitute.dsp.HelmException: failed to download "stable/nginx-ingress" (hint: running `helm repo update` may help)
	at org.broadinstitute.dsde.workbench.leonardo.monitor.LeoPubsubMessageSubscriber.handleKubernetesError(LeoPubsubMessageSubscriber.scala:1030)
	at org.broadinstitute.dsde.workbench.leonardo.monitor.LeoPubsubMessageSubscriber.$anonfun$handleBatchNodepoolCreateMessage$4(LeoPubsubMessageSubscriber.scala:895)
	at org.broadinstitute.dsde.workbench.leonardo.AsyncTaskProcessor.$anonfun$handler$6(AsyncTaskProcessor.scala:39)
	at cats.instances.OptionInstances$$anon$1.traverse(option.scala:87)
	at cats.instances.OptionInstances$$anon$1.traverse(option.scala:15)
	at cats.Traverse$Ops.traverse(Traverse.scala:19)
	at cats.Traverse$Ops.traverse$(Traverse.scala:19)
	at cats.Traverse$ToTraverseOps$$anon$2.traverse(Traverse.scala:19)
	at org.broadinstitute.dsde.workbench.leonardo.AsyncTaskProcessor.$anonfun$handler$5(AsyncTaskProcessor.scala:39)
```

The Leo application seems to shut down after this error, causing all subsequent tests to fail. 

So there are 2 issues:
1. The `nginx-ingress` chart no longer exists in the repository we're using
2. The `HelmException` thrown by `pollCluster` was not being caught and was actually falling through to `Boot` and shutting down the Leo app!

This PR aims to fix both of these things: update the nginx chart repo and handle relevant helm/GKE errors in `LeoPubsubMessageSubscriber`.



---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
