### PR TITLE
QA-1360: make flakey test re-use same notebook across stop/start instead of create new one

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookGCECustomizationSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookGCECustomizationSpec.scala
@@ -197,7 +197,7 @@ final class NotebookGCECustomizationSpec extends GPAllocFixtureSpec with Paralle
               withOpenNotebook(runtime, notebookPath, 10.minutes) { notebookPage =>
                 // old output should still exist
                 val firstCell = notebookPage.firstCell
-                notebookPage.cellOutput(firstCell).get shouldBe "1"
+                notebookPage.cellOutput(firstCell) shouldBe Some(CellOutput("1", None))
                 // execute a new cell to make sure the startup script worked
                 notebookPage.runAllCells()
                 notebookPage.executeCell("!cat $JUPYTER_HOME/leo_test_start_count.txt").get shouldBe "2"

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookGCECustomizationSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookGCECustomizationSpec.scala
@@ -1,5 +1,7 @@
 package org.broadinstitute.dsde.workbench.leonardo.notebooks
 
+import java.io.File
+
 import org.broadinstitute.dsde.workbench.ResourceFile
 import org.broadinstitute.dsde.workbench.auth.AuthToken
 import org.broadinstitute.dsde.workbench.dao.Google.googleStorageDAO
@@ -190,12 +192,18 @@ final class NotebookGCECustomizationSpec extends GPAllocFixtureSpec with Paralle
               // Start the cluster
               startAndMonitorRuntime(runtime.googleProject, runtime.clusterName)
 
-              withNewNotebook(runtime, Python3) { notebookPage =>
+              val notebookPath = new File("Untitled.ipynb")
+              // Use a longer timeout than default because opening notebooks after resume can be slow
+              withOpenNotebook(runtime, notebookPath, 10.minutes) { notebookPage =>
+                // old output should still exist
+                val firstCell = notebookPage.firstCell
+                notebookPage.cellOutput(firstCell).get shouldBe "1"
+                // execute a new cell to make sure the startup script worked
+                notebookPage.runAllCells()
                 notebookPage.executeCell("!cat $JUPYTER_HOME/leo_test_start_count.txt").get shouldBe "2"
               }
             }
           }
-
         }
       }
     }


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/QA-1360

This test frequently fails [here](https://github.com/DataBiosphere/leonardo/blob/develop/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookGCECustomizationSpec.scala#L193) when it tries to create a new notebook after a runtime stop/start due to unexpected selenium alerts.

I noticed [this test](https://github.com/DataBiosphere/leonardo/blob/develop/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookGCEClusterMonitoringSpec.scala#L54) (which rarely fails) also stop/starts a runtime but opens an existing notebook.

Trying a similar approach in this test where I re-use the same notebook instead of creating a new one after stop/start.

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
