### PR TITLE
IA-2534: issue loading genes in IGV Viewer

### DIFF
--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -410,6 +410,7 @@ contentSecurityPolicy {
     "https://data.broadinstitute.org",
     "https://s3.amazonaws.com/igv.broadinstitute.org/",
     "https://s3.amazonaws.com/igv.org.genomes/",
+    "https://portals.broadinstitute.org/webservices/igv/",
     "https://raw.githubusercontent.com/PAIR-code/facets/1.0.0/facets-dist/facets-jupyter.html",
     "https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/1.3.3/webcomponents-lite.js"
   ]

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -411,6 +411,7 @@ contentSecurityPolicy {
     "https://s3.amazonaws.com/igv.broadinstitute.org/",
     "https://s3.amazonaws.com/igv.org.genomes/",
     "https://portals.broadinstitute.org/webservices/igv/",
+    "https://igv.org/genomes/",
     "https://raw.githubusercontent.com/PAIR-code/facets/1.0.0/facets-dist/facets-jupyter.html",
     "https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/1.3.3/webcomponents-lite.js"
   ]

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/config/ContentSecurityPolicyConfigSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/config/ContentSecurityPolicyConfigSpec.scala
@@ -1,14 +1,7 @@
 package org.broadinstitute.dsde.workbench.leonardo
 package config
-import org.broadinstitute.dsde.workbench.leonardo.{CommonTestData, LeonardoTestSuite}
-import org.broadinstitute.dsde.workbench.leonardo.config.ContentSecurityPolicyComponent.{
-  ConnectSrc,
-  FrameAncestors,
-  ObjectSrc,
-  ReportUri,
-  ScriptSrc,
-  StyleSrc
-}
+
+import org.broadinstitute.dsde.workbench.leonardo.config.ContentSecurityPolicyComponent._
 import org.scalatest.flatspec.AnyFlatSpecLike
 
 class ContentSecurityPolicyConfigSpec extends LeonardoTestSuite with AnyFlatSpecLike {
@@ -74,13 +67,13 @@ class ContentSecurityPolicyConfigSpec extends LeonardoTestSuite with AnyFlatSpec
     )
 
     test.asString shouldBe
