### PR TITLE
[no ticket] Removing predeleting status update for nodepools

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/kubernetesModels.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/kubernetesModels.scala
@@ -151,10 +151,6 @@ object NodepoolStatus {
     override def toString: String = "PRECREATING"
   }
 
-  final case object Predeleting extends NodepoolStatus {
-    override def toString: String = "PREDELETING"
-  }
-
   final case object Unclaimed extends NodepoolStatus {
     override def toString: String = "UNCLAIMED"
   }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/KubernetesServiceDbQueries.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/KubernetesServiceDbQueries.scala
@@ -187,7 +187,6 @@ object KubernetesServiceDbQueries {
 
   def markPreDeleting(nodepoolId: NodepoolLeoId, appId: AppId)(implicit ec: ExecutionContext): DBIO[Unit] =
     for {
-      _ <- nodepoolQuery.updateStatus(nodepoolId, NodepoolStatus.Predeleting)
       _ <- appQuery.updateStatus(appId, AppStatus.Predeleting)
     } yield ()
 

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/KubernetesServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/KubernetesServiceInterpSpec.scala
@@ -250,6 +250,7 @@ final class KubernetesServiceInterpSpec extends AnyFlatSpec with LeonardoTestSui
 
     //we can't delete while its creating, so set it to Running
     dbFutureValue(appQuery.updateStatus(appResultPreStatusUpdate.get.app.id, AppStatus.Running))
+    dbFutureValue(nodepoolQuery.updateStatus(appResultPreStatusUpdate.get.nodepool.id, NodepoolStatus.Running))
 
     val appResultPreDelete = dbFutureValue {
       KubernetesServiceDbQueries.getActiveFullAppByName(project, appName)

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/KubernetesServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/KubernetesServiceInterpSpec.scala
@@ -265,7 +265,7 @@ final class KubernetesServiceInterpSpec extends AnyFlatSpec with LeonardoTestSui
 
     clusterPostDelete.length shouldEqual 1
     val nodepool = clusterPostDelete.head.nodepools.head
-    nodepool.status shouldEqual NodepoolStatus.Predeleting
+    nodepool.status shouldEqual NodepoolStatus.Running
     val app = nodepool.apps.head
     app.status shouldEqual AppStatus.Predeleting
 


### PR DESCRIPTION
Found while doing some Perf test debugging. We shouldn't have a pre-deleting status for nodepools since only cronjobs should be deleting it
---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
