### PR TITLE
[no ticket] ignore galaxy stop/start test

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/AppCreationSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/AppCreationSpec.scala
@@ -81,7 +81,10 @@ class AppCreationSpec extends GPAllocFixtureSpec with LeonardoTestUtils with GPA
     }
   }
 
-  "stop and start an app" in { _ =>
+  // TODO this test fails intermittently because the final delete fails to delete the Galaxy app.
+  // It looks like the Galaxy pre-delete job is erroring out. Need to determine why stop/start can
+  // sometimes cause this.
+  "stop and start an app" ignore { _ =>
     withNewProject { googleProject =>
       val appName = randomAppName
 


### PR DESCRIPTION
Per conversation in #dsde-qa, disabling this test temporarily

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
