### PR TITLE
[IA-2540] Bump GKE to supported version

### DIFF
--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -188,8 +188,8 @@ gke {
                           "69.173.112.0/21"
     ]
     # See https://cloud.google.com/kubernetes-engine/docs/release-notes
-    # As of 2020-10-09, 1.16.x is the default but it does not work with the Galaxy chart.
-    version = "1.16.15-gke.6000"
+    # As of 2021-02-22, 1.17.x is the default but the Galaxy chart expects 1.16.x.
+    version = "1.16.15-gke.11800"
     nodepoolLockCacheExpiryTime = 1 hour
     nodepoolLockCacheMaxSize = 200
   }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/config/ConfigSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/config/ConfigSpec.scala
@@ -82,7 +82,7 @@ final class ConfigSpec extends AnyFlatSpec with Matchers {
         "69.173.127.240/28",
         "69.173.112.0/21"
       ).map(CidrIP),
-      KubernetesClusterVersion("1.16.15-gke.6000"),
+      KubernetesClusterVersion("1.16.15-gke.11800"),
       1 hour,
       200
     )


### PR DESCRIPTION
Unfortunately auto-tests started failing with:
```
{
  "code" : 400,
  "errors" : [ {
    "domain" : "global",
    "message" : "Master version \"1.16.15-gke.6000\" is unsupported.",
    "reason" : "badRequest"
  } ],
  "message" : "Master version \"1.16.15-gke.6000\" is unsupported.",
  "status" : "INVALID_ARGUMENT"
}
```

This has happened before, would be nice to get notified from GCP about these changes..

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
