### PR TITLE
IA-2397 Use terra-app-setup-chart and persist PVC ids

### DIFF
--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -46,8 +46,9 @@ jobs:
         JAVA_OPTS: -Xmx3G
         JVM_OPTS:  -Xmx3G
       run: |
-         sbt -Denv.type=test "project core" coverage test coverageReport
-         sbt -Denv.type=test -Dmysql.host=localhost -Dmysql.port=3307 "project http" coverage test coverageReport
+         export SBT_OPTS="-Duser.timezone=UTC -Denv.type=test -Dmysql.host=localhost -Dmysql.port=3307"
+         sbt "project core" coverage test coverageReport
+         sbt "project http" coverage test coverageReport
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/master
 # Add the repos containing nginx and galaxy charts
 RUN helm repo add center https://repo.chartcenter.io && \
     helm repo add galaxy https://raw.githubusercontent.com/cloudve/helm-charts/anvil/ && \
-    helm repo add terra-app-setup-charts https://storage.googleapis.com/terra-app-setup-chart \
+    helm repo add terra-app-setup-charts https://storage.googleapis.com/terra-app-setup-chart && \
     helm repo update
 
 # .Files helm helper can't access files outside a chart. Hence in order to populate cert file properly, we're

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,18 @@ RUN curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/master
 # Add the repos containing nginx and galaxy charts
 RUN helm repo add center https://repo.chartcenter.io && \
     helm repo add galaxy https://raw.githubusercontent.com/cloudve/helm-charts/anvil/ && \
+    helm repo add terra-app-setup-charts https://storage.googleapis.com/terra-app-setup-chart \
     helm repo update
+
+# .Files helm helper can't access files outside a chart. Hence in order to populate cert file properly, we're
+# pulling `terra-app-setup` locally and add cert files to the chart.
+# Leonardo will install the chart from local version.
+RUN pushd /leonardo && \
+    helm pull terra-app-setup-charts/terra-app-setup --untar && \
+    cp /etc/rootCA.pem terra-app-setup/ca.crt && \
+    cp /etc/jupyter-server.crt terra-app-setup/tls.crt && \
+    cp /etc/jupyter-server.key terra-app-setup/tls.key && \
+    popd
 
 # Add Leonardo as a service (it will start when the container starts)
 CMD java $JAVA_OPTS -jar $(find /leonardo -name 'leonardo*.jar')

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,9 +41,6 @@ RUN helm repo add center https://repo.chartcenter.io && \
 # Leonardo will install the chart from local version.
 RUN pushd /leonardo && \
     helm pull terra-app-setup-charts/terra-app-setup --untar && \
