### PR TITLE
IA-2393 config remote properly

### DIFF
--- a/docker/build.sh
+++ b/docker/build.sh
@@ -40,6 +40,7 @@ set -e
 TARGET="${TARGET:-leonardo}"
 DB_CONTAINER="leonardo-mysql"
 GIT_BRANCH="${BRANCH:-$(git rev-parse --abbrev-ref HEAD)}"
+REMOTE=$(if [[ ${GIT_BRANCH} == "update/"* ]]; then echo "scalaSteward"; else echo "origin"; fi)
 DOCKER_REGISTRY="dockerhub"  # Must be either "dockerhub" or "gcr"
 BUILD_UI=false
 DOCKER_CMD=""
@@ -163,7 +164,7 @@ function docker_cmd()
 {
     if [ $DOCKER_CMD = "build" ] || [ $DOCKER_CMD = "push" ]; then
         echo "building $TARGET docker image..."
-        GIT_SHA=$(git rev-parse origin/${GIT_BRANCH})
+        GIT_SHA=$(git rev-parse ${REMOTE}/${GIT_BRANCH})
         echo GIT_SHA=$GIT_SHA > env.properties
 
         if [ -n "$DOCKER_TAG" ]; then

--- a/jenkins/jenkins_build.sh
+++ b/jenkins/jenkins_build.sh
@@ -16,7 +16,8 @@ if [ "$skip_docker_build" = false ]; then
   # clean up
   rm -f dspci-wb-gcr-service-account.json
 else
-  GIT_SHA=$(git rev-parse origin/${BRANCH})
+  REMOTE=$(if [[ ${BRANCH} == "update/"* ]]; then echo "scalaSteward"; else echo "origin"; fi)
+  GIT_SHA=$(git rev-parse ${REMOTE}/${BRANCH})
   echo GIT_SHA=$GIT_SHA > env.properties
 fi
 


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-2393

https://github.com/broadinstitute/dsp-jenkins/pull/471 will add scalaSteward as a remote as well. This PR assumes that if the branch starts with `update/`, it's a PR from `scalaSteward` (a bit hacky, but not sure if there's a better way).

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
