### PR TITLE
IA-2342: Adding Stopped as a deleteable status for App Pause/Resume UI

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/kubernetesModels.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/kubernetesModels.scala
@@ -418,7 +418,7 @@ object AppStatus {
   def stringToObject: Map[String, AppStatus] = values.map(v => v.toString -> v).toMap
 
   val deletableStatuses: Set[AppStatus] =
-    Set(Unspecified, Running, Error)
+    Set(Unspecified, Running, Stopped, Error)
 
   val stoppableStatuses: Set[AppStatus] =
     Set(Running, Starting)


### PR DESCRIPTION
Since we are implementing Pause/Resume into the UI. It makes sense for us to add stopped as an eligible status to be deleted. 

I think it should just be a change here, but wanted to check to make sure there wasn't anything else that needed to be added

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
