### PR TITLE
Revert "Point Leo at google projects instead of billing projects (#1810)"

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/samModels.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/samModels.scala
@@ -14,7 +14,7 @@ sealed trait SamResourceType extends Product with Serializable {
 }
 object SamResourceType {
   final case object Project extends SamResourceType {
-    val asString = "google-project"
+    val asString = "billing-project"
   }
   final case object Runtime extends SamResourceType {
     val asString = "notebook-cluster"


### PR DESCRIPTION
This reverts commit d1385d8db744947b9b2ca7be99fdb544b9299391.

Original PR: https://github.com/DataBiosphere/leonardo/pull/1810

Rolling back this change temporarily because it breaks app creation; going to discuss a solution with @dvoet & team.

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
