### PR TITLE
Add zone to createRuntime requests

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/JsonCodec.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/JsonCodec.scala
@@ -266,6 +266,7 @@ object JsonCodec {
       numberOfPreemptibleWorkers <- c.downField("numberOfPreemptibleWorkers").as[Option[Int]]
       propertiesOpt <- c.downField("properties").as[Option[LabelMap]]
       properties = propertiesOpt.getOrElse(Map.empty)
+      zone <-c.downField("zone").as[ZoneName]
     } yield RuntimeConfig.DataprocConfig(numberOfWorkers,
                                          masterMachineType,
                                          masterDiskSize,
@@ -273,7 +274,8 @@ object JsonCodec {
                                          workerDiskSize,
                                          numberOfWorkerLocalSSDs,
                                          numberOfPreemptibleWorkers,
-                                         properties)
+                                         properties,
+                                         zone)
   }
 
   implicit val runtimeConfigDecoder: Decoder[RuntimeConfig] = Decoder.instance { x =>

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/JsonCodec.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/JsonCodec.scala
@@ -323,16 +323,18 @@ object JsonCodec {
   implicit val diskTypeDecoder: Decoder[DiskType] =
     Decoder.decodeString.emap(x => DiskType.stringToObject.get(x).toRight(s"Invalid disk type: $x"))
 
-  implicit val gceWithPdConfigDecoder: Decoder[RuntimeConfig.GceWithPdConfig] = Decoder.forProduct3(
+  implicit val gceWithPdConfigDecoder: Decoder[RuntimeConfig.GceWithPdConfig] = Decoder.forProduct4(
     "machineType",
     "persistentDiskId",
-    "bootDiskSize"
+    "bootDiskSize",
+    "zone"
   )(RuntimeConfig.GceWithPdConfig.apply)
-  implicit val gceConfigDecoder: Decoder[RuntimeConfig.GceConfig] = Decoder.forProduct3(
+  implicit val gceConfigDecoder: Decoder[RuntimeConfig.GceConfig] = Decoder.forProduct4(
     "machineType",
     "diskSize",
-    "bootDiskSize"
-  )((mt, ds, bds) => RuntimeConfig.GceConfig(mt, ds, bds))
+    "bootDiskSize",
+    "zone"
+  )((mt, ds, bds, z) => RuntimeConfig.GceConfig(mt, ds, bds, z))
 
   implicit val persistentDiskRequestDecoder: Decoder[PersistentDiskRequest] = Decoder.instance { x =>
     for {

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/JsonCodec.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/JsonCodec.scala
@@ -266,7 +266,7 @@ object JsonCodec {
       numberOfPreemptibleWorkers <- c.downField("numberOfPreemptibleWorkers").as[Option[Int]]
       propertiesOpt <- c.downField("properties").as[Option[LabelMap]]
       properties = propertiesOpt.getOrElse(Map.empty)
-      zone <-c.downField("zone").as[ZoneName]
+      zone <- c.downField("zone").as[ZoneName]
     } yield RuntimeConfig.DataprocConfig(numberOfWorkers,
                                          masterMachineType,
                                          masterDiskSize,

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/JsonCodec.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/JsonCodec.scala
@@ -71,7 +71,7 @@ object JsonCodec {
   implicit val diskStatusEncoder: Encoder[DiskStatus] = Encoder.encodeString.contramap(_.entryName)
   implicit val diskTypeEncoder: Encoder[DiskType] = Encoder.encodeString.contramap(_.asString)
 
-  implicit val dataprocConfigEncoder: Encoder[RuntimeConfig.DataprocConfig] = Encoder.forProduct8(
+  implicit val dataprocConfigEncoder: Encoder[RuntimeConfig.DataprocConfig] = Encoder.forProduct9(
     "numberOfWorkers",
     "masterMachineType",
     "masterDiskSize",
@@ -80,7 +80,8 @@ object JsonCodec {
     "workerDiskSize",
     "numberOfWorkerLocalSSDs",
     "numberOfPreemptibleWorkers",
-    "cloudService"
+    "cloudService",
+    "zone"
   )(x =>
     (x.numberOfWorkers,
      x.machineType,
@@ -89,14 +90,16 @@ object JsonCodec {
      x.workerDiskSize,
      x.numberOfWorkerLocalSSDs,
      x.numberOfPreemptibleWorkers,
-     x.cloudService)
+     x.cloudService,
+     x.zone)
   )
-  implicit val gceRuntimeConfigEncoder: Encoder[RuntimeConfig.GceConfig] = Encoder.forProduct4(
+  implicit val gceRuntimeConfigEncoder: Encoder[RuntimeConfig.GceConfig] = Encoder.forProduct5(
     "machineType",
     "diskSize",
     "cloudService",
-    "bootDiskSize"
-  )(x => (x.machineType, x.diskSize, x.cloudService, x.bootDiskSize))
+    "bootDiskSize",
+    "zone"
+  )(x => (x.machineType, x.diskSize, x.cloudService, x.bootDiskSize, x.zone))
   implicit val userJupyterExtensionConfigEncoder: Encoder[UserJupyterExtensionConfig] = Encoder.forProduct4(
     "nbExtensions",
     "serverExtensions",
@@ -117,12 +120,13 @@ object JsonCodec {
     "imageUrl",
     "timestamp"
   )(x => RuntimeImage.unapply(x).get)
-  implicit val gceWithPdConfigEncoder: Encoder[RuntimeConfig.GceWithPdConfig] = Encoder.forProduct4(
+  implicit val gceWithPdConfigEncoder: Encoder[RuntimeConfig.GceWithPdConfig] = Encoder.forProduct5(
     "machineType",
     "persistentDiskId",
     "cloudService",
-    "bootDiskSize"
-  )(x => (x.machineType, x.persistentDiskId, x.cloudService, x.bootDiskSize))
+    "bootDiskSize",
+    "zone"
+  )(x => (x.machineType, x.persistentDiskId, x.cloudService, x.bootDiskSize, x.zone))
 
   implicit val runtimeConfigEncoder: Encoder[RuntimeConfig] = Encoder.instance(x =>
     x match {

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/runtimeRoutesModels.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/runtimeRoutesModels.scala
@@ -55,7 +55,8 @@ object RuntimeConfigRequest {
                                   workerDiskSize: Option[DiskSize] = None, //min 10
                                   numberOfWorkerLocalSSDs: Option[Int] = None, //min 0 max 8
                                   numberOfPreemptibleWorkers: Option[Int] = None,
-                                  properties: Map[String, String])
+                                  properties: Map[String, String],
+                                  zone: Option[ZoneName] = None)
       extends RuntimeConfigRequest {
     val cloudService: CloudService = CloudService.Dataproc
   }

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/runtimeRoutesModels.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/runtimeRoutesModels.scala
@@ -1,6 +1,6 @@
 package org.broadinstitute.dsde.workbench.leonardo.http
 
-import org.broadinstitute.dsde.workbench.google2.MachineTypeName
+import org.broadinstitute.dsde.workbench.google2.{MachineTypeName, ZoneName}
 import org.broadinstitute.dsde.workbench.leonardo.{
   AsyncRuntimeFields,
   AuditInfo,
@@ -33,14 +33,16 @@ sealed trait RuntimeConfigRequest extends Product with Serializable {
 object RuntimeConfigRequest {
   final case class GceConfig(
     machineType: Option[MachineTypeName],
-    diskSize: Option[DiskSize]
+    diskSize: Option[DiskSize],
+    zone: Option[ZoneName] = None
   ) extends RuntimeConfigRequest {
     val cloudService: CloudService = CloudService.GCE
   }
 
   final case class GceWithPdConfig(
     machineType: Option[MachineTypeName],
-    persistentDisk: PersistentDiskRequest
+    persistentDisk: PersistentDiskRequest,
+    zone: Option[ZoneName] = None
   ) extends RuntimeConfigRequest {
     val cloudService: CloudService = CloudService.GCE
   }

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/runtimeModels.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/runtimeModels.scala
@@ -197,7 +197,7 @@ object RuntimeConfig {
     bootDiskSize: Option[
       DiskSize
     ], //This is optional for supporting old runtimes which only have 1 disk. All new runtime will have a boot disk
-    zone: Option[ZoneName]
+    zone: ZoneName
   ) extends RuntimeConfig {
     val cloudService: CloudService = CloudService.GCE
   }
@@ -206,7 +206,7 @@ object RuntimeConfig {
   final case class GceWithPdConfig(machineType: MachineTypeName,
                                    persistentDiskId: Option[DiskId],
                                    bootDiskSize: DiskSize,
-                                   zone: Option[ZoneName])
+                                   zone: ZoneName)
       extends RuntimeConfig {
     val cloudService: CloudService = CloudService.GCE
   }
@@ -219,7 +219,8 @@ object RuntimeConfig {
                                   workerDiskSize: Option[DiskSize] = None, //min 10
                                   numberOfWorkerLocalSSDs: Option[Int] = None, //min 0 max 8
                                   numberOfPreemptibleWorkers: Option[Int] = None,
-                                  properties: Map[String, String])
+                                  properties: Map[String, String],
+                                  zone: ZoneName)
       extends RuntimeConfig {
     val cloudService: CloudService = CloudService.Dataproc
     val machineType: MachineTypeName = masterMachineType

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/runtimeModels.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/runtimeModels.scala
@@ -6,7 +6,7 @@ import java.time.Instant
 import cats.syntax.all._
 import enumeratum.{Enum, EnumEntry}
 import monocle.Prism
-import org.broadinstitute.dsde.workbench.google2.{MachineTypeName, OperationName}
+import org.broadinstitute.dsde.workbench.google2.{MachineTypeName, OperationName, ZoneName}
 import org.broadinstitute.dsde.workbench.google2.DataprocRole.SecondaryWorker
 import org.broadinstitute.dsde.workbench.leonardo.RuntimeContainerServiceType.JupyterService
 import org.broadinstitute.dsde.workbench.leonardo.RuntimeImageType.{Jupyter, RStudio, VM, Welder}
@@ -196,7 +196,8 @@ object RuntimeConfig {
     diskSize: DiskSize,
     bootDiskSize: Option[
       DiskSize
-    ] //This is optional for supporting old runtimes which only have 1 disk. All new runtime will have a boot disk
+    ], //This is optional for supporting old runtimes which only have 1 disk. All new runtime will have a boot disk
+    zone: Option[ZoneName]
   ) extends RuntimeConfig {
     val cloudService: CloudService = CloudService.GCE
   }
@@ -204,7 +205,8 @@ object RuntimeConfig {
   // When persistentDiskId is None, then we don't have any disk attached to the runtime
   final case class GceWithPdConfig(machineType: MachineTypeName,
                                    persistentDiskId: Option[DiskId],
-                                   bootDiskSize: DiskSize)
+                                   bootDiskSize: DiskSize,
+                                   zone: Option[ZoneName])
       extends RuntimeConfig {
     val cloudService: CloudService = CloudService.GCE
   }

--- a/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/JsonCodecSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/JsonCodecSpec.scala
@@ -4,7 +4,7 @@ import JsonCodec._
 import io.circe.CursorOp.DownField
 import io.circe.{DecodingFailure, Json}
 import io.circe.parser._
-import org.broadinstitute.dsde.workbench.google2.MachineTypeName
+import org.broadinstitute.dsde.workbench.google2.{MachineTypeName, ZoneName}
 
 import org.scalatest.flatspec.AnyFlatSpecLike
 import org.scalatest.matchers.should.Matchers
@@ -50,6 +50,7 @@ class JsonCodecSpec extends LeonardoTestSuite with Matchers with AnyFlatSpecLike
     val expected = RuntimeConfig.GceConfig(
       MachineTypeName("n1-standard-8"),
       DiskSize(500),
+      None,
       None
     )
     res shouldBe (Right(expected))
@@ -70,7 +71,8 @@ class JsonCodecSpec extends LeonardoTestSuite with Matchers with AnyFlatSpecLike
     val expected = RuntimeConfig.GceWithPdConfig(
       MachineTypeName("n1-standard-8"),
       None,
-      DiskSize(50)
+      DiskSize(50),
+      None
     )
     res shouldBe (Right(expected))
   }
@@ -101,12 +103,13 @@ class JsonCodecSpec extends LeonardoTestSuite with Matchers with AnyFlatSpecLike
         |   "cloudService": "gce",
         |   "machineType": "n1-standard-8",
         |   "persistentDiskId": 50,
-        |   "bootDiskSize": 50
+        |   "bootDiskSize": 50,
+        |   "zone": "us-east2-b"
         |}
         |""".stripMargin
 
     val res = decode[RuntimeConfig](inputString)
-    res shouldBe Right(RuntimeConfig.GceWithPdConfig(MachineTypeName("n1-standard-8"), Some(DiskId(50)), DiskSize(50)))
+    res shouldBe Right(RuntimeConfig.GceWithPdConfig(MachineTypeName("n1-standard-8"), Some(DiskId(50)), DiskSize(50), Some(ZoneName("us-east2-b"))))
   }
 
   it should "fail decoding if diskName has upper case" in {

--- a/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/JsonCodecSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/JsonCodecSpec.scala
@@ -18,7 +18,8 @@ class JsonCodecSpec extends LeonardoTestSuite with Matchers with AnyFlatSpecLike
         |   "masterMachineType": "n1-standard-8",
         |   "masterDiskSize": 500,
         |   "numberOfPreemptibleWorkers": -1,
-        |   "cloudService": "DATAPROC"
+        |   "cloudService": "DATAPROC",
+        |   "zone": "us-west2-b"
         |}
         |""".stripMargin
 
@@ -31,7 +32,8 @@ class JsonCodecSpec extends LeonardoTestSuite with Matchers with AnyFlatSpecLike
       None,
       None,
       Some(-1),
-      Map.empty
+      Map.empty,
+      ZoneName("us-west2-b")
     )
     res shouldBe (Right(expected))
   }
@@ -43,6 +45,7 @@ class JsonCodecSpec extends LeonardoTestSuite with Matchers with AnyFlatSpecLike
         |   "machineType": "n1-standard-8",
         |   "diskSize": 500,
         |   "cloudService": "GCE"
+        |   "zone" "us-west2-b"
         |}
         |""".stripMargin
 
@@ -51,7 +54,7 @@ class JsonCodecSpec extends LeonardoTestSuite with Matchers with AnyFlatSpecLike
       MachineTypeName("n1-standard-8"),
       DiskSize(500),
       None,
-      None
+      ZoneName("us-west2-b")
     )
     res shouldBe (Right(expected))
   }
@@ -63,7 +66,8 @@ class JsonCodecSpec extends LeonardoTestSuite with Matchers with AnyFlatSpecLike
         |{
         |   "machineType": "n1-standard-8",
         |   "cloudService": "GCE",
-        |   "bootDiskSize": 50
+        |   "bootDiskSize": 50,
+        |   "zone": "us-west2-b"
         |}
         |""".stripMargin
 
@@ -72,7 +76,7 @@ class JsonCodecSpec extends LeonardoTestSuite with Matchers with AnyFlatSpecLike
       MachineTypeName("n1-standard-8"),
       None,
       DiskSize(50),
-      None
+      ZoneName("us-west2-b")
     )
     res shouldBe (Right(expected))
   }
@@ -104,14 +108,14 @@ class JsonCodecSpec extends LeonardoTestSuite with Matchers with AnyFlatSpecLike
         |   "machineType": "n1-standard-8",
         |   "persistentDiskId": 50,
         |   "bootDiskSize": 50,
-        |   "zone": "us-east2-b"
+        |   "zone": "us-west2-b"
         |}
         |""".stripMargin
 
     val res = decode[RuntimeConfig](inputString)
     res shouldBe Right(
       RuntimeConfig
-        .GceWithPdConfig(MachineTypeName("n1-standard-8"), Some(DiskId(50)), DiskSize(50), Some(ZoneName("us-east2-b")))
+        .GceWithPdConfig(MachineTypeName("n1-standard-8"), Some(DiskId(50)), DiskSize(50), ZoneName("us-east2-b"))
     )
   }
 

--- a/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/JsonCodecSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/JsonCodecSpec.scala
@@ -109,7 +109,10 @@ class JsonCodecSpec extends LeonardoTestSuite with Matchers with AnyFlatSpecLike
         |""".stripMargin
 
     val res = decode[RuntimeConfig](inputString)
-    res shouldBe Right(RuntimeConfig.GceWithPdConfig(MachineTypeName("n1-standard-8"), Some(DiskId(50)), DiskSize(50), Some(ZoneName("us-east2-b"))))
+    res shouldBe Right(
+      RuntimeConfig
+        .GceWithPdConfig(MachineTypeName("n1-standard-8"), Some(DiskId(50)), DiskSize(50), Some(ZoneName("us-east2-b")))
+    )
   }
 
   it should "fail decoding if diskName has upper case" in {

--- a/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/JsonCodecSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/JsonCodecSpec.scala
@@ -44,8 +44,8 @@ class JsonCodecSpec extends LeonardoTestSuite with Matchers with AnyFlatSpecLike
         |{
         |   "machineType": "n1-standard-8",
         |   "diskSize": 500,
-        |   "cloudService": "GCE"
-        |   "zone" "us-west2-b"
+        |   "cloudService": "GCE",
+        |   "zone": "us-west2-b"
         |}
         |""".stripMargin
 
@@ -115,7 +115,7 @@ class JsonCodecSpec extends LeonardoTestSuite with Matchers with AnyFlatSpecLike
     val res = decode[RuntimeConfig](inputString)
     res shouldBe Right(
       RuntimeConfig
-        .GceWithPdConfig(MachineTypeName("n1-standard-8"), Some(DiskId(50)), DiskSize(50), ZoneName("us-east2-b"))
+        .GceWithPdConfig(MachineTypeName("n1-standard-8"), Some(DiskId(50)), DiskSize(50), ZoneName("us-west2-b"))
     )
   }
 

--- a/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changelog.xml
+++ b/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changelog.xml
@@ -70,5 +70,5 @@
     <include file="changesets/20210122_remove_stop_after_creation.xml" relativeToChangelogFile="true" />
     <include file="changesets/20210217_add_app_pvc_id.xml" relativeToChangelogFile="true" />
     <include file="changesets/20210203_custom_app.xml" relativeToChangelogFile="true" />
-    <include file="changesets/20210225_add_zone.xml" relativeToChangelogFile="true">
+    <include file="changesets/20210225_add_zone.xml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changelog.xml
+++ b/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changelog.xml
@@ -70,4 +70,5 @@
     <include file="changesets/20210122_remove_stop_after_creation.xml" relativeToChangelogFile="true" />
     <include file="changesets/20210217_add_app_pvc_id.xml" relativeToChangelogFile="true" />
     <include file="changesets/20210203_custom_app.xml" relativeToChangelogFile="true" />
+    <include file="changesets/20210225_add_zone.xml" relativeToChangelogFile="true">
 </databaseChangeLog>

--- a/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/20210225_add_zone.xml
+++ b/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/20210225_add_zone.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog logicalFilePath="leonardo" xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+
+    <changeSet logicalFilePath="leonardo" author="willyn" id="add_zone">
+        <addColumn tableName="RUNTIME_CONFIG">
+            <column name="zone" type="varchar(254)">
+                <constraints nullable="true"/>
+            </column>
+        </addColumn>
+
+    </changeSet>
+
+</databaseChangeLog>

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -31,6 +31,7 @@ dataproc {
     workerDiskSize = 100
     numberOfWorkerLocalSSDs = 0
     numberOfPreemptibleWorkers = 0
+    zone = "us-central1-a"
   }
   # This image is used for legacy jupyter image where hail is compatible with earlier version of spark
   legacyCustomDataprocImage = "projects/broad-dsp-gcr-public/global/images/custom-leo-image-dataproc-1-2-79-debian9-d26876f"

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -71,6 +71,7 @@ gce {
     machineType = "n1-standard-4"
     diskSize = 30 # This is default size for just user disk
     bootDiskSize = 50
+    zone = "us-central1-a"
   }
   gceReservedMemory = 1g
 

--- a/http/src/main/resources/swagger/api-docs.yaml
+++ b/http/src/main/resources/swagger/api-docs.yaml
@@ -2503,6 +2503,10 @@ components:
                 or "n1-highmem-64". If unspecified, defaults to creating a "n1-standard-4" machine. To decide which is right for you,
 
                 see https://cloud.google.com/compute/docs/machine-types
+            zone:
+              type: string
+              description: >
+                Optional, the deployment area of the GCE VM. For example, us-east1-a or europe-west2-c.
     GceWithPdConfig:
       description: Configuration for Google Compute Engine instances.
       allOf:
@@ -2523,6 +2527,10 @@ components:
                 or "n1-highmem-64". If unspecified, defaults to creating a "n1-standard-4" machine. To decide which is right for you,
 
                 see https://cloud.google.com/compute/docs/machine-types
+            zone:
+              type: string
+              description: >
+                Optional, the deployment area of the GCE VM. For example, us-east1-a or europe-west2-c.
     DataprocConfig:
       description: Configuration for a single Dataproc cluster.
       allOf:
@@ -2586,6 +2594,10 @@ components:
               type: object
               additionalProperties:
                 type: string
+            zone:
+              type: string
+              description: >
+                Optional, the deployment area of the cluster. For example, us-east1-a or europe-west2-c.
     UserJupyterExtensionConfig:
       description: Specification of Jupyter Extensions to be installed on the cluster
       properties:

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/LeoLenses.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/LeoLenses.scala
@@ -49,7 +49,8 @@ object LeoLenses {
               throw new Exception(
                 "Can't use this RuntimeConfig as RuntimeConfigInCreateRuntimeMessage due to bootDiskSize not defined"
               )
-            )
+            ),
+          x.zone
         )
       )
     case x: RuntimeConfig.GceWithPdConfig =>
@@ -61,7 +62,8 @@ object LeoLenses {
               "Can't use this RuntimeConfig as RuntimeConfigInCreateRuntimeMessage due to persistentDiskId not defined"
             )
           ),
-          x.bootDiskSize
+          x.bootDiskSize,
+          x.zone
         )
       )
     case x: RuntimeConfig.DataprocConfig =>
@@ -71,13 +73,15 @@ object LeoLenses {
       RuntimeConfig.GceConfig(
         x.machineType,
         x.diskSize,
-        Some(x.bootDiskSize)
+        Some(x.bootDiskSize),
+        x.zone
       )
     case x: RuntimeConfigInCreateRuntimeMessage.GceWithPdConfig =>
       RuntimeConfig.GceWithPdConfig(
         x.machineType,
         Some(x.persistentDiskId),
-        x.bootDiskSize
+        x.bootDiskSize,
+        x.zone
       )
     case x: RuntimeConfigInCreateRuntimeMessage.DataprocConfig =>
       dataprocInCreateRuntimeMsgToDataprocRuntime(x)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
@@ -74,7 +74,8 @@ object Config {
         config.getAs[DiskSize]("workerDiskSize"),
         config.getAs[Int]("numberOfWorkerLocalSSDs"),
         config.getAs[Int]("numberOfPreemptibleWorkers"),
-        Map.empty
+        Map.empty,
+        config.as[ZoneName]("zone")
       )
   }
 
@@ -83,7 +84,7 @@ object Config {
       machineType = config.as[MachineTypeName]("machineType"),
       diskSize = config.as[DiskSize]("diskSize"),
       bootDiskSize = Some(config.as[DiskSize]("bootDiskSize")),
-      zone = Some(config.as[ZoneName]("zone"))
+      zone = config.as[ZoneName]("zone")
     )
   }
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
@@ -82,7 +82,8 @@ object Config {
     RuntimeConfig.GceConfig(
       machineType = config.as[MachineTypeName]("machineType"),
       diskSize = config.as[DiskSize]("diskSize"),
-      bootDiskSize = Some(config.as[DiskSize]("bootDiskSize"))
+      bootDiskSize = Some(config.as[DiskSize]("bootDiskSize")),
+      zone = Some(config.as[ZoneName]("zone"))
     )
   }
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/RuntimeConfigQueries.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/RuntimeConfigQueries.scala
@@ -67,7 +67,7 @@ object RuntimeConfigQueries {
     runtimeConfigs
       .filter(x => x.id === id)
       .map(c => (c.zone, c.dateAccessed))
-      .update((Some(zone), dateAccessed))
+      .update((zone, dateAccessed))
 
   def updatePersistentDiskId(id: RuntimeConfigId, persistentDiskId: Option[DiskId], dateAccessed: Instant): DBIO[Int] =
     runtimeConfigs

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/RuntimeConfigQueries.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/RuntimeConfigQueries.scala
@@ -3,7 +3,7 @@ package db
 
 import java.time.Instant
 
-import org.broadinstitute.dsde.workbench.google2.MachineTypeName
+import org.broadinstitute.dsde.workbench.google2.{MachineTypeName, ZoneName}
 import org.broadinstitute.dsde.workbench.leonardo.db.LeoProfile.api._
 import org.broadinstitute.dsde.workbench.leonardo.db.LeoProfile.mappedColumnImplicits._
 import org.broadinstitute.dsde.workbench.leonardo.db.RuntimeServiceDbQueries.RuntimeJoinLabel
@@ -62,6 +62,12 @@ object RuntimeConfigQueries {
       .filter(x => x.id === id)
       .map(c => (c.machineType, c.dateAccessed))
       .update((machineType, dateAccessed))
+
+  def updateZone(id: RuntimeConfigId, zone: ZoneName, dateAccessed: Instant): DBIO[Int] =
+    runtimeConfigs
+      .filter(x => x.id === id)
+      .map(c => (c.zone, c.dateAccessed))
+      .update((Some(zone), dateAccessed))
 
   def updatePersistentDiskId(id: RuntimeConfigId, persistentDiskId: Option[DiskId], dateAccessed: Instant): DBIO[Int] =
     runtimeConfigs

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/RuntimeConfigTable.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/RuntimeConfigTable.scala
@@ -22,7 +22,7 @@ class RuntimeConfigTable(tag: Tag) extends Table[RuntimeConfigRecord](tag, "RUNT
   def dateAccessed = column[Instant]("dateAccessed", O.SqlType("TIMESTAMP(6)"))
   def dataprocProperties = column[Option[Map[String, String]]]("dataprocProperties")
   def persistentDiskId = column[Option[DiskId]]("persistentDiskId")
-  def zone = column[Option[ZoneName]]("zone", O.Length(254))
+  def zone = column[ZoneName]("zone", O.Length(254))
 
   def * =
     (
@@ -77,7 +77,8 @@ class RuntimeConfigTable(tag: Tag) extends Table[RuntimeConfigRecord](tag, "RUNT
               workerDiskSize,
               numberOfWorkerLocalSSDs,
               numberOfPreemptibleWorkers,
-              dataprocProperties.getOrElse(Map.empty)
+              dataprocProperties.getOrElse(Map.empty),
+              zone
             )
         }
         RuntimeConfigRecord(id, r, dateAccessed)
@@ -112,7 +113,7 @@ class RuntimeConfigTable(tag: Tag) extends Table[RuntimeConfigRecord](tag, "RUNT
              r.numberOfPreemptibleWorkers,
              Some(r.properties),
              None,
-             None),
+             r.zone),
             x.dateAccessed
           )
         case r: RuntimeConfig.GceWithPdConfig =>

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/project/build.properties
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version=1.4.7

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/project/build.properties
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.4.7

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterp.scala
@@ -111,7 +111,8 @@ class RuntimeServiceInterp[F[_]: Parallel](config: RuntimeServiceConfig,
             defaultRuntimeConfig = RuntimeConfigInCreateRuntimeMessage.GceConfig(
               config.gceConfig.runtimeConfigDefaults.machineType,
               config.gceConfig.runtimeConfigDefaults.diskSize,
-              bootDiskSize
+              bootDiskSize,
+              config.gceConfig.runtimeConfigDefaults.zone
             )
             runtimeConfig <- req.runtimeConfig
               .fold[F[RuntimeConfigInCreateRuntimeMessage]](F.pure(defaultRuntimeConfig)) { // default to gce if no runtime specific config is provided
@@ -122,7 +123,8 @@ class RuntimeServiceInterp[F[_]: Parallel](config: RuntimeServiceConfig,
                         RuntimeConfigInCreateRuntimeMessage.GceConfig(
                           gce.machineType.getOrElse(config.gceConfig.runtimeConfigDefaults.machineType),
                           gce.diskSize.getOrElse(config.gceConfig.runtimeConfigDefaults.diskSize),
-                          bootDiskSize
+                          bootDiskSize,
+                          gce.zone.getOrElse(config.gceConfig.runtimeConfigDefaults.zone)
                         ): RuntimeConfigInCreateRuntimeMessage
                       )
                     case dataproc: RuntimeConfigRequest.DataprocConfig =>
@@ -143,7 +145,8 @@ class RuntimeServiceInterp[F[_]: Parallel](config: RuntimeServiceConfig,
                           RuntimeConfigInCreateRuntimeMessage.GceWithPdConfig(
                             gce.machineType.getOrElse(config.gceConfig.runtimeConfigDefaults.machineType),
                             diskResult.disk.id,
-                            bootDiskSize
+                            bootDiskSize,
+                            gce.zone.getOrElse(config.gceConfig.runtimeConfigDefaults.zone)
                           ): RuntimeConfigInCreateRuntimeMessage
                         )
                   }
@@ -656,7 +659,7 @@ class RuntimeServiceInterp[F[_]: Parallel](config: RuntimeServiceConfig,
                                                diskUpdate,
                                                context.traceId)
           } yield r
-        case (dataprocConfig @ RuntimeConfig.DataprocConfig(_, _, _, _, _, _, _, _),
+        case (dataprocConfig @ RuntimeConfig.DataprocConfig(_, _, _, _, _, _, _, _, _),
               req @ UpdateRuntimeConfigRequest.DataprocConfig(_, _, _, _)) =>
           processUpdateDataprocConfigRequest(req, allowStop, runtime, dataprocConfig)
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterp.scala
@@ -613,7 +613,7 @@ class RuntimeServiceInterp[F[_]: Parallel](config: RuntimeServiceConfig,
     for {
       context <- ctx.ask
       msg <- (runtimeConfig, request) match {
-        case (RuntimeConfig.GceConfig(machineType, existngDiskSize, _),
+        case (RuntimeConfig.GceConfig(machineType, existngDiskSize, _, _),
               UpdateRuntimeConfigRequest.GceConfig(newMachineType, diskSizeInRequest)) =>
           for {
             targetDiskSize <- traverseIfChanged(diskSizeInRequest, existngDiskSize) { d =>
@@ -632,7 +632,7 @@ class RuntimeServiceInterp[F[_]: Parallel](config: RuntimeServiceConfig,
                                                targetDiskSize,
                                                context.traceId)
           } yield r
-        case (RuntimeConfig.GceWithPdConfig(machineType, diskIdOpt, _),
+        case (RuntimeConfig.GceWithPdConfig(machineType, diskIdOpt, _, _),
               UpdateRuntimeConfigRequest.GceConfig(newMachineType, diskSizeInRequest)) =>
           for {
             // should disk size be updated?

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/MonitorAtBoot.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/MonitorAtBoot.scala
@@ -204,7 +204,8 @@ class MonitorAtBoot[F[_]: Timer](publisherQueue: fs2.concurrent.Queue[F, LeoPubs
               } yield RuntimeConfigInCreateRuntimeMessage.GceConfig(
                 x.machineType,
                 x.diskSize,
-                bootDiskSize
+                bootDiskSize,
+                x.zone
               ): RuntimeConfigInCreateRuntimeMessage
             case x: RuntimeConfig.GceWithPdConfig =>
               for {
@@ -214,7 +215,8 @@ class MonitorAtBoot[F[_]: Timer](publisherQueue: fs2.concurrent.Queue[F, LeoPubs
               } yield RuntimeConfigInCreateRuntimeMessage.GceWithPdConfig(
                 x.machineType,
                 diskId,
-                x.bootDiskSize
+                x.bootDiskSize,
+                x.zone
               ): RuntimeConfigInCreateRuntimeMessage
             case _: RuntimeConfig.DataprocConfig =>
               Right(

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/leoPubsubMessageSubscriberModels.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/leoPubsubMessageSubscriberModels.scala
@@ -34,12 +34,13 @@ object RuntimeConfigInCreateRuntimeMessage {
   final case class GceConfig(
     machineType: MachineTypeName,
     diskSize: DiskSize,
-    bootDiskSize: DiskSize
+    bootDiskSize: DiskSize,
+    zone: Option[ZoneName] = None
   ) extends RuntimeConfigInCreateRuntimeMessage {
     val cloudService: CloudService = CloudService.GCE
   }
 
-  final case class GceWithPdConfig(machineType: MachineTypeName, persistentDiskId: DiskId, bootDiskSize: DiskSize)
+  final case class GceWithPdConfig(machineType: MachineTypeName, persistentDiskId: DiskId, bootDiskSize: DiskSize, zone: Option[ZoneName] = None)
       extends RuntimeConfigInCreateRuntimeMessage {
     val cloudService: CloudService = CloudService.GCE
   }
@@ -559,17 +560,19 @@ object LeoPubsubCodec {
   }
 
   implicit val gceConfigInCreateRuntimeMessageDecoder: Decoder[RuntimeConfigInCreateRuntimeMessage.GceConfig] =
-    Decoder.forProduct3(
+    Decoder.forProduct4(
       "machineType",
       "diskSize",
-      "bootDiskSize"
+      "bootDiskSize",
+      "zone"
     )(RuntimeConfigInCreateRuntimeMessage.GceConfig.apply)
 
   implicit val gceWithPdConfigInCreateRuntimeMessageDecoder
-    : Decoder[RuntimeConfigInCreateRuntimeMessage.GceWithPdConfig] = Decoder.forProduct3(
+    : Decoder[RuntimeConfigInCreateRuntimeMessage.GceWithPdConfig] = Decoder.forProduct4(
     "machineType",
     "persistentDiskId",
-    "bootDiskSize"
+    "bootDiskSize",
+    "zone"
   )(RuntimeConfigInCreateRuntimeMessage.GceWithPdConfig.apply)
 
   implicit val runtimeConfigInCreateRuntimeMessageDecoder: Decoder[RuntimeConfigInCreateRuntimeMessage] =

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/leoPubsubMessageSubscriberModels.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/leoPubsubMessageSubscriberModels.scala
@@ -40,7 +40,10 @@ object RuntimeConfigInCreateRuntimeMessage {
     val cloudService: CloudService = CloudService.GCE
   }
 
-  final case class GceWithPdConfig(machineType: MachineTypeName, persistentDiskId: DiskId, bootDiskSize: DiskSize, zone: Option[ZoneName] = None)
+  final case class GceWithPdConfig(machineType: MachineTypeName,
+                                   persistentDiskId: DiskId,
+                                   bootDiskSize: DiskSize,
+                                   zone: Option[ZoneName] = None)
       extends RuntimeConfigInCreateRuntimeMessage {
     val cloudService: CloudService = CloudService.GCE
   }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/leoPubsubMessageSubscriberModels.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/leoPubsubMessageSubscriberModels.scala
@@ -484,21 +484,23 @@ object LeoPubsubCodec {
     dataprocConfigEncoder.contramap(x => dataprocInCreateRuntimeMsgToDataprocRuntime(x))
 
   implicit val gceRuntimeConfigInCreateRuntimeMessageEncoder: Encoder[RuntimeConfigInCreateRuntimeMessage.GceConfig] =
-    Encoder.forProduct4(
+    Encoder.forProduct5(
       "machineType",
       "diskSize",
       "cloudService",
-      "bootDiskSize"
-    )(x => (x.machineType, x.diskSize, x.cloudService, x.bootDiskSize))
+      "bootDiskSize",
+      "zone"
+    )(x => (x.machineType, x.diskSize, x.cloudService, x.bootDiskSize, x.zone))
 
   implicit val gceWithPdConfigInCreateRuntimeMessageEncoder
     : Encoder[RuntimeConfigInCreateRuntimeMessage.GceWithPdConfig] =
-    Encoder.forProduct4(
+    Encoder.forProduct5(
       "machineType",
       "persistentDiskId",
       "cloudService",
-      "bootDiskSize"
-    )(x => (x.machineType, x.persistentDiskId, x.cloudService, x.bootDiskSize))
+      "bootDiskSize",
+      "zone"
+    )(x => (x.machineType, x.persistentDiskId, x.cloudService, x.bootDiskSize, x.zone))
 
   implicit val runtimeConfigEncoder: Encoder[RuntimeConfigInCreateRuntimeMessage] = Encoder.instance {
     case x: RuntimeConfigInCreateRuntimeMessage.DataprocConfig  => x.asJson

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GceInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GceInterpreter.scala
@@ -252,9 +252,7 @@ class GceInterpreter[F[_]: Parallel: ContextShift](
         //.setShieldedInstanceConfig(???)  // investigate shielded VM on Albano's recommendation
         .build()
 
-      operation <- googleComputeService.createInstance(params.runtimeProjectAndName.googleProject,
-                                                       zoneParam,
-                                                       instance)
+      operation <- googleComputeService.createInstance(params.runtimeProjectAndName.googleProject, zoneParam, instance)
 
       asyncRuntimeFields = AsyncRuntimeFields(GoogleId(operation.getTargetId),
                                               OperationName(operation.getName),

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/CommonTestData.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/CommonTestData.scala
@@ -186,7 +186,7 @@ object CommonTestData {
     Map.empty
   )
   val defaultGceRuntimeConfig =
-    RuntimeConfig.GceConfig(MachineTypeName("n1-standard-4"), DiskSize(500), bootDiskSize = Some(DiskSize(50)))
+    RuntimeConfig.GceConfig(MachineTypeName("n1-standard-4"), DiskSize(500), bootDiskSize = Some(DiskSize(50)), zone = Some(ZoneName("us-west2-b")))
   val defaultRuntimeConfigRequest =
     RuntimeConfigRequest.DataprocConfig(Some(0),
                                         Some(MachineTypeName("n1-standard-4")),
@@ -197,9 +197,9 @@ object CommonTestData {
                                         None,
                                         Map.empty[String, String])
   val gceRuntimeConfig =
-    RuntimeConfig.GceConfig(MachineTypeName("n1-standard-4"), DiskSize(500), bootDiskSize = Some(DiskSize(50)))
+    RuntimeConfig.GceConfig(MachineTypeName("n1-standard-4"), DiskSize(500), bootDiskSize = Some(DiskSize(50)), zone = Some(ZoneName("us-west2-b")))
   val gceWithPdRuntimeConfig =
-    RuntimeConfig.GceWithPdConfig(MachineTypeName("n1-standard-4"), Some(DiskId(1234)), DiskSize(50))
+    RuntimeConfig.GceWithPdConfig(MachineTypeName("n1-standard-4"), Some(DiskId(1234)), DiskSize(50), Some(ZoneName("us-west2-b")))
 
   def makeCluster(index: Int): Runtime = {
     val clusterName = RuntimeName("clustername" + index.toString)

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/CommonTestData.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/CommonTestData.scala
@@ -186,7 +186,10 @@ object CommonTestData {
     Map.empty
   )
   val defaultGceRuntimeConfig =
-    RuntimeConfig.GceConfig(MachineTypeName("n1-standard-4"), DiskSize(500), bootDiskSize = Some(DiskSize(50)), zone = Some(ZoneName("us-west2-b")))
+    RuntimeConfig.GceConfig(MachineTypeName("n1-standard-4"),
+                            DiskSize(500),
+                            bootDiskSize = Some(DiskSize(50)),
+                            zone = Some(ZoneName("us-west2-b")))
   val defaultRuntimeConfigRequest =
     RuntimeConfigRequest.DataprocConfig(Some(0),
                                         Some(MachineTypeName("n1-standard-4")),
@@ -197,9 +200,15 @@ object CommonTestData {
                                         None,
                                         Map.empty[String, String])
   val gceRuntimeConfig =
-    RuntimeConfig.GceConfig(MachineTypeName("n1-standard-4"), DiskSize(500), bootDiskSize = Some(DiskSize(50)), zone = Some(ZoneName("us-west2-b")))
+    RuntimeConfig.GceConfig(MachineTypeName("n1-standard-4"),
+                            DiskSize(500),
+                            bootDiskSize = Some(DiskSize(50)),
+                            zone = Some(ZoneName("us-west2-b")))
   val gceWithPdRuntimeConfig =
-    RuntimeConfig.GceWithPdConfig(MachineTypeName("n1-standard-4"), Some(DiskId(1234)), DiskSize(50), Some(ZoneName("us-west2-b")))
+    RuntimeConfig.GceWithPdConfig(MachineTypeName("n1-standard-4"),
+                                  Some(DiskId(1234)),
+                                  DiskSize(50),
+                                  Some(ZoneName("us-west2-b")))
 
   def makeCluster(index: Int): Runtime = {
     val clusterName = RuntimeName("clustername" + index.toString)

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/CommonTestData.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/CommonTestData.scala
@@ -169,7 +169,7 @@ object CommonTestData {
     )
   val defaultMachineType = MachineTypeName("n1-standard-4")
   val defaultDataprocRuntimeConfig =
-    RuntimeConfig.DataprocConfig(0, MachineTypeName("n1-standard-4"), DiskSize(500), None, None, None, None, Map.empty)
+    RuntimeConfig.DataprocConfig(0, MachineTypeName("n1-standard-4"), DiskSize(500), None, None, None, None, Map.empty, ZoneName("us-central1-a"))
 
   val defaultCreateRuntimeRequest = CreateRuntime2Request(
     Map("lbl1" -> "true"),
@@ -189,7 +189,7 @@ object CommonTestData {
     RuntimeConfig.GceConfig(MachineTypeName("n1-standard-4"),
                             DiskSize(500),
                             bootDiskSize = Some(DiskSize(50)),
-                            zone = Some(ZoneName("us-west2-b")))
+                            zone = ZoneName("us-west2-b"))
   val defaultRuntimeConfigRequest =
     RuntimeConfigRequest.DataprocConfig(Some(0),
                                         Some(MachineTypeName("n1-standard-4")),
@@ -203,12 +203,12 @@ object CommonTestData {
     RuntimeConfig.GceConfig(MachineTypeName("n1-standard-4"),
                             DiskSize(500),
                             bootDiskSize = Some(DiskSize(50)),
-                            zone = Some(ZoneName("us-west2-b")))
+                            zone = ZoneName("us-west2-b"))
   val gceWithPdRuntimeConfig =
     RuntimeConfig.GceWithPdConfig(MachineTypeName("n1-standard-4"),
                                   Some(DiskId(1234)),
                                   DiskSize(50),
-                                  Some(ZoneName("us-west2-b")))
+                                  ZoneName("us-west2-b"))
 
   def makeCluster(index: Int): Runtime = {
     val clusterName = RuntimeName("clustername" + index.toString)

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/CommonTestData.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/CommonTestData.scala
@@ -169,7 +169,15 @@ object CommonTestData {
     )
   val defaultMachineType = MachineTypeName("n1-standard-4")
   val defaultDataprocRuntimeConfig =
-    RuntimeConfig.DataprocConfig(0, MachineTypeName("n1-standard-4"), DiskSize(500), None, None, None, None, Map.empty, ZoneName("us-central1-a"))
+    RuntimeConfig.DataprocConfig(0,
+                                 MachineTypeName("n1-standard-4"),
+                                 DiskSize(500),
+                                 None,
+                                 None,
+                                 None,
+                                 None,
+                                 Map.empty,
+                                 ZoneName("us-central1-a"))
 
   val defaultCreateRuntimeRequest = CreateRuntime2Request(
     Map("lbl1" -> "true"),

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponentSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponentSpec.scala
@@ -7,7 +7,7 @@ import java.time.temporal.ChronoUnit
 import java.util.UUID
 
 import cats.effect.IO
-import org.broadinstitute.dsde.workbench.google2.MachineTypeName
+import org.broadinstitute.dsde.workbench.google2.{MachineTypeName, ZoneName}
 import org.broadinstitute.dsde.workbench.leonardo.TestUtils.{clusterEq, clusterSeqEq, stripFieldsForListCluster}
 import org.broadinstitute.dsde.workbench.leonardo.CommonTestData._
 import org.broadinstitute.dsde.workbench.leonardo.monitor.{RuntimePatchDetails, RuntimeToMonitor}
@@ -322,14 +322,14 @@ class ClusterComponentSpec extends AnyFlatSpecLike with TestComponent with GcsPa
       savedDisk <- makePersistentDisk(None).save()
       savedRuntime <- IO(
         makeCluster(1).saveWithRuntimeConfig(
-          RuntimeConfig.GceWithPdConfig(defaultMachineType, Some(savedDisk.id), bootDiskSize = DiskSize(50))
+          RuntimeConfig.GceWithPdConfig(defaultMachineType, Some(savedDisk.id), bootDiskSize = DiskSize(50), zone = Some(ZoneName("us-west2-b")))
         )
       )
       retrievedRuntime <- clusterQuery.getClusterById(savedRuntime.id).transaction
       runtimeConfig <- RuntimeConfigQueries.getRuntimeConfig(retrievedRuntime.get.runtimeConfigId).transaction
       error <- IO(
         makeCluster(2).saveWithRuntimeConfig(
-          RuntimeConfig.GceWithPdConfig(defaultMachineType, Some(DiskId(-1)), bootDiskSize = DiskSize(50))
+          RuntimeConfig.GceWithPdConfig(defaultMachineType, Some(DiskId(-1)), bootDiskSize = DiskSize(50), zone = Some(ZoneName("us-west2-b")))
         )
       ).attempt
     } yield {

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponentSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponentSpec.scala
@@ -58,7 +58,8 @@ class ClusterComponentSpec extends AnyFlatSpecLike with TestComponent with GcsPa
         Some(DiskSize(200)),
         Some(2),
         Some(1),
-        Map.empty
+        Map.empty,
+        ZoneName("test-zone")
       )
     )
     savedCluster3.copy(runtimeConfigId = RuntimeConfigId(-1)) shouldEqual cluster3
@@ -231,7 +232,8 @@ class ClusterComponentSpec extends AnyFlatSpecLike with TestComponent with GcsPa
           Some(DiskSize(200)),
           Some(2),
           Some(1),
-          Map.empty
+          Map.empty,
+          ZoneName("test-zone")
         )
       )
 
@@ -252,7 +254,8 @@ class ClusterComponentSpec extends AnyFlatSpecLike with TestComponent with GcsPa
         Some(DiskSize(200)),
         Some(2),
         Some(1),
-        Map.empty
+        Map.empty,
+        ZoneName("test-zone")
       )
     )
 
@@ -308,7 +311,8 @@ class ClusterComponentSpec extends AnyFlatSpecLike with TestComponent with GcsPa
       Some(DiskSize(200)),
       Some(2),
       Some(1),
-      Map.empty
+      Map.empty,
+      ZoneName("test-zone")
     )
 
     val savedCluster = makeCluster(1)
@@ -325,7 +329,7 @@ class ClusterComponentSpec extends AnyFlatSpecLike with TestComponent with GcsPa
           RuntimeConfig.GceWithPdConfig(defaultMachineType,
                                         Some(savedDisk.id),
                                         bootDiskSize = DiskSize(50),
-                                        zone = Some(ZoneName("us-west2-b")))
+                                        zone = ZoneName("us-west2-b"))
         )
       )
       retrievedRuntime <- clusterQuery.getClusterById(savedRuntime.id).transaction
@@ -335,7 +339,7 @@ class ClusterComponentSpec extends AnyFlatSpecLike with TestComponent with GcsPa
           RuntimeConfig.GceWithPdConfig(defaultMachineType,
                                         Some(DiskId(-1)),
                                         bootDiskSize = DiskSize(50),
-                                        zone = Some(ZoneName("us-west2-b")))
+                                        zone = ZoneName("us-west2-b"))
         )
       ).attempt
     } yield {

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponentSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponentSpec.scala
@@ -322,14 +322,20 @@ class ClusterComponentSpec extends AnyFlatSpecLike with TestComponent with GcsPa
       savedDisk <- makePersistentDisk(None).save()
       savedRuntime <- IO(
         makeCluster(1).saveWithRuntimeConfig(
-          RuntimeConfig.GceWithPdConfig(defaultMachineType, Some(savedDisk.id), bootDiskSize = DiskSize(50), zone = Some(ZoneName("us-west2-b")))
+          RuntimeConfig.GceWithPdConfig(defaultMachineType,
+                                        Some(savedDisk.id),
+                                        bootDiskSize = DiskSize(50),
+                                        zone = Some(ZoneName("us-west2-b")))
         )
       )
       retrievedRuntime <- clusterQuery.getClusterById(savedRuntime.id).transaction
       runtimeConfig <- RuntimeConfigQueries.getRuntimeConfig(retrievedRuntime.get.runtimeConfigId).transaction
       error <- IO(
         makeCluster(2).saveWithRuntimeConfig(
-          RuntimeConfig.GceWithPdConfig(defaultMachineType, Some(DiskId(-1)), bootDiskSize = DiskSize(50), zone = Some(ZoneName("us-west2-b")))
+          RuntimeConfig.GceWithPdConfig(defaultMachineType,
+                                        Some(DiskId(-1)),
+                                        bootDiskSize = DiskSize(50),
+                                        zone = Some(ZoneName("us-west2-b")))
         )
       ).attempt
     } yield {

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/RuntimeConfigQueriesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/RuntimeConfigQueriesSpec.scala
@@ -21,7 +21,8 @@ class RuntimeConfigQueriesSpec extends AnyFlatSpecLike with TestComponent with L
       workerDiskSize = None,
       numberOfPreemptibleWorkers = Some(0),
       numberOfWorkerLocalSSDs = None,
-      properties = Map("spark:spark.executor.memory" -> "10g")
+      properties = Map("spark:spark.executor.memory" -> "10g"),
+      zone = ZoneName("us-central1-a")
     )
     val res = for {
       now <- testTimer.clock.realTime(TimeUnit.MILLISECONDS)
@@ -38,13 +39,13 @@ class RuntimeConfigQueriesSpec extends AnyFlatSpecLike with TestComponent with L
       MachineTypeName("n1-standard-4"),
       DiskSize(100),
       Some(DiskSize(50)),
-      Some(ZoneName("us-west2-b"))
+      ZoneName("us-west2-b")
     )
     val runtimeConfig2 = RuntimeConfig.GceConfig(
       MachineTypeName("n1-standard-4"),
       DiskSize(100),
       None,
-      Some(ZoneName("us-west2-b"))
+      ZoneName("us-west2-b")
     )
     val res = for {
       now <- testTimer.clock.realTime(TimeUnit.MILLISECONDS)
@@ -68,7 +69,7 @@ class RuntimeConfigQueriesSpec extends AnyFlatSpecLike with TestComponent with L
         MachineTypeName("n1-standard-4"),
         Some(savedDisk.id),
         DiskSize(50),
-        Some(ZoneName("us-west2-b"))
+        ZoneName("us-west2-b")
       )
       id <- RuntimeConfigQueries.insertRuntimeConfig(runtimeConfig, Instant.ofEpochMilli(now)).transaction
       rc <- RuntimeConfigQueries.getRuntimeConfig(id).transaction

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/RuntimeConfigQueriesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/RuntimeConfigQueriesSpec.scala
@@ -3,7 +3,7 @@ package org.broadinstitute.dsde.workbench.leonardo.db
 import java.time.Instant
 import java.util.concurrent.TimeUnit
 
-import org.broadinstitute.dsde.workbench.google2.MachineTypeName
+import org.broadinstitute.dsde.workbench.google2.{MachineTypeName, ZoneName}
 import org.broadinstitute.dsde.workbench.leonardo.CommonTestData.makePersistentDisk
 import org.broadinstitute.dsde.workbench.leonardo.http.dbioToIO
 import org.broadinstitute.dsde.workbench.leonardo.{DiskSize, LeonardoTestSuite, RuntimeConfig}
@@ -37,12 +37,14 @@ class RuntimeConfigQueriesSpec extends AnyFlatSpecLike with TestComponent with L
     val runtimeConfig1 = RuntimeConfig.GceConfig(
       MachineTypeName("n1-standard-4"),
       DiskSize(100),
-      Some(DiskSize(50))
+      Some(DiskSize(50)),
+      Some(ZoneName("us-west2-b"))
     )
     val runtimeConfig2 = RuntimeConfig.GceConfig(
       MachineTypeName("n1-standard-4"),
       DiskSize(100),
-      None
+      None,
+      Some(ZoneName("us-west2-b"))
     )
     val res = for {
       now <- testTimer.clock.realTime(TimeUnit.MILLISECONDS)
@@ -65,7 +67,8 @@ class RuntimeConfigQueriesSpec extends AnyFlatSpecLike with TestComponent with L
       runtimeConfig = RuntimeConfig.GceWithPdConfig(
         MachineTypeName("n1-standard-4"),
         Some(savedDisk.id),
-        DiskSize(50)
+        DiskSize(50),
+        Some(ZoneName("us-west2-b"))
       )
       id <- RuntimeConfigQueries.insertRuntimeConfig(runtimeConfig, Instant.ofEpochMilli(now)).transaction
       rc <- RuntimeConfigQueries.getRuntimeConfig(id).transaction

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/RuntimeServiceDbQueriesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/RuntimeServiceDbQueriesSpec.scala
@@ -52,7 +52,7 @@ class RuntimeServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent wit
       d1RuntimeConfig = RuntimeConfig.GceWithPdConfig(defaultMachineType,
                                                       Some(d1.id),
                                                       bootDiskSize = DiskSize(50),
-                                                      zone = Some(ZoneName("us-west2-b")))
+                                                      zone = ZoneName("us-west2-b"))
       c1 <- IO(
         makeCluster(1).saveWithRuntimeConfig(d1RuntimeConfig)
       )
@@ -61,7 +61,7 @@ class RuntimeServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent wit
       d2RuntimeConfig = RuntimeConfig.GceWithPdConfig(defaultMachineType,
                                                       Some(d2.id),
                                                       bootDiskSize = DiskSize(50),
-                                                      zone = Some(ZoneName("us-west2-b")))
+                                                      zone = ZoneName("us-west2-b"))
       c2 <- IO(
         makeCluster(2).saveWithRuntimeConfig(d2RuntimeConfig)
       )
@@ -88,13 +88,13 @@ class RuntimeServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent wit
       c1RuntimeConfig = RuntimeConfig.GceWithPdConfig(defaultMachineType,
                                                       Some(d1.id),
                                                       bootDiskSize = DiskSize(50),
-                                                      zone = Some(ZoneName("us-west2-b")))
+                                                      zone = ZoneName("us-west2-b"))
       c1 <- IO(makeCluster(1).saveWithRuntimeConfig(c1RuntimeConfig))
       d2 <- makePersistentDisk(Some(DiskName("d2"))).save()
       c2RuntimeConfig = RuntimeConfig.GceWithPdConfig(defaultMachineType,
                                                       Some(d2.id),
                                                       bootDiskSize = DiskSize(50),
-                                                      zone = Some(ZoneName("us-west2-b")))
+                                                      zone = ZoneName("us-west2-b"))
       c2 <- IO(makeCluster(2).saveWithRuntimeConfig(c2RuntimeConfig))
       labels1 = Map("googleProject" -> c1.googleProject.value,
                     "clusterName" -> c1.runtimeName.asString,
@@ -135,7 +135,7 @@ class RuntimeServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent wit
       c1RuntimeConfig = RuntimeConfig.GceWithPdConfig(defaultMachineType,
                                                       Some(d1.id),
                                                       bootDiskSize = DiskSize(50),
-                                                      zone = Some(ZoneName("us-west2-b")))
+                                                      zone = ZoneName("us-west2-b"))
       c1 <- IO(
         makeCluster(1).saveWithRuntimeConfig(c1RuntimeConfig)
       )
@@ -143,7 +143,7 @@ class RuntimeServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent wit
       c2RuntimeConfig = RuntimeConfig.GceWithPdConfig(defaultMachineType,
                                                       Some(d2.id),
                                                       bootDiskSize = DiskSize(50),
-                                                      zone = Some(ZoneName("us-west2-b")))
+                                                      zone = ZoneName("us-west2-b"))
       c2 <- IO(
         makeCluster(2).saveWithRuntimeConfig(c2RuntimeConfig)
       )
@@ -170,7 +170,7 @@ class RuntimeServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent wit
       c1RuntimeConfig = RuntimeConfig.GceWithPdConfig(defaultMachineType,
                                                       Some(d1.id),
                                                       bootDiskSize = DiskSize(50),
-                                                      zone = Some(ZoneName("us-west2-b")))
+                                                      zone = ZoneName("us-west2-b"))
       c1 <- IO(
         makeCluster(1)
           .copy(status = RuntimeStatus.Deleted)
@@ -180,7 +180,7 @@ class RuntimeServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent wit
       c2RuntimeConfig = RuntimeConfig.GceWithPdConfig(defaultMachineType,
                                                       Some(d2.id),
                                                       bootDiskSize = DiskSize(50),
-                                                      zone = Some(ZoneName("us-west2-b")))
+                                                      zone = ZoneName("us-west2-b"))
       c2 <- IO(
         makeCluster(2)
           .copy(status = RuntimeStatus.Deleted)
@@ -190,13 +190,13 @@ class RuntimeServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent wit
       c3RuntimeConfig = RuntimeConfig.GceWithPdConfig(defaultMachineType,
                                                       Some(d3.id),
                                                       bootDiskSize = DiskSize(50),
-                                                      zone = Some(ZoneName("us-west2-b")))
+                                                      zone = ZoneName("us-west2-b"))
       c3 <- IO(
         makeCluster(3).saveWithRuntimeConfig(
           RuntimeConfig.GceWithPdConfig(defaultMachineType,
                                         Some(d3.id),
                                         bootDiskSize = DiskSize(50),
-                                        zone = Some(ZoneName("us-west2-b")))
+                                        zone = ZoneName("us-west2-b"))
         )
       )
       list1 <- RuntimeServiceDbQueries.listRuntimes(Map.empty, true, None).transaction
@@ -222,7 +222,7 @@ class RuntimeServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent wit
       c1RuntimeConfig = RuntimeConfig.GceWithPdConfig(defaultMachineType,
                                                       Some(disk.id),
                                                       bootDiskSize = DiskSize(50),
-                                                      zone = Some(ZoneName("us-west2-b")))
+                                                      zone = ZoneName("us-west2-b"))
       c1 <- IO(makeCluster(1).saveWithRuntimeConfig(c1RuntimeConfig))
       get1 <- RuntimeServiceDbQueries.getRuntime(c1.googleProject, c1.runtimeName).transaction
       get2 <- RuntimeServiceDbQueries.getRuntime(c1.googleProject, RuntimeName("does-not-exist")).transaction.attempt

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/RuntimeServiceDbQueriesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/RuntimeServiceDbQueriesSpec.scala
@@ -6,7 +6,7 @@ import java.time.Instant
 import java.util.concurrent.TimeUnit
 
 import cats.effect.IO
-import org.broadinstitute.dsde.workbench.google2.DiskName
+import org.broadinstitute.dsde.workbench.google2.{DiskName, ZoneName}
 import org.broadinstitute.dsde.workbench.leonardo.CommonTestData.{makeCluster, _}
 import org.broadinstitute.dsde.workbench.leonardo.config.Config
 import org.broadinstitute.dsde.workbench.leonardo.db.{
@@ -49,13 +49,13 @@ class RuntimeServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent wit
       start <- testTimer.clock.monotonic(TimeUnit.MILLISECONDS)
       list1 <- RuntimeServiceDbQueries.listRuntimes(Map.empty, false, None).transaction
       d1 <- makePersistentDisk(Some(DiskName("d1"))).save()
-      d1RuntimeConfig = RuntimeConfig.GceWithPdConfig(defaultMachineType, Some(d1.id), bootDiskSize = DiskSize(50))
+      d1RuntimeConfig = RuntimeConfig.GceWithPdConfig(defaultMachineType, Some(d1.id), bootDiskSize = DiskSize(50), zone = Some(ZoneName("us-west2-b")))
       c1 <- IO(
         makeCluster(1).saveWithRuntimeConfig(d1RuntimeConfig)
       )
       list2 <- RuntimeServiceDbQueries.listRuntimes(Map.empty, false, None).transaction
       d2 <- makePersistentDisk(Some(DiskName("d2"))).save()
-      d2RuntimeConfig = RuntimeConfig.GceWithPdConfig(defaultMachineType, Some(d2.id), bootDiskSize = DiskSize(50))
+      d2RuntimeConfig = RuntimeConfig.GceWithPdConfig(defaultMachineType, Some(d2.id), bootDiskSize = DiskSize(50), zone = Some(ZoneName("us-west2-b")))
       c2 <- IO(
         makeCluster(2).saveWithRuntimeConfig(d2RuntimeConfig)
       )
@@ -79,10 +79,10 @@ class RuntimeServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent wit
     val res = for {
       start <- testTimer.clock.monotonic(TimeUnit.MILLISECONDS)
       d1 <- makePersistentDisk(Some(DiskName("d1"))).save()
-      c1RuntimeConfig = RuntimeConfig.GceWithPdConfig(defaultMachineType, Some(d1.id), bootDiskSize = DiskSize(50))
+      c1RuntimeConfig = RuntimeConfig.GceWithPdConfig(defaultMachineType, Some(d1.id), bootDiskSize = DiskSize(50), zone = Some(ZoneName("us-west2-b")))
       c1 <- IO(makeCluster(1).saveWithRuntimeConfig(c1RuntimeConfig))
       d2 <- makePersistentDisk(Some(DiskName("d2"))).save()
-      c2RuntimeConfig = RuntimeConfig.GceWithPdConfig(defaultMachineType, Some(d2.id), bootDiskSize = DiskSize(50))
+      c2RuntimeConfig = RuntimeConfig.GceWithPdConfig(defaultMachineType, Some(d2.id), bootDiskSize = DiskSize(50), zone = Some(ZoneName("us-west2-b")))
       c2 <- IO(makeCluster(2).saveWithRuntimeConfig(c2RuntimeConfig))
       labels1 = Map("googleProject" -> c1.googleProject.value,
                     "clusterName" -> c1.runtimeName.asString,
@@ -120,12 +120,12 @@ class RuntimeServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent wit
     val res = for {
       start <- testTimer.clock.monotonic(TimeUnit.MILLISECONDS)
       d1 <- makePersistentDisk(Some(DiskName("d1"))).save()
-      c1RuntimeConfig = RuntimeConfig.GceWithPdConfig(defaultMachineType, Some(d1.id), bootDiskSize = DiskSize(50))
+      c1RuntimeConfig = RuntimeConfig.GceWithPdConfig(defaultMachineType, Some(d1.id), bootDiskSize = DiskSize(50), zone = Some(ZoneName("us-west2-b")))
       c1 <- IO(
         makeCluster(1).saveWithRuntimeConfig(c1RuntimeConfig)
       )
       d2 <- makePersistentDisk(Some(DiskName("d2"))).save()
-      c2RuntimeConfig = RuntimeConfig.GceWithPdConfig(defaultMachineType, Some(d2.id), bootDiskSize = DiskSize(50))
+      c2RuntimeConfig = RuntimeConfig.GceWithPdConfig(defaultMachineType, Some(d2.id), bootDiskSize = DiskSize(50), zone = Some(ZoneName("us-west2-b")))
       c2 <- IO(
         makeCluster(2).saveWithRuntimeConfig(c2RuntimeConfig)
       )
@@ -149,24 +149,24 @@ class RuntimeServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent wit
     val res = for {
       start <- testTimer.clock.monotonic(TimeUnit.MILLISECONDS)
       d1 <- makePersistentDisk(Some(DiskName("d1"))).save()
-      c1RuntimeConfig = RuntimeConfig.GceWithPdConfig(defaultMachineType, Some(d1.id), bootDiskSize = DiskSize(50))
+      c1RuntimeConfig = RuntimeConfig.GceWithPdConfig(defaultMachineType, Some(d1.id), bootDiskSize = DiskSize(50), zone = Some(ZoneName("us-west2-b")))
       c1 <- IO(
         makeCluster(1)
           .copy(status = RuntimeStatus.Deleted)
           .saveWithRuntimeConfig(c1RuntimeConfig)
       )
       d2 <- makePersistentDisk(Some(DiskName("d2"))).save()
-      c2RuntimeConfig = RuntimeConfig.GceWithPdConfig(defaultMachineType, Some(d2.id), bootDiskSize = DiskSize(50))
+      c2RuntimeConfig = RuntimeConfig.GceWithPdConfig(defaultMachineType, Some(d2.id), bootDiskSize = DiskSize(50), zone = Some(ZoneName("us-west2-b")))
       c2 <- IO(
         makeCluster(2)
           .copy(status = RuntimeStatus.Deleted)
           .saveWithRuntimeConfig(c2RuntimeConfig)
       )
       d3 <- makePersistentDisk(None).save()
-      c3RuntimeConfig = RuntimeConfig.GceWithPdConfig(defaultMachineType, Some(d3.id), bootDiskSize = DiskSize(50))
+      c3RuntimeConfig = RuntimeConfig.GceWithPdConfig(defaultMachineType, Some(d3.id), bootDiskSize = DiskSize(50), zone = Some(ZoneName("us-west2-b")))
       c3 <- IO(
         makeCluster(3).saveWithRuntimeConfig(
-          RuntimeConfig.GceWithPdConfig(defaultMachineType, Some(d3.id), bootDiskSize = DiskSize(50))
+          RuntimeConfig.GceWithPdConfig(defaultMachineType, Some(d3.id), bootDiskSize = DiskSize(50), zone = Some(ZoneName("us-west2-b")))
         )
       )
       list1 <- RuntimeServiceDbQueries.listRuntimes(Map.empty, true, None).transaction
@@ -189,7 +189,7 @@ class RuntimeServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent wit
   it should "get a runtime" in isolatedDbTest {
     val res = for {
       disk <- makePersistentDisk(None).save()
-      c1RuntimeConfig = RuntimeConfig.GceWithPdConfig(defaultMachineType, Some(disk.id), bootDiskSize = DiskSize(50))
+      c1RuntimeConfig = RuntimeConfig.GceWithPdConfig(defaultMachineType, Some(disk.id), bootDiskSize = DiskSize(50), zone = Some(ZoneName("us-west2-b")))
       c1 <- IO(makeCluster(1).saveWithRuntimeConfig(c1RuntimeConfig))
       get1 <- RuntimeServiceDbQueries.getRuntime(c1.googleProject, c1.runtimeName).transaction
       get2 <- RuntimeServiceDbQueries.getRuntime(c1.googleProject, RuntimeName("does-not-exist")).transaction.attempt

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/RuntimeServiceDbQueriesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/RuntimeServiceDbQueriesSpec.scala
@@ -49,13 +49,19 @@ class RuntimeServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent wit
       start <- testTimer.clock.monotonic(TimeUnit.MILLISECONDS)
       list1 <- RuntimeServiceDbQueries.listRuntimes(Map.empty, false, None).transaction
       d1 <- makePersistentDisk(Some(DiskName("d1"))).save()
-      d1RuntimeConfig = RuntimeConfig.GceWithPdConfig(defaultMachineType, Some(d1.id), bootDiskSize = DiskSize(50), zone = Some(ZoneName("us-west2-b")))
+      d1RuntimeConfig = RuntimeConfig.GceWithPdConfig(defaultMachineType,
+                                                      Some(d1.id),
+                                                      bootDiskSize = DiskSize(50),
+                                                      zone = Some(ZoneName("us-west2-b")))
       c1 <- IO(
         makeCluster(1).saveWithRuntimeConfig(d1RuntimeConfig)
       )
       list2 <- RuntimeServiceDbQueries.listRuntimes(Map.empty, false, None).transaction
       d2 <- makePersistentDisk(Some(DiskName("d2"))).save()
-      d2RuntimeConfig = RuntimeConfig.GceWithPdConfig(defaultMachineType, Some(d2.id), bootDiskSize = DiskSize(50), zone = Some(ZoneName("us-west2-b")))
+      d2RuntimeConfig = RuntimeConfig.GceWithPdConfig(defaultMachineType,
+                                                      Some(d2.id),
+                                                      bootDiskSize = DiskSize(50),
+                                                      zone = Some(ZoneName("us-west2-b")))
       c2 <- IO(
         makeCluster(2).saveWithRuntimeConfig(d2RuntimeConfig)
       )
@@ -79,10 +85,16 @@ class RuntimeServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent wit
     val res = for {
       start <- testTimer.clock.monotonic(TimeUnit.MILLISECONDS)
       d1 <- makePersistentDisk(Some(DiskName("d1"))).save()
-      c1RuntimeConfig = RuntimeConfig.GceWithPdConfig(defaultMachineType, Some(d1.id), bootDiskSize = DiskSize(50), zone = Some(ZoneName("us-west2-b")))
+      c1RuntimeConfig = RuntimeConfig.GceWithPdConfig(defaultMachineType,
+                                                      Some(d1.id),
+                                                      bootDiskSize = DiskSize(50),
+                                                      zone = Some(ZoneName("us-west2-b")))
       c1 <- IO(makeCluster(1).saveWithRuntimeConfig(c1RuntimeConfig))
       d2 <- makePersistentDisk(Some(DiskName("d2"))).save()
-      c2RuntimeConfig = RuntimeConfig.GceWithPdConfig(defaultMachineType, Some(d2.id), bootDiskSize = DiskSize(50), zone = Some(ZoneName("us-west2-b")))
+      c2RuntimeConfig = RuntimeConfig.GceWithPdConfig(defaultMachineType,
+                                                      Some(d2.id),
+                                                      bootDiskSize = DiskSize(50),
+                                                      zone = Some(ZoneName("us-west2-b")))
       c2 <- IO(makeCluster(2).saveWithRuntimeConfig(c2RuntimeConfig))
       labels1 = Map("googleProject" -> c1.googleProject.value,
                     "clusterName" -> c1.runtimeName.asString,
@@ -120,12 +132,18 @@ class RuntimeServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent wit
     val res = for {
       start <- testTimer.clock.monotonic(TimeUnit.MILLISECONDS)
       d1 <- makePersistentDisk(Some(DiskName("d1"))).save()
-      c1RuntimeConfig = RuntimeConfig.GceWithPdConfig(defaultMachineType, Some(d1.id), bootDiskSize = DiskSize(50), zone = Some(ZoneName("us-west2-b")))
+      c1RuntimeConfig = RuntimeConfig.GceWithPdConfig(defaultMachineType,
+                                                      Some(d1.id),
+                                                      bootDiskSize = DiskSize(50),
+                                                      zone = Some(ZoneName("us-west2-b")))
       c1 <- IO(
         makeCluster(1).saveWithRuntimeConfig(c1RuntimeConfig)
       )
       d2 <- makePersistentDisk(Some(DiskName("d2"))).save()
-      c2RuntimeConfig = RuntimeConfig.GceWithPdConfig(defaultMachineType, Some(d2.id), bootDiskSize = DiskSize(50), zone = Some(ZoneName("us-west2-b")))
+      c2RuntimeConfig = RuntimeConfig.GceWithPdConfig(defaultMachineType,
+                                                      Some(d2.id),
+                                                      bootDiskSize = DiskSize(50),
+                                                      zone = Some(ZoneName("us-west2-b")))
       c2 <- IO(
         makeCluster(2).saveWithRuntimeConfig(c2RuntimeConfig)
       )
@@ -149,24 +167,36 @@ class RuntimeServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent wit
     val res = for {
       start <- testTimer.clock.monotonic(TimeUnit.MILLISECONDS)
       d1 <- makePersistentDisk(Some(DiskName("d1"))).save()
-      c1RuntimeConfig = RuntimeConfig.GceWithPdConfig(defaultMachineType, Some(d1.id), bootDiskSize = DiskSize(50), zone = Some(ZoneName("us-west2-b")))
+      c1RuntimeConfig = RuntimeConfig.GceWithPdConfig(defaultMachineType,
+                                                      Some(d1.id),
+                                                      bootDiskSize = DiskSize(50),
+                                                      zone = Some(ZoneName("us-west2-b")))
       c1 <- IO(
         makeCluster(1)
           .copy(status = RuntimeStatus.Deleted)
           .saveWithRuntimeConfig(c1RuntimeConfig)
       )
       d2 <- makePersistentDisk(Some(DiskName("d2"))).save()
-      c2RuntimeConfig = RuntimeConfig.GceWithPdConfig(defaultMachineType, Some(d2.id), bootDiskSize = DiskSize(50), zone = Some(ZoneName("us-west2-b")))
+      c2RuntimeConfig = RuntimeConfig.GceWithPdConfig(defaultMachineType,
+                                                      Some(d2.id),
+                                                      bootDiskSize = DiskSize(50),
+                                                      zone = Some(ZoneName("us-west2-b")))
       c2 <- IO(
         makeCluster(2)
           .copy(status = RuntimeStatus.Deleted)
           .saveWithRuntimeConfig(c2RuntimeConfig)
       )
       d3 <- makePersistentDisk(None).save()
-      c3RuntimeConfig = RuntimeConfig.GceWithPdConfig(defaultMachineType, Some(d3.id), bootDiskSize = DiskSize(50), zone = Some(ZoneName("us-west2-b")))
+      c3RuntimeConfig = RuntimeConfig.GceWithPdConfig(defaultMachineType,
+                                                      Some(d3.id),
+                                                      bootDiskSize = DiskSize(50),
+                                                      zone = Some(ZoneName("us-west2-b")))
       c3 <- IO(
         makeCluster(3).saveWithRuntimeConfig(
-          RuntimeConfig.GceWithPdConfig(defaultMachineType, Some(d3.id), bootDiskSize = DiskSize(50), zone = Some(ZoneName("us-west2-b")))
+          RuntimeConfig.GceWithPdConfig(defaultMachineType,
+                                        Some(d3.id),
+                                        bootDiskSize = DiskSize(50),
+                                        zone = Some(ZoneName("us-west2-b")))
         )
       )
       list1 <- RuntimeServiceDbQueries.listRuntimes(Map.empty, true, None).transaction
@@ -189,7 +219,10 @@ class RuntimeServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent wit
   it should "get a runtime" in isolatedDbTest {
     val res = for {
       disk <- makePersistentDisk(None).save()
-      c1RuntimeConfig = RuntimeConfig.GceWithPdConfig(defaultMachineType, Some(disk.id), bootDiskSize = DiskSize(50), zone = Some(ZoneName("us-west2-b")))
+      c1RuntimeConfig = RuntimeConfig.GceWithPdConfig(defaultMachineType,
+                                                      Some(disk.id),
+                                                      bootDiskSize = DiskSize(50),
+                                                      zone = Some(ZoneName("us-west2-b")))
       c1 <- IO(makeCluster(1).saveWithRuntimeConfig(c1RuntimeConfig))
       get1 <- RuntimeServiceDbQueries.getRuntime(c1.googleProject, c1.runtimeName).transaction
       get2 <- RuntimeServiceDbQueries.getRuntime(c1.googleProject, RuntimeName("does-not-exist")).transaction.attempt

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/RuntimeRoutesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/RuntimeRoutesSpec.scala
@@ -355,7 +355,8 @@ class RuntimeRoutesSpec extends AnyFlatSpec with Matchers with LeonardoTestSuite
         |    "machineType" : "n1-standard-4",
         |    "diskSize" : 500,
         |    "cloudService" : "GCE",
-        |    "bootDiskSize" : 50
+        |    "bootDiskSize" : 50,
+        |    "zone" : "us-west2-b"
         |  },
         |  "proxyUrl" : "https://leo.org/proxy",
         |  "status" : "Running",
@@ -420,7 +421,8 @@ class RuntimeRoutesSpec extends AnyFlatSpec with Matchers with LeonardoTestSuite
         |    "machineType" : "n1-standard-4",
         |    "diskSize" : 500,
         |    "cloudService" : "GCE",
-        |    "bootDiskSize" : 50
+        |    "bootDiskSize" : 50,
+        |    "zone" : "us-west2-b"
         |  },
         |  "proxyUrl" : "https://leo.org/proxy",
         |  "status" : "Running",

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/RuntimeRoutesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/RuntimeRoutesSpec.scala
@@ -7,7 +7,7 @@ import io.circe.CursorOp.DownField
 import io.circe.DecodingFailure
 import io.circe.parser.decode
 import io.circe.syntax._
-import org.broadinstitute.dsde.workbench.google2.{DiskName, MachineTypeName}
+import org.broadinstitute.dsde.workbench.google2.{DiskName, MachineTypeName, ZoneName}
 import org.broadinstitute.dsde.workbench.leonardo.CommonTestData.{
   auditInfo,
   cryptoDetectorImage,
@@ -610,7 +610,8 @@ class RuntimeRoutesSpec extends AnyFlatSpec with Matchers with LeonardoTestSuite
         |  "runtimeConfig": {
         |    "cloudService": "gce",
         |    "machineType": "n1-standard-4",
-        |    "diskSize": 100
+        |    "diskSize": 100,
+        |    "zone": "us-central2-b"
         |  }
         |}
         |""".stripMargin
@@ -621,7 +622,8 @@ class RuntimeRoutesSpec extends AnyFlatSpec with Matchers with LeonardoTestSuite
       Some(
         RuntimeConfigRequest.GceConfig(
           Some(MachineTypeName("n1-standard-4")),
-          Some(DiskSize(100))
+          Some(DiskSize(100)),
+          Some(ZoneName("us-central2-b"))
         )
       ),
       None,

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/DiskServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/DiskServiceInterpSpec.scala
@@ -7,7 +7,7 @@ import java.util.UUID
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import cats.effect.IO
 import cats.mtl.Ask
-import org.broadinstitute.dsde.workbench.google2.{DiskName, MachineTypeName}
+import org.broadinstitute.dsde.workbench.google2.{DiskName, MachineTypeName, ZoneName}
 import org.broadinstitute.dsde.workbench.leonardo.CommonTestData._
 import org.broadinstitute.dsde.workbench.leonardo.config.Config
 import org.broadinstitute.dsde.workbench.leonardo.db._
@@ -203,7 +203,7 @@ class DiskServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with Test
       disk <- makePersistentDisk(None).copy(samResource = diskSamResource).save()
       _ <- IO(
         makeCluster(1).saveWithRuntimeConfig(
-          RuntimeConfig.GceWithPdConfig(MachineTypeName("n1-standard-4"), Some(disk.id), bootDiskSize = DiskSize(50))
+          RuntimeConfig.GceWithPdConfig(MachineTypeName("n1-standard-4"), Some(disk.id), bootDiskSize = DiskSize(50), zone = Some(ZoneName("us-west2-b")))
         )
       )
       err <- diskService.deleteDisk(userInfo, disk.googleProject, disk.name).attempt

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/DiskServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/DiskServiceInterpSpec.scala
@@ -206,7 +206,7 @@ class DiskServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with Test
           RuntimeConfig.GceWithPdConfig(MachineTypeName("n1-standard-4"),
                                         Some(disk.id),
                                         bootDiskSize = DiskSize(50),
-                                        zone = Some(ZoneName("us-west2-b")))
+                                        zone = ZoneName("us-west2-b"))
         )
       )
       err <- diskService.deleteDisk(userInfo, disk.googleProject, disk.name).attempt

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/DiskServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/DiskServiceInterpSpec.scala
@@ -203,7 +203,10 @@ class DiskServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with Test
       disk <- makePersistentDisk(None).copy(samResource = diskSamResource).save()
       _ <- IO(
         makeCluster(1).saveWithRuntimeConfig(
-          RuntimeConfig.GceWithPdConfig(MachineTypeName("n1-standard-4"), Some(disk.id), bootDiskSize = DiskSize(50), zone = Some(ZoneName("us-west2-b")))
+          RuntimeConfig.GceWithPdConfig(MachineTypeName("n1-standard-4"),
+                                        Some(disk.id),
+                                        bootDiskSize = DiskSize(50),
+                                        zone = Some(ZoneName("us-west2-b")))
         )
       )
       err <- diskService.deleteDisk(userInfo, disk.googleProject, disk.name).attempt

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterpSpec.scala
@@ -9,7 +9,7 @@ import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import cats.effect.IO
 import cats.mtl.Ask
 import fs2.concurrent.InspectableQueue
-import org.broadinstitute.dsde.workbench.google2.{DataprocRole, DiskName, InstanceName, MachineTypeName}
+import org.broadinstitute.dsde.workbench.google2.{DataprocRole, DiskName, InstanceName, MachineTypeName, ZoneName}
 import org.broadinstitute.dsde.workbench.google2.mock.{
   FakeGoogleComputeService,
   FakeGooglePublisher,
@@ -537,7 +537,8 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
       runtimeConfig shouldBe RuntimeConfig.GceWithPdConfig(
         MachineTypeName("n1-standard-4"),
         Some(disk.id),
-        bootDiskSize = DiskSize(50)
+        bootDiskSize = DiskSize(50),
+        zone = Some(ZoneName("us-central1-a"))
       ) //TODO: this is a problem in terms of inconsistency
       val expectedMessage = CreateRuntimeMessage
         .fromRuntime(runtime, runtimeConfigRequest, Some(context.traceId))
@@ -827,7 +828,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
       testRuntime <- IO(
         makeCluster(1).saveWithRuntimeConfig(
           RuntimeConfig
-            .GceWithPdConfig(MachineTypeName("n1-standard-4"), Some(pd.id), bootDiskSize = DiskSize(50))
+            .GceWithPdConfig(MachineTypeName("n1-standard-4"), Some(pd.id), bootDiskSize = DiskSize(50), zone = Some(ZoneName("us-central1-a")))
         )
       )
 
@@ -1534,7 +1535,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
       savedDisk <- makePersistentDisk(None).save()
       _ <- IO(
         makeCluster(1).saveWithRuntimeConfig(
-          RuntimeConfig.GceWithPdConfig(defaultMachineType, Some(savedDisk.id), bootDiskSize = DiskSize(50))
+          RuntimeConfig.GceWithPdConfig(defaultMachineType, Some(savedDisk.id), bootDiskSize = DiskSize(50), Some(ZoneName("us-central1-a")))
         )
       )
       req = PersistentDiskRequest(savedDisk.name, Some(savedDisk.size), Some(savedDisk.diskType), savedDisk.labels)

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterpSpec.scala
@@ -538,7 +538,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
         MachineTypeName("n1-standard-4"),
         Some(disk.id),
         bootDiskSize = DiskSize(50),
-        zone = Some(ZoneName("us-central1-a"))
+        zone = ZoneName("us-central1-a")
       ) //TODO: this is a problem in terms of inconsistency
       val expectedMessage = CreateRuntimeMessage
         .fromRuntime(runtime, runtimeConfigRequest, Some(context.traceId))
@@ -552,7 +552,8 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
           scopes = Config.gceConfig.defaultScopes,
           runtimeConfig = RuntimeConfigInCreateRuntimeMessage.GceWithPdConfig(runtimeConfig.machineType,
                                                                               disk.id,
-                                                                              bootDiskSize = DiskSize(50))
+                                                                              bootDiskSize = DiskSize(50),
+                                                                              zone = ZoneName("us-central1-a"))
         )
       message shouldBe expectedMessage
     }
@@ -831,7 +832,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
             .GceWithPdConfig(MachineTypeName("n1-standard-4"),
                              Some(pd.id),
                              bootDiskSize = DiskSize(50),
-                             zone = Some(ZoneName("us-central1-a")))
+                             zone = ZoneName("us-central1-a"))
         )
       )
 
@@ -1541,7 +1542,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
           RuntimeConfig.GceWithPdConfig(defaultMachineType,
                                         Some(savedDisk.id),
                                         bootDiskSize = DiskSize(50),
-                                        Some(ZoneName("us-central1-a")))
+                                        ZoneName("us-central1-a"))
         )
       )
       req = PersistentDiskRequest(savedDisk.name, Some(savedDisk.size), Some(savedDisk.diskType), savedDisk.labels)

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterpSpec.scala
@@ -828,7 +828,10 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
       testRuntime <- IO(
         makeCluster(1).saveWithRuntimeConfig(
           RuntimeConfig
-            .GceWithPdConfig(MachineTypeName("n1-standard-4"), Some(pd.id), bootDiskSize = DiskSize(50), zone = Some(ZoneName("us-central1-a")))
+            .GceWithPdConfig(MachineTypeName("n1-standard-4"),
+                             Some(pd.id),
+                             bootDiskSize = DiskSize(50),
+                             zone = Some(ZoneName("us-central1-a")))
         )
       )
 
