### PR TITLE
IA-2541 Add logging for gke pollOperation and fix starting timeout bug

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/runtimeModels.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/runtimeModels.scala
@@ -70,29 +70,60 @@ object Runtime {
 }
 
 /** Runtime status enum */
-sealed trait RuntimeStatus extends EnumEntry with Product with Serializable
+sealed trait RuntimeStatus extends EnumEntry with Product with Serializable {
+  // end status if it is a transition status. For instance, terminalStatus for `Starting` is `Running`
+  def terminalStatus: Option[RuntimeStatus]
+}
 object RuntimeStatus extends Enum[RuntimeStatus] {
   val values = findValues
   // Leonardo defined runtime statuses.
 
   // These statuses exist when we save a runtime during an API request, but we haven't published the event to back leo
-  case object PreCreating extends RuntimeStatus
-  case object PreDeleting extends RuntimeStatus
-  case object PreStarting extends RuntimeStatus
-  case object PreStopping extends RuntimeStatus
+  case object PreCreating extends RuntimeStatus {
+    override def terminalStatus: Option[RuntimeStatus] = Some(Running)
+  }
+  case object PreDeleting extends RuntimeStatus {
+    override def terminalStatus: Option[RuntimeStatus] = Some(Deleted)
+  }
+  case object PreStarting extends RuntimeStatus {
+    override def terminalStatus: Option[RuntimeStatus] = Some(Running)
+  }
+  case object PreStopping extends RuntimeStatus {
+    override def terminalStatus: Option[RuntimeStatus] = Some(Stopped)
+  }
 
   // NOTE: Remember to update the definition of this enum in Swagger when you add new ones
-  case object Creating extends RuntimeStatus
-  case object Updating extends RuntimeStatus //only for dataproc status
-  case object Deleting extends RuntimeStatus
-  case object Starting extends RuntimeStatus
-  case object Stopping extends RuntimeStatus
+  case object Creating extends RuntimeStatus {
+    override def terminalStatus: Option[RuntimeStatus] = Some(Running)
+  }
+  case object Updating extends RuntimeStatus {
+    override def terminalStatus: Option[RuntimeStatus] = Some(Running)
+  } //only for dataproc status
+  case object Deleting extends RuntimeStatus {
+    override def terminalStatus: Option[RuntimeStatus] = Some(Deleted)
+  }
+  case object Starting extends RuntimeStatus {
+    override def terminalStatus: Option[RuntimeStatus] = Some(Running)
+  }
+  case object Stopping extends RuntimeStatus {
+    override def terminalStatus: Option[RuntimeStatus] = Some(Stopped)
+  }
 
-  case object Running extends RuntimeStatus
-  case object Error extends RuntimeStatus
-  case object Unknown extends RuntimeStatus
-  case object Stopped extends RuntimeStatus
-  case object Deleted extends RuntimeStatus
+  case object Running extends RuntimeStatus {
+    override def terminalStatus: Option[RuntimeStatus] = None
+  }
+  case object Error extends RuntimeStatus {
+    override def terminalStatus: Option[RuntimeStatus] = None
+  }
+  case object Unknown extends RuntimeStatus {
+    override def terminalStatus: Option[RuntimeStatus] = None
+  }
+  case object Stopped extends RuntimeStatus {
+    override def terminalStatus: Option[RuntimeStatus] = None
+  }
+  case object Deleted extends RuntimeStatus {
+    override def terminalStatus: Option[RuntimeStatus] = None
+  }
 
   def fromDataprocClusterStatus(dataprocClusterStatus: DataprocClusterStatus): RuntimeStatus =
     dataprocClusterStatus match {

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/AutopauseMonitor.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/AutopauseMonitor.scala
@@ -80,7 +80,7 @@ class AutopauseMonitor[F[_]: ContextShift: Timer](
         val traceId = TraceId(s"fromAutopause_${UUID.randomUUID().toString}")
         for {
           _ <- clusterQuery.updateClusterStatus(cl.id, RuntimeStatus.PreStopping, now).transaction
-          _ <- logger.info(s"${traceId.asString} | Auto freezing runtime ${cl.projectNameString}")
+          _ <- logger.info(Map("traceId" -> traceId.asString))(s"Auto freezing runtime ${cl.projectNameString}")
           _ <- publisherQueue.enqueue1(LeoPubsubMessage.StopRuntimeMessage(cl.id, Some(traceId)))
         } yield ()
       }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/AutopauseMonitor.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/AutopauseMonitor.scala
@@ -2,12 +2,11 @@ package org.broadinstitute.dsde.workbench.leonardo
 package monitor
 
 import java.util.UUID
-
 import cats.effect.{Async, ContextShift, Timer}
 import cats.syntax.all._
 import fs2.Stream
 import fs2.concurrent.InspectableQueue
-import io.chrisdavenport.log4cats.Logger
+import io.chrisdavenport.log4cats.StructuredLogger
 import org.broadinstitute.dsde.workbench.leonardo.config.AutoFreezeConfig
 import org.broadinstitute.dsde.workbench.leonardo.dao.JupyterDAO
 import org.broadinstitute.dsde.workbench.leonardo.db._
@@ -26,7 +25,7 @@ class AutopauseMonitor[F[_]: ContextShift: Timer](
   publisherQueue: InspectableQueue[F, LeoPubsubMessage]
 )(implicit F: Async[F],
   metrics: OpenTelemetryMetrics[F],
-  logger: Logger[F],
+  logger: StructuredLogger[F],
   dbRef: DbReference[F],
   ec: ExecutionContext) {
 
@@ -93,7 +92,7 @@ object AutopauseMonitor {
                                        publisherQueue: InspectableQueue[F, LeoPubsubMessage])(
     implicit F: Async[F],
     metrics: OpenTelemetryMetrics[F],
-    logger: Logger[F],
+    logger: StructuredLogger[F],
     dbRef: DbReference[F],
     ec: ExecutionContext
   ): AutopauseMonitor[F] =

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/BaseCloudServiceRuntimeMonitor.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/BaseCloudServiceRuntimeMonitor.scala
@@ -253,7 +253,8 @@ abstract class BaseCloudServiceRuntimeMonitor[F[_]] {
         case _ =>
           logger
             .info(monitorContext.loggingContext)(
-              s"Runtime ${runtimeAndRuntimeConfig.runtime.projectNameString} is not in final state yet and has taken ${timeElapsed.toSeconds} seconds so far. Checking again in ${monitorConfig.pollingInterval}. ${message
+              s"Runtime ${runtimeAndRuntimeConfig.runtime.projectNameString} is not in ${runtimeAndRuntimeConfig.runtime.status.terminalStatus
+                .getOrElse("final")} state yet and has taken ${timeElapsed.toSeconds} seconds so far. Checking again in ${monitorConfig.pollingInterval}. ${message
                 .getOrElse("")}"
             )
             .as(((), Some(Check(runtimeAndRuntimeConfig))))
@@ -488,7 +489,7 @@ abstract class BaseCloudServiceRuntimeMonitor[F[_]] {
     val result = for {
       ctx <- ev.ask
       _ <- clusterErrorQuery
-        .save(runtimeId, RuntimeError(errorDetails.longMessage, errorDetails.code, ctx.now))
+        .save(runtimeId, RuntimeError(errorDetails.longMessage, errorDetails.code, ctx.now, Some(ctx.traceId)))
         .transaction
         .void
         .adaptError {

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/BaseCloudServiceRuntimeMonitor.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/BaseCloudServiceRuntimeMonitor.scala
@@ -7,7 +7,6 @@ import cats.mtl.Ask
 import com.google.cloud.storage.BucketInfo
 import fs2.Stream
 import io.chrisdavenport.log4cats.StructuredLogger
-import monocle.macros.syntax.lens._
 import org.broadinstitute.dsde.workbench.DoneCheckable
 import org.broadinstitute.dsde.workbench.google2.{streamFUntilDone, GcsBlobName, GoogleStorageService}
 import org.broadinstitute.dsde.workbench.leonardo._
@@ -233,13 +232,9 @@ abstract class BaseCloudServiceRuntimeMonitor[F[_]] {
                 )
                 // Stopping the runtime
                 _ <- clusterQuery
-                  .updateClusterStatusAndHostIp(runtimeAndRuntimeConfig.runtime.id, RuntimeStatus.Stopping, ip, now)
+                  .updateClusterStatusAndHostIp(runtimeAndRuntimeConfig.runtime.id, RuntimeStatus.Stopping, None, now)
                   .transaction
-                runtimeAndRuntimeConfigAfterSetIp = ip.fold(runtimeAndRuntimeConfig)(i =>
-                  LeoLenses.ipRuntimeAndRuntimeConfig.set(i)(runtimeAndRuntimeConfig)
-                )
-                rrc = runtimeAndRuntimeConfigAfterSetIp.lens(_.runtime.status).set(RuntimeStatus.Stopping)
-              } yield ((), Some(MonitorState.Check(rrc))): CheckResult
+              } yield ((), None): CheckResult
             } else
               failedRuntime(
                 monitorContext,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/BaseCloudServiceRuntimeMonitor.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/BaseCloudServiceRuntimeMonitor.scala
@@ -85,7 +85,7 @@ abstract class BaseCloudServiceRuntimeMonitor[F[_]] {
           logger
             .error(ctx.loggingCtx)(s"disappeared from database in the middle of status transition!")
             .as(((), None))
-        case Some(status) if (status != monitorContext.action) && monitorState.newTransition.isEmpty =>
+        case Some(status) if (status != monitorContext.action) =>
           val tags = Map("original_status" -> monitorContext.action.toString, "interrupted_by" -> status.toString)
           openTelemetry.incrementCounter("earlyTerminationOfMonitoring", 1, tags) >> logger
             .warn(ctx.loggingCtx)(

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/GceRuntimeMonitor.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/GceRuntimeMonitor.scala
@@ -278,7 +278,6 @@ class GceRuntimeMonitor[F[_]: Parallel](
           GceInstanceStatus.Suspending,
           GceInstanceStatus.Provisioning,
           GceInstanceStatus.Staging,
-          GceInstanceStatus.Terminated,
           GceInstanceStatus.Suspended,
           GceInstanceStatus.Stopping
         )

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
@@ -186,13 +186,13 @@ class GKEInterpreter[F[_]: Parallel: ContextShift: Timer](
         )
       else
         logger.error(ctx.loggingCtx)(
-          s"Create cluster operation has failed for cluster ${dbCluster.getGkeClusterId.toString}"
+          s"Create cluster operation timed out or failed for cluster ${dbCluster.getGkeClusterId.toString}"
         ) >>
           // Note LeoPubsubMessageSubscriber will transition things to Error status if an exception is thrown
           F.raiseError[Unit](
             ClusterCreationException(
               ctx.traceId,
-              s"Failed to poll cluster creation operation to completion for cluster ${dbCluster.getGkeClusterId.toString} | trace id: ${ctx.traceId}"
+              s"Cluster creation timed out or failed for ${dbCluster.getGkeClusterId.toString} | trace id: ${ctx.traceId}"
             )
           )
 

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/mocks.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/mocks.scala
@@ -152,7 +152,7 @@ object MockRuntimeAlgebra extends RuntimeAlgebra[IO] {
 
   override def stopRuntime(params: StopRuntimeParams)(
     implicit ev: Ask[IO, AppContext]
-  ): IO[Option[Operation]] = ???
+  ): IO[Option[Operation]] = IO.pure(None)
 
   override def startRuntime(params: StartRuntimeParams)(implicit ev: Ask[IO, AppContext]): IO[Unit] = ???
 

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/BaseCloudServiceRuntimeMonitorSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/BaseCloudServiceRuntimeMonitorSpec.scala
@@ -41,6 +41,22 @@ class BaseCloudServiceRuntimeMonitorSpec extends AnyFlatSpec with Matchers with 
     res.unsafeRunSync()
   }
 
+  it should "transition cluster to Stopping if Starting times out" in isolatedDbTest {
+    val res = for {
+      runtime <- IO(makeCluster(0).copy(status = RuntimeStatus.Starting).save())
+      runtimeMonitor = new MockRuntimeMonitor(true, Map(RuntimeStatus.Starting -> 2.seconds)) {
+        override def handleCheck(monitorContext: MonitorContext, runtimeAndRuntimeConfig: RuntimeAndRuntimeConfig)(
+          implicit ev: Ask[IO, AppContext]
+        ): IO[(Unit, Option[MonitorState])] = checkAgain(monitorContext, runtimeAndRuntimeConfig, Set.empty, None, None)
+      }
+      assersions = for {
+        status <- clusterQuery.getClusterStatus(runtime.id).transaction
+      } yield status.get shouldBe RuntimeStatus.Stopping
+      _ <- withInfiniteStream(runtimeMonitor.process(runtime.id, RuntimeStatus.Starting), assersions)
+    } yield ()
+    res.unsafeRunSync()
+  }
+
   "handleCheckTools" should "move to Running status if all tools are ready" in isolatedDbTest {
     val runtimeMonitor = baseRuntimeMonitor(true)
 
@@ -121,53 +137,57 @@ class BaseCloudServiceRuntimeMonitorSpec extends AnyFlatSpec with Matchers with 
     res.unsafeRunSync()
   }
 
-  def baseRuntimeMonitor(isWelderReady: Boolean): BaseCloudServiceRuntimeMonitor[IO] =
-    new BaseCloudServiceRuntimeMonitor[IO] {
-      implicit override def F: Async[IO] = IO.ioConcurrentEffect(cs)
+  class MockRuntimeMonitor(isWelderReady: Boolean, timeouts: Map[RuntimeStatus, FiniteDuration])
+      extends BaseCloudServiceRuntimeMonitor[IO] {
+    implicit override def F: Async[IO] = IO.ioConcurrentEffect(cs)
 
-      implicit override def parallel: Parallel[IO] = IO.ioParallel(cs)
+    implicit override def parallel: Parallel[IO] = IO.ioParallel(cs)
 
-      override def timer: Timer[IO] = testTimer
+    override def timer: Timer[IO] = testTimer
 
-      implicit override def dbRef: DbReference[IO] = testDbRef
+    implicit override def dbRef: DbReference[IO] = testDbRef
 
-      implicit override def ec: ExecutionContext = global
+    implicit override def ec: ExecutionContext = global
 
-      implicit override def runtimeToolToToolDao
-        : RuntimeContainerServiceType => ToolDAO[IO, RuntimeContainerServiceType] = x => {
-        x match {
-          case RuntimeContainerServiceType.WelderService => MockToolDAO(isWelderReady)
-          case _                                         => MockToolDAO(true)
-        }
+    implicit override def runtimeToolToToolDao
+      : RuntimeContainerServiceType => ToolDAO[IO, RuntimeContainerServiceType] = x => {
+      x match {
+        case RuntimeContainerServiceType.WelderService => MockToolDAO(isWelderReady)
+        case _                                         => MockToolDAO(true)
       }
-
-      implicit override def openTelemetry: OpenTelemetryMetrics[IO] = metrics
-
-      override def runtimeAlg: RuntimeAlgebra[IO] = MockRuntimeAlgebra
-
-      override def logger: StructuredLogger[IO] = loggerIO
-
-      override def googleStorage: GoogleStorageService[IO] = ???
-
-      override def monitorConfig: MonitorConfig = MonitorConfig.GceMonitorConfig(
-        2 seconds,
-        1 seconds,
-        5,
-        1 seconds,
-        10,
-        RuntimeBucketConfig(3 seconds),
-        Map.empty,
-        ZoneName("zoneName"),
-        Config.imageConfig
-      )
-
-      override def pollCheck(googleProject: GoogleProject,
-                             runtimeAndRuntimeConfig: RuntimeAndRuntimeConfig,
-                             operation: Operation,
-                             action: RuntimeStatus)(implicit ev: Ask[IO, TraceId]): IO[Unit] = ???
-
-      override def handleCheck(monitorContext: MonitorContext, runtimeAndRuntimeConfig: RuntimeAndRuntimeConfig)(
-        implicit ev: Ask[IO, AppContext]
-      ): IO[(Unit, Option[MonitorState])] = IO.pure(((), Some(MonitorState.Check(runtimeAndRuntimeConfig))))
     }
+
+    implicit override def openTelemetry: OpenTelemetryMetrics[IO] = metrics
+
+    override def runtimeAlg: RuntimeAlgebra[IO] = MockRuntimeAlgebra
+
+    override def logger: StructuredLogger[IO] = loggerIO
+
+    override def googleStorage: GoogleStorageService[IO] = ???
+
+    override def monitorConfig: MonitorConfig = MonitorConfig.GceMonitorConfig(
+      2 seconds,
+      1 seconds,
+      5,
+      1 seconds,
+      10,
+      RuntimeBucketConfig(3 seconds),
+      timeouts,
+      ZoneName("zoneName"),
+      Config.imageConfig
+    )
+
+    override def pollCheck(googleProject: GoogleProject,
+                           runtimeAndRuntimeConfig: RuntimeAndRuntimeConfig,
+                           operation: Operation,
+                           action: RuntimeStatus)(implicit ev: Ask[IO, TraceId]): IO[Unit] = ???
+
+    override def handleCheck(monitorContext: MonitorContext, runtimeAndRuntimeConfig: RuntimeAndRuntimeConfig)(
+      implicit ev: Ask[IO, AppContext]
+    ): IO[(Unit, Option[MonitorState])] = IO.pure(((), Some(MonitorState.Check(runtimeAndRuntimeConfig, None))))
+  }
+
+  def baseRuntimeMonitor(isWelderReady: Boolean,
+                         timeouts: Map[RuntimeStatus, FiniteDuration] = Map.empty): BaseCloudServiceRuntimeMonitor[IO] =
+    new MockRuntimeMonitor(isWelderReady, timeouts)
 }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/DataprocRuntimeMonitorSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/DataprocRuntimeMonitorSpec.scala
@@ -52,7 +52,7 @@ class DataprocRuntimeMonitorSpec extends AnyFlatSpec with TestComponent with Leo
       runtimeAndRuntimeConfig = RuntimeAndRuntimeConfig(savedRuntime, CommonTestData.defaultDataprocRuntimeConfig)
       r <- monitor.creatingRuntime(None, monitorContext, runtimeAndRuntimeConfig)
     } yield {
-      r._2 shouldBe (Some(Check(runtimeAndRuntimeConfig)))
+      r._2 shouldBe (Some(Check(runtimeAndRuntimeConfig, None)))
     }
 
     res.unsafeRunSync()
@@ -77,8 +77,8 @@ class DataprocRuntimeMonitorSpec extends AnyFlatSpec with TestComponent with Leo
       r1 <- monitor.creatingRuntime(Some(cluster1), monitorContext, runtimeAndRuntimeConfig)
       r2 <- monitor.creatingRuntime(Some(cluster2), monitorContext, runtimeAndRuntimeConfig)
     } yield {
-      r1._2 shouldBe (Some(Check(runtimeAndRuntimeConfig)))
-      r2._2 shouldBe (Some(Check(runtimeAndRuntimeConfig)))
+      r1._2 shouldBe (Some(Check(runtimeAndRuntimeConfig, None)))
+      r2._2 shouldBe (Some(Check(runtimeAndRuntimeConfig, None)))
     }
 
     res.unsafeRunSync()
@@ -101,7 +101,7 @@ class DataprocRuntimeMonitorSpec extends AnyFlatSpec with TestComponent with Leo
       runtimeAndRuntimeConfig = RuntimeAndRuntimeConfig(savedRuntime, CommonTestData.defaultDataprocRuntimeConfig)
       r <- monitor.creatingRuntime(Some(cluster), monitorContext, runtimeAndRuntimeConfig)
     } yield {
-      r._2 shouldBe (Some(Check(runtimeAndRuntimeConfig)))
+      r._2 shouldBe (Some(Check(runtimeAndRuntimeConfig, None)))
     }
 
     res.unsafeRunSync()
@@ -260,7 +260,7 @@ class DataprocRuntimeMonitorSpec extends AnyFlatSpec with TestComponent with Leo
       runtimeAndRuntimeConfig = RuntimeAndRuntimeConfig(savedRuntime, CommonTestData.defaultDataprocRuntimeConfig)
       r <- monitor.startingRuntime(Some(cluster), monitorContext, runtimeAndRuntimeConfig)
     } yield {
-      r._2 shouldBe (Some(Check(runtimeAndRuntimeConfig)))
+      r._2 shouldBe (Some(Check(runtimeAndRuntimeConfig, None)))
     }
 
     res.unsafeRunSync()
@@ -285,7 +285,7 @@ class DataprocRuntimeMonitorSpec extends AnyFlatSpec with TestComponent with Leo
       runtimeAndRuntimeConfig = RuntimeAndRuntimeConfig(savedRuntime, CommonTestData.defaultDataprocRuntimeConfig)
       r <- monitor.startingRuntime(Some(cluster), monitorContext, runtimeAndRuntimeConfig)
     } yield {
-      r._2 shouldBe (Some(Check(runtimeAndRuntimeConfig)))
+      r._2 shouldBe (Some(Check(runtimeAndRuntimeConfig, None)))
     }
 
     res.unsafeRunSync()
@@ -334,7 +334,7 @@ class DataprocRuntimeMonitorSpec extends AnyFlatSpec with TestComponent with Leo
       runtimeAndRuntimeConfig = RuntimeAndRuntimeConfig(savedRuntime, CommonTestData.defaultDataprocRuntimeConfig)
       r <- monitor.stoppingRuntime(Some(cluster), monitorContext, runtimeAndRuntimeConfig)
     } yield {
-      r._2 shouldBe (Some(Check(runtimeAndRuntimeConfig)))
+      r._2 shouldBe (Some(Check(runtimeAndRuntimeConfig, None)))
     }
 
     res.unsafeRunSync()
