### PR TITLE
[IA-2325] Optimize Galaxy tests

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoApiClient.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoApiClient.scala
@@ -88,7 +88,7 @@ object LeonardoApiClient {
   )
 
   val defaultBatchNodepoolRequest = BatchNodepoolCreateRequest(
-    NumNodepools(10),
+    NumNodepools(2),
     None,
     None
   )
@@ -499,6 +499,46 @@ object LeonardoApiClient {
             IO.raiseError(
               RestError(s"Failed to batch create node pools in project ${googleProject.value}", status, None)
             )
+          else
+            IO.unit
+        }
+    } yield r
+
+  def stopApp(googleProject: GoogleProject, appName: AppName)(implicit client: Client[IO],
+                                                              authHeader: Authorization): IO[Unit] =
+    for {
+      traceIdHeader <- genTraceIdHeader()
+      r <- client
+        .status(
+          Request[IO](
+            method = Method.POST,
+            headers = Headers.of(authHeader, traceIdHeader),
+            uri = rootUri.withPath(s"/api/google/v1/apps/${googleProject.value}/${appName.value}/stop")
+          )
+        )
+        .flatMap { status =>
+          if (!status.isSuccess)
+            IO.raiseError(RestError(s"Failed to stop app ${googleProject.value}/${appName.value}", status, None))
+          else
+            IO.unit
+        }
+    } yield r
+
+  def startApp(googleProject: GoogleProject, appName: AppName)(implicit client: Client[IO],
+                                                               authHeader: Authorization): IO[Unit] =
+    for {
+      traceIdHeader <- genTraceIdHeader()
+      r <- client
+        .status(
+          Request[IO](
+            method = Method.POST,
+            headers = Headers.of(authHeader, traceIdHeader),
+            uri = rootUri.withPath(s"/api/google/v1/apps/${googleProject.value}/${appName.value}/start")
+          )
+        )
+        .flatMap { status =>
+          if (!status.isSuccess)
+            IO.raiseError(RestError(s"Failed to start app ${googleProject.value}/${appName.value}", status, None))
           else
             IO.unit
         }

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoApiClient.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoApiClient.scala
@@ -397,19 +397,6 @@ object LeonardoApiClient {
         }
     } yield r
 
-  def createAppWithRetry(
-    googleProject: GoogleProject,
-    appName: AppName,
-    createAppRequest: CreateAppRequest = defaultCreateAppRequest
-  )(implicit client: Client[IO], authHeader: Authorization, timer: Timer[IO]): IO[Unit] =
-    fs2.Stream
-      .retry(createApp(googleProject, appName, createAppRequest), 30 seconds, _ => 30 seconds, 10, _ match {
-        case RestError(_, Status.Conflict, _) => true
-        case _                                => false
-      })
-      .compile
-      .drain
-
   def deleteApp(googleProject: GoogleProject, appName: AppName)(implicit client: Client[IO],
                                                                 authHeader: Authorization): IO[Unit] =
     for {

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoApiClient.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoApiClient.scala
@@ -3,21 +3,16 @@ package org.broadinstitute.dsde.workbench.leonardo
 import java.util.UUID
 import java.util.concurrent.TimeoutException
 
-import cats.syntax.all._
 import cats.effect.{IO, Resource, Timer}
+import cats.syntax.all._
 import org.broadinstitute.dsde.workbench.DoneCheckable
+import org.broadinstitute.dsde.workbench.DoneCheckableSyntax._
 import org.broadinstitute.dsde.workbench.google2.{streamFUntilDone, DiskName}
-import org.broadinstitute.dsde.workbench.leonardo.http.{
-  BatchNodepoolCreateRequest,
-  CreateAppRequest,
-  CreateDiskRequest,
-  CreateRuntime2Request,
-  GetAppResponse,
-  GetPersistentDiskResponse,
-  ListAppResponse,
-  ListPersistentDiskResponse,
-  UpdateRuntimeRequest
-}
+import org.broadinstitute.dsde.workbench.leonardo.ApiJsonDecoder._
+import org.broadinstitute.dsde.workbench.leonardo.http.AppRoutesTestJsonCodec._
+import org.broadinstitute.dsde.workbench.leonardo.http.DiskRoutesTestJsonCodec._
+import org.broadinstitute.dsde.workbench.leonardo.http.RuntimeRoutesTestJsonCodec._
+import org.broadinstitute.dsde.workbench.leonardo.http._
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.broadinstitute.dsde.workbench.util2.ExecutionContexts
 import org.http4s._
@@ -27,12 +22,7 @@ import org.http4s.client.{blaze, Client}
 import org.http4s.headers._
 
 import scala.concurrent.ExecutionContext.global
-import org.broadinstitute.dsde.workbench.DoneCheckableSyntax._
 import scala.concurrent.duration._
-import org.broadinstitute.dsde.workbench.leonardo.http.AppRoutesTestJsonCodec._
-import org.broadinstitute.dsde.workbench.leonardo.http.DiskRoutesTestJsonCodec._
-import org.broadinstitute.dsde.workbench.leonardo.http.RuntimeRoutesTestJsonCodec._
-import ApiJsonDecoder._
 import scala.util.control.NoStackTrace
 
 object LeonardoApiClient {
@@ -101,7 +91,7 @@ object LeonardoApiClient {
     for {
       traceIdHeader <- genTraceIdHeader()
       r <- client
-        .status(
+        .run(
           Request[IO](
             method = Method.POST,
             headers = Headers.of(authHeader, defaultMediaType, traceIdHeader),
@@ -109,12 +99,11 @@ object LeonardoApiClient {
             body = createRuntime2Request
           )
         )
-        .flatMap { status =>
-          if (!status.isSuccess)
-            IO.raiseError(
-              RestError(s"Failed to create runtime ${googleProject.value}/${runtimeName.asString}", status, None)
-            )
-          else
+        .use { resp =>
+          if (!resp.status.isSuccess) {
+            onError(s"Failed to create runtime ${googleProject.value}/${runtimeName.asString}")(resp)
+              .flatMap(IO.raiseError)
+          } else
             IO.unit
         }
     } yield r
@@ -138,19 +127,18 @@ object LeonardoApiClient {
     for {
       traceIdHeader <- genTraceIdHeader()
       r <- client
-        .status(
+        .run(
           Request[IO](
             method = Method.POST,
             headers = Headers.of(authHeader, traceIdHeader),
             uri = rootUri.withPath(s"/api/google/v1/runtimes/${googleProject.value}/${runtimeName.asString}/start")
           )
         )
-        .flatMap { status =>
-          if (!status.isSuccess)
-            IO.raiseError(
-              RestError(s"Failed to start runtime ${googleProject.value}/${runtimeName.asString}", status, None)
-            )
-          else
+        .use { resp =>
+          if (!resp.status.isSuccess) {
+            onError(s"Failed to start runtime ${googleProject.value}/${runtimeName.asString}")(resp)
+              .flatMap(IO.raiseError)
+          } else
             IO.unit
         }
     } yield r
@@ -172,7 +160,7 @@ object LeonardoApiClient {
     for {
       traceIdHeader <- genTraceIdHeader()
       r <- client
-        .status(
+        .run(
           Request[IO](
             method = Method.PATCH,
             headers = Headers.of(authHeader, defaultMediaType, traceIdHeader),
@@ -180,12 +168,11 @@ object LeonardoApiClient {
             body = req
           )
         )
-        .flatMap { status =>
-          if (!status.isSuccess)
-            IO.raiseError(
-              RestError(s"Failed to update runtime ${googleProject.value}/${runtimeName.asString}", status, None)
-            )
-          else
+        .use { resp =>
+          if (!resp.status.isSuccess) {
+            onError(s"Failed to update runtime ${googleProject.value}/${runtimeName.asString}")(resp)
+              .flatMap(IO.raiseError)
+          } else
             IO.unit
         }
     } yield r
@@ -241,7 +228,7 @@ object LeonardoApiClient {
     for {
       traceIdHeader <- genTraceIdHeader()
       r <- client
-        .status(
+        .run(
           Request[IO](
             method = Method.DELETE,
             headers = Headers.of(authHeader, traceIdHeader),
@@ -250,12 +237,11 @@ object LeonardoApiClient {
               .withQueryParam("deleteDisk", deleteDisk)
           )
         )
-        .flatMap { status =>
-          if (!status.isSuccess)
-            IO.raiseError(
-              RestError(s"Failed to delete runtime ${googleProject.value}/${runtimeName.asString}", status, None)
-            )
-          else
+        .use { resp =>
+          if (!resp.status.isSuccess) {
+            onError(s"Failed to delete runtime ${googleProject.value}/${runtimeName.asString}")(resp)
+              .flatMap(IO.raiseError)
+          } else
             IO.unit
         }
     } yield r
@@ -281,7 +267,7 @@ object LeonardoApiClient {
     for {
       traceIdHeader <- genTraceIdHeader()
       r <- client
-        .status(
+        .run(
           Request[IO](
             method = Method.POST,
             headers = Headers.of(authHeader, defaultMediaType, traceIdHeader),
@@ -289,10 +275,11 @@ object LeonardoApiClient {
             body = createDiskRequest
           )
         )
-        .flatMap { status =>
-          if (!status.isSuccess)
-            IO.raiseError(RestError(s"Failed to create disk ${googleProject.value}/${diskName.value}", status, None))
-          else
+        .use { resp =>
+          if (!resp.status.isSuccess) {
+            onError(s"Failed to create disk ${googleProject.value}/${diskName.value}")(resp)
+              .flatMap(IO.raiseError)
+          } else
             IO.unit
         }
     } yield r
@@ -352,17 +339,18 @@ object LeonardoApiClient {
     for {
       traceIdHeader <- genTraceIdHeader()
       r <- client
-        .status(
+        .run(
           Request[IO](
             method = Method.DELETE,
             headers = Headers.of(authHeader, traceIdHeader),
             uri = rootUri.withPath(s"/api/google/v1/disks/${googleProject.value}/${diskName.value}")
           )
         )
-        .flatMap { status =>
-          if (!status.isSuccess)
-            IO.raiseError(RestError(s"Failed to delete disk ${googleProject.value}/${diskName.value}", status, None))
-          else
+        .use { resp =>
+          if (!resp.status.isSuccess) {
+            onError(s"Failed to delete disk ${googleProject.value}/${diskName.value}")(resp)
+              .flatMap(IO.raiseError)
+          } else
             IO.unit
         }
     } yield r
@@ -393,7 +381,7 @@ object LeonardoApiClient {
     for {
       traceIdHeader <- genTraceIdHeader()
       r <- client
-        .status(
+        .run(
           Request[IO](
             method = Method.POST,
             headers = Headers.of(authHeader, defaultMediaType, traceIdHeader),
@@ -401,11 +389,11 @@ object LeonardoApiClient {
             body = createAppRequest
           )
         )
-        .flatMap { status =>
-          if (!status.isSuccess)
-            IO.raiseError(RestError(s"Failed to create app ${googleProject.value}/${appName.value}", status, None))
-          else
+        .use { resp =>
+          if (resp.status.isSuccess)
             IO.unit
+          else
+            onError(s"Failed to create app ${googleProject.value}/${appName.value}")(resp).flatMap(IO.raiseError)
         }
     } yield r
 
@@ -414,17 +402,18 @@ object LeonardoApiClient {
     for {
       traceIdHeader <- genTraceIdHeader()
       r <- client
-        .status(
+        .run(
           Request[IO](
             method = Method.DELETE,
             headers = Headers.of(authHeader, traceIdHeader),
             uri = rootUri.withPath(s"/api/google/v1/apps/${googleProject.value}/${appName.value}")
           )
         )
-        .flatMap { status =>
-          if (!status.isSuccess)
-            IO.raiseError(RestError(s"Failed to delete app ${googleProject.value}/${appName.value}", status, None))
-          else
+        .use { resp =>
+          if (!resp.status.isSuccess) {
+            onError(s"Failed to delete app ${googleProject.value}/${appName.value}")(resp)
+              .flatMap(IO.raiseError)
+          } else
             IO.unit
         }
     } yield r
@@ -486,7 +475,7 @@ object LeonardoApiClient {
     for {
       traceIdHeader <- genTraceIdHeader()
       r <- client
-        .status(
+        .run(
           Request[IO](
             method = Method.POST,
             headers = Headers.of(authHeader, defaultMediaType, traceIdHeader),
@@ -494,12 +483,11 @@ object LeonardoApiClient {
             body = req
           )
         )
-        .flatMap { status =>
-          if (!status.isSuccess)
-            IO.raiseError(
-              RestError(s"Failed to batch create node pools in project ${googleProject.value}", status, None)
-            )
-          else
+        .use { resp =>
+          if (!resp.status.isSuccess) {
+            onError(s"Failed to batch create node pools in project ${googleProject.value}")(resp)
+              .flatMap(IO.raiseError)
+          } else
             IO.unit
         }
     } yield r
@@ -509,17 +497,18 @@ object LeonardoApiClient {
     for {
       traceIdHeader <- genTraceIdHeader()
       r <- client
-        .status(
+        .run(
           Request[IO](
             method = Method.POST,
             headers = Headers.of(authHeader, traceIdHeader),
             uri = rootUri.withPath(s"/api/google/v1/apps/${googleProject.value}/${appName.value}/stop")
           )
         )
-        .flatMap { status =>
-          if (!status.isSuccess)
-            IO.raiseError(RestError(s"Failed to stop app ${googleProject.value}/${appName.value}", status, None))
-          else
+        .use { resp =>
+          if (!resp.status.isSuccess) {
+            onError(s"Failed to stop app ${googleProject.value}/${appName.value}")(resp)
+              .flatMap(IO.raiseError)
+          } else
             IO.unit
         }
     } yield r
@@ -529,17 +518,18 @@ object LeonardoApiClient {
     for {
       traceIdHeader <- genTraceIdHeader()
       r <- client
-        .status(
+        .run(
           Request[IO](
             method = Method.POST,
             headers = Headers.of(authHeader, traceIdHeader),
             uri = rootUri.withPath(s"/api/google/v1/apps/${googleProject.value}/${appName.value}/start")
           )
         )
-        .flatMap { status =>
-          if (!status.isSuccess)
-            IO.raiseError(RestError(s"Failed to start app ${googleProject.value}/${appName.value}", status, None))
-          else
+        .use { resp =>
+          if (!resp.status.isSuccess) {
+            onError(s"Failed to start app ${googleProject.value}/${appName.value}")(resp)
+              .flatMap(IO.raiseError)
+          } else
             IO.unit
         }
     } yield r

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoApiClient.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoApiClient.scala
@@ -397,6 +397,19 @@ object LeonardoApiClient {
         }
     } yield r
 
+  def createAppWithRetry(
+    googleProject: GoogleProject,
+    appName: AppName,
+    createAppRequest: CreateAppRequest = defaultCreateAppRequest
+  )(implicit client: Client[IO], authHeader: Authorization, timer: Timer[IO]): IO[Unit] =
+    fs2.Stream
+      .retry(createApp(googleProject, appName, createAppRequest), 30 seconds, _ => 30 seconds, 10, _ match {
+        case RestError(_, Status.Conflict, _) => true
+        case _                                => false
+      })
+      .compile
+      .drain
+
   def deleteApp(googleProject: GoogleProject, appName: AppName)(implicit client: Client[IO],
                                                                 authHeader: Authorization): IO[Unit] =
     for {

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
@@ -696,6 +696,9 @@ trait LeonardoTestUtils
   def appDeleted(appName: AppName): DoneCheckable[List[ListAppResponse]] =
     x => x.filter(_.appName == appName).map(_.status).distinct == List(AppStatus.Deleted)
 
+  def appsDeleted(appNames: Set[AppName]): DoneCheckable[List[ListAppResponse]] =
+    x => x.filter(r => appNames.contains(r.appName)).map(_.status).distinct == List(AppStatus.Deleted)
+
   def appInStateOrError(status: AppStatus): DoneCheckable[GetAppResponse] =
     x => x.status == AppStatus.Running || x.status == AppStatus.Error
 

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
@@ -700,6 +700,6 @@ trait LeonardoTestUtils
     x => x.filter(r => appNames.contains(r.appName)).map(_.status).distinct == List(AppStatus.Deleted)
 
   def appInStateOrError(status: AppStatus): DoneCheckable[GetAppResponse] =
-    x => x.status == AppStatus.Running || x.status == AppStatus.Error
+    x => x.status == status || x.status == AppStatus.Error
 
 }

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
@@ -9,13 +9,13 @@ import cats.effect.IO
 import cats.effect.concurrent.Semaphore
 import cats.syntax.all._
 import com.typesafe.scalalogging.LazyLogging
-import org.broadinstitute.dsde.workbench.ResourceFile
+import org.broadinstitute.dsde.workbench.{DoneCheckable, ResourceFile}
 import org.broadinstitute.dsde.workbench.auth.{AuthToken, AuthTokenScopes, UserAuthToken}
 import org.broadinstitute.dsde.workbench.config.Credentials
 import org.broadinstitute.dsde.workbench.dao.Google.{googleIamDAO, googleStorageDAO}
 import org.broadinstitute.dsde.workbench.google2.{DiskName, GoogleDiskService, GoogleStorageService}
 import org.broadinstitute.dsde.workbench.leonardo.ClusterStatus.{deletableStatuses, ClusterStatus}
-import org.broadinstitute.dsde.workbench.leonardo.http.CreateRuntime2Request
+import org.broadinstitute.dsde.workbench.leonardo.http.{CreateRuntime2Request, GetAppResponse, ListAppResponse}
 import org.broadinstitute.dsde.workbench.leonardo.notebooks.Notebook
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
 import org.broadinstitute.dsde.workbench.model.google._
@@ -692,5 +692,11 @@ trait LeonardoTestUtils
 
   def randomAppName: AppName = AppName(s"automation-test-app-a${makeRandomId().toLowerCase}z")
   def randomDiskName: DiskName = DiskName(s"automation-test-disk-a${makeRandomId().toLowerCase}z")
+
+  def appDeleted(appName: AppName): DoneCheckable[List[ListAppResponse]] =
+    x => x.filter(_.appName == appName).map(_.status).distinct == List(AppStatus.Deleted)
+
+  def appInStateOrError(status: AppStatus): DoneCheckable[GetAppResponse] =
+    x => x.status == AppStatus.Running || x.status == AppStatus.Error
 
 }

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/AppCreationSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/AppCreationSpec.scala
@@ -34,7 +34,7 @@ class AppCreationSpec extends GPAllocFixtureSpec with LeonardoTestUtils with GPA
         _ <- loggerIO.info(s"AppCreationSpec: About to create app ${googleProject.value}/${appName.value}")
 
         // Create the app
-        _ <- LeonardoApiClient.createApp(googleProject, appName, createAppRequest)
+        _ <- LeonardoApiClient.createAppWithRetry(googleProject, appName, createAppRequest)
 
         // Verify the initial getApp call
         getApp = LeonardoApiClient.getApp(googleProject, appName)
@@ -99,7 +99,7 @@ class AppCreationSpec extends GPAllocFixtureSpec with LeonardoTestUtils with GPA
         _ <- loggerIO.info(s"AppCreationSpec: About to create app ${googleProject.value}/${appName.value}")
 
         // Create the app
-        _ <- LeonardoApiClient.createApp(googleProject, appName, createAppRequest)
+        _ <- LeonardoApiClient.createAppWithRetry(googleProject, appName, createAppRequest)
 
         // Verify the initial getApp call
         getApp = LeonardoApiClient.getApp(googleProject, appName)

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/AppCreationSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/AppCreationSpec.scala
@@ -130,9 +130,9 @@ class AppCreationSpec extends GPAllocFixtureSpec with LeonardoTestUtils with GPA
         _ <- testTimer.sleep(30 seconds)
         monitorStopResult <- streamUntilDoneOrTimeout(
           getApp,
-          120,
+          180,
           10 seconds,
-          s"AppCreationSpec: app ${googleProject.value}/${appName.value} did not finish stoppingg after 20 minutes"
+          s"AppCreationSpec: app ${googleProject.value}/${appName.value} did not finish stopping after 30 minutes"
         )(implicitly, implicitly, appInStateOrError(AppStatus.Stopped))
         _ <- loggerIO.info(
           s"AppCreationSpec: app ${googleProject.value}/${appName.value} stop result: $monitorStopResult"

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/AppCreationSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/AppCreationSpec.scala
@@ -29,7 +29,7 @@ class AppCreationSpec extends GPAllocFixtureSpec with LeonardoTestUtils with GPA
       )
     )
 
-    LeonardoApiClient.client.use { implicit client =>
+    val res = LeonardoApiClient.client.use { implicit client =>
       for {
         _ <- loggerIO.info(s"AppCreationSpec: About to create app ${googleProject.value}/${appName.value}")
 
@@ -76,6 +76,8 @@ class AppCreationSpec extends GPAllocFixtureSpec with LeonardoTestUtils with GPA
 
       } yield ()
     }
+
+    res.unsafeRunSync()
   }
 
   "stop and start an app" in { googleProject =>
@@ -92,7 +94,7 @@ class AppCreationSpec extends GPAllocFixtureSpec with LeonardoTestUtils with GPA
       )
     )
 
-    LeonardoApiClient.client.use { implicit client =>
+    val res = LeonardoApiClient.client.use { implicit client =>
       for {
         _ <- loggerIO.info(s"AppCreationSpec: About to create app ${googleProject.value}/${appName.value}")
 
@@ -179,6 +181,8 @@ class AppCreationSpec extends GPAllocFixtureSpec with LeonardoTestUtils with GPA
 
       } yield ()
     }
+
+    res.unsafeRunSync()
   }
 
 }

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/AppCreationSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/AppCreationSpec.scala
@@ -15,174 +15,174 @@ class AppCreationSpec extends GPAllocFixtureSpec with LeonardoTestUtils with GPA
   implicit val auth: Authorization =
     Authorization(Credentials.Token(AuthScheme.Bearer, ronCreds.makeAuthToken().value))
 
-  "create and delete an app" in { googleProject =>
-    val appName = randomAppName
+  "create and delete an app" in { _ =>
+    withNewProject { googleProject =>
+      val appName = randomAppName
 
-    val createAppRequest = defaultCreateAppRequest.copy(
-      diskConfig = Some(
-        PersistentDiskRequest(
-          randomDiskName,
-          Some(DiskSize(500)),
-          None,
-          Map.empty
+      val createAppRequest = defaultCreateAppRequest.copy(
+        diskConfig = Some(
+          PersistentDiskRequest(
+            randomDiskName,
+            Some(DiskSize(500)),
+            None,
+            Map.empty
+          )
         )
       )
-    )
 
-    val res = LeonardoApiClient.client.use { implicit client =>
-      for {
-        _ <- loggerIO.info(s"AppCreationSpec: About to create app ${googleProject.value}/${appName.value}")
+      LeonardoApiClient.client.use { implicit client =>
+        for {
+          _ <- loggerIO.info(s"AppCreationSpec: About to create app ${googleProject.value}/${appName.value}")
 
-        // Create the app
-        _ <- LeonardoApiClient.createAppWithRetry(googleProject, appName, createAppRequest)
+          // Create the app
+          _ <- LeonardoApiClient.createApp(googleProject, appName, createAppRequest)
 
-        // Verify the initial getApp call
-        getApp = LeonardoApiClient.getApp(googleProject, appName)
-        getAppResponse <- getApp
-        _ = getAppResponse.status should (be(AppStatus.Provisioning) or be(AppStatus.Precreating))
+          // Verify the initial getApp call
+          getApp = LeonardoApiClient.getApp(googleProject, appName)
+          getAppResponse <- getApp
+          _ = getAppResponse.status should (be(AppStatus.Provisioning) or be(AppStatus.Precreating))
 
-        // Verify the app eventually becomes Running
-        _ <- testTimer.sleep(60 seconds)
-        monitorCreateResult <- streamUntilDoneOrTimeout(
-          getApp,
-          120,
-          10 seconds,
-          s"AppCreationSpec: app ${googleProject.value}/${appName.value} did not finish creating after 20 minutes"
-        )(implicitly, implicitly, appInStateOrError(AppStatus.Running))
-        _ <- loggerIO.info(
-          s"AppCreationSpec: app ${googleProject.value}/${appName.value} monitor result: ${monitorCreateResult}"
-        )
-        _ = monitorCreateResult.status shouldBe AppStatus.Running
+          // Verify the app eventually becomes Running
+          _ <- testTimer.sleep(60 seconds)
+          monitorCreateResult <- streamUntilDoneOrTimeout(
+            getApp,
+            120,
+            10 seconds,
+            s"AppCreationSpec: app ${googleProject.value}/${appName.value} did not finish creating after 20 minutes"
+          )(implicitly, implicitly, appInStateOrError(AppStatus.Running))
+          _ <- loggerIO.info(
+            s"AppCreationSpec: app ${googleProject.value}/${appName.value} monitor result: ${monitorCreateResult}"
+          )
+          _ = monitorCreateResult.status shouldBe AppStatus.Running
 
-        // Delete the app
-        _ <- LeonardoApiClient.deleteApp(googleProject, appName)
+          // Delete the app
+          _ <- LeonardoApiClient.deleteApp(googleProject, appName)
 
-        // Verify getApp again
-        getAppResponse <- getApp
-        _ = getAppResponse.status should (be(AppStatus.Deleting) or be(AppStatus.Predeleting))
+          // Verify getApp again
+          getAppResponse <- getApp
+          _ = getAppResponse.status should (be(AppStatus.Deleting) or be(AppStatus.Predeleting))
 
-        // Verify the app eventually becomes Deleted
-        listApps = LeonardoApiClient.listApps(googleProject, true)
-        _ <- testTimer.sleep(30 seconds)
-        monitorDeleteResult <- streamUntilDoneOrTimeout(
-          listApps,
-          120,
-          10 seconds,
-          s"AppCreationSpec: app ${googleProject.value}/${appName.value} did not finish deleting after 20 minutes"
-        )(implicitly, implicitly, appDeleted(appName))
-        _ <- loggerIO.info(
-          s"AppCreationSpec: app ${googleProject.value}/${appName.value} delete result: $monitorDeleteResult"
-        )
+          // Verify the app eventually becomes Deleted
+          listApps = LeonardoApiClient.listApps(googleProject, true)
+          _ <- testTimer.sleep(30 seconds)
+          monitorDeleteResult <- streamUntilDoneOrTimeout(
+            listApps,
+            120,
+            10 seconds,
+            s"AppCreationSpec: app ${googleProject.value}/${appName.value} did not finish deleting after 20 minutes"
+          )(implicitly, implicitly, appDeleted(appName))
+          _ <- loggerIO.info(
+            s"AppCreationSpec: app ${googleProject.value}/${appName.value} delete result: $monitorDeleteResult"
+          )
 
-      } yield ()
+        } yield ()
+      }
     }
-
-    res.unsafeRunSync()
   }
 
-  "stop and start an app" in { googleProject =>
-    val appName = randomAppName
+  "stop and start an app" in { _ =>
+    withNewProject { googleProject =>
+      val appName = randomAppName
 
-    val createAppRequest = defaultCreateAppRequest.copy(
-      diskConfig = Some(
-        PersistentDiskRequest(
-          randomDiskName,
-          Some(DiskSize(500)),
-          None,
-          Map.empty
+      val createAppRequest = defaultCreateAppRequest.copy(
+        diskConfig = Some(
+          PersistentDiskRequest(
+            randomDiskName,
+            Some(DiskSize(500)),
+            None,
+            Map.empty
+          )
         )
       )
-    )
 
-    val res = LeonardoApiClient.client.use { implicit client =>
-      for {
-        _ <- loggerIO.info(s"AppCreationSpec: About to create app ${googleProject.value}/${appName.value}")
+      LeonardoApiClient.client.use { implicit client =>
+        for {
+          _ <- loggerIO.info(s"AppCreationSpec: About to create app ${googleProject.value}/${appName.value}")
 
-        // Create the app
-        _ <- LeonardoApiClient.createAppWithRetry(googleProject, appName, createAppRequest)
+          // Create the app
+          _ <- LeonardoApiClient.createApp(googleProject, appName, createAppRequest)
 
-        // Verify the initial getApp call
-        getApp = LeonardoApiClient.getApp(googleProject, appName)
-        getAppResponse <- getApp
-        _ = getAppResponse.status should (be(AppStatus.Provisioning) or be(AppStatus.Precreating))
+          // Verify the initial getApp call
+          getApp = LeonardoApiClient.getApp(googleProject, appName)
+          getAppResponse <- getApp
+          _ = getAppResponse.status should (be(AppStatus.Provisioning) or be(AppStatus.Precreating))
 
-        // Verify the app eventually becomes Running
-        _ <- testTimer.sleep(60 seconds)
-        monitorCreateResult <- streamUntilDoneOrTimeout(
-          getApp,
-          120,
-          10 seconds,
-          s"AppCreationSpec: app ${googleProject.value}/${appName.value} did not finish creating after 20 minutes"
-        )(implicitly, implicitly, appInStateOrError(AppStatus.Running))
-        _ <- loggerIO.info(
-          s"AppCreationSpec: app ${googleProject.value}/${appName.value} monitor result: ${monitorCreateResult}"
-        )
-        _ = monitorCreateResult.status shouldBe AppStatus.Running
+          // Verify the app eventually becomes Running
+          _ <- testTimer.sleep(60 seconds)
+          monitorCreateResult <- streamUntilDoneOrTimeout(
+            getApp,
+            120,
+            10 seconds,
+            s"AppCreationSpec: app ${googleProject.value}/${appName.value} did not finish creating after 20 minutes"
+          )(implicitly, implicitly, appInStateOrError(AppStatus.Running))
+          _ <- loggerIO.info(
+            s"AppCreationSpec: app ${googleProject.value}/${appName.value} monitor result: ${monitorCreateResult}"
+          )
+          _ = monitorCreateResult.status shouldBe AppStatus.Running
 
-        // Stop the app
-        _ <- LeonardoApiClient.stopApp(googleProject, appName)
+          // Stop the app
+          _ <- LeonardoApiClient.stopApp(googleProject, appName)
 
-        // Verify getApp again
-        getAppResponse <- getApp
-        _ = getAppResponse.status should (be(AppStatus.Stopping) or be(AppStatus.PreStopping))
+          // Verify getApp again
+          getAppResponse <- getApp
+          _ = getAppResponse.status should (be(AppStatus.Stopping) or be(AppStatus.PreStopping))
 
-        // Verify the app eventually becomes Stopped
-        _ <- testTimer.sleep(30 seconds)
-        monitorStopResult <- streamUntilDoneOrTimeout(
-          getApp,
-          180,
-          10 seconds,
-          s"AppCreationSpec: app ${googleProject.value}/${appName.value} did not finish stopping after 30 minutes"
-        )(implicitly, implicitly, appInStateOrError(AppStatus.Stopped))
-        _ <- loggerIO.info(
-          s"AppCreationSpec: app ${googleProject.value}/${appName.value} stop result: $monitorStopResult"
-        )
-        _ = monitorStopResult.status shouldBe AppStatus.Stopped
+          // Verify the app eventually becomes Stopped
+          _ <- testTimer.sleep(30 seconds)
+          monitorStopResult <- streamUntilDoneOrTimeout(
+            getApp,
+            180,
+            10 seconds,
+            s"AppCreationSpec: app ${googleProject.value}/${appName.value} did not finish stopping after 30 minutes"
+          )(implicitly, implicitly, appInStateOrError(AppStatus.Stopped))
+          _ <- loggerIO.info(
+            s"AppCreationSpec: app ${googleProject.value}/${appName.value} stop result: $monitorStopResult"
+          )
+          _ = monitorStopResult.status shouldBe AppStatus.Stopped
 
-        // Start the app
-        _ <- LeonardoApiClient.startApp(googleProject, appName)
+          // Start the app
+          _ <- LeonardoApiClient.startApp(googleProject, appName)
 
-        // Verify getApp again
-        getAppResponse <- getApp
-        _ = getAppResponse.status should (be(AppStatus.Starting) or be(AppStatus.PreStarting))
+          // Verify getApp again
+          getAppResponse <- getApp
+          _ = getAppResponse.status should (be(AppStatus.Starting) or be(AppStatus.PreStarting))
 
-        // Verify the app eventually becomes Running
-        _ <- testTimer.sleep(30 seconds)
-        monitorStartResult <- streamUntilDoneOrTimeout(
-          getApp,
-          120,
-          10 seconds,
-          s"AppCreationSpec: app ${googleProject.value}/${appName.value} did not finish starting after 20 minutes"
-        )(implicitly, implicitly, appInStateOrError(AppStatus.Running))
-        _ <- loggerIO.info(
-          s"AppCreationSpec: app ${googleProject.value}/${appName.value} start result: $monitorStartResult"
-        )
-        _ = monitorStartResult.status shouldBe AppStatus.Running
+          // Verify the app eventually becomes Running
+          _ <- testTimer.sleep(30 seconds)
+          monitorStartResult <- streamUntilDoneOrTimeout(
+            getApp,
+            120,
+            10 seconds,
+            s"AppCreationSpec: app ${googleProject.value}/${appName.value} did not finish starting after 20 minutes"
+          )(implicitly, implicitly, appInStateOrError(AppStatus.Running))
+          _ <- loggerIO.info(
+            s"AppCreationSpec: app ${googleProject.value}/${appName.value} start result: $monitorStartResult"
+          )
+          _ = monitorStartResult.status shouldBe AppStatus.Running
 
-        // Delete the app
-        _ <- LeonardoApiClient.deleteApp(googleProject, appName)
+          // Delete the app
+          _ <- LeonardoApiClient.deleteApp(googleProject, appName)
 
-        // Verify getApp again
-        getAppResponse <- getApp
-        _ = getAppResponse.status should (be(AppStatus.Deleting) or be(AppStatus.Predeleting))
+          // Verify getApp again
+          getAppResponse <- getApp
+          _ = getAppResponse.status should (be(AppStatus.Deleting) or be(AppStatus.Predeleting))
 
-        // Verify the app eventually becomes Deleted
-        listApps = LeonardoApiClient.listApps(googleProject, true)
-        _ <- testTimer.sleep(30 seconds)
-        monitorDeleteResult <- streamUntilDoneOrTimeout(
-          listApps,
-          120,
-          10 seconds,
-          s"AppCreationSpec: app ${googleProject.value}/${appName.value} did not finish deleting after 20 minutes"
-        )(implicitly, implicitly, appDeleted(appName))
-        _ <- loggerIO.info(
-          s"AppCreationSpec: app ${googleProject.value}/${appName.value} delete result: $monitorDeleteResult"
-        )
+          // Verify the app eventually becomes Deleted
+          listApps = LeonardoApiClient.listApps(googleProject, true)
+          _ <- testTimer.sleep(30 seconds)
+          monitorDeleteResult <- streamUntilDoneOrTimeout(
+            listApps,
+            120,
+            10 seconds,
+            s"AppCreationSpec: app ${googleProject.value}/${appName.value} did not finish deleting after 20 minutes"
+          )(implicitly, implicitly, appDeleted(appName))
+          _ <- loggerIO.info(
+            s"AppCreationSpec: app ${googleProject.value}/${appName.value} delete result: $monitorDeleteResult"
+          )
 
-      } yield ()
+        } yield ()
+      }
     }
-
-    res.unsafeRunSync()
   }
 
 }

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/AppCreationSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/AppCreationSpec.scala
@@ -137,10 +137,10 @@ class AppCreationSpec extends GPAllocFixtureSpec with LeonardoTestUtils with GPA
         _ <- loggerIO.info(
           s"AppCreationSpec: app ${googleProject.value}/${appName.value} stop result: $monitorStopResult"
         )
-        _ = monitorStopResult.status shouldBe AppStatus.Running
+        _ = monitorStopResult.status shouldBe AppStatus.Stopped
 
         // Start the app
-        _ <- LeonardoApiClient.stopApp(googleProject, appName)
+        _ <- LeonardoApiClient.startApp(googleProject, appName)
 
         // Verify getApp again
         getAppResponse <- getApp

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/BatchNodepoolCreationSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/BatchNodepoolCreationSpec.scala
@@ -62,14 +62,17 @@ class BatchNodepoolCreationSpec
           _ <- testTimer.sleep(5 minutes)
 
           // Create 2 apps in the pre-created nodepools
-          createAppRequest = defaultCreateAppRequest.copy(diskConfig =
+          createAppRequest1 = defaultCreateAppRequest.copy(diskConfig =
+            Some(PersistentDiskRequest(randomDiskName, None, None, Map.empty))
+          )
+          createAppRequest2 = defaultCreateAppRequest.copy(diskConfig =
             Some(PersistentDiskRequest(randomDiskName, None, None, Map.empty))
           )
           _ <- loggerIO.info(s"BatchNodepoolCreationSpec: About to create app ${googleProject.value}/${appName1.value}")
-          _ <- LeonardoApiClient.createApp(googleProject, appName1, createAppRequest)
+          _ <- LeonardoApiClient.createApp(googleProject, appName1, createAppRequest1)
 
           _ <- loggerIO.info(s"BatchNodepoolCreationSpec: About to create app ${googleProject.value}/${appName2.value}")
-          _ <- LeonardoApiClient.createApp(googleProject, appName2, createAppRequest)
+          _ <- LeonardoApiClient.createApp(googleProject, appName2, createAppRequest2)
 
           // Verify the initial getApp calls
           getApp1 = LeonardoApiClient.getApp(googleProject, appName1)

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/BatchNodepoolCreationSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/BatchNodepoolCreationSpec.scala
@@ -45,7 +45,7 @@ class BatchNodepoolCreationSpec
           request = defaultBatchNodepoolRequest.copy(clusterName = Some(clusterName))
           _ <- LeonardoApiClient.batchNodepoolCreate(googleProject, request)
 
-          // Verify the cluster gets created in GKE with 2 nodepools
+          // Verify the cluster gets created in GKE with 3 nodepools
           clusterId = KubernetesClusterId(googleProject, LeonardoConfig.Leonardo.location, clusterName)
           getCluster = gkeServiceResource.use(_.getCluster(clusterId))
           _ <- testTimer.sleep(30 seconds)
@@ -55,7 +55,7 @@ class BatchNodepoolCreationSpec
             10 seconds,
             s"Cluster ${clusterId} did not finish creating in Google after 10 minutes"
           )
-          _ = monitorBatchCreationResult.map(_.getNodePoolsList().size()) shouldBe Some(2)
+          _ = monitorBatchCreationResult.map(_.getNodePoolsList().size()) shouldBe Some(3)
 
           // Here we sleep, because the above verifies Google state and we need to wait until Leo has polled
           // and updated its internal state to proceed.

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookAouSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookAouSpec.scala
@@ -24,7 +24,9 @@ class NotebookAouSpec extends RuntimeFixtureSpec with NotebookTestUtils {
     "should have Pandas automatically installed" in { runtimeFixture =>
       withWebDriver { implicit driver =>
         withNewNotebook(runtimeFixture.runtime, Python3) { notebookPage =>
-          notebookPage.executeCell("import pandas") shouldBe None
+          notebookPage.executeCell("import pandas") should (be(None) or be(
+            Some("Matplotlib is building the font cache; this may take a moment.")
+          ))
         }
       }
     }

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -202,7 +202,7 @@ gke {
   galaxyNodepool {
     machineType = "n1-standard-8"
     numNodes = 2
-    autoscalingEnabled = true
+    autoscalingEnabled = false
     autoscalingConfig {
        autoscalingMin = 0
        autoscalingMax = 2

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
@@ -946,7 +946,6 @@ class LeoPubsubMessageSubscriber[F[_]: Timer: ContextShift: Parallel](
       // The app must be deleted before the nodepool and disk, to future proof against the app potentially flushing the postgres db somewhere
       task = for {
         _ <- deleteApp
-        _ <- deleteNodepool
         _ <- if (!errorAfterDelete)
           dbApp.app.status match {
             // If the message is resubmitted, and this step has already been run, we don't want to re-notify the app creator and update the deleted timestamp
@@ -957,6 +956,7 @@ class LeoPubsubMessageSubscriber[F[_]: Timer: ContextShift: Parallel](
                 .void
           }
         else F.unit
+        _ <- deleteNodepool
         _ <- deleteDisksInParallel
       } yield ()
 

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/config/ConfigSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/config/ConfigSpec.scala
@@ -98,7 +98,7 @@ final class ConfigSpec extends AnyFlatSpec with Matchers {
   it should "read GalaxyNodepoolConfig properly" in {
     val expectedResult = GalaxyNodepoolConfig(MachineTypeName("n1-standard-8"),
                                               NumNodes(2),
-                                              true,
+                                              false,
                                               AutoscalingConfig(AutoscalingMin(0), AutoscalingMax(2)))
     Config.gkeGalaxyNodepoolConfig shouldBe expectedResult
   }


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-2325

* Refactor Galaxy tests, they run a bit faster now
* Add Galaxy pause/resume tests
* Fix flakey AoU test
* Improve Leo client to log errors

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
