### PR TITLE
[IA-2385] Support public GHCR images

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/containerModels.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/containerModels.scala
@@ -5,7 +5,7 @@ import enumeratum.{Enum, EnumEntry}
 
 import scala.util.matching.Regex
 
-/** Container registry, e.g. GCR, Dockerhub */
+/** Container registry, e.g. Google Container Repository, GitHub Container Repository, Dockerhub */
 sealed trait ContainerRegistry extends EnumEntry with Product with Serializable {
   def regex: Regex
 }
@@ -16,6 +16,12 @@ object ContainerRegistry extends Enum[ContainerRegistry] {
     val regex: Regex =
       """^((?:us\.|eu\.|asia\.)?gcr.io)/([\w.-]+/[\w.-]+)(?::(\w[\w.-]+))?(?:@([\w+.-]+:[A-Fa-f0-9]{32,}))?$""".r
     override def toString: String = "GCR"
+  }
+
+  final case object GHCR extends ContainerRegistry {
+    val regex: Regex =
+      """^(ghcr.io)(/([\w.-]+/)+[\w.-]+)(?::(\w[\w.-]+))?(?:@([\w+.-]+:[A-Fa-f0-9]{32,}))?$""".r
+    override def toString: String = "GHCR"
   }
 
   // Repo format: https://docs.docker.com/docker-hub/repos/

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/containerModels.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/containerModels.scala
@@ -20,7 +20,7 @@ object ContainerRegistry extends Enum[ContainerRegistry] {
 
   final case object GHCR extends ContainerRegistry {
     val regex: Regex =
-      """^(ghcr.io)(/([\w.-]+/)+[\w.-]+)(?::(\w[\w.-]+))?(?:@([\w+.-]+:[A-Fa-f0-9]{32,}))?$""".r
+      """^(ghcr.io)/((?:[\w.-]+/)+[\w.-]+)(?::(\w[\w.-]+))?(?:@([\w+.-]+:[A-Fa-f0-9]{32,}))?$""".r
     override def toString: String = "GHCR"
   }
 

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/containerModels.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/containerModels.scala
@@ -31,7 +31,7 @@ object ContainerRegistry extends Enum[ContainerRegistry] {
   }
 
   def inferRegistry(imageUrl: String): Option[ContainerRegistry] =
-    List(ContainerRegistry.GCR, ContainerRegistry.DockerHub)
+    allRegistries
       .find(image => image.regex.pattern.asPredicate().test(imageUrl))
 
   val allRegistries: Set[ContainerRegistry] = sealerate.values[ContainerRegistry]

--- a/http/src/main/resources/swagger/api-docs.yaml
+++ b/http/src/main/resources/swagger/api-docs.yaml
@@ -2665,8 +2665,9 @@ components:
           description: Deprecated. Please use toolDockerImage.
         toolDockerImage:
           type: string
-          description: The tool docker image to install. May be Dockerhub or GCR. If not
-            set, a default Jupyter image will be installed.
+          description: The tool docker image to install. May be Google Container Repository (GCR),
+            GitHub Container Repository (GHCR), or Dockerhub. If not set, a default Jupyter image will
+            be installed.
         welderRegistry:
           type: string
           enum: [GCR, DockerHub]
@@ -2748,8 +2749,9 @@ components:
           description: The default Google Client ID.
         toolDockerImage:
           type: string
-          description: The tool docker image to install. May be Dockerhub or GCR. If not
-            set, a default Jupyter image will be installed.
+          description: The tool docker image to install. May be Google Container Repository (GCR),
+            GitHub Container Repository (GHCR), or Dockerhub. If not set, a default Jupyter image
+            will be installed.
         welderRegistry:
           type: string
           enum: [GCR, DockerHub]

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpDockerDAO.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpDockerDAO.scala
@@ -106,8 +106,8 @@ class HttpDockerDAO[F[_]] private (httpClient: Client[F])(implicit logger: Logge
             headers = Headers.of(acceptHeader)
           )
         )(onError)
-      // GHCR accepts a personal github access token, but it seems to work for public images
-      // as long as any token is sent.
+      // GHCR accepts a personal github access token for private repo support, but it seems to
+      // work for public images as long as any token is sent.
       case ContainerRegistry.GHCR => F.pure(Some(Token("")))
     }
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpDockerDAO.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpDockerDAO.scala
@@ -28,7 +28,7 @@ import org.broadinstitute.dsde.workbench.leonardo.http.service.InvalidImage
  *
  * Currently supports:
  * - Jupyter or RStudio images
- * - Dockerhub or GCR repos
+ * - Dockerhub, GCR, or GHCR repos
  * - Tagged or untagged images
  * Does not support:
  * - Private images