-      "frame-ancestors 'self' *.terra.bio https://bvdp-saturn-prod.appspot.com https://all-of-us-rw-staging.appspot.com https://all-of-us-rw-stable.appspot.com https://stable.fake-research-aou.org https://workbench.researchallofus.org terra.biodatacatalyst.nhlbi.nih.gov; script-src 'self' data: 'unsafe-inline' 'unsafe-eval' https://apis.google.com https://cdn.jsdelivr.net https://cdn.pydata.org; style-src 'self' 'unsafe-inline' data: https://cdn.pydata.org; connect-src 'self' wss://*.broadinstitute.org:* wss://notebooks.firecloud.org:* *.googleapis.com https://*.npmjs.org https://data.broadinstitute.org https://s3.amazonaws.com/igv.broadinstitute.org/ https://s3.amazonaws.com/igv.org.genomes/ https://raw.githubusercontent.com/PAIR-code/facets/1.0.0/facets-dist/facets-jupyter.html https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/1.3.3/webcomponents-lite.js; object-src 'none'; report-uri https://terra.report-uri.com/r/d/csp/reportOnly"
+      "frame-ancestors 'self' *.terra.bio https://bvdp-saturn-prod.appspot.com https://all-of-us-rw-staging.appspot.com https://all-of-us-rw-stable.appspot.com https://stable.fake-research-aou.org https://workbench.researchallofus.org terra.biodatacatalyst.nhlbi.nih.gov; script-src 'self' data: 'unsafe-inline' 'unsafe-eval' https://apis.google.com https://cdn.jsdelivr.net https://cdn.pydata.org; style-src 'self' 'unsafe-inline' data: https://cdn.pydata.org; connect-src 'self' wss://*.broadinstitute.org:* wss://notebooks.firecloud.org:* *.googleapis.com https://*.npmjs.org https://data.broadinstitute.org https://s3.amazonaws.com/igv.broadinstitute.org/ https://s3.amazonaws.com/igv.org.genomes/ https://portals.broadinstitute.org/webservices/igv/ https://raw.githubusercontent.com/PAIR-code/facets/1.0.0/facets-dist/facets-jupyter.html https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/1.3.3/webcomponents-lite.js; object-src 'none'; report-uri https://terra.report-uri.com/r/d/csp/reportOnly"
 
   }
 
   it should "parse config values correctly" in {
     CommonTestData.contentSecurityPolicy shouldBe
-      "frame-ancestors 'none'; script-src 'self' data: 'unsafe-inline' 'unsafe-eval' https://apis.google.com https://cdn.jsdelivr.net https://cdn.pydata.org; style-src 'self' 'unsafe-inline' data: https://cdn.pydata.org; connect-src 'self' wss://*.broadinstitute.org:* wss://notebooks.firecloud.org:* *.googleapis.com https://*.npmjs.org https://data.broadinstitute.org https://s3.amazonaws.com/igv.broadinstitute.org/ https://s3.amazonaws.com/igv.org.genomes/ https://raw.githubusercontent.com/PAIR-code/facets/1.0.0/facets-dist/facets-jupyter.html https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/1.3.3/webcomponents-lite.js; object-src 'none'; report-uri https://terra.report-uri.com/r/d/csp/reportOnly"
+      "frame-ancestors 'none'; script-src 'self' data: 'unsafe-inline' 'unsafe-eval' https://apis.google.com https://cdn.jsdelivr.net https://cdn.pydata.org; style-src 'self' 'unsafe-inline' data: https://cdn.pydata.org; connect-src 'self' wss://*.broadinstitute.org:* wss://notebooks.firecloud.org:* *.googleapis.com https://*.npmjs.org https://data.broadinstitute.org https://s3.amazonaws.com/igv.broadinstitute.org/ https://s3.amazonaws.com/igv.org.genomes/ https://portals.broadinstitute.org/webservices/igv/ https://raw.githubusercontent.com/PAIR-code/facets/1.0.0/facets-dist/facets-jupyter.html https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/1.3.3/webcomponents-lite.js; object-src 'none'; report-uri https://terra.report-uri.com/r/d/csp/reportOnly"
   }
 
 }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/config/ContentSecurityPolicyConfigSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/config/ContentSecurityPolicyConfigSpec.scala
@@ -50,6 +50,7 @@ class ContentSecurityPolicyConfigSpec extends LeonardoTestSuite with AnyFlatSpec
           "https://s3.amazonaws.com/igv.broadinstitute.org/",
           "https://s3.amazonaws.com/igv.org.genomes/",
           "https://portals.broadinstitute.org/webservices/igv/",
+          "https://igv.org/genomes/",
           "https://raw.githubusercontent.com/PAIR-code/facets/1.0.0/facets-dist/facets-jupyter.html",
           "https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/1.3.3/webcomponents-lite.js"
         )
@@ -67,13 +68,13 @@ class ContentSecurityPolicyConfigSpec extends LeonardoTestSuite with AnyFlatSpec
     )
 
     test.asString shouldBe
-      "frame-ancestors 'self' *.terra.bio https://bvdp-saturn-prod.appspot.com https://all-of-us-rw-staging.appspot.com https://all-of-us-rw-stable.appspot.com https://stable.fake-research-aou.org https://workbench.researchallofus.org terra.biodatacatalyst.nhlbi.nih.gov; script-src 'self' data: 'unsafe-inline' 'unsafe-eval' https://apis.google.com https://cdn.jsdelivr.net https://cdn.pydata.org; style-src 'self' 'unsafe-inline' data: https://cdn.pydata.org; connect-src 'self' wss://*.broadinstitute.org:* wss://notebooks.firecloud.org:* *.googleapis.com https://*.npmjs.org https://data.broadinstitute.org https://s3.amazonaws.com/igv.broadinstitute.org/ https://s3.amazonaws.com/igv.org.genomes/ https://portals.broadinstitute.org/webservices/igv/ https://raw.githubusercontent.com/PAIR-code/facets/1.0.0/facets-dist/facets-jupyter.html https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/1.3.3/webcomponents-lite.js; object-src 'none'; report-uri https://terra.report-uri.com/r/d/csp/reportOnly"
+      "frame-ancestors 'self' *.terra.bio https://bvdp-saturn-prod.appspot.com https://all-of-us-rw-staging.appspot.com https://all-of-us-rw-stable.appspot.com https://stable.fake-research-aou.org https://workbench.researchallofus.org terra.biodatacatalyst.nhlbi.nih.gov; script-src 'self' data: 'unsafe-inline' 'unsafe-eval' https://apis.google.com https://cdn.jsdelivr.net https://cdn.pydata.org; style-src 'self' 'unsafe-inline' data: https://cdn.pydata.org; connect-src 'self' wss://*.broadinstitute.org:* wss://notebooks.firecloud.org:* *.googleapis.com https://*.npmjs.org https://data.broadinstitute.org https://s3.amazonaws.com/igv.broadinstitute.org/ https://s3.amazonaws.com/igv.org.genomes/ https://portals.broadinstitute.org/webservices/igv/ https://igv.org/genomes/ https://raw.githubusercontent.com/PAIR-code/facets/1.0.0/facets-dist/facets-jupyter.html https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/1.3.3/webcomponents-lite.js; object-src 'none'; report-uri https://terra.report-uri.com/r/d/csp/reportOnly"
 
   }
 
   it should "parse config values correctly" in {
     CommonTestData.contentSecurityPolicy shouldBe
-      "frame-ancestors 'none'; script-src 'self' data: 'unsafe-inline' 'unsafe-eval' https://apis.google.com https://cdn.jsdelivr.net https://cdn.pydata.org; style-src 'self' 'unsafe-inline' data: https://cdn.pydata.org; connect-src 'self' wss://*.broadinstitute.org:* wss://notebooks.firecloud.org:* *.googleapis.com https://*.npmjs.org https://data.broadinstitute.org https://s3.amazonaws.com/igv.broadinstitute.org/ https://s3.amazonaws.com/igv.org.genomes/ https://portals.broadinstitute.org/webservices/igv/ https://raw.githubusercontent.com/PAIR-code/facets/1.0.0/facets-dist/facets-jupyter.html https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/1.3.3/webcomponents-lite.js; object-src 'none'; report-uri https://terra.report-uri.com/r/d/csp/reportOnly"
+      "frame-ancestors 'none'; script-src 'self' data: 'unsafe-inline' 'unsafe-eval' https://apis.google.com https://cdn.jsdelivr.net https://cdn.pydata.org; style-src 'self' 'unsafe-inline' data: https://cdn.pydata.org; connect-src 'self' wss://*.broadinstitute.org:* wss://notebooks.firecloud.org:* *.googleapis.com https://*.npmjs.org https://data.broadinstitute.org https://s3.amazonaws.com/igv.broadinstitute.org/ https://s3.amazonaws.com/igv.org.genomes/ https://portals.broadinstitute.org/webservices/igv/ https://igv.org/genomes/ https://raw.githubusercontent.com/PAIR-code/facets/1.0.0/facets-dist/facets-jupyter.html https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/1.3.3/webcomponents-lite.js; object-src 'none'; report-uri https://terra.report-uri.com/r/d/csp/reportOnly"
   }
 
 }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/config/ContentSecurityPolicyConfigSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/config/ContentSecurityPolicyConfigSpec.scala
@@ -56,6 +56,7 @@ class ContentSecurityPolicyConfigSpec extends LeonardoTestSuite with AnyFlatSpec
           "https://data.broadinstitute.org",
           "https://s3.amazonaws.com/igv.broadinstitute.org/",
           "https://s3.amazonaws.com/igv.org.genomes/",
+          "https://portals.broadinstitute.org/webservices/igv/",
           "https://raw.githubusercontent.com/PAIR-code/facets/1.0.0/facets-dist/facets-jupyter.html",
           "https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/1.3.3/webcomponents-lite.js"
         )


### PR DESCRIPTION
See explanation in https://broadworkbench.atlassian.net/browse/IA-2534.

I think automation testing would be hard for this, as it involves interacting with the IGV widget. Testing in a fiab.

Test case:
1. Launch runtime with the `gs://rtitle_test/install_igv.sh` user script
2. Open a notebook, run cells:
```
import igv
IGV_Explore = igv.Browser(
  {"genome": "hg19"}  
)
IGV_Explore.show()
```
3. Type "itgam" in the IGV search bar

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
