### PR TITLE
[IA-2350] Upgrade to latest workbench-libs DataprocService

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/JsonCodec.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/JsonCodec.scala
@@ -77,16 +77,15 @@ object JsonCodec {
     "numberOfWorkerLocalSSDs",
     "numberOfPreemptibleWorkers",
     "cloudService"
-  )(
-    x =>
-      (x.numberOfWorkers,
-       x.machineType,
-       x.diskSize,
-       x.workerMachineType,
-       x.workerDiskSize,
-       x.numberOfWorkerLocalSSDs,
-       x.numberOfPreemptibleWorkers,
-       x.cloudService)
+  )(x =>
+    (x.numberOfWorkers,
+     x.machineType,
+     x.diskSize,
+     x.workerMachineType,
+     x.workerDiskSize,
+     x.numberOfWorkerLocalSSDs,
+     x.numberOfPreemptibleWorkers,
+     x.cloudService)
   )
   implicit val gceRuntimeConfigEncoder: Encoder[RuntimeConfig.GceConfig] = Encoder.forProduct4(
     "machineType",
@@ -121,12 +120,11 @@ object JsonCodec {
     "bootDiskSize"
   )(x => (x.machineType, x.persistentDiskId, x.cloudService, x.bootDiskSize))
 
-  implicit val runtimeConfigEncoder: Encoder[RuntimeConfig] = Encoder.instance(
-    x =>
-      x match {
-        case x: RuntimeConfig.DataprocConfig  => x.asJson
-        case x: RuntimeConfig.GceConfig       => x.asJson
-        case x: RuntimeConfig.GceWithPdConfig => x.asJson
+  implicit val runtimeConfigEncoder: Encoder[RuntimeConfig] = Encoder.instance(x =>
+    x match {
+      case x: RuntimeConfig.DataprocConfig  => x.asJson
+      case x: RuntimeConfig.GceConfig       => x.asJson
+      case x: RuntimeConfig.GceWithPdConfig => x.asJson
     }
   )
   implicit val defaultRuntimeLabelsEncoder: Encoder[DefaultRuntimeLabels] = Encoder.forProduct7(
@@ -153,16 +151,15 @@ object JsonCodec {
   implicit val errorSourceEncoder: Encoder[ErrorSource] = Encoder.encodeString.contramap(_.toString)
   implicit val errorActionEncoder: Encoder[ErrorAction] = Encoder.encodeString.contramap(_.toString)
   implicit val kubernetesErrorEncoder: Encoder[AppError] =
-    Encoder.forProduct5("errorMessage", "timestamp", "action", "source", "googleErrorCode")(
-      x => AppError.unapply(x).get
+    Encoder.forProduct5("errorMessage", "timestamp", "action", "source", "googleErrorCode")(x =>
+      AppError.unapply(x).get
     )
   implicit val nodepoolIdEncoder: Encoder[NodepoolLeoId] = Encoder.encodeLong.contramap(_.id)
   implicit val nodepoolNameEncoder: Encoder[NodepoolName] = Encoder.encodeString.contramap(_.value)
-  implicit val nodepoolStatusEncoder: Encoder[NodepoolStatus] = Encoder.encodeString.contramap(
-    status =>
-      status match {
-        case NodepoolStatus.Precreating => NodepoolStatus.Provisioning.toString
-        case _                          => status.toString
+  implicit val nodepoolStatusEncoder: Encoder[NodepoolStatus] = Encoder.encodeString.contramap(status =>
+    status match {
+      case NodepoolStatus.Precreating => NodepoolStatus.Provisioning.toString
+      case _                          => status.toString
     }
   )
   implicit val numNodesEncoder: Encoder[NumNodes] = Encoder.encodeInt.contramap(_.amount)
@@ -176,11 +173,10 @@ object JsonCodec {
   implicit val locationEncoder: Encoder[Location] = Encoder.encodeString.contramap(_.value)
   implicit val kubeClusterIdEncoder: Encoder[KubernetesClusterLeoId] = Encoder.encodeLong.contramap(_.id)
   implicit val kubeClusterNameEncoder: Encoder[KubernetesClusterName] = Encoder.encodeString.contramap(_.value)
-  implicit val kubeClusterStatusEncoder: Encoder[KubernetesClusterStatus] = Encoder.encodeString.contramap(
-    status =>
-      status match {
-        case KubernetesClusterStatus.Precreating => KubernetesClusterStatus.Provisioning.toString
-        case _                                   => status.toString
+  implicit val kubeClusterStatusEncoder: Encoder[KubernetesClusterStatus] = Encoder.encodeString.contramap(status =>
+    status match {
+      case KubernetesClusterStatus.Precreating => KubernetesClusterStatus.Provisioning.toString
+      case _                                   => status.toString
     }
   )
   implicit val kubeSamIdEncoder: Encoder[AppSamResourceId] = Encoder.encodeString.contramap(_.resourceId)
@@ -198,8 +194,8 @@ object JsonCodec {
   implicit val networkFieldsEncoder: Encoder[NetworkFields] =
     Encoder.forProduct3("networkName", "subNetworkName", "subNetworkIpRange")(x => NetworkFields.unapply(x).get)
   implicit val kubeAsyncFieldEncoder: Encoder[KubernetesClusterAsyncFields] =
-    Encoder.forProduct3("loadBalancerIp", "apiServerIp", "networkInfo")(
-      x => KubernetesClusterAsyncFields.unapply(x).get
+    Encoder.forProduct3("loadBalancerIp", "apiServerIp", "networkInfo")(x =>
+      KubernetesClusterAsyncFields.unapply(x).get
     )
 
   implicit val instanceNameEncoder: Encoder[InstanceName] = Encoder.encodeString.contramap(_.value)
@@ -219,15 +215,15 @@ object JsonCodec {
   implicit val containerImageDecoder: Decoder[ContainerImage] =
     Decoder.decodeString.emap(s => ContainerImage.fromImageUrl(s).toRight(s"invalid container image ${s}"))
   implicit val containerRegistryDecoder: Decoder[ContainerRegistry] =
-    Decoder.decodeString.emap(
-      s => ContainerRegistry.withNameInsensitiveOption(s).toRight(s"Unsupported container registry ${s}")
+    Decoder.decodeString.emap(s =>
+      ContainerRegistry.withNameInsensitiveOption(s).toRight(s"Unsupported container registry ${s}")
     )
   implicit val cloudServiceDecoder: Decoder[CloudService] =
     Decoder.decodeString.emap(s => CloudService.withNameInsensitiveOption(s).toRight(s"Unsupported cloud service ${s}"))
   implicit val runtimeNameDecoder: Decoder[RuntimeName] = Decoder.decodeString.map(RuntimeName)
   implicit val runtimeStatusDecoder: Decoder[RuntimeStatus] = Decoder.decodeString.map(s => RuntimeStatus.withName(s))
-  implicit val machineTypeDecoder: Decoder[MachineTypeName] = Decoder.decodeString.emap(
-    s => if (s.isEmpty) Left("machine type cannot be an empty string") else Right(MachineTypeName(s))
+  implicit val machineTypeDecoder: Decoder[MachineTypeName] = Decoder.decodeString.emap(s =>
+    if (s.isEmpty) Left("machine type cannot be an empty string") else Right(MachineTypeName(s))
   )
   implicit val instantDecoder: Decoder[Instant] =
     Decoder.decodeString.emap(s => Either.catchNonFatal(Instant.parse(s)).leftMap(_.getMessage))
@@ -240,8 +236,8 @@ object JsonCodec {
   implicit val blockSizeDecoder: Decoder[BlockSize] =
     Decoder.decodeInt.emap(d => if (d < 0) Left("Negative number is not allowed") else Right(BlockSize(d)))
   implicit val workbenchEmailDecoder: Decoder[WorkbenchEmail] = Decoder.decodeString.map(WorkbenchEmail)
-  implicit val runtimeImageTypeDecoder: Decoder[RuntimeImageType] = Decoder.decodeString.emap(
-    s => RuntimeImageType.stringToRuntimeImageType.get(s).toRight(s"invalid RuntimeImageType ${s}")
+  implicit val runtimeImageTypeDecoder: Decoder[RuntimeImageType] = Decoder.decodeString.emap(s =>
+    RuntimeImageType.stringToRuntimeImageType.get(s).toRight(s"invalid RuntimeImageType ${s}")
   )
 
   implicit val runtimeImageDecoder: Decoder[RuntimeImage] = Decoder.forProduct3(
@@ -266,15 +262,14 @@ object JsonCodec {
       numberOfPreemptibleWorkers <- c.downField("numberOfPreemptibleWorkers").as[Option[Int]]
       propertiesOpt <- c.downField("properties").as[Option[LabelMap]]
       properties = propertiesOpt.getOrElse(Map.empty)
-    } yield
-      RuntimeConfig.DataprocConfig(numberOfWorkers,
-                                   masterMachineType,
-                                   masterDiskSize,
-                                   workerMachineType,
-                                   workerDiskSize,
-                                   numberOfWorkerLocalSSDs,
-                                   numberOfPreemptibleWorkers,
-                                   properties)
+    } yield RuntimeConfig.DataprocConfig(numberOfWorkers,
+                                         masterMachineType,
+                                         masterDiskSize,
+                                         workerMachineType,
+                                         workerDiskSize,
+                                         numberOfWorkerLocalSSDs,
+                                         numberOfPreemptibleWorkers,
+                                         properties)
   }
 
   implicit val runtimeConfigDecoder: Decoder[RuntimeConfig] = Decoder.instance { x =>
@@ -304,11 +299,10 @@ object JsonCodec {
       se <- c.downField("serverExtensions").as[Option[Map[String, String]]]
       ce <- c.downField("combinedExtensions").as[Option[Map[String, String]]]
       le <- c.downField("labExtensions").as[Option[Map[String, String]]]
-    } yield
-      UserJupyterExtensionConfig(ne.getOrElse(Map.empty),
-                                 se.getOrElse(Map.empty),
-                                 ce.getOrElse(Map.empty),
-                                 le.getOrElse(Map.empty))
+    } yield UserJupyterExtensionConfig(ne.getOrElse(Map.empty),
+                                       se.getOrElse(Map.empty),
+                                       ce.getOrElse(Map.empty),
+                                       le.getOrElse(Map.empty))
   }
 
   implicit val clusterProjectAndNameDecoder: Decoder[RuntimeProjectAndName] =
@@ -384,8 +378,8 @@ object JsonCodec {
   implicit val kubeClusterIdDecoder: Decoder[KubernetesClusterLeoId] = Decoder.decodeLong.map(KubernetesClusterLeoId)
   implicit val kubeClusterNameDecoder: Decoder[KubernetesClusterName] =
     Decoder.decodeString.emap(s => KubernetesName.withValidation(s, KubernetesClusterName).leftMap(_.getMessage))
-  implicit val kubeClusterStatusDecoder: Decoder[KubernetesClusterStatus] = Decoder.decodeString.emap(
-    s => KubernetesClusterStatus.stringToObject.get(s).toRight(s"Invalid cluster status ${s}")
+  implicit val kubeClusterStatusDecoder: Decoder[KubernetesClusterStatus] = Decoder.decodeString.emap(s =>
+    KubernetesClusterStatus.stringToObject.get(s).toRight(s"Invalid cluster status ${s}")
   )
   implicit val appSamIdDecoder: Decoder[AppSamResourceId] = Decoder.decodeString.map(AppSamResourceId)
   implicit val namespaceNameDecoder: Decoder[NamespaceName] =

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/JsonCodec.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/JsonCodec.scala
@@ -77,15 +77,16 @@ object JsonCodec {
     "numberOfWorkerLocalSSDs",
     "numberOfPreemptibleWorkers",
     "cloudService"
-  )(x =>
-    (x.numberOfWorkers,
-     x.machineType,
-     x.diskSize,
-     x.workerMachineType,
-     x.workerDiskSize,
-     x.numberOfWorkerLocalSSDs,
-     x.numberOfPreemptibleWorkers,
-     x.cloudService)
+  )(
+    x =>
+      (x.numberOfWorkers,
+       x.machineType,
+       x.diskSize,
+       x.workerMachineType,
+       x.workerDiskSize,
+       x.numberOfWorkerLocalSSDs,
+       x.numberOfPreemptibleWorkers,
+       x.cloudService)
   )
   implicit val gceRuntimeConfigEncoder: Encoder[RuntimeConfig.GceConfig] = Encoder.forProduct4(
     "machineType",
@@ -120,11 +121,12 @@ object JsonCodec {
     "bootDiskSize"
   )(x => (x.machineType, x.persistentDiskId, x.cloudService, x.bootDiskSize))
 
-  implicit val runtimeConfigEncoder: Encoder[RuntimeConfig] = Encoder.instance(x =>
-    x match {
-      case x: RuntimeConfig.DataprocConfig  => x.asJson
-      case x: RuntimeConfig.GceConfig       => x.asJson
-      case x: RuntimeConfig.GceWithPdConfig => x.asJson
+  implicit val runtimeConfigEncoder: Encoder[RuntimeConfig] = Encoder.instance(
+    x =>
+      x match {
+        case x: RuntimeConfig.DataprocConfig  => x.asJson
+        case x: RuntimeConfig.GceConfig       => x.asJson
+        case x: RuntimeConfig.GceWithPdConfig => x.asJson
     }
   )
   implicit val defaultRuntimeLabelsEncoder: Encoder[DefaultRuntimeLabels] = Encoder.forProduct7(
@@ -151,15 +153,16 @@ object JsonCodec {
   implicit val errorSourceEncoder: Encoder[ErrorSource] = Encoder.encodeString.contramap(_.toString)
   implicit val errorActionEncoder: Encoder[ErrorAction] = Encoder.encodeString.contramap(_.toString)
   implicit val kubernetesErrorEncoder: Encoder[AppError] =
-    Encoder.forProduct5("errorMessage", "timestamp", "action", "source", "googleErrorCode")(x =>
-      AppError.unapply(x).get
+    Encoder.forProduct5("errorMessage", "timestamp", "action", "source", "googleErrorCode")(
+      x => AppError.unapply(x).get
     )
   implicit val nodepoolIdEncoder: Encoder[NodepoolLeoId] = Encoder.encodeLong.contramap(_.id)
   implicit val nodepoolNameEncoder: Encoder[NodepoolName] = Encoder.encodeString.contramap(_.value)
-  implicit val nodepoolStatusEncoder: Encoder[NodepoolStatus] = Encoder.encodeString.contramap(status =>
-    status match {
-      case NodepoolStatus.Precreating => NodepoolStatus.Provisioning.toString
-      case _                          => status.toString
+  implicit val nodepoolStatusEncoder: Encoder[NodepoolStatus] = Encoder.encodeString.contramap(
+    status =>
+      status match {
+        case NodepoolStatus.Precreating => NodepoolStatus.Provisioning.toString
+        case _                          => status.toString
     }
   )
   implicit val numNodesEncoder: Encoder[NumNodes] = Encoder.encodeInt.contramap(_.amount)
@@ -173,10 +176,11 @@ object JsonCodec {
   implicit val locationEncoder: Encoder[Location] = Encoder.encodeString.contramap(_.value)
   implicit val kubeClusterIdEncoder: Encoder[KubernetesClusterLeoId] = Encoder.encodeLong.contramap(_.id)
   implicit val kubeClusterNameEncoder: Encoder[KubernetesClusterName] = Encoder.encodeString.contramap(_.value)
-  implicit val kubeClusterStatusEncoder: Encoder[KubernetesClusterStatus] = Encoder.encodeString.contramap(status =>
-    status match {
-      case KubernetesClusterStatus.Precreating => KubernetesClusterStatus.Provisioning.toString
-      case _                                   => status.toString
+  implicit val kubeClusterStatusEncoder: Encoder[KubernetesClusterStatus] = Encoder.encodeString.contramap(
+    status =>
+      status match {
+        case KubernetesClusterStatus.Precreating => KubernetesClusterStatus.Provisioning.toString
+        case _                                   => status.toString
     }
   )
   implicit val kubeSamIdEncoder: Encoder[AppSamResourceId] = Encoder.encodeString.contramap(_.resourceId)
@@ -194,8 +198,8 @@ object JsonCodec {
   implicit val networkFieldsEncoder: Encoder[NetworkFields] =
     Encoder.forProduct3("networkName", "subNetworkName", "subNetworkIpRange")(x => NetworkFields.unapply(x).get)
   implicit val kubeAsyncFieldEncoder: Encoder[KubernetesClusterAsyncFields] =
-    Encoder.forProduct3("loadBalancerIp", "apiServerIp", "networkInfo")(x =>
-      KubernetesClusterAsyncFields.unapply(x).get
+    Encoder.forProduct3("loadBalancerIp", "apiServerIp", "networkInfo")(
+      x => KubernetesClusterAsyncFields.unapply(x).get
     )
 
   implicit val instanceNameEncoder: Encoder[InstanceName] = Encoder.encodeString.contramap(_.value)
@@ -215,15 +219,15 @@ object JsonCodec {
   implicit val containerImageDecoder: Decoder[ContainerImage] =
     Decoder.decodeString.emap(s => ContainerImage.fromImageUrl(s).toRight(s"invalid container image ${s}"))
   implicit val containerRegistryDecoder: Decoder[ContainerRegistry] =
-    Decoder.decodeString.emap(s =>
-      ContainerRegistry.withNameInsensitiveOption(s).toRight(s"Unsupported container registry ${s}")
+    Decoder.decodeString.emap(
+      s => ContainerRegistry.withNameInsensitiveOption(s).toRight(s"Unsupported container registry ${s}")
     )
   implicit val cloudServiceDecoder: Decoder[CloudService] =
     Decoder.decodeString.emap(s => CloudService.withNameInsensitiveOption(s).toRight(s"Unsupported cloud service ${s}"))
   implicit val runtimeNameDecoder: Decoder[RuntimeName] = Decoder.decodeString.map(RuntimeName)
   implicit val runtimeStatusDecoder: Decoder[RuntimeStatus] = Decoder.decodeString.map(s => RuntimeStatus.withName(s))
-  implicit val machineTypeDecoder: Decoder[MachineTypeName] = Decoder.decodeString.emap(s =>
-    if (s.isEmpty) Left("machine type cannot be an empty string") else Right(MachineTypeName(s))
+  implicit val machineTypeDecoder: Decoder[MachineTypeName] = Decoder.decodeString.emap(
+    s => if (s.isEmpty) Left("machine type cannot be an empty string") else Right(MachineTypeName(s))
   )
   implicit val instantDecoder: Decoder[Instant] =
     Decoder.decodeString.emap(s => Either.catchNonFatal(Instant.parse(s)).leftMap(_.getMessage))
@@ -236,8 +240,8 @@ object JsonCodec {
   implicit val blockSizeDecoder: Decoder[BlockSize] =
     Decoder.decodeInt.emap(d => if (d < 0) Left("Negative number is not allowed") else Right(BlockSize(d)))
   implicit val workbenchEmailDecoder: Decoder[WorkbenchEmail] = Decoder.decodeString.map(WorkbenchEmail)
-  implicit val runtimeImageTypeDecoder: Decoder[RuntimeImageType] = Decoder.decodeString.emap(s =>
-    RuntimeImageType.stringToRuntimeImageType.get(s).toRight(s"invalid RuntimeImageType ${s}")
+  implicit val runtimeImageTypeDecoder: Decoder[RuntimeImageType] = Decoder.decodeString.emap(
+    s => RuntimeImageType.stringToRuntimeImageType.get(s).toRight(s"invalid RuntimeImageType ${s}")
   )
 
   implicit val runtimeImageDecoder: Decoder[RuntimeImage] = Decoder.forProduct3(
@@ -262,14 +266,15 @@ object JsonCodec {
       numberOfPreemptibleWorkers <- c.downField("numberOfPreemptibleWorkers").as[Option[Int]]
       propertiesOpt <- c.downField("properties").as[Option[LabelMap]]
       properties = propertiesOpt.getOrElse(Map.empty)
-    } yield RuntimeConfig.DataprocConfig(numberOfWorkers,
-                                         masterMachineType,
-                                         masterDiskSize,
-                                         workerMachineType,
-                                         workerDiskSize,
-                                         numberOfWorkerLocalSSDs,
-                                         numberOfPreemptibleWorkers,
-                                         properties)
+    } yield
+      RuntimeConfig.DataprocConfig(numberOfWorkers,
+                                   masterMachineType,
+                                   masterDiskSize,
+                                   workerMachineType,
+                                   workerDiskSize,
+                                   numberOfWorkerLocalSSDs,
+                                   numberOfPreemptibleWorkers,
+                                   properties)
   }
 
   implicit val runtimeConfigDecoder: Decoder[RuntimeConfig] = Decoder.instance { x =>
@@ -299,10 +304,11 @@ object JsonCodec {
       se <- c.downField("serverExtensions").as[Option[Map[String, String]]]
       ce <- c.downField("combinedExtensions").as[Option[Map[String, String]]]
       le <- c.downField("labExtensions").as[Option[Map[String, String]]]
-    } yield UserJupyterExtensionConfig(ne.getOrElse(Map.empty),
-                                       se.getOrElse(Map.empty),
-                                       ce.getOrElse(Map.empty),
-                                       le.getOrElse(Map.empty))
+    } yield
+      UserJupyterExtensionConfig(ne.getOrElse(Map.empty),
+                                 se.getOrElse(Map.empty),
+                                 ce.getOrElse(Map.empty),
+                                 le.getOrElse(Map.empty))
   }
 
   implicit val clusterProjectAndNameDecoder: Decoder[RuntimeProjectAndName] =
@@ -311,7 +317,7 @@ object JsonCodec {
   implicit val asyncRuntimeFieldsDecoder: Decoder[AsyncRuntimeFields] =
     Decoder.forProduct4("googleId", "operationName", "stagingBucket", "hostIp")(AsyncRuntimeFields.apply)
 
-  implicit val zoneDecoder: Decoder[ZoneName] = Decoder.decodeString.map(ZoneName)
+  implicit val zoneDecoder: Decoder[ZoneName] = Decoder.decodeString.map(ZoneName(_))
   implicit val diskNameDecoder: Decoder[DiskName] = Decoder.decodeString.emap(s => validateName(s).map(DiskName))
   implicit val diskIdDecoder: Decoder[DiskId] = Decoder.decodeLong.map(DiskId)
   implicit val diskStatusDecoder: Decoder[DiskStatus] =
@@ -378,8 +384,8 @@ object JsonCodec {
   implicit val kubeClusterIdDecoder: Decoder[KubernetesClusterLeoId] = Decoder.decodeLong.map(KubernetesClusterLeoId)
   implicit val kubeClusterNameDecoder: Decoder[KubernetesClusterName] =
     Decoder.decodeString.emap(s => KubernetesName.withValidation(s, KubernetesClusterName).leftMap(_.getMessage))
-  implicit val kubeClusterStatusDecoder: Decoder[KubernetesClusterStatus] = Decoder.decodeString.emap(s =>
-    KubernetesClusterStatus.stringToObject.get(s).toRight(s"Invalid cluster status ${s}")
+  implicit val kubeClusterStatusDecoder: Decoder[KubernetesClusterStatus] = Decoder.decodeString.emap(
+    s => KubernetesClusterStatus.stringToObject.get(s).toRight(s"Invalid cluster status ${s}")
   )
   implicit val appSamIdDecoder: Decoder[AppSamResourceId] = Decoder.decodeString.map(AppSamResourceId)
   implicit val namespaceNameDecoder: Decoder[NamespaceName] =

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/Boot.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/Boot.scala
@@ -98,52 +98,60 @@ object Boot extends IOApp {
                            googleDependencies.googleComputeService,
                            googleDependencies.computePollOperation)
 
-      val dataprocInterp = new DataprocInterpreter(dataprocInterpreterConfig,
-                                                   bucketHelper,
-                                                   vpcInterp,
-                                                   googleDependencies.googleDataprocDAO,
-                                                   googleDependencies.googleComputeService,
-                                                   googleDependencies.googleDiskService,
-                                                   googleDependencies.googleDirectoryDAO,
-                                                   googleDependencies.googleIamDAO,
-                                                   googleDependencies.googleProjectDAO,
-                                                   appDependencies.welderDAO,
-                                                   appDependencies.blocker)
+      val dataprocInterp = new DataprocInterpreter(
+        dataprocInterpreterConfig,
+        bucketHelper,
+        vpcInterp,
+        googleDependencies.googleDataprocDAO,
+        googleDependencies.googleComputeService,
+        googleDependencies.googleDiskService,
+        googleDependencies.googleDirectoryDAO,
+        googleDependencies.googleIamDAO,
+        googleDependencies.googleProjectDAO,
+        appDependencies.welderDAO,
+        appDependencies.blocker
+      )
 
-      val gceInterp = new GceInterpreter(gceInterpreterConfig,
-                                         bucketHelper,
-                                         vpcInterp,
-                                         googleDependencies.googleComputeService,
-                                         googleDependencies.googleDiskService,
-                                         appDependencies.welderDAO,
-                                         appDependencies.blocker)
+      val gceInterp = new GceInterpreter(
+        gceInterpreterConfig,
+        bucketHelper,
+        vpcInterp,
+        googleDependencies.googleComputeService,
+        googleDependencies.googleDiskService,
+        appDependencies.welderDAO,
+        appDependencies.blocker
+      )
       implicit val runtimeInstances = new RuntimeInstances(dataprocInterp, gceInterp)
 
-      val leonardoService = new LeonardoService(dataprocConfig,
-                                                imageConfig,
-                                                appDependencies.welderDAO,
-                                                proxyConfig,
-                                                swaggerConfig,
-                                                autoFreezeConfig,
-                                                zombieRuntimeMonitorConfig,
-                                                welderConfig,
-                                                googleDependencies.petGoogleStorageDAO,
-                                                appDependencies.authProvider,
-                                                appDependencies.serviceAccountProvider,
-                                                bucketHelper,
-                                                appDependencies.dockerDAO,
-                                                appDependencies.publisherQueue)
+      val leonardoService = new LeonardoService(
+        dataprocConfig,
+        imageConfig,
+        appDependencies.welderDAO,
+        proxyConfig,
+        swaggerConfig,
+        autoFreezeConfig,
+        zombieRuntimeMonitorConfig,
+        welderConfig,
+        googleDependencies.petGoogleStorageDAO,
+        appDependencies.authProvider,
+        appDependencies.serviceAccountProvider,
+        bucketHelper,
+        appDependencies.dockerDAO,
+        appDependencies.publisherQueue
+      )
       val dateAccessedUpdater =
         new DateAccessedUpdater(dateAccessUpdaterConfig, appDependencies.dateAccessedUpdaterQueue)
-      val proxyService = new ProxyService(appDependencies.sslContext,
-                                          proxyConfig,
-                                          appDependencies.jupyterDAO,
-                                          appDependencies.runtimeDnsCache,
-                                          googleDependencies.kubernetesDnsCache,
-                                          appDependencies.authProvider,
-                                          appDependencies.dateAccessedUpdaterQueue,
-                                          googleDependencies.googleOauth2DAO,
-                                          appDependencies.blocker)
+      val proxyService = new ProxyService(
+        appDependencies.sslContext,
+        proxyConfig,
+        appDependencies.jupyterDAO,
+        appDependencies.runtimeDnsCache,
+        googleDependencies.kubernetesDnsCache,
+        appDependencies.authProvider,
+        appDependencies.dateAccessedUpdaterQueue,
+        googleDependencies.googleOauth2DAO,
+        appDependencies.blocker
+      )
       val statusService = new StatusService(googleDependencies.googleDataprocDAO,
                                             appDependencies.samDAO,
                                             appDependencies.dbReference,
@@ -183,15 +191,17 @@ object Boot extends IOApp {
                                        leoKubernetesConfig,
                                        appDependencies.publisherQueue)
 
-      val httpRoutes = new HttpRoutes(swaggerConfig,
-                                      statusService,
-                                      proxyService,
-                                      leonardoService,
-                                      runtimeService,
-                                      diskService,
-                                      leoKubernetesService,
-                                      StandardUserInfoDirectives,
-                                      contentSecurityPolicy)
+      val httpRoutes = new HttpRoutes(
+        swaggerConfig,
+        statusService,
+        proxyService,
+        leonardoService,
+        runtimeService,
+        diskService,
+        leoKubernetesService,
+        StandardUserInfoDirectives,
+        contentSecurityPolicy
+      )
       val httpServer = for {
         _ <- if (leoExecutionModeConfig == LeoExecutionModeConfig.BackLeoOnly) {
           dataprocInterp.setupDataprocImageGoogleGroup()
@@ -246,26 +256,30 @@ object Boot extends IOApp {
           // only needed for backleo
           val asyncTasks = AsyncTaskProcessor(asyncTaskProcessorConfig, appDependencies.asyncTasksQueue)
 
-          val gkeAlg = new GKEInterpreter[IO](gkeInterpConfig,
-                                              vpcInterp,
-                                              googleDependencies.gkeService,
-                                              googleDependencies.kubeService,
-                                              appDependencies.helmClient,
-                                              appDependencies.galaxyDAO,
-                                              googleDependencies.credentials,
-                                              googleDependencies.googleIamDAO,
-                                              appDependencies.blocker,
-                                              appDependencies.nodepoolLock)
+          val gkeAlg = new GKEInterpreter[IO](
+            gkeInterpConfig,
+            vpcInterp,
+            googleDependencies.gkeService,
+            googleDependencies.kubeService,
+            appDependencies.helmClient,
+            appDependencies.galaxyDAO,
+            googleDependencies.credentials,
+            googleDependencies.googleIamDAO,
+            appDependencies.blocker,
+            appDependencies.nodepoolLock
+          )
 
           val pubsubSubscriber =
-            new LeoPubsubMessageSubscriber[IO](leoPubsubMessageSubscriberConfig,
-                                               appDependencies.subscriber,
-                                               appDependencies.asyncTasksQueue,
-                                               googleDiskService,
-                                               googleDependencies.computePollOperation,
-                                               appDependencies.authProvider,
-                                               gkeAlg,
-                                               googleDependencies.errorReporting)
+            new LeoPubsubMessageSubscriber[IO](
+              leoPubsubMessageSubscriberConfig,
+              appDependencies.subscriber,
+              appDependencies.asyncTasksQueue,
+              googleDiskService,
+              googleDependencies.computePollOperation,
+              appDependencies.authProvider,
+              gkeAlg,
+              googleDependencies.errorReporting
+            )
 
           val autopauseMonitor = AutopauseMonitor(
             autoFreezeConfig,
@@ -413,6 +427,7 @@ object Boot extends IOApp {
                                                                   semaphore,
                                                                   googleComputeRetryPolicy)
       dataprocService <- GoogleDataprocService.resource(
+        googleComputeService,
         pathToCredentialJson,
         blocker,
         semaphore,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
@@ -381,8 +381,8 @@ object Config {
   implicit private val dataprocCustomImageReader: ValueReader[DataprocCustomImage] =
     stringValueReader.map(DataprocCustomImage)
   implicit private val gceCustomImageReader: ValueReader[GceCustomImage] = stringValueReader.map(GceCustomImage)
-  implicit private val containerImageValueReader: ValueReader[ContainerImage] = stringValueReader.map(
-    s => ContainerImage.fromImageUrl(s).getOrElse(throw new RuntimeException(s"Unable to parse ContainerImage from $s"))
+  implicit private val containerImageValueReader: ValueReader[ContainerImage] = stringValueReader.map(s =>
+    ContainerImage.fromImageUrl(s).getOrElse(throw new RuntimeException(s"Unable to parse ContainerImage from $s"))
   )
   implicit private val runtimeResourceValueReader: ValueReader[RuntimeResource] = stringValueReader.map(RuntimeResource)
   implicit private val memorySizeReader: ValueReader[MemorySize] = (config: TypeSafeConfig, path: String) =>
@@ -396,8 +396,8 @@ object Config {
   implicit private val networkLabelValueReader: ValueReader[NetworkLabel] = stringValueReader.map(NetworkLabel)
   implicit private val subnetworkLabelValueReader: ValueReader[SubnetworkLabel] = stringValueReader.map(SubnetworkLabel)
   implicit private val diskSizeValueReader: ValueReader[DiskSize] = intValueReader.map(DiskSize)
-  implicit private val diskTypeValueReader: ValueReader[DiskType] = stringValueReader.map(
-    s => DiskType.stringToObject.getOrElse(s, throw new RuntimeException(s"Unable to parse diskType from $s"))
+  implicit private val diskTypeValueReader: ValueReader[DiskType] = stringValueReader.map(s =>
+    DiskType.stringToObject.getOrElse(s, throw new RuntimeException(s"Unable to parse diskType from $s"))
   )
   implicit private val blockSizeValueReader: ValueReader[BlockSize] = intValueReader.map(BlockSize)
   implicit private val frameAncestorsReader: ValueReader[FrameAncestors] =
@@ -564,11 +564,10 @@ object Config {
   }
 
   implicit private val secretNameReader: ValueReader[SecretName] =
-    stringValueReader.map(
-      s =>
-        KubernetesName
-          .withValidation(s, SecretName)
-          .getOrElse(throw new RuntimeException(s"Unable to parse the secret name $s into a valid kubernetes name"))
+    stringValueReader.map(s =>
+      KubernetesName
+        .withValidation(s, SecretName)
+        .getOrElse(throw new RuntimeException(s"Unable to parse the secret name $s into a valid kubernetes name"))
     )
 
   implicit private val secretConfigReader: ValueReader[SecretConfig] = ValueReader.relative { config =>
@@ -630,11 +629,10 @@ object Config {
   implicit private val numNodesValueReader: ValueReader[NumNodes] = intValueReader.map(NumNodes)
   implicit private val autoscalingMinValueReader: ValueReader[AutoscalingMin] = intValueReader.map(AutoscalingMin)
   implicit private val autoscalingMaxValueReader: ValueReader[AutoscalingMax] = intValueReader.map(AutoscalingMax)
-  implicit private val serviceNameValueReader: ValueReader[ServiceName] = stringValueReader.map(
-    s =>
-      KubernetesName
-        .withValidation(s, ServiceName)
-        .getOrElse(throw new Exception(s"Invalid service name in config: ${s}"))
+  implicit private val serviceNameValueReader: ValueReader[ServiceName] = stringValueReader.map(s =>
+    KubernetesName
+      .withValidation(s, ServiceName)
+      .getOrElse(throw new Exception(s"Invalid service name in config: ${s}"))
   )
   implicit private val serviceKindValueReader: ValueReader[KubernetesServiceKindName] =
     stringValueReader.map(KubernetesServiceKindName)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
@@ -375,14 +375,14 @@ object Config {
   implicit private val workbenchEmailValueReader: ValueReader[WorkbenchEmail] = stringValueReader.map(WorkbenchEmail)
   implicit private val googleProjectValueReader: ValueReader[GoogleProject] = stringValueReader.map(GoogleProject)
   implicit private val pathValueReader: ValueReader[Path] = stringValueReader.map(s => Paths.get(s))
-  implicit private val regionNameReader: ValueReader[RegionName] = stringValueReader.map(RegionName)
-  implicit private val zoneNameReader: ValueReader[ZoneName] = stringValueReader.map(ZoneName)
+  implicit private val regionNameReader: ValueReader[RegionName] = stringValueReader.map(RegionName(_))
+  implicit private val zoneNameReader: ValueReader[ZoneName] = stringValueReader.map(ZoneName(_))
   implicit private val machineTypeReader: ValueReader[MachineTypeName] = stringValueReader.map(MachineTypeName)
   implicit private val dataprocCustomImageReader: ValueReader[DataprocCustomImage] =
     stringValueReader.map(DataprocCustomImage)
   implicit private val gceCustomImageReader: ValueReader[GceCustomImage] = stringValueReader.map(GceCustomImage)
-  implicit private val containerImageValueReader: ValueReader[ContainerImage] = stringValueReader.map(s =>
-    ContainerImage.fromImageUrl(s).getOrElse(throw new RuntimeException(s"Unable to parse ContainerImage from $s"))
+  implicit private val containerImageValueReader: ValueReader[ContainerImage] = stringValueReader.map(
+    s => ContainerImage.fromImageUrl(s).getOrElse(throw new RuntimeException(s"Unable to parse ContainerImage from $s"))
   )
   implicit private val runtimeResourceValueReader: ValueReader[RuntimeResource] = stringValueReader.map(RuntimeResource)
   implicit private val memorySizeReader: ValueReader[MemorySize] = (config: TypeSafeConfig, path: String) =>
@@ -396,8 +396,8 @@ object Config {
   implicit private val networkLabelValueReader: ValueReader[NetworkLabel] = stringValueReader.map(NetworkLabel)
   implicit private val subnetworkLabelValueReader: ValueReader[SubnetworkLabel] = stringValueReader.map(SubnetworkLabel)
   implicit private val diskSizeValueReader: ValueReader[DiskSize] = intValueReader.map(DiskSize)
-  implicit private val diskTypeValueReader: ValueReader[DiskType] = stringValueReader.map(s =>
-    DiskType.stringToObject.get(s).getOrElse(throw new RuntimeException(s"Unable to parse diskType from $s"))
+  implicit private val diskTypeValueReader: ValueReader[DiskType] = stringValueReader.map(
+    s => DiskType.stringToObject.getOrElse(s, throw new RuntimeException(s"Unable to parse diskType from $s"))
   )
   implicit private val blockSizeValueReader: ValueReader[BlockSize] = intValueReader.map(BlockSize)
   implicit private val frameAncestorsReader: ValueReader[FrameAncestors] =
@@ -564,10 +564,11 @@ object Config {
   }
 
   implicit private val secretNameReader: ValueReader[SecretName] =
-    stringValueReader.map(s =>
-      KubernetesName
-        .withValidation(s, SecretName)
-        .getOrElse(throw new RuntimeException(s"Unable to parse the secret name $s into a valid kubernetes name"))
+    stringValueReader.map(
+      s =>
+        KubernetesName
+          .withValidation(s, SecretName)
+          .getOrElse(throw new RuntimeException(s"Unable to parse the secret name $s into a valid kubernetes name"))
     )
 
   implicit private val secretConfigReader: ValueReader[SecretConfig] = ValueReader.relative { config =>
@@ -629,10 +630,11 @@ object Config {
   implicit private val numNodesValueReader: ValueReader[NumNodes] = intValueReader.map(NumNodes)
   implicit private val autoscalingMinValueReader: ValueReader[AutoscalingMin] = intValueReader.map(AutoscalingMin)
   implicit private val autoscalingMaxValueReader: ValueReader[AutoscalingMax] = intValueReader.map(AutoscalingMax)
-  implicit private val serviceNameValueReader: ValueReader[ServiceName] = stringValueReader.map(s =>
-    KubernetesName
-      .withValidation(s, ServiceName)
-      .getOrElse(throw new Exception(s"Invalid service name in config: ${s}"))
+  implicit private val serviceNameValueReader: ValueReader[ServiceName] = stringValueReader.map(
+    s =>
+      KubernetesName
+        .withValidation(s, ServiceName)
+        .getOrElse(throw new Exception(s"Invalid service name in config: ${s}"))
   )
   implicit private val serviceKindValueReader: ValueReader[KubernetesServiceKindName] =
     stringValueReader.map(KubernetesServiceKindName)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/DataprocRuntimeMonitor.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/DataprocRuntimeMonitor.scala
@@ -169,8 +169,8 @@ class DataprocRuntimeMonitor[F[_]: Parallel](
                 case _ =>
                   val operationName = runtimeAndRuntimeConfig.runtime.asyncRuntimeFields.map(_.operationName)
                   for {
-                    error <- operationName.flatTraverse(
-                      o => googleDataprocService.getClusterError(google2.OperationName(o.value))
+                    error <- operationName.flatTraverse(o =>
+                      googleDataprocService.getClusterError(google2.OperationName(o.value))
                     )
                     r <- failedRuntime(
                       monitorContext,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -15,11 +15,11 @@ object Dependencies {
   val monocleV = "2.1.0"
   val opencensusV = "0.28.2"
 
-  private val workbenchLibsHash = "1e1f697"
+  private val workbenchLibsHash = "626dbbc"
   val serviceTestV = s"0.18-${workbenchLibsHash}"
   val workbenchModelV = s"0.14-${workbenchLibsHash}"
   val workbenchGoogleV = s"0.21-${workbenchLibsHash}"
-  val workbenchGoogle2V = s"0.17-${workbenchLibsHash}"
+  val workbenchGoogle2V = s"0.18-${workbenchLibsHash}"
   val workbenchOpenTelemetryV = s"0.1-${workbenchLibsHash}"
   val workbenchErrorReportingV = s"0.1-${workbenchLibsHash}"
 


### PR DESCRIPTION
Pulling in the workbench-libs changes ([Ability to resize and stop Dataproc clusters](https://github.com/broadinstitute/workbench-libs/pull/373)) which included a breaking change in `GoogleDataprocService` constructor.

Some of the diff's are due to `scalafmt` formatting differently than before for some reason 🤷‍♂️ 