### PR TITLE
[IA-2609] Run tests multiple times on PR

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,6 +10,7 @@ I, the developer opening this PR, do solemnly pinky swear that:
 In all cases:
 
 - [ ] Get a thumbsworth of review and PO signoff if necessary
-- [ ] Verify all tests go green
+- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
+- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
 - [ ] Squash and merge; Delete your branch after this
 - [ ] Test this change deployed correctly and works on dev environment after deployment

--- a/jenkins/pr-multi-build/Jenkinsfile
+++ b/jenkins/pr-multi-build/Jenkinsfile
@@ -7,7 +7,6 @@ pipeline {
 
     stages {
         stage('Run tests') {
-            failFast true
             parallel {
                 stage('Run tests in parallel') {
                     steps {

--- a/jenkins/pr-multi-build/Jenkinsfile
+++ b/jenkins/pr-multi-build/Jenkinsfile
@@ -17,7 +17,7 @@ pipeline {
                             def numRuns = Integer.parseInt("$NUM_RUNS")
 
                             for (int i = 0; i < numRuns; i++) {
-                            def params = [
+                                def params = [
                                     string(name: "RUN_ID", value: "$i"),
                                     string(name: "leonardo_img", value: "$ghprbSourceBranch"),
                                     booleanParam(name: "build_leonardo", value: true),
@@ -30,6 +30,7 @@ pipeline {
                                 }
                                 tests.put(i,run)
                             }
+
                             println("Running swatomation tests $NUM_RUNS times")
                             parallel(tests)
                         }

--- a/jenkins/pr-multi-build/Jenkinsfile
+++ b/jenkins/pr-multi-build/Jenkinsfile
@@ -1,0 +1,41 @@
+pipeline {
+    agent { label 'docker' }
+    parameters {
+        string(name: "NUM_RUNS", defaultValue: "3",
+            description: "The (integer) number of times to run the automation tests.")
+    }
+
+    stages {
+        stage('Run tests') {
+            failFast true
+            parallel {
+                stage('Run tests in parallel') {
+                    steps {
+                        script {
+                            def tests = [:]
+
+                            def numRuns = Integer.parseInt("$NUM_RUNS")
+
+                            for (int i = 0; i < numRuns; i++) {
+                            def params = [
+                                    string(name: "RUN_ID", value: "$i"),
+                                    string(name: "leonardo_img", value: "$ghprbSourceBranch"),
+                                    booleanParam(name: "build_leonardo", value: true),
+                                    string(name: "TRIGGER_SERVICE", value: "leonardo"),
+                                    string(name: "GOOGLE_PROJ", value: "broad-dsde-qa"),
+                                    string(name: "MESSAGE", value: "leonardo multi-PR: $ghprbPullTitle, $ghprbSourceBranch")
+                                ]
+                                def run = {
+                                    build(job: "swatomation-pipeline", parameters: params)
+                                }
+                                tests.put(i,run)
+                            }
+                            println("Running swatomation tests $NUM_RUNS times")
+                            parallel(tests)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Currently, the trigger word is configured in the [jenkins job](https://fc-jenkins.dsp-techops.broadinstitute.org/job/Leonardo-PR-fiab-multi-test/configure), `multi-test`. This is where a good bit of the plugin configuration lives (you need to click `advanced` under `Github Pull Request Builder` in `Build Triggers` section)

Unfortunately, there is no way to have the plugin parse the comment for a variable number of tests, and it must be configured via the Jenkinsfile.

All of the multi-test comments below are just me iterating, not a reflection of the stability of the finished script.