### PR TITLE
Don't include welder for rstudio runtimes IA-2353

### DIFF
--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/BaseCloudServiceRuntimeMonitor.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/BaseCloudServiceRuntimeMonitor.scala
@@ -459,9 +459,6 @@ abstract class BaseCloudServiceRuntimeMonitor[F[_]] {
       availableTools <- streamFUntilDone(checkTools,
                                          monitorConfig.checkToolsMaxAttempts,
                                          monitorConfig.checkToolsInterval).compile.lastOrError
-      _ <- availableTools.traverse(x =>
-        logger.info("!!!RuntimeImageType:" + x._1.toString + "Boolean:" + x._2.toString)
-      )
       r <- availableTools match {
         case a if a.forall(_._2) =>
           readyRuntime(runtimeAndRuntimeConfig, ip, monitorContext, dataprocInstances)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/BaseCloudServiceRuntimeMonitor.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/BaseCloudServiceRuntimeMonitor.scala
@@ -459,6 +459,9 @@ abstract class BaseCloudServiceRuntimeMonitor[F[_]] {
       availableTools <- streamFUntilDone(checkTools,
                                          monitorConfig.checkToolsMaxAttempts,
                                          monitorConfig.checkToolsInterval).compile.lastOrError
+      _ <- availableTools.traverse(x =>
+        logger.info("!!!RuntimeImageType:" + x._1.toString + "Boolean:" + x._2.toString)
+      )
       r <- availableTools match {
         case a if a.forall(_._2) =>
           readyRuntime(runtimeAndRuntimeConfig, ip, monitorContext, dataprocInstances)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/RuntimeServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/RuntimeServiceInterp.scala
@@ -27,7 +27,7 @@ import org.broadinstitute.dsde.workbench.google2.{
   PollError
 }
 import org.broadinstitute.dsde.workbench.leonardo.JsonCodec._
-import org.broadinstitute.dsde.workbench.leonardo.RuntimeImageType.{CryptoDetector, Jupyter, Proxy, Welder}
+import org.broadinstitute.dsde.workbench.leonardo.RuntimeImageType.{CryptoDetector, Jupyter, Proxy, RStudio, Welder}
 import org.broadinstitute.dsde.workbench.leonardo.config._
 import org.broadinstitute.dsde.workbench.leonardo.dao.DockerDAO
 import org.broadinstitute.dsde.workbench.leonardo.db._
@@ -543,16 +543,24 @@ class RuntimeServiceInterp[F[_]: Parallel](config: RuntimeServiceConfig,
       // - If present, we will use the client-supplied image.
       // - Otherwise we will pull the latest from the specified welderRegistry.
       // - If welderRegistry is undefined, we take the default GCR image from config.
-      welderImage = RuntimeImage(
-        Welder,
-        welderDockerImage
-          .map(_.imageUrl)
-          .getOrElse(welderRegistry match {
-            case Some(ContainerRegistry.DockerHub) => config.imageConfig.welderDockerHubImage.imageUrl
-            case _                                 => config.imageConfig.welderGcrImage.imageUrl
-          }),
-        now
-      )
+      //TODO: add about rstudio
+      welderImage = toolImage.imageType match {
+        case RuntimeImageType.RStudio => None
+        case _ =>
+          Some(
+            RuntimeImage(
+              Welder,
+              welderDockerImage
+                .map(_.imageUrl)
+                .getOrElse(welderRegistry match {
+                  case Some(ContainerRegistry.DockerHub) => config.imageConfig.welderDockerHubImage.imageUrl
+                  case _                                 => config.imageConfig.welderGcrImage.imageUrl
+                }),
+              now
+            )
+          )
+      }
+
       // Get the proxy image
       proxyImage = RuntimeImage(Proxy, config.imageConfig.proxyImage.imageUrl, now)
       // Crypto detector image - note it's not currently supported on Dockerhub
@@ -560,7 +568,7 @@ class RuntimeServiceInterp[F[_]: Parallel](config: RuntimeServiceConfig,
         case Some(ContainerRegistry.DockerHub) => None
         case _                                 => Some(RuntimeImage(CryptoDetector, config.imageConfig.cryptoDetectorImage.imageUrl, now))
       }
-    } yield Set(Some(toolImage), Some(welderImage), Some(proxyImage), cryptoDetectorImageOpt).flatten
+    } yield Set(Some(toolImage), welderImage, Some(proxyImage), cryptoDetectorImageOpt).flatten
 
   private[service] def validateBucketObjectUri(userEmail: WorkbenchEmail,
                                                userToken: String,
@@ -842,6 +850,13 @@ object RuntimeServiceInterp {
         else req.scopes //default to create gce runtime if runtimeConfig is not specified
     }
 
+    // Do not enable welder for rstudio
+    val welderEnabled =
+      clusterImages.map(_.imageType).filterNot(_ == Welder).headOption match {
+        case Some(RStudio) => false
+        case _             => true
+      }
+
     for {
       // check the labels do not contain forbidden keys
       labels <- if (allLabels.contains(includeDeletedKey))
@@ -869,7 +884,7 @@ object RuntimeServiceInterp {
       defaultClientId = req.defaultClientId,
       runtimeImages = clusterImages,
       scopes = clusterScopes,
-      welderEnabled = true,
+      welderEnabled = welderEnabled,
       customEnvironmentVariables = req.customEnvironmentVariables,
       allowStop = false, //TODO: double check this should be false when cluster is created
       runtimeConfigId = RuntimeConfigId(-1),

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/RuntimeServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/RuntimeServiceInterp.scala
@@ -27,7 +27,7 @@ import org.broadinstitute.dsde.workbench.google2.{
   PollError
 }
 import org.broadinstitute.dsde.workbench.leonardo.JsonCodec._
-import org.broadinstitute.dsde.workbench.leonardo.RuntimeImageType.{CryptoDetector, Jupyter, Proxy, RStudio, Welder}
+import org.broadinstitute.dsde.workbench.leonardo.RuntimeImageType.{CryptoDetector, Jupyter, Proxy, Welder}
 import org.broadinstitute.dsde.workbench.leonardo.config._
 import org.broadinstitute.dsde.workbench.leonardo.dao.DockerDAO
 import org.broadinstitute.dsde.workbench.leonardo.db._
@@ -543,7 +543,7 @@ class RuntimeServiceInterp[F[_]: Parallel](config: RuntimeServiceConfig,
       // - If present, we will use the client-supplied image.
       // - Otherwise we will pull the latest from the specified welderRegistry.
       // - If welderRegistry is undefined, we take the default GCR image from config.
-      //TODO: add about rstudio
+      // - If the tool is RStudio do not include a welder image
       welderImage = toolImage.imageType match {
         case RuntimeImageType.RStudio => None
         case _ =>
@@ -851,11 +851,7 @@ object RuntimeServiceInterp {
     }
 
     // Do not enable welder for rstudio
-    val welderEnabled =
-      clusterImages.map(_.imageType).filterNot(_ == Welder).headOption match {
-        case Some(RStudio) => false
-        case _             => true
-      }
+    val welderEnabled = clusterImages.map(_.imageType).contains(Welder)
 
     for {
       // check the labels do not contain forbidden keys

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoServiceSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoServiceSpec.scala
@@ -271,7 +271,7 @@ class LeonardoServiceSpec
     val rstudioImage = ContainerImage("some-rstudio-image", GCR)
 
     // create the cluster
-    val clusterRequest = testClusterRequest.copy(toolDockerImage = Some(rstudioImage), enableWelder = Some(true))
+    val clusterRequest = testClusterRequest.copy(toolDockerImage = Some(rstudioImage), enableWelder = Some(false))
     implicit val runtimeInstances = new RuntimeInstances[IO](dataprocInterp, gceInterp)
     val leoForTest = new LeonardoService(dataprocConfig,
                                          imageConfig,
@@ -294,12 +294,11 @@ class LeonardoServiceSpec
     val dbCluster = dbFutureValue(clusterQuery.getClusterById(clusterResponse.id))
     TestUtils.compareClusterAndCreateClusterAPIResponse(dbCluster.get, clusterResponse)
 
-    // cluster images should contain welder and RStudio
+    // cluster images should contain only RStudio
     clusterResponse.clusterImages.find(_.imageType == RStudio).map(_.imageUrl) shouldBe Some(rstudioImage.imageUrl)
     clusterResponse.clusterImages.find(_.imageType == Jupyter) shouldBe None
-    clusterResponse.clusterImages.find(_.imageType == Welder).map(_.imageUrl) shouldBe Some(
-      imageConfig.welderGcrImage.imageUrl
-    )
+    clusterResponse.clusterImages.find(_.imageType == Welder) shouldBe None
+
     clusterResponse.labels.get("tool") shouldBe Some("RStudio")
     clusterResponse.clusterUrl shouldBe new URL(s"https://leo/proxy/${project.value}/${name1.asString}/rstudio")
 


### PR DESCRIPTION
Don't add welder for Rstudio runtimes.

Manual Tests:
Create an rstudio runtime through Terra-UI
- check the Cluster_Image table and see welder is not there
- ssh into the cluster and don’t see welder
- run locally on Terra-UI (after hotswapping) and it’s good to go

Create a jupyter cluster through Terra-UI
- check that cluster_image table and that welder is there
- ssh into the cluster and see welder
- run locally on Terra-UI (after hotswapping) and it’s good to go

<img width="1152" alt="Screen Shot 2021-01-06 at 3 17 24 PM" src="https://user-images.githubusercontent.com/54322292/103816171-8d0da280-5032-11eb-9fd3-d68e59c0684a.png">

<img width="1145" alt="Screen Shot 2021-01-06 at 3 17 29 PM" src="https://user-images.githubusercontent.com/54322292/103816182-91d25680-5032-11eb-8b18-009f1d1788de.png">

<img width="1527" alt="Screen Shot 2021-01-06 at 3 17 41 PM" src="https://user-images.githubusercontent.com/54322292/103816194-9434b080-5032-11eb-9e0c-9017fa6c3f91.png">

Updated the unit test that creates a new Rstudio to make sure that Welder is not there

---

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
