### PR TITLE
[IA-2460] Change R package installation dir

### DIFF
--- a/http/src/main/resources/init-resources/gce-init.sh
+++ b/http/src/main/resources/init-resources/gce-init.sh
@@ -480,7 +480,6 @@ if [ ! -z "$RSTUDIO_DOCKER_IMAGE" ] ; then
   if [ $EXIT_CODE -ne 0 ]; then
     echo "RStudio user package installation directory creation failed, creating /packages directory"
     docker exec ${RSTUDIO_SERVER_NAME} /bin/bash -c "mkdir -p ${RSTUDIO_USER_HOME}/packages && chmod a+rwx ${RSTUDIO_USER_HOME}/packages"
-    exit $EXIT_CODE
   fi
 fi
 

--- a/http/src/main/resources/init-resources/gce-init.sh
+++ b/http/src/main/resources/init-resources/gce-init.sh
@@ -113,6 +113,8 @@ IS_GCE_FORMATTED=$(isGceFormatted)
 JUPYTER_HOME=/etc/jupyter
 JUPYTER_SCRIPTS=${JUPYTER_HOME}/scripts
 JUPYTER_USER_HOME=/home/jupyter-user
+RSTUDIO_SCRIPTS=/etc/rstudio/scripts
+RSTUDIO_USER_HOME=/home/rstudio
 KERNELSPEC_HOME=/usr/local/share/jupyter/kernels
 SERVER_CRT=$(proxyServerCrt)
 SERVER_KEY=$(proxyServerKey)
@@ -146,9 +148,6 @@ if [ "$IS_GCE_FORMATTED" == "false" ] ; then
   mkfs.ext4 -m 0 -E lazy_itable_init=0,lazy_journal_init=0,discard /dev/${DISK_DEVICE_ID}
 fi
 mount -o discard,defaults /dev/${DISK_DEVICE_ID} /work
-# Directory to store user installed packages so they persist
-mkdir -p /work/packages
-chmod a+rwx /work/packages
 # Ensure persistent disk re-mounts if runtime stops and restarts
 cp /etc/fstab /etc/fstab.backup
 echo UUID=`blkid -s UUID -o value /dev/${DISK_DEVICE_ID}` /work ext4 discard,defaults,nofail 0 2 | tee -a /etc/fstab
@@ -294,6 +293,10 @@ STEP_TIMINGS+=($(date +%s))
 # Jupyter-specific setup, only do if Jupyter is installed
 if [ ! -z "$JUPYTER_DOCKER_IMAGE" ] ; then
   log 'Installing Jupydocker kernelspecs...'
+
+  # user package installation directory
+  mkdir -p /work/packages
+  chmod a+rwx /work/packages
 
   # Used to pip install packacges
   # TODO: update this if we upgrade python version
@@ -468,6 +471,17 @@ if [ ! -z "$JUPYTER_DOCKER_IMAGE" ] ; then
 
   # done start Jupyter
   STEP_TIMINGS+=($(date +%s))
+fi
+
+# RStudio specific setup; only do if RStudio is installed
+if [ ! -z "$RSTUDIO_DOCKER_IMAGE" ] ; then
+  EXIT_CODE=0
+  retry 3 docker exec ${RSTUDIO_SERVER_NAME} ${RSTUDIO_SCRIPTS}/set_up_package_dir.sh || EXIT_CODE=$?
+  if [ $EXIT_CODE -ne 0 ]; then
+    echo "RStudio user package installation directory creation failed, creating /packages directory"
+    docker exec ${RSTUDIO_SERVER_NAME} /bin/bash -c "mkdir -p ${RSTUDIO_USER_HOME}/packages && chmod a+rwx ${RSTUDIO_USER_HOME}/packages"
+    exit $EXIT_CODE
+  fi
 fi
 
 # Remove any unneeded cached images to save disk space.


### PR DESCRIPTION
Tested in a fiab.. created an rstudio runtime using the newest anvil-rstudio-bioconductor image in this PR: https://github.com/anvilproject/anvil-docker/pull/23 and verified that the correct dir is created for R packages and tested that packages install correctly and persist between runtimes

R packages will now be in the directory `/home/rstudio/R/x86_64-pc-linux-gnu-library/{R_VERSION}-${BIOCONDUCTOR_VERSION}` which is more R native package directory. for more questions about this directory, reach out to @nturaga 

The only concern I have is that if a user creates an RStudio VM, installs R packages and then deletes their runtime but keeps their PD then creates a Jupyter runtime they will have the R packages previously installed on their disk in a directory that is bioconductor specific (see screenshot). 
![Screen Shot 2021-01-19 at 3 52 54 PM](https://user-images.githubusercontent.com/23626109/105093934-7b37f080-5a71-11eb-8a08-da370793101a.png)

not sure if this is a blocker, i'm leaning towards leaving it as is because i tested installing the same R package but in jupyter and it works fine and does not even recognize the package in `/home/rstudio/R/x86_64-pc-linux-gnu-library/{R_VERSION}-${BIOCONDUCTOR_VERSION}` (see second screenshot)
![Screen Shot 2021-01-19 at 4 13 27 PM](https://user-images.githubusercontent.com/23626109/105093949-825efe80-5a71-11eb-83b0-1398760c04a5.png)


---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
