### PR TITLE
[IA-2439] Improve docker image auto-detection and error reporting

### DIFF
--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeoException.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeoException.scala
@@ -10,8 +10,6 @@ class LeoException(val message: String = null,
     extends WorkbenchException(message, cause) {
   override def getMessage: String = if (message != null) message else super.getMessage
 
-//  override def getCause = cause
-
   def toErrorReport: ErrorReport =
     ErrorReport(Option(getMessage).getOrElse(""), Some(statusCode), Seq(), Seq(), Some(this.getClass))
 }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeoException.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeoException.scala
@@ -7,8 +7,11 @@ import org.broadinstitute.dsde.workbench.leonardo.http.errorReportSource
 class LeoException(val message: String = null,
                    val statusCode: StatusCode = StatusCodes.InternalServerError,
                    val cause: Throwable = null)
-    extends WorkbenchException(message) {
+    extends WorkbenchException(message, cause) {
   override def getMessage: String = if (message != null) message else super.getMessage
+
+//  override def getCause = cause
+
   def toErrorReport: ErrorReport =
     ErrorReport(Option(getMessage).getOrElse(""), Some(statusCode), Seq(), Seq(), Some(this.getClass))
 }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoService.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoService.scala
@@ -132,7 +132,7 @@ final case class InvalidImage(traceId: TraceId, image: ContainerImage, throwable
     extends LeoException(
       s"${traceId} | Image ${image.imageUrl} doesn't have JUPYTER_HOME or RSTUDIO_HOME environment variables defined. Make sure your custom image extends from one of the Terra base images.",
       StatusCodes.NotFound,
-      throwable.getOrElse(null)
+      throwable.orNull
     )
 
 final case class CloudServiceNotSupportedException(cloudService: CloudService)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoService.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoService.scala
@@ -128,10 +128,11 @@ case class InvalidDataprocMachineConfigException(errorMsg: String)
 final case class ImageNotFoundException(traceId: TraceId, image: ContainerImage)
     extends LeoException(s"${traceId} | Image ${image.imageUrl} not found", StatusCodes.NotFound)
 
-final case class InvalidImage(traceId: TraceId, image: ContainerImage)
+final case class InvalidImage(traceId: TraceId, image: ContainerImage, throwable: Option[Throwable])
     extends LeoException(
       s"${traceId} | Image ${image.imageUrl} doesn't have JUPYTER_HOME or RSTUDIO_HOME environment variables defined. Make sure your custom image extends from one of the Terra base images.",
-      StatusCodes.NotFound
+      StatusCodes.NotFound,
+      throwable.getOrElse(null)
     )
 
 final case class CloudServiceNotSupportedException(cloudService: CloudService)

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpDockerDAOSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpDockerDAOSpec.scala
@@ -18,6 +18,7 @@ class HttpDockerDAOSpec extends AnyFlatSpec with Matchers with BeforeAndAfterAll
     // TODO this will break if AoU moves off Dockerhub and we delete these images
     // dockerhub with tag
     ContainerImage("broadinstitute/terra-jupyter-aou:1.0.17", DockerHub),
+    ContainerImage("kkimler/r4.0_tca:2020_11_09", DockerHub), // added after a bug fix (see ticket IA-2439)
     // dockerhub with sha
     // TODO: shas are currently not working
 //    DockerHub(
@@ -69,17 +70,6 @@ class HttpDockerDAOSpec extends AnyFlatSpec with Matchers with BeforeAndAfterAll
     dockerDAOResource.use(dao => IO(testCode(dao))).unsafeRunSync()
   }
 
-  it should s"detect tool as Jupyter for image kimler" in withDockerDAO { dockerDAO =>
-    val image1 = ContainerImage("broadinstitute/terra-jupyter-aou:1.0.17", DockerHub)
-    val image2 = ContainerImage("kkimler/r4.0_tca:2020_11_09", DockerHub)
-
-    val response1 = dockerDAO.detectTool(image1).unsafeRunSync()
-    response1 shouldBe Jupyter
-
-    val response2 = dockerDAO.detectTool(image2).unsafeRunSync()
-    response2 shouldBe Jupyter
-  }
-
   Map(Jupyter -> jupyterImages, RStudio -> rstudioImages).foreach {
     case (tool, images) =>
       images.foreach { image =>
@@ -108,7 +98,7 @@ class HttpDockerDAOSpec extends AnyFlatSpec with Matchers with BeforeAndAfterAll
         ctx <- appContext.ask[AppContext]
         response <- dockerDAO.detectTool(image).attempt
       } yield {
-        response shouldBe Left(InvalidImage(ctx.traceId, image))
+        response shouldBe Left(InvalidImage(ctx.traceId, image, None))
       }
       res.unsafeRunSync()
   }
@@ -120,7 +110,7 @@ class HttpDockerDAOSpec extends AnyFlatSpec with Matchers with BeforeAndAfterAll
         ctx <- appContext.ask[AppContext]
         response <- dockerDAO.detectTool(image).attempt
       } yield {
-        response shouldBe Left(InvalidImage(ctx.traceId, image))
+        response shouldBe Left(InvalidImage(ctx.traceId, image, None))
       }
       res.unsafeRunSync()
   }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpDockerDAOSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpDockerDAOSpec.scala
