### PR TITLE
[QA-1411] cache charts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,8 @@ EXPOSE 8080
 EXPOSE 5050
 
 ENV GIT_HASH $GIT_HASH
+# TODO: remove this
+ENV HELM_DEBUG 1
 
 RUN mkdir /leonardo
 COPY ./leonardo*.jar /leonardo

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,8 +40,11 @@ RUN helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx && \
 # .Files helm helper can't access files outside a chart. Hence in order to populate cert file properly, we're
 # pulling `terra-app-setup` locally and add cert files to the chart.
 # Leonardo will install the chart from local version.
+# We are also cacheing charts so they are not downloaded with every helm-install
 RUN pushd /leonardo && \
     helm pull terra-app-setup-charts/terra-app-setup --untar && \
+    helm pull galaxy/galaxykubeman --untar && \
+    helm pull terra/terra-app --untar && \
     popd
 
 # Add Leonardo as a service (it will start when the container starts)

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,7 @@ RUN pushd /leonardo && \
     helm pull terra-app-setup-charts/terra-app-setup --untar && \
     helm pull galaxy/galaxykubeman --untar && \
     helm pull terra/terra-app --untar && \
+    helm pull ingress-nginx/ingress-nginx --untar && \
     popd
 
 # Add Leonardo as a service (it will start when the container starts)

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -211,7 +211,7 @@ gke {
   ingress {
     namespace = "nginx"
     release = "nginx"
-    chartName = "ingress-nginx/ingress-nginx"
+    chartName = "/leonardo/ingress-nginx"
     chartVersion = "3.23.0"
     loadBalancerService = "nginx-ingress-nginx-controller"
     values = [

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -224,7 +224,7 @@ gke {
     # only need to be unique within a namespace, but something in the Galaxy chart requires them
     # to be unique within a cluster.
     releaseNameSuffix = "gxy-rls"
-    chartName = "galaxy/galaxykubeman"
+    chartName = "/leonardo/galaxykubeman"
     chartVersion = "0.8.0"
     namespaceNameSuffix = "gxy-ns"
     serviceAccountName = "gxy-ksa"
@@ -253,7 +253,7 @@ gke {
     postgresDiskBlockSize = 4096
   }
   customApp {
-    chartName = "terra/terra-app"
+    chartName = "/leonardo/terra-app"
     chartVersion = "0.3.0"
     releaseNameSuffix = "rls"
   }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/KubernetesTestData.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/KubernetesTestData.scala
@@ -36,7 +36,7 @@ object KubernetesTestData {
 
   val galaxyApp = AppType.Galaxy
 
-  val galaxyChartName = ChartName("galaxy/galaxykubeman")
+  val galaxyChartName = ChartName("/leonardo/galaxykubeman")
   val galaxyChartVersion = ChartVersion("0.8.0")
   val galaxyChart = Chart(galaxyChartName, galaxyChartVersion)
 

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HTTPAppDescriptorDAOSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HTTPAppDescriptorDAOSpec.scala
@@ -71,13 +71,6 @@ class HTTPAppDescriptorDAOSpec extends AnyFlatSpec with Matchers with BeforeAndA
     )
   }
 
-  it should "successfully retrieve and parse a remote object" in {
-    withAppDescriptorDAO { dao =>
-      val app = dao.getDescriptor(appYamlURI).unsafeRunSync()
-      app.name shouldBe "rstudio"
-    }
-  }
-
   //allows you to specify the response of requests
   def withStubbedAppDescriptorDAO(response: String, testCode: HttpAppDescriptorDAO[IO] => Any): Unit = {
     val fixedRespClient = Client.fromHttpApp[IO](


### PR DESCRIPTION
Hoping to address some automation test stability issues along the lines  of

```2021/03/22 10:52:41 failed to download "galaxy/galaxykubeman" (hint: running `helm repo update` may help)```
```{"kubernetesRuntimeConfig":{"numNodes":1,"machineType":"n1-highmem-8","autoscalingEnabled":false},"errors":[{"errorMessage":"failed to download \"ingress-nginx/ingress-nginx\" (hint: running `helm repo update` may help)",...```