### PR TITLE
IA-2341 Galaxy stop/start

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/KeyLock.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/KeyLock.scala
@@ -5,7 +5,7 @@ import java.util.concurrent.TimeUnit
 import cats.effect.concurrent.Semaphore
 import cats.effect.implicits._
 import cats.effect.{Blocker, ConcurrentEffect, ContextShift}
-import cats.implicits._
+import cats.syntax.all._
 import com.google.common.cache.{CacheBuilder, CacheLoader}
 
 import scala.concurrent.duration.FiniteDuration

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/KeyLock.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/KeyLock.scala
@@ -4,28 +4,32 @@ import java.util.concurrent.TimeUnit
 
 import cats.effect.concurrent.Semaphore
 import cats.effect.implicits._
-import cats.effect.{Blocker, Concurrent, ConcurrentEffect, ContextShift, Effect}
+import cats.effect.{Blocker, ConcurrentEffect, ContextShift}
 import cats.implicits._
 import com.google.common.cache.{CacheBuilder, CacheLoader}
 
 import scala.concurrent.duration.FiniteDuration
 
+/**
+ * A functional lock which works on a per-key basis.
+ */
 abstract class KeyLock[F[_], K] {
   def acquire(key: K): F[Unit]
   def release(key: K): F[Unit]
   def withKeyLock[A](key: K)(fa: F[A]): F[A]
 }
 object KeyLock {
-  def apply[F[_]: ConcurrentEffect: ContextShift, K <: AnyRef](expiryTime: FiniteDuration,
-                                                               maxSize: Int,
-                                                               blocker: Blocker): F[KeyLock[F, K]] =
-    Effect[F].delay(new KeyLockImpl(expiryTime, maxSize, blocker))
+  def apply[F[_]: ContextShift, K <: AnyRef](expiryTime: FiniteDuration, maxSize: Int, blocker: Blocker)(
+    implicit F: ConcurrentEffect[F]
+  ): F[KeyLock[F, K]] =
+    F.delay(new KeyLockImpl(expiryTime, maxSize, blocker))
 
   // A KeyLock implementation backed by a guava cache
-  final private class KeyLockImpl[F[_]: ConcurrentEffect: ContextShift, K <: AnyRef](expiryTime: FiniteDuration,
-                                                                                     maxSize: Int,
-                                                                                     blocker: Blocker)
-      extends KeyLock[F, K] {
+  final private class KeyLockImpl[F[_]: ContextShift, K <: AnyRef](expiryTime: FiniteDuration,
+                                                                   maxSize: Int,
+                                                                   blocker: Blocker)(
+    implicit F: ConcurrentEffect[F]
+  ) extends KeyLock[F, K] {
 
     private val cache = CacheBuilder
       .newBuilder()
@@ -41,19 +45,19 @@ object KeyLock {
 
     override def acquire(key: K): F[Unit] =
       for {
-        lock <- blocker.blockOn(Concurrent[F].delay(cache.get(key)))
+        lock <- blocker.blockOn(F.delay(cache.get(key)))
         _ <- lock.acquire
       } yield ()
 
     override def release(key: K): F[Unit] =
       for {
-        lock <- blocker.blockOn(Concurrent[F].delay(cache.get(key)))
+        lock <- blocker.blockOn(F.delay(cache.get(key)))
         _ <- lock.release
       } yield ()
 
     override def withKeyLock[A](key: K)(fa: F[A]): F[A] =
       for {
-        lock <- blocker.blockOn(Concurrent[F].delay(cache.get(key)))
+        lock <- blocker.blockOn(F.delay(cache.get(key)))
         res <- lock.withPermit(fa)
       } yield res
   }

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/KeyLock.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/KeyLock.scala
@@ -2,7 +2,7 @@ package org.broadinstitute.dsde.workbench.leonardo
 
 import java.util.concurrent.TimeUnit
 
-import cats.effect.concurrent.MVar
+import cats.effect.concurrent.{MVar, MVar2}
 import cats.effect.implicits._
 import cats.effect.{Blocker, Concurrent, ConcurrentEffect, ContextShift, Effect}
 import cats.implicits._
@@ -21,7 +21,7 @@ object Lock {
 
   // A Lock implementation backed by an MVar
   // Inspired from https://typelevel.org/cats-effect/concurrency/mvar.html#use-case-asynchronous-lock-binary-semaphore-mutex
-  final private class LockImpl[F[_]: Concurrent](lock: MVar[F, Unit]) extends Lock[F] {
+  final private class LockImpl[F[_]: Concurrent](lock: MVar2[F, Unit]) extends Lock[F] {
     def acquire: F[Unit] = lock.take
     def release: F[Unit] = lock.put(())
     def withLock[A](fa: F[A]): F[A] =

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/KeyLock.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/KeyLock.scala
@@ -14,8 +14,6 @@ import scala.concurrent.duration.FiniteDuration
  * A functional lock which works on a per-key basis.
  */
 abstract class KeyLock[F[_], K] {
-  def acquire(key: K): F[Unit]
-  def release(key: K): F[Unit]
   def withKeyLock[A](key: K)(fa: F[A]): F[A]
 }
 object KeyLock {
@@ -42,18 +40,6 @@ object KeyLock {
             Semaphore(1L).toIO.unsafeRunSync()
         }
       )
-
-    override def acquire(key: K): F[Unit] =
-      for {
-        lock <- blocker.blockOn(F.delay(cache.get(key)))
-        _ <- lock.acquire
-      } yield ()
-
-    override def release(key: K): F[Unit] =
-      for {
-        lock <- blocker.blockOn(F.delay(cache.get(key)))
-        _ <- lock.release
-      } yield ()
 
     override def withKeyLock[A](key: K)(fa: F[A]): F[A] =
       for {

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/KeyLock.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/KeyLock.scala
@@ -1,0 +1,79 @@
+package org.broadinstitute.dsde.workbench.leonardo
+
+import java.util.concurrent.TimeUnit
+
+import cats.effect.concurrent.MVar
+import cats.effect.implicits._
+import cats.effect.{Blocker, Concurrent, ConcurrentEffect, ContextShift, Effect}
+import cats.implicits._
+import com.google.common.cache.{CacheBuilder, CacheLoader}
+
+import scala.concurrent.duration.FiniteDuration
+
+abstract class Lock[F[_]] {
+  def acquire: F[Unit]
+  def release: F[Unit]
+  def withLock[A](fa: F[A]): F[A]
+}
+object Lock {
+  def apply[F[_]: Concurrent]: F[Lock[F]] =
+    MVar.of(()).map(l => new LockImpl(l))
+
+  // A Lock implementation backed by an MVar
+  // Inspired from https://typelevel.org/cats-effect/concurrency/mvar.html#use-case-asynchronous-lock-binary-semaphore-mutex
+  final private class LockImpl[F[_]: Concurrent](lock: MVar[F, Unit]) extends Lock[F] {
+    def acquire: F[Unit] = lock.take
+    def release: F[Unit] = lock.put(())
+    def withLock[A](fa: F[A]): F[A] =
+      acquire.bracket(_ => fa)(_ => release)
+  }
+}
+
+abstract class KeyLock[F[_], K] {
+  def acquire(key: K): F[Unit]
+  def release(key: K): F[Unit]
+  def withKeyLock[A](key: K, fa: F[A]): F[A]
+}
+object KeyLock {
+  def apply[F[_]: ConcurrentEffect: ContextShift, K <: AnyRef](expiryTime: FiniteDuration,
+                                                               maxSize: Int,
+                                                               blocker: Blocker): F[KeyLock[F, K]] =
+    Effect[F].delay(new KeyLockImpl(expiryTime, maxSize, blocker))
+
+  // A KeyLock implementation backed by a guava cache
+  final private class KeyLockImpl[F[_]: ConcurrentEffect: ContextShift, K <: AnyRef](expiryTime: FiniteDuration,
+                                                                                     maxSize: Int,
+                                                                                     blocker: Blocker)
+      extends KeyLock[F, K] {
+
+    private val cache = CacheBuilder
+      .newBuilder()
+      .expireAfterWrite(expiryTime.toSeconds, TimeUnit.SECONDS)
+      .maximumSize(maxSize)
+      .recordStats
+      .build(
+        new CacheLoader[K, Lock[F]] {
+          def load(key: K): Lock[F] =
+            Lock[F].toIO.unsafeRunSync()
+        }
+      )
+
+    override def acquire(key: K): F[Unit] =
+      for {
+        lock <- blocker.blockOn(Concurrent[F].delay(cache.get(key)))
+        _ <- lock.acquire
+      } yield ()
+
+    override def release(key: K): F[Unit] =
+      for {
+        lock <- blocker.blockOn(Concurrent[F].delay(cache.get(key)))
+        _ <- lock.release
+      } yield ()
+
+    override def withKeyLock[A](key: K, fa: F[A]): F[A] =
+      for {
+        lock <- blocker.blockOn(Concurrent[F].delay(cache.get(key)))
+        res <- lock.withLock(fa)
+      } yield res
+  }
+}

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/KeyLock.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/KeyLock.scala
@@ -32,7 +32,7 @@ object Lock {
 abstract class KeyLock[F[_], K] {
   def acquire(key: K): F[Unit]
   def release(key: K): F[Unit]
-  def withKeyLock[A](key: K, fa: F[A]): F[A]
+  def withKeyLock[A](key: K)(fa: F[A]): F[A]
 }
 object KeyLock {
   def apply[F[_]: ConcurrentEffect: ContextShift, K <: AnyRef](expiryTime: FiniteDuration,
@@ -70,7 +70,7 @@ object KeyLock {
         _ <- lock.release
       } yield ()
 
-    override def withKeyLock[A](key: K, fa: F[A]): F[A] =
+    override def withKeyLock[A](key: K)(fa: F[A]): F[A] =
       for {
         lock <- blocker.blockOn(Concurrent[F].delay(cache.get(key)))
         res <- lock.withLock(fa)

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/kubernetesModels.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/kubernetesModels.scala
@@ -379,11 +379,37 @@ object AppStatus {
     override def toString: String = "PROVISIONING"
   }
 
+  final case object PreStopping extends AppStatus {
+    override def toString: String = "PRESTOPPING"
+  }
+
+  final case object Stopping extends AppStatus {
+    override def toString: String = "STOPPING"
+  }
+
+  final case object Stopped extends AppStatus {
+    override def toString: String = "STOPPED"
+  }
+
+  final case object PreStarting extends AppStatus {
+    override def toString: String = "PRESTARTING"
+  }
+
+  final case object Starting extends AppStatus {
+    override def toString: String = "STARTING"
+  }
+
   def values: Set[AppStatus] = sealerate.values[AppStatus]
   def stringToObject: Map[String, AppStatus] = values.map(v => v.toString -> v).toMap
 
   val deletableStatuses: Set[AppStatus] =
     Set(Unspecified, Running, Error)
+
+  val stoppableStatuses: Set[AppStatus] =
+    Set(Running, Starting)
+
+  val startableStatuses: Set[AppStatus] =
+    Set(Stopped, Stopping)
 
   val monitoredStatuses: Set[AppStatus] =
     Set(Deleting, Provisioning)

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/kubernetesModels.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/kubernetesModels.scala
@@ -254,6 +254,14 @@ object ErrorAction {
     override def toString: String = "deleteGalaxyApp"
   }
 
+  case object StopGalaxyApp extends ErrorAction {
+    override def toString: String = "stopGalaxyApp"
+  }
+
+  case object StartGalaxyApp extends ErrorAction {
+    override def toString: String = "startGalaxyApp"
+  }
+
   def values: Set[ErrorAction] = sealerate.values[ErrorAction]
   def stringToObject: Map[String, ErrorAction] = values.map(v => v.toString -> v).toMap
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/KeyLockSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/KeyLockSpec.scala
@@ -8,38 +8,6 @@ import scala.concurrent.duration._
 
 class KeyLockSpec extends LeonardoTestSuite with Matchers with AnyFlatSpecLike {
 
-  "Lock" should "block on acquire/release" in {
-    val res = for {
-      test <- Lock[IO]
-      // try to acquire the lock twice
-      _ <- test.acquire
-      f <- test.acquire.start
-      // the second acquire should block
-      timeoutErr <- f.join.timeout(1 second).attempt
-      // release the lock, the second acquire should now succeed
-      _ <- test.release
-      _ <- f.join
-      _ <- test.release
-    } yield {
-      timeoutErr.isLeft shouldBe true
-    }
-
-    res.timeout(5 seconds).unsafeRunSync()
-  }
-
-  it should "perform operations using withLock" in {
-    val res = for {
-      test <- Lock[IO]
-      r1 <- test.withLock(IO(10))
-      r2 <- test.withLock(IO(20))
-    } yield {
-      r1 shouldBe 10
-      r2 shouldBe 20
-    }
-
-    res.timeout(5 seconds).unsafeRunSync()
-  }
-
   "KeyLock" should "block on acquire/release for the same key" in {
     val res = for {
       test <- KeyLock[IO, String](1 minute, 10, blocker)

--- a/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/KeyLockSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/KeyLockSpec.scala
@@ -8,46 +8,7 @@ import scala.concurrent.duration._
 
 class KeyLockSpec extends LeonardoTestSuite with Matchers with AnyFlatSpecLike {
 
-  "KeyLock" should "block on acquire/release for the same key" in {
-    val res = for {
-      test <- KeyLock[IO, String](1 minute, 10, blocker)
-      key = "key"
-      // try to acquire the lock twice for the same key
-      _ <- test.acquire(key)
-      f <- test.acquire(key).start
-      // the second acquire should block
-      timeoutErr <- f.join.timeout(1 second).attempt
-      // release the lock, the second acquire should now succeed
-      _ <- test.release(key)
-      _ <- f.join
-      _ <- test.release(key)
-    } yield {
-      timeoutErr.isLeft shouldBe true
-    }
-
-    res.timeout(5 seconds).unsafeRunSync()
-  }
-
-  it should "not block on acquire/release for different keys" in {
-    val res = for {
-      test <- KeyLock[IO, String](1 minute, 10, blocker)
-      key1 = "key1"
-      key2 = "key2"
-      // try to acquire the lock twice for different keys, it should not block
-      _ <- test.acquire(key1)
-      _ <- test.acquire(key2)
-      r1 <- IO(10)
-      // release the locks
-      _ <- test.release(key1)
-      _ <- test.release(key2)
-    } yield {
-      r1 shouldBe 10
-    }
-
-    res.timeout(5 seconds).unsafeRunSync()
-  }
-
-  it should "perform operations using withKeyLock" in {
+  "KeyLock" should "perform operations using withKeyLock" in {
     val res = for {
       test <- KeyLock[IO, String](1 minute, 10, blocker)
       key1 = "key1"
@@ -59,6 +20,23 @@ class KeyLockSpec extends LeonardoTestSuite with Matchers with AnyFlatSpecLike {
       r1 shouldBe 10
       r2 shouldBe 20
       r3 shouldBe 30
+    }
+
+    res.timeout(5 seconds).unsafeRunSync()
+  }
+
+  it should "block on withKeyLock for the same key" in {
+    val res = for {
+      test <- KeyLock[IO, String](1 minute, 10, blocker)
+      key = "key"
+      timeoutErr <- test
+        .withKeyLock(key)(
+          test.withKeyLock(key)(IO(10))
+        )
+        .timeout(1 second)
+        .attempt
+    } yield {
+      timeoutErr.isLeft shouldBe true
     }
 
     res.timeout(5 seconds).unsafeRunSync()

--- a/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/KeyLockSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/KeyLockSpec.scala
@@ -1,0 +1,98 @@
+package org.broadinstitute.dsde.workbench.leonardo
+
+import cats.effect.IO
+import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.matchers.should.Matchers
+
+import scala.concurrent.duration._
+
+class KeyLockSpec extends LeonardoTestSuite with Matchers with AnyFlatSpecLike {
+
+  "Lock" should "block on acquire/release" in {
+    val res = for {
+      test <- Lock[IO]
+      // try to acquire the lock twice
+      _ <- test.acquire
+      f <- test.acquire.start
+      // the second acquire should block
+      timeoutErr <- f.join.timeout(1 second).attempt
+      // release the lock, the second acquire should now succeed
+      _ <- test.release
+      _ <- f.join
+      _ <- test.release
+    } yield {
+      timeoutErr.isLeft shouldBe true
+    }
+
+    res.timeout(5 seconds).unsafeRunSync()
+  }
+
+  it should "perform operations using withLock" in {
+    val res = for {
+      test <- Lock[IO]
+      r1 <- test.withLock(IO(10))
+      r2 <- test.withLock(IO(20))
+    } yield {
+      r1 shouldBe 10
+      r2 shouldBe 20
+    }
+
+    res.timeout(5 seconds).unsafeRunSync()
+  }
+
+  "KeyLock" should "block on acquire/release for the same key" in {
+    val res = for {
+      test <- KeyLock[IO, String](1 minute, 10, blocker)
+      key = "key"
+      // try to acquire the lock twice for the same key
+      _ <- test.acquire(key)
+      f <- test.acquire(key).start
+      // the second acquire should block
+      timeoutErr <- f.join.timeout(1 second).attempt
+      // release the lock, the second acquire should now succeed
+      _ <- test.release(key)
+      _ <- f.join
+      _ <- test.release(key)
+    } yield {
+      timeoutErr.isLeft shouldBe true
+    }
+
+    res.timeout(5 seconds).unsafeRunSync()
+  }
+
+  it should "not block on acquire/release for different keys" in {
+    val res = for {
+      test <- KeyLock[IO, String](1 minute, 10, blocker)
+      key1 = "key1"
+      key2 = "key2"
+      // try to acquire the lock twice for different keys, it should not block
+      _ <- test.acquire(key1)
+      _ <- test.acquire(key2)
+      r1 <- IO(10)
+      // release the locks
+      _ <- test.release(key1)
+      _ <- test.release(key2)
+    } yield {
+      r1 shouldBe 10
+    }
+
+    res.timeout(5 seconds).unsafeRunSync()
+  }
+
+  it should "perform operations using withKeyLock" in {
+    val res = for {
+      test <- KeyLock[IO, String](1 minute, 10, blocker)
+      key1 = "key1"
+      key2 = "key2"
+      r1 <- test.withKeyLock(key1)(IO(10))
+      r2 <- test.withKeyLock(key2)(IO(20))
+      r3 <- test.withKeyLock(key1)(IO(30))
+    } yield {
+      r1 shouldBe 10
+      r2 shouldBe 20
+      r3 shouldBe 30
+    }
+
+    res.timeout(5 seconds).unsafeRunSync()
+  }
+}

--- a/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestSuite.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestSuite.scala
@@ -8,6 +8,7 @@ import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
 import org.broadinstitute.dsde.workbench.openTelemetry.FakeOpenTelemetryMetricsInterpreter
 import org.scalatest.{Assertion, Assertions}
 import fs2.Stream
+import org.broadinstitute.dsde.workbench.google2.GKEModels.KubernetesClusterId
 import org.scalatest.prop.Configuration
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 
@@ -24,6 +25,7 @@ trait LeonardoTestSuite extends Matchers {
 
   val blocker = Blocker.liftExecutionContext(global)
   val semaphore = Semaphore[IO](10).unsafeRunSync()
+  val nodepoolLock = KeyLock[IO, KubernetesClusterId](1 minute, 10, blocker).unsafeRunSync()
 
   def withInfiniteStream(stream: Stream[IO, Unit], validations: IO[Assertion], maxRetry: Int = 30): IO[Assertion] = {
     val process = Stream.eval(Deferred[IO, Assertion]).flatMap { signalToStop =>

--- a/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestSuite.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestSuite.scala
@@ -25,7 +25,7 @@ trait LeonardoTestSuite extends Matchers {
 
   val blocker = Blocker.liftExecutionContext(global)
   val semaphore = Semaphore[IO](10).unsafeRunSync()
-  val nodepoolLock = KeyLock[IO, KubernetesClusterId](1 minute, 10, blocker).unsafeRunSync()
+  val nodepoolLock = KeyLock[IO, KubernetesClusterId](1 minute, 10, blocker)
 
   def withInfiniteStream(stream: Stream[IO, Unit], validations: IO[Assertion], maxRetry: Int = 30): IO[Assertion] = {
     val process = Stream.eval(Deferred[IO, Assertion]).flatMap { signalToStop =>

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -190,6 +190,8 @@ gke {
     # See https://cloud.google.com/kubernetes-engine/docs/release-notes
     # As of 2020-10-09, 1.16.x is the default but it does not work with the Galaxy chart.
     version = "1.15.12-gke.4000"
+    nodepoolLockCacheExpiryTime = 1 hour
+    nodepoolLockCacheMaxSize = 200
   }
   defaultNodepool {
     machineType = "n1-standard-1"

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -514,6 +514,18 @@ pubsub {
       interval = 10 seconds
       max-attempts = 120 # 10 seconds * 120 = 20 min
     }
+    scaleNodepool {
+      max-attempts = 90 # 10 seconds * 90 is 15 min
+      interval = 10 seconds
+    }
+    setNodepoolAutoscaling {
+      max-attempts = 90 # 10 seconds * 90 is 15 min
+      interval = 10 seconds
+    }
+    startApp {
+      max-attempts = 100 # 3 seconds * 100 is 5 min
+      interval = 3 seconds
+    }
   }
 
   subscriber {

--- a/http/src/main/resources/swagger/api-docs.yaml
+++ b/http/src/main/resources/swagger/api-docs.yaml
@@ -1418,6 +1418,93 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorReport"
+  "/api/google/v1/apps/{googleProject}/{appName}/stop":
+    post:
+      summary: Stops an app with the given project and name
+      description: >
+        Stops the running compute, but retains any data persisted on disk. The app may be restarted with the /start endpoint.
+      operationId: stopApp
+      tags:
+        - apps
+      parameters:
+        - in: path
+          name: googleProject
+          description: googleProject
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: appName
+          description: appName
+          required: true
+          schema:
+            type: string
+      responses:
+        "202":
+          description: App stop request accepted
+        "403":
+          description: User does not have permission to perform action on app
+        "404":
+          description: App not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorReport"
+        "409":
+          description: App cannot be stopped
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorReport"
+        "500":
+          description: Internal Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorReport"
+  "/api/google/v1/apps/{googleProject}/{appName}/start":
+    post:
+      summary: Starts an app with the given project and name
+      description: Starts the stopped app
+      operationId: startApp
+      tags:
+        - apps
+      parameters:
+        - in: path
+          name: googleProject
+          description: googleProject
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: appName
+          description: appName
+          required: true
+          schema:
+            type: string
+      responses:
+        "202":
+          description: App start request accepted
+        "403":
+          description: User does not have permission to perform action on app
+        "404":
+          description: App not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorReport"
+        "409":
+          description: App cannot be started
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorReport"
+        "500":
+          description: Internal Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorReport"
 
   ## Deprecated Notebook API ##
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/Boot.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/Boot.scala
@@ -247,15 +247,15 @@ object Boot extends IOApp {
           val asyncTasks = AsyncTaskProcessor(asyncTaskProcessorConfig, appDependencies.asyncTasksQueue)
 
           val gkeAlg = new GKEInterpreter[IO](gkeInterpConfig,
-                                                 vpcInterp,
-                                                 googleDependencies.gkeService,
-                                                 googleDependencies.kubeService,
-                                                 appDependencies.helmClient,
-                                                 appDependencies.galaxyDAO,
-                                                 googleDependencies.credentials,
-                                                 googleDependencies.googleIamDAO,
-                                                 appDependencies.blocker,
-                                                 appDependencies.nodepoolLock)
+                                              vpcInterp,
+                                              googleDependencies.gkeService,
+                                              googleDependencies.kubeService,
+                                              appDependencies.helmClient,
+                                              appDependencies.galaxyDAO,
+                                              googleDependencies.credentials,
+                                              googleDependencies.googleIamDAO,
+                                              appDependencies.blocker,
+                                              appDependencies.nodepoolLock)
 
           val pubsubSubscriber =
             new LeoPubsubMessageSubscriber[IO](leoPubsubMessageSubscriberConfig,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/Boot.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/Boot.scala
@@ -426,6 +426,7 @@ object Boot extends IOApp {
                                                       applicationConfig.applicationName,
                                                       ProjectName.of(applicationConfig.leoGoogleProject.value))
       googleOauth2DAO <- GoogleOAuth2Service.resource(blocker, semaphore)
+      // TODO add to config
       nodepoolLock <- Resource.liftF(KeyLock[F, KubernetesClusterId](1 hour, 1000, blocker))
 
       googleDependencies = GoogleDependencies(

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/Boot.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/Boot.scala
@@ -426,8 +426,11 @@ object Boot extends IOApp {
                                                       applicationConfig.applicationName,
                                                       ProjectName.of(applicationConfig.leoGoogleProject.value))
       googleOauth2DAO <- GoogleOAuth2Service.resource(blocker, semaphore)
-      // TODO add to config
-      nodepoolLock <- Resource.liftF(KeyLock[F, KubernetesClusterId](1 hour, 1000, blocker))
+      nodepoolLock <- Resource.liftF(
+        KeyLock[F, KubernetesClusterId](gkeClusterConfig.nodepoolLockCacheExpiryTime,
+                                        gkeClusterConfig.nodepoolLockCacheMaxSize,
+                                        blocker)
+      )
 
       googleDependencies = GoogleDependencies(
         petGoogleStorageDAO,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/LeoPublisher.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/LeoPublisher.scala
@@ -86,6 +86,7 @@ final class LeoPublisher[F[_]: Logger: Timer](
           }
         case m: LeoPubsubMessage.BatchNodepoolCreateMessage =>
           KubernetesServiceDbQueries.markPendingBatchCreating(m.clusterId, m.nodepools).transaction
+        // TODO stop and start app messages
         case _ => F.unit
       }
     } yield ()

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/LeoPublisher.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/LeoPublisher.scala
@@ -9,7 +9,7 @@ import fs2.{Pipe, Stream}
 import io.chrisdavenport.log4cats.Logger
 import io.circe.syntax._
 import org.broadinstitute.dsde.workbench.google2.GooglePublisher
-import org.broadinstitute.dsde.workbench.leonardo.db.{clusterQuery, DbReference, KubernetesServiceDbQueries}
+import org.broadinstitute.dsde.workbench.leonardo.db.{appQuery, clusterQuery, DbReference, KubernetesServiceDbQueries}
 import org.broadinstitute.dsde.workbench.leonardo.http.dbioToIO
 import org.broadinstitute.dsde.workbench.leonardo.monitor.LeoPubsubCodec._
 import org.broadinstitute.dsde.workbench.leonardo.monitor.{ClusterNodepoolAction, LeoPubsubMessage}
@@ -86,7 +86,10 @@ final class LeoPublisher[F[_]: Logger: Timer](
           }
         case m: LeoPubsubMessage.BatchNodepoolCreateMessage =>
           KubernetesServiceDbQueries.markPendingBatchCreating(m.clusterId, m.nodepools).transaction
-        // TODO stop and start app messages
+        case m: LeoPubsubMessage.StopAppMessage =>
+          appQuery.updateStatus(m.appId, AppStatus.Stopping).transaction
+        case m: LeoPubsubMessage.StartAppMessage =>
+          appQuery.updateStatus(m.appId, AppStatus.Starting).transaction
         case _ => F.unit
       }
     } yield ()

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/AppRoutes.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/AppRoutes.scala
@@ -92,22 +92,22 @@ class AppRoutes(kubernetesService: KubernetesService[IO], userInfoDirectives: Us
                                 )
                               )
                             }
-                          } ~
-                          path("stop") {
-                            post {
-                              complete {
-                                stopAppHandler(userInfo, googleProject, appName)
-                              }
-                            }
-                          } ~
-                          path("start") {
-                            post {
-                              complete {
-                                startAppHandler(userInfo, googleProject, appName)
-                              }
+                          }
+                      } ~
+                        path("stop") {
+                          post {
+                            complete {
+                              stopAppHandler(userInfo, googleProject, appName)
                             }
                           }
-                      }
+                        } ~
+                        path("start") {
+                          post {
+                            complete {
+                              startAppHandler(userInfo, googleProject, appName)
+                            }
+                          }
+                        }
                     }
                   }
               }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/RuntimeRoutes.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/RuntimeRoutes.scala
@@ -193,7 +193,7 @@ class RuntimeRoutes(runtimeService: RuntimeService[IO], userInfoDirectives: User
     implicit ev: Ask[IO, AppContext]
   ): IO[ToResponseMarshallable] =
     for {
-      ctx <- ev.ask
+      ctx <- ev.ask[AppContext]
       // if `deleteDisk` is explicitly set to true, then we delete disk; otherwise, we don't
       deleteDisk = params.get("deleteDisk").exists(_ == "true")
       request = DeleteRuntimeRequest(userInfo, googleProject, runtimeName, deleteDisk)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/RuntimeRoutes.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/RuntimeRoutes.scala
@@ -49,7 +49,6 @@ class RuntimeRoutes(runtimeService: RuntimeService[IO], userInfoDirectives: User
                     )
                   )
                 }
-
               }
             } ~
               pathPrefix(googleProjectSegment) { googleProject =>
@@ -64,7 +63,6 @@ class RuntimeRoutes(runtimeService: RuntimeService[IO], userInfoDirectives: User
                         )
                       )
                     }
-
                   }
                 } ~
                   pathPrefix(Segment) { runtimeNameString =>
@@ -90,7 +88,6 @@ class RuntimeRoutes(runtimeService: RuntimeService[IO], userInfoDirectives: User
                             )
                           )
                         } ~ patch {
-
                           entity(as[UpdateRuntimeRequest]) { req =>
                             complete(
                               updateRuntimeHandler(
@@ -101,7 +98,6 @@ class RuntimeRoutes(runtimeService: RuntimeService[IO], userInfoDirectives: User
                               )
                             )
                           }
-
                         } ~ delete {
                           parameterMap { params =>
                             complete(
@@ -112,12 +108,10 @@ class RuntimeRoutes(runtimeService: RuntimeService[IO], userInfoDirectives: User
                                 params
                               )
                             )
-
                           }
                         }
                       } ~
                         path("stop") {
-
                           post {
                             complete(
                               stopRuntimeHandler(
@@ -127,10 +121,8 @@ class RuntimeRoutes(runtimeService: RuntimeService[IO], userInfoDirectives: User
                               )
                             )
                           }
-
                         } ~
                         path("start") {
-
                           post {
                             complete(
                               startRuntimeHandler(
@@ -140,7 +132,6 @@ class RuntimeRoutes(runtimeService: RuntimeService[IO], userInfoDirectives: User
                               )
                             )
                           }
-
                         }
                     }
                   }
@@ -202,11 +193,9 @@ class RuntimeRoutes(runtimeService: RuntimeService[IO], userInfoDirectives: User
     implicit ev: Ask[IO, AppContext]
   ): IO[ToResponseMarshallable] =
     for {
-      ctx <- ev.ask[AppContext]
-      deleteDisk = params
-        .get("deleteDisk")
-        .map(s => if (s == "true") true else false)
-        .getOrElse(false) //if `deleteDisk` is explicitly set to true, then we delete disk; otherwise, we don't
+      ctx <- ev.ask
+      // if `deleteDisk` is explicitly set to true, then we delete disk; otherwise, we don't
+      deleteDisk = params.get("deleteDisk").exists(_ == "true")
       request = DeleteRuntimeRequest(userInfo, googleProject, runtimeName, deleteDisk)
       apiCall = runtimeService.deleteRuntime(request)
       _ <- metrics.incrementCounter("deleteRuntime")

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/AppMonitorConfig.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/AppMonitorConfig.scala
@@ -8,4 +8,7 @@ case class AppMonitorConfig(nodepoolCreate: PollMonitorConfig,
                             clusterDelete: PollMonitorConfig,
                             createIngress: PollMonitorConfig,
                             createApp: PollMonitorConfig,
-                            deleteApp: PollMonitorConfig)
+                            deleteApp: PollMonitorConfig,
+                            scaleNodepool: PollMonitorConfig,
+                            setNodepoolAutoscaling: PollMonitorConfig,
+                            startApp: PollMonitorConfig)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
@@ -520,7 +520,9 @@ object Config {
       config.as[Location]("location"),
       config.as[RegionName]("region"),
       config.as[List[CidrIP]]("authorizedNetworks"),
-      config.as[KubernetesClusterVersion]("version")
+      config.as[KubernetesClusterVersion]("version"),
+      config.as[FiniteDuration]("nodepoolLockCacheExpiryTime"),
+      config.getInt("nodepoolLockCacheMaxSize")
     )
   }
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
@@ -7,20 +7,13 @@ import com.google.pubsub.v1.{ProjectSubscriptionName, ProjectTopicName, TopicNam
 import com.typesafe.config.{ConfigFactory, Config => TypeSafeConfig}
 import net.ceedubs.ficus.Ficus._
 import net.ceedubs.ficus.readers.ValueReader
-import org.broadinstitute.dsde.workbench.google2.KubernetesSerializableName.{
-  NamespaceName,
-  SecretKey,
-  SecretName,
-  ServiceAccountName,
-  ServiceName
-}
+import org.broadinstitute.dsde.workbench.google2.KubernetesSerializableName._
 import org.broadinstitute.dsde.workbench.google2.{
   DeviceName,
   FirewallRuleName,
   KubernetesName,
   Location,
   MachineTypeName,
-  MaxRetries,
   NetworkName,
   PublisherConfig,
   RegionName,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
@@ -14,6 +14,7 @@ import org.broadinstitute.dsde.workbench.google2.{
   KubernetesName,
   Location,
   MachineTypeName,
+  MaxRetries,
   NetworkName,
   PublisherConfig,
   RegionName,
@@ -46,8 +47,8 @@ import org.broadinstitute.dsde.workbench.util.toScalaDuration
 import org.broadinstitute.dsp.{ChartName, ChartVersion, Release}
 import org.http4s.Uri
 
-import scala.jdk.CollectionConverters._
 import scala.concurrent.duration._
+import scala.jdk.CollectionConverters._
 
 object Config {
   val config = ConfigFactory.parseResources("leonardo.conf").withFallback(ConfigFactory.load()).resolve()

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
@@ -723,7 +723,10 @@ object Config {
       config.as[PollMonitorConfig]("deleteCluster"),
       config.as[PollMonitorConfig]("createIngress"),
       config.as[PollMonitorConfig]("createApp"),
-      config.as[PollMonitorConfig]("deleteApp")
+      config.as[PollMonitorConfig]("deleteApp"),
+      config.as[PollMonitorConfig]("scaleNodepool"),
+      config.as[PollMonitorConfig]("setNodepoolAutoscaling"),
+      config.as[PollMonitorConfig]("startApp")
     )
   }
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/KubernetesClusterConfig.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/KubernetesClusterConfig.scala
@@ -3,9 +3,13 @@ package org.broadinstitute.dsde.workbench.leonardo.config
 import org.broadinstitute.dsde.workbench.google2.{Location, RegionName}
 import org.broadinstitute.dsde.workbench.leonardo.{CidrIP, KubernetesClusterVersion}
 
+import scala.concurrent.duration.FiniteDuration
+
 case class KubernetesClusterConfig(
   location: Location,
   region: RegionName,
   authorizedNetworks: List[CidrIP],
-  version: KubernetesClusterVersion
+  version: KubernetesClusterVersion,
+  nodepoolLockCacheExpiryTime: FiniteDuration,
+  nodepoolLockCacheMaxSize: Int
 )

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/KubernetesServiceDbQueries.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/KubernetesServiceDbQueries.scala
@@ -216,6 +216,18 @@ object KubernetesServiceDbQueries {
       _ <- diskId.fold[DBIO[Int]](DBIO.successful(0))(diskId => persistentDiskQuery.markPendingDeletion(diskId, now))
     } yield ()
 
+  def markPreStopping(nodepoolId: NodepoolLeoId, appId: AppId)(implicit ec: ExecutionContext): DBIO[Unit] =
+    for {
+      _ <- nodepoolQuery.scaleToN(nodepoolId, NumNodes(0))
+      _ <- appQuery.updateStatus(appId, AppStatus.PreStopping)
+    } yield ()
+
+  def markPreStarting(nodepoolId: NodepoolLeoId, appId: AppId)(implicit ec: ExecutionContext): DBIO[Unit] =
+    for {
+      _ <- nodepoolQuery.scaleToN(nodepoolId, NumNodes(1))
+      _ <- appQuery.updateStatus(appId, AppStatus.PreStarting)
+    } yield ()
+
   private[db] def listClustersByProject(
     googleProject: Option[GoogleProject],
     includeDeleted: Boolean = false

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/KubernetesServiceDbQueries.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/KubernetesServiceDbQueries.scala
@@ -222,10 +222,11 @@ object KubernetesServiceDbQueries {
       _ <- appQuery.updateStatus(appId, AppStatus.PreStopping)
     } yield ()
 
-  // TODO set to numNodes not 1
-  def markPreStarting(nodepoolId: NodepoolLeoId, appId: AppId)(implicit ec: ExecutionContext): DBIO[Unit] =
+  def markPreStarting(nodepoolId: NodepoolLeoId, appId: AppId, numNodes: NumNodes)(
+    implicit ec: ExecutionContext
+  ): DBIO[Unit] =
     for {
-      _ <- nodepoolQuery.scaleToN(nodepoolId, NumNodes(1))
+      _ <- nodepoolQuery.scaleToN(nodepoolId, numNodes)
       _ <- appQuery.updateStatus(appId, AppStatus.PreStarting)
     } yield ()
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/KubernetesServiceDbQueries.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/KubernetesServiceDbQueries.scala
@@ -1,9 +1,9 @@
 package org.broadinstitute.dsde.workbench.leonardo
 package db
 
-import akka.http.scaladsl.model.StatusCodes
 import java.time.Instant
 
+import akka.http.scaladsl.model.StatusCodes
 import cats.data.Chain
 import cats.syntax.all._
 import org.broadinstitute.dsde.workbench.leonardo.db.LeoProfile.api._
@@ -214,20 +214,6 @@ object KubernetesServiceDbQueries {
       _ <- nodepoolQuery.markPendingDeletion(nodepoolId)
       _ <- appQuery.markPendingDeletion(appId)
       _ <- diskId.fold[DBIO[Int]](DBIO.successful(0))(diskId => persistentDiskQuery.markPendingDeletion(diskId, now))
-    } yield ()
-
-  def markPreStopping(nodepoolId: NodepoolLeoId, appId: AppId)(implicit ec: ExecutionContext): DBIO[Unit] =
-    for {
-      _ <- nodepoolQuery.scaleToN(nodepoolId, NumNodes(0))
-      _ <- appQuery.updateStatus(appId, AppStatus.PreStopping)
-    } yield ()
-
-  def markPreStarting(nodepoolId: NodepoolLeoId, appId: AppId, numNodes: NumNodes)(
-    implicit ec: ExecutionContext
-  ): DBIO[Unit] =
-    for {
-      _ <- nodepoolQuery.scaleToN(nodepoolId, numNodes)
-      _ <- appQuery.updateStatus(appId, AppStatus.PreStarting)
     } yield ()
 
   private[db] def listClustersByProject(

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/KubernetesServiceDbQueries.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/KubernetesServiceDbQueries.scala
@@ -222,6 +222,7 @@ object KubernetesServiceDbQueries {
       _ <- appQuery.updateStatus(appId, AppStatus.PreStopping)
     } yield ()
 
+  // TODO set to numNodes not 1
   def markPreStarting(nodepoolId: NodepoolLeoId, appId: AppId)(implicit ec: ExecutionContext): DBIO[Unit] =
     for {
       _ <- nodepoolQuery.scaleToN(nodepoolId, NumNodes(1))

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/NodepoolComponent.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/NodepoolComponent.scala
@@ -3,9 +3,9 @@ package org.broadinstitute.dsde.workbench.leonardo.db
 import java.time.Instant
 
 import org.broadinstitute.dsde.workbench.google2.GKEModels.NodepoolName
-import org.broadinstitute.dsde.workbench.leonardo.{App}
 import org.broadinstitute.dsde.workbench.google2.MachineTypeName
 import org.broadinstitute.dsde.workbench.leonardo.{
+  App,
   AuditInfo,
   AutoscalingConfig,
   AutoscalingMax,
@@ -173,20 +173,6 @@ object nodepoolQuery extends TableQuery(new NodepoolTable(_)) {
       .filter(_.isDefault === true)
       .result
       .map(ns => ns.map(n => unmarshalNodepool(n, List())).headOption)
-
-  // disables autoscaling and explicitly scales to N nodes
-  def scaleToN(id: NodepoolLeoId, n: NumNodes): DBIO[Int] =
-    // TODO is Provisioning the right status for this? What is the google status when the nodepool is scaling?
-    findByNodepoolIdQuery(id)
-      .map(np => (np.status, np.autoscalingEnabled, np.numNodes))
-      .update((NodepoolStatus.Provisioning, false, n))
-
-  // enables autoscalingg
-  def enableAutoscaling(id: NodepoolLeoId): DBIO[Int] =
-    // TODO is Provisioning the right status for this? What is the google status when autoscaling is enabled?
-    findByNodepoolIdQuery(id)
-      .map(np => (np.status, np.autoscalingEnabled))
-      .update((NodepoolStatus.Provisioning, true))
 
   private[db] def pendingDeletionFromQuery(baseQuery: Query[NodepoolTable, NodepoolRecord, Seq]): DBIO[Int] =
     baseQuery

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
@@ -1065,7 +1065,6 @@ class LeoPubsubMessageSubscriber[F[_]: Timer: ContextShift: Parallel](
       _ <- asyncTasks.enqueue1(Task(ctx.traceId, startNodepool, Some(handleKubernetesError), ctx.now))
     } yield ()
 
-
   private def handleKubernetesError(e: Throwable)(implicit ev: Ask[F, AppContext]): F[Unit] =
     e match {
       case e: PubsubKubernetesError =>

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
@@ -716,9 +716,9 @@ class LeoPubsubMessageSubscriber[F[_]: Timer: ContextShift: Parallel](
       ctx <- ev.ask
 
       // The "create app" flow potentially does a number of things:
-      //  1. creates a Kubernetes cluster
-      //  2. creates a nodepool within the cluster
-      //  3. creates a disk
+      //  1. creates a Kubernetes cluster if it doesn't exist
+      //  2. creates a nodepool within the cluster if it doesn't exist
+      //  3. creates a disk if it doesn't exist
       //  4. creates an app
       //
       // Numbers 1-3 are all Google calls; (4) is a helm call. If (1) is needed, we will do the

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
@@ -552,7 +552,7 @@ class LeoPubsubMessageSubscriber[F[_]: Timer: ContextShift: Parallel](
       _ <- logger.info(s"Beginning postgres disk creation for app ${appName.value} | trace id: ${ctx.traceId}")
       operationOpt <- googleDiskService.createDisk(project,
                                                    zone,
-                                                   gkeInterp.createGalaxyPostgresDisk(project, zone, namespaceName))
+                                                   gkeInterp.buildGalaxyPostgresDisk(zone, namespaceName))
       whenDone = logger.info(
         s"Completed postgres disk creation for app ${appName.value} in project ${project.value} | trace id: ${ctx.traceId}"
       )

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
@@ -1028,20 +1028,20 @@ class LeoPubsubMessageSubscriber[F[_]: Timer: ContextShift: Parallel](
   private[monitor] def handleStopAppMessage(msg: StopAppMessage)(implicit ev: Ask[F, AppContext]): F[Unit] =
     for {
       ctx <- ev.ask
-      stopNodepool = gkeInterp
-        .stopAndPollNodepool(StopNodepoolParams(msg.appId, msg.nodepoolId, msg.project))
+      stopApp = gkeInterp
+        .stopAndPollApp(StopAppParams(msg.appId, msg.appName, msg.project))
         .adaptError {
           case e =>
             PubsubKubernetesError(
-              AppError(e.getMessage, ctx.now, ErrorAction.StopGalaxyApp, ErrorSource.Nodepool, None),
+              AppError(e.getMessage, ctx.now, ErrorAction.StopGalaxyApp, ErrorSource.App, None),
               Some(msg.appId),
               false,
-              Some(msg.nodepoolId),
+              None,
               None
             )
         }
 
-      _ <- asyncTasks.enqueue1(Task(ctx.traceId, stopNodepool, Some(handleKubernetesError), ctx.now))
+      _ <- asyncTasks.enqueue1(Task(ctx.traceId, stopApp, Some(handleKubernetesError), ctx.now))
     } yield ()
 
   private[monitor] def handleStartAppMessage(
@@ -1049,20 +1049,20 @@ class LeoPubsubMessageSubscriber[F[_]: Timer: ContextShift: Parallel](
   )(implicit ev: Ask[F, AppContext]): F[Unit] =
     for {
       ctx <- ev.ask
-      startNodepool = gkeInterp
-        .startAndPollNodepool(StartNodepoolParams(msg.appId, msg.nodepoolId, msg.project))
+      startApp = gkeInterp
+        .startAndPollApp(StartAppParams(msg.appId, msg.appName, msg.project))
         .adaptError {
           case e =>
             PubsubKubernetesError(
-              AppError(e.getMessage, ctx.now, ErrorAction.StartGalaxyApp, ErrorSource.Nodepool, None),
+              AppError(e.getMessage, ctx.now, ErrorAction.StartGalaxyApp, ErrorSource.App, None),
               Some(msg.appId),
               false,
-              Some(msg.nodepoolId),
+              None,
               None
             )
         }
 
-      _ <- asyncTasks.enqueue1(Task(ctx.traceId, startNodepool, Some(handleKubernetesError), ctx.now))
+      _ <- asyncTasks.enqueue1(Task(ctx.traceId, startApp, Some(handleKubernetesError), ctx.now))
     } yield ()
 
   private def handleKubernetesError(e: Throwable)(implicit ev: Ask[F, AppContext]): F[Unit] =

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
@@ -1065,49 +1065,6 @@ class LeoPubsubMessageSubscriber[F[_]: Timer: ContextShift: Parallel](
       _ <- asyncTasks.enqueue1(Task(ctx.traceId, startNodepool, Some(handleKubernetesError), ctx.now))
     } yield ()
 
-  private def cleanUpAfterCreateClusterError(clusterId: KubernetesClusterLeoId,
-                                             project: GoogleProject)(implicit ev: Ask[F, AppContext]): F[Unit] =
-    for {
-      ctx <- ev.ask
-      _ <- logger.info(
-        s"Beginning clean up for cluster $clusterId in project $project due to an error during cluster creation"
-      )
-      _ <- kubernetesClusterQuery.markPendingDeletion(clusterId).transaction
-      _ <- gkeInterp.deleteAndPollCluster(DeleteClusterParams(clusterId, project)).handleErrorWith { e =>
-        // we do not want to bubble up errors with cluster clean-up
-        logger.error(e)(
-          s"An error occurred during resource clean up for cluster ${clusterId} in project ${project}. | trace id: ${ctx.traceId}"
-        )
-      }
-    } yield ()
-
-  // clean-up resources in the event of an app creation error
-  private def cleanUpAfterCreateAppError(appId: AppId,
-                                         appName: AppName,
-                                         project: GoogleProject,
-                                         diskId: Option[DiskId])(
-    implicit ev: Ask[F, AppContext]
-  ): F[Unit] =
-    for {
-      ctx <- ev.ask
-      _ <- logger.info(
-        s"Attempting to clean up resources due to app creation error for app ${appName} in project ${project}. | trace id: ${ctx.traceId}"
-      )
-      // we need to look up the app because we always want to clean up the nodepool associated with an errored app, even if it was pre-created
-      appOpt <- KubernetesServiceDbQueries.getFullAppByName(project, appId).transaction
-      // note that this will only clean up the disk if it was created as part of this app creation.
-      // it should not clean up the disk if it already existed
-      _ <- appOpt.traverse { app =>
-        val deleteMsg =
-          DeleteAppMessage(appId, appName, app.nodepool.id, project, diskId, Some(ctx.traceId))
-        // This is a good-faith attempt at clean-up. We do not want to take any action if clean-up fails for some reason.
-        deleteApp(deleteMsg, true, true).handleErrorWith { e =>
-          logger.error(e)(
-            s"An error occurred during resource clean up for app ${appName} in project ${project}. | trace id: ${ctx.traceId}"
-          )
-        }
-      }
-    } yield ()
 
   private def handleKubernetesError(e: Throwable)(implicit ev: Ask[F, AppContext]): F[Unit] =
     e match {

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
@@ -83,6 +83,10 @@ class LeoPubsubMessageSubscriber[F[_]: Timer: ContextShift: Parallel](
         handleDeleteAppMessage(msg)
       case msg: BatchNodepoolCreateMessage =>
         handleBatchNodepoolCreateMessage(msg)
+      case msg: StopAppMessage =>
+        handleStopAppMessage(msg)
+      case msg: StartAppMessage =>
+        handleStartAppMessage(msg)
     }
 
   private[monitor] def messageHandler(event: Event[LeoPubsubMessage]): F[Unit] = {
@@ -1020,6 +1024,20 @@ class LeoPubsubMessageSubscriber[F[_]: Timer: ContextShift: Parallel](
           )
         }
       }
+    } yield ()
+
+  private[monitor] def handleStopAppMessage(msg: StopAppMessage)(implicit ev: Ask[F, AppContext]): F[Unit] =
+    for {
+      ctx <- ev.ask
+      // TODO implement
+    } yield ()
+
+  private[monitor] def handleStartAppMessage(
+    msg: StartAppMessage
+  )(implicit ev: Ask[F, AppContext]): F[Unit] =
+    for {
+      ctx <- ev.ask
+      // TODO implement
     } yield ()
 
   private def handleKubernetesError(e: Throwable)(implicit ev: Ask[F, AppContext]): F[Unit] =

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/MonitorAtBoot.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/MonitorAtBoot.scala
@@ -152,6 +152,7 @@ class MonitorAtBoot[F[_]: Timer](publisherQueue: fs2.concurrent.Queue[F, LeoPubs
             diskIdOpt,
             app.customEnvironmentVariables,
             app.appType,
+            app.appResources.namespace.name,
             Some(traceId)
           )
         } yield msg

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/leoPubsubMessageSubscriberModels.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/leoPubsubMessageSubscriberModels.scala
@@ -249,18 +249,12 @@ object LeoPubsubMessage {
     val messageType: LeoPubsubMessageType = LeoPubsubMessageType.BatchNodepoolCreate
   }
 
-  final case class StopAppMessage(appId: AppId,
-                                  nodepoolId: NodepoolLeoId,
-                                  project: GoogleProject,
-                                  traceId: Option[TraceId])
+  final case class StopAppMessage(appId: AppId, appName: AppName, project: GoogleProject, traceId: Option[TraceId])
       extends LeoPubsubMessage {
     val messageType: LeoPubsubMessageType = LeoPubsubMessageType.StopApp
   }
 
-  final case class StartAppMessage(appId: AppId,
-                                   nodepoolId: NodepoolLeoId,
-                                   project: GoogleProject,
-                                   traceId: Option[TraceId])
+  final case class StartAppMessage(appId: AppId, appName: AppName, project: GoogleProject, traceId: Option[TraceId])
       extends LeoPubsubMessage {
     val messageType: LeoPubsubMessageType = LeoPubsubMessageType.StartApp
   }
@@ -440,10 +434,10 @@ object LeoPubsubCodec {
     Decoder.forProduct4("clusterId", "nodepools", "project", "traceId")(BatchNodepoolCreateMessage.apply)
 
   implicit val stopAppDecoder: Decoder[StopAppMessage] =
-    Decoder.forProduct4("appId", "nodepoolId", "project", "traceId")(StopAppMessage.apply)
+    Decoder.forProduct4("appId", "appName", "project", "traceId")(StopAppMessage.apply)
 
   implicit val startAppDecoder: Decoder[StartAppMessage] =
-    Decoder.forProduct4("appId", "nodepoolId", "project", "traceId")(StartAppMessage.apply)
+    Decoder.forProduct4("appId", "appName", "project", "traceId")(StartAppMessage.apply)
 
   implicit val leoPubsubMessageTypeDecoder: Decoder[LeoPubsubMessageType] = Decoder.decodeString.emap { x =>
     Either.catchNonFatal(LeoPubsubMessageType.withName(x)).leftMap(_.getMessage)
@@ -743,13 +737,13 @@ object LeoPubsubCodec {
     )
 
   implicit val stopAppMessageEncoder: Encoder[StopAppMessage] =
-    Encoder.forProduct5("messageType", "appId", "nodepoolId", "project", "traceId")(x =>
-      (x.messageType, x.appId, x.nodepoolId, x.project, x.traceId)
+    Encoder.forProduct5("messageType", "appId", "appName", "project", "traceId")(x =>
+      (x.messageType, x.appId, x.appName, x.project, x.traceId)
     )
 
   implicit val startAppMessageEncoder: Encoder[StartAppMessage] =
-    Encoder.forProduct5("messageType", "appId", "nodepoolId", "project", "traceId")(x =>
-      (x.messageType, x.appId, x.nodepoolId, x.project, x.traceId)
+    Encoder.forProduct5("messageType", "appId", "appName", "project", "traceId")(x =>
+      (x.messageType, x.appId, x.appName, x.project, x.traceId)
     )
 
   implicit val leoPubsubMessageEncoder: Encoder[LeoPubsubMessage] = Encoder.instance {

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/leoPubsubMessageSubscriberModels.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/leoPubsubMessageSubscriberModels.scala
@@ -450,19 +450,19 @@ object LeoPubsubCodec {
     for {
       messageType <- message.downField("messageType").as[LeoPubsubMessageType]
       value <- messageType match {
-        case LeoPubsubMessageType.CreateDisk              => message.as[CreateDiskMessage]
-        case LeoPubsubMessageType.UpdateDisk              => message.as[UpdateDiskMessage]
-        case LeoPubsubMessageType.DeleteDisk              => message.as[DeleteDiskMessage]
-        case LeoPubsubMessageType.CreateRuntime           => message.as[CreateRuntimeMessage]
-        case LeoPubsubMessageType.DeleteRuntime           => message.as[DeleteRuntimeMessage]
-        case LeoPubsubMessageType.StopRuntime             => message.as[StopRuntimeMessage]
-        case LeoPubsubMessageType.StartRuntime            => message.as[StartRuntimeMessage]
-        case LeoPubsubMessageType.UpdateRuntime           => message.as[UpdateRuntimeMessage]
-        case LeoPubsubMessageType.CreateApp               => message.as[CreateAppMessage]
-        case LeoPubsubMessageType.DeleteApp               => message.as[DeleteAppMessage]
-        case LeoPubsubMessageType.BatchNodepoolCreate     => message.as[BatchNodepoolCreateMessage]
-        case LeoPubsubMessageType.StopApp                 => message.as[StopAppMessage]
-        case LeoPubsubMessageType.StartApp                => message.as[StartAppMessage]
+        case LeoPubsubMessageType.CreateDisk          => message.as[CreateDiskMessage]
+        case LeoPubsubMessageType.UpdateDisk          => message.as[UpdateDiskMessage]
+        case LeoPubsubMessageType.DeleteDisk          => message.as[DeleteDiskMessage]
+        case LeoPubsubMessageType.CreateRuntime       => message.as[CreateRuntimeMessage]
+        case LeoPubsubMessageType.DeleteRuntime       => message.as[DeleteRuntimeMessage]
+        case LeoPubsubMessageType.StopRuntime         => message.as[StopRuntimeMessage]
+        case LeoPubsubMessageType.StartRuntime        => message.as[StartRuntimeMessage]
+        case LeoPubsubMessageType.UpdateRuntime       => message.as[UpdateRuntimeMessage]
+        case LeoPubsubMessageType.CreateApp           => message.as[CreateAppMessage]
+        case LeoPubsubMessageType.DeleteApp           => message.as[DeleteAppMessage]
+        case LeoPubsubMessageType.BatchNodepoolCreate => message.as[BatchNodepoolCreateMessage]
+        case LeoPubsubMessageType.StopApp             => message.as[StopAppMessage]
+        case LeoPubsubMessageType.StartApp            => message.as[StartAppMessage]
       }
     } yield value
   }
@@ -752,19 +752,19 @@ object LeoPubsubCodec {
     )
 
   implicit val leoPubsubMessageEncoder: Encoder[LeoPubsubMessage] = Encoder.instance {
-    case m: CreateDiskMessage              => m.asJson
-    case m: UpdateDiskMessage              => m.asJson
-    case m: DeleteDiskMessage              => m.asJson
-    case m: CreateRuntimeMessage           => m.asJson
-    case m: DeleteRuntimeMessage           => m.asJson
-    case m: StopRuntimeMessage             => m.asJson
-    case m: StartRuntimeMessage            => m.asJson
-    case m: UpdateRuntimeMessage           => m.asJson
-    case m: CreateAppMessage               => m.asJson
-    case m: DeleteAppMessage               => m.asJson
-    case m: BatchNodepoolCreateMessage     => m.asJson
-    case m: StopAppMessage                 => m.asJson
-    case m: StartAppMessage                => m.asJson
+    case m: CreateDiskMessage          => m.asJson
+    case m: UpdateDiskMessage          => m.asJson
+    case m: DeleteDiskMessage          => m.asJson
+    case m: CreateRuntimeMessage       => m.asJson
+    case m: DeleteRuntimeMessage       => m.asJson
+    case m: StopRuntimeMessage         => m.asJson
+    case m: StartRuntimeMessage        => m.asJson
+    case m: UpdateRuntimeMessage       => m.asJson
+    case m: CreateAppMessage           => m.asJson
+    case m: DeleteAppMessage           => m.asJson
+    case m: BatchNodepoolCreateMessage => m.asJson
+    case m: StopAppMessage             => m.asJson
+    case m: StartAppMessage            => m.asJson
   }
 }
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/leoPubsubMessageSubscriberModels.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/leoPubsubMessageSubscriberModels.scala
@@ -7,6 +7,7 @@ import enumeratum.{Enum, EnumEntry}
 import io.circe.syntax._
 import io.circe.{Decoder, Encoder}
 import org.broadinstitute.dsde.workbench.google2.JsonCodec.{traceIdDecoder, traceIdEncoder}
+import org.broadinstitute.dsde.workbench.google2.KubernetesSerializableName.NamespaceName
 import org.broadinstitute.dsde.workbench.google2.{DiskName, MachineTypeName, ZoneName}
 import org.broadinstitute.dsde.workbench.leonardo.JsonCodec._
 import org.broadinstitute.dsde.workbench.leonardo.http.{
@@ -226,6 +227,7 @@ object LeoPubsubMessage {
                                     createDisk: Option[DiskId],
                                     customEnvironmentVariables: Map[String, String],
                                     appType: AppType,
+                                    namespaceName: NamespaceName,
                                     traceId: Option[TraceId])
       extends LeoPubsubMessage {
     val messageType: LeoPubsubMessageType = LeoPubsubMessageType.CreateApp
@@ -418,13 +420,14 @@ object LeoPubsubCodec {
   }
 
   implicit val createAppDecoder: Decoder[CreateAppMessage] =
-    Decoder.forProduct8("project",
+    Decoder.forProduct9("project",
                         "clusterNodepoolAction",
                         "appId",
                         "appName",
                         "createDisk",
                         "customEnvironmentVariables",
                         "appType",
+                        "namespaceName",
                         "traceId")(CreateAppMessage.apply)
 
   implicit val deleteAppDecoder: Decoder[DeleteAppMessage] =
@@ -704,7 +707,7 @@ object LeoPubsubCodec {
     }
 
   implicit val createAppMessageEncoder: Encoder[CreateAppMessage] =
-    Encoder.forProduct9(
+    Encoder.forProduct10(
       "messageType",
       "project",
       "clusterNodepoolAction",
@@ -713,6 +716,7 @@ object LeoPubsubCodec {
       "createDisk",
       "customEnvironmentVariables",
       "appType",
+      "namespaceName",
       "traceId"
     )(x =>
       (x.messageType,
@@ -723,6 +727,7 @@ object LeoPubsubCodec {
        x.createDisk,
        x.customEnvironmentVariables,
        x.appType,
+       x.namespaceName,
        x.traceId)
     )
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/leoPubsubMessageSubscriberModels.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/leoPubsubMessageSubscriberModels.scala
@@ -135,6 +135,12 @@ object LeoPubsubMessageType extends Enum[LeoPubsubMessageType] {
     val asString = "batchNodepoolCreate"
   }
 
+  final case object StopApp extends LeoPubsubMessageType {
+    val asString = "stopApp"
+  }
+  final case object StartApp extends LeoPubsubMessageType {
+    val asString = "startApp"
+  }
 }
 
 sealed trait LeoPubsubMessage {
@@ -241,6 +247,22 @@ object LeoPubsubMessage {
                                               traceId: Option[TraceId])
       extends LeoPubsubMessage {
     val messageType: LeoPubsubMessageType = LeoPubsubMessageType.BatchNodepoolCreate
+  }
+
+  final case class StopAppMessage(appId: AppId,
+                                  nodepoolId: NodepoolLeoId,
+                                  project: GoogleProject,
+                                  traceId: Option[TraceId])
+      extends LeoPubsubMessage {
+    val messageType: LeoPubsubMessageType = LeoPubsubMessageType.StopApp
+  }
+
+  final case class StartAppMessage(appId: AppId,
+                                   nodepoolId: NodepoolLeoId,
+                                   project: GoogleProject,
+                                   traceId: Option[TraceId])
+      extends LeoPubsubMessage {
+    val messageType: LeoPubsubMessageType = LeoPubsubMessageType.StartApp
   }
 
   final case class DeleteRuntimeMessage(runtimeId: Long,
@@ -417,6 +439,12 @@ object LeoPubsubCodec {
   implicit val batchNodepoolCreateDecoder: Decoder[BatchNodepoolCreateMessage] =
     Decoder.forProduct4("clusterId", "nodepools", "project", "traceId")(BatchNodepoolCreateMessage.apply)
 
+  implicit val stopAppDecoder: Decoder[StopAppMessage] =
+    Decoder.forProduct4("appId", "nodepoolId", "project", "traceId")(StopAppMessage.apply)
+
+  implicit val startAppDecoder: Decoder[StartAppMessage] =
+    Decoder.forProduct4("appId", "nodepoolId", "project", "traceId")(StartAppMessage.apply)
+
   implicit val leoPubsubMessageTypeDecoder: Decoder[LeoPubsubMessageType] = Decoder.decodeString.emap { x =>
     Either.catchNonFatal(LeoPubsubMessageType.withName(x)).leftMap(_.getMessage)
   }
@@ -425,17 +453,19 @@ object LeoPubsubCodec {
     for {
       messageType <- message.downField("messageType").as[LeoPubsubMessageType]
       value <- messageType match {
-        case LeoPubsubMessageType.CreateDisk          => message.as[CreateDiskMessage]
-        case LeoPubsubMessageType.UpdateDisk          => message.as[UpdateDiskMessage]
-        case LeoPubsubMessageType.DeleteDisk          => message.as[DeleteDiskMessage]
-        case LeoPubsubMessageType.CreateRuntime       => message.as[CreateRuntimeMessage]
-        case LeoPubsubMessageType.DeleteRuntime       => message.as[DeleteRuntimeMessage]
-        case LeoPubsubMessageType.StopRuntime         => message.as[StopRuntimeMessage]
-        case LeoPubsubMessageType.StartRuntime        => message.as[StartRuntimeMessage]
-        case LeoPubsubMessageType.UpdateRuntime       => message.as[UpdateRuntimeMessage]
-        case LeoPubsubMessageType.CreateApp           => message.as[CreateAppMessage]
-        case LeoPubsubMessageType.DeleteApp           => message.as[DeleteAppMessage]
-        case LeoPubsubMessageType.BatchNodepoolCreate => message.as[BatchNodepoolCreateMessage]
+        case LeoPubsubMessageType.CreateDisk              => message.as[CreateDiskMessage]
+        case LeoPubsubMessageType.UpdateDisk              => message.as[UpdateDiskMessage]
+        case LeoPubsubMessageType.DeleteDisk              => message.as[DeleteDiskMessage]
+        case LeoPubsubMessageType.CreateRuntime           => message.as[CreateRuntimeMessage]
+        case LeoPubsubMessageType.DeleteRuntime           => message.as[DeleteRuntimeMessage]
+        case LeoPubsubMessageType.StopRuntime             => message.as[StopRuntimeMessage]
+        case LeoPubsubMessageType.StartRuntime            => message.as[StartRuntimeMessage]
+        case LeoPubsubMessageType.UpdateRuntime           => message.as[UpdateRuntimeMessage]
+        case LeoPubsubMessageType.CreateApp               => message.as[CreateAppMessage]
+        case LeoPubsubMessageType.DeleteApp               => message.as[DeleteAppMessage]
+        case LeoPubsubMessageType.BatchNodepoolCreate     => message.as[BatchNodepoolCreateMessage]
+        case LeoPubsubMessageType.StopApp                 => message.as[StopAppMessage]
+        case LeoPubsubMessageType.StartApp                => message.as[StartAppMessage]
       }
     } yield value
   }
@@ -712,18 +742,30 @@ object LeoPubsubCodec {
       (x.messageType, x.appId, x.appName, x.nodepoolId, x.project, x.diskId, x.traceId)
     )
 
+  implicit val stopAppMessageEncoder: Encoder[StopAppMessage] =
+    Encoder.forProduct5("messageType", "appId", "nodepoolId", "project", "traceId")(x =>
+      (x.messageType, x.appId, x.nodepoolId, x.project, x.traceId)
+    )
+
+  implicit val startAppMessageEncoder: Encoder[StartAppMessage] =
+    Encoder.forProduct5("messageType", "appId", "nodepoolId", "project", "traceId")(x =>
+      (x.messageType, x.appId, x.nodepoolId, x.project, x.traceId)
+    )
+
   implicit val leoPubsubMessageEncoder: Encoder[LeoPubsubMessage] = Encoder.instance {
-    case m: CreateDiskMessage          => m.asJson
-    case m: UpdateDiskMessage          => m.asJson
-    case m: DeleteDiskMessage          => m.asJson
-    case m: CreateRuntimeMessage       => m.asJson
-    case m: DeleteRuntimeMessage       => m.asJson
-    case m: StopRuntimeMessage         => m.asJson
-    case m: StartRuntimeMessage        => m.asJson
-    case m: UpdateRuntimeMessage       => m.asJson
-    case m: CreateAppMessage           => m.asJson
-    case m: DeleteAppMessage           => m.asJson
-    case m: BatchNodepoolCreateMessage => m.asJson
+    case m: CreateDiskMessage              => m.asJson
+    case m: UpdateDiskMessage              => m.asJson
+    case m: DeleteDiskMessage              => m.asJson
+    case m: CreateRuntimeMessage           => m.asJson
+    case m: DeleteRuntimeMessage           => m.asJson
+    case m: StopRuntimeMessage             => m.asJson
+    case m: StartRuntimeMessage            => m.asJson
+    case m: UpdateRuntimeMessage           => m.asJson
+    case m: CreateAppMessage               => m.asJson
+    case m: DeleteAppMessage               => m.asJson
+    case m: BatchNodepoolCreateMessage     => m.asJson
+    case m: StopAppMessage                 => m.asJson
+    case m: StartAppMessage                => m.asJson
   }
 }
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/KubernetesService.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/KubernetesService.scala
@@ -39,4 +39,12 @@ trait KubernetesService[F[_]] {
   def deleteApp(request: DeleteAppRequest)(
     implicit as: Ask[F, AppContext]
   ): F[Unit]
+
+  def stopApp(userInfo: UserInfo, googleProject: GoogleProject, appName: AppName)(
+    implicit as: ApplicativeAsk[F, AppContext]
+  ): F[Unit]
+
+  def startApp(userInfo: UserInfo, googleProject: GoogleProject, appName: AppName)(
+    implicit as: ApplicativeAsk[F, AppContext]
+  ): F[Unit]
 }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/KubernetesService.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/KubernetesService.scala
@@ -41,10 +41,10 @@ trait KubernetesService[F[_]] {
   ): F[Unit]
 
   def stopApp(userInfo: UserInfo, googleProject: GoogleProject, appName: AppName)(
-    implicit as: ApplicativeAsk[F, AppContext]
+    implicit as: Ask[F, AppContext]
   ): F[Unit]
 
   def startApp(userInfo: UserInfo, googleProject: GoogleProject, appName: AppName)(
-    implicit as: ApplicativeAsk[F, AppContext]
+    implicit as: Ask[F, AppContext]
   ): F[Unit]
 }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/KubernetesServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/KubernetesServiceInterp.scala
@@ -10,7 +10,7 @@ import cats.Parallel
 import cats.data.NonEmptyList
 import cats.effect.Async
 import cats.implicits._
-import cats.mtl.ApplicativeAsk
+import cats.mtl.Ask
 import io.chrisdavenport.log4cats.StructuredLogger
 import org.apache.commons.lang3.RandomStringUtils
 import org.broadinstitute.dsde.workbench.google2.GKEModels.{KubernetesClusterName, NodepoolName}
@@ -24,13 +24,7 @@ import org.broadinstitute.dsde.workbench.leonardo.http.service.LeoKubernetesServ
 import org.broadinstitute.dsde.workbench.leonardo.http.service.LeonardoService.includeDeletedKey
 import org.broadinstitute.dsde.workbench.leonardo.model.SamResourceAction._
 import org.broadinstitute.dsde.workbench.leonardo.model.{LeoAuthProvider, ServiceAccountProviderConfig, _}
-import org.broadinstitute.dsde.workbench.leonardo.monitor.LeoPubsubMessage.{
-  BatchNodepoolCreateMessage,
-  CreateAppMessage,
-  DeleteAppMessage,
-  StartAppMessage,
-  StopAppMessage
-}
+import org.broadinstitute.dsde.workbench.leonardo.monitor.LeoPubsubMessage._
 import org.broadinstitute.dsde.workbench.leonardo.monitor.{ClusterNodepoolAction, LeoPubsubMessage}
 import org.broadinstitute.dsde.workbench.leonardo.service.KubernetesService
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/KubernetesServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/KubernetesServiceInterp.scala
@@ -9,8 +9,8 @@ import akka.http.scaladsl.model.StatusCodes
 import cats.Parallel
 import cats.data.NonEmptyList
 import cats.effect.Async
-import cats.implicits._
 import cats.mtl.Ask
+import cats.syntax.all._
 import io.chrisdavenport.log4cats.StructuredLogger
 import org.apache.commons.lang3.RandomStringUtils
 import org.broadinstitute.dsde.workbench.google2.GKEModels.{KubernetesClusterName, NodepoolName}

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/KubernetesServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/KubernetesServiceInterp.scala
@@ -332,10 +332,10 @@ final class LeoKubernetesServiceInterp[F[_]: Parallel](
           AppCannotBeStoppedException(googleProject, appName, appResult.app.status, ctx.traceId)
         )
 
-      _ <- KubernetesServiceDbQueries.markPreStopping(appResult.nodepool.id, appResult.app.id).transaction
+      _ <- appQuery.updateStatus(appResult.app.id, AppStatus.PreStopping).transaction
       message = StopAppMessage(
         appResult.app.id,
-        appResult.nodepool.id,
+        appResult.app.appName,
         appResult.cluster.googleProject,
         Some(ctx.traceId)
       )
@@ -368,12 +368,10 @@ final class LeoKubernetesServiceInterp[F[_]: Parallel](
           AppCannotBeStartedException(googleProject, appName, appResult.app.status, ctx.traceId)
         )
 
-      _ <- KubernetesServiceDbQueries
-        .markPreStarting(appResult.nodepool.id, appResult.app.id, appResult.nodepool.numNodes)
-        .transaction
+      _ <- appQuery.updateStatus(appResult.app.id, AppStatus.PreStarting).transaction
       message = StartAppMessage(
         appResult.app.id,
-        appResult.nodepool.id,
+        appResult.app.appName,
         appResult.cluster.googleProject,
         Some(ctx.traceId)
       )

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/KubernetesServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/KubernetesServiceInterp.scala
@@ -146,6 +146,7 @@ final class LeoKubernetesServiceInterp[F[_]: Parallel](
         diskResultOpt.flatMap(d => if (d.creationNeeded) Some(d.disk.id) else None),
         req.customEnvironmentVariables,
         req.appType,
+        app.appResources.namespace.name,
         Some(ctx.traceId)
       )
       _ <- publisherQueue.enqueue1(createAppMessage)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/KubernetesServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/KubernetesServiceInterp.scala
@@ -338,8 +338,6 @@ final class LeoKubernetesServiceInterp[F[_]: Parallel](
           AppCannotBeStoppedException(googleProject, appName, appResult.app.status, ctx.traceId)
         )
 
-      // TODO note no hasOperationInProgress check, we plan to queue nodepool actions
-
       _ <- KubernetesServiceDbQueries.markPreStopping(appResult.nodepool.id, appResult.app.id).transaction
       message = StopAppMessage(
         appResult.app.id,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/KubernetesServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/KubernetesServiceInterp.scala
@@ -376,7 +376,9 @@ final class LeoKubernetesServiceInterp[F[_]: Parallel](
           AppCannotBeStartedException(googleProject, appName, appResult.app.status, ctx.traceId)
         )
 
-      _ <- KubernetesServiceDbQueries.markPreStarting(appResult.nodepool.id, appResult.app.id).transaction
+      _ <- KubernetesServiceDbQueries
+        .markPreStarting(appResult.nodepool.id, appResult.app.id, appResult.nodepool.numNodes)
+        .transaction
       message = StartAppMessage(
         appResult.app.id,
         appResult.nodepool.id,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/KubernetesServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/KubernetesServiceInterp.scala
@@ -318,12 +318,12 @@ final class LeoKubernetesServiceInterp[F[_]: Parallel](
       listOfPermissions <- authProvider.getActions(appResult.app.samResourceId, userInfo)
 
       // throw 404 if no StopStartApp permission
-      hasReadPermission = listOfPermissions.toSet.contains(AppAction.StopStartApp)
+      hasReadPermission = listOfPermissions.toSet.contains(AppAction.StopApp)
       _ <- if (hasReadPermission) F.unit
       else F.raiseError[Unit](AppNotFoundException(googleProject, appName, ctx.traceId))
 
       // throw 403 if no StopStartApp permission
-      hasStopStartPermission = listOfPermissions.toSet.contains(AppAction.StopStartApp)
+      hasStopStartPermission = listOfPermissions.toSet.contains(AppAction.StopApp)
       _ <- if (hasStopStartPermission) F.unit else F.raiseError[Unit](AuthorizationError(userInfo.userEmail))
 
       canStop = AppStatus.stoppableStatuses.contains(appResult.app.status)
@@ -354,12 +354,12 @@ final class LeoKubernetesServiceInterp[F[_]: Parallel](
       listOfPermissions <- authProvider.getActions(appResult.app.samResourceId, userInfo)
 
       // throw 404 if no StopStartApp permission
-      hasReadPermission = listOfPermissions.toSet.contains(AppAction.StopStartApp)
+      hasReadPermission = listOfPermissions.toSet.contains(AppAction.StartApp)
       _ <- if (hasReadPermission) F.unit
       else F.raiseError[Unit](AppNotFoundException(googleProject, appName, ctx.traceId))
 
       // throw 403 if no StopStartApp permission
-      hasStopStartPermission = listOfPermissions.toSet.contains(AppAction.StopStartApp)
+      hasStopStartPermission = listOfPermissions.toSet.contains(AppAction.StartApp)
       _ <- if (hasStopStartPermission) F.unit else F.raiseError[Unit](AuthorizationError(userInfo.userEmail))
 
       canStop = AppStatus.startableStatuses.contains(appResult.app.status)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEAlgebra.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEAlgebra.scala
@@ -2,7 +2,6 @@ package org.broadinstitute.dsde.workbench.leonardo.util
 
 import cats.mtl.Ask
 import org.broadinstitute.dsde.workbench.google2.GKEModels.{
-  KubernetesClusterId,
   KubernetesNetwork,
   KubernetesOperationId,
   KubernetesSubNetwork
@@ -21,13 +20,10 @@ trait GKEAlgebra[F[_]] {
    */
   def pollCluster(params: PollClusterParams)(implicit ev: Ask[F, AppContext]): F[Unit]
 
-  /** Creates a GKE nodepool but doesn't wait for its completion. */
-  def createNodepool(params: CreateNodepoolParams)(implicit ev: Ask[F, AppContext]): F[Option[CreateNodepoolResult]]
+  /** Creates a GKE nodepool and polls it for completion */
+  def createAndPollNodepool(params: CreateNodepoolParams)(implicit ev: Ask[F, AppContext]): F[Unit]
 
-  /** Polls a creating nodepool for its completion. */
-  def pollNodepool(params: PollNodepoolParams)(implicit ev: Ask[F, AppContext]): F[Unit]
-
-  /** Creates an app and polls it for completion. */
+  /** Creates an app and polls it for completion */
   def createAndPollApp(params: CreateAppParams)(implicit ev: Ask[F, AppContext]): F[Unit]
 
   /** Deletes a cluster and polls for completion */
@@ -39,8 +35,10 @@ trait GKEAlgebra[F[_]] {
   /** Deletes an app and polls for completion */
   def deleteAndPollApp(params: DeleteAppParams)(implicit ev: Ask[F, AppContext]): F[Unit]
 
+  /** Stops an app and polls for completion */
   def stopAndPollApp(params: StopAppParams)(implicit ev: Ask[F, AppContext]): F[Unit]
 
+  /** Starts an app and polls for completion */
   def startAndPollApp(params: StartAppParams)(implicit ev: Ask[F, AppContext]): F[Unit]
 }
 
@@ -59,10 +57,6 @@ final case class PollClusterParams(clusterId: KubernetesClusterLeoId,
                                    createResult: CreateClusterResult)
 
 final case class CreateNodepoolParams(nodepoolId: NodepoolLeoId, googleProject: GoogleProject)
-
-final case class CreateNodepoolResult(op: KubernetesOperationId, clusterId: KubernetesClusterId)
-
-final case class PollNodepoolParams(nodepoolId: NodepoolLeoId, createResult: CreateNodepoolResult)
 
 final case class CreateAppParams(appId: AppId, googleProject: GoogleProject, appName: AppName)
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEAlgebra.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEAlgebra.scala
@@ -37,6 +37,10 @@ trait GKEAlgebra[F[_]] {
 
   /** Deletes an app and polls for completion */
   def deleteAndPollApp(params: DeleteAppParams)(implicit ev: Ask[F, AppContext]): F[Unit]
+
+  def stopAndPollNodepool(params: StopNodepoolParams)(implicit ev: Ask[F, AppContext]): F[Unit]
+
+  def startAndPollNodepool(params: StartNodepoolParams)(implicit ev: Ask[F, AppContext]): F[Unit]
 }
 
 final case class CreateClusterParams(clusterId: KubernetesClusterLeoId,
@@ -69,3 +73,7 @@ final case class DeleteAppParams(appId: AppId,
                                  googleProject: GoogleProject,
                                  appName: AppName,
                                  errorAfterDelete: Boolean)
+
+final case class StopNodepoolParams(appId: AppId, nodepoolId: NodepoolLeoId, googleProject: GoogleProject)
+
+final case class StartNodepoolParams(appId: AppId, nodepoolId: NodepoolLeoId, googleProject: GoogleProject)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEAlgebra.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEAlgebra.scala
@@ -39,9 +39,9 @@ trait GKEAlgebra[F[_]] {
   /** Deletes an app and polls for completion */
   def deleteAndPollApp(params: DeleteAppParams)(implicit ev: Ask[F, AppContext]): F[Unit]
 
-  def stopAndPollNodepool(params: StopNodepoolParams)(implicit ev: Ask[F, AppContext]): F[Unit]
+  def stopAndPollApp(params: StopAppParams)(implicit ev: Ask[F, AppContext]): F[Unit]
 
-  def startAndPollNodepool(params: StartNodepoolParams)(implicit ev: Ask[F, AppContext]): F[Unit]
+  def startAndPollApp(params: StartAppParams)(implicit ev: Ask[F, AppContext]): F[Unit]
 }
 
 final case class CreateClusterParams(clusterId: KubernetesClusterLeoId,
@@ -75,6 +75,6 @@ final case class DeleteAppParams(appId: AppId,
                                  appName: AppName,
                                  errorAfterDelete: Boolean)
 
-final case class StopNodepoolParams(appId: AppId, nodepoolId: NodepoolLeoId, googleProject: GoogleProject)
+final case class StopAppParams(appId: AppId, appName: AppName, googleProject: GoogleProject)
 
-final case class StartNodepoolParams(appId: AppId, nodepoolId: NodepoolLeoId, googleProject: GoogleProject)
+final case class StartAppParams(appId: AppId, appName: AppName, googleProject: GoogleProject)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEAlgebra.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEAlgebra.scala
@@ -2,6 +2,7 @@ package org.broadinstitute.dsde.workbench.leonardo.util
 
 import cats.mtl.Ask
 import org.broadinstitute.dsde.workbench.google2.GKEModels.{
+  KubernetesClusterId,
   KubernetesNetwork,
   KubernetesOperationId,
   KubernetesSubNetwork
@@ -59,7 +60,7 @@ final case class PollClusterParams(clusterId: KubernetesClusterLeoId,
 
 final case class CreateNodepoolParams(nodepoolId: NodepoolLeoId, googleProject: GoogleProject)
 
-final case class CreateNodepoolResult(op: KubernetesOperationId)
+final case class CreateNodepoolResult(op: KubernetesOperationId, clusterId: KubernetesClusterId)
 
 final case class PollNodepoolParams(nodepoolId: NodepoolLeoId, createResult: CreateNodepoolResult)
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
@@ -7,8 +7,8 @@ import java.util.Base64
 import _root_.io.chrisdavenport.log4cats.StructuredLogger
 import cats.Parallel
 import cats.effect.{Async, Blocker, ConcurrentEffect, ContextShift, IO, Timer}
-import cats.syntax.all._
 import cats.mtl.Ask
+import cats.syntax.all._
 import com.google.auth.oauth2.GoogleCredentials
 import com.google.cloud.compute.v1.Disk
 import com.google.container.v1._

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
@@ -654,6 +654,7 @@ class GKEInterpreter[F[_]: Parallel: ContextShift: Timer](
       }
 
       _ <- appQuery.updateStatus(params.appId, AppStatus.Running).transaction
+      _ <- nodepoolQuery.enableAutoscaling(dbNodepool.id).transaction
 
       _ <- nodepoolLock.withKeyLock(dbCluster.getGkeClusterId) {
         for {

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
@@ -258,7 +258,8 @@ class GKEInterpreter[F[_]: Parallel: ContextShift: Timer](
         buildGoogleNodepool(dbNodepool)
       )
 
-      // acquire lock
+      // Acquire lock for nodepool creation
+      // Note: the lock is released in pollNodepool(), or if an error occurs
       _ <- nodepoolLock.acquire(dbCluster.getGkeClusterId)
 
       operationOpt <- gkeService.createNodepool(req).onError {
@@ -289,7 +290,7 @@ class GKEInterpreter[F[_]: Parallel: ContextShift: Timer](
             nodepoolLock.release(params.createResult.clusterId)
         }
 
-      // release lock
+      // Release lock acquired by createNodepool
       _ <- nodepoolLock.release(params.createResult.clusterId)
 
       _ <- if (lastOp.isDone)

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/KubernetesTestData.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/KubernetesTestData.scala
@@ -93,9 +93,9 @@ object KubernetesTestData {
       NodepoolStatus.Unspecified,
       auditInfo,
       MachineTypeName("n1-standard-4"),
-      NumNodes(2),
-      false,
-      None,
+      NumNodes(if (isDefault) 1 else 2),
+      !isDefault,
+      if (isDefault) None else Some(AutoscalingConfig(AutoscalingMin(0), AutoscalingMax(2))),
       List(),
       isDefault
     )

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/HttpRoutesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/HttpRoutesSpec.scala
@@ -428,6 +428,20 @@ class HttpRoutesSpec
     }
   }
 
+  it should "stop an app" in {
+    Post("/api/google/v1/apps/googleProject1/app1/stop") ~> routes.route ~> check {
+      status shouldEqual StatusCodes.Accepted
+      validateRawCookie(header("Set-Cookie"))
+    }
+  }
+
+  it should "start an app" in {
+    Post("/api/google/v1/apps/googleProject1/app1/start") ~> routes.route ~> check {
+      status shouldEqual StatusCodes.Accepted
+      validateRawCookie(header("Set-Cookie"))
+    }
+  }
+
   def fakeRoutes(runtimeService: RuntimeService[IO]): HttpRoutes =
     new HttpRoutes(
       swaggerConfig,

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/config/ConfigSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/config/ConfigSpec.scala
@@ -82,7 +82,9 @@ final class ConfigSpec extends AnyFlatSpec with Matchers {
         "69.173.127.240/28",
         "69.173.112.0/21"
       ).map(CidrIP),
-      KubernetesClusterVersion("1.15.12-gke.4000")
+      KubernetesClusterVersion("1.15.12-gke.4000"),
+      1 hour,
+      200
     )
     Config.gkeClusterConfig shouldBe expectedResult
   }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/mocks.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/mocks.scala
@@ -181,12 +181,7 @@ class MockGKEService extends GKEAlgebra[IO] {
   override def pollCluster(params: PollClusterParams)(implicit ev: Ask[IO, AppContext]): IO[Unit] = IO.unit
 
   /** Creates a GKE nodepool but doesn't wait for its completion. */
-  override def createNodepool(params: CreateNodepoolParams)(
-    implicit ev: Ask[IO, AppContext]
-  ): IO[Option[CreateNodepoolResult]] = IO.pure(None)
-
-  /** Polls a creating nodepool for its completion. */
-  override def pollNodepool(params: PollNodepoolParams)(implicit ev: Ask[IO, AppContext]): IO[Unit] = IO.unit
+  override def createAndPollNodepool(params: CreateNodepoolParams)(implicit ev: Ask[IO, AppContext]): IO[Unit] = IO.unit
 
   /** Creates an app and polls it for completion. */
   override def createAndPollApp(params: CreateAppParams)(implicit ev: Ask[IO, AppContext]): IO[Unit] = IO.unit
@@ -199,4 +194,10 @@ class MockGKEService extends GKEAlgebra[IO] {
 
   /** Deletes an app and polls for completion */
   override def deleteAndPollApp(params: DeleteAppParams)(implicit ev: Ask[IO, AppContext]): IO[Unit] = IO.unit
+
+  /** Stops an app and polls for completion */
+  override def stopAndPollApp(params: StopAppParams)(implicit ev: Ask[IO, AppContext]): IO[Unit] = IO.unit
+
+  /** Starts an app and polls for completion */
+  override def startAndPollApp(params: StartAppParams)(implicit ev: Ask[IO, AppContext]): IO[Unit] = IO.unit
 }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubCodecSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubCodecSpec.scala
@@ -3,7 +3,14 @@ package org.broadinstitute.dsde.workbench.leonardo.monitor
 import java.time.Instant
 import java.util.UUID
 
+import _root_.io.circe.parser.decode
+import _root_.io.circe.syntax._
+import io.circe.Printer
+import org.broadinstitute.dsde.workbench.google2.KubernetesSerializableName.NamespaceName
 import org.broadinstitute.dsde.workbench.google2.{DiskName, MachineTypeName}
+import org.broadinstitute.dsde.workbench.leonardo.AppType.Galaxy
+import org.broadinstitute.dsde.workbench.leonardo.monitor.LeoPubsubCodec._
+import org.broadinstitute.dsde.workbench.leonardo.monitor.LeoPubsubMessage.{CreateAppMessage, CreateRuntimeMessage}
 import org.broadinstitute.dsde.workbench.leonardo.{
   AppId,
   AppName,
@@ -15,16 +22,10 @@ import org.broadinstitute.dsde.workbench.leonardo.{
   RuntimeName,
   RuntimeProjectAndName
 }
-import org.broadinstitute.dsde.workbench.leonardo.monitor.LeoPubsubMessage.{CreateAppMessage, CreateRuntimeMessage}
-import org.broadinstitute.dsde.workbench.model.{TraceId, WorkbenchEmail}
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
-import org.scalatest.matchers.should.Matchers
-import _root_.io.circe.syntax._
-import _root_.io.circe.parser.decode
-import LeoPubsubCodec._
-import io.circe.Printer
-import org.broadinstitute.dsde.workbench.leonardo.AppType.Galaxy
+import org.broadinstitute.dsde.workbench.model.{TraceId, WorkbenchEmail}
 import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 class LeoPubsubCodecSpec extends AnyFlatSpec with Matchers {
   it should "encode/decode CreateRuntimeMessage.GceConfig properly" in {
@@ -109,6 +110,7 @@ class LeoPubsubCodecSpec extends AnyFlatSpec with Matchers {
       Some(DiskId(1)),
       Map.empty,
       Galaxy,
+      NamespaceName("ns"),
       Some(traceId)
     )
 

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriberSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriberSpec.scala
@@ -121,8 +121,8 @@ class LeoPubsubMessageSubscriberSpec
                            MockGalaxyDAO,
                            credentials,
                            iamDAOKubernetes,
-                           whitelistAuthProvider,
-                           blocker)
+                           blocker,
+                           nodepoolLock)
 
   val dataprocInterp = new DataprocInterpreter[IO](Config.dataprocInterpreterConfig,
                                                    bucketHelper,
@@ -1125,8 +1125,8 @@ class LeoPubsubMessageSubscriberSpec
                              MockGalaxyDAO,
                              credentials,
                              iamDAOKubernetes,
-                             whitelistAuthProvider,
-                             blocker)
+                             blocker,
+                             nodepoolLock)
 
     val assertions = for {
       getAppOpt <- KubernetesServiceDbQueries.getFullAppByName(savedCluster1.googleProject, savedApp1.id).transaction
@@ -1179,8 +1179,8 @@ class LeoPubsubMessageSubscriberSpec
                              MockGalaxyDAO,
                              credentials,
                              iamDAOKubernetes,
-                             whitelistAuthProvider,
-                             blocker)
+                             blocker,
+                             nodepoolLock)
 
     val assertions = for {
       getAppOpt <- KubernetesServiceDbQueries.getFullAppByName(savedCluster1.googleProject, savedApp1.id).transaction
@@ -1437,8 +1437,8 @@ class LeoPubsubMessageSubscriberSpec
                              MockGalaxyDAO,
                              credentials,
                              iamDAOKubernetes,
-                             whitelistAuthProvider,
-                             blocker)
+                             blocker,
+                             nodepoolLock)
 
     val assertions = for {
       clusterOpt <- kubernetesClusterQuery.getMinimalClusterById(savedCluster1.id).transaction
@@ -1518,8 +1518,8 @@ class LeoPubsubMessageSubscriberSpec
                              MockGalaxyDAO,
                              credentials,
                              iamDAOKubernetes,
-                             whitelistAuthProvider,
-                             blocker)
+                             blocker,
+                             nodepoolLock)
 
     val assertions = for {
       clusterOpt <- kubernetesClusterQuery.getMinimalClusterById(savedCluster1.id).transaction
@@ -1595,8 +1595,8 @@ class LeoPubsubMessageSubscriberSpec
                              MockGalaxyDAO,
                              credentials,
                              iamDAO,
-                             whitelistAuthProvider,
-                             blocker)
+                             blocker,
+                             nodepoolLock)
 
     val assertions = for {
       clusterOpt <- kubernetesClusterQuery.getMinimalClusterById(savedCluster1.id, true).transaction

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/MonitorAtBootSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/MonitorAtBootSpec.scala
@@ -129,6 +129,7 @@ class MonitorAtBootSpec extends AnyFlatSpec with TestComponent with LeonardoTest
         Some(disk.id),
         Map.empty,
         AppType.Galaxy,
+        savedApp.appResources.namespace.name,
         None
       )
       (msg eqv Some(expected)) shouldBe true
@@ -157,6 +158,7 @@ class MonitorAtBootSpec extends AnyFlatSpec with TestComponent with LeonardoTest
         Some(disk.id),
         Map.empty,
         AppType.Galaxy,
+        savedApp.appResources.namespace.name,
         None
       )
       (msg eqv Some(expected)) shouldBe true
@@ -185,6 +187,7 @@ class MonitorAtBootSpec extends AnyFlatSpec with TestComponent with LeonardoTest
         Some(disk.id),
         Map.empty,
         AppType.Galaxy,
+        savedApp.appResources.namespace.name,
         None
       )
       (msg eqv Some(expected)) shouldBe true

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/KubernetesServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/KubernetesServiceInterpSpec.scala
@@ -705,7 +705,7 @@ final class KubernetesServiceInterpSpec extends AnyFlatSpec with LeonardoTestSui
       kubeServiceInterp = makeInterp(publisherQueue)
 
       savedCluster <- IO(makeKubeCluster(1).copy(status = KubernetesClusterStatus.Running).save())
-      savedNodepool <- IO(makeNodepool(1, savedCluster.id).save())
+      savedNodepool <- IO(makeNodepool(1, savedCluster.id).copy(status = NodepoolStatus.Running).save())
       savedApp <- IO(makeApp(1, savedNodepool.id).copy(status = AppStatus.Running).save())
 
       _ <- kubeServiceInterp.stopApp(userInfo, savedCluster.googleProject, savedApp.appName)
@@ -718,9 +718,9 @@ final class KubernetesServiceInterpSpec extends AnyFlatSpec with LeonardoTestSui
         } yield {
           dbAppOpt.isDefined shouldBe true
           dbAppOpt.get.app.status shouldBe AppStatus.Stopping
-          dbAppOpt.get.nodepool.status shouldBe NodepoolStatus.Provisioning
-          dbAppOpt.get.nodepool.numNodes shouldBe NumNodes(0)
-          dbAppOpt.get.nodepool.autoscalingEnabled shouldBe false
+          dbAppOpt.get.nodepool.status shouldBe NodepoolStatus.Running
+          dbAppOpt.get.nodepool.numNodes shouldBe NumNodes(2)
+          dbAppOpt.get.nodepool.autoscalingEnabled shouldBe true
           dbAppOpt.get.cluster.status shouldBe KubernetesClusterStatus.Running
 
           msg shouldBe None
@@ -737,7 +737,7 @@ final class KubernetesServiceInterpSpec extends AnyFlatSpec with LeonardoTestSui
       kubeServiceInterp = makeInterp(publisherQueue)
 
       savedCluster <- IO(makeKubeCluster(1).copy(status = KubernetesClusterStatus.Running).save())
-      savedNodepool <- IO(makeNodepool(1, savedCluster.id).save())
+      savedNodepool <- IO(makeNodepool(1, savedCluster.id).copy(status = NodepoolStatus.Running).save())
       savedApp <- IO(makeApp(1, savedNodepool.id).copy(status = AppStatus.Stopped).save())
 
       _ <- kubeServiceInterp.startApp(userInfo, savedCluster.googleProject, savedApp.appName)
@@ -750,9 +750,9 @@ final class KubernetesServiceInterpSpec extends AnyFlatSpec with LeonardoTestSui
         } yield {
           dbAppOpt.isDefined shouldBe true
           dbAppOpt.get.app.status shouldBe AppStatus.Starting
-          dbAppOpt.get.nodepool.status shouldBe NodepoolStatus.Provisioning
+          dbAppOpt.get.nodepool.status shouldBe NodepoolStatus.Running
           dbAppOpt.get.nodepool.numNodes shouldBe NumNodes(2)
-          dbAppOpt.get.nodepool.autoscalingEnabled shouldBe false
+          dbAppOpt.get.nodepool.autoscalingEnabled shouldBe true
           dbAppOpt.get.cluster.status shouldBe KubernetesClusterStatus.Running
 
           msg shouldBe None

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/MockKubernetesServiceInterp.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/MockKubernetesServiceInterp.scala
@@ -40,11 +40,11 @@ class MockKubernetesServiceInterp extends KubernetesService[IO] {
   ): IO[Unit] = IO.unit
 
   override def stopApp(userInfo: UserInfo, googleProject: GoogleProject, appName: AppName)(
-    implicit as: ApplicativeAsk[IO, AppContext]
+    implicit as: Ask[IO, AppContext]
   ): IO[Unit] = IO.unit
 
   override def startApp(userInfo: UserInfo, googleProject: GoogleProject, appName: AppName)(
-    implicit as: ApplicativeAsk[IO, AppContext]
+    implicit as: Ask[IO, AppContext]
   ): IO[Unit] = IO.unit
 }
 

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/MockKubernetesServiceInterp.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/MockKubernetesServiceInterp.scala
@@ -38,6 +38,14 @@ class MockKubernetesServiceInterp extends KubernetesService[IO] {
   override def batchNodepoolCreate(userInfo: UserInfo, googleProject: GoogleProject, req: BatchNodepoolCreateRequest)(
     implicit ev: Ask[IO, AppContext]
   ): IO[Unit] = IO.unit
+
+  override def stopApp(userInfo: UserInfo, googleProject: GoogleProject, appName: AppName)(
+    implicit as: ApplicativeAsk[IO, AppContext]
+  ): IO[Unit] = IO.unit
+
+  override def startApp(userInfo: UserInfo, googleProject: GoogleProject, appName: AppName)(
+    implicit as: ApplicativeAsk[IO, AppContext]
+  ): IO[Unit] = IO.unit
 }
 
 object MockKubernetesServiceInterp extends MockKubernetesServiceInterp

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreterSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreterSpec.scala
@@ -6,10 +6,10 @@ import java.util.Base64
 
 import cats.effect.IO
 import org.broadinstitute.dsde.workbench.google.mock.{MockGoogleIamDAO, MockGoogleProjectDAO}
+import org.broadinstitute.dsde.workbench.google2.DiskName
 import org.broadinstitute.dsde.workbench.google2.GKEModels.NodepoolName
 import org.broadinstitute.dsde.workbench.google2.KubernetesModels.{KubernetesPodStatus, PodStatus}
 import org.broadinstitute.dsde.workbench.google2.KubernetesSerializableName._
-import org.broadinstitute.dsde.workbench.google2.DiskName
 import org.broadinstitute.dsde.workbench.google2.mock.{
   FakeGoogleComputeService,
   MockComputePollOperation,
@@ -50,8 +50,8 @@ class GKEInterpreterSpec extends AnyFlatSpecLike with TestComponent with Leonard
                            MockGalaxyDAO,
                            credentials,
                            googleIamDao,
-                           whitelistAuthProvider,
-                           blocker)
+                           blocker,
+                           nodepoolLock)
 
   "GKEInterpreter" should "create a nodepool with autoscaling" in isolatedDbTest {
     val savedCluster1 = makeKubeCluster(1).save()

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreterSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreterSpec.scala
@@ -51,7 +51,7 @@ class GKEInterpreterSpec extends AnyFlatSpecLike with TestComponent with Leonard
                            credentials,
                            googleIamDao,
                            blocker,
-                           nodepoolLock)
+                           nodepoolLock.unsafeRunSync())
 
   "GKEInterpreter" should "create a nodepool with autoscaling" in isolatedDbTest {
     val savedCluster1 = makeKubeCluster(1).save()


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-2341

This PR adds new `stop` and `start` endpoints for apps, and associated PubSub handling and GKE operations. Note this PR does NOT include autostop detection for Galaxy. Will likely create a separate for PR the autostop piece.

This PR also adds locking functionality to serialize nodepool operations within a cluster. This allows us to remove the "fail-fast" semantics in front Leo and handle queued nodepool operations reliably in back Leo.

Here is a [diagram](https://lucid.app/lucidchart/177a0d3e-63db-4271-90ba-d80eb4609c67/edit?beaconFlowId=68ECC8F6AFB84971&page=0_0#?folder_id=home&browser=icon) of the stop/start flow for Kubernetes apps:

![image](https://user-images.githubusercontent.com/5368863/99754823-429e8980-2ab7-11eb-83a9-dbc461ad97ce.png)

Dependent PRs:
* https://github.com/broadinstitute/workbench-libs/pull/374
* https://github.com/broadinstitute/sam/pull/485

Testing:
- Unit tests pass
- Manually tested on fiab
- Existing automation tests pass
- TODO: add new automation tests (will do in a separate PR)

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