@@ -1535,7 +1538,10 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
       savedDisk <- makePersistentDisk(None).save()
       _ <- IO(
         makeCluster(1).saveWithRuntimeConfig(
-          RuntimeConfig.GceWithPdConfig(defaultMachineType, Some(savedDisk.id), bootDiskSize = DiskSize(50), Some(ZoneName("us-central1-a")))
+          RuntimeConfig.GceWithPdConfig(defaultMachineType,
+                                        Some(savedDisk.id),
+                                        bootDiskSize = DiskSize(50),
+                                        Some(ZoneName("us-central1-a")))
         )
       )
       req = PersistentDiskRequest(savedDisk.name, Some(savedDisk.size), Some(savedDisk.diskType), savedDisk.labels)

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubCodecSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubCodecSpec.scala
@@ -7,7 +7,7 @@ import _root_.io.circe.parser.decode
 import _root_.io.circe.syntax._
 import io.circe.Printer
 import org.broadinstitute.dsde.workbench.google2.KubernetesSerializableName.NamespaceName
-import org.broadinstitute.dsde.workbench.google2.{DiskName, MachineTypeName}
+import org.broadinstitute.dsde.workbench.google2.{DiskName, MachineTypeName, ZoneName}
 import org.broadinstitute.dsde.workbench.leonardo.AppType.Galaxy
 import org.broadinstitute.dsde.workbench.leonardo.monitor.LeoPubsubCodec._
 import org.broadinstitute.dsde.workbench.leonardo.monitor.LeoPubsubMessage.{CreateAppMessage, CreateRuntimeMessage}
@@ -46,7 +46,8 @@ class LeoPubsubCodecSpec extends AnyFlatSpec with Matchers {
       Map.empty,
       RuntimeConfigInCreateRuntimeMessage.GceConfig(MachineTypeName("n1-standard-4"),
                                                     DiskSize(50),
-                                                    bootDiskSize = DiskSize(50)),
+                                                    bootDiskSize = DiskSize(50),
+                                                    zone = ZoneName("us-central1-a")),
       None
     )
 
@@ -73,7 +74,8 @@ class LeoPubsubCodecSpec extends AnyFlatSpec with Matchers {
       Map.empty,
       RuntimeConfigInCreateRuntimeMessage.GceWithPdConfig(MachineTypeName("n1-standard-4"),
                                                           DiskId(2),
-                                                          bootDiskSize = DiskSize(50)),
+                                                          bootDiskSize = DiskSize(50),
+                                                          zone = ZoneName("us-central1-a")),
       None
     )
 

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriberSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriberSpec.scala
@@ -215,7 +215,8 @@ class LeoPubsubMessageSubscriberSpec
       disk <- makePersistentDisk(None, Some(FormattedBy.GCE)).save()
       runtimeConfig = RuntimeConfig.GceWithPdConfig(MachineTypeName("n1-standard-4"),
                                                     bootDiskSize = DiskSize(50),
-                                                    persistentDiskId = Some(disk.id))
+                                                    persistentDiskId = Some(disk.id),
+                                                    zone = Some(ZoneName("us-central1-a")))
 
       runtime <- IO(makeCluster(1).copy(status = RuntimeStatus.Deleting).saveWithRuntimeConfig(runtimeConfig))
       tr <- traceId.ask[TraceId]
