### PR TITLE
IA-2567 RStudio env vars are missing

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/RuntimeFixtureSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/RuntimeFixtureSpec.scala
@@ -173,8 +173,7 @@ object RuntimeFixtureSpec {
       defaultClientId = None,
       welderRegistry = None,
       scopes = Set.empty,
-      customEnvironmentVariables =
-        Map("WORKSPACE_NAME" -> "TestWorkspace", "WORKSPACE_BUCKET" -> "gs://test-workspace-bucket")
+      customEnvironmentVariables = Map("TEST_EV1" -> "test1", "TEST_EV2" -> "test2")
     )
   }
 }

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/RuntimeFixtureSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/RuntimeFixtureSpec.scala
@@ -173,7 +173,8 @@ object RuntimeFixtureSpec {
       defaultClientId = None,
       welderRegistry = None,
       scopes = Set.empty,
-      customEnvironmentVariables = Map.empty
+      customEnvironmentVariables =
+        Map("WORKSPACE_NAME" -> "TestWorkspace", "WORKSPACE_BUCKET" -> "gs://test-workspace-bucket")
     )
   }
 }

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookGCEClusterMonitoringSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookGCEClusterMonitoringSpec.scala
@@ -80,6 +80,7 @@ class NotebookGCEClusterMonitoringSpec
             await visible cssSelector("[title~='ns']")
             rstudioPage.variableExists("ns") shouldBe true
             rstudioPage.variableExists(s""""${runtime.googleProject.value}"""") shouldBe true
+            Thread.sleep(5000)
           }
 
           // Stop the cluster

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookGCEClusterMonitoringSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookGCEClusterMonitoringSpec.scala
@@ -92,7 +92,7 @@ class NotebookGCEClusterMonitoringSpec
           withNewRStudio(runtime) { rstudioPage =>
             await visible cssSelector("[title~='ns']")
             rstudioPage.variableExists("ns") shouldBe true
-            rstudioPage.variableExists(runtime.googleProject.value) shouldBe true
+            rstudioPage.variableExists(s""""${runtime.googleProject.value}"""") shouldBe true
           }
         }
       }

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookGCEClusterMonitoringSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookGCEClusterMonitoringSpec.scala
@@ -4,13 +4,13 @@ import java.io.File
 
 import org.broadinstitute.dsde.workbench.auth.AuthToken
 import org.broadinstitute.dsde.workbench.leonardo._
-import org.broadinstitute.dsde.workbench.leonardo.rstudio.RStudio
+import org.broadinstitute.dsde.workbench.leonardo.rstudio.RStudioTestUtils
 import org.http4s.AuthScheme
 import org.http4s.headers.Authorization
+import org.openqa.selenium.Keys
 import org.scalatest.{DoNotDiscover, ParallelTestExecution}
 
 import scala.concurrent.duration._
-import scala.util.Try
 
 /**
  * This spec verifies cluster status transitions like pause/resume and cluster PATCH.
@@ -18,7 +18,11 @@ import scala.util.Try
  * so lives in the notebooks sub-package.
  */
 @DoNotDiscover
