### PR TITLE
[no ticket] Make proxy redirect server more reliable

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoSuite.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoSuite.scala
@@ -106,11 +106,8 @@ trait GPAllocBeforeAndAfterAll extends GPAllocUtils with BeforeAndAfterAll {
     val res = for {
       _ <- IO(super.beforeAll())
       _ <- loggerIO.info(s"Running GPAllocBeforeAndAfterAll beforeAll")
-      bindAttempt <- IO.fromFuture(IO(ProxyRedirectClient.startServer)).attempt
-      _ <- bindAttempt match {
-        case Left(e)  => loggerIO.warn(s"Failed to start proxy redirect server due to ${e.getMessage}")
-        case Right(b) => loggerIO.info(s"Started proxy redirect server on ${b.localAddress.toString}")
-      }
+      // Start the proxy redirect server and forget about it
+      _ <- ProxyRedirectClient.server.use(_ => IO.never).start
       claimAttempt <- claimProject().attempt
       _ <- claimAttempt match {
         case Left(e) => IO(sys.props.put(gpallocProjectKey, gpallocErrorPrefix + e.getMessage))

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/ProxyRedirectClient.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/ProxyRedirectClient.scala
@@ -5,6 +5,7 @@ import com.typesafe.scalalogging.LazyLogging
 import fs2._
 import org.broadinstitute.dsde.workbench.service.RestClient
 import org.broadinstitute.dsde.workbench.util2.ExecutionContexts
+import org.http4s.client.Client
 import org.http4s.dsl.io._
 import org.http4s.headers.`Content-Type`
 import org.http4s.implicits._
@@ -19,6 +20,29 @@ object ProxyRedirectClient extends RestClient with LazyLogging {
 
   def get(rurl: String): String =
     s"http://$host:$port/proxyRedirectClient?rurl=${rurl}"
+
+  def testConnection(rurl: String)(implicit client: Client[IO]): IO[Unit] =
+    for {
+      r <- client
+        .run(
+          Request[IO](
+            method = Method.GET,
+            uri = Uri.unsafeFromString(get(rurl))
+          )
+        )
+        .use { resp =>
+          if (!resp.status.isSuccess) {
+            onError(s"Could not load proxy redirect page at url: ${get(rurl)}")(resp)
+              .flatMap(IO.raiseError)
+          } else
+            IO.unit
+        }
+    } yield r
+
+  private def onError(message: String)(response: Response[IO]): IO[Throwable] =
+    for {
+      body <- response.bodyText.compile.foldMonoid
+    } yield RestError(message, response.status, Some(body))
 
   private def getContent(rurl: String, blocker: Blocker)(implicit cs: ContextShift[IO]): Stream[IO, Byte] =
     io.readInputStream(IO(getClass.getClassLoader.getResourceAsStream("redirect-proxy-page.html")), 4096, blocker)

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/ProxyRedirectClient.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/ProxyRedirectClient.scala
@@ -41,7 +41,7 @@ object ProxyRedirectClient extends RestClient with LazyLogging {
             Ok(getContent(rurl, blocker), `Content-Type`(MediaType.text.html))
         }
         .orNotFound
-      server <- BlazeServerBuilder[IO](blockingEc).bindHttp(port, host).withHttpApp(route).resource
+      server <- BlazeServerBuilder[IO](blockingEc).bindHttp(port, "0.0.0.0").withHttpApp(route).resource
     } yield server
 
   object Rurl extends QueryParamDecoderMatcher[String]("rurl")

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/lab/Lab.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/lab/Lab.scala
@@ -15,7 +15,7 @@ object Lab extends RestClient with LazyLogging {
 
   private val url = LeonardoConfig.Leonardo.apiUrl
 
-  private val refererUrl = s"http://${ProxyRedirectClient.host}:${ProxyRedirectClient.port}"
+  private val refererUrl = ProxyRedirectClient.baseUri.map(_.renderString).unsafeRunSync()
 
   def labPath(googleProject: GoogleProject, clusterName: RuntimeName): String =
     s"notebooks/${googleProject.value}/${clusterName.asString}/lab"

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/Notebook.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/Notebook.scala
@@ -25,7 +25,7 @@ object Notebook extends RestClient with LazyLogging {
 
   private val url = LeonardoConfig.Leonardo.apiUrl
 
-  private val refererUrl = s"http://${ProxyRedirectClient.host}:${ProxyRedirectClient.port}"
+  private val refererUrl = ProxyRedirectClient.baseUri.map(_.renderString).unsafeRunSync()
 
   def handleContentItemResponse(response: String): ContentItem =
     mapper.readValue(response, classOf[ContentItem])

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/Welder.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/Welder.scala
@@ -25,7 +25,7 @@ object Welder extends RestClient with LazyLogging {
   implicit val cs: ContextShift[IO] = IO.contextShift(global)
   private val url = LeonardoConfig.Leonardo.apiUrl
 
-  private val refererUrl = s"http://${ProxyRedirectClient.host}:${ProxyRedirectClient.port}"
+  private val refererUrl = ProxyRedirectClient.baseUri.map(_.renderString).unsafeRunSync()
 
   case class Metadata(syncMode: String,
                       syncStatus: Option[String],

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/rstudio/RStudio.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/rstudio/RStudio.scala
@@ -17,7 +17,7 @@ object RStudio extends RestClient with LazyLogging {
 
   private val url = LeonardoConfig.Leonardo.apiUrl
 
-  private val refererUrl = s"http://${ProxyRedirectClient.host}:${ProxyRedirectClient.port}"
+  private val refererUrl = ProxyRedirectClient.baseUri.map(_.renderString).unsafeRunSync()
 
   def rstudioPath(googleProject: GoogleProject, clusterName: RuntimeName): String =
     s"proxy/${googleProject.value}/${clusterName.asString}/rstudio/"

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/page/ProxyRedirectPage.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/page/ProxyRedirectPage.scala
@@ -1,6 +1,7 @@
 package org.broadinstitute.dsde.workbench.page
 
 import cats.effect.{IO, Timer}
+import cats.implicits._
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.workbench.auth.AuthToken
 import org.broadinstitute.dsde.workbench.leonardo.{LeonardoApiClient, ProxyRedirectClient}
@@ -16,36 +17,36 @@ trait ProxyRedirectPage[P <: Page] extends Page with PageUtil[P] with WebBrowser
 
   override def open(implicit webDriver: WebDriver): P = {
     val res = for {
-      _ <- IO(logger.info(s"Setting LeoToken cookie for page ${url}"))
-
       // Go to the target page. This will initially return 401.
       _ <- IO(go.to(this))
 
       // Set the LeoToken cookie. Note this needs to be done from the same domain as the target page.
+      _ <- IO(logger.info(s"Setting LeoToken cookie for page ${url}"))
       _ <- IO(addCookie("LeoToken", authToken.value))
 
-      _ <- IO(logger.info(s"Testing connection to ${ProxyRedirectClient.get(url)}"))
-
       // Test connection to the proxy redirect server before loading it in WebDriver
-      _ <- LeonardoApiClient.client.use { implicit client =>
-        fs2.Stream.retry(ProxyRedirectClient.testConnection(url), 2 seconds, _ * 2, 5).compile.lastOrError
+      proxyRedirectUrl <- ProxyRedirectClient.get(url).map(_.renderString)
+      test = LeonardoApiClient.client.use { implicit client =>
+        fs2.Stream
+          .retry(
+            IO(logger.info(s"Testing connection to ${proxyRedirectUrl}")) >> ProxyRedirectClient.testConnection(url),
+            2 seconds,
+            _ * 2,
+            5
+          )
+          .compile
+          .lastOrError
       }
-
-      _ <- IO(logger.info(s"Proxy redirect server is up at ${ProxyRedirectClient.get(url)}!"))
+      _ <- IO(logger.info(s"Proxy redirect server is up at ${proxyRedirectUrl}"))
 
       // Go to the proxy redirect page, specifying the target page as the `rurl`. This will automatically
       // redirect to the target page. This is done so the Referer is set correctly.
       redirect = for {
-        _ <- IO(logger.info(s"Going to redirect page at url ${ProxyRedirectClient.get(url)}"))
-
-        _ <- IO(go.to(ProxyRedirectClient.get(url)))
-
-        _ <- IO(logger.info(s"Waiting for redirect page at url ${ProxyRedirectClient.get(url)} to redirect"))
-
-        // Wait for the target page to load after redirect.
+        _ <- IO(logger.info(s"Going to redirect page at url ${proxyRedirectUrl}"))
+        _ <- IO(go.to(proxyRedirectUrl))
+        _ <- IO(logger.info(s"Waiting for redirect page at url ${proxyRedirectUrl} to redirect"))
         res <- IO(awaitLoaded())
-
-        _ <- IO(logger.info(s"Successfully redirected to ${url}!"))
+        _ <- IO(logger.info(s"Successfully redirected to ${url}"))
       } yield res
 
       // Retry above operation

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/page/ProxyRedirectPage.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/page/ProxyRedirectPage.scala
@@ -3,7 +3,7 @@ package org.broadinstitute.dsde.workbench.page
 import cats.effect.{IO, Timer}
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.workbench.auth.AuthToken
-import org.broadinstitute.dsde.workbench.leonardo.ProxyRedirectClient
+import org.broadinstitute.dsde.workbench.leonardo.{LeonardoApiClient, ProxyRedirectClient}
 import org.broadinstitute.dsde.workbench.service.test.WebBrowserUtil
 import org.openqa.selenium.WebDriver
 import org.scalatestplus.selenium.Page
@@ -16,19 +16,36 @@ trait ProxyRedirectPage[P <: Page] extends Page with PageUtil[P] with WebBrowser
 
   override def open(implicit webDriver: WebDriver): P = {
     val res = for {
+      _ <- IO(logger.info(s"Setting LeoToken cookie for page ${url}"))
+
       // Go to the target page. This will initially return 401.
       _ <- IO(go.to(this))
 
       // Set the LeoToken cookie. Note this needs to be done from the same domain as the target page.
       _ <- IO(addCookie("LeoToken", authToken.value))
 
+      _ <- IO(logger.info(s"Testing connection to ${ProxyRedirectClient.get(url)}"))
+
+      // Test connection to the proxy redirect server before loading it in WebDriver
+      _ <- LeonardoApiClient.client.use { implicit client =>
+        fs2.Stream.retry(ProxyRedirectClient.testConnection(url), 2 seconds, _ * 2, 5).compile.lastOrError
+      }
+
+      _ <- IO(logger.info(s"Proxy redirect server is up at ${ProxyRedirectClient.get(url)}!"))
+
       // Go to the proxy redirect page, specifying the target page as the `rurl`. This will automatically
       // redirect to the target page. This is done so the Referer is set correctly.
       redirect = for {
+        _ <- IO(logger.info(s"Going to redirect page at url ${ProxyRedirectClient.get(url)}"))
+
         _ <- IO(go.to(ProxyRedirectClient.get(url)))
+
+        _ <- IO(logger.info(s"Waiting for redirect page at url ${ProxyRedirectClient.get(url)} to redirect"))
 
         // Wait for the target page to load after redirect.
         res <- IO(awaitLoaded())
+
+        _ <- IO(logger.info(s"Successfully redirected to ${url}!"))
       } yield res
 
       // Retry above operation

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -114,6 +114,7 @@ object Dependencies {
   val http4sCirce =       "org.http4s"        %% "http4s-circe"         % http4sVersion
   val circeYaml =         "io.circe"          %% "circe-yaml"           % "0.13.1"
   val http4sBlazeClient = "org.http4s"        %% "http4s-blaze-client"  % http4sVersion
+  val http4sBlazeServer = "org.http4s"        %% "http4s-blaze-server"  % http4sVersion
   val http4sDsl =         "org.http4s"        %% "http4s-dsl"           % http4sVersion
   val guava: ModuleID =   "com.google.guava"  % "guava"                 % guavaV
 
@@ -173,7 +174,7 @@ object Dependencies {
 
     // Dependent on the trace exporters you want to use add one or more of the following
     "io.opencensus" % "opencensus-exporter-trace-stackdriver" % opencensusV,
-    "org.http4s" %% "http4s-blaze-server" % http4sVersion % Test,
+    http4sBlazeServer % Test,
     scalaTestSelenium,
     scalaTestMockito
   )
@@ -198,6 +199,7 @@ object Dependencies {
     akkaHttpSprayJson,
     scalaTest,
     scalaTestSelenium,
-    scalaTestMockito
+    scalaTestMockito,
+    http4sBlazeServer % Test
   )
 }


### PR DESCRIPTION
Tests are occasionally failing because it can't load the proxy redirect page. Failure screenshot:

![image](https://user-images.githubusercontent.com/5368863/112481962-ee99ff00-8d4d-11eb-9d9e-640b666306dd.png)

I can't see any errors that would explain why. But currently the akka-http server is sharing an execution context with all the client calls the tests are making, so maybe it is getting overloaded. In this PR I changed it to use `http4s` instead with a dedicated execution context for serving the redirect page.

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
