### PR TITLE
[QA-1411] Bugfixes for custom apps

### DIFF
--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -215,7 +215,8 @@ gke {
     chartVersion = "3.23.0"
     loadBalancerService = "nginx-ingress-nginx-controller"
     values = [
-      "controller.publishService.enabled=true"
+      "controller.publishService.enabled=true",
+      "controller.admissionWebhooks.timeoutSeconds=60"
     ]
   }
   galaxyApp {

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -216,7 +216,7 @@ gke {
     loadBalancerService = "nginx-ingress-nginx-controller"
     values = [
       "controller.publishService.enabled=true",
-      "controller.admissionWebhooks.timeoutSeconds=60"
+      "controller.admissionWebhooks.timeoutSeconds=30"
     ]
   }
   galaxyApp {

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
@@ -922,34 +922,42 @@ class LeoPubsubMessageSubscriber[F[_]: Timer: ContextShift: Parallel](
 
       deleteDisksInParallel = List(deleteDisk, deletePostgresDisk).parSequence_
 
-      // For Galaxy apps, wait for the postgres disk to detach before deleting the disks
-      // TODO should we do this for the other disk too?
-      deleteAppAndWaitForDiskDetach = if (dbApp.app.appType == AppType.Galaxy) {
-        val getGalaxyPostgresDisk = googleDiskService.getDisk(
-          msg.project,
-          zone,
-          gkeInterp.getGalaxyPostgresDiskName(dbApp.app.appResources.namespace.name)
-        )
-        for {
-          // we record the last disk detach timestamp here, before it is removed from galaxy
-          originalDiskOpt <- getGalaxyPostgresDisk
-          originalDetachTimestampOpt = originalDiskOpt.map(_.getLastDetachTimestamp)
+      task = for {
+        // For Galaxy apps, wait for the postgres disk to detach before deleting the disks
+        // TODO should we do this for the other disk too?
+        originalDetachTimestampOpt <- if (dbApp.app.appType == AppType.Galaxy) {
+          googleDiskService
+            .getDisk(
+              msg.project,
+              zone,
+              gkeInterp.getGalaxyPostgresDiskName(dbApp.app.appResources.namespace.name)
+            )
+            .map(_.map(_.getLastDetachTimestamp))
+        } else F.pure(None)
 
-          _ <- deleteApp
-          _ <- if (!errorAfterDelete)
-            dbApp.app.status match {
-              // If the message is resubmitted, and this step has already been run, we don't want to re-notify the app creator and update the deleted timestamp
-              case AppStatus.Deleted => F.unit
-              case _ =>
-                appQuery.markAsDeleted(msg.appId, ctx.now).transaction.void >> authProvider
-                  .notifyResourceDeleted(dbApp.app.samResourceId, dbApp.app.auditInfo.creator, msg.project)
-                  .void
-            }
-          else F.unit
+        // Do the helm uninstall
+        _ <- deleteApp
+        _ <- if (!errorAfterDelete)
+          dbApp.app.status match {
+            // If the message is resubmitted, and this step has already been run, we don't want to re-notify the app creator and update the deleted timestamp
+            case AppStatus.Deleted => F.unit
+            case _ =>
+              appQuery.markAsDeleted(msg.appId, ctx.now).transaction.void >> authProvider
+                .notifyResourceDeleted(dbApp.app.samResourceId, dbApp.app.auditInfo.creator, msg.project)
+                .void
+          }
+        else F.unit
 
-          // we now use the detach timestamp recorded prior to helm uninstall so we can observe when galaxy actually 'detaches' the disk from google's perspective
-          _ <- streamUntilDoneOrTimeout(
-            getDiskDetachStatus(originalDetachTimestampOpt, getGalaxyPostgresDisk),
+        // If this is a Galaxy app, wait for the postgres disk to be detached before moving on
+        _ <- if (dbApp.app.appType == AppType.Galaxy) {
+          streamUntilDoneOrTimeout(
+            getDiskDetachStatus(originalDetachTimestampOpt,
+                                googleDiskService
+                                  .getDisk(
+                                    msg.project,
+                                    zone,
+                                    gkeInterp.getGalaxyPostgresDiskName(dbApp.app.appResources.namespace.name)
+                                  )),
             30,
             5 seconds,
             "The disk failed to detach within the time limit, cannot proceed with delete disk"
@@ -963,11 +971,9 @@ class LeoPubsubMessageSubscriber[F[_]: Timer: ContextShift: Parallel](
                 None
               )
           }
-        } yield ()
-      } else deleteApp
+        } else F.unit
 
-      task = for {
-        _ <- deleteAppAndWaitForDiskDetach
+        // Delete the disks
         _ <- deleteDisksInParallel
       } yield ()
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
@@ -8,12 +8,12 @@ import _root_.io.chrisdavenport.log4cats.StructuredLogger
 import cats.Parallel
 import cats.effect.implicits._
 import cats.effect.{ConcurrentEffect, ContextShift, Timer}
-import cats.syntax.all._
 import cats.mtl.Ask
+import cats.syntax.all._
 import com.google.cloud.compute.v1.Disk
 import fs2.Stream
 import fs2.concurrent.InspectableQueue
-import org.broadinstitute.dsde.workbench.{DoneCheckable}
+import org.broadinstitute.dsde.workbench.DoneCheckable
 import org.broadinstitute.dsde.workbench.errorReporting.ErrorReporting
 import org.broadinstitute.dsde.workbench.errorReporting.ReportWorthySyntax._
 import org.broadinstitute.dsde.workbench.google2.KubernetesSerializableName.NamespaceName
@@ -40,9 +40,9 @@ import org.broadinstitute.dsde.workbench.leonardo.util._
 import org.broadinstitute.dsde.workbench.model.google.{GcsObjectName, GcsPath, GoogleProject}
 import org.broadinstitute.dsde.workbench.model.{ErrorReport, TraceId, WorkbenchException}
 
-import scala.jdk.CollectionConverters._
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
+import scala.jdk.CollectionConverters._
 
 class LeoPubsubMessageSubscriber[F[_]: Timer: ContextShift: Parallel](
   config: LeoPubsubMessageSubscriberConfig,
@@ -906,34 +906,57 @@ class LeoPubsubMessageSubscriber[F[_]: Timer: ContextShift: Parallel](
       dbAppOpt <- KubernetesServiceDbQueries.getFullAppByName(msg.project, msg.appId).transaction
       dbApp <- F.fromOption(dbAppOpt, AppNotFoundException(msg.project, msg.appName, ctx.traceId))
       zone = ZoneName("us-central1-a")
-      deletePostgresDisk = deleteGalaxyPostgresDiskOnlyInGoogle(msg.project,
-                                                                zone,
-                                                                msg.appName,
-                                                                dbApp.app.appResources.namespace.name)
-        .adaptError {
-          case e =>
-            PubsubKubernetesError(
-              AppError(e.getMessage, ctx.now, ErrorAction.DeleteApp, ErrorSource.PostgresDisk, None),
-              Some(msg.appId),
-              false,
-              None,
-              None
-            )
-        }
+      deletePostgresDisk = if (dbApp.app.appType == AppType.Galaxy)
+        deleteGalaxyPostgresDiskOnlyInGoogle(msg.project, zone, msg.appName, dbApp.app.appResources.namespace.name)
+          .adaptError {
+            case e =>
+              PubsubKubernetesError(
+                AppError(e.getMessage, ctx.now, ErrorAction.DeleteApp, ErrorSource.PostgresDisk, None),
+                Some(msg.appId),
+                false,
+                None,
+                None
+              )
+          }
+      else F.unit
 
       deleteDisksInParallel = List(deleteDisk, deletePostgresDisk).parSequence_
 
-      // The app must be deleted before the nodepool and disk, to future proof against the app potentially flushing the postgres db somewhere
-      task = for {
-        //we record the last disk detach timestamp here, before it is removed from galaxy
-        originalDiskOpt <- googleDiskService.getDisk(
+      deleteAppAndWaitForDiskDetach = if (dbApp.app.appType == AppType.Galaxy) {
+        val getGalaxyPostgresDisk = googleDiskService.getDisk(
           msg.project,
           zone,
           gkeInterp.getGalaxyPostgresDiskName(dbApp.app.appResources.namespace.name)
         )
-        originalDetachTimestampOpt = originalDiskOpt.map(_.getLastDetachTimestamp)
+        for {
+          // we record the last disk detach timestamp here, before it is removed from galaxy
+          originalDiskOpt <- getGalaxyPostgresDisk
+          originalDetachTimestampOpt = originalDiskOpt.map(_.getLastDetachTimestamp)
 
-        _ <- deleteApp
+          _ <- deleteApp
+
+          // we now use the detach timestamp recorded prior to helm uninstall so we can observe when galaxy actually 'detaches' the disk from google's perspective
+          diskDetachResult <- streamUntilDoneOrTimeout(
+            getDiskDetachStatus(originalDetachTimestampOpt, getGalaxyPostgresDisk),
+            30,
+            5 seconds,
+            "The disk failed to detach within the time limit, cannot proceed with delete disk"
+          ).adaptError {
+            case e =>
+              PubsubKubernetesError(
+                AppError(e.getMessage, ctx.now, ErrorAction.DeleteApp, ErrorSource.Disk, None),
+                Some(msg.appId),
+                false,
+                None,
+                None
+              )
+          }
+        } yield ()
+      } else deleteApp
+
+      // The app must be deleted before the nodepool and disk, to future proof against the app potentially flushing the postgres db somewhere
+      task = for {
+        _ <- deleteAppAndWaitForDiskDetach
         _ <- if (!errorAfterDelete)
           dbApp.app.status match {
             // If the message is resubmitted, and this step has already been run, we don't want to re-notify the app creator and update the deleted timestamp
@@ -944,25 +967,6 @@ class LeoPubsubMessageSubscriber[F[_]: Timer: ContextShift: Parallel](
                 .void
           }
         else F.unit
-        // we now use the detach timestamp recorded prior to helm uninstall so we can observe when galaxy actually 'detaches' the disk from google's perspective
-        getDisk = googleDiskService.getDisk(msg.project,
-                                            zone,
-                                            gkeInterp.getGalaxyPostgresDiskName(dbApp.app.appResources.namespace.name))
-        diskDetachResult <- streamUntilDoneOrTimeout(
-          getDiskDetachStatus(originalDetachTimestampOpt, getDisk),
-          30,
-          5 seconds,
-          "The disk failed to detach within the time limit, cannot proceed with delete disk"
-        ).adaptError {
-          case e =>
-            PubsubKubernetesError(
-              AppError(e.getMessage, ctx.now, ErrorAction.DeleteApp, ErrorSource.Disk, None),
-              Some(msg.appId),
-              false,
-              None,
-              None
-            )
-        }
 
         _ <- deleteDisksInParallel
       } yield ()

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
@@ -549,12 +549,8 @@ class GKEInterpreter[F[_]: Parallel: ContextShift: Timer](
         for {
           helmAuthContext <- getHelmAuthContext(googleCluster, dbCluster, namespaceName)
 
-          chart = app.appType match {
-            case AppType.Galaxy => config.galaxyAppConfig.chart
-            case AppType.Custom => config.customAppConfig.chart
-          }
           _ <- logger.info(ctx.loggingCtx)(
-            s"Uninstalling helm chart ${chart} for app ${app.appName.value} in cluster ${dbCluster.getGkeClusterId.toString}"
+            s"Uninstalling release ${app.release.asString} for ${app.appType.toString} app ${app.appName.value} in cluster ${dbCluster.getGkeClusterId.toString}"
           )
 
           // helm uninstall the app chart and wait


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/QA-1411

This can wait till next week, but I wanted to make this PR while fresh.

I noticed `CustomAppCreationSpec` occasionally failing in Jenkins and made the following fixes:

1. increase admission webhook timeout to address this failure at custom app helm install time:
   ```
   custom app failed with: err is %!(EXTRA *errors.StatusError=Internal error occurred: failed calling webhook "validate.nginx.ingress.kubernetes.io": Post https://nginx-ingress-nginx-controller-admission.nginx.svc:443/networking/v1beta1/ingresses?timeout=10s: no endpoints available for service "nginx-ingress-nginx-controller-admission", string=)
   ```
   Googling suggests the 10s timeout may be too small under load. This webhook can also be disabled, but seeing if this resolves it first.

2. Fix bugs in `deleteApp` flow for custom apps. It was helm uninstalling the chart correctly, but still trying to do Galaxy-specific things like delete the postgres disk (which doesn't exist for custom apps). It was also logging "Deleting Galaxy chart" which was confusing. WIP, there may be more to fix here.

 
---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