-class NotebookGCEClusterMonitoringSpec extends GPAllocFixtureSpec with ParallelTestExecution with NotebookTestUtils {
+class NotebookGCEClusterMonitoringSpec
+    extends GPAllocFixtureSpec
+    with ParallelTestExecution
+    with NotebookTestUtils
+    with RStudioTestUtils {
   implicit val ronToken: AuthToken = ronAuthToken
   implicit val auth: Authorization = Authorization(
     org.http4s.Credentials.Token(AuthScheme.Bearer, ronCreds.makeAuthToken().value)
@@ -68,26 +72,29 @@ class NotebookGCEClusterMonitoringSpec extends GPAllocFixtureSpec with ParallelT
           toolDockerImage = Some(LeonardoConfig.Leonardo.rstudioBioconductorImage)
         )
       ) { runtime =>
-        // Make sure RStudio is up
-        // See this ticket for adding more comprehensive selenium tests for RStudio:
-        // https://broadworkbench.atlassian.net/browse/IA-697
-        val getResult = Try(RStudio.getApi(runtime.googleProject, runtime.clusterName))
-        getResult.isSuccess shouldBe true
-        getResult.get should include("unsupported_browser")
-        getResult.get should not include "ProxyException"
+        withWebDriver { implicit driver =>
+          // Make sure RStudio is up
+          withNewRStudio(runtime) { rstudioPage =>
+            rstudioPage.pressKeys("""ns <- Sys.getEnv("WORKSPACE_NAMESPACE")""")
+            rstudioPage.pressKeys(Keys.ENTER.toString)
+            await visible cssSelector("[title~='ns']")
+            rstudioPage.variableExists("ns") shouldBe true
+            rstudioPage.variableExists(runtime.googleProject.value) shouldBe true
+          }
 
-        // Stop the cluster
-        stopAndMonitorRuntime(runtime.googleProject, runtime.clusterName)
+          // Stop the cluster
+          stopAndMonitorRuntime(runtime.googleProject, runtime.clusterName)
 
-        // Start the cluster
-        startAndMonitorRuntime(runtime.googleProject, runtime.clusterName)
+          // Start the cluster
+          startAndMonitorRuntime(runtime.googleProject, runtime.clusterName)
 
-        // RStudio should still be up
-        // TODO: also check that the session is preserved after IA-697 is done
-        val getResultAfterResume = Try(RStudio.getApi(runtime.googleProject, runtime.clusterName))
-        getResultAfterResume.isSuccess shouldBe true
-        getResultAfterResume.get should include("unsupported_browser")
-        getResultAfterResume.get should not include "ProxyException"
+          // Make sure RStudio session is preserved
+          withNewRStudio(runtime) { rstudioPage =>
+            await visible cssSelector("[title~='ns']")
+            rstudioPage.variableExists("ns") shouldBe true
+            rstudioPage.variableExists(runtime.googleProject.value) shouldBe true
+          }
+        }
       }
     }
 

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookGCEClusterMonitoringSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookGCEClusterMonitoringSpec.scala
@@ -75,7 +75,7 @@ class NotebookGCEClusterMonitoringSpec
         withWebDriver { implicit driver =>
           // Make sure RStudio is up
           withNewRStudio(runtime) { rstudioPage =>
-            rstudioPage.pressKeys("""ns <- Sys.getEnv("WORKSPACE_NAMESPACE")""")
+            rstudioPage.pressKeys("""ns <- Sys.getenv("WORKSPACE_NAMESPACE")""")
             rstudioPage.pressKeys(Keys.ENTER.toString)
             await visible cssSelector("[title~='ns']")
             rstudioPage.variableExists("ns") shouldBe true

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookGCEClusterMonitoringSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookGCEClusterMonitoringSpec.scala
@@ -79,7 +79,7 @@ class NotebookGCEClusterMonitoringSpec
             rstudioPage.pressKeys(Keys.ENTER.toString)
             await visible cssSelector("[title~='ns']")
             rstudioPage.variableExists("ns") shouldBe true
-            rstudioPage.variableExists(runtime.googleProject.value) shouldBe true
+            rstudioPage.variableExists(s""""${runtime.googleProject.value}"""") shouldBe true
           }
 
           // Stop the cluster

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/rstudio/RStudioPage.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/rstudio/RStudioPage.scala
@@ -36,7 +36,7 @@ class RStudioPage(override val url: String)(implicit override val authToken: Aut
   }
 
   def variableExists(variable: String): Boolean =
-    find(checkGlobalVariable(variable)).size > 0
+    find(checkGlobalVariable(variable)).isDefined
 
   // Opens an example app from the shiny package.
   // Valid examples are:
@@ -57,7 +57,7 @@ class RStudioPage(override val url: String)(implicit override val authToken: Aut
     }
 
     // Do verifications
-    val rshinyPage = new RShinyPage(currentUrl).awaitLoaded
+    val rshinyPage = new RShinyPage(currentUrl).awaitLoaded()
     val result = Try(testCode(rshinyPage))
     result.get
   }

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/rstudio/RStudioSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/rstudio/RStudioSpec.scala
@@ -53,6 +53,7 @@ class RStudioSpec extends RuntimeFixtureSpec with RStudioTestUtils {
     "should launch an RShiny app" in { runtimeFixture =>
       withWebDriver { implicit driver =>
         withNewRStudio(runtimeFixture.runtime) { rstudioPage =>
+          rstudioPage.pressKeys(Keys.ENTER.toString)
           rstudioPage.withRShinyExample("01_hello")(rshinyPage =>
             rshinyPage.getExampleHeader shouldBe Some("Hello Shiny!")
           )

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/rstudio/RStudioSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/rstudio/RStudioSpec.scala
@@ -40,6 +40,7 @@ class RStudioSpec extends RuntimeFixtureSpec with RStudioTestUtils {
             case (k, v) =>
               rstudioPage.pressKeys(s"""var_$k <- Sys.getenv("$k")""")
               rstudioPage.pressKeys(Keys.ENTER.toString)
+              Thread.sleep(2000)
               await visible cssSelector(s"[title~='var_$k']")
               rstudioPage.variableExists(s"var_$k") shouldBe true
               rstudioPage.variableExists(s""""$v"""") shouldBe true

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/rstudio/RStudioSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/rstudio/RStudioSpec.scala
@@ -42,7 +42,7 @@ class RStudioSpec extends RuntimeFixtureSpec with RStudioTestUtils {
               rstudioPage.pressKeys(Keys.ENTER.toString)
               await visible cssSelector(s"[title~='var_$k']")
               rstudioPage.variableExists(s"var_$k") shouldBe true
-              rstudioPage.variableExists(s"$v") shouldBe true
+              rstudioPage.variableExists(s""""$v"""") shouldBe true
           }
         }
       }

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/rstudio/RStudioSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/rstudio/RStudioSpec.scala
@@ -42,8 +42,8 @@ class RStudioSpec extends RuntimeFixtureSpec with RStudioTestUtils {
             "CLUSTER_NAME" -> runtimeFixture.runtime.clusterName.asString,
             "RUNTIME_NAME" -> runtimeFixture.runtime.clusterName.asString,
             "OWNER_EMAIL" -> runtimeFixture.runtime.creator.value,
-            "WORKSPACE_NAME" -> "TestWorkspace",
-            "WORKSPACE_BUCKET" -> "gs://test-workspace-bucket"
+            "TEST_EV1" -> "test1",
+            "TEST_EV2" -> "test2"
           )
 
           expectedEVs.foreach {

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/rstudio/RStudioSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/rstudio/RStudioSpec.scala
@@ -23,16 +23,6 @@ class RStudioSpec extends RuntimeFixtureSpec with RStudioTestUtils {
       }
     }
 
-    "should launch an RShiny app" in { runtimeFixture =>
-      withWebDriver { implicit driver =>
-        withNewRStudio(runtimeFixture.runtime) { rstudioPage =>
-          rstudioPage.withRShinyExample("01_hello")(rshinyPage =>
-            rshinyPage.getExampleHeader shouldBe Some("Hello Shiny!")
-          )
-        }
-      }
-    }
-
     "environment variables should be available in RStudio" in { runtimeFixture =>
       withWebDriver { implicit driver =>
         withNewRStudio(runtimeFixture.runtime) { rstudioPage =>
@@ -54,6 +44,17 @@ class RStudioSpec extends RuntimeFixtureSpec with RStudioTestUtils {
               rstudioPage.variableExists(s"var_$k") shouldBe true
               rstudioPage.variableExists(s"$v") shouldBe true
           }
+        }
+      }
+    }
+
+    // Note this test should be last because the test infrastructure does not close the shiny app
+    "should launch an RShiny app" in { runtimeFixture =>
+      withWebDriver { implicit driver =>
+        withNewRStudio(runtimeFixture.runtime) { rstudioPage =>
+          rstudioPage.withRShinyExample("01_hello")(rshinyPage =>
+            rshinyPage.getExampleHeader shouldBe Some("Hello Shiny!")
+          )
         }
       }
     }

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/rstudio/RStudioSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/rstudio/RStudioSpec.scala
@@ -46,14 +46,16 @@ class RStudioSpec extends RuntimeFixtureSpec with RStudioTestUtils {
             "WORKSPACE_BUCKET" -> "gs://test-workspace-bucket"
           )
 
-          expectedEVs.foreach { case (k, v) =>
-            rstudioPage.pressKeys(s"""var_$k <- System.getenv("$k")""")
-            rstudioPage.pressKeys(Keys.ENTER.toString)
-            await visible cssSelector(s"[title~='var_$k']")
-            rstudioPage.variableExists(s"var_$k") shouldBe true
-            rstudioPage.variableExists(s"$v") shouldBe true
+          expectedEVs.foreach {
+            case (k, v) =>
+              rstudioPage.pressKeys(s"""var_$k <- System.getenv("$k")""")
+              rstudioPage.pressKeys(Keys.ENTER.toString)
+              await visible cssSelector(s"[title~='var_$k']")
+              rstudioPage.variableExists(s"var_$k") shouldBe true
+              rstudioPage.variableExists(s"$v") shouldBe true
           }
         }
       }
     }
+  }
 }

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/rstudio/RStudioSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/rstudio/RStudioSpec.scala
@@ -54,5 +54,6 @@ class RStudioSpec extends RuntimeFixtureSpec with RStudioTestUtils {
             rstudioPage.variableExists(s"$v") shouldBe true
           }
         }
+      }
     }
 }

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/rstudio/RStudioSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/rstudio/RStudioSpec.scala
@@ -38,7 +38,7 @@ class RStudioSpec extends RuntimeFixtureSpec with RStudioTestUtils {
 
           expectedEVs.foreach {
             case (k, v) =>
-              rstudioPage.pressKeys(s"""var_$k <- System.getenv("$k")""")
+              rstudioPage.pressKeys(s"""var_$k <- Sys.getenv("$k")""")
               rstudioPage.pressKeys(Keys.ENTER.toString)
               await visible cssSelector(s"[title~='var_$k']")
               rstudioPage.variableExists(s"var_$k") shouldBe true

--- a/http/src/main/resources/init-resources/gce-init.sh
+++ b/http/src/main/resources/init-resources/gce-init.sh
@@ -481,6 +481,20 @@ if [ ! -z "$RSTUDIO_DOCKER_IMAGE" ] ; then
     echo "RStudio user package installation directory creation failed, creating /packages directory"
     docker exec ${RSTUDIO_SERVER_NAME} /bin/bash -c "mkdir -p ${RSTUDIO_USER_HOME}/packages && chmod a+rwx ${RSTUDIO_USER_HOME}/packages"
   fi
+
+  # Add the EVs specified in rstudio-docker-compose.yaml to Renviron.site
+  retry 3 docker exec ${RSTUDIO_SERVER_NAME} /bin/bash -c 'echo "GOOGLE_PROJECT=$GOOGLE_PROJECT
+WORKSPACE_NAMESPACE=$WORKSPACE_NAMESPACE
+CLUSTER_NAME=$CLUSTER_NAME
+RUNTIME_NAME=$RUNTIME_NAME
+OWNER_EMAIL=$OWNER_EMAIL" >> /usr/local/lib/R/etc/Renviron.site'
+
+  # Add custom_env_vars.env to Renviron.site
+  retry 3 docker cp /etc/custom_env_vars.env /usr/local/lib/R/etc/custom_env_vars.env
+  retry 3 docker exec ${RSTUDIO_SERVER_NAME} /bin/bash -c 'cat /etc/custom_env_vars.env >> /usr/local/lib/R/etc/Renviron.site'
+
+  # Start RStudio server
+  retry 3 docker exec -d ${RSTUDIO_SERVER_NAME} /init
 fi
 
 # Remove any unneeded cached images to save disk space.

--- a/http/src/main/resources/init-resources/gce-init.sh
+++ b/http/src/main/resources/init-resources/gce-init.sh
@@ -491,7 +491,7 @@ OWNER_EMAIL=$OWNER_EMAIL" >> /usr/local/lib/R/etc/Renviron.site'
 
   # Add custom_env_vars.env to Renviron.site
   retry 3 docker cp /etc/custom_env_vars.env /usr/local/lib/R/etc/custom_env_vars.env
-  retry 3 docker exec ${RSTUDIO_SERVER_NAME} /bin/bash -c 'cat /etc/custom_env_vars.env >> /usr/local/lib/R/etc/Renviron.site'
+  retry 3 docker exec ${RSTUDIO_SERVER_NAME} /bin/bash -c 'cat /usr/local/lib/R/etc/custom_env_vars.env >> /usr/local/lib/R/etc/Renviron.site'
 
   # Start RStudio server
   retry 3 docker exec -d ${RSTUDIO_SERVER_NAME} /init

--- a/http/src/main/resources/init-resources/gce-init.sh
+++ b/http/src/main/resources/init-resources/gce-init.sh
@@ -490,7 +490,7 @@ RUNTIME_NAME=$RUNTIME_NAME
 OWNER_EMAIL=$OWNER_EMAIL" >> /usr/local/lib/R/etc/Renviron.site'
 
   # Add custom_env_vars.env to Renviron.site
-  retry 3 docker cp /etc/custom_env_vars.env /usr/local/lib/R/etc/custom_env_vars.env
+  retry 3 docker cp /etc/custom_env_vars.env ${RSTUDIO_SERVER_NAME}:/usr/local/lib/R/etc/custom_env_vars.env
   retry 3 docker exec ${RSTUDIO_SERVER_NAME} /bin/bash -c 'cat /usr/local/lib/R/etc/custom_env_vars.env >> /usr/local/lib/R/etc/Renviron.site'
 
   # Start RStudio server

--- a/http/src/main/resources/init-resources/gce-init.sh
+++ b/http/src/main/resources/init-resources/gce-init.sh
@@ -490,8 +490,11 @@ RUNTIME_NAME=$RUNTIME_NAME
 OWNER_EMAIL=$OWNER_EMAIL" >> /usr/local/lib/R/etc/Renviron.site'
 
   # Add custom_env_vars.env to Renviron.site
-  retry 3 docker cp /etc/custom_env_vars.env ${RSTUDIO_SERVER_NAME}:/usr/local/lib/R/etc/custom_env_vars.env
-  retry 3 docker exec ${RSTUDIO_SERVER_NAME} /bin/bash -c 'cat /usr/local/lib/R/etc/custom_env_vars.env >> /usr/local/lib/R/etc/Renviron.site'
+  CUSTOM_ENV_VARS_FILE=/etc/custom_env_vars.env
+  if [ -f "$CUSTOM_ENV_VARS_FILE" ]; then
+    retry 3 docker cp /etc/custom_env_vars.env ${RSTUDIO_SERVER_NAME}:/usr/local/lib/R/etc/custom_env_vars.env
+    retry 3 docker exec ${RSTUDIO_SERVER_NAME} /bin/bash -c 'cat /usr/local/lib/R/etc/custom_env_vars.env >> /usr/local/lib/R/etc/Renviron.site'
+  fi
 
   # Start RStudio server
   retry 3 docker exec -d ${RSTUDIO_SERVER_NAME} /init

--- a/http/src/main/resources/init-resources/init-actions.sh
+++ b/http/src/main/resources/init-resources/init-actions.sh
@@ -508,8 +508,11 @@ RUNTIME_NAME=$RUNTIME_NAME
 OWNER_EMAIL=$OWNER_EMAIL" >> /usr/local/lib/R/etc/Renviron.site'
 
     # Add custom_env_vars.env to Renviron.site
-    retry 3 docker cp /etc/custom_env_vars.env ${RSTUDIO_SERVER_NAME}:/usr/local/lib/R/etc/custom_env_vars.env
-    retry 3 docker exec ${RSTUDIO_SERVER_NAME} /bin/bash -c 'cat /usr/local/lib/R/etc/custom_env_vars.env >> /usr/local/lib/R/etc/Renviron.site'
+    CUSTOM_ENV_VARS_FILE=/etc/custom_env_vars.env
+    if [ -f "$CUSTOM_ENV_VARS_FILE" ]; then
+      retry 3 docker cp ${CUSTOM_ENV_VARS_FILE} ${RSTUDIO_SERVER_NAME}:/usr/local/lib/R/etc/custom_env_vars.env
+      retry 3 docker exec ${RSTUDIO_SERVER_NAME} /bin/bash -c 'cat /usr/local/lib/R/etc/custom_env_vars.env >> /usr/local/lib/R/etc/Renviron.site'
+    fi
 
     # Start RStudio server
     retry 3 docker exec -d ${RSTUDIO_SERVER_NAME} /init

--- a/http/src/main/resources/init-resources/init-actions.sh
+++ b/http/src/main/resources/init-resources/init-actions.sh
@@ -489,39 +489,38 @@ END
 
       STEP_TIMINGS+=($(date +%s))
     fi
-  fi
 
-  # RStudio specific setup; only do if RStudio is installed
-  if [ ! -z "$RSTUDIO_DOCKER_IMAGE" ] ; then
-    EXIT_CODE=0
-    retry 3 docker exec ${RSTUDIO_SERVER_NAME} ${RSTUDIO_SCRIPTS}/set_up_package_dir.sh || EXIT_CODE=$?
-    if [ $EXIT_CODE -ne 0 ]; then
-      echo "RStudio user package installation directory creation failed, creating /packages directory"
-      docker exec ${RSTUDIO_SERVER_NAME} /bin/bash -c "mkdir -p ${RSTUDIO_USER_HOME}/packages && chmod a+rwx ${RSTUDIO_USER_HOME}/packages"
-    fi
+    # RStudio specific setup; only do if RStudio is installed
+    if [ ! -z "$RSTUDIO_DOCKER_IMAGE" ] ; then
+      EXIT_CODE=0
+      retry 3 docker exec ${RSTUDIO_SERVER_NAME} ${RSTUDIO_SCRIPTS}/set_up_package_dir.sh || EXIT_CODE=$?
+      if [ $EXIT_CODE -ne 0 ]; then
+        echo "RStudio user package installation directory creation failed, creating /packages directory"
+        docker exec ${RSTUDIO_SERVER_NAME} /bin/bash -c "mkdir -p ${RSTUDIO_USER_HOME}/packages && chmod a+rwx ${RSTUDIO_USER_HOME}/packages"
+      fi
 
-    # Add the EVs specified in rstudio-docker-compose.yaml to Renviron.site
-    retry 3 docker exec ${RSTUDIO_SERVER_NAME} /bin/bash -c 'echo "GOOGLE_PROJECT=$GOOGLE_PROJECT
+      # Add the EVs specified in rstudio-docker-compose.yaml to Renviron.site
+      retry 3 docker exec ${RSTUDIO_SERVER_NAME} /bin/bash -c 'echo "GOOGLE_PROJECT=$GOOGLE_PROJECT
 WORKSPACE_NAMESPACE=$WORKSPACE_NAMESPACE
 CLUSTER_NAME=$CLUSTER_NAME
 RUNTIME_NAME=$RUNTIME_NAME
 OWNER_EMAIL=$OWNER_EMAIL" >> /usr/local/lib/R/etc/Renviron.site'
 
-    # Add custom_env_vars.env to Renviron.site
-    CUSTOM_ENV_VARS_FILE=/etc/custom_env_vars.env
-    if [ -f "$CUSTOM_ENV_VARS_FILE" ]; then
-      retry 3 docker cp ${CUSTOM_ENV_VARS_FILE} ${RSTUDIO_SERVER_NAME}:/usr/local/lib/R/etc/custom_env_vars.env
-      retry 3 docker exec ${RSTUDIO_SERVER_NAME} /bin/bash -c 'cat /usr/local/lib/R/etc/custom_env_vars.env >> /usr/local/lib/R/etc/Renviron.site'
+      # Add custom_env_vars.env to Renviron.site
+      CUSTOM_ENV_VARS_FILE=/etc/custom_env_vars.env
+      if [ -f "$CUSTOM_ENV_VARS_FILE" ]; then
+        retry 3 docker cp ${CUSTOM_ENV_VARS_FILE} ${RSTUDIO_SERVER_NAME}:/usr/local/lib/R/etc/custom_env_vars.env
+        retry 3 docker exec ${RSTUDIO_SERVER_NAME} /bin/bash -c 'cat /usr/local/lib/R/etc/custom_env_vars.env >> /usr/local/lib/R/etc/Renviron.site'
+      fi
+
+      # Start RStudio server
+      retry 3 docker exec -d ${RSTUDIO_SERVER_NAME} /init
     fi
 
-    # Start RStudio server
-    retry 3 docker exec -d ${RSTUDIO_SERVER_NAME} /init
-  fi
-
-  # Remove any unneeded cached images to save disk space.
-  # Do this asynchronously so it doesn't hold up cluster creation
-  log 'Pruning docker images...'
-  docker image prune -a -f &
+    # Remove any unneeded cached images to save disk space.
+    # Do this asynchronously so it doesn't hold up cluster creation
+    log 'Pruning docker images...'
+    docker image prune -a -f &
 fi
 
 log 'All done!'

--- a/http/src/main/resources/init-resources/init-actions.sh
+++ b/http/src/main/resources/init-resources/init-actions.sh
@@ -143,6 +143,8 @@ if [[ "${ROLE}" == 'Master' ]]; then
     JUPYTER_NOTEBOOK_FRONTEND_CONFIG_URI=$(jupyterNotebookFrontendConfigUri)
     CUSTOM_ENV_VARS_CONFIG_URI=$(customEnvVarsConfigUri)
     RSTUDIO_LICENSE_FILE=$(rstudioLicenseFile)
+    RSTUDIO_SCRIPTS=/etc/rstudio/scripts
+    RSTUDIO_USER_HOME=/home/rstudio
 
     STEP_TIMINGS+=($(date +%s))
 

--- a/http/src/main/resources/init-resources/rstudio-docker-compose.yaml
+++ b/http/src/main/resources/init-resources/rstudio-docker-compose.yaml
@@ -7,6 +7,8 @@ services:
   rstudio:
     container_name: "${RSTUDIO_SERVER_NAME}"
     image: "${RSTUDIO_DOCKER_IMAGE}"
+    # Override the entrypoint from the Dockerfile so rserver starts with the below environment variables
+    entrypoint: "/init"
     network_mode: host
     restart: always
     environment:

--- a/http/src/main/resources/init-resources/rstudio-docker-compose.yaml
+++ b/http/src/main/resources/init-resources/rstudio-docker-compose.yaml
@@ -8,7 +8,7 @@ services:
     container_name: "${RSTUDIO_SERVER_NAME}"
     image: "${RSTUDIO_DOCKER_IMAGE}"
     # Override the entrypoint from the Dockerfile so rserver starts with the below environment variables
-    entrypoint: "/init"
+    entrypoint: "tail -f /dev/null"
     network_mode: host
     restart: always
     environment:

--- a/http/src/main/resources/init-resources/startup.sh
+++ b/http/src/main/resources/init-resources/startup.sh
@@ -51,9 +51,11 @@ export CLUSTER_NAME=$(clusterName)
 export RUNTIME_NAME=$(clusterName)
 export OWNER_EMAIL=$(loginHint)
 export JUPYTER_SERVER_NAME=$(jupyterServerName)
+export RSTUDIO_SERVER_NAME=$(rstudioServerName)
 export WELDER_SERVER_NAME=$(welderServerName)
 export NOTEBOOKS_DIR=$(notebooksDir)
 export JUPYTER_DOCKER_IMAGE=$(jupyterDockerImage)
+export RSTUDIO_DOCKER_IMAGE=$(rstudioDockerImage)
 export WELDER_ENABLED=$(welderEnabled)
 export UPDATE_WELDER=$(updateWelder)
 export WELDER_DOCKER_IMAGE=$(welderDockerImage)
@@ -147,6 +149,17 @@ if [ ! -z "$JUPYTER_DOCKER_IMAGE" ] ; then
         # TODO: remove this when we stop supporting the legacy docker image
         docker exec -u root jupyter-server sed -i -e 's/export WORKSPACE_NAME=.*/export WORKSPACE_NAME="$(basename "$(dirname "$(pwd)")")"/' /etc/jupyter/scripts/kernel/kernel_bootstrap.sh
     fi
+fi
+
+# Configuring RStudio, if enabled
+if [ ! -z "$RSTUDIO_DOCKER_IMAGE" ] ; then
+    echo "Starting RStudio on cluster $GOOGLE_PROJECT / $CLUSTER_NAME..."
+
+    # update container MEM_LIMIT to reflect VM's MEM_LIMIT
+    docker update $RSTUDIO_SERVER_NAME --memory $MEM_LIMIT
+
+    # Start RStudio server
+    docker exec -d $RSTUDIO_SERVER_NAME /init
 fi
 
 # Configuring Welder, if enabled


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-2567

Geraldine noticed this. I think this broke because of the switch to base the AnVIL RStudio image off the Bioconductor image. It now uses `s6-overlay` to launch RStudio, so RStudio does not have access to the EVs in the container (they need to be explicitly added to `Renviron.site`).

This PR adds all the EVs we normally set through `docker-compose` to `Renviron.site`. It's a little hacky but seems to work on my instance. I added an automation test too (haven't run it yet).

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