@@ -434,7 +434,7 @@ class DataprocRuntimeMonitorSpec extends AnyFlatSpec with TestComponent with Leo
       runtimeAndRuntimeConfig = RuntimeAndRuntimeConfig(savedRuntime, CommonTestData.defaultDataprocRuntimeConfig)
       r <- monitor.updatingRuntime(Some(cluster), monitorContext, runtimeAndRuntimeConfig)
     } yield {
-      r._2 shouldBe Some(Check(runtimeAndRuntimeConfig))
+      r._2 shouldBe Some(Check(runtimeAndRuntimeConfig, None))
     }
 
     res.unsafeRunSync()
@@ -459,7 +459,7 @@ class DataprocRuntimeMonitorSpec extends AnyFlatSpec with TestComponent with Leo
       runtimeAndRuntimeConfig = RuntimeAndRuntimeConfig(savedRuntime, CommonTestData.defaultDataprocRuntimeConfig)
       r <- monitor.updatingRuntime(Some(cluster), monitorContext, runtimeAndRuntimeConfig)
     } yield {
-      r._2 shouldBe Some(Check(runtimeAndRuntimeConfig))
+      r._2 shouldBe Some(Check(runtimeAndRuntimeConfig, None))
     }
 
     res.unsafeRunSync()
@@ -484,7 +484,7 @@ class DataprocRuntimeMonitorSpec extends AnyFlatSpec with TestComponent with Leo
       runtimeAndRuntimeConfig = RuntimeAndRuntimeConfig(savedRuntime, CommonTestData.defaultDataprocRuntimeConfig)
       r <- monitor.updatingRuntime(Some(cluster), monitorContext, runtimeAndRuntimeConfig)
     } yield {
-      r._2 shouldBe Some(Check(runtimeAndRuntimeConfig))
+      r._2 shouldBe Some(Check(runtimeAndRuntimeConfig, None))
     }
 
     res.unsafeRunSync()
@@ -534,7 +534,7 @@ class DataprocRuntimeMonitorSpec extends AnyFlatSpec with TestComponent with Leo
       runtimeAndRuntimeConfig = RuntimeAndRuntimeConfig(savedRuntime, CommonTestData.defaultDataprocRuntimeConfig)
       r <- monitor.deletedRuntime(Some(cluster), monitorContext, runtimeAndRuntimeConfig)
     } yield {
-      r._2 shouldBe Some(Check(runtimeAndRuntimeConfig))
+      r._2 shouldBe Some(Check(runtimeAndRuntimeConfig, None))
     }
 
     res.unsafeRunSync()

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/GceRuntimeMonitorSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/GceRuntimeMonitorSpec.scala
@@ -322,6 +322,35 @@ class GceRuntimeMonitorSpec
     res.unsafeRunSync()
   }
 
+//  it should "transition gce runtime to Stopping if Starting times out" in isolatedDbTest {
+//    def computeService(start: Long): GoogleComputeService[IO] = new FakeGoogleComputeService {
+//      override def getInstance(project: GoogleProject, zone: ZoneName, instanceName: InstanceName)(
+//        implicit ev: Ask[IO, TraceId]
+//      ): IO[Option[Instance]] = {
+//        val beforeInstance = Instance.newBuilder().setStatus("Provisioning").build()
+//        val afterInstance = Instance.newBuilder().setStatus("Stopped").build()
+//
+//        for {
+//          now <- testTimer.clock.realTime(TimeUnit.MILLISECONDS)
+//          res <- if (now - start < 5000)
+//            IO.pure(Some(beforeInstance))
+//          else IO.pure(Some(afterInstance))
+//        } yield res
+//      }
+//    }
+//
+//    val res = for {
+//      start <- nowInstant[IO]
+//      monitor = gceRuntimeMonitor(googleComputeService = computeService(start.toEpochMilli))
+//      runtime <- IO(makeCluster(0).copy(status = RuntimeStatus.Starting).save())
+//      assersions = for {
+//        status <- clusterQuery.getClusterStatus(runtime.id).transaction
+//      } yield status.get shouldBe RuntimeStatus.Stopped
+//      _ <- withInfiniteStream(monitor.process(runtime.id, RuntimeStatus.Starting), assersions)
+//    } yield ()
+//    res.unsafeRunSync()
+//  }
+
   it should "terminate if instance is terminated after 5 seconds when trying to Starting one" in isolatedDbTest {
     val runtime = makeCluster(1).copy(
       serviceAccount = clusterServiceAccountFromProject(project).get,

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/GceRuntimeMonitorSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/GceRuntimeMonitorSpec.scala
@@ -322,34 +322,35 @@ class GceRuntimeMonitorSpec
     res.unsafeRunSync()
   }
 
-//  it should "transition gce runtime to Stopping if Starting times out" in isolatedDbTest {
-//    def computeService(start: Long): GoogleComputeService[IO] = new FakeGoogleComputeService {
-//      override def getInstance(project: GoogleProject, zone: ZoneName, instanceName: InstanceName)(
-//        implicit ev: Ask[IO, TraceId]
-//      ): IO[Option[Instance]] = {
-//        val beforeInstance = Instance.newBuilder().setStatus("Provisioning").build()
-//        val afterInstance = Instance.newBuilder().setStatus("Stopped").build()
-//
-//        for {
-//          now <- testTimer.clock.realTime(TimeUnit.MILLISECONDS)
-//          res <- if (now - start < 5000)
-//            IO.pure(Some(beforeInstance))
-//          else IO.pure(Some(afterInstance))
-//        } yield res
-//      }
-//    }
-//
-//    val res = for {
-//      start <- nowInstant[IO]
-//      monitor = gceRuntimeMonitor(googleComputeService = computeService(start.toEpochMilli))
-//      runtime <- IO(makeCluster(0).copy(status = RuntimeStatus.Starting).save())
-//      assersions = for {
-//        status <- clusterQuery.getClusterStatus(runtime.id).transaction
-//      } yield status.get shouldBe RuntimeStatus.Stopped
-//      _ <- withInfiniteStream(monitor.process(runtime.id, RuntimeStatus.Starting), assersions)
-//    } yield ()
-//    res.unsafeRunSync()
-//  }
+  it should "transition gce runtime to Stopping if Starting times out" in isolatedDbTest {
+    def computeService(start: Long): GoogleComputeService[IO] = new FakeGoogleComputeService {
+      override def getInstance(project: GoogleProject, zone: ZoneName, instanceName: InstanceName)(
+        implicit ev: Ask[IO, TraceId]
+      ): IO[Option[Instance]] = {
+        val beforeInstance = Instance.newBuilder().setStatus("Provisioning").build()
+        val afterInstance = Instance.newBuilder().setStatus("Stopped").build()
+
+        for {
+          now <- testTimer.clock.realTime(TimeUnit.MILLISECONDS)
+          res <- if (now - start < 5000)
+            IO.pure(Some(beforeInstance))
+          else IO.pure(Some(afterInstance))
+        } yield res
+      }
+    }
+
+    val res = for {
+      start <- nowInstant[IO]
+      monitor = gceRuntimeMonitor(googleComputeService = computeService(start.toEpochMilli),
+                                  monitorStatusTimeouts = Some(Map(RuntimeStatus.Starting -> 2.seconds)))
+      runtime <- IO(makeCluster(0).copy(status = RuntimeStatus.Starting).save())
+      assersions = for {
+        status <- clusterQuery.getClusterStatus(runtime.id).transaction
+      } yield status.get shouldBe RuntimeStatus.Stopped
+      _ <- withInfiniteStream(monitor.process(runtime.id, RuntimeStatus.Starting), assersions)
+    } yield ()
+    res.unsafeRunSync()
+  }
 
   it should "terminate if instance is terminated after 5 seconds when trying to Starting one" in isolatedDbTest {
     val runtime = makeCluster(1).copy(
@@ -752,12 +753,15 @@ class GceRuntimeMonitorSpec
   def gceRuntimeMonitor(
     googleComputeService: GoogleComputeService[IO] = FakeGoogleComputeService,
     computePollOperation: ComputePollOperation[IO] = new MockComputePollOperation,
-    publisherQueue: fs2.concurrent.Queue[IO, LeoPubsubMessage] = QueueFactory.makePublisherQueue()
+    publisherQueue: fs2.concurrent.Queue[IO, LeoPubsubMessage] = QueueFactory.makePublisherQueue(),
+    monitorStatusTimeouts: Option[Map[RuntimeStatus, FiniteDuration]] = None
   ): GceRuntimeMonitor[IO] = {
     val config =
       Config.gceMonitorConfig.copy(initialDelay = 2 seconds, pollingInterval = 1 seconds, pollCheckMaxAttempts = 5)
+    val configWithCustomTimeouts =
+      monitorStatusTimeouts.fold(config)(timeouts => config.copy(monitorStatusTimeouts = timeouts))
     new GceRuntimeMonitor[IO](
-      config,
+      configWithCustomTimeouts,
       googleComputeService,
       computePollOperation,
       MockAuthProvider,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -15,7 +15,7 @@ object Dependencies {
   val monocleV = "2.1.0"
   val opencensusV = "0.28.3"
 
-  private val workbenchLibsHash = "9d5dce0"
+  private val workbenchLibsHash = "0297f0b"
   val serviceTestV = s"0.18-$workbenchLibsHash"
   val workbenchModelV = s"0.14-$workbenchLibsHash"
   val workbenchGoogleV = s"0.21-$workbenchLibsHash"


### PR DESCRIPTION
1. Use wb-libs published in https://github.com/broadinstitute/workbench-libs/pull/554, which adds logging for gke pollOperation
2. This PR also address a few bugs revealed by [this ticket](https://broadworkbench.atlassian.net/browse/IA-2541)
*  when a VM times out in starting, we should stop runtime, update DB, and that should monitor the new status transition. But we have a bug currently that doesn't monitor the new status transition properly
```
"status transitioned from Starting -> Stopping. This could be caused by a new status transition call!"
```
* When we see a VM is `Terminated` in Google, we shouldn't keep checking if the VM will eventually become `Running`. Instead, we should update status in DB and terminate the monitor stream.


A bit more context for what happened to the VM in the bug ticket (below is a few log entries that demonstrates what happened)
![Screen Shot 2021-03-19 at 3 00 42 PM](https://user-images.githubusercontent.com/32771737/111830231-0c85e080-88c4-11eb-86b0-6a83ee62eec2.png)
![Screen Shot 2021-03-19 at 3 00 58 PM](https://user-images.githubusercontent.com/32771737/111830249-127bc180-88c4-11eb-8b39-60b6a422e37a.png)
![Screen Shot 2021-03-19 at 3 01 12 PM](https://user-images.githubusercontent.com/32771737/111830264-160f4880-88c4-11eb-9c75-7f5030c7b2c2.png)

As you can see from the log. Leo received request to start the VM, VM fails to start for some reason (I checked VM's log, and found it was shutdown due to`Instance terminated by guest OS shutdown.`), VM then transitions to `Terminated`, Leo keeps expecting the VM to come up eventually (a bug should be fixed in this PR), which will never happens, and time out kicks in (which didn't terminate the monitor stream as expected due to bug that should be fixed in this PR)

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
