### PR TITLE
[No ticket] remove patch check

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -16,6 +16,7 @@ comment:
   require_changes: no
 coverage:
   status:
+    patch: off
     project:
       default:
         target: 70%    # the required coverage value


### PR DESCRIPTION
Will remove 1/2 of the codecov banners in a PR. The one relative to 'dev' will remain, but the 'patch' one is relative to the first commit in a given PR, which is fairly useless, and causes all PRs to be marked with 'X' essentially because tests are usually added at the end of a PR

See this PR to see what I mean: https://github.com/DataBiosphere/leonardo/pull/1919
Intended behavior is check thats green in this PR would remain, but other check would go away. 