### PR TITLE
[IA-2545] Update Galaxy default conf to 1 n1-highmem-8 node

### DIFF
--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -200,8 +200,8 @@ gke {
     maxNodepoolsPerDefaultNode = 16
   }
   galaxyNodepool {
-    machineType = "n1-standard-8"
-    numNodes = 2
+    machineType = "n1-highmem-8"
+    numNodes = 1
     autoscalingEnabled = false
     autoscalingConfig {
        autoscalingMin = 0

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/config/ConfigSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/config/ConfigSpec.scala
@@ -96,8 +96,8 @@ final class ConfigSpec extends AnyFlatSpec with Matchers {
   }
 
   it should "read GalaxyNodepoolConfig properly" in {
-    val expectedResult = GalaxyNodepoolConfig(MachineTypeName("n1-standard-8"),
-                                              NumNodes(2),
+    val expectedResult = GalaxyNodepoolConfig(MachineTypeName("n1-highmem-8"),
+                                              NumNodes(1),
                                               false,
                                               AutoscalingConfig(AutoscalingMin(0), AutoscalingMax(2)))
     Config.gkeGalaxyNodepoolConfig shouldBe expectedResult


### PR DESCRIPTION
See explanation in https://broadworkbench.atlassian.net/browse/IA-2545

Tested locally, corresponding Terra UI PR: https://github.com/DataBiosphere/terra-ui/pull/2392


---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
