### PR TITLE
[no ticket] Make boot streams resilient to errors

### DIFF
--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/Boot.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/Boot.scala
@@ -332,7 +332,7 @@ object Boot extends IOApp {
       val app = Stream.emits(allStreams).covary[IO].parJoin(allStreams.length)
 
       app
-        .handleErrorWith(error => Stream.eval(logger.error(error)("Failed to start leonardo")))
+        .handleErrorWith(error => Stream.eval(logger.error(error)("Unhandled error occurred")) ++ app)
         .compile
         .drain
     }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/Boot.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/Boot.scala
@@ -332,7 +332,7 @@ object Boot extends IOApp {
       val app = Stream.emits(allStreams).covary[IO].parJoin(allStreams.length)
 
       app
-        .handleErrorWith(error => Stream.eval(logger.error(error)("Unhandled Leonardo error occurred")) ++ app)
+        .handleErrorWith(error => Stream.eval(logger.error(error)("Failed to start leonardo")))
         .compile
         .drain
     }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/Boot.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/Boot.scala
@@ -332,7 +332,7 @@ object Boot extends IOApp {
       val app = Stream.emits(allStreams).covary[IO].parJoin(allStreams.length)
 
       app
-        .handleErrorWith(error => Stream.eval(logger.error(error)("Unhandled error occurred")) ++ app)
+        .handleErrorWith(error => Stream.eval(logger.error(error)("Unhandled Leonardo error occurred")) ++ app)
         .compile
         .drain
     }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/AutopauseMonitor.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/AutopauseMonitor.scala
@@ -31,7 +31,10 @@ class AutopauseMonitor[F[_]: ContextShift: Timer](
   ec: ExecutionContext) {
 
   val process: Stream[F, Unit] =
-    (Stream.sleep[F](config.autoFreezeCheckInterval) ++ Stream.eval(autoPauseCheck)).repeat
+    (Stream.sleep[F](config.autoFreezeCheckInterval) ++ Stream.eval(
+      autoPauseCheck
+        .handleErrorWith(e => logger.error(e)("Unexpected error occurred during auto-pause monitoring"))
+    )).repeat
 
   private[monitor] val autoPauseCheck: F[Unit] =
     for {


### PR DESCRIPTION
Relates to: https://broadworkbench.atlassian.net/browse/PROD-467

`Stream.handleErrorWith` actually aborts the stream if an error occurs, so this had the effect of an unhandled error in _any_ sub-stream causing the entire app to shut down. This happened on 12/12 when the Leo DB went down for a couple minutes: Leo logged `"Failed to start leonardo"` and was down for ~1 hour until it was manually restarted.

This change immediately tries to restart the app if an unhandled error occurs, which should hopefully make it more resilient to transient errors. 

Gonna try to do a test to see if the behavior is correct, feedback welcome.

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
