### PR TITLE
Removing subversions from GKE version

### DIFF
--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -189,7 +189,7 @@ gke {
     ]
     # See https://cloud.google.com/kubernetes-engine/docs/release-notes
     # As of 2021-02-22, 1.17.x is the default but the Galaxy chart expects 1.16.x.
-    version = "1.16.15-gke.12500"
+    version = "1.16"
     nodepoolLockCacheExpiryTime = 1 hour
     nodepoolLockCacheMaxSize = 200
   }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/config/ConfigSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/config/ConfigSpec.scala
@@ -82,7 +82,7 @@ final class ConfigSpec extends AnyFlatSpec with Matchers {
         "69.173.127.240/28",
         "69.173.112.0/21"
       ).map(CidrIP),
-      KubernetesClusterVersion("1.16.15-gke.12500"),
+      KubernetesClusterVersion("1.16"),
       1 hour,
       200
     )


### PR DESCRIPTION
Trying to not hardcode specific versions to avoid having to bump GKE subversions within a Kubernetes version.

(This is not tested, just a suggestion as a starting point based on the fact that on the command-line I can do `--cluster-version=1.16`)

Alternatively, can use something like `gcloud container get-server-config 2>&1 | grep -o "1.16.*" | head -1` to get the latest available GKE version of a K8S version.

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
