### PR TITLE
[no ticket]Fix docker spec due to deleted image

### DIFF
--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpDockerDAOSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpDockerDAOSpec.scala
@@ -15,10 +15,9 @@ import org.scalatest.matchers.should.Matchers
 
 class HttpDockerDAOSpec extends AnyFlatSpec with Matchers with BeforeAndAfterAll with LeonardoTestSuite {
   val jupyterImages = List(
-    // dockerhub no tag
-    ContainerImage("broadinstitute/leonardo-notebooks", DockerHub),
+    // TODO this will break if AoU moves off Dockerhub and we delete these images
     // dockerhub with tag
-    ContainerImage("broadinstitute/leonardo-notebooks:dev", DockerHub),
+    ContainerImage("broadinstitute/terra-jupyter-aou:1.0.17", DockerHub),
     // dockerhub with sha
     // TODO: shas are currently not working
 //    DockerHub(


### PR DESCRIPTION
The `broadinstitute/leonardo-notebooks` image was deleted which broke this test. :)

It's probably good to test autodetection against a real DH aou image, although if we migrate off DH we might need to change this test again.

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
