### PR TITLE
[no ticket] bump GKE version

### DIFF
--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -189,7 +189,7 @@ gke {
     ]
     # See https://cloud.google.com/kubernetes-engine/docs/release-notes
     # As of 2021-02-22, 1.17.x is the default but the Galaxy chart expects 1.16.x.
-    version = "1.16.15-gke.11800"
+    version = "1.16.15-gke.12500"
     nodepoolLockCacheExpiryTime = 1 hour
     nodepoolLockCacheMaxSize = 200
   }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/config/ConfigSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/config/ConfigSpec.scala
@@ -82,7 +82,7 @@ final class ConfigSpec extends AnyFlatSpec with Matchers {
         "69.173.127.240/28",
         "69.173.112.0/21"
       ).map(CidrIP),
-      KubernetesClusterVersion("1.16.15-gke.11800"),
+      KubernetesClusterVersion("1.16.15-gke.12500"),
       1 hour,
       200
     )


### PR DESCRIPTION
The old one got un-supported:
```
{"@timestamp":"2021-04-03T10:38:43.000Z","@version":"1","message":"{\"response\":null,\"result\":\"Failed\"}","logger_name":"org.broadinstitute.dsde.workbench.leonardo.http.Boot","thread_name":"ioapp-compute-2","severity":"ERROR","level_value":40000,"stack_trace":"com.google.api.client.googleapis.json.GoogleJsonResponseException: 400 Bad Request\nPOST https://container.googleapis.com/v1/projects/gpalloc-qa-master-immntls/locations/us-central1-a/clusters\n{\n  \"code\" : 400,\n  \"errors\" : [ {\n    \"domain\" : \"global\",\n    \"message\" : \"Master version \\\"1.16.15-gke.11800\\\" is unsupported.\",\n    \"reason\" : \"badRequest\"\n  } ],\n  \"message\" : \"Master version \\\"1.16.15-gke.11800\\\" is unsupported.\",\n  \"status\" : \"INVALID_ARGUMENT\"\n}
```

GKE now offers:
![image](https://user-images.githubusercontent.com/5368863/113477786-60f79700-9452-11eb-8f17-96e47de66682.png)


I haven't tested whether 1.17 works with Galaxy. But I figure staying on 1.16 should be safe for now.

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
