### PR TITLE
[IA-2587] Have automation tests re-use the same cluster for apps

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoApiClient.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoApiClient.scala
@@ -466,8 +466,8 @@ object LeonardoApiClient {
     // retries app creation on 409 from Leo due to cluster being created
     implicit val doneCheckable: DoneCheckable[Either[Throwable, Unit]] = x =>
       x match {
-        case Left(RestError(message, Status.Conflict, _))
-            if message.contains("You cannot create an app while a cluster is in Set(PRECREATING, PROVISIONING)") =>
+        case Left(RestError(_, Status.Conflict, body))
+            if body.contains("You cannot create an app while a cluster is in Set(PRECREATING, PROVISIONING)") =>
           false
         case _ => true
       }

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoApiClient.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoApiClient.scala
@@ -447,16 +447,6 @@ object LeonardoApiClient {
         }
     } yield r
 
-  def createAppWithWait(
-    googleProject: GoogleProject,
-    appName: AppName,
-    createAppRequest: CreateAppRequest = defaultCreateAppRequest
-  )(implicit client: Client[IO], authHeader: Authorization, logger: StructuredLogger[IO], timer: Timer[IO]): IO[Unit] =
-    for {
-      _ <- createApp(googleProject, appName, createAppRequest)
-      _ <- waitUntilAppRunning(googleProject, appName, true)
-    } yield ()
-
   def createAppWithRetry(
     googleProject: GoogleProject,
     appName: AppName,

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoApiClient.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoApiClient.scala
@@ -463,11 +463,11 @@ object LeonardoApiClient {
     createAppRequest: CreateAppRequest = defaultCreateAppRequest
   )(implicit client: Client[IO], timer: Timer[IO], authHeader: Authorization): IO[Unit] = {
     val ioa = createApp(googleProject, appName, createAppRequest).attempt
-    // retries app creation on 409 from Leo due to cluster creation
+    // retries app creation on 409 from Leo due to cluster being created
     implicit val doneCheckable: DoneCheckable[Either[Throwable, Unit]] = x =>
       x match {
         case Left(RestError(message, Status.Conflict, _))
-            if message.contains("You cannot create an app while a cluster is in Set") =>
+            if message.contains("You cannot create an app while a cluster is in Set(PRECREATING, PROVISIONING)") =>
           false
         case _ => true
       }

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoApiClient.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoApiClient.scala
@@ -466,7 +466,7 @@ object LeonardoApiClient {
     // retries app creation on 409 from Leo due to cluster being created
     implicit val doneCheckable: DoneCheckable[Either[Throwable, Unit]] = x =>
       x match {
-        case Left(RestError(_, Status.Conflict, body))
+        case Left(RestError(_, Status.Conflict, Some(body)))
             if body.contains("You cannot create an app while a cluster is in Set(PRECREATING, PROVISIONING)") =>
           false
         case _ => true

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoApiClient.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoApiClient.scala
@@ -1,10 +1,7 @@
 package org.broadinstitute.dsde.workbench.leonardo
 
-import java.util.UUID
-import java.util.concurrent.TimeoutException
 import cats.effect.{IO, Resource, Timer}
 import cats.syntax.all._
-import org.typelevel.log4cats.StructuredLogger
 import org.broadinstitute.dsde.workbench.DoneCheckable
 import org.broadinstitute.dsde.workbench.DoneCheckableSyntax._
 import org.broadinstitute.dsde.workbench.google2.{streamFUntilDone, streamUntilDoneOrTimeout, DiskName, MachineTypeName}
@@ -21,6 +18,8 @@ import org.http4s.client.middleware.Logger
 import org.http4s.client.{blaze, Client}
 import org.http4s.headers._
 
+import java.util.UUID
+import java.util.concurrent.TimeoutException
 import scala.concurrent.ExecutionContext.global
 import scala.concurrent.duration._
 import scala.util.control.NoStackTrace
@@ -232,8 +231,7 @@ object LeonardoApiClient {
   def waitUntilAppRunning(googleProject: GoogleProject, appName: AppName)(
     implicit timer: Timer[IO],
     client: Client[IO],
-    authHeader: Authorization,
-    logger: StructuredLogger[IO]
+    authHeader: Authorization
   ): IO[GetAppResponse] = {
     val ioa = getApp(googleProject, appName)
     implicit val doneCheckeable: DoneCheckable[GetAppResponse] = x =>
@@ -258,8 +256,7 @@ object LeonardoApiClient {
   def waitUntilAppStopped(googleProject: GoogleProject, appName: AppName)(
     implicit timer: Timer[IO],
     client: Client[IO],
-    authHeader: Authorization,
-    logger: StructuredLogger[IO]
+    authHeader: Authorization
   ): IO[GetAppResponse] = {
     val ioa = getApp(googleProject, appName)
     implicit val doneCheckeable: DoneCheckable[GetAppResponse] = x =>
@@ -284,8 +281,7 @@ object LeonardoApiClient {
   def waitUntilAppDeleted(googleProject: GoogleProject, appName: AppName)(
     implicit timer: Timer[IO],
     client: Client[IO],
-    authHeader: Authorization,
-    logger: StructuredLogger[IO]
+    authHeader: Authorization
   ): IO[Unit] = {
     val ioa = getApp(googleProject, appName).attempt
     for {

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
@@ -36,6 +36,7 @@ import org.scalatest.time.{Minutes, Seconds, Span}
 import java.io.{ByteArrayInputStream, File, FileOutputStream}
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
+import scala.jdk.CollectionConverters._
 import scala.concurrent.duration._
 import scala.util.{Failure, Random, Success, Try}
 

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/AppCreationSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/AppCreationSpec.scala
@@ -40,7 +40,7 @@ class AppCreationSpec extends GPAllocFixtureSpec with LeonardoTestUtils with GPA
           _ <- loggerIO.info(s"AppCreationSpec: About to create app ${googleProject.value}/${appName.value}")
 
           // Create the app
-          _ <- LeonardoApiClient.createApp(googleProject, appName, createAppRequest)
+          _ <- LeonardoApiClient.createAppWithRetry(googleProject, appName, createAppRequest)
 
           // Verify the initial getApp call
           getApp = LeonardoApiClient.getApp(googleProject, appName)
@@ -119,7 +119,7 @@ class AppCreationSpec extends GPAllocFixtureSpec with LeonardoTestUtils with GPA
           _ <- loggerIO.info(s"AppCreationSpec: About to create app ${googleProject.value}/${appName.value}")
 
           // Create the app
-          _ <- LeonardoApiClient.createApp(googleProject, appName, createAppRequest)
+          _ <- LeonardoApiClient.createAppWithRetry(googleProject, appName, createAppRequest)
 
           // Verify the initial getApp call
           getApp = LeonardoApiClient.getApp(googleProject, appName)

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/AppCreationSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/AppCreationSpec.scala
@@ -17,25 +17,25 @@ class AppCreationSpec extends GPAllocFixtureSpec with LeonardoTestUtils with GPA
   implicit val auth: Authorization =
     Authorization(Credentials.Token(AuthScheme.Bearer, ronCreds.makeAuthToken().value))
 
-  "create, delete an app and re-create an app with same disk" taggedAs Tags.SmokeTest in { _ =>
-    withNewProject { googleProject =>
-      val appName = randomAppName
-      val restoreAppName = AppName(s"restore-${appName.value}")
-      val diskName = Generators.genDiskName.sample.get
+  "create, delete an app and re-create an app with same disk" taggedAs Tags.SmokeTest in { googleProject =>
+    val appName = randomAppName
+    val restoreAppName = AppName(s"restore-${appName.value}")
+    val diskName = Generators.genDiskName.sample.get
 
-      val createAppRequest = defaultCreateAppRequest.copy(
-        diskConfig = Some(
-          PersistentDiskRequest(
-            diskName,
-            Some(DiskSize(300)),
-            None,
-            Map.empty
-          )
-        ),
-        customEnvironmentVariables = Map("WORKSPACE_NAME" -> "Galaxy-Workshop-ASHG_2020_GWAS_Demo")
-      )
+    val createAppRequest = defaultCreateAppRequest.copy(
+      diskConfig = Some(
+        PersistentDiskRequest(
+          diskName,
+          Some(DiskSize(300)),
+          None,
+          Map.empty
+        )
+      ),
+      customEnvironmentVariables = Map("WORKSPACE_NAME" -> "Galaxy-Workshop-ASHG_2020_GWAS_Demo")
+    )
 
-      LeonardoApiClient.client.use { implicit client =>
+    LeonardoApiClient.client
+      .use { implicit client =>
         for {
           _ <- loggerIO.info(s"AppCreationSpec: About to create app ${googleProject.value}/${appName.value}")
 
@@ -95,26 +95,26 @@ class AppCreationSpec extends GPAllocFixtureSpec with LeonardoTestUtils with GPA
           }
         } yield ()
       }
-    }
+      .unsafeRunSync()
   }
 
-  "stop and start an app" taggedAs Tags.SmokeTest in { _ =>
-    withNewProject { googleProject =>
-      val appName = randomAppName
-      val diskName = Generators.genDiskName.sample.get
+  "stop and start an app" taggedAs Tags.SmokeTest in { googleProject =>
+    val appName = randomAppName
+    val diskName = Generators.genDiskName.sample.get
 
-      val createAppRequest = defaultCreateAppRequest.copy(
-        diskConfig = Some(
-          PersistentDiskRequest(
-            diskName,
-            Some(DiskSize(500)),
-            None,
-            Map.empty
-          )
+    val createAppRequest = defaultCreateAppRequest.copy(
+      diskConfig = Some(
+        PersistentDiskRequest(
+          diskName,
+          Some(DiskSize(500)),
+          None,
+          Map.empty
         )
       )
+    )
 
-      LeonardoApiClient.client.use { implicit client =>
+    LeonardoApiClient.client
+      .use { implicit client =>
         for {
           _ <- loggerIO.info(s"AppCreationSpec: About to create app ${googleProject.value}/${appName.value}")
 
@@ -211,7 +211,7 @@ class AppCreationSpec extends GPAllocFixtureSpec with LeonardoTestUtils with GPA
           }
         } yield ()
       }
-    }
+      .unsafeRunSync()
   }
 
 }

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/AppCreationSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/AppCreationSpec.scala
@@ -72,7 +72,7 @@ class AppCreationSpec extends GPAllocFixtureSpec with LeonardoTestUtils with GPA
                   s"AppCreationSpec: app ${googleProject.value}/${appName.value} has been deleted."
                 )
                 _ <- LeonardoApiClient.createAppWithRetry(googleProject, restoreAppName, createAppRequest)
-                _ <- waitUntilAppRunning(googleProject, appName)
+                _ <- waitUntilAppRunning(googleProject, restoreAppName)
               } yield ()
           }
         } yield ()

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/AppCreationSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/AppCreationSpec.scala
@@ -98,7 +98,7 @@ class AppCreationSpec extends GPAllocFixtureSpec with LeonardoTestUtils with GPA
       .unsafeRunSync()
   }
 
-  "stop and start an app" taggedAs Tags.SmokeTest in { googleProject =>
+  "stop and start an app" in { googleProject =>
     val appName = randomAppName
     val diskName = Generators.genDiskName.sample.get
 

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/CustomAppCreationSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/CustomAppCreationSpec.scala
@@ -40,7 +40,7 @@ class CustomAppCreationSpec extends GPAllocFixtureSpec with LeonardoTestUtils wi
           _ <- loggerIO.info(s"CustomAppCreationSpec: About to create app ${googleProject.value}/${appName.value}")
 
           // Create the app
-          _ <- LeonardoApiClient.createApp(googleProject, appName, createAppRequest)
+          _ <- LeonardoApiClient.createAppWithRetry(googleProject, appName, createAppRequest)
 
           // Verify the initial getApp call
           getApp = LeonardoApiClient.getApp(googleProject, appName)

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/CustomAppCreationSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/CustomAppCreationSpec.scala
@@ -12,34 +12,30 @@ import org.scalatest.{DoNotDiscover, ParallelTestExecution}
 import scala.concurrent.duration._
 
 @DoNotDiscover
-class CustomAppCreationSpec
-    extends GPAllocFixtureSpec
-    with LeonardoTestUtils
-    with GPAllocUtils
-    with ParallelTestExecution {
+class CustomAppCreationSpec extends GPAllocFixtureSpec with LeonardoTestUtils with ParallelTestExecution {
   implicit val auth: Authorization =
     Authorization(Credentials.Token(AuthScheme.Bearer, ronCreds.makeAuthToken().value))
 
-  "create and delete a custom app" in { _ =>
-    withNewProject { googleProject =>
-      val appName = randomAppName
+  "create and delete a custom app" in { googleProject =>
+    val appName = randomAppName
 
-      val createAppRequest = defaultCreateAppRequest.copy(
-        diskConfig = Some(
-          PersistentDiskRequest(
-            randomDiskName,
-            Some(DiskSize(500)),
-            None,
-            Map.empty
-          )
-        ),
-        descriptorPath = Some(
-          Uri.uri("https://raw.githubusercontent.com/DataBiosphere/terra-app/main/apps/ucsc_genome_browser/app.yaml")
-        ),
-        appType = AppType.Custom
-      )
+    val createAppRequest = defaultCreateAppRequest.copy(
+      diskConfig = Some(
+        PersistentDiskRequest(
+          randomDiskName,
+          Some(DiskSize(500)),
+          None,
+          Map.empty
+        )
+      ),
+      descriptorPath = Some(
+        Uri.uri("https://raw.githubusercontent.com/DataBiosphere/terra-app/main/apps/ucsc_genome_browser/app.yaml")
+      ),
+      appType = AppType.Custom
+    )
 
-      LeonardoApiClient.client.use { implicit client =>
+    LeonardoApiClient.client
+      .use { implicit client =>
         for {
           _ <- loggerIO.info(s"CustomAppCreationSpec: About to create app ${googleProject.value}/${appName.value}")
 
@@ -89,6 +85,6 @@ class CustomAppCreationSpec
           _ = monitorDeleteResult.map(_.status) shouldBe List(AppStatus.Deleted)
         } yield ()
       }
-    }
+      .unsafeRunSync()
   }
 }


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-2587

Make test cases in `AppSpec` use the same gpalloc project (and hence the same cluster). This should be possible now that we have the nodepool lock and preserve the nodepool after app deletion. This may make the tests more efficient.

I kept `BatchNodepoolCreationSpec` in its own project, because I think that test does explicitly want to test cluster creation. 

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