@@ -2,7 +2,6 @@ package org.broadinstitute.dsde.workbench.leonardo
 package dao
 
 import cats.effect.IO
-import cats.syntax.all.none
 import io.circe.CursorOp.DownField
 import io.circe.parser.decode
 import io.circe.DecodingFailure

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpDockerDAOSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpDockerDAOSpec.scala
@@ -7,7 +7,10 @@ import io.circe.parser.decode
 import io.circe.DecodingFailure
 import org.broadinstitute.dsde.workbench.leonardo.ContainerRegistry.{DockerHub, GCR, GHCR}
 import org.broadinstitute.dsde.workbench.leonardo.RuntimeImageType.{Jupyter, RStudio}
-import org.broadinstitute.dsde.workbench.leonardo.dao.HttpDockerDAO.containerConfigDecoder
+import org.broadinstitute.dsde.workbench.leonardo.dao.HttpDockerDAO.{
+  containerConfigDecoder,
+  containerConfigResponseDecoder
+}
 import org.broadinstitute.dsde.workbench.leonardo.http.service.InvalidImage
 import org.http4s.client.blaze.BlazeClientBuilder
 import org.http4s.client.middleware.Logger
@@ -143,8 +146,8 @@ class HttpDockerDAOSpec extends AnyFlatSpec with Matchers with BeforeAndAfterAll
         |  }
         |}
         |""".stripMargin
-    val expectedResult = ContainerConfig(ContainerEnv(List("key1=value1", "key2=value2")))
-    decode[ContainerConfig](jsonString) shouldBe Right(expectedResult)
+    val expectedResult = ContainerConfigResponse(ContainerConfig(List("key1=value1", "key2=value2")))
+    decode[ContainerConfigResponse](jsonString) shouldBe Right(expectedResult)
   }
 
   it should "correctly decode 'config' field from Docker API response if container_config does not exist" in {
@@ -156,8 +159,8 @@ class HttpDockerDAOSpec extends AnyFlatSpec with Matchers with BeforeAndAfterAll
         |  }
         |}
         |""".stripMargin
-    val expectedResult = ContainerConfig(ContainerEnv(List("keyX=valueX", "keyY=valueY")))
-    decode[ContainerConfig](jsonString) shouldBe Right(expectedResult)
+    val expectedResult = ContainerConfigResponse(ContainerConfig(List("keyX=valueX", "keyY=valueY")))
+    decode[ContainerConfigResponse](jsonString) shouldBe Right(expectedResult)
   }
 
   it should "fail to decode Docker API response if it does not contain 'container_config' or 'config' fields" in {
@@ -171,7 +174,7 @@ class HttpDockerDAOSpec extends AnyFlatSpec with Matchers with BeforeAndAfterAll
         |""".stripMargin
     val expectedResult =
       DecodingFailure("Attempt to decode value on failed cursor", List(DownField("config")))
-    decode[ContainerConfig](jsonString) shouldBe Left(expectedResult)
+    decode[ContainerConfigResponse](jsonString) shouldBe Left(expectedResult)
   }
 
   it should "fail to decode Docker API response if it does not contain 'Env' field" in {
@@ -185,7 +188,7 @@ class HttpDockerDAOSpec extends AnyFlatSpec with Matchers with BeforeAndAfterAll
         |""".stripMargin
     val expectedResult =
       DecodingFailure("Attempt to decode value on failed cursor", List(DownField("Env"), DownField("container_config")))
-    decode[ContainerConfig](jsonString) shouldBe Left(expectedResult)
+    decode[ContainerConfigResponse](jsonString) shouldBe Left(expectedResult)
   }
 
   it should s"detect tool RStudio for image rtitle/anvil-rstudio-base:0.0.1" in withDockerDAO { dockerDAO =>

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpDockerDAOSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpDockerDAOSpec.scala
@@ -69,6 +69,17 @@ class HttpDockerDAOSpec extends AnyFlatSpec with Matchers with BeforeAndAfterAll
     dockerDAOResource.use(dao => IO(testCode(dao))).unsafeRunSync()
   }
 
+  it should s"detect tool as Jupyter for image kimler" in withDockerDAO { dockerDAO =>
+    val image1 = ContainerImage("broadinstitute/terra-jupyter-aou:1.0.17", DockerHub)
+    val image2 = ContainerImage("kkimler/r4.0_tca:2020_11_09", DockerHub)
+
+    val response1 = dockerDAO.detectTool(image1).unsafeRunSync()
+    response1 shouldBe Jupyter
+
+    val response2 = dockerDAO.detectTool(image2).unsafeRunSync()
+    response2 shouldBe Jupyter
+  }
+
   Map(Jupyter -> jupyterImages, RStudio -> rstudioImages).foreach {
     case (tool, images) =>
       images.foreach { image =>


### PR DESCRIPTION
- Fixes the issues described in the [JIRA ticket](https://broadworkbench.atlassian.net/browse/IA-2439).
- As part of our docker image auto-detection process, we had been expecting the field `container_config` to be present in the response coming back from a Docker API. In a user's custom image case, that field doesn't exist for some reason. Instead we use the `config` field's `env` variables.
- Since we hadn't been catching the error thrown when JSON decoding fails, we were reporting a very low-level error message to the user. That's now fixed. We do also include the cause for debug purposes, though.