@@ -247,7 +248,8 @@ class LeoPubsubMessageSubscriberSpec
       disk <- makePersistentDisk(None, Some(FormattedBy.GCE)).save()
       runtimeConfig = RuntimeConfig.GceWithPdConfig(MachineTypeName("n1-standard-4"),
                                                     bootDiskSize = DiskSize(50),
-                                                    persistentDiskId = Some(disk.id))
+                                                    persistentDiskId = Some(disk.id),
+                                                    zone = Some(ZoneName("us-cetnral1-a")))
 
       runtime <- IO(makeCluster(1).copy(status = RuntimeStatus.Deleting).saveWithRuntimeConfig(runtimeConfig))
       tr <- traceId.ask[TraceId]

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriberSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriberSpec.scala
@@ -216,7 +216,7 @@ class LeoPubsubMessageSubscriberSpec
       runtimeConfig = RuntimeConfig.GceWithPdConfig(MachineTypeName("n1-standard-4"),
                                                     bootDiskSize = DiskSize(50),
                                                     persistentDiskId = Some(disk.id),
-                                                    zone = Some(ZoneName("us-central1-a")))
+                                                    zone = ZoneName("us-central1-a"))
 
       runtime <- IO(makeCluster(1).copy(status = RuntimeStatus.Deleting).saveWithRuntimeConfig(runtimeConfig))
       tr <- traceId.ask[TraceId]
