### PR TITLE
IA-2435  ci optimization

### DIFF
--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -11,13 +11,24 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
+    services:
+      mysql:
+        image: mysql/mysql-server:5.6
+        env:
+          MYSQL_ROOT_PASSWORD: leonardo-test
+          MYSQL_USER: leonardo-test
+          MYSQL_PASSWORD: leonardo-test
+          MYSQL_DATABASE: leotestdb
+        options: >-
+          --health-cmd="mysqladmin ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 3307:3306
+
     steps:
     - uses: actions/checkout@v2
-    - name: Set up mysql docker container
-      run: |
-         docker rm -f mysql || true
-         docker pull mysql/mysql-server:5.6
-         docker run -p 3307:3306 --name mysql -e MYSQL_ROOT_PASSWORD=leonardo-test -e MYSQL_USER=leonardo-test -e MYSQL_PASSWORD=leonardo-test -e MYSQL_DATABASE=leotestdb -d mysql/mysql-server:5.6
 
     - name: Set up JDK 1.8
       uses: actions/setup-java@v1

--- a/docker/sql_validate.sh
+++ b/docker/sql_validate.sh
@@ -3,8 +3,11 @@
 SERVICE=$1
 
 # validate mysql
-echo "sleeping for 60 seconds during mysql boot..."
-sleep 60
+echo "Checking every 3s for mysql to be ready"
+while ! mysqladmin ping --host=mysql --port=3306 --silent; do
+  sleep 3
+done
+
 mysql -uroot -p${SERVICE}-test --host=mysql --port=3306 -e "SELECT VERSION();SELECT NOW()"
 mysql -u${SERVICE}-test -p${SERVICE}-test --host=mysql --port=3306 -e "SELECT VERSION();SELECT NOW()"
 mysql -u${SERVICE}-test -p${SERVICE}-test --host=mysql --port=3306 -e "SELECT VERSION();SELECT NOW()" leotestdb

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -149,7 +149,7 @@ object Dependencies {
     akkaTestKit,
     akkaHttpTestKit,
     akkaStream,
-    "de.heikoseeberger" %% "akka-http-circe" % "1.35.2" excludeAll(excludeAkkaHttp, excludeAkkaStream),
+    "de.heikoseeberger" %% "akka-http-circe" % "1.35.3" excludeAll(excludeAkkaHttp, excludeAkkaStream),
     googleDataproc,
     googleRpc,
     googleErrorReporting, // forcing an older versin of google-cloud-errorreporting because latest version brings in higher version of gax-grpc, which isn't compatible with other google dependencies


### PR DESCRIPTION
Borrow some ideas from https://github.com/broadinstitute/rawls/pull/1339

* reduce the amount of time we wait for mysql
* Use github workflow's built-in service support for mysql
* Bump `akka-http-circe` version

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
