### PR TITLE
[IA-2395] Remove nodepool cleanup from app deletion

### DIFF
--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/LeoPublisher.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/LeoPublisher.scala
@@ -68,7 +68,7 @@ final class LeoPublisher[F[_]: Logger: Timer](
         case m: LeoPubsubMessage.DeleteRuntimeMessage =>
           clusterQuery.markPendingDeletion(m.runtimeId, now).transaction
         case m: LeoPubsubMessage.DeleteAppMessage =>
-          KubernetesServiceDbQueries.markPendingDeletion(m.nodepoolId, m.appId, m.diskId, now).transaction
+          KubernetesServiceDbQueries.markPendingAppDeletion(m.appId, m.diskId, now).transaction
         case m: LeoPubsubMessage.CreateAppMessage =>
           m.clusterNodepoolAction match {
             case Some(ClusterNodepoolAction.CreateClusterAndNodepool(clusterId, defaultNodepoolId, nodepoolId)) =>

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/KubernetesServiceDbQueries.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/KubernetesServiceDbQueries.scala
@@ -200,11 +200,10 @@ object KubernetesServiceDbQueries {
       _ <- appQuery.updateStatus(appId, AppStatus.Predeleting)
     } yield ()
 
-  def markPendingDeletion(nodepoolId: NodepoolLeoId, appId: AppId, diskId: Option[DiskId], now: Instant)(
+  def markPendingAppDeletion(appId: AppId, diskId: Option[DiskId], now: Instant)(
     implicit ec: ExecutionContext
   ): DBIO[Unit] =
     for {
-      _ <- nodepoolQuery.markPendingDeletion(nodepoolId)
       _ <- appQuery.markPendingDeletion(appId)
       _ <- diskId.fold[DBIO[Int]](DBIO.successful(0))(diskId => persistentDiskQuery.markPendingDeletion(diskId, now))
     } yield ()

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/KubernetesServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/KubernetesServiceInterp.scala
@@ -269,7 +269,6 @@ final class LeoKubernetesServiceInterp[F[_]: Parallel](
           deleteMessage = DeleteAppMessage(
             appResult.app.id,
             appResult.app.appName,
-            appResult.nodepool.id,
             appResult.cluster.googleProject,
             diskOpt,
             Some(ctx.traceId)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/MonitorAtBoot.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/MonitorAtBoot.scala
@@ -162,7 +162,6 @@ class MonitorAtBoot[F[_]: Timer](publisherQueue: fs2.concurrent.Queue[F, LeoPubs
           DeleteAppMessage(
             app.id,
             app.appName,
-            nodepool.id,
             cluster.googleProject,
             None, // Assume we do not want to delete the disk, since we don't currently persist that information
             Some(traceId)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/leoPubsubMessageSubscriberModels.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/leoPubsubMessageSubscriberModels.scala
@@ -236,7 +236,6 @@ object LeoPubsubMessage {
 
   final case class DeleteAppMessage(appId: AppId,
                                     appName: AppName,
-                                    nodepoolId: NodepoolLeoId,
                                     project: GoogleProject,
                                     diskId: Option[DiskId],
                                     traceId: Option[TraceId])
@@ -433,7 +432,7 @@ object LeoPubsubCodec {
                         "traceId")(CreateAppMessage.apply)
 
   implicit val deleteAppDecoder: Decoder[DeleteAppMessage] =
-    Decoder.forProduct6("appId", "appName", "nodepoolId", "project", "diskId", "traceId")(DeleteAppMessage.apply)
+    Decoder.forProduct5("appId", "appName", "project", "diskId", "traceId")(DeleteAppMessage.apply)
 
   implicit val batchNodepoolCreateDecoder: Decoder[BatchNodepoolCreateMessage] =
     Decoder.forProduct4("clusterId", "nodepools", "project", "traceId")(BatchNodepoolCreateMessage.apply)
@@ -739,8 +738,8 @@ object LeoPubsubCodec {
     )
 
   implicit val deleteAppMessageEncoder: Encoder[DeleteAppMessage] =
-    Encoder.forProduct7("messageType", "appId", "appName", "nodepoolId", "project", "diskId", "traceId")(x =>
-      (x.messageType, x.appId, x.appName, x.nodepoolId, x.project, x.diskId, x.traceId)
+    Encoder.forProduct6("messageType", "appId", "appName", "project", "diskId", "traceId")(x =>
+      (x.messageType, x.appId, x.appName, x.project, x.diskId, x.traceId)
     )
 
   implicit val stopAppMessageEncoder: Encoder[StopAppMessage] =

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/KubernetesServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/KubernetesServiceInterpSpec.scala
@@ -277,7 +277,6 @@ final class KubernetesServiceInterpSpec extends AnyFlatSpec with LeonardoTestSui
     message.messageType shouldBe LeoPubsubMessageType.DeleteApp
     val deleteAppMessage = message.asInstanceOf[DeleteAppMessage]
     deleteAppMessage.appId shouldBe app.id
-    deleteAppMessage.nodepoolId shouldBe nodepool.id
     deleteAppMessage.project shouldBe project
     deleteAppMessage.diskId shouldBe None
   }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriberSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriberSpec.scala
@@ -19,9 +19,9 @@ import org.broadinstitute.dsde.workbench.google2.KubernetesModels.PodStatus
 import org.broadinstitute.dsde.workbench.google2.KubernetesSerializableName.ServiceAccountName
 import org.broadinstitute.dsde.workbench.google2.mock.{
   FakeGoogleComputeService,
+  FakeGoogleDataprocService,
   MockComputePollOperation,
   MockGKEService
-//  MockKubernetesService => WbLibsMockKubernetesService
 }
 import org.broadinstitute.dsde.workbench.google2.{
   ComputePollOperation,
@@ -80,7 +80,6 @@ class LeoPubsubMessageSubscriberSpec
                                memberEmail: WorkbenchEmail): scala.concurrent.Future[Boolean] =
       scala.concurrent.Future.successful(true)
   }
-  val gdDAO = new MockGoogleDataprocDAO
   val storageDAO = new MockGoogleStorageDAO
   // Kubernetes doesn't actually create a new Service Account when calling googleIamDAO
   val iamDAOKubernetes = new MockGoogleIamDAO {
@@ -113,7 +112,7 @@ class LeoPubsubMessageSubscriberSpec
   val dataprocInterp = new DataprocInterpreter[IO](Config.dataprocInterpreterConfig,
                                                    bucketHelper,
                                                    vpcInterp,
-                                                   gdDAO,
+                                                   FakeGoogleDataprocService,
                                                    FakeGoogleComputeService,
                                                    MockGoogleDiskService,
                                                    mockGoogleDirectoryDAO,

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/MonitorAtBootSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/MonitorAtBootSpec.scala
@@ -211,7 +211,6 @@ class MonitorAtBootSpec extends AnyFlatSpec with TestComponent with LeonardoTest
       val expected = DeleteAppMessage(
         savedApp.id,
         savedApp.appName,
-        nodepool.id,
         cluster.googleProject,
         None,
         None


### PR DESCRIPTION
This will be accompanied by a PR in leonardo cron job repo to clean up nodepools in the scope of the same ticket. There is no dependency on delaying keeping the nodepool around during app deletion, since the cron job will operate on some time window and clean up any old nodepools when it starts running. 