### PR TITLE
Attempt to fix QA-1360 again: don't keep WebDriver open between runtime stop/start

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookGCEClusterMonitoringSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookGCEClusterMonitoringSpec.scala
@@ -41,15 +41,16 @@ class NotebookGCEClusterMonitoringSpec
           withNewNotebook(runtime, kernel = Python3) { notebookPage =>
             notebookPage.executeCell(s"""print("$printStr")""") shouldBe Some(printStr)
           }
+        }
 
-          // Stop the runtime
-          stopAndMonitorRuntime(runtime.googleProject, runtime.clusterName)
+        // Stop the runtime
+        stopAndMonitorRuntime(runtime.googleProject, runtime.clusterName)
 
-          // Start the runtime
-          startAndMonitorRuntime(runtime.googleProject, runtime.clusterName)
+        // Start the runtime
+        startAndMonitorRuntime(runtime.googleProject, runtime.clusterName)
 
-          // TODO make tests rename notebooks?
-          val notebookPath = new File("Untitled.ipynb")
+        val notebookPath = new File("Untitled.ipynb")
+        withWebDriver { implicit driver =>
           // Use a longer timeout than default because opening notebooks after resume can be slow
           withOpenNotebook(runtime, notebookPath, 10.minutes) { notebookPage =>
             // old output should still exist
@@ -83,27 +84,29 @@ class NotebookGCEClusterMonitoringSpec
             rstudioPage.variableExists(s""""${runtime.googleProject.value}"""") shouldBe true
             Thread.sleep(5000)
           }
+        }
 
-          // Stop the cluster
-          stopAndMonitorRuntime(runtime.googleProject, runtime.clusterName)
+        // Stop the cluster
+        stopAndMonitorRuntime(runtime.googleProject, runtime.clusterName)
 
-          // Start the cluster
-          startAndMonitorRuntime(runtime.googleProject, runtime.clusterName)
+        // Start the cluster
+        startAndMonitorRuntime(runtime.googleProject, runtime.clusterName)
 
-          val getResultAfterResume = Try(RStudio.getApi(runtime.googleProject, runtime.clusterName))
-          getResultAfterResume.isSuccess shouldBe true
-          getResultAfterResume.get should include("unsupported_browser")
-          getResultAfterResume.get should not include "ProxyException"
+        val getResultAfterResume = Try(RStudio.getApi(runtime.googleProject, runtime.clusterName))
+        getResultAfterResume.isSuccess shouldBe true
+        getResultAfterResume.get should include("unsupported_browser")
+        getResultAfterResume.get should not include "ProxyException"
 
-          // Make sure RStudio session is preserved
-          // TODO: commenting because this is flakey: the variables pane sometimes does
-          // not appear by default when RStudio is restarted, causing the selenium check to fail.
+      // Make sure RStudio session is preserved
+      // TODO: commenting because this is flakey: the variables pane sometimes does
+      // not appear by default when RStudio is restarted, causing the selenium check to fail.
+//        withWebDriver { implicit driver =>
 //          withNewRStudio(runtime) { rstudioPage =>
 //            await visible cssSelector("[title~='ns']")
 //            rstudioPage.variableExists("ns") shouldBe true
 //            rstudioPage.variableExists(s""""${runtime.googleProject.value}"""") shouldBe true
 //          }
-        }
+//        }
       }
     }
 

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookGCECustomizationSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookGCECustomizationSpec.scala
@@ -149,9 +149,6 @@ final class NotebookGCECustomizationSpec extends GPAllocFixtureSpec with Paralle
       }
     }
 
-    // TODO: This test has flaky selenium logic, ignoring for now. More details in:
-    // https://broadworkbench.atlassian.net/browse/QA-1199
-    // https://broadworkbench.atlassian.net/browse/IA-2050
     "should execute user-specified start script" in { billingProject =>
       implicit val ronToken: AuthToken = ronAuthToken
 
@@ -185,14 +182,16 @@ final class NotebookGCECustomizationSpec extends GPAllocFixtureSpec with Paralle
               withNewNotebook(runtime, Python3) { notebookPage =>
                 notebookPage.executeCell("!cat $JUPYTER_HOME/leo_test_start_count.txt").get shouldBe "1"
               }
+            }
 
-              // Stop the cluster
-              stopAndMonitorRuntime(runtime.googleProject, runtime.clusterName)
+            // Stop the cluster
+            stopAndMonitorRuntime(runtime.googleProject, runtime.clusterName)
 
-              // Start the cluster
-              startAndMonitorRuntime(runtime.googleProject, runtime.clusterName)
+            // Start the cluster
+            startAndMonitorRuntime(runtime.googleProject, runtime.clusterName)
 
-              val notebookPath = new File("Untitled.ipynb")
+            val notebookPath = new File("Untitled.ipynb")
+            withWebDriver { implicit driver =>
               // Use a longer timeout than default because opening notebooks after resume can be slow
               withOpenNotebook(runtime, notebookPath, 10.minutes) { notebookPage =>
                 // old output should still exist


### PR DESCRIPTION
Rationale:

The tests are occasionally failing with:
```
org.openqa.selenium.UnhandledAlertException: unexpected alert open: {Alert text : }
```

Which means there is a browser `Alert` happening which is not being handled by Selenium. The test logs don't show a screenshot of the alert, and the alert doesn't appear to have any text.

My theory is that pause/resuming the runtime while the Jupyter notebook is loaded in the browser will cause Selenium to barf when 40x errors are thrown by the Leo proxy. Thinking that re-initializing the WebDriver after resume will help in this case.


---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
