### PR TITLE
IA-2601 Let users delete app when no attached disk is found

### DIFF
--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/AppServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/AppServiceInterp.scala
@@ -674,13 +674,6 @@ case class AppCannotBeDeletedException(googleProject: GoogleProject,
       traceId = Some(traceId)
     )
 
-case class NoDiskForAppException(googleProject: GoogleProject, appName: AppName, traceId: TraceId)
-    extends LeoException(
-      s"Specified delete disk for app ${googleProject.value}/${appName.value}, but this app does not have a disk.",
-      StatusCodes.BadRequest,
-      traceId = Some(traceId)
-    )
-
 case class AppCannotBeCreatedException(googleProject: GoogleProject,
                                        appName: AppName,
                                        status: AppStatus,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/AppServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/AppServiceInterp.scala
@@ -2,15 +2,12 @@ package org.broadinstitute.dsde.workbench.leonardo
 package http
 package service
 
-import java.time.Instant
-import java.util.UUID
 import akka.http.scaladsl.model.StatusCodes
 import cats.Parallel
 import cats.data.NonEmptyList
 import cats.effect.Async
 import cats.mtl.Ask
 import cats.syntax.all._
-import org.typelevel.log4cats.StructuredLogger
 import org.apache.commons.lang3.RandomStringUtils
 import org.broadinstitute.dsde.workbench.google2.GKEModels.{KubernetesClusterName, NodepoolName}
 import org.broadinstitute.dsde.workbench.google2.KubernetesName
@@ -31,7 +28,10 @@ import org.broadinstitute.dsde.workbench.leonardo.monitor.{ClusterNodepoolAction
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.broadinstitute.dsde.workbench.model.{TraceId, UserInfo, WorkbenchEmail}
 import org.broadinstitute.dsp.{ChartVersion, Release}
+import org.typelevel.log4cats.StructuredLogger
 
+import java.time.Instant
+import java.util.UUID
 import scala.concurrent.ExecutionContext
 
 final class LeoAppServiceInterp[F[_]: Parallel](
@@ -304,13 +304,8 @@ final class LeoAppServiceInterp[F[_]: Parallel](
           AppCannotBeDeletedException(request.googleProject, request.appName, appResult.app.status, ctx.traceId)
         )
 
-      diskOpt <- if (request.deleteDisk)
-        appResult.app.appResources.disk.fold(
-          F.raiseError[Option[DiskId]](
-            NoDiskForAppException(appResult.cluster.googleProject, appResult.app.appName, ctx.traceId)
-          )
-        )(d => F.pure(Some(d.id)))
-      else F.pure[Option[DiskId]](None)
+      // Get the disk to delete if specified
+      diskOpt = if (request.deleteDisk) appResult.app.appResources.disk.map(_.id) else None
 
       // If the app status is Error, we can assume that the underlying app/nodepool
       // has already been deleted. So we just transition the app to Deleted status


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-2601

Fix this error when I tried to delete an `Error`'d app:

![image](https://user-images.githubusercontent.com/5368863/113872315-c6fd5a80-9781-11eb-812e-8902952747fe.png)

I think what happens is:
1. App creation fails
2. [cleanUpAfterCreateAppError](https://github.com/DataBiosphere/leonardo/blob/develop/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala#L856) deletes the disk if it was a newly-created disk in the `createApp` request (which I think is reasonable).
3. End state is app is in `Error` status with no disk

I simply made the code in `AppServiceInterp` tolerate this case and updated a unit test to cover it.

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
