### PR TITLE
[no ticket] add sleep before app deletion

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/AppCreationSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/AppCreationSpec.scala
@@ -55,6 +55,8 @@ class AppCreationSpec extends GPAllocFixtureSpec with LeonardoTestUtils with GPA
           )
           _ = monitorCreateResult.status shouldBe AppStatus.Running
 
+          _ <- testTimer.sleep(1 minute)
+
           // Delete the app
           _ <- LeonardoApiClient.deleteApp(googleProject, appName)
 
@@ -64,7 +66,6 @@ class AppCreationSpec extends GPAllocFixtureSpec with LeonardoTestUtils with GPA
 
           // Verify the app eventually becomes Deleted
           listApps = LeonardoApiClient.listApps(googleProject, true)
-          _ <- testTimer.sleep(30 seconds)
           monitorDeleteResult <- streamUntilDoneOrTimeout(
             listApps,
             120,
@@ -160,6 +161,8 @@ class AppCreationSpec extends GPAllocFixtureSpec with LeonardoTestUtils with GPA
           )
           _ = monitorStartResult.status shouldBe AppStatus.Running
 
+          _ <- testTimer.sleep(1 minute)
+
           // Delete the app
           _ <- LeonardoApiClient.deleteApp(googleProject, appName)
 
@@ -169,7 +172,6 @@ class AppCreationSpec extends GPAllocFixtureSpec with LeonardoTestUtils with GPA
 
           // Verify the app eventually becomes Deleted
           listApps = LeonardoApiClient.listApps(googleProject, true)
-          _ <- testTimer.sleep(30 seconds)
           monitorDeleteResult <- streamUntilDoneOrTimeout(
             listApps,
             120,

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/BatchNodepoolCreationSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/BatchNodepoolCreationSpec.scala
@@ -99,6 +99,8 @@ class BatchNodepoolCreationSpec
           res <- List(pollCreate1, pollCreate2).parSequence
           _ = res.foreach(_.status shouldBe AppStatus.Running)
 
+          _ <- testTimer.sleep(1 minute)
+
           // Delete both apps
           _ <- LeonardoApiClient.deleteApp(googleProject, appName1)
           _ <- LeonardoApiClient.deleteApp(googleProject, appName2)
@@ -113,7 +115,6 @@ class BatchNodepoolCreationSpec
 
           // Wait until both are deleted
           listApps = LeonardoApiClient.listApps(googleProject, true)
-          _ <- testTimer.sleep(30 seconds)
           monitorDeleteResult <- streamUntilDoneOrTimeout(
             listApps,
             120,


### PR DESCRIPTION
I'm seeing some tests fail with:
```
AppCreationSpec: app gpalloc-qa-master-vjselre/automation-test-app-aoftke8gz did not finish deleting after 20 minutes
```
It looks like the Galaxy `pre-delete` job sometimes fails, causing the app to not be deleted. It seems to happen most often after a stop/start. Seeing if adding a sleep before delete makes it more reliable.

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
