### PR TITLE
[IA-2641] Bump GKE to 1.18

### DIFF
--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -316,8 +316,7 @@ gke {
                           "69.173.112.0/21"
     ]
     # See https://cloud.google.com/kubernetes-engine/docs/release-notes
-    # As of 2021-02-22, 1.17.x is the default but the Galaxy chart expects 1.16.x.
-    version = "1.16.15-gke.12500"
+    version = "1.18"
     nodepoolLockCacheExpiryTime = 1 hour
     nodepoolLockCacheMaxSize = 200
   }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/config/ConfigSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/config/ConfigSpec.scala
@@ -81,7 +81,7 @@ final class ConfigSpec extends AnyFlatSpec with Matchers {
         "69.173.127.240/28",
         "69.173.112.0/21"
       ).map(CidrIP),
-      KubernetesClusterVersion("1.16.15-gke.12500"),
+      KubernetesClusterVersion("1.18"),
       1 hour,
       200
     )


### PR DESCRIPTION
JIRA: https://broadworkbench.atlassian.net/browse/IA-2641

Remove minor version from GKE version config, which is allowed in the [GKE Java API](https://developers.google.com/resources/api-libraries/documentation/container/v1/java/latest/com/google/api/services/container/model/Cluster.html#setInitialClusterVersion-java.lang.String-).

Also bump to 1.18 which should work with `galaxykubeman` and is the current latest stable version supported by GKE.

Copied from https://github.com/DataBiosphere/leonardo/pull/2007

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