-    cp /etc/rootCA.pem terra-app-setup/ca.crt && \
-    cp /etc/jupyter-server.crt terra-app-setup/tls.crt && \
-    cp /etc/jupyter-server.key terra-app-setup/tls.key && \
     popd
 
 # Add Leonardo as a service (it will start when the container starts)

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeoException.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeoException.scala
@@ -11,5 +11,5 @@ abstract class LeoException(val message: String = null,
   implicit val errorReportSource = ErrorReportSource("test")
 
   def toErrorReport: ErrorReport =
-    ErrorReport(Option(getMessage).getOrElse(""), Some(statusCode), Seq(), Seq(), Some(this.getClass))
+    ErrorReport(Option(getMessage).getOrElse(""), Some(statusCode), Seq(), Seq(), Some(this.getClass), None)
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/ConfigImplicits.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/ConfigImplicits.scala
@@ -1,0 +1,17 @@
+package org.broadinstitute.dsde.workbench.leonardo
+
+import pureconfig.ConfigReader
+import cats.syntax.all._
+import org.broadinstitute.dsp.{ChartName, ChartVersion}
+import pureconfig.error.ExceptionThrown
+
+import java.nio.file.{Path, Paths}
+
+object ConfigImplicits {
+  implicit val pathConfigReader: ConfigReader[Path] =
+    ConfigReader.stringConfigReader.emap(s => Either.catchNonFatal(Paths.get(s)).leftMap(err => ExceptionThrown(err)))
+  implicit val chartNameConfigReader: ConfigReader[ChartName] =
+    ConfigReader.stringConfigReader.map(s => ChartName(s))
+  implicit val chartVersionConfigReader: ConfigReader[ChartVersion] =
+    ConfigReader.stringConfigReader.map(s => ChartVersion(s))
+}

--- a/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changelog.xml
+++ b/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changelog.xml
@@ -68,4 +68,5 @@
     <include file="changesets/20201026_drop_not_null_constraint_on_error_code_table.xml" relativeToChangelogFile="true" />
     <include file="changesets/20201104_add_deletedFrom.xml" relativeToChangelogFile="true" />
     <include file="changesets/20210122_remove_stop_after_creation.xml" relativeToChangelogFile="true" />
+    <include file="changesets/20210217_add_app_pvc_id.xml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/20210217_add_app_pvc_id.xml
+++ b/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/20210217_add_app_pvc_id.xml
@@ -12,12 +12,12 @@
                 <constraints nullable="true"/>
             </column>
 
-            <column name="usedBy" type="BIGINT">
+            <column name="lastUsedBy" type="BIGINT">
                 <constraints nullable="true"/>
             </column>
         </addColumn>
 
-        <addForeignKeyConstraint baseColumnNames="usedBy" baseTableName="PERSISTENT_DISK" constraintName="FK_DISK_APP_ID" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="id" referencedTableName="APP"/>
+        <addForeignKeyConstraint baseColumnNames="lastUsedBy" baseTableName="PERSISTENT_DISK" constraintName="FK_DISK_APP_ID" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="id" referencedTableName="APP"/>
     </changeSet>
 
 </databaseChangeLog>

--- a/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/20210217_add_app_pvc_id.xml
+++ b/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/20210217_add_app_pvc_id.xml
@@ -2,12 +2,21 @@
 <databaseChangeLog logicalFilePath="leonardo" xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
 
     <changeSet logicalFilePath="leonardo" author="qi" id="add_app_pvc_id">
-        <addColumn tableName="APP">
+        <addColumn tableName="PERSISTENT_DISK">
             <column name="galaxyPvcId" type="varchar(254)">
                 <constraints nullable="true"/>
             </column>
 
+            <!-- this is a second PVC id. We store this record in the same row for galaxy pvc Id because we don't currently persist disk Id for cvmfs. If we persist cmvfs disk separately in the future, we should move this field to new row -->
             <column name="cvmfsPvcId" type="varchar(254)">
+                <constraints nullable="true"/>
+            </column>
+
+            <column name="chart" type="varchar(254)">
+                <constraints nullable="true"/>
+            </column>
+
+            <column name="release" type="varchar(254)">
                 <constraints nullable="true"/>
             </column>
         </addColumn>

--- a/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/20210217_add_app_pvc_id.xml
+++ b/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/20210217_add_app_pvc_id.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog logicalFilePath="leonardo" xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+
+    <changeSet logicalFilePath="leonardo" author="qi" id="add_app_pvc_id">
+        <addColumn tableName="APP">
+            <column name="galaxyPvcId" type="varchar(254)">
+                <constraints nullable="true"/>
+            </column>
+
+            <column name="cvmfsPvcId" type="varchar(254)">
+                <constraints nullable="true"/>
+            </column>
+        </addColumn>
+    </changeSet>
+
+</databaseChangeLog>

--- a/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/20210217_add_app_pvc_id.xml
+++ b/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/20210217_add_app_pvc_id.xml
@@ -12,14 +12,12 @@
                 <constraints nullable="true"/>
             </column>
 
-            <column name="chart" type="varchar(254)">
-                <constraints nullable="true"/>
-            </column>
-
-            <column name="release" type="varchar(254)">
+            <column name="usedBy" type="BIGINT">
                 <constraints nullable="true"/>
             </column>
         </addColumn>
+
+        <addForeignKeyConstraint baseColumnNames="usedBy" baseTableName="PERSISTENT_DISK" constraintName="FK_DISK_APP_ID" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="id" referencedTableName="APP"/>
     </changeSet>
 
 </databaseChangeLog>

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -221,30 +221,6 @@ gke {
       "rbac.create=true",
       "controller.publishService.enabled=true"
     ]
-    secrets = [
-      {
-        name = "ca-secret"
-        secretFiles = [
-          {
-            name = "ca.crt"
-            path = ${clusterFiles.proxyRootCaPem}
-          }
-        ]
-      },
-      {
-        name = "tls-secret"
-        secretFiles = [
-          {
-            name = "tls.crt"
-            path = ${clusterFiles.proxyServerCrt}
-          },
-          {
-            name = "tls.key"
-            path = ${clusterFiles.proxyServerKey}
-          }
-        ]
-      }
-    ]
   }
   galaxyApp {
     # See comment in KubernetesServiceInterp for more context. Theoretically release names should
@@ -615,4 +591,11 @@ ui {
 async-task-processor {
   queue-bound = 500
   max-concurrent-tasks = 200
+}
+
+terra-app-setup-chart {
+  # During Leonardo deployment. Leo will `helm pull` the chart locally, and then move
+  # cert files into the local chart.
+  chart-name = "/leonardo/terra-app-setup"
+  chart-version = "0.0.1"
 }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
@@ -563,24 +563,6 @@ object Config {
       config.as[AutoscalingMax]("autoscalingMax")
     )
   }
-  implicit private val secretKeyReader: ValueReader[SecretKey] = stringValueReader.map(SecretKey)
-  implicit private val secretFileReader: ValueReader[SecretFile] = ValueReader.relative { config =>
-    SecretFile(
-      config.as[SecretKey]("name"),
-      config.as[Path]("path")
-    )
-  }
-
-  implicit private val secretNameReader: ValueReader[SecretName] =
-    stringValueReader.map(s =>
-      KubernetesName
-        .withValidation(s, SecretName)
-        .getOrElse(throw new RuntimeException(s"Unable to parse the secret name $s into a valid kubernetes name"))
-    )
-
-  implicit private val secretConfigReader: ValueReader[SecretConfig] = ValueReader.relative { config =>
-    SecretConfig(config.as[SecretName]("name"), config.as[List[SecretFile]]("secretFiles"))
-  }
 
   implicit private val ingressConfigReader: ValueReader[KubernetesIngressConfig] = ValueReader.relative { config =>
     KubernetesIngressConfig(
@@ -589,8 +571,7 @@ object Config {
       config.as[ChartName]("chartName"),
       config.as[ChartVersion]("chartVersion"),
       config.as[ServiceName]("loadBalancerService"),
-      config.as[List[ValueConfig]]("values"),
-      config.as[List[SecretConfig]]("secrets")
+      config.as[List[ValueConfig]]("values")
     )
   }
 
@@ -754,11 +735,13 @@ object Config {
   val gkeMonitorConfig = config.as[AppMonitorConfig]("pubsub.kubernetes-monitor")
 
   val gkeInterpConfig =
-    GKEInterpreterConfig(securityFilesConfig,
-                         gkeIngressConfig,
-                         gkeGalaxyAppConfig,
-                         gkeMonitorConfig,
-                         gkeClusterConfig,
-                         proxyConfig,
-                         gkeGalaxyDiskConfig)
+    GKEInterpreterConfig(
+      org.broadinstitute.dsde.workbench.leonardo.http.ConfigReader.appConfig.terraAppSetupChart,
+      gkeIngressConfig,
+      gkeGalaxyAppConfig,
+      gkeMonitorConfig,
+      gkeClusterConfig,
+      proxyConfig,
+      gkeGalaxyDiskConfig
+    )
 }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/KubernetesIngressConfig.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/KubernetesIngressConfig.scala
@@ -1,14 +1,6 @@
 package org.broadinstitute.dsde.workbench.leonardo
 package config
-import java.nio.file.Path
-
-import org.broadinstitute.dsde.workbench.google2.KubernetesSerializableName.{
-  NamespaceName,
-  SecretKey,
-  SecretName,
-  ServiceName
-}
-import org.broadinstitute.dsde.workbench.leonardo.Chart
+import org.broadinstitute.dsde.workbench.google2.KubernetesSerializableName.{NamespaceName, ServiceName}
 import org.broadinstitute.dsp.{ChartName, ChartVersion, Release}
 
 final case class KubernetesIngressConfig(namespace: NamespaceName,
@@ -16,12 +8,9 @@ final case class KubernetesIngressConfig(namespace: NamespaceName,
                                          chartName: ChartName,
                                          chartVersion: ChartVersion,
                                          loadBalancerService: ServiceName,
-                                         values: List[ValueConfig],
-                                         secrets: List[SecretConfig]) {
+                                         values: List[ValueConfig]) {
 
   def chart: Chart = Chart(chartName, chartVersion)
 }
 
 final case class ValueConfig(value: String) extends AnyVal
-final case class SecretConfig(name: SecretName, secretFiles: List[SecretFile])
-final case class SecretFile(name: SecretKey, path: Path)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/AppComponent.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/AppComponent.scala
@@ -188,15 +188,10 @@ object appQuery extends TableQuery(new AppTable(_)) {
       .map(_.status)
       .update(status)
 
-  def updatePvcIds(id: AppId, galaxyPvcId: PvcId, cvmfsPvcId: PvcId)(implicit ec: ExecutionContext): DBIO[Unit] =
-    for {
-      _ <- getByIdQuery(id)
-        .map(_.galaxyPvcId)
-        .update(Some(galaxyPvcId))
-      _ <- getByIdQuery(id)
-        .map(_.cvmfsPvcId)
-        .update(Some(cvmfsPvcId))
-    } yield ()
+  def updatePvcIds(id: AppId, galaxyPvcId: PvcId, cvmfsPvcId: PvcId): DBIO[Int] =
+    getByIdQuery(id)
+      .map(x => (x.galaxyPvcId, x.cvmfsPvcId))
+      .update((Some(galaxyPvcId), Some(cvmfsPvcId)))
 
   def updateChart(id: AppId, chart: Chart): DBIO[Int] =
     getByIdQuery(id)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/DbReference.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/DbReference.scala
@@ -115,13 +115,14 @@ final class DataAccess(blocker: Blocker) {
       TableQuery[PatchTable].delete andThen
       TableQuery[ClusterTable].delete andThen
       RuntimeConfigQueries.runtimeConfigs.delete andThen
+      persistentDiskQuery.nullifyDiskIds andThen
       TableQuery[ServiceTable].delete andThen
       TableQuery[AppErrorTable].delete andThen
       TableQuery[AppTable].delete andThen
       TableQuery[NamespaceTable].delete andThen
       TableQuery[NodepoolTable].delete andThen
       TableQuery[KubernetesClusterTable].delete andThen
-      TableQuery[PersistentDiskTable].delete
+      persistentDiskQuery.tableQuery.delete
 
   def sqlDBStatus() =
     sql"select version()".as[String]

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/DiskServiceDbQueries.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/DiskServiceDbQueries.scala
@@ -20,8 +20,8 @@ object DiskServiceDbQueries {
     implicit ec: ExecutionContext
   ): DBIO[List[PersistentDisk]] = {
     val diskQueryFilteredByDeletion =
-      if (includeDeleted) persistentDiskQuery
-      else persistentDiskQuery.filterNot(_.status === (DiskStatus.Deleted: DiskStatus))
+      if (includeDeleted) persistentDiskQuery.tableQuery
+      else persistentDiskQuery.tableQuery.filterNot(_.status === (DiskStatus.Deleted: DiskStatus))
 
     val diskQueryFilteredByProject =
       googleProjectOpt.fold(diskQueryFilteredByDeletion)(p => diskQueryFilteredByDeletion.filter(_.googleProject === p))

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/KubernetesClusterComponent.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/KubernetesClusterComponent.scala
@@ -245,3 +245,5 @@ case class SaveKubernetesCluster(googleProject: GoogleProject,
       None
     )
 }
+
+final case class PvcId(asString: String) extends AnyVal

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/KubernetesClusterComponent.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/KubernetesClusterComponent.scala
@@ -139,8 +139,7 @@ object kubernetesClusterQuery extends TableQuery(new KubernetesClusterTable(_)) 
     clusterQuery: Query[KubernetesClusterTable, KubernetesClusterRecord, Seq],
     nodepoolQuery: Query[NodepoolTable, NodepoolRecord, Seq]
   )(implicit ec: ExecutionContext): DBIO[List[KubernetesCluster]] =
-    joinMinimalCluster(clusterQuery, nodepoolQuery).result
-      .map(recs => aggregateJoinedCluster(recs).toList)
+    joinMinimalCluster(clusterQuery, nodepoolQuery).result.map(recs => aggregateJoinedCluster(recs).toList)
 
   private[db] def joinMinimalCluster(clusterQuery: Query[KubernetesClusterTable, KubernetesClusterRecord, Seq],
                                      nodepoolQuery: Query[NodepoolTable, NodepoolRecord, Seq]) =
@@ -148,7 +147,9 @@ object kubernetesClusterQuery extends TableQuery(new KubernetesClusterTable(_)) 
       ((cluster, nodepoolOpt), namespaceOpt) <- clusterQuery joinLeft
         nodepoolQuery on (_.id === _.clusterId) joinLeft
         namespaceQuery on (_._1.id === _.clusterId)
-    } yield (cluster, nodepoolOpt, namespaceOpt)
+    } yield {
+      (cluster, nodepoolOpt, namespaceOpt)
+    }
 
   private[db] def aggregateJoinedCluster(
     records: Seq[(KubernetesClusterRecord, Option[NodepoolRecord], Option[NamespaceRecord])]

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/KubernetesServiceDbQueries.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/KubernetesServiceDbQueries.scala
@@ -251,7 +251,7 @@ object KubernetesServiceDbQueries {
         namespaceQuery on (_._1._2.id === _.clusterId) join
         namespaceQuery on (_._1._1._1._1.namespaceId === _.id) joinLeft
         serviceQuery on (_._1._1._1._1._1.id === _.appId) joinLeft
-        persistentDiskQuery on (_._1._1._1._1._1._1.diskId === _.id) joinLeft
+        persistentDiskQuery.tableQuery on (_._1._1._1._1._1._1.diskId === _.id) joinLeft
         labelQuery on {
         case (c, lbl) =>
           lbl.resourceId

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/LeoProfile.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/LeoProfile.scala
@@ -119,6 +119,8 @@ private[leonardo] object LeoProfile extends MySQLProfile {
       MappedColumnType.base[DiskType, String](_.entryName, DiskType.withName)
     implicit val blockSizeMappedColumnType: BaseColumnType[BlockSize] =
       MappedColumnType.base[BlockSize, Int](_.bytes, BlockSize.apply)
+    implicit val pvcIdMappedColumnType: BaseColumnType[PvcId] =
+      MappedColumnType.base[PvcId, String](_.asString, PvcId.apply)
     implicit val labelResourceTypeColumnMapper: BaseColumnType[LabelResourceType] =
       MappedColumnType.base[LabelResourceType, String](
         _.asString,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/PersistentDiskComponent.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/PersistentDiskComponent.scala
@@ -165,6 +165,10 @@ object persistentDiskQuery extends TableQuery(new PersistentDiskTable(_)) {
          Some(galaxyDiskRestore.release))
       )
 
+  def isUsedByGalaxy(id: DiskId)(implicit ec: ExecutionContext): DBIO[Option[Boolean]] =
+    findByIdQuery(id).result
+      .map(_.headOption.map(_.galaxyDiskRestore.isDefined))
+
   def getGalaxyDiskRestore(id: DiskId)(implicit ec: ExecutionContext): DBIO[Option[GalaxyDiskRestore]] =
     findByIdQuery(id).result.map(_.headOption.flatMap(_.galaxyDiskRestore))
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/PersistentDiskComponent.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/PersistentDiskComponent.scala
@@ -49,7 +49,7 @@ class PersistentDiskTable(tag: Tag) extends Table[PersistentDiskRecord](tag, "PE
   def formattedBy = column[Option[FormattedBy]]("formattedBy", O.Length(255))
   def galaxyPvcId = column[Option[PvcId]]("galaxyPvcId", O.Length(254))
   def cvmfsPvcId = column[Option[PvcId]]("cvmfsPvcId", O.Length(254))
-  def usedBy = column[Option[AppId]]("usedBy")
+  def lastUsedBy = column[Option[AppId]]("lastUsedBy")
 
   override def * =
     (id,
@@ -68,7 +68,7 @@ class PersistentDiskTable(tag: Tag) extends Table[PersistentDiskRecord](tag, "PE
      diskType,
      blockSize,
      formattedBy,
-     (galaxyPvcId, cvmfsPvcId, usedBy)) <> ({
+     (galaxyPvcId, cvmfsPvcId, lastUsedBy)) <> ({
       case (id,
             googleProject,
             zone,
@@ -85,7 +85,7 @@ class PersistentDiskTable(tag: Tag) extends Table[PersistentDiskRecord](tag, "PE
             diskType,
             blockSize,
             formattedBy,
-            (galaxyPvcId, cvmfsPvcId, usedBy)) =>
+            (galaxyPvcId, cvmfsPvcId, lastUsedBy)) =>
         PersistentDiskRecord(
           id,
           googleProject,
@@ -103,7 +103,7 @@ class PersistentDiskTable(tag: Tag) extends Table[PersistentDiskRecord](tag, "PE
           diskType,
           blockSize,
           formattedBy,
-          (galaxyPvcId, cvmfsPvcId, usedBy).mapN((gp, cp, l) => GalaxyDiskRestore(gp, cp, l))
+          (galaxyPvcId, cvmfsPvcId, lastUsedBy).mapN((gp, cp, l) => GalaxyDiskRestore(gp, cp, l))
         )
     }, { record: PersistentDiskRecord =>
       Some(
@@ -125,22 +125,24 @@ class PersistentDiskTable(tag: Tag) extends Table[PersistentDiskRecord](tag, "PE
         record.formattedBy,
         (record.galaxyDiskRestore.map(_.galaxyPvcId),
          record.galaxyDiskRestore.map(_.cvmfsPvcId),
-         record.galaxyDiskRestore.map(_.usedBy))
+         record.galaxyDiskRestore.map(_.lastUsedBy))
       )
     })
 }
 
-object persistentDiskQuery extends TableQuery(new PersistentDiskTable(_)) {
-  private[db] def findByIdQuery(id: DiskId) = persistentDiskQuery.filter(_.id === id)
+object persistentDiskQuery {
+  val tableQuery = TableQuery[PersistentDiskTable]
+
+  private[db] def findByIdQuery(id: DiskId) = tableQuery.filter(_.id === id)
 
   private[db] def findActiveByNameQuery(googleProject: GoogleProject, name: DiskName) =
-    persistentDiskQuery
+    tableQuery
       .filter(_.googleProject === googleProject)
       .filter(_.name === name)
       .filter(_.destroyedDate === dummyDate)
 
   private[db] def findByNameQuery(googleProject: GoogleProject, name: DiskName) =
-    persistentDiskQuery
+    tableQuery
       .filter(_.googleProject === googleProject)
       .filter(_.name === name)
 
@@ -154,9 +156,9 @@ object persistentDiskQuery extends TableQuery(new PersistentDiskTable(_)) {
 
   def updateGalaxyDiskRestore(id: DiskId, galaxyDiskRestore: GalaxyDiskRestore): DBIO[Int] =
     findByIdQuery(id)
-      .map(x => (x.galaxyPvcId, x.cvmfsPvcId, x.usedBy))
+      .map(x => (x.galaxyPvcId, x.cvmfsPvcId, x.lastUsedBy))
       .update(
-        (Some(galaxyDiskRestore.galaxyPvcId), Some(galaxyDiskRestore.cvmfsPvcId), Some(galaxyDiskRestore.usedBy))
+        (Some(galaxyDiskRestore.galaxyPvcId), Some(galaxyDiskRestore.cvmfsPvcId), Some(galaxyDiskRestore.lastUsedBy))
       )
 
   def isUsedByGalaxy(id: DiskId)(implicit ec: ExecutionContext): DBIO[Option[Boolean]] =
@@ -168,7 +170,7 @@ object persistentDiskQuery extends TableQuery(new PersistentDiskTable(_)) {
 
   def save(disk: PersistentDisk)(implicit ec: ExecutionContext): DBIO[PersistentDisk] =
     for {
-      diskId <- (persistentDiskQuery returning persistentDiskQuery.map(_.id)) += marshalPersistentDisk(disk)
+      diskId <- (tableQuery returning tableQuery.map(_.id)) += marshalPersistentDisk(disk)
       _ <- labelQuery.saveAllForResource(diskId.value, LabelResourceType.PersistentDisk, disk.labels)
     } yield disk.copy(diskId)
 
@@ -197,6 +199,8 @@ object persistentDiskQuery extends TableQuery(new PersistentDiskTable(_)) {
     findByIdQuery(id)
       .map(d => (d.status, d.dateAccessed))
       .update((DiskStatus.Deleting, dateAccessed))
+
+  def nullifyDiskIds = persistentDiskQuery.tableQuery.map(x => (x.lastUsedBy)).update(None)
 
   def delete(id: DiskId, destroyedDate: Instant) =
     findByIdQuery(id)
@@ -289,4 +293,4 @@ object persistentDiskQuery extends TableQuery(new PersistentDiskTable(_)) {
     )
 }
 
-final case class GalaxyDiskRestore(galaxyPvcId: PvcId, cvmfsPvcId: PvcId, usedBy: AppId)
+final case class GalaxyDiskRestore(galaxyPvcId: PvcId, cvmfsPvcId: PvcId, lastUsedBy: AppId)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/RuntimeServiceDbQueries.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/RuntimeServiceDbQueries.scala
@@ -46,7 +46,7 @@ object RuntimeServiceDbQueries {
     val activeRuntime = fullClusterQueryByUniqueKey(googleProject, runtimeName, None)
       .join(runtimeConfigs)
       .on(_._1.runtimeConfigId === _.id)
-      .joinLeft(persistentDiskQuery)
+      .joinLeft(persistentDiskQuery.tableQuery)
       .on { case (a, b) => a._2.persistentDiskId.isDefined && a._2.persistentDiskId === b.id }
     activeRuntime.result.flatMap { recs =>
       val runtimeRecs = recs.map(_._1._1)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/ConfigReader.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/ConfigReader.scala
@@ -12,6 +12,8 @@ object ConfigReader {
     .loadOrThrow[AppConfig]
 }
 
+// Note: pureconfig supports reading kebab case into camel case in code by default
+// More docs see https://pureconfig.github.io/docs/index.html
 final case class AppConfig(
   terraAppSetupChart: TerraAppSetupChartConfig
 )

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/ConfigReader.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/ConfigReader.scala
@@ -1,0 +1,17 @@
+package org.broadinstitute.dsde.workbench.leonardo
+package http
+
+import pureconfig.ConfigSource
+import _root_.pureconfig.generic.auto._
+import org.broadinstitute.dsde.workbench.leonardo.ConfigImplicits._
+import org.broadinstitute.dsde.workbench.leonardo.util.TerraAppSetupChartConfig
+
+object ConfigReader {
+  val appConfig = ConfigSource
+    .fromConfig(org.broadinstitute.dsde.workbench.leonardo.config.Config.config)
+    .loadOrThrow[AppConfig]
+}
+
+final case class AppConfig(
+  terraAppSetupChart: TerraAppSetupChartConfig
+)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
@@ -398,8 +398,7 @@ class GKEInterpreter[F[_]: Parallel: ContextShift: Timer](
                 val galaxyDiskRestore = GalaxyDiskRestore(
                   PvcId(gp.getMetadata.getUid),
                   PvcId(cp.getMetadata.getUid),
-                  app.chart,
-                  app.release
+                  app.id
                 )
                 persistentDiskQuery
                   .updateGalaxyDiskRestore(diskId, galaxyDiskRestore)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
@@ -525,13 +525,13 @@ class GKEInterpreter[F[_]: Parallel: ContextShift: Timer](
       _ <- googleClusterOpt.traverse(googleCluster =>
         for {
           helmAuthContext <- getHelmAuthContext(googleCluster, dbCluster, namespaceName)
+          _ <- uninstallGalaxy(helmAuthContext, dbCluster, app.appName, app.release, namespaceName)
           _ <- helmClient
             .uninstall(
               getTerraAppSetupChartReleaseName(app.release),
               config.galaxyAppConfig.uninstallKeepHistory
             )
             .run(helmAuthContext)
-          _ <- uninstallGalaxy(helmAuthContext, dbCluster, app.appName, app.release, namespaceName)
         } yield ()
       )
 

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/TestLeoRoutes.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/TestLeoRoutes.scala
@@ -3,7 +3,6 @@ package http
 package api
 
 import java.io.ByteArrayInputStream
-
 import akka.http.scaladsl.model.HttpHeader
 import akka.http.scaladsl.model.headers.{`Set-Cookie`, HttpCookiePair}
 import akka.http.scaladsl.testkit.ScalatestRouteTest
@@ -29,6 +28,7 @@ import org.broadinstitute.dsde.workbench.leonardo.http.service.MockDiskServiceIn
 import org.broadinstitute.dsde.workbench.leonardo.util._
 import org.broadinstitute.dsde.workbench.model.UserInfo
 import org.scalactic.source.Position
+import org.scalatest.concurrent.PatienceConfiguration.Interval
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.time.{Seconds, Span}
@@ -47,7 +47,7 @@ trait TestLeoRoutes {
       .createGroup(Config.googleGroupsConfig.dataprocImageProjectGroupName,
                    Config.googleGroupsConfig.dataprocImageProjectGroupEmail,
                    Option(dao.lockedDownGroupSettings))
-      .futureValue(mockGoogleDirectoryDAOPatience, Position.here)
+      .futureValue(Interval(Span(30, Seconds)))(mockGoogleDirectoryDAOPatience, Position.here)
     dao
   }
 

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriberSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriberSpec.scala
@@ -586,7 +586,6 @@ class LeoPubsubMessageSubscriberSpec
     val leoSubscriber = makeLeoSubscriber()
 
     val res = for {
-      now <- IO(Instant.now)
       disk <- makePersistentDisk(None).copy(status = DiskStatus.Ready).save()
       tr <- traceId.ask[TraceId]
 
@@ -604,7 +603,6 @@ class LeoPubsubMessageSubscriberSpec
   it should "handle create app message with a create cluster" in isolatedDbTest {
     val savedCluster1 = makeKubeCluster(1).save()
     val savedNodepool1 = makeNodepool(1, savedCluster1.id).save()
-
     val disk = makePersistentDisk(None).save().unsafeRunSync()
     val makeApp1 = makeApp(1, savedNodepool1.id)
     val savedApp1 = makeApp1
@@ -661,7 +659,9 @@ class LeoPubsubMessageSubscriberSpec
         Some(tr)
       )
       queue <- InspectableQueue.bounded[IO, Task[IO]](10)
-      leoSubscriber = makeLeoSubscriber(asyncTaskQueue = queue)
+      lock <- nodepoolLock
+      leoSubscriber = makeLeoSubscriber(asyncTaskQueue = queue,
+                                        gkeInterpreter = makeGKEInterp(lock, List(savedApp1.release)))
       asyncTaskProcessor = AsyncTaskProcessor(AsyncTaskProcessor.Config(10, 10), queue)
       _ <- leoSubscriber.handleCreateAppMessage(msg)
       _ <- withInfiniteStream(asyncTaskProcessor.process, assertions)
@@ -755,7 +755,11 @@ class LeoPubsubMessageSubscriberSpec
         Some(tr)
       )
       queue <- InspectableQueue.bounded[IO, Task[IO]](10)
-      leoSubscriber = makeLeoSubscriber(asyncTaskQueue = queue)
+      lock <- nodepoolLock
+      leoSubscriber = makeLeoSubscriber(
+        asyncTaskQueue = queue,
+        gkeInterpreter = makeGKEInterp(lock, List(savedApp1.release, savedApp2.release))
+      )
       asyncTaskProcessor = AsyncTaskProcessor(AsyncTaskProcessor.Config(10, 10), queue)
       _ <- leoSubscriber.handleCreateAppMessage(msg1)
       _ <- leoSubscriber.handleCreateAppMessage(msg2)
@@ -1108,25 +1112,6 @@ class LeoPubsubMessageSubscriberSpec
     val savedApp1 = makeApp(1, savedNodepool1.id).save()
     val mockAckConsumer = mock[AckReplyConsumer]
 
-    val mockKubernetesService = new MockKubernetesService(PodStatus.Failed) {
-      override def deleteNamespace(
-        clusterId: GKEModels.KubernetesClusterId,
-        namespace: KubernetesModels.KubernetesNamespace
-      )(implicit ev: Ask[IO, TraceId]): IO[Unit] = IO.raiseError(new Exception("test error"))
-    }
-    val makeGKEInterp = for {
-      lock <- nodepoolLock
-    } yield new GKEInterpreter[IO](Config.gkeInterpConfig,
-                                   vpcInterp,
-                                   MockGKEService,
-                                   mockKubernetesService,
-                                   MockHelm,
-                                   MockGalaxyDAO,
-                                   credentials,
-                                   iamDAOKubernetes,
-                                   blocker,
-                                   lock)
-
     val assertions = for {
       getAppOpt <- KubernetesServiceDbQueries.getFullAppByName(savedCluster1.googleProject, savedApp1.id).transaction
       getApp = getAppOpt.get
@@ -1142,7 +1127,24 @@ class LeoPubsubMessageSubscriberSpec
       tr <- traceId.ask[TraceId]
       msg = DeleteAppMessage(savedApp1.id, savedApp1.appName, savedCluster1.googleProject, None, Some(tr))
       queue <- InspectableQueue.bounded[IO, Task[IO]](10)
-      leoSubscriber = makeLeoSubscriber(asyncTaskQueue = queue, makeGKEInterp = makeGKEInterp)
+      lock <- nodepoolLock
+      mockKubernetesService = new MockKubernetesService(PodStatus.Failed, appRelease = List(savedApp1.release)) {
+        override def deleteNamespace(
+          clusterId: GKEModels.KubernetesClusterId,
+          namespace: KubernetesModels.KubernetesNamespace
+        )(implicit ev: Ask[IO, TraceId]): IO[Unit] = IO.raiseError(new Exception("test error"))
+      }
+      gkeInter = new GKEInterpreter[IO](Config.gkeInterpConfig,
+                                        vpcInterp,
+                                        MockGKEService,
+                                        mockKubernetesService,
+                                        MockHelm,
+                                        MockGalaxyDAO,
+                                        credentials,
+                                        iamDAOKubernetes,
+                                        blocker,
+                                        lock)
+      leoSubscriber = makeLeoSubscriber(asyncTaskQueue = queue, gkeInterpreter = gkeInter)
       asyncTaskProcessor = AsyncTaskProcessor(AsyncTaskProcessor.Config(10, 10), queue)
       _ <- leoSubscriber.messageHandler(Event(msg, None, timestamp, mockAckConsumer))
       _ <- withInfiniteStream(asyncTaskProcessor.process, assertions)
@@ -1276,7 +1278,9 @@ class LeoPubsubMessageSubscriberSpec
         Some(tr)
       )
       queue <- InspectableQueue.bounded[IO, Task[IO]](10)
-      leoSubscriber = makeLeoSubscriber(asyncTaskQueue = queue)
+      lock <- nodepoolLock
+      leoSubscriber = makeLeoSubscriber(asyncTaskQueue = queue,
+                                        gkeInterpreter = makeGKEInterp(lock, List(savedApp1.release)))
       asyncTaskProcessor = AsyncTaskProcessor(AsyncTaskProcessor.Config(10, 10), queue)
       _ <- leoSubscriber.handleCreateAppMessage(msg)
       _ <- withInfiniteStream(asyncTaskProcessor.process, assertions)
@@ -1347,16 +1351,6 @@ class LeoPubsubMessageSubscriberSpec
     //we could use mockito for this functionality, but it would be overly complicated since we wish to override other functionality of the mock as well
     var deleteCalled = false
 
-    val mockKubernetesService = new MockKubernetesService(PodStatus.Succeeded) {
-      override def deleteNamespace(
-        clusterId: GKEModels.KubernetesClusterId,
-        namespace: KubernetesModels.KubernetesNamespace
-      )(implicit ev: Ask[IO, TraceId]): IO[Unit] =
-        IO {
-          deleteCalled = true
-        }
-    }
-
     val helmClient = new MockHelm {
       override def installChart(release: Release,
                                 chartName: ChartName,
@@ -1366,19 +1360,6 @@ class LeoPubsubMessageSubscriberSpec
           Kleisli.liftF(IO.raiseError(new Exception("this is an intentional test exception")))
         else Kleisli.liftF(IO.unit)
     }
-
-    val makeGKEInterp = for {
-      lock <- nodepoolLock
-    } yield new GKEInterpreter[IO](Config.gkeInterpConfig,
-                                   vpcInterp,
-                                   MockGKEService,
-                                   mockKubernetesService,
-                                   helmClient,
-                                   MockGalaxyDAO,
-                                   credentials,
-                                   iamDAOKubernetes,
-                                   blocker,
-                                   lock)
 
     val assertions = for {
       clusterOpt <- kubernetesClusterQuery.getMinimalClusterById(savedCluster1.id).transaction
@@ -1417,9 +1398,29 @@ class LeoPubsubMessageSubscriberSpec
         Some(tr)
       )
       queue <- InspectableQueue.bounded[IO, Task[IO]](10)
+      lock <- nodepoolLock
+      mockKubernetesService = new MockKubernetesService(PodStatus.Succeeded, List(savedApp1.release)) {
+        override def deleteNamespace(
+          clusterId: GKEModels.KubernetesClusterId,
+          namespace: KubernetesModels.KubernetesNamespace
+        )(implicit ev: Ask[IO, TraceId]): IO[Unit] =
+          IO {
+            deleteCalled = true
+          }
+      }
+      gkeInterp = new GKEInterpreter[IO](Config.gkeInterpConfig,
+                                         vpcInterp,
+                                         MockGKEService,
+                                         mockKubernetesService,
+                                         helmClient,
+                                         MockGalaxyDAO,
+                                         credentials,
+                                         iamDAOKubernetes,
+                                         blocker,
+                                         lock)
       leoSubscriber = makeLeoSubscriber(asyncTaskQueue = queue,
-                                        makeGKEInterp = makeGKEInterp,
-                                        diskInterp = makeDetachingDiskInterp)
+                                        diskInterp = makeDetachingDiskInterp,
+                                        gkeInterpreter = gkeInterp)
       asyncTaskProcessor = AsyncTaskProcessor(AsyncTaskProcessor.Config(10, 10), queue)
       _ <- leoSubscriber.handleCreateAppMessage(msg)
       _ <- withInfiniteStream(asyncTaskProcessor.process, assertions, maxRetry = 50)
@@ -1510,9 +1511,7 @@ class LeoPubsubMessageSubscriberSpec
         Some(tr)
       )
       queue <- InspectableQueue.bounded[IO, Task[IO]](10)
-      leoSubscriber = makeLeoSubscriber(asyncTaskQueue = queue,
-                                        makeGKEInterp = makeGKEInterp,
-                                        diskInterp = makeDetachingDiskInterp)
+      leoSubscriber = makeLeoSubscriber(asyncTaskQueue = queue, diskInterp = makeDetachingDiskInterp)
       asyncTaskProcessor = AsyncTaskProcessor(AsyncTaskProcessor.Config(10, 10), queue)
       _ <- leoSubscriber.handleCreateAppMessage(msg)
       _ <- withInfiniteStream(asyncTaskProcessor.process, assertions, maxRetry = 50)
@@ -1543,19 +1542,6 @@ class LeoPubsubMessageSubscriberSpec
       ): IO[Option[com.google.api.services.container.model.Operation]] = IO.raiseError(new Exception("test exception"))
     }
 
-    val makeGKEInterp = for {
-      lock <- nodepoolLock
-    } yield new GKEInterpreter[IO](Config.gkeInterpConfig,
-                                   vpcInterp,
-                                   mockGKEService,
-                                   new MockKubernetesService(PodStatus.Succeeded),
-                                   MockHelm,
-                                   MockGalaxyDAO,
-                                   credentials,
-                                   iamDAO,
-                                   blocker,
-                                   lock)
-
     val assertions = for {
       clusterOpt <- kubernetesClusterQuery.getMinimalClusterById(savedCluster1.id, true).transaction
       getCluster = clusterOpt.get
@@ -1585,7 +1571,18 @@ class LeoPubsubMessageSubscriberSpec
         Some(tr)
       )
       queue <- InspectableQueue.bounded[IO, Task[IO]](10)
-      leoSubscriber = makeLeoSubscriber(asyncTaskQueue = queue, makeGKEInterp = makeGKEInterp)
+      lock <- nodepoolLock
+      gkeInterp = new GKEInterpreter[IO](Config.gkeInterpConfig,
+                                         vpcInterp,
+                                         mockGKEService,
+                                         new MockKubernetesService(PodStatus.Succeeded),
+                                         MockHelm,
+                                         MockGalaxyDAO,
+                                         credentials,
+                                         iamDAO,
+                                         blocker,
+                                         lock)
+      leoSubscriber = makeLeoSubscriber(asyncTaskQueue = queue, gkeInterpreter = gkeInterp)
       _ <- leoSubscriber.messageHandler(Event(msg, None, timestamp, mockAckConsumer))
     } yield ()
 
@@ -1711,7 +1708,9 @@ class LeoPubsubMessageSubscriberSpec
         Some(tr)
       )
       queue <- InspectableQueue.bounded[IO, Task[IO]](10)
-      leoSubscriber = makeLeoSubscriber(asyncTaskQueue = queue)
+      lock <- nodepoolLock
+      leoSubscriber = makeLeoSubscriber(asyncTaskQueue = queue,
+                                        gkeInterpreter = makeGKEInterp(lock, List(savedApp1.release)))
       asyncTaskProcessor = AsyncTaskProcessor(AsyncTaskProcessor.Config(10, 10), queue)
       // send message twice
       _ <- leoSubscriber.handleCreateAppMessage(msg)
@@ -1791,26 +1790,26 @@ class LeoPubsubMessageSubscriberSpec
     res.unsafeRunSync()
   }
 
-  def makeGKEInterp(): IO[GKEInterpreter[IO]] =
-    for {
-      lock <- nodepoolLock
-    } yield new GKEInterpreter[IO](Config.gkeInterpConfig,
-                                   vpcInterp,
-                                   MockGKEService,
-                                   new MockKubernetesService(PodStatus.Succeeded),
-                                   MockHelm,
-                                   MockGalaxyDAO,
-                                   credentials,
-                                   iamDAOKubernetes,
-                                   blocker,
-                                   lock)
+  def makeGKEInterp(lock: KeyLock[IO, GKEModels.KubernetesClusterId],
+                    appRelease: List[Release] = List.empty): GKEInterpreter[IO] =
+    new GKEInterpreter[IO](Config.gkeInterpConfig,
+                           vpcInterp,
+                           MockGKEService,
+                           new MockKubernetesService(PodStatus.Succeeded, appRelease = appRelease),
+                           MockHelm,
+                           MockGalaxyDAO,
+                           credentials,
+                           iamDAOKubernetes,
+                           blocker,
+                           lock)
 
-  def makeLeoSubscriber(runtimeMonitor: RuntimeMonitor[IO, CloudService] = MockRuntimeMonitor,
-                        asyncTaskQueue: InspectableQueue[IO, Task[IO]] =
-                          InspectableQueue.bounded[IO, Task[IO]](10).unsafeRunSync,
-                        computePollOperation: ComputePollOperation[IO] = new MockComputePollOperation,
-                        makeGKEInterp: IO[GKEInterpreter[IO]] = makeGKEInterp,
-                        diskInterp: GoogleDiskService[IO] = MockGoogleDiskService): LeoPubsubMessageSubscriber[IO] = {
+  def makeLeoSubscriber(
+    runtimeMonitor: RuntimeMonitor[IO, CloudService] = MockRuntimeMonitor,
+    asyncTaskQueue: InspectableQueue[IO, Task[IO]] = InspectableQueue.bounded[IO, Task[IO]](10).unsafeRunSync,
+    computePollOperation: ComputePollOperation[IO] = new MockComputePollOperation,
+    gkeInterpreter: GKEInterpreter[IO] = makeGKEInterp(nodepoolLock.unsafeRunSync(), appRelease = List.empty),
+    diskInterp: GoogleDiskService[IO] = MockGoogleDiskService
+  ): LeoPubsubMessageSubscriber[IO] = {
     val googleSubscriber = new FakeGoogleSubcriber[LeoPubsubMessage]
 
     implicit val monitor: RuntimeMonitor[IO, CloudService] = runtimeMonitor
@@ -1824,7 +1823,7 @@ class LeoPubsubMessageSubscriberSpec
       diskInterp,
       computePollOperation,
       MockAuthProvider,
-      makeGKEInterp.unsafeRunSync(),
+      gkeInterpreter,
       org.broadinstitute.dsde.workbench.errorReporting.FakeErrorReporting
     )
   }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriberSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriberSpec.scala
@@ -623,6 +623,7 @@ class LeoPubsubMessageSubscriberSpec
       getApp = getAppOpt.get
       getDiskOpt <- persistentDiskQuery.getById(savedApp1.appResources.disk.get.id).transaction
       getDisk = getDiskOpt.get
+      galaxyRestore <- persistentDiskQuery.getGalaxyDiskRestore(savedApp1.appResources.disk.get.id).transaction
     } yield {
       getCluster.status shouldBe KubernetesClusterStatus.Running
       getCluster.nodepools.size shouldBe 2
@@ -642,6 +643,9 @@ class LeoPubsubMessageSubscriberSpec
                                                    Config.vpcConfig.subnetworkIpRange))
       )
       getDisk.status shouldBe DiskStatus.Ready
+      galaxyRestore shouldBe Some(
+        GalaxyDiskRestore(PvcId(s"nfs-pvc-id1"), PvcId("cvmfs-pvc-id1"), getApp.app.chart, getApp.app.release)
+      )
     }
 
     val res = for {

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriberSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriberSpec.scala
@@ -644,7 +644,7 @@ class LeoPubsubMessageSubscriberSpec
       )
       getDisk.status shouldBe DiskStatus.Ready
       galaxyRestore shouldBe Some(
-        GalaxyDiskRestore(PvcId(s"nfs-pvc-id1"), PvcId("cvmfs-pvc-id1"), getApp.app.chart, getApp.app.release)
+        GalaxyDiskRestore(PvcId(s"nfs-pvc-id1"), PvcId("cvmfs-pvc-id1"), getApp.app.id)
       )
     }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -15,7 +15,7 @@ object Dependencies {
   val monocleV = "2.1.0"
   val opencensusV = "0.28.3"
 
-  private val workbenchLibsHash = "b9a4c640-SNAP"
+  private val workbenchLibsHash = "3889a04"
   val serviceTestV = s"0.18-$workbenchLibsHash"
   val workbenchModelV = s"0.14-$workbenchLibsHash"
   val workbenchGoogleV = s"0.21-$workbenchLibsHash"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,7 +8,7 @@ object Dependencies {
   val googleV = "1.23.0"
   val automationGoogleV = "1.30.5"
   val scalaLoggingV = "3.9.2"
-  val scalaTestV = "3.2.3"
+  val scalaTestV = "3.2.4"
   val slickV = "3.3.3"
   val http4sVersion = "0.21.15"
   val guavaV = "30.1-jre"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -129,6 +129,9 @@ object Dependencies {
     "net.logstash.logback" % "logstash-logback-encoder" % "6.6", // for structured logging in logback
     "com.github.julien-truffaut" %%  "monocle-core"  % monocleV,
     "com.github.julien-truffaut" %%  "monocle-macro" % monocleV,
+    // using provided because `http` depends on `core`, and `http`'s `opencensus-exporter-trace-stackdriver`
+    // brings in an older version of `pureconfig`
+    "com.github.pureconfig" %% "pureconfig" % "0.14.0" % Provided,
     sealerate,
     enumeratum,
     http4sCirce,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -15,13 +15,13 @@ object Dependencies {
   val monocleV = "2.1.0"
   val opencensusV = "0.28.3"
 
-  private val workbenchLibsHash = "ca18699"
-  val serviceTestV = s"0.18-${workbenchLibsHash}"
-  val workbenchModelV = s"0.14-${workbenchLibsHash}"
-  val workbenchGoogleV = s"0.21-${workbenchLibsHash}"
-  val workbenchGoogle2V = s"0.19-${workbenchLibsHash}"
-  val workbenchOpenTelemetryV = s"0.1-${workbenchLibsHash}"
-  val workbenchErrorReportingV = s"0.1-${workbenchLibsHash}"
+  private val workbenchLibsHash = "b9a4c640-SNAP"
+  val serviceTestV = s"0.18-$workbenchLibsHash"
+  val workbenchModelV = s"0.14-$workbenchLibsHash"
+  val workbenchGoogleV = s"0.21-$workbenchLibsHash"
+  val workbenchGoogle2V = s"0.19-$workbenchLibsHash"
+  val workbenchOpenTelemetryV = s"0.1-$workbenchLibsHash"
+  val workbenchErrorReportingV = s"0.1-$workbenchLibsHash"
 
   val helmScalaSdkV = "0.0.1-RC4"
 


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-2397
https://broadworkbench.atlassian.net/browse/IA-2533

Automation test failed becuz https://github.com/broadinstitute/firecloud-develop/pull/2426 needs to be merged

* use set up chart
* Persist pvc ids


Validated persisting pvc part working properly in fiab
```
qi@cloudshell:~ (qi-billing-2)$ kubectl get pvc -n ya8b8r-gxy-ns ya8b8r-gxy-rls-galaxy-pvc -o=jsonpath='{.metadata.uid}'
7d5ab7f8-5b75-422d-b4f5-0ee1b93a404e
qi@cloudshell:~ (qi-billing-2)$ kubectl get pvc -n ya8b8r-gxy-ns ya8b8r-gxy-rls-cvmfs-alien-cache-pvc -o=jsonpath='{.metadata.uid}'
939ec32a-6e8e-4a63-b6b5-a6802412bb9f
qi@cloudshell:~ (qi-billing-2)$
```
and this is what's in leo db

```
| id | nodepoolId | appType | appName | status  | samResourceId                        | creator                           | createdDate                | destroyedDate              | dateAccessed               | namespaceId | diskId | customEnvironmentVariables | googleServiceAccount                                               | kubernetesServiceAccount | chart                      | release        | galaxyPvcId                          | cvmfsPvcId                           |
+----+------------+---------+---------+---------+--------------------------------------+-----------------------------------+----------------------------+----------------------------+----------------------------+-------------+--------+----------------------------+--------------------------------------------------------------------+--------------------------+----------------------------+----------------+--------------------------------------+--------------------------------------+
|  1 |          4 | GALAXY  | pvc-0   | RUNNING | 5ca2d63e-59fb-4979-b7b7-10b905a75f5d | hermione.owner@test.firecloud.org | 2021-02-18 17:24:54.945000 | 1970-01-01 00:00:01.000000 | 2021-02-18 17:24:54.945000 |           1 |      1 | NULL                       | b153pet-110530393451290928813@qi-billing-2.iam.gserviceaccount.com | gxy-ksa                  | galaxy/galaxykubeman-0.7.2 | ya8b8r-gxy-rls | 7d5ab7f8-5b75-422d-b4f5-0ee1b93a404e | 939ec32a-6e8e-4a63-b6b5-a6802412bb9f |
```


TODO:
* Move pvc ids to PD table
* Add `lastUsedBy` in PD table
* 
---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
