### PR TITLE
[no ticket] add patchInProgress to getRuntime response

### DIFF
--- a/http/src/main/resources/swagger/api-docs.yaml
+++ b/http/src/main/resources/swagger/api-docs.yaml
@@ -2349,6 +2349,9 @@ components:
           description: Optional environment variables to be set on the runtime.
         diskConfig:
           $ref: "#/components/schemas/DiskConfig"
+        patchInProgress:
+          type: boolean
+          description: Whether there is a patch in progress on the runtime. Is used to indicate updates that require status transitions.
     ListClusterResponse:
       description: ""
       required:

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/RuntimeRoutes.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/RuntimeRoutes.scala
@@ -400,7 +400,7 @@ object RuntimeRoutes {
 
   // we're reusing same `GetRuntimeResponse` in LeonardoService.scala as well, but we don't want to encode this object the same way the legacy
   // API does
-  implicit val getRuntimeResponseEncoder: Encoder[GetRuntimeResponse] = Encoder.forProduct20(
+  implicit val getRuntimeResponseEncoder: Encoder[GetRuntimeResponse] = Encoder.forProduct21(
     "id",
     "runtimeName",
     "googleProject",
@@ -420,7 +420,8 @@ object RuntimeRoutes {
     "runtimeImages",
     "scopes",
     "customEnvironmentVariables",
-    "diskConfig"
+    "diskConfig",
+    "patchInProgress"
   )(x =>
     (
       x.id,
@@ -442,7 +443,8 @@ object RuntimeRoutes {
       x.clusterImages,
       x.scopes,
       x.customClusterEnvironmentVariables,
-      x.diskConfig
+      x.diskConfig,
+      x.patchInProgress
     )
   )
 


### PR DESCRIPTION
AoU noticed this field was in the `list` response but not the `get` response. Added a couple unit tests to hopefully help us catch future discrepancies between the `get`/`list` models and encoders.


---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
