### PR TITLE
IA-2052 IA-2535 Support galaxy restore data from disk 

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoSuite.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoSuite.scala
@@ -145,7 +145,7 @@ trait GPAllocBeforeAndAfterAll extends GPAllocUtils with BeforeAndAfterAll {
           .createRuntimeWithWait(
             project,
             initalRuntimeName,
-            LeonardoApiClient.defaultCreateDataprocRuntimeRequest
+            LeonardoApiClient.defaultCreateRuntime2Request
           )
           .attempt
         _ <- res match {

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
@@ -708,7 +708,7 @@ trait LeonardoTestUtils
   def noop[A](x: A): Unit = ()
 
   def randomAppName: AppName = AppName(s"automation-test-app-a${makeRandomId().toLowerCase}z")
-  def randomDiskName: DiskName = DiskName(s"automation-test-disk-a${makeRandomId().toLowerCase}z")
+  def randomDiskName(): DiskName = DiskName(s"automation-test-disk-a${makeRandomId().toLowerCase}z")
 
   def appDeleted(appName: AppName): DoneCheckable[List[ListAppResponse]] =
     x => x.filter(_.appName == appName).map(_.status).distinct == List(AppStatus.Deleted)

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/BatchNodepoolCreationSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/BatchNodepoolCreationSpec.scala
@@ -63,10 +63,10 @@ class BatchNodepoolCreationSpec
 
           // Create 2 apps in the pre-created nodepools
           createAppRequest1 = defaultCreateAppRequest.copy(diskConfig =
-            Some(PersistentDiskRequest(randomDiskName, None, None, Map.empty))
+            Some(PersistentDiskRequest(randomDiskName(), None, None, Map.empty))
           )
           createAppRequest2 = defaultCreateAppRequest.copy(diskConfig =
-            Some(PersistentDiskRequest(randomDiskName, None, None, Map.empty))
+            Some(PersistentDiskRequest(randomDiskName(), None, None, Map.empty))
           )
           _ <- loggerIO.info(s"BatchNodepoolCreationSpec: About to create app ${googleProject.value}/${appName1.value}")
           _ <- LeonardoApiClient.createApp(googleProject, appName1, createAppRequest1)

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/JsonCodec.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/JsonCodec.scala
@@ -31,6 +31,8 @@ import org.broadinstitute.dsde.workbench.model.google.{
   GoogleProject
 }
 import org.http4s.Uri
+import org.broadinstitute.dsde.workbench.google2.JsonCodec.traceIdEncoder
+import org.broadinstitute.dsde.workbench.google2.JsonCodec.traceIdDecoder
 
 object JsonCodec {
   // Errors
@@ -155,7 +157,7 @@ object JsonCodec {
   implicit val errorSourceEncoder: Encoder[ErrorSource] = Encoder.encodeString.contramap(_.toString)
   implicit val errorActionEncoder: Encoder[ErrorAction] = Encoder.encodeString.contramap(_.toString)
   implicit val kubernetesErrorEncoder: Encoder[AppError] =
-    Encoder.forProduct5("errorMessage", "timestamp", "action", "source", "googleErrorCode")(x =>
+    Encoder.forProduct6("errorMessage", "timestamp", "action", "source", "googleErrorCode", "traceId")(x =>
       AppError.unapply(x).get
     )
   implicit val nodepoolIdEncoder: Encoder[NodepoolLeoId] = Encoder.encodeLong.contramap(_.id)
@@ -362,7 +364,7 @@ object JsonCodec {
   implicit val errorActionDecoder: Decoder[ErrorAction] =
     Decoder.decodeString.emap(s => ErrorAction.stringToObject.get(s).toRight(s"Invalid error action ${s}"))
   implicit val kubernetesErrorDecoder: Decoder[AppError] =
-    Decoder.forProduct5("errorMessage", "timestamp", "action", "source", "googleErrorCode")(AppError.apply)
+    Decoder.forProduct6("errorMessage", "timestamp", "action", "source", "googleErrorCode", "traceId")(AppError.apply)
 
   implicit val nodepoolIdDecoder: Decoder[NodepoolLeoId] = Decoder.decodeLong.map(NodepoolLeoId)
   implicit val nodepoolNameDecoder: Decoder[NodepoolName] =

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/diskModels.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/diskModels.scala
@@ -18,6 +18,7 @@ final case class PersistentDisk(id: DiskId,
                                 diskType: DiskType,
                                 blockSize: BlockSize,
                                 formattedBy: Option[FormattedBy],
+                                galaxyRestore: Option[GalaxyRestore],
                                 labels: LabelMap) {
   def projectNameString: String = s"${googleProject.value}/${name.value}"
 }
@@ -109,3 +110,7 @@ object FormattedBy extends Enum[FormattedBy] {
     override def asString: String = "CUSTOM"
   }
 }
+
+final case class PvcId(asString: String) extends AnyVal
+// information needed for restoring a galaxy app
+final case class GalaxyRestore(galaxyPvcId: PvcId, cvmfsPvcId: PvcId, lastUsedBy: AppId)

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/kubernetesModels.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/kubernetesModels.scala
@@ -3,7 +3,6 @@ package org.broadinstitute.dsde.workbench.leonardo
 import java.net.URL
 import java.time.Instant
 import java.util.UUID
-
 import ca.mrvisser.sealerate
 import org.broadinstitute.dsde.workbench.google2.GKEModels.{KubernetesClusterId, KubernetesClusterName, NodepoolName}
 import org.broadinstitute.dsde.workbench.google2.KubernetesSerializableName.{
@@ -19,7 +18,7 @@ import org.broadinstitute.dsde.workbench.google2.{
   RegionName,
   SubnetworkName
 }
-import org.broadinstitute.dsde.workbench.model.{IP, WorkbenchEmail}
+import org.broadinstitute.dsde.workbench.model.{IP, TraceId, WorkbenchEmail}
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.broadinstitute.dsp.{ChartName, ChartVersion, Release}
 import org.http4s.Uri
@@ -270,7 +269,8 @@ final case class AppError(errorMessage: String,
                           timestamp: Instant,
                           action: ErrorAction,
                           source: ErrorSource,
-                          googleErrorCode: Option[Int])
+                          googleErrorCode: Option[Int],
+                          traceId: Option[TraceId] = None)
 
 final case class KubernetesErrorId(value: Long) extends AnyVal
 

--- a/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestSuite.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestSuite.scala
@@ -33,7 +33,7 @@ trait LeonardoTestSuite extends Matchers {
       val signal = Stream.unfoldEval(accumulator) { acc =>
         if (acc.maxRetry < 0)
           signalToStop
-            .complete(Assertions.fail(s"time out after retries", acc.throwable.orNull))
+            .complete(Assertions.fail(s"time out after ${maxRetry} retries", acc.throwable.orNull))
             .as(None)
         else
           testTimer.sleep(1 seconds) >> validations.attempt.flatMap {

--- a/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changelog.xml
+++ b/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changelog.xml
@@ -70,4 +70,5 @@
     <include file="changesets/20210122_remove_stop_after_creation.xml" relativeToChangelogFile="true" />
     <include file="changesets/20210217_add_app_pvc_id.xml" relativeToChangelogFile="true" />
     <include file="changesets/20210203_custom_app.xml" relativeToChangelogFile="true" />
+    <include file="changesets/20210224_drop_release_uniq_constraint.xml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/20210224_drop_release_uniq_constraint.xml
+++ b/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/20210224_drop_release_uniq_constraint.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog logicalFilePath="leonardo" xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+
+    <changeSet logicalFilePath="leonardo" author="qi" id="drop_release_uniq_constraint">
+        <dropUniqueConstraint tableName="APP"
+                              constraintName="IDX_APP_RELEASE_UNIQUE"
+                              uniqueColumns="release"/>
+    </changeSet>
+
+</databaseChangeLog>

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -225,7 +225,7 @@ gke {
     # to be unique within a cluster.
     releaseNameSuffix = "gxy-rls"
     chartName = "galaxy/galaxykubeman"
-    chartVersion = "0.7.3"
+    chartVersion = "0.8.0"
     namespaceNameSuffix = "gxy-ns"
     serviceAccountName = "gxy-ksa"
     # Setting uninstallKeepHistory will cause the `helm uninstall` command to keep a record of

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
@@ -27,7 +27,7 @@ import org.broadinstitute.dsde.workbench.leonardo.CustomImage.{DataprocCustomIma
 import org.broadinstitute.dsde.workbench.leonardo.auth.SamAuthProviderConfig
 import org.broadinstitute.dsde.workbench.leonardo.config.ContentSecurityPolicyComponent._
 import org.broadinstitute.dsde.workbench.leonardo.dao.HttpSamDaoConfig
-import org.broadinstitute.dsde.workbench.leonardo.http.service.LeoKubernetesServiceInterp.LeoKubernetesConfig
+import org.broadinstitute.dsde.workbench.leonardo.http.service.LeoAppServiceInterp.LeoKubernetesConfig
 import org.broadinstitute.dsde.workbench.leonardo.model.ServiceAccountProviderConfig
 import org.broadinstitute.dsde.workbench.leonardo.monitor.MonitorConfig.{DataprocMonitorConfig, GceMonitorConfig}
 import org.broadinstitute.dsde.workbench.leonardo.monitor.{

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/KubernetesClusterComponent.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/KubernetesClusterComponent.scala
@@ -246,5 +246,3 @@ case class SaveKubernetesCluster(googleProject: GoogleProject,
       None
     )
 }
-
-final case class PvcId(asString: String) extends AnyVal

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/Boot.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/Boot.scala
@@ -53,7 +53,7 @@ import org.broadinstitute.dsde.workbench.leonardo.dao.google.GoogleOAuth2Service
 import org.broadinstitute.dsde.workbench.leonardo.db.DbReference
 import org.broadinstitute.dsde.workbench.leonardo.dns.{KubernetesDnsCache, RuntimeDnsCache}
 import org.broadinstitute.dsde.workbench.leonardo.http.api.{HttpRoutes, StandardUserInfoDirectives}
-import org.broadinstitute.dsde.workbench.leonardo.http.service.{LeoKubernetesServiceInterp, DiskServiceInterp, _}
+import org.broadinstitute.dsde.workbench.leonardo.http.service.{LeoAppServiceInterp, DiskServiceInterp, _}
 import org.broadinstitute.dsde.workbench.leonardo.model.ServiceAccountProvider
 import org.broadinstitute.dsde.workbench.leonardo.monitor.LeoPubsubCodec._
 import org.broadinstitute.dsde.workbench.leonardo.monitor.NonLeoMessageSubscriber.nonLeoMessageDecoder
@@ -167,11 +167,11 @@ object Boot extends IOApp {
         appDependencies.publisherQueue
       )
 
-      val leoKubernetesService: LeoKubernetesServiceInterp[IO] =
-        new LeoKubernetesServiceInterp(appDependencies.authProvider,
-                                       appDependencies.serviceAccountProvider,
-                                       leoKubernetesConfig,
-                                       appDependencies.publisherQueue)
+      val leoKubernetesService: LeoAppServiceInterp[IO] =
+        new LeoAppServiceInterp(appDependencies.authProvider,
+                                appDependencies.serviceAccountProvider,
+                                leoKubernetesConfig,
+                                appDependencies.publisherQueue)
 
       val httpRoutes = new HttpRoutes(
         swaggerConfig,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/AppRoutes.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/AppRoutes.scala
@@ -14,13 +14,13 @@ import io.opencensus.scala.akka.http.TracingDirective.traceRequestForService
 import org.broadinstitute.dsde.workbench.google2.KubernetesSerializableName.ServiceName
 import org.broadinstitute.dsde.workbench.leonardo.JsonCodec._
 import org.broadinstitute.dsde.workbench.leonardo.http.api.AppRoutes._
-import org.broadinstitute.dsde.workbench.leonardo.http.service.KubernetesService
+import org.broadinstitute.dsde.workbench.leonardo.http.service.AppService
 import org.broadinstitute.dsde.workbench.model.UserInfo
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.broadinstitute.dsde.workbench.openTelemetry.OpenTelemetryMetrics
 import org.http4s.Uri
 
-class AppRoutes(kubernetesService: KubernetesService[IO], userInfoDirectives: UserInfoDirectives)(
+class AppRoutes(kubernetesService: AppService[IO], userInfoDirectives: UserInfoDirectives)(
   implicit metrics: OpenTelemetryMetrics[IO]
 ) {
   val routes: server.Route = traceRequestForService(serviceData) { span =>
@@ -195,7 +195,8 @@ class AppRoutes(kubernetesService: KubernetesService[IO], userInfoDirectives: Us
       apiCall = kubernetesService.deleteApp(
         deleteParams
       )
-      _ <- metrics.incrementCounter("deleteApp")
+      tags = Map("deleteDisk" -> deleteDisk.toString)
+      _ <- metrics.incrementCounter("deleteApp", 1, tags)
       _ <- ctx.span.fold(apiCall)(span => spanResource[IO](span, "deleteApp").use(_ => apiCall))
     } yield StatusCodes.Accepted
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/HttpRoutes.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/HttpRoutes.scala
@@ -15,8 +15,8 @@ import com.typesafe.scalalogging.LazyLogging
 import io.circe.Encoder
 import org.broadinstitute.dsde.workbench.leonardo.config.{RefererConfig, SwaggerConfig}
 import org.broadinstitute.dsde.workbench.leonardo.http.service.{
+  AppService,
   DiskService,
-  KubernetesService,
   ProxyService,
   RuntimeService,
   StatusService
@@ -36,7 +36,7 @@ class HttpRoutes(
   proxyService: ProxyService,
   runtimeService: RuntimeService[IO],
   diskService: DiskService[IO],
-  kubernetesService: KubernetesService[IO],
+  kubernetesService: AppService[IO],
   userInfoDirectives: UserInfoDirectives,
   contentSecurityPolicy: String,
   refererConfig: RefererConfig

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/package.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/package.scala
@@ -28,6 +28,7 @@ import slick.dbio.DBIO
 package object http {
   val includeDeletedKey = "includeDeleted"
   val bucketPathMaxLength = 1024
+  val WORKSPACE_NAME_KEY = "WORKSPACE_NAME"
 
   implicit val errorReportSource = ErrorReportSource("leonardo")
   implicit def dbioToIO[A](dbio: DBIO[A]): DBIOOps[A] = new DBIOOps(dbio)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/AppService.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/AppService.scala
@@ -6,7 +6,7 @@ import org.broadinstitute.dsde.workbench.leonardo.{AppContext, AppName}
 import org.broadinstitute.dsde.workbench.model.UserInfo
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 
-trait KubernetesService[F[_]] {
+trait AppService[F[_]] {
   def batchNodepoolCreate(userInfo: UserInfo, googleProject: GoogleProject, req: BatchNodepoolCreateRequest)(
     implicit ev: Ask[F, AppContext]
   ): F[Unit]

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/DiskServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/DiskServiceInterp.scala
@@ -264,6 +264,7 @@ object DiskServiceInterp {
       req.diskType.getOrElse(config.defaultDiskType),
       req.blockSize.getOrElse(config.defaultBlockSizeBytes),
       None,
+      None,
       labels
     )
   }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeoException.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeoException.scala
@@ -21,6 +21,9 @@ class LeoException(val message: String = null,
     ErrorReport(Option(getMessage).getOrElse(""), Some(statusCode), Seq(), Seq(), Some(this.getClass), traceId)
 }
 
+final case class BadRequestException(msg: String, traceId: Option[TraceId])
+    extends LeoException(msg, StatusCodes.BadRequest, traceId = traceId)
+
 final case class AuthenticationError(email: Option[WorkbenchEmail] = None)
     extends LeoException(s"${email.map(e => s"'${e.value}'").getOrElse("Your account")} is not authenticated",
                          StatusCodes.Unauthorized,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
@@ -734,7 +734,12 @@ class LeoPubsubMessageSubscriber[F[_]: Timer: ContextShift: Parallel](
               .adaptError {
                 case e =>
                   PubsubKubernetesError(
-                    AppError(e.getMessage, ctx.now, ErrorAction.CreateApp, ErrorSource.Cluster, None),
+                    AppError(e.getMessage,
+                             ctx.now,
+                             ErrorAction.CreateApp,
+                             ErrorSource.Cluster,
+                             None,
+                             Some(ctx.traceId)),
                     Some(msg.appId),
                     false,
                     // We leave cluster id and default nodepool id as none here because we want the status to stay as DELETED and not transition to ERROR.
@@ -750,7 +755,12 @@ class LeoPubsubMessageSubscriber[F[_]: Timer: ContextShift: Parallel](
                 .adaptError {
                   case e =>
                     PubsubKubernetesError(
-                      AppError(e.getMessage, ctx.now, ErrorAction.CreateApp, ErrorSource.Cluster, None),
+                      AppError(e.getMessage,
+                               ctx.now,
+                               ErrorAction.CreateApp,
+                               ErrorSource.Cluster,
+                               None,
+                               Some(ctx.traceId)),
                       Some(msg.appId),
                       false,
                       // We leave cluster id and default nodepool id as none here because we want the status to stay as DELETED and not transition to ERROR.
@@ -770,7 +780,12 @@ class LeoPubsubMessageSubscriber[F[_]: Timer: ContextShift: Parallel](
               .adaptError {
                 case e =>
                   PubsubKubernetesError(
-                    AppError(e.getMessage, ctx.now, ErrorAction.CreateApp, ErrorSource.Nodepool, None),
+                    AppError(e.getMessage,
+                             ctx.now,
+                             ErrorAction.CreateApp,
+                             ErrorSource.Nodepool,
+                             None,
+                             Some(ctx.traceId)),
                     Some(msg.appId),
                     false,
                     Some(nodepoolId),
@@ -787,7 +802,7 @@ class LeoPubsubMessageSubscriber[F[_]: Timer: ContextShift: Parallel](
           createDiskForApp(diskId).adaptError {
             case e =>
               PubsubKubernetesError(
-                AppError(e.getMessage, ctx.now, ErrorAction.CreateApp, ErrorSource.Disk, None),
+                AppError(e.getMessage, ctx.now, ErrorAction.CreateApp, ErrorSource.Disk, None, Some(ctx.traceId)),
                 Some(msg.appId),
                 false,
                 None,
@@ -803,7 +818,7 @@ class LeoPubsubMessageSubscriber[F[_]: Timer: ContextShift: Parallel](
           .adaptError {
             case e =>
               PubsubKubernetesError(
-                AppError(e.getMessage, ctx.now, ErrorAction.CreateApp, ErrorSource.Disk, None),
+                AppError(e.getMessage, ctx.now, ErrorAction.CreateApp, ErrorSource.Disk, None, Some(ctx.traceId)),
                 Some(msg.appId),
                 false,
                 None,
@@ -828,7 +843,7 @@ class LeoPubsubMessageSubscriber[F[_]: Timer: ContextShift: Parallel](
           .adaptError {
             case e =>
               PubsubKubernetesError(
-                AppError(e.getMessage, ctx.now, ErrorAction.CreateApp, ErrorSource.App, None),
+                AppError(e.getMessage, ctx.now, ErrorAction.CreateApp, ErrorSource.App, None, Some(ctx.traceId)),
                 Some(msg.appId),
                 false,
                 None,
@@ -856,7 +871,7 @@ class LeoPubsubMessageSubscriber[F[_]: Timer: ContextShift: Parallel](
         .adaptError {
           case e =>
             PubsubKubernetesError(
-              AppError(e.getMessage, ctx.now, ErrorAction.CreateApp, ErrorSource.Cluster, None),
+              AppError(e.getMessage, ctx.now, ErrorAction.CreateApp, ErrorSource.Cluster, None, Some(ctx.traceId)),
               None,
               false,
               None,
@@ -871,7 +886,7 @@ class LeoPubsubMessageSubscriber[F[_]: Timer: ContextShift: Parallel](
           .adaptError {
             case e =>
               PubsubKubernetesError(
-                AppError(e.getMessage, ctx.now, ErrorAction.CreateApp, ErrorSource.Cluster, None),
+                AppError(e.getMessage, ctx.now, ErrorAction.CreateApp, ErrorSource.Cluster, None, Some(ctx.traceId)),
                 None,
                 false,
                 None,
@@ -905,7 +920,7 @@ class LeoPubsubMessageSubscriber[F[_]: Timer: ContextShift: Parallel](
           .adaptError {
             case e =>
               PubsubKubernetesError(
-                AppError(e.getMessage, ctx.now, ErrorAction.DeleteApp, ErrorSource.App, None),
+                AppError(e.getMessage, ctx.now, ErrorAction.DeleteApp, ErrorSource.App, None, Some(ctx.traceId)),
                 Some(msg.appId),
                 false,
                 None,
@@ -942,7 +957,7 @@ class LeoPubsubMessageSubscriber[F[_]: Timer: ContextShift: Parallel](
                 ).adaptError {
                   case e =>
                     PubsubKubernetesError(
-                      AppError(e.getMessage, ctx.now, ErrorAction.DeleteApp, ErrorSource.Disk, None),
+                      AppError(e.getMessage, ctx.now, ErrorAction.DeleteApp, ErrorSource.Disk, None, Some(ctx.traceId)),
                       Some(msg.appId),
                       false,
                       None,
@@ -954,7 +969,7 @@ class LeoPubsubMessageSubscriber[F[_]: Timer: ContextShift: Parallel](
             deleteDataDisk = deleteDisk(diskId, true).adaptError {
               case e =>
                 PubsubKubernetesError(
-                  AppError(e.getMessage, ctx.now, ErrorAction.DeleteApp, ErrorSource.Disk, None),
+                  AppError(e.getMessage, ctx.now, ErrorAction.DeleteApp, ErrorSource.Disk, None, Some(ctx.traceId)),
                   Some(msg.appId),
                   false,
                   None,
@@ -970,7 +985,12 @@ class LeoPubsubMessageSubscriber[F[_]: Timer: ContextShift: Parallel](
                 .adaptError {
                   case e =>
                     PubsubKubernetesError(
-                      AppError(e.getMessage, ctx.now, ErrorAction.DeleteApp, ErrorSource.PostgresDisk, None),
+                      AppError(e.getMessage,
+                               ctx.now,
+                               ErrorAction.DeleteApp,
+                               ErrorSource.PostgresDisk,
+                               None,
+                               Some(ctx.traceId)),
                       Some(msg.appId),
                       false,
                       None,
@@ -1063,7 +1083,7 @@ class LeoPubsubMessageSubscriber[F[_]: Timer: ContextShift: Parallel](
         .adaptError {
           case e =>
             PubsubKubernetesError(
-              AppError(e.getMessage, ctx.now, ErrorAction.StopApp, ErrorSource.App, None),
+              AppError(e.getMessage, ctx.now, ErrorAction.StopApp, ErrorSource.App, None, Some(ctx.traceId)),
               Some(msg.appId),
               false,
               None,
@@ -1084,7 +1104,7 @@ class LeoPubsubMessageSubscriber[F[_]: Timer: ContextShift: Parallel](
         .adaptError {
           case e =>
             PubsubKubernetesError(
-              AppError(e.getMessage, ctx.now, ErrorAction.StartApp, ErrorSource.App, None),
+              AppError(e.getMessage, ctx.now, ErrorAction.StartApp, ErrorSource.App, None, Some(ctx.traceId)),
               Some(msg.appId),
               false,
               None,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
@@ -3,7 +3,6 @@ package leonardo
 package util
 
 import java.util.Base64
-
 import _root_.io.chrisdavenport.log4cats.StructuredLogger
 import cats.Parallel
 import cats.effect.{Async, Blocker, ConcurrentEffect, ContextShift, IO, Timer}
@@ -29,6 +28,7 @@ import org.broadinstitute.dsde.workbench.google2.{
   tracedRetryGoogleF,
   DiskName,
   KubernetesClusterNotFoundException,
+  PvName,
   ZoneName
 }
 import org.broadinstitute.dsde.workbench.leonardo.config._
@@ -42,6 +42,7 @@ import org.broadinstitute.dsp.{AuthContext, ChartName, ChartVersion, HelmAlgebra
 import org.http4s.Uri
 
 import scala.concurrent.ExecutionContext
+import scala.concurrent.duration._
 import scala.jdk.CollectionConverters._
 
 class GKEInterpreter[F[_]: Parallel: ContextShift: Timer](
@@ -264,7 +265,7 @@ class GKEInterpreter[F[_]: Parallel: ContextShift: Timer](
         for {
           opOpt <- gkeService.createNodepool(req)
           lastOpOpt <- opOpt.traverse { op =>
-            gkeService
+            Timer[F].sleep(10 seconds) >> gkeService
               .pollOperation(
                 KubernetesOperationId(params.googleProject, dbCluster.location, op.getName),
                 config.monitorConfig.nodepoolCreate.interval,
@@ -313,10 +314,8 @@ class GKEInterpreter[F[_]: Parallel: ContextShift: Timer](
 
       // Create namespace and secrets
       _ <- logger.info(ctx.loggingCtx)(
-        s"Begin App(${app.appName.value}) Creation. Creating namespace ${namespaceName.value} in cluster ${gkeClusterId.toString}"
+        s"Begin App(${app.appName.value}) Creation."
       )
-
-      _ <- kubeService.createNamespace(gkeClusterId, KubernetesNamespace(namespaceName))
 
       // Create KSA
       ksaName = config.galaxyAppConfig.serviceAccount
@@ -343,7 +342,8 @@ class GKEInterpreter[F[_]: Parallel: ContextShift: Timer](
           config.terraAppSetupChartConfig.chartVersion,
           org.broadinstitute.dsp.Values(
             s"serviceAccount.annotations.gcpServiceAccount=${gsa.value},serviceAccount.name=${ksaName.value}"
-          )
+          ),
+          true
         )
         .run(helmAuthContext)
       // update KSA in DB
@@ -371,6 +371,10 @@ class GKEInterpreter[F[_]: Parallel: ContextShift: Timer](
         s"googleIamDAO.addIamPolicyBindingOnServiceAccount for GSA ${gsa.value} & KSA ${ksaName.value}"
       ).compile.lastOrError
 
+      // helm install galaxy and wait
+      //TODO: validate app release is the same as retore release
+      galaxyRestore <- persistentDiskQuery.getGalaxyDiskRestore(diskId).transaction
+
       // helm install and wait
       _ <- app.appType match {
         case AppType.Galaxy =>
@@ -378,13 +382,15 @@ class GKEInterpreter[F[_]: Parallel: ContextShift: Timer](
             helmAuthContext,
             app.appName,
             app.release,
+            app.chart,
             dbCluster,
             dbApp.nodepool.nodepoolName,
             namespaceName,
             app.auditInfo.creator,
             app.customEnvironmentVariables,
             ksaName,
-            nfsDisk
+            nfsDisk,
+            galaxyRestore
           )
         case AppType.Custom =>
           installCustomApp(
@@ -401,15 +407,16 @@ class GKEInterpreter[F[_]: Parallel: ContextShift: Timer](
             app.customEnvironmentVariables
           )
       }
-
       _ <- logger.info(ctx.loggingCtx)(
         s"Finished app creation for app ${app.appName.value} in cluster ${gkeClusterId.toString}"
       )
 
-      // TODO: this logic will be changed in the next PR
-      isUsedByGalaxy <- persistentDiskQuery.isUsedByGalaxy(diskId).transaction
-      _ <- if (isUsedByGalaxy.exists(identity) || app.appType != AppType.Galaxy) F.unit
-      else
+      _ <- if (galaxyRestore.isDefined)
+        persistentDiskQuery
+          .updateLastUsedBy(diskId, app.id)
+          .transaction
+          .void
+      else if (app.appType == AppType.Galaxy)
         for {
           pvcs <- kubeService.listPersistentVolumeClaims(gkeClusterId,
                                                          KubernetesNamespace(app.appResources.namespace.name))
@@ -419,7 +426,7 @@ class GKEInterpreter[F[_]: Parallel: ContextShift: Timer](
           _ <- (galaxyPvc, cvmfsPvc).tupled
             .fold(F.raiseError[Unit](new LeoException("Fail to retrieve pvc ids", traceId = Some(ctx.traceId)))) {
               case (gp, cp) =>
-                val galaxyDiskRestore = GalaxyDiskRestore(
+                val galaxyDiskRestore = GalaxyRestore(
                   PvcId(gp.getMetadata.getUid),
                   PvcId(cp.getMetadata.getUid),
                   app.id
@@ -430,6 +437,7 @@ class GKEInterpreter[F[_]: Parallel: ContextShift: Timer](
                   .void
             }
         } yield ()
+      else F.unit
 
       _ <- appQuery.updateStatus(params.appId, AppStatus.Running).transaction
     } yield ()
@@ -591,6 +599,12 @@ class GKEInterpreter[F[_]: Parallel: ContextShift: Timer](
         s"Delete app operation has finished for app ${app.appName.value} in cluster ${gkeClusterId.toString}"
       )
 
+      _ <- dbApp.app.appResources.disk.flatMap(_.galaxyRestore).traverse { restore =>
+        for {
+          _ <- kubeService.deletePv(dbCluster.getGkeClusterId, PvName(s"pvc-${restore.galaxyPvcId.asString}"))
+          _ <- kubeService.deletePv(dbCluster.getGkeClusterId, PvName(s"pvc-${restore.cvmfsPvcId.asString}"))
+        } yield ()
+      }
       _ <- if (!params.errorAfterDelete) {
         F.unit
       } else {
@@ -806,12 +820,6 @@ class GKEInterpreter[F[_]: Parallel: ContextShift: Timer](
     for {
       ctx <- ev.ask
 
-      // Create namespace for nginx
-      _ <- logger.info(ctx.loggingCtx)(
-        s"Creating namespace ${config.ingressConfig.namespace.value} in cluster ${dbCluster.getGkeClusterId.toString}"
-      )
-      _ <- kubeService.createNamespace(dbCluster.getGkeClusterId, KubernetesNamespace(config.ingressConfig.namespace))
-
       _ <- logger.info(ctx.loggingCtx)(
         s"Installing ingress helm chart ${config.ingressConfig.chart} in cluster ${dbCluster.getGkeClusterId.toString}"
       )
@@ -824,7 +832,8 @@ class GKEInterpreter[F[_]: Parallel: ContextShift: Timer](
           config.ingressConfig.release,
           config.ingressConfig.chartName,
           config.ingressConfig.chartVersion,
-          org.broadinstitute.dsp.Values(config.ingressConfig.values.map(_.value).mkString(","))
+          org.broadinstitute.dsp.Values(config.ingressConfig.values.map(_.value).mkString(",")),
+          true
         )
         .run(helmAuthContext)
 
@@ -853,13 +862,15 @@ class GKEInterpreter[F[_]: Parallel: ContextShift: Timer](
   private[util] def installGalaxy(helmAuthContext: AuthContext,
                                   appName: AppName,
                                   release: Release,
+                                  chart: Chart,
                                   dbCluster: KubernetesCluster,
                                   nodepoolName: NodepoolName,
                                   namespaceName: NamespaceName,
                                   userEmail: WorkbenchEmail,
                                   customEnvironmentVariables: Map[String, String],
                                   kubernetesServiceAccount: ServiceAccountName,
-                                  nfsDisk: PersistentDisk)(
+                                  nfsDisk: PersistentDisk,
+                                  galaxyRestore: Option[GalaxyRestore])(
     implicit ev: Ask[F, AppContext]
   ): F[Unit] =
     for {
@@ -869,27 +880,34 @@ class GKEInterpreter[F[_]: Parallel: ContextShift: Timer](
         s"Installing helm chart ${config.galaxyAppConfig.chart} for app ${appName.value} in cluster ${dbCluster.getGkeClusterId.toString}"
       )
 
-      chartValues = buildGalaxyChartOverrideValuesString(appName,
-                                                         release,
-                                                         dbCluster,
-                                                         nodepoolName,
-                                                         userEmail,
-                                                         customEnvironmentVariables,
-                                                         kubernetesServiceAccount,
-                                                         namespaceName,
-                                                         nfsDisk)
+      chartValues = buildGalaxyChartOverrideValuesString(
+        appName,
+        release,
+        dbCluster,
+        nodepoolName,
+        userEmail,
+        customEnvironmentVariables,
+        kubernetesServiceAccount,
+        namespaceName,
+        nfsDisk,
+        galaxyRestore
+      )
 
       _ <- logger.info(ctx.loggingCtx)(
-        s"Chart override values are: ${chartValues}"
+        s"Chart override values are: ${chartValues.map(s =>
+          if (s.contains("galaxyDatabasePassword")) "persistence.postgres.galaxyDatabasePassword=<redacted>"
+          else s
+        )}"
       )
 
       // Invoke helm
       _ <- helmClient
         .installChart(
           release,
-          config.galaxyAppConfig.chartName,
-          config.galaxyAppConfig.chartVersion,
-          org.broadinstitute.dsp.Values(chartValues)
+          chart.name,
+          chart.version,
+          org.broadinstitute.dsp.Values(chartValues.mkString(",")),
+          false
         )
         .run(helmAuthContext)
 
@@ -1104,7 +1122,8 @@ class GKEInterpreter[F[_]: Parallel: ContextShift: Timer](
                                                          customEnvironmentVariables: Map[String, String],
                                                          ksa: ServiceAccountName,
                                                          namespaceName: NamespaceName,
-                                                         nfsDisk: PersistentDisk): String = {
+                                                         nfsDisk: PersistentDisk,
+                                                         galaxyRestore: Option[GalaxyRestore]): List[String] = {
     val k8sProxyHost = kubernetesProxyHost(cluster, config.proxyConfig.proxyDomain).address
     val leoProxyhost = config.proxyConfig.getProxyServerHostName
     val ingressPath = s"/proxy/google/v1/apps/${cluster.googleProject.value}/${appName.value}/galaxy"
@@ -1121,10 +1140,18 @@ class GKEInterpreter[F[_]: Parallel: ContextShift: Timer](
         )
     }
 
+    val galaxyRestoreSettings = galaxyRestore.fold(List.empty[String])(g =>
+      List(
+        raw"""restore.persistence.nfs.galaxy.pvcID=${g.galaxyPvcId.asString}""",
+        raw"""restore.persistence.nfs.cvmfsCache.pvcID=${g.cvmfsPvcId.asString}""",
+        raw"""galaxy.persistence.existingClaim=${release.asString}-galaxy-pvc""",
+        raw"""cvmfs.cache.alienCache.existingClaim=${release.asString}-cvmfs-alien-cache-pvc"""
+      )
+    )
     // Using the string interpolator raw""" since the chart keys include quotes to escape Helm
     // value override special characters such as '.'
     // https://helm.sh/docs/intro/using_helm/#the-format-and-limitations-of---set
-    (List(
+    List(
       // Storage class configs
       raw"""nfs.storageClass.name=nfs-${release.asString}""",
       raw"""cvmfs.repositories.cvmfs-gxy-data-${release.asString}=data.galaxyproject.org""",
@@ -1169,7 +1196,7 @@ class GKEInterpreter[F[_]: Parallel: ContextShift: Timer](
       raw"""persistence.nfs.persistentVolume.extraSpec.gcePersistentDisk.pdName=${nfsDisk.name.value}""",
       raw"""persistence.nfs.size=${nfsDisk.size.gb.toString}Gi""",
       raw"""persistence.postgres.name=${namespaceName.value}-${config.galaxyDiskConfig.postgresPersistenceName}""",
-      raw"""persistence.postgres.galaxyDatabasePassword=${config.galaxyAppConfig.postgresPassword}""",
+      raw"""galaxy.postgresql.galaxyDatabasePassword=${config.galaxyAppConfig.postgresPassword}""",
       raw"""persistence.postgres.persistentVolume.extraSpec.gcePersistentDisk.pdName=${getGalaxyPostgresDiskName(
         namespaceName
       ).value}""",
@@ -1178,7 +1205,7 @@ class GKEInterpreter[F[_]: Parallel: ContextShift: Timer](
       raw"""nfs.persistence.size=${nfsDisk.size.gb.toString}Gi""",
       raw"""galaxy.postgresql.persistence.existingClaim=${namespaceName.value}-${config.galaxyDiskConfig.postgresPersistenceName}-pvc""",
       raw"""galaxy.persistence.size=200Gi"""
-    ) ++ configs).mkString(",")
+    ) ++ configs ++ galaxyRestoreSettings
   }
 
   private def getTerraAppSetupChartReleaseName(appReleaseName: Release): Release =

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/CommonTestData.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/CommonTestData.scala
@@ -311,7 +311,9 @@ object CommonTestData {
     )
     .build()
 
-  def makePersistentDisk(diskName: Option[DiskName] = None, formattedBy: Option[FormattedBy] = None): PersistentDisk =
+  def makePersistentDisk(diskName: Option[DiskName] = None,
+                         formattedBy: Option[FormattedBy] = None,
+                         galaxyRestore: Option[GalaxyRestore] = None): PersistentDisk =
     PersistentDisk(
       DiskId(-1),
       project,
@@ -326,6 +328,7 @@ object CommonTestData {
       diskType,
       blockSize,
       formattedBy,
+      galaxyRestore,
       Map.empty
     )
 

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/KubernetesTestData.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/KubernetesTestData.scala
@@ -37,7 +37,7 @@ object KubernetesTestData {
   val galaxyApp = AppType.Galaxy
 
   val galaxyChartName = ChartName("galaxy/galaxykubeman")
-  val galaxyChartVersion = ChartVersion("0.7.3")
+  val galaxyChartVersion = ChartVersion("0.8.0")
   val galaxyChart = Chart(galaxyChartName, galaxyChartVersion)
 
   val galaxyReleasePrefix = "gxy-release"
@@ -126,7 +126,9 @@ object KubernetesTestData {
     Namespace(NamespaceId(-1), name)
   }
 
-  def makeApp(index: Int, nodepoolId: NodepoolLeoId): App = {
+  def makeApp(index: Int,
+              nodepoolId: NodepoolLeoId,
+              customEnvironmentVariables: Map[String, String] = Map.empty): App = {
     val name = AppName("app" + index)
     val namespace = makeNamespace(index, "app")
     App(
@@ -148,7 +150,7 @@ object KubernetesTestData {
         Option.empty
       ),
       List.empty,
-      Map.empty,
+      customEnvironmentVariables,
       None,
       List.empty
     )

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/auth/SamAuthProviderSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/auth/SamAuthProviderSpec.scala
@@ -344,7 +344,6 @@ class SamAuthProviderSpec extends AnyFlatSpec with LeonardoTestSuite with Before
 
     val newApp = AppSamResourceId("new_app")
     mockSam.createResourceWithManagerPolicy(newApp, userEmail2, project).unsafeRunSync()
-    println(mockSam.appCreators)
     samAuthProvider.filterUserVisible(NonEmptyList.of(appSamId, newApp), userInfo).unsafeRunSync() shouldBe List(
       appSamId
     )

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/AppServiceDbQueriesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/AppServiceDbQueriesSpec.scala
@@ -12,7 +12,7 @@ import org.scalatest.flatspec.AnyFlatSpecLike
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
-class KubernetesServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent {
+class AppServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent {
 
   it should "return None when there is no matching app" in isolatedDbTest {
     val cluster1 = makeKubeCluster(1).save()

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/HttpRoutesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/HttpRoutesSpec.scala
@@ -19,11 +19,11 @@ import org.broadinstitute.dsde.workbench.leonardo.http.DiskRoutesTestJsonCodec._
 import org.broadinstitute.dsde.workbench.leonardo.http.RuntimeRoutesTestJsonCodec._
 import org.broadinstitute.dsde.workbench.leonardo.http.api.HttpRoutesSpec._
 import org.broadinstitute.dsde.workbench.leonardo.http.service.{
+  AppService,
   BaseMockRuntimeServiceInterp,
   DeleteRuntimeRequest,
-  KubernetesService,
+  MockAppService,
   MockDiskServiceInterp,
-  MockKubernetesServiceInterp,
   MockRuntimeServiceInterp,
   RuntimeService
 }
@@ -52,7 +52,7 @@ class HttpRoutesSpec
     proxyService,
     MockRuntimeServiceInterp,
     MockDiskServiceInterp,
-    MockKubernetesServiceInterp,
+    MockAppService,
     timedUserInfoDirectives,
     contentSecurityPolicy,
     refererConfig
@@ -264,7 +264,7 @@ class HttpRoutesSpec
   }
 
   it should "not delete disk when deleting a kubernetes app with PD enabled if deleteDisk is not set" in {
-    val kubernetesService = new MockKubernetesServiceInterp {
+    val kubernetesService = new MockAppService {
       override def deleteApp(request: DeleteAppRequest)(
         implicit as: Ask[IO, AppContext]
       ): IO[Unit] = IO {
@@ -561,13 +561,13 @@ class HttpRoutesSpec
       proxyService,
       runtimeService,
       MockDiskServiceInterp,
-      MockKubernetesServiceInterp,
+      MockAppService,
       timedUserInfoDirectives,
       contentSecurityPolicy,
       refererConfig
     )
 
-  def fakeRoutes(kubernetesService: KubernetesService[IO]): HttpRoutes =
+  def fakeRoutes(kubernetesService: AppService[IO]): HttpRoutes =
     new HttpRoutes(
       swaggerConfig,
       statusService,

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/TestLeoRoutes.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/TestLeoRoutes.scala
@@ -96,7 +96,7 @@ trait TestLeoRoutes {
                            blocker)
   val runtimeInstances = new RuntimeInstances[IO](dataprocInterp, gceInterp)
 
-  val leoKubernetesService: LeoKubernetesServiceInterp[IO] = new LeoKubernetesServiceInterp[IO](
+  val leoKubernetesService: LeoAppServiceInterp[IO] = new LeoAppServiceInterp[IO](
     whitelistAuthProvider,
     serviceAccountProvider,
     Config.leoKubernetesConfig,

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/MockAppService.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/MockAppService.scala
@@ -15,7 +15,7 @@ import org.broadinstitute.dsde.workbench.leonardo.http.{
 import org.broadinstitute.dsde.workbench.model.UserInfo
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 
-class MockKubernetesServiceInterp extends KubernetesService[IO] {
+class MockAppService extends AppService[IO] {
   override def createApp(userInfo: UserInfo, googleProject: GoogleProject, appName: AppName, req: CreateAppRequest)(
     implicit as: Ask[IO, AppContext]
   ): IO[Unit] =
@@ -49,4 +49,4 @@ class MockKubernetesServiceInterp extends KubernetesService[IO] {
   ): IO[Unit] = IO.unit
 }
 
-object MockKubernetesServiceInterp extends MockKubernetesServiceInterp
+object MockAppService extends MockAppService

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/mocks.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/mocks.scala
@@ -22,7 +22,8 @@ import org.broadinstitute.dsde.workbench.google2.{
   GcsBlobName,
   GetMetadataResponse,
   GoogleSubscriber,
-  KubernetesModels
+  KubernetesModels,
+  PvName
 }
 import org.broadinstitute.dsde.workbench.leonardo.model.{
   LeoAuthProvider,
@@ -191,6 +192,9 @@ class MockKubernetesService(podStatus: PodStatus = PodStatus.Running, appRelease
         List(nfsPvc, cvmfsPvc)
       )
     }
+
+  override def deletePv(clusterId: KubernetesClusterId, pv: PvName)(implicit ev: Ask[IO, TraceId]): IO[Unit] =
+    IO.unit
 }
 
 class MockGKEService extends GKEAlgebra[IO] {

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriberSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriberSpec.scala
@@ -629,7 +629,7 @@ class LeoPubsubMessageSubscriberSpec
       getCluster.status shouldBe KubernetesClusterStatus.Running
       getCluster.nodepools.size shouldBe 2
       getCluster.nodepools.filter(_.isDefault).head.status shouldBe NodepoolStatus.Running
-      getApp.app.errors shouldBe List()
+      getApp.app.errors shouldBe List.empty
       getApp.app.status shouldBe AppStatus.Running
       getApp.app.appResources.kubernetesServiceAccountName shouldBe Some(
         ServiceAccountName("gxy-ksa")
@@ -645,7 +645,7 @@ class LeoPubsubMessageSubscriberSpec
       )
       getDisk.status shouldBe DiskStatus.Ready
       galaxyRestore shouldBe Some(
-        GalaxyDiskRestore(PvcId(s"nfs-pvc-id1"), PvcId("cvmfs-pvc-id1"), getApp.app.id)
+        GalaxyRestore(PvcId(s"nfs-pvc-id1"), PvcId("cvmfs-pvc-id1"), getApp.app.id)
       )
     }
 
@@ -1034,7 +1034,7 @@ class LeoPubsubMessageSubscriberSpec
       tr <- traceId.ask[TraceId]
       msg = DeleteAppMessage(savedApp1.id, savedApp1.appName, savedCluster1.googleProject, None, Some(tr))
       queue <- InspectableQueue.bounded[IO, Task[IO]](10)
-      leoSubscriber = makeLeoSubscriber(asyncTaskQueue = queue)
+      leoSubscriber = makeLeoSubscriber(asyncTaskQueue = queue, diskInterp = makeDetachingDiskInterp)
       asyncTaskProcessor = AsyncTaskProcessor(AsyncTaskProcessor.Config(10, 10), queue)
       _ <- leoSubscriber.handleDeleteAppMessage(msg)
       _ <- withInfiniteStream(asyncTaskProcessor.process, assertions)
@@ -1334,7 +1334,8 @@ class LeoPubsubMessageSubscriberSpec
       override def installChart(release: Release,
                                 chartName: ChartName,
                                 chartVersion: ChartVersion,
-                                values: Values): Kleisli[IO, AuthContext, Unit] =
+                                values: Values,
+                                createNamespace: Boolean): Kleisli[IO, AuthContext, Unit] =
         if (chartName == Config.gkeInterpConfig.terraAppSetupChartConfig.chartName)
           Kleisli.liftF(IO.raiseError(new Exception("this is an intentional test exception")))
         else Kleisli.liftF(IO.unit)
@@ -1437,7 +1438,8 @@ class LeoPubsubMessageSubscriberSpec
       override def installChart(release: Release,
                                 chartName: ChartName,
                                 chartVersion: ChartVersion,
-                                values: Values): Kleisli[IO, AuthContext, Unit] =
+                                values: Values,
+                                createNamespace: Boolean): Kleisli[IO, AuthContext, Unit] =
         if (chartName == Config.gkeInterpConfig.terraAppSetupChartConfig.chartName)
           Kleisli.liftF(IO.raiseError(new Exception("this is an intentional test exception")))
         else Kleisli.liftF(IO.unit)

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreterSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreterSpec.scala
@@ -1,34 +1,27 @@
 package org.broadinstitute.dsde.workbench.leonardo
 package util
 
-import java.nio.file.Files
-import java.util.Base64
-
 import cats.effect.IO
 import org.broadinstitute.dsde.workbench.google.mock.MockGoogleIamDAO
 import org.broadinstitute.dsde.workbench.google2.DiskName
 import org.broadinstitute.dsde.workbench.google2.GKEModels.NodepoolName
 import org.broadinstitute.dsde.workbench.google2.KubernetesModels.{KubernetesPodStatus, PodStatus}
 import org.broadinstitute.dsde.workbench.google2.KubernetesSerializableName._
-import org.broadinstitute.dsde.workbench.google2.mock.{
-  FakeGoogleComputeService,
-  FakeGoogleResourceService,
-  MockComputePollOperation,
-  MockGKEService,
-  MockKubernetesService
-}
+import org.broadinstitute.dsde.workbench.google2.mock._
 import org.broadinstitute.dsde.workbench.leonardo.CommonTestData._
-import org.broadinstitute.dsde.workbench.leonardo.http.dbioToIO
 import org.broadinstitute.dsde.workbench.leonardo.KubernetesTestData.{makeKubeCluster, makeNodepool}
 import org.broadinstitute.dsde.workbench.leonardo.config.Config
 import org.broadinstitute.dsde.workbench.leonardo.dao.{MockAppDAO, MockAppDescriptorDAO}
 import org.broadinstitute.dsde.workbench.leonardo.db.{kubernetesClusterQuery, nodepoolQuery, TestComponent}
+import org.broadinstitute.dsde.workbench.leonardo.http.dbioToIO
 import org.broadinstitute.dsp.Release
 import org.broadinstitute.dsp.mocks._
 import org.scalatest.flatspec.AnyFlatSpecLike
 
-import scala.jdk.CollectionConverters._
+import java.nio.file.Files
+import java.util.Base64
 import scala.concurrent.ExecutionContext.Implicits.global
+import scala.jdk.CollectionConverters._
 
 class GKEInterpreterSpec extends AnyFlatSpecLike with TestComponent with LeonardoTestSuite {
   val googleIamDao = new MockGoogleIamDAO
@@ -89,7 +82,7 @@ class GKEInterpreterSpec extends AnyFlatSpecLike with TestComponent with Leonard
   }
 
   it should "build Galaxy override values string" in {
-    val savedCluster1 = makeKubeCluster(1).save()
+    val savedCluster1 = makeKubeCluster(1)
     val savedDisk1 = makePersistentDisk(Some(DiskName("disk1")), Some(FormattedBy.Galaxy))
     val result = gkeInterp.buildGalaxyChartOverrideValuesString(
       AppName("app1"),
@@ -100,10 +93,32 @@ class GKEInterpreterSpec extends AnyFlatSpecLike with TestComponent with Leonard
       Map("WORKSPACE_NAME" -> "test-workspace", "WORKSPACE_BUCKET" -> "gs://test-bucket"),
       ServiceAccountName("app1-galaxy-ksa"),
       NamespaceName("ns"),
-      savedDisk1
+      savedDisk1,
+      None
     )
 
-    result shouldBe """nfs.storageClass.name=nfs-app1-galaxy-rls,cvmfs.repositories.cvmfs-gxy-data-app1-galaxy-rls=data.galaxyproject.org,cvmfs.repositories.cvmfs-gxy-main-app1-galaxy-rls=main.galaxyproject.org,cvmfs.cache.alienCache.storageClass=nfs-app1-galaxy-rls,galaxy.persistence.storageClass=nfs-app1-galaxy-rls,galaxy.cvmfs.data.pvc.storageClassName=cvmfs-gxy-data-app1-galaxy-rls,galaxy.cvmfs.main.pvc.storageClassName=cvmfs-gxy-main-app1-galaxy-rls,galaxy.nodeSelector.cloud\.google\.com/gke-nodepool=pool1,nfs.nodeSelector.cloud\.google\.com/gke-nodepool=pool1,galaxy.configs.job_conf\.yml.runners.k8s.k8s_node_selector=cloud.google.com/gke-nodepool: pool1,galaxy.ingress.path=/proxy/google/v1/apps/dsp-leo-test1/app1/galaxy,galaxy.ingress.annotations.nginx\.ingress\.kubernetes\.io/proxy-redirect-from=https://1455694897.jupyter.firecloud.org,galaxy.ingress.annotations.nginx\.ingress\.kubernetes\.io/proxy-redirect-to=https://leo,galaxy.ingress.hosts[0]=1455694897.jupyter.firecloud.org,galaxy.ingress.tls[0].hosts[0]=1455694897.jupyter.firecloud.org,galaxy.ingress.tls[0].secretName=tls-secret,galaxy.configs.galaxy\.yml.galaxy.single_user=user1@example.com,galaxy.configs.galaxy\.yml.galaxy.admin_users=user1@example.com,galaxy.terra.launch.workspace=test-workspace,galaxy.terra.launch.namespace=dsp-leo-test1,galaxy.configs.file_sources_conf\.yml[0].api_url=https://firecloud-orchestration.dsde-dev.broadinstitute.org/api/,galaxy.configs.file_sources_conf\.yml[0].drs_url=https://us-central1-broad-dsde-dev.cloudfunctions.net/martha_v3,galaxy.configs.file_sources_conf\.yml[0].doc=test-workspace,galaxy.configs.file_sources_conf\.yml[0].id=test-workspace,galaxy.configs.file_sources_conf\.yml[0].workspace=test-workspace,galaxy.configs.file_sources_conf\.yml[0].namespace=dsp-leo-test1,galaxy.configs.file_sources_conf\.yml[0].type=anvil,galaxy.configs.file_sources_conf\.yml[0].on_anvil=True,galaxy.rbac.enabled=false,galaxy.rbac.serviceAccount=app1-galaxy-ksa,rbac.serviceAccount=app1-galaxy-ksa,persistence.nfs.name=ns-nfs-disk,persistence.nfs.persistentVolume.extraSpec.gcePersistentDisk.pdName=disk1,persistence.nfs.size=250Gi,persistence.postgres.name=ns-postgres-disk,persistence.postgres.galaxyDatabasePassword=replace-me,persistence.postgres.persistentVolume.extraSpec.gcePersistentDisk.pdName=ns-gxy-postres-disk,persistence.postgres.size=10Gi,nfs.persistence.existingClaim=ns-nfs-disk-pvc,nfs.persistence.size=250Gi,galaxy.postgresql.persistence.existingClaim=ns-postgres-disk-pvc,galaxy.persistence.size=200Gi,configs.WORKSPACE_NAME=test-workspace,extraEnv[0].name=WORKSPACE_NAME,extraEnv[0].valueFrom.configMapKeyRef.name=app1-galaxy-rls-galaxykubeman-configs,extraEnv[0].valueFrom.configMapKeyRef.key=WORKSPACE_NAME,configs.WORKSPACE_BUCKET=gs://test-bucket,extraEnv[1].name=WORKSPACE_BUCKET,extraEnv[1].valueFrom.configMapKeyRef.name=app1-galaxy-rls-galaxykubeman-configs,extraEnv[1].valueFrom.configMapKeyRef.key=WORKSPACE_BUCKET"""
+    result.mkString(",") shouldBe """nfs.storageClass.name=nfs-app1-galaxy-rls,cvmfs.repositories.cvmfs-gxy-data-app1-galaxy-rls=data.galaxyproject.org,cvmfs.repositories.cvmfs-gxy-main-app1-galaxy-rls=main.galaxyproject.org,cvmfs.cache.alienCache.storageClass=nfs-app1-galaxy-rls,galaxy.persistence.storageClass=nfs-app1-galaxy-rls,galaxy.cvmfs.data.pvc.storageClassName=cvmfs-gxy-data-app1-galaxy-rls,galaxy.cvmfs.main.pvc.storageClassName=cvmfs-gxy-main-app1-galaxy-rls,galaxy.nodeSelector.cloud\.google\.com/gke-nodepool=pool1,nfs.nodeSelector.cloud\.google\.com/gke-nodepool=pool1,galaxy.configs.job_conf\.yml.runners.k8s.k8s_node_selector=cloud.google.com/gke-nodepool: pool1,galaxy.ingress.path=/proxy/google/v1/apps/dsp-leo-test1/app1/galaxy,galaxy.ingress.annotations.nginx\.ingress\.kubernetes\.io/proxy-redirect-from=https://1455694897.jupyter.firecloud.org,galaxy.ingress.annotations.nginx\.ingress\.kubernetes\.io/proxy-redirect-to=https://leo,galaxy.ingress.hosts[0]=1455694897.jupyter.firecloud.org,galaxy.ingress.tls[0].hosts[0]=1455694897.jupyter.firecloud.org,galaxy.ingress.tls[0].secretName=tls-secret,galaxy.configs.galaxy\.yml.galaxy.single_user=user1@example.com,galaxy.configs.galaxy\.yml.galaxy.admin_users=user1@example.com,galaxy.terra.launch.workspace=test-workspace,galaxy.terra.launch.namespace=dsp-leo-test1,galaxy.configs.file_sources_conf\.yml[0].api_url=https://firecloud-orchestration.dsde-dev.broadinstitute.org/api/,galaxy.configs.file_sources_conf\.yml[0].drs_url=https://us-central1-broad-dsde-dev.cloudfunctions.net/martha_v3,galaxy.configs.file_sources_conf\.yml[0].doc=test-workspace,galaxy.configs.file_sources_conf\.yml[0].id=test-workspace,galaxy.configs.file_sources_conf\.yml[0].workspace=test-workspace,galaxy.configs.file_sources_conf\.yml[0].namespace=dsp-leo-test1,galaxy.configs.file_sources_conf\.yml[0].type=anvil,galaxy.configs.file_sources_conf\.yml[0].on_anvil=True,galaxy.rbac.enabled=false,galaxy.rbac.serviceAccount=app1-galaxy-ksa,rbac.serviceAccount=app1-galaxy-ksa,persistence.nfs.name=ns-nfs-disk,persistence.nfs.persistentVolume.extraSpec.gcePersistentDisk.pdName=disk1,persistence.nfs.size=250Gi,persistence.postgres.name=ns-postgres-disk,galaxy.postgresql.galaxyDatabasePassword=replace-me,persistence.postgres.persistentVolume.extraSpec.gcePersistentDisk.pdName=ns-gxy-postres-disk,persistence.postgres.size=10Gi,nfs.persistence.existingClaim=ns-nfs-disk-pvc,nfs.persistence.size=250Gi,galaxy.postgresql.persistence.existingClaim=ns-postgres-disk-pvc,galaxy.persistence.size=200Gi,configs.WORKSPACE_NAME=test-workspace,extraEnv[0].name=WORKSPACE_NAME,extraEnv[0].valueFrom.configMapKeyRef.name=app1-galaxy-rls-galaxykubeman-configs,extraEnv[0].valueFrom.configMapKeyRef.key=WORKSPACE_NAME,configs.WORKSPACE_BUCKET=gs://test-bucket,extraEnv[1].name=WORKSPACE_BUCKET,extraEnv[1].valueFrom.configMapKeyRef.name=app1-galaxy-rls-galaxykubeman-configs,extraEnv[1].valueFrom.configMapKeyRef.key=WORKSPACE_BUCKET"""
+  }
+
+  it should "build Galaxy override values string with restore info" in {
+    val savedCluster1 = makeKubeCluster(1)
+    val savedDisk1 = makePersistentDisk(Some(DiskName("disk1")), Some(FormattedBy.Galaxy))
+    val result = gkeInterp.buildGalaxyChartOverrideValuesString(
+      AppName("app1"),
+      Release("app1-galaxy-rls"),
+      savedCluster1,
+      NodepoolName("pool1"),
+      userEmail,
+      Map("WORKSPACE_NAME" -> "test-workspace", "WORKSPACE_BUCKET" -> "gs://test-bucket"),
+      ServiceAccountName("app1-galaxy-ksa"),
+      NamespaceName("ns"),
+      savedDisk1,
+      Some(
+        GalaxyRestore(PvcId("galaxy-pvc-id"), PvcId("cvmfs-pvc-id"), AppId(123))
+      )
+    )
+
+    result.mkString(",") shouldBe """nfs.storageClass.name=nfs-app1-galaxy-rls,cvmfs.repositories.cvmfs-gxy-data-app1-galaxy-rls=data.galaxyproject.org,cvmfs.repositories.cvmfs-gxy-main-app1-galaxy-rls=main.galaxyproject.org,cvmfs.cache.alienCache.storageClass=nfs-app1-galaxy-rls,galaxy.persistence.storageClass=nfs-app1-galaxy-rls,galaxy.cvmfs.data.pvc.storageClassName=cvmfs-gxy-data-app1-galaxy-rls,galaxy.cvmfs.main.pvc.storageClassName=cvmfs-gxy-main-app1-galaxy-rls,galaxy.nodeSelector.cloud\.google\.com/gke-nodepool=pool1,nfs.nodeSelector.cloud\.google\.com/gke-nodepool=pool1,galaxy.configs.job_conf\.yml.runners.k8s.k8s_node_selector=cloud.google.com/gke-nodepool: pool1,galaxy.ingress.path=/proxy/google/v1/apps/dsp-leo-test1/app1/galaxy,galaxy.ingress.annotations.nginx\.ingress\.kubernetes\.io/proxy-redirect-from=https://1455694897.jupyter.firecloud.org,galaxy.ingress.annotations.nginx\.ingress\.kubernetes\.io/proxy-redirect-to=https://leo,galaxy.ingress.hosts[0]=1455694897.jupyter.firecloud.org,galaxy.ingress.tls[0].hosts[0]=1455694897.jupyter.firecloud.org,galaxy.ingress.tls[0].secretName=tls-secret,galaxy.configs.galaxy\.yml.galaxy.single_user=user1@example.com,galaxy.configs.galaxy\.yml.galaxy.admin_users=user1@example.com,galaxy.terra.launch.workspace=test-workspace,galaxy.terra.launch.namespace=dsp-leo-test1,galaxy.configs.file_sources_conf\.yml[0].api_url=https://firecloud-orchestration.dsde-dev.broadinstitute.org/api/,galaxy.configs.file_sources_conf\.yml[0].drs_url=https://us-central1-broad-dsde-dev.cloudfunctions.net/martha_v3,galaxy.configs.file_sources_conf\.yml[0].doc=test-workspace,galaxy.configs.file_sources_conf\.yml[0].id=test-workspace,galaxy.configs.file_sources_conf\.yml[0].workspace=test-workspace,galaxy.configs.file_sources_conf\.yml[0].namespace=dsp-leo-test1,galaxy.configs.file_sources_conf\.yml[0].type=anvil,galaxy.configs.file_sources_conf\.yml[0].on_anvil=True,galaxy.rbac.enabled=false,galaxy.rbac.serviceAccount=app1-galaxy-ksa,rbac.serviceAccount=app1-galaxy-ksa,persistence.nfs.name=ns-nfs-disk,persistence.nfs.persistentVolume.extraSpec.gcePersistentDisk.pdName=disk1,persistence.nfs.size=250Gi,persistence.postgres.name=ns-postgres-disk,galaxy.postgresql.galaxyDatabasePassword=replace-me,persistence.postgres.persistentVolume.extraSpec.gcePersistentDisk.pdName=ns-gxy-postres-disk,persistence.postgres.size=10Gi,nfs.persistence.existingClaim=ns-nfs-disk-pvc,nfs.persistence.size=250Gi,galaxy.postgresql.persistence.existingClaim=ns-postgres-disk-pvc,galaxy.persistence.size=200Gi,configs.WORKSPACE_NAME=test-workspace,extraEnv[0].name=WORKSPACE_NAME,extraEnv[0].valueFrom.configMapKeyRef.name=app1-galaxy-rls-galaxykubeman-configs,extraEnv[0].valueFrom.configMapKeyRef.key=WORKSPACE_NAME,configs.WORKSPACE_BUCKET=gs://test-bucket,extraEnv[1].name=WORKSPACE_BUCKET,extraEnv[1].valueFrom.configMapKeyRef.name=app1-galaxy-rls-galaxykubeman-configs,extraEnv[1].valueFrom.configMapKeyRef.key=WORKSPACE_BUCKET,restore.persistence.nfs.galaxy.pvcID=galaxy-pvc-id,restore.persistence.nfs.cvmfsCache.pvcID=cvmfs-pvc-id,galaxy.persistence.existingClaim=app1-galaxy-rls-galaxy-pvc,cvmfs.cache.alienCache.existingClaim=app1-galaxy-rls-cvmfs-alien-cache-pvc""".stripMargin
   }
 
   it should "check if a pod is done" in {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -15,7 +15,7 @@ object Dependencies {
   val monocleV = "2.1.0"
   val opencensusV = "0.28.3"
 
-  private val workbenchLibsHash = "3889a04"
+  private val workbenchLibsHash = "244a616"
   val serviceTestV = s"0.18-$workbenchLibsHash"
   val workbenchModelV = s"0.14-$workbenchLibsHash"
   val workbenchGoogleV = s"0.21-$workbenchLibsHash"
@@ -23,7 +23,7 @@ object Dependencies {
   val workbenchOpenTelemetryV = s"0.1-$workbenchLibsHash"
   val workbenchErrorReportingV = s"0.1-$workbenchLibsHash"
 
-  val helmScalaSdkV = "0.0.1-RC4"
+  val helmScalaSdkV = "0.0.1-RC5"
 
   val excludeAkkaHttp = ExclusionRule(organization = "com.typesafe.akka", name = s"akka-http_${scalaV}")
   val excludeAkkaStream = ExclusionRule(organization = "com.typesafe.akka", name = s"akka-stream_${scalaV}")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -23,7 +23,7 @@ object Dependencies {
   val workbenchOpenTelemetryV = s"0.1-$workbenchLibsHash"
   val workbenchErrorReportingV = s"0.1-$workbenchLibsHash"
 
-  val helmScalaSdkV = "0.0.1-RC5"
+  val helmScalaSdkV = "0.0.1"
 
   val excludeAkkaHttp = ExclusionRule(organization = "com.typesafe.akka", name = s"akka-http_${scalaV}")
   val excludeAkkaStream = ExclusionRule(organization = "com.typesafe.akka", name = s"akka-stream_${scalaV}")


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-2052
https://broadworkbench.atlassian.net/browse/IA-2535

1. Use new version of helm-scala-sdk with `createNamespace` option enabled. This automatically adds `name` label for the namespace created as well, which is required for enabling network policy in the future.
2. for automation test, switch initial runtime to a gce runtime instead of dataproc to reduce overhead. If we see increased dataproc related test failure, we should switch back.
3. Make `deleteDisk` flag work.
4. Enabled logging header in automation tests. This way, we'll be able to see traceId(`X-Cloud-Trace-Context`) used in automation tests, and use that to look for relevant leo logs. Example, 
```
11:24:35 [scala-execution-context-global-207      ] INFO  [o.h.c.m.RequestLogger    :$anonfun$impl$3] - HTTP/1.1 GET https://leonardo-fiab.dsde-dev.broadinstitute.org:30443/api/google/v1/apps/gpalloc-dev-master-e45nldi/automation-test-app-aj1jfzkkz Headers(Authorization: <REDACTED>, X-Cloud-Trace-Context: c4a6d474-6893-4c8c-a361-322b0f49fd25, Accept: application/json) body=""
```
5.  Support restore from disk flow


---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
