### PR TITLE
[IA-2472] Turn on debug-level logging when JUPYTER_DEBUG_LOGGING env var is true

### DIFF
--- a/http/src/main/resources/init-resources/jupyter_notebook_config.py
+++ b/http/src/main/resources/init-resources/jupyter_notebook_config.py
@@ -5,6 +5,10 @@
 import os
 
 c = get_config()
+
+if os.environ.get('JUPYTER_DEBUG_LOGGING') == 'true':
+  c.Application.log_level = 'DEBUG'
+
 c.NotebookApp.ip = '0.0.0.0'
 c.NotebookApp.port = 8000
 c.NotebookApp.open_browser = False


### PR DESCRIPTION
The goal here is to allow clients to conditionally turn on debug-level logs in Leo clusters. Based on a bit of searching around, this seems to be the most appropriate config value to turn on for debug logs. There is also a c.Session value (ref), but that's likely overkill for what AoU is looking for.