### PR TITLE
[IA-2460] bump anvil rstudio bioconductor image to 0.0.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN mkdir /helm-go-lib-build && \
     cd helm-go-lib && \
     go build -o libhelm.so -buildmode=c-shared main.go
 
-FROM oracle/graalvm-ce:20.2.0-java8-ol8
+FROM ghcr.io/graalvm/graalvm-ce:ol8-java8-21.0.0
 
 EXPOSE 8080
 EXPOSE 5050

--- a/automation/src/test/resources/reference.conf
+++ b/automation/src/test/resources/reference.conf
@@ -7,7 +7,7 @@ leonardo.baseImageUrl = "us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:0.0.1
 leonardo.bioconductorImageUrl = "us.gcr.io/broad-dsp-gcr-public/terra-jupyter-bioconductor:1.0.11"
 leonardo.gcrWelderUri = "us.gcr.io/broad-dsp-gcr-public/welder-server"
 leonardo.dockerHubWelderUri = "broadinstitute/welder-server"
-leonardo.rstudioBioconductorImageUrl = "us.gcr.io/anvil-gcr-public/anvil-rstudio-bioconductor:0.0.9"
+leonardo.rstudioBioconductorImageUrl = "us.gcr.io/anvil-gcr-public/anvil-rstudio-bioconductor:0.0.10"
 //each fiab will have a unique topic name sourced from leonardo.conf, this is never published to in automation tests to ensure pub/sub components can auth properly, but never read from to avoid conflicts.
 leonardo.topicName = "leonardo-pubsub-test"
 leonardo.location = "us-central1-a"

--- a/jenkins/dataproc-custom-images/prepare-custom-leonardo-jupyter-dataproc-image.sh
+++ b/jenkins/dataproc-custom-images/prepare-custom-leonardo-jupyter-dataproc-image.sh
@@ -28,7 +28,7 @@ terra_jupyter_aou="us.gcr.io/broad-dsp-gcr-public/terra-jupyter-aou:1.0.20"
 
 welder_server="us.gcr.io/broad-dsp-gcr-public/welder-server:4d380f2"
 openidc_proxy="broadinstitute/openidc-proxy:2.3.1_2"
-anvil_rstudio_bioconductor="us.gcr.io/anvil-gcr-public/anvil-rstudio-bioconductor:0.0.9"
+anvil_rstudio_bioconductor="us.gcr.io/anvil-gcr-public/anvil-rstudio-bioconductor:0.0.10"
 
 # Not replaced by Jenkins. If you change this you must also change Leo reference.conf!
 cryptomining_detector="us.gcr.io/broad-dsp-gcr-public/cryptomining-detector:0.0.1"

--- a/jenkins/gce-custom-images/prepare_custom_leonardo_gce_image.sh
+++ b/jenkins/gce-custom-images/prepare_custom_leonardo_gce_image.sh
@@ -30,7 +30,7 @@ terra_jupyter_aou="us.gcr.io/broad-dsp-gcr-public/terra-jupyter-aou:1.0.20"
 
 welder_server="us.gcr.io/broad-dsp-gcr-public/welder-server:4d380f2"
 openidc_proxy="broadinstitute/openidc-proxy:2.3.1_2"
-anvil_rstudio_bioconductor="us.gcr.io/anvil-gcr-public/anvil-rstudio-bioconductor:0.0.9"
+anvil_rstudio_bioconductor="us.gcr.io/anvil-gcr-public/anvil-rstudio-bioconductor:0.0.10"
 
 # Not replaced by Jenkins. If you change this you must also change Leo reference.conf!
 cryptomining_detector="us.gcr.io/broad-dsp-gcr-public/cryptomining-detector:0.0.1"


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-2460

manually built and pushed `us.gcr.io/anvil-gcr-public/anvil-rstudio-bioconductor:0.0.10` to GCR

hoping this will trigger a custom image build (similar to when we bumped to 0.0.9: https://github.com/DataBiosphere/leonardo/pull/1796)

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
