### PR TITLE
[IA-2469] preventing csrf attacks in Leo proxy

### DIFF
--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -443,6 +443,12 @@ contentSecurityPolicy {
   ]
 }
 
+refererConfig {
+  # list of valid hosts and enabled flag is environment specific so it's overriden in firecloud develop
+  validHosts = []
+  enabled = false // false for dev and QA environments, true everywhere else
+}
+
 swagger {
   #googleClientId = "client_id"
   #realm = "broad-dsde-dev"

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
@@ -258,6 +258,14 @@ object Config {
       )
     }
 
+  implicit private val refererConfigReader: ValueReader[RefererConfig] =
+    ValueReader.relative { config =>
+      RefererConfig(
+        config.as[Set[String]]("validHosts"),
+        config.as[Boolean]("enabled")
+      )
+    }
+
   implicit private val swaggerReader: ValueReader[SwaggerConfig] = ValueReader.relative { config =>
     SwaggerConfig(
       config.getString("googleClientId"),
@@ -440,6 +448,7 @@ object Config {
   val serviceAccountProviderConfig = config.as[ServiceAccountProviderConfig]("serviceAccounts.providerConfig")
   val kubeServiceAccountProviderConfig = config.as[ServiceAccountProviderConfig]("serviceAccounts.kubeConfig")
   val contentSecurityPolicy = config.as[ContentSecurityPolicyConfig]("contentSecurityPolicy").asString
+  val refererConfig = config.as[RefererConfig]("refererConfig")
 
   implicit private val zombieClusterConfigValueReader: ValueReader[ZombieRuntimeMonitorConfig] = ValueReader.relative {
     config =>

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/RefererConfig.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/RefererConfig.scala
@@ -1,0 +1,4 @@
+package org.broadinstitute.dsde.workbench.leonardo
+package config
+
+final case class RefererConfig(validHosts: Set[String], enabled: Boolean)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/Boot.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/Boot.scala
@@ -181,7 +181,8 @@ object Boot extends IOApp {
         diskService,
         leoKubernetesService,
         StandardUserInfoDirectives,
-        contentSecurityPolicy
+        contentSecurityPolicy,
+        refererConfig
       )
       val httpServer = for {
         start <- Timer[IO].clock.realTime(TimeUnit.MILLISECONDS)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/HttpRoutes.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/HttpRoutes.scala
@@ -13,7 +13,7 @@ import akka.stream.scaladsl.Sink
 import cats.effect.{ContextShift, IO}
 import com.typesafe.scalalogging.LazyLogging
 import io.circe.Encoder
-import org.broadinstitute.dsde.workbench.leonardo.config.SwaggerConfig
+import org.broadinstitute.dsde.workbench.leonardo.config.{RefererConfig, SwaggerConfig}
 import org.broadinstitute.dsde.workbench.leonardo.http.service.{
   DiskService,
   KubernetesService,
@@ -38,13 +38,14 @@ class HttpRoutes(
   diskService: DiskService[IO],
   kubernetesService: KubernetesService[IO],
   userInfoDirectives: UserInfoDirectives,
-  contentSecurityPolicy: String
+  contentSecurityPolicy: String,
+  refererConfig: RefererConfig
 )(implicit ec: ExecutionContext, ac: ActorSystem, cs: ContextShift[IO], metrics: OpenTelemetryMetrics[IO])
     extends LazyLogging {
   private val swaggerRoutes = new SwaggerRoutes(swaggerConfig)
   private val statusRoutes = new StatusRoutes(statusService)
   private val corsSupport = new CorsSupport(contentSecurityPolicy)
-  private val proxyRoutes = new ProxyRoutes(proxyService, corsSupport)
+  private val proxyRoutes = new ProxyRoutes(proxyService, corsSupport, refererConfig)
   private val runtimeRoutes = new RuntimeRoutes(runtimeService, userInfoDirectives)
   private val diskRoutes = new DiskRoutes(diskService, userInfoDirectives)
   private val kubernetesRoutes = new AppRoutes(kubernetesService, userInfoDirectives)

--- a/http/src/test/resources/reference.conf
+++ b/http/src/test/resources/reference.conf
@@ -105,6 +105,13 @@ proxy {
   proxyPort = 8001
 }
 
+refererConfig {
+  validHosts = [
+    "example.com"
+  ]
+  enabled = true
+}
+
 swagger {
   googleClientId = "test.apps.googleusercontent.com"
   realm = "broad-dsde-test"

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/CommonTestData.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/CommonTestData.scala
@@ -116,6 +116,7 @@ object CommonTestData {
   val proxyUrlBase = proxyConfig.proxyUrlBase
   val clusterBucketConfig = Config.clusterBucketConfig
   val contentSecurityPolicy = Config.contentSecurityPolicy
+  val refererConfig = Config.refererConfig
   val leoKubernetesConfig = Config.leoKubernetesConfig
   val singleNodeDefaultMachineConfig = dataprocConfig.runtimeConfigDefaults
   val singleNodeDefaultMachineConfigRequest = RuntimeConfigRequest.DataprocConfig(
@@ -138,6 +139,8 @@ object CommonTestData {
   val tokenName = "LeoToken"
   val tokenValue = "accessToken"
   val tokenCookie = HttpCookiePair(tokenName, tokenValue)
+
+  val validRefererUri = "http://example.com/this/is/a/test"
 
   val networkName = NetworkName("default")
   val subNetworkName = SubnetworkName("default")

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/config/RefererConfigSpec/RefererConfigSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/config/RefererConfigSpec/RefererConfigSpec.scala
@@ -1,0 +1,10 @@
+package org.broadinstitute.dsde.workbench.leonardo
+package config
+import org.scalatest.flatspec.AnyFlatSpecLike
+
+class RefererConfigSpec extends LeonardoTestSuite with AnyFlatSpecLike {
+  it should "parse config values correctly" in {
+    CommonTestData.refererConfig.validHosts shouldBe Set("example.com")
+    CommonTestData.refererConfig.enabled shouldBe true
+  }
+}

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/HttpRoutesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/HttpRoutesSpec.scala
@@ -54,7 +54,8 @@ class HttpRoutesSpec
     MockDiskServiceInterp,
     MockKubernetesServiceInterp,
     timedUserInfoDirectives,
-    contentSecurityPolicy
+    contentSecurityPolicy,
+    refererConfig
   )
 
   "RuntimeRoutes" should "create runtime" in {
@@ -562,7 +563,8 @@ class HttpRoutesSpec
       MockDiskServiceInterp,
       MockKubernetesServiceInterp,
       timedUserInfoDirectives,
-      contentSecurityPolicy
+      contentSecurityPolicy,
+      refererConfig
     )
 
   def fakeRoutes(kubernetesService: KubernetesService[IO]): HttpRoutes =
@@ -574,7 +576,8 @@ class HttpRoutesSpec
       MockDiskServiceInterp,
       kubernetesService,
       timedUserInfoDirectives,
-      contentSecurityPolicy
+      contentSecurityPolicy,
+      refererConfig
     )
 }
 

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/TestLeoRoutes.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/TestLeoRoutes.scala
@@ -149,7 +149,8 @@ trait TestLeoRoutes {
     MockDiskServiceInterp,
     leoKubernetesService,
     userInfoDirectives,
-    contentSecurityPolicy
+    contentSecurityPolicy,
+    refererConfig
   )
   val timedHttpRoutes = new HttpRoutes(swaggerConfig,
                                        statusService,
@@ -158,7 +159,8 @@ trait TestLeoRoutes {
                                        MockDiskServiceInterp,
                                        leoKubernetesService,
                                        timedUserInfoDirectives,
-                                       contentSecurityPolicy)
+                                       contentSecurityPolicy,
+                                       refererConfig)
 
   def roundUpToNearestTen(d: Long): Long = (Math.ceil(d / 10.0) * 10).toLong
   val cookieMaxAgeRegex: Regex = "Max-Age=(\\d+);".r


### PR DESCRIPTION
jira ticket: https://broadworkbench.atlassian.net/browse/IA-2469

accompanying firecloud-develop PR: https://github.com/broadinstitute/firecloud-develop/pull/2408

added unit tests and tested in a fiab manually adding `refererConfig` to [reference.conf](https://github.com/DataBiosphere/leonardo/pull/1854/files#diff-9024d8d3f171d065fa3b61dbc7dc2c56bdc6587644fde470722fdc92e7068f61R445). the config that was manually added is identical to the config added to firecloud-develop in this [PR](https://github.com/broadinstitute/firecloud-develop/pull/2408) for the dev environment. Just kicked off a `fiab-start` job that will test these changes alongside the firecloud-develop changes as well

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