@@ -93,7 +93,7 @@ class HttpDockerDAO[F[_]] private (httpClient: Client[F])(implicit logger: Logge
                             petTokenOpt: Option[String])(implicit ev: Ask[F, TraceId]): F[Option[Token]] =
     parsedImage.registry match {
       // If it's a GCR repo, use the pet token
-      case ContainerRegistry.GCR => Concurrent[F].pure(petTokenOpt.map(Token))
+      case ContainerRegistry.GCR => F.pure(petTokenOpt.map(Token))
       // If it's a Dockerhub repo, need to request a token from Dockerhub
       case ContainerRegistry.DockerHub =>
         httpClient.expectOptionOr[Token](
@@ -106,6 +106,9 @@ class HttpDockerDAO[F[_]] private (httpClient: Client[F])(implicit logger: Logge
             headers = Headers.of(acceptHeader)
           )
         )(onError)
+      // GHCR accepts a personal github access token, but it seems to work for public images
+      // as long as any token is sent.
+      case ContainerRegistry.GHCR => F.pure(Some(Token("")))
     }
 
   private def onError(response: Response[F])(implicit ev: Ask[F, TraceId]): F[Throwable] =
@@ -137,6 +140,12 @@ class HttpDockerDAO[F[_]] private (httpClient: Client[F])(implicit logger: Logge
           .orElse(Option(shaOpt).map(Sha))
           .getOrElse(Tag("latest"))
         F.pure(ParsedImage(DockerHub, dockerHubRegistryUri, imageName, identifier))
+      case GHCR.regex(registry, imageName, tagOpt, shaOpt) =>
+        val identifier = Option(tagOpt)
+          .map(Tag)
+          .orElse(Option(shaOpt).map(Sha))
+          .getOrElse(Tag("latest"))
+        F.pure(ParsedImage(GHCR, Uri.unsafeFromString(s"https://$registry/v2"), imageName, identifier))
       case _ =>
         for {
           traceId <- ev.ask

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/BaseRuntimeInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/BaseRuntimeInterpreter.scala
@@ -126,7 +126,8 @@ abstract private[util] class BaseRuntimeInterpreter[F[_]: Async: ContextShift: L
           .toRight(new Exception(s"Unable to update welder because current welder image is not available"))
           .flatMap(x =>
             x.registry match {
-              case Some(ContainerRegistry.GCR)       => Right(config.imageConfig.welderGcrImage.imageUrl)
+              case Some(ContainerRegistry.GCR) | Some(ContainerRegistry.GHCR) =>
+                Right(config.imageConfig.welderGcrImage.imageUrl)
               case Some(ContainerRegistry.DockerHub) => Right(config.imageConfig.welderDockerHubImage.imageUrl)
               case None                              => Left(new Exception(s"Unable to update Welder: registry for ${x.imageUrl} not parsable"))
             }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeonardoModelSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeonardoModelSpec.scala
@@ -271,6 +271,22 @@ class LeonardoModelSpec extends LeonardoTestSuite with AnyFlatSpecLike {
       .asPredicate()
       .test("myrepo/mydocker; mysql -c \"DROP ALL TABLES\"; sudo rm -rf / ") shouldBe (false)
     ContainerRegistry.DockerHub.regex.pattern.asPredicate().test("a///////") shouldBe (false)
+    ContainerRegistry.GHCR.regex.pattern.asPredicate().test("ghcr.io/github/super-linter:latest") shouldBe (true)
+    ContainerRegistry.GHCR.regex.pattern
+      .asPredicate()
+      .test("ghcr.io/lucidtronix/ml4h/ml4h_terra:20201117_123026") shouldBe (true)
+    ContainerRegistry.GHCR.regex.pattern
+      .asPredicate()
+      .test("ghcr.io/lucidtronix/ml4h/ml4h_terra:latest") shouldBe (true)
+    ContainerRegistry.GHCR.regex.pattern
+      .asPredicate()
+      .test("us.ghcr.io/lucidtronix/ml4h/ml4h_terra:20201117_123026") shouldBe (false)
+    ContainerRegistry.GHCR.regex.pattern
+      .asPredicate()
+      .test("ghcr.io/github/super-linter:latest; foo") shouldBe (false)
+    ContainerRegistry.GHCR.regex.pattern
+      .asPredicate()
+      .test("ghcr.io:foo") shouldBe (false)
   }
 
   "ContainerImage.stringToJupyterDockerImage" should "match GCR first, and then dockerhub" in {


### PR DESCRIPTION
See https://broadworkbench.atlassian.net/browse/IA-2385

Tested with `ghcr.io/lucidtronix/ml4h/ml4h_terra:20201117_123026`, it seems to work:

![image](https://user-images.githubusercontent.com/5368863/100689257-2077f780-3352-11eb-83a0-95229793af98.png)

(Verified `ghcr.io/broadinstitute/ml4h/ml4h_terra:20201119_180431` too)

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