@@ -249,7 +249,7 @@ class LeoPubsubMessageSubscriberSpec
       runtimeConfig = RuntimeConfig.GceWithPdConfig(MachineTypeName("n1-standard-4"),
                                                     bootDiskSize = DiskSize(50),
                                                     persistentDiskId = Some(disk.id),
-                                                    zone = Some(ZoneName("us-cetnral1-a")))
+                                                    zone = ZoneName("us-cetnral1-a"))
 
       runtime <- IO(makeCluster(1).copy(status = RuntimeStatus.Deleting).saveWithRuntimeConfig(runtimeConfig))
       tr <- traceId.ask[TraceId]

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/DataprocInterpreterSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/DataprocInterpreterSpec.scala
@@ -18,7 +18,7 @@ import org.broadinstitute.dsde.workbench.google2.mock.{
   FakeGoogleResourceService,
   MockComputePollOperation
 }
-import org.broadinstitute.dsde.workbench.google2.{MachineTypeName, MockGoogleDiskService}
+import org.broadinstitute.dsde.workbench.google2.{MachineTypeName, MockGoogleDiskService, ZoneName}
 import org.broadinstitute.dsde.workbench.leonardo.CommonTestData._
 import org.broadinstitute.dsde.workbench.leonardo.RuntimeStatus.Creating
 import org.broadinstitute.dsde.workbench.leonardo.config.Config
@@ -201,7 +201,8 @@ class DataprocInterpreterSpec
                                                      None,
                                                      None,
                                                      None,
-                                                     Map.empty[String, String])
+                                                     Map.empty[String, String],
+                                                     ZoneName("us-central1-a"))
     val resourceConstraints = dataprocInterp
       .getClusterResourceContraints(testClusterClusterProjectAndName, runtimeConfig.machineType)
       .unsafeRunSync()


### PR DESCRIPTION
What I expect this PR does:
- Add an optional zone parameter to the createRuntime API
- Updates Swagger docs
- Adds a migration to add zone to the RUNTIME_CONFIG table
- Updates appropriate slick mapping
- I _think_ the zone is already passed to GCE. 

What I still need help with:
- Testing this locally. I think I have the right approach, but I still don't know how to check that what I'm doing will actually work?
- Testing the liquibase migration. How can I test this?
- I'm seeing unit test failures that all look like `java.sql.SQLTransientConnectionException: mysql.db - Connection is not available, request timed out after 5000ms.` I'm not sure if this is expected to not work, or if there is something I need to fix? I ran the docker commands for mysql that is mentioned in the README.

In general I am asking for feedback on if this is the right approach so far, and how I should proceed to make sure this change works. Thanks!
---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
