### PR TITLE
IA-2607: attempt to fix RStudio initialization error

### DIFF
--- a/http/src/main/resources/init-resources/startup.sh
+++ b/http/src/main/resources/init-resources/startup.sh
@@ -158,6 +158,9 @@ if [ ! -z "$RSTUDIO_DOCKER_IMAGE" ] ; then
     # update container MEM_LIMIT to reflect VM's MEM_LIMIT
     docker update $RSTUDIO_SERVER_NAME --memory $MEM_LIMIT
 
+    # Warm up R before starting the RStudio session (see above comment).
+    docker exec $RSTUDIO_SERVER_NAME /bin/bash -c "R -e '1+1'" || true
+
     # Start RStudio server
     docker exec -d $RSTUDIO_SERVER_NAME /init
 fi


### PR DESCRIPTION
See https://broadworkbench.atlassian.net/browse/IA-2607

This is attempt to fix this error reported by multiple users:

![image](https://user-images.githubusercontent.com/5368863/113234910-35b55200-9270-11eb-88ff-be33eff67f6a.png)

I have yet to reproduce the error myself so this is really just a guess. But I recall we had a similar issue with Jupyter: the R kernel would sometimes not start up after a pause/resume. The fix (mysteriously) was to run a dummy R command before starting the kernel which made it work reliably. Perhaps we need to do a similar thing for RStudio: "warm up" R before loading the user's session.

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
