### PR TITLE
IA-2586 Add workflow that merges all scala-steward PRs into one

### DIFF
--- a/.github/workflows/merge_scalasteward_prs.yml
+++ b/.github/workflows/merge_scalasteward_prs.yml
@@ -24,4 +24,4 @@ jobs:
           git merge -m "merging" $curBranch
         done <<< `gh pr list | grep scala-steward | cut -d$'\t'  -f 1`
         git push origin merged-scala-steward-prs
-        gh pr create --title "Bump dependencies" --body "Consolidate scala-steward PRs"
+        gh pr create --title "[No Ticket] Bump dependencies" --body "Consolidate scala-steward PRs"

--- a/.github/workflows/merge_scalasteward_prs.yml
+++ b/.github/workflows/merge_scalasteward_prs.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Merge scala-steward PRs
       id: msp
       run: |
-        export GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
+        export GITHUB_TOKEN=${{ secrets.BROADBOT_GITHUB_TOKEN }}
         while IFS= read -r pr
         do
           echo "$pr"

--- a/.github/workflows/merge_scalasteward_prs.yml
+++ b/.github/workflows/merge_scalasteward_prs.yml
@@ -1,0 +1,40 @@
+name: Dependency Bot
+
+on:
+  # Remove before merging
+  push:
+    branches: [ develop ]
+
+  workflow_dispatch:
+  # Allows manually triggering of workflow on a selected branch via the GitHub Actions tab.
+  # GitHub blog demo: https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/.
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Merge scala-steward PRs
+      run: |
+        git remote add scala-steward	git@github.com:scala-steward/leonardo
+
+        while IFS= read -r branch
+        do
+          eval "$branch"
+          git merge $branch
+        done <<< `git for-each-ref --format='%(authorname),%(refname)' --sort=authorname |grep heads|grep "Scala Steward"|cut -b 26-`
+    - name: Create Pull Request
+      id: cpr
+      uses: peter-evans/create-pull-request@v3
+      with:
+        token: ${{ secrets.BROADBOT_GITHUB_TOKEN }}
+        commit-message: Update dependencies
+        committer: broadbot <broadbot@broadinstitute.org>
+        author: broadbot <broadbot@broadinstitute.org>
+        branch: merged-scala-steward-prs
+        delete-branch: true
+        title: 'Bump dependencies'
+        body: |
+          *This PR was opened by the [${{ github.workflow }} GitHub Actions workflow](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}).*

--- a/.github/workflows/merge_scalasteward_prs.yml
+++ b/.github/workflows/merge_scalasteward_prs.yml
@@ -5,6 +5,9 @@ on:
   # Allows manually triggering of workflow on a selected branch via the GitHub Actions tab.
   # GitHub blog demo: https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/.
 
+  push:
+     braches: ['workflow']
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/merge_scalasteward_prs.yml
+++ b/.github/workflows/merge_scalasteward_prs.yml
@@ -23,7 +23,7 @@ jobs:
           echo "$pr"
           gh pr checkout $pr
           curBranch=`git branch --show-current`
-          git checkout -b merged-scala-steward-prs
+          git checkout -B merged-scala-steward-prs
           git merge -m "merging" $curBranch
         done <<< `gh pr list | grep scala-steward | cut -d$'\t'  -f 1`
         git push origin merged-scala-steward-prs

--- a/.github/workflows/merge_scalasteward_prs.yml
+++ b/.github/workflows/merge_scalasteward_prs.yml
@@ -5,9 +5,6 @@ on:
   # Allows manually triggering of workflow on a selected branch via the GitHub Actions tab.
   # GitHub blog demo: https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/.
 
-  push:
-     braches: ['workflow']
-
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/merge_scalasteward_prs.yml
+++ b/.github/workflows/merge_scalasteward_prs.yml
@@ -1,10 +1,6 @@
-name: Dependency Bot
+name: dependency-bot
 
 on:
-  # Remove before merging
-  push:
-    branches: [ develop ]
-
   workflow_dispatch:
   # Allows manually triggering of workflow on a selected branch via the GitHub Actions tab.
   # GitHub blog demo: https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/.
@@ -15,26 +11,17 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-
     - name: Merge scala-steward PRs
+      id: msp
       run: |
-        git remote add scala-steward	git@github.com:scala-steward/leonardo
-
-        while IFS= read -r branch
+        export GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
+        while IFS= read -r pr
         do
-          eval "$branch"
-          git merge $branch
-        done <<< `git for-each-ref --format='%(authorname),%(refname)' --sort=authorname |grep heads|grep "Scala Steward"|cut -b 26-`
-    - name: Create Pull Request
-      id: cpr
-      uses: peter-evans/create-pull-request@v3
-      with:
-        token: ${{ secrets.BROADBOT_GITHUB_TOKEN }}
-        commit-message: Update dependencies
-        committer: broadbot <broadbot@broadinstitute.org>
-        author: broadbot <broadbot@broadinstitute.org>
-        branch: merged-scala-steward-prs
-        delete-branch: true
-        title: 'Bump dependencies'
-        body: |
-          *This PR was opened by the [${{ github.workflow }} GitHub Actions workflow](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}).*
+          echo "$pr"
+          gh pr checkout $pr
+          curBranch=`git branch --show-current`
+          git checkout -b merged-scala-steward-prs
+          git merge -m "merging" $curBranch
+        done <<< `gh pr list | grep scala-steward | cut -d$'\t'  -f 1`
+        git push origin merged-scala-steward-prs
+        gh pr create --title "Bump dependencies" --body "Consolidate scala-steward PRs"


### PR DESCRIPTION
Example: https://github.com/DataBiosphere/leonardo/pull/1976

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
