### PR TITLE
IA-2640 persist disk zone properly

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoApiClient.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoApiClient.scala
@@ -50,6 +50,7 @@ object LeonardoApiClient {
     Map.empty,
     None,
     None,
+    None,
     None
   )
 

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeGceSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeGceSpec.scala
@@ -2,12 +2,12 @@ package org.broadinstitute.dsde.workbench.leonardo
 package runtimes
 
 import java.util.UUID
-
 import cats.effect.IO
 import cats.mtl.Ask
+import org.broadinstitute.dsde.workbench.google2.Generators.genDiskName
 import org.broadinstitute.dsde.workbench.google2.{MachineTypeName, ZoneName}
 import org.broadinstitute.dsde.workbench.leonardo.LeonardoApiClient.defaultCreateRuntime2Request
-import org.broadinstitute.dsde.workbench.leonardo.http.RuntimeConfigRequest
+import org.broadinstitute.dsde.workbench.leonardo.http.{PersistentDiskRequest, RuntimeConfigRequest}
 import org.broadinstitute.dsde.workbench.leonardo.notebooks.NotebookTestUtils
 import org.broadinstitute.dsde.workbench.model.TraceId
 import org.http4s.headers.Authorization
@@ -26,6 +26,7 @@ class RuntimeGceSpec
 
   "should create a GCE instance in a non-default zone" in { project =>
     val runtimeName = randomClusterName
+    val diskName = genDiskName.sample.get
     val targetZone = ZoneName(
       "europe-west1-b"
     )
@@ -33,9 +34,14 @@ class RuntimeGceSpec
     // In a europe zone
     val createRuntimeRequest = defaultCreateRuntime2Request.copy(
       runtimeConfig = Some(
-        RuntimeConfigRequest.GceConfig(
+        RuntimeConfigRequest.GceWithPdConfig(
           Some(MachineTypeName("n1-standard-4")),
-          Some(DiskSize(10)),
+          PersistentDiskRequest(
+            diskName,
+            None,
+            None,
+            Map.empty
+          ),
           Some(targetZone)
         )
       )
@@ -44,7 +50,7 @@ class RuntimeGceSpec
       implicit val httpClient = c
       for {
         getRuntimeResponse <- LeonardoApiClient.createRuntimeWithWait(project, runtimeName, createRuntimeRequest)
-        _ = getRuntimeResponse.runtimeConfig.asInstanceOf[RuntimeConfig.GceConfig].zone shouldBe targetZone
+        _ = getRuntimeResponse.runtimeConfig.asInstanceOf[RuntimeConfig.GceWithPdConfig].zone shouldBe targetZone
         disk <- LeonardoApiClient.getDisk(project, getRuntimeResponse.diskConfig.get.name)
         _ = disk.zone shouldBe targetZone
         _ <- LeonardoApiClient.deleteRuntime(project, runtimeName)

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/ConfigImplicits.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/ConfigImplicits.scala
@@ -2,6 +2,7 @@ package org.broadinstitute.dsde.workbench.leonardo
 
 import pureconfig.ConfigReader
 import cats.syntax.all._
+import org.broadinstitute.dsde.workbench.google2.ZoneName
 import org.broadinstitute.dsp.{ChartName, ChartVersion}
 import pureconfig.error.ExceptionThrown
 
@@ -14,4 +15,12 @@ object ConfigImplicits {
     ConfigReader.stringConfigReader.map(s => ChartName(s))
   implicit val chartVersionConfigReader: ConfigReader[ChartVersion] =
     ConfigReader.stringConfigReader.map(s => ChartVersion(s))
+  implicit val zoneNameConfigReader: ConfigReader[ZoneName] =
+    ConfigReader.stringConfigReader.map(s => ZoneName(s))
+  implicit val diskTypeConfigReader: ConfigReader[DiskType] =
+    ConfigReader.stringConfigReader.map(s => DiskType.stringToObject(s))
+  implicit val diskDiszeConfigReader: ConfigReader[DiskSize] =
+    ConfigReader.intConfigReader.map(s => DiskSize(s))
+  implicit val blockSizeConfigReader: ConfigReader[BlockSize] =
+    ConfigReader.intConfigReader.map(s => BlockSize(s))
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/diskRoutesModels.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/diskRoutesModels.scala
@@ -9,11 +9,12 @@ import org.broadinstitute.dsde.workbench.leonardo.SamResourceId.PersistentDiskSa
 final case class CreateDiskRequest(labels: LabelMap,
                                    size: Option[DiskSize],
                                    diskType: Option[DiskType],
-                                   blockSize: Option[BlockSize])
+                                   blockSize: Option[BlockSize],
+                                   zone: Option[ZoneName])
 
 object CreateDiskRequest {
-  def fromDiskConfigRequest(create: PersistentDiskRequest): CreateDiskRequest =
-    CreateDiskRequest(create.labels, create.size, create.diskType, None)
+  def fromDiskConfigRequest(create: PersistentDiskRequest, zone: Option[ZoneName]): CreateDiskRequest =
+    CreateDiskRequest(create.labels, create.size, create.diskType, None, zone)
 }
 
 final case class PersistentDiskRequest(name: DiskName,

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -704,12 +704,12 @@ zombieRuntimeMonitor {
   concurrency = 100
 }
 
-persistentDisk {
-  defaultDiskSizeGB = 30
-  defaultDiskType = "pd-standard"
-  defaultBlockSizeBytes = 4096
-  zone = "us-central1-a"
-  defaultGalaxyNFSDiskSizeGB = 250
+persistent-disk {
+  default-disk-size-gb = 30
+  default-disk-type = "pd-standard"
+  default-block-size-bytes = 4096
+  default-zone = "us-central1-a"
+  default-galaxy-nfsdisk-size-gb = 250
 }
 
 clusterToolMonitor {

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
@@ -2,6 +2,7 @@ package org.broadinstitute.dsde.workbench.leonardo
 package config
 
 import java.nio.file.{Path, Paths}
+
 import com.google.pubsub.v1.{ProjectSubscriptionName, ProjectTopicName, TopicName}
 import com.typesafe.config.{ConfigFactory, Config => TypeSafeConfig}
 import net.ceedubs.ficus.Ficus._
@@ -26,6 +27,7 @@ import org.broadinstitute.dsde.workbench.leonardo.CustomImage.{DataprocCustomIma
 import org.broadinstitute.dsde.workbench.leonardo.auth.SamAuthProviderConfig
 import org.broadinstitute.dsde.workbench.leonardo.config.ContentSecurityPolicyComponent._
 import org.broadinstitute.dsde.workbench.leonardo.dao.HttpSamDaoConfig
+import org.broadinstitute.dsde.workbench.leonardo.http.ConfigReader
 import org.broadinstitute.dsde.workbench.leonardo.http.service.LeoAppServiceInterp.LeoKubernetesConfig
 import org.broadinstitute.dsde.workbench.leonardo.model.ServiceAccountProviderConfig
 import org.broadinstitute.dsde.workbench.leonardo.monitor.MonitorConfig.{DataprocMonitorConfig, GceMonitorConfig}
@@ -261,16 +263,6 @@ object Config {
       toScalaDuration(config.getDuration("autoFreezeAfter")),
       toScalaDuration(config.getDuration("autoFreezeCheckScheduler")),
       toScalaDuration(config.getDuration("maxKernelBusyLimit"))
-    )
-  }
-
-  implicit private val persistentDiskConfigReader: ValueReader[PersistentDiskConfig] = ValueReader.relative { config =>
-    PersistentDiskConfig(
-      config.as[DiskSize]("defaultDiskSizeGB"),
-      config.as[DiskType]("defaultDiskType"),
-      config.as[BlockSize]("defaultBlockSizeBytes"),
-      config.as[ZoneName]("zone"),
-      config.as[DiskSize]("defaultGalaxyNFSDiskSizeGB")
     )
   }
 
@@ -660,7 +652,7 @@ object Config {
                                                 gkeNodepoolConfig,
                                                 gkeIngressConfig,
                                                 gkeGalaxyAppConfig,
-                                                persistentDiskConfig)
+                                                ConfigReader.appConfig.persistentDiskConfig)
 
   val pubsubConfig = config.as[PubsubConfig]("pubsub")
   val vpcConfig = config.as[VPCConfig]("vpc")

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
@@ -450,7 +450,6 @@ object Config {
   val clusterResourcesConfig = config.as[ClusterResourcesConfig]("clusterResources")
   val samConfig = config.as[SamConfig]("sam")
   val autoFreezeConfig = config.as[AutoFreezeConfig]("autoFreeze")
-  val persistentDiskConfig = config.as[PersistentDiskConfig]("persistentDisk")
   val serviceAccountProviderConfig = config.as[ServiceAccountProviderConfig]("serviceAccounts.providerConfig")
   val kubeServiceAccountProviderConfig = config.as[ServiceAccountProviderConfig]("serviceAccounts.kubeConfig")
   val contentSecurityPolicy = config.as[ContentSecurityPolicyConfig]("contentSecurityPolicy").asString

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
@@ -652,7 +652,7 @@ object Config {
                                                 gkeNodepoolConfig,
                                                 gkeIngressConfig,
                                                 gkeGalaxyAppConfig,
-                                                ConfigReader.appConfig.persistentDiskConfig)
+                                                ConfigReader.appConfig.persistentDisk)
 
   val pubsubConfig = config.as[PubsubConfig]("pubsub")
   val vpcConfig = config.as[VPCConfig]("vpc")

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/PersistentDiskConfig.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/PersistentDiskConfig.scala
@@ -7,6 +7,6 @@ final case class PersistentDiskConfig(
   defaultDiskSizeGB: DiskSize,
   defaultDiskType: DiskType,
   defaultBlockSizeBytes: BlockSize,
-  zone: ZoneName,
+  defaultZone: ZoneName,
   defaultGalaxyNFSDiskSizeGB: DiskSize
 )

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/PersistentDiskConfig.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/PersistentDiskConfig.scala
@@ -1,12 +1,12 @@
 package org.broadinstitute.dsde.workbench.leonardo
 package config
+
 import org.broadinstitute.dsde.workbench.google2.ZoneName
-import org.broadinstitute.dsde.workbench.leonardo.{BlockSize, DiskSize, DiskType}
 
 final case class PersistentDiskConfig(
-  defaultDiskSizeGB: DiskSize,
+  defaultDiskSizeGb: DiskSize,
   defaultDiskType: DiskType,
   defaultBlockSizeBytes: BlockSize,
   defaultZone: ZoneName,
-  defaultGalaxyNFSDiskSizeGB: DiskSize
+  defaultGalaxyNfsdiskSizeGb: DiskSize
 )

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/Boot.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/Boot.scala
@@ -147,7 +147,7 @@ object Boot extends IOApp {
       )
       val runtimeService = RuntimeService(
         runtimeServiceConfig,
-        persistentDiskConfig,
+        ConfigReader.appConfig.persistentDiskConfig,
         appDependencies.authProvider,
         appDependencies.serviceAccountProvider,
         appDependencies.dockerDAO,
@@ -157,7 +157,7 @@ object Boot extends IOApp {
         appDependencies.publisherQueue
       )
       val diskService = new DiskServiceInterp[IO](
-        persistentDiskConfig,
+        ConfigReader.appConfig.persistentDiskConfig,
         appDependencies.authProvider,
         appDependencies.serviceAccountProvider,
         appDependencies.publisherQueue

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/Boot.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/Boot.scala
@@ -147,7 +147,7 @@ object Boot extends IOApp {
       )
       val runtimeService = RuntimeService(
         runtimeServiceConfig,
-        ConfigReader.appConfig.persistentDiskConfig,
+        ConfigReader.appConfig.persistentDisk,
         appDependencies.authProvider,
         appDependencies.serviceAccountProvider,
         appDependencies.dockerDAO,
@@ -157,7 +157,7 @@ object Boot extends IOApp {
         appDependencies.publisherQueue
       )
       val diskService = new DiskServiceInterp[IO](
-        ConfigReader.appConfig.persistentDiskConfig,
+        ConfigReader.appConfig.persistentDisk,
         appDependencies.authProvider,
         appDependencies.serviceAccountProvider,
         appDependencies.publisherQueue

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/Boot.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/Boot.scala
@@ -145,7 +145,7 @@ object Boot extends IOApp {
         dataprocConfig,
         gceConfig
       )
-      val runtimeService = new RuntimeServiceInterp[IO](
+      val runtimeService = RuntimeService(
         runtimeServiceConfig,
         persistentDiskConfig,
         appDependencies.authProvider,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/ConfigReader.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/ConfigReader.scala
@@ -8,14 +8,15 @@ import org.broadinstitute.dsde.workbench.leonardo.util.TerraAppSetupChartConfig
 import org.broadinstitute.dsde.workbench.leonardo.config.PersistentDiskConfig
 
 object ConfigReader {
-  val appConfig = ConfigSource
-    .fromConfig(org.broadinstitute.dsde.workbench.leonardo.config.Config.config)
-    .loadOrThrow[AppConfig]
+  val appConfig =
+    ConfigSource
+      .fromConfig(org.broadinstitute.dsde.workbench.leonardo.config.Config.config)
+      .loadOrThrow[AppConfig]
 }
 
 // Note: pureconfig supports reading kebab case into camel case in code by default
 // More docs see https://pureconfig.github.io/docs/index.html
 final case class AppConfig(
   terraAppSetupChart: TerraAppSetupChartConfig,
-  persistentDiskConfig: PersistentDiskConfig
+  persistentDisk: PersistentDiskConfig
 )

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/ConfigReader.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/ConfigReader.scala
@@ -5,6 +5,7 @@ import pureconfig.ConfigSource
 import _root_.pureconfig.generic.auto._
 import org.broadinstitute.dsde.workbench.leonardo.ConfigImplicits._
 import org.broadinstitute.dsde.workbench.leonardo.util.TerraAppSetupChartConfig
+import org.broadinstitute.dsde.workbench.leonardo.config.PersistentDiskConfig
 
 object ConfigReader {
   val appConfig = ConfigSource
@@ -15,5 +16,6 @@ object ConfigReader {
 // Note: pureconfig supports reading kebab case into camel case in code by default
 // More docs see https://pureconfig.github.io/docs/index.html
 final case class AppConfig(
-  terraAppSetupChart: TerraAppSetupChartConfig
+  terraAppSetupChart: TerraAppSetupChartConfig,
+  persistentDiskConfig: PersistentDiskConfig
 )

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/DiskRoutes.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/DiskRoutes.scala
@@ -11,7 +11,7 @@ import cats.effect.IO
 import cats.mtl.Ask
 import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
 import io.circe.{Decoder, Encoder}
-import org.broadinstitute.dsde.workbench.google2.DiskName
+import org.broadinstitute.dsde.workbench.google2.{DiskName, ZoneName}
 import org.broadinstitute.dsde.workbench.leonardo.JsonCodec._
 import io.opencensus.scala.akka.http.TracingDirective.traceRequestForService
 import org.broadinstitute.dsde.workbench.leonardo.http.api.DiskRoutes._
@@ -177,11 +177,13 @@ object DiskRoutes {
       s <- c.downField("size").as[Option[DiskSize]]
       t <- c.downField("diskType").as[Option[DiskType]]
       bs <- c.downField("blockSize").as[Option[BlockSize]]
+      zone <- c.downField("zone").as[Option[ZoneName]]
     } yield CreateDiskRequest(
       l.getOrElse(Map.empty),
       s,
       t,
-      bs
+      bs,
+      zone
     )
   }
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/AppServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/AppServiceInterp.scala
@@ -127,6 +127,7 @@ final class LeoAppServiceInterp[F[_]: Parallel](
       diskResultOpt <- req.diskConfig.traverse(diskReq =>
         RuntimeServiceInterp.processPersistentDiskRequest(
           diskReq,
+          leoKubernetesConfig.diskConfig.zone, //this need to be updated if we support non-default zone for k8s apps
           googleProject,
           userInfo,
           petSA,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/AppServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/AppServiceInterp.scala
@@ -127,7 +127,7 @@ final class LeoAppServiceInterp[F[_]: Parallel](
       diskResultOpt <- req.diskConfig.traverse(diskReq =>
         RuntimeServiceInterp.processPersistentDiskRequest(
           diskReq,
-          leoKubernetesConfig.diskConfig.zone, //this need to be updated if we support non-default zone for k8s apps
+          leoKubernetesConfig.diskConfig.defaultZone, //this need to be updated if we support non-default zone for k8s apps
           googleProject,
           userInfo,
           petSA,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/DiskServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/DiskServiceInterp.scala
@@ -254,7 +254,7 @@ object DiskServiceInterp {
     } yield PersistentDisk(
       DiskId(0),
       googleProject,
-      req.zone.getOrElse(config.zone),
+      req.zone.getOrElse(config.defaultZone),
       diskName,
       None,
       serviceAccount,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/DiskServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/DiskServiceInterp.scala
@@ -261,8 +261,8 @@ object DiskServiceInterp {
       samResource,
       DiskStatus.Creating,
       AuditInfo(userInfo.userEmail, now, None, now),
-      if (willBeUsedByGalaxy) req.size.getOrElse(config.defaultGalaxyNFSDiskSizeGB)
-      else req.size.getOrElse(config.defaultDiskSizeGB),
+      if (willBeUsedByGalaxy) req.size.getOrElse(config.defaultGalaxyNfsdiskSizeGb)
+      else req.size.getOrElse(config.defaultDiskSizeGb),
       req.diskType.getOrElse(config.defaultDiskType),
       req.blockSize.getOrElse(config.defaultBlockSizeBytes),
       None,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/DiskServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/DiskServiceInterp.scala
@@ -254,7 +254,7 @@ object DiskServiceInterp {
     } yield PersistentDisk(
       DiskId(0),
       googleProject,
-      config.zone,
+      req.zone.getOrElse(config.zone),
       diskName,
       None,
       serviceAccount,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeService.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeService.scala
@@ -2,10 +2,22 @@ package org.broadinstitute.dsde.workbench.leonardo
 package http
 package service
 
+import cats.Parallel
+import cats.effect.Async
 import cats.mtl.Ask
+import org.broadinstitute.dsde.workbench.google2.{ComputePollOperation, GoogleComputeService, GoogleStorageService}
+import org.broadinstitute.dsde.workbench.leonardo.config.PersistentDiskConfig
+import org.broadinstitute.dsde.workbench.leonardo.dao.DockerDAO
+import org.broadinstitute.dsde.workbench.leonardo.db.DbReference
 import org.broadinstitute.dsde.workbench.leonardo.http.api.ListRuntimeResponse2
+import org.broadinstitute.dsde.workbench.leonardo.model.{LeoAuthProvider, ServiceAccountProvider}
+import org.broadinstitute.dsde.workbench.leonardo.monitor.LeoPubsubMessage
 import org.broadinstitute.dsde.workbench.model.UserInfo
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
+import org.broadinstitute.dsde.workbench.openTelemetry.OpenTelemetryMetrics
+import org.typelevel.log4cats.StructuredLogger
+
+import scala.concurrent.ExecutionContext
 
 trait RuntimeService[F[_]] {
   def createRuntime(userInfo: UserInfo,
@@ -37,6 +49,35 @@ trait RuntimeService[F[_]] {
                     googleProject: GoogleProject,
                     runtimeName: RuntimeName,
                     req: UpdateRuntimeRequest)(implicit as: Ask[F, AppContext]): F[Unit]
+}
+
+object RuntimeService {
+  def apply[F[_]: Parallel](config: RuntimeServiceConfig,
+                            diskConfig: PersistentDiskConfig,
+                            authProvider: LeoAuthProvider[F],
+                            serviceAccountProvider: ServiceAccountProvider[F],
+                            dockerDAO: DockerDAO[F],
+                            googleStorageService: GoogleStorageService[F],
+                            googleComputeService: GoogleComputeService[F],
+                            computePollOperation: ComputePollOperation[F],
+                            publisherQueue: fs2.concurrent.Queue[F, LeoPubsubMessage])(
+    implicit F: Async[F],
+    log: StructuredLogger[F],
+    dbReference: DbReference[F],
+    ec: ExecutionContext,
+    metrics: OpenTelemetryMetrics[F]
+  ): RuntimeService[F] =
+    new RuntimeServiceInterp(
+      config,
+      diskConfig,
+      authProvider,
+      serviceAccountProvider,
+      dockerDAO,
+      googleStorageService,
+      googleComputeService,
+      computePollOperation,
+      publisherQueue
+    )
 }
 
 final case class DeleteRuntimeRequest(userInfo: UserInfo,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterp.scala
@@ -911,7 +911,7 @@ object RuntimeServiceInterp {
             else
               F.raiseError(
                 BadRequestException(
-                  s"existing disk ${pd.name.value} is in zone ${pd.zone.value} while the target zone ${targetZone.value}. They have to be in the same zone",
+                  s"existing disk ${pd.projectNameString} is in zone ${pd.zone.value}, and cannot be attached to a runtime in zone ${targetZone.value}. Please create a your runtime in zone ${pd.zone.value} if you'd like to use this disk; or opt to use a new disk",
                   Some(ctx.traceId)
                 )
               )

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterp.scala
@@ -911,7 +911,7 @@ object RuntimeServiceInterp {
             else
               F.raiseError(
                 BadRequestException(
-                  s"existing disk ${pd.projectNameString} is in zone ${pd.zone.value}, and cannot be attached to a runtime in zone ${targetZone.value}. Please create a your runtime in zone ${pd.zone.value} if you'd like to use this disk; or opt to use a new disk",
+                  s"existing disk ${pd.projectNameString} is in zone ${pd.zone.value}, and cannot be attached to a runtime in zone ${targetZone.value}. Please create your runtime in zone ${pd.zone.value} if you'd like to use this disk; or opt to use a new disk",
                   Some(ctx.traceId)
                 )
               )

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/CommonTestData.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/CommonTestData.scala
@@ -335,11 +335,13 @@ object CommonTestData {
 
   def makePersistentDisk(diskName: Option[DiskName] = None,
                          formattedBy: Option[FormattedBy] = None,
-                         galaxyRestore: Option[GalaxyRestore] = None): PersistentDisk =
+                         galaxyRestore: Option[GalaxyRestore] = None,
+                         zoneName: Option[ZoneName] = None,
+                         googleProject: Option[GoogleProject] = None): PersistentDisk =
     PersistentDisk(
       DiskId(-1),
-      project,
-      zone,
+      googleProject.getOrElse(project),
+      zoneName.getOrElse(zone),
       diskName.getOrElse(DiskName("disk")),
       Some(googleId),
       serviceAccount,

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/config/ConfigSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/config/ConfigSpec.scala
@@ -2,7 +2,7 @@ package org.broadinstitute.dsde.workbench.leonardo
 package config
 
 import org.broadinstitute.dsde.workbench.google2.KubernetesSerializableName.{ServiceAccountName, ServiceName}
-import org.broadinstitute.dsde.workbench.google2.{Location, MachineTypeName, RegionName, ZoneName}
+import org.broadinstitute.dsde.workbench.google2.{Location, MachineTypeName, RegionName}
 import org.broadinstitute.dsde.workbench.leonardo.KubernetesTestData.{galaxyChartName, galaxyChartVersion}
 import org.broadinstitute.dsde.workbench.leonardo.monitor.MonitorConfig.GceMonitorConfig
 import org.broadinstitute.dsde.workbench.leonardo.monitor.{
@@ -16,18 +16,6 @@ import org.scalatest.matchers.should.Matchers
 import scala.concurrent.duration._
 
 final class ConfigSpec extends AnyFlatSpec with Matchers {
-  it should "read PersistentDiskConfig properly" in {
-    val expectedResult = PersistentDiskConfig(
-      DiskSize(30),
-      DiskType.Standard,
-      BlockSize(4096),
-      ZoneName("us-central1-a"),
-      DiskSize(250)
-    )
-
-    Config.persistentDiskConfig shouldBe expectedResult
-  }
-
   it should "read LeoPubsubMessageSubscriberConfig properly" in {
     val expectedResult = LeoPubsubMessageSubscriberConfig(
       100,

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/ConfigReaderSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/ConfigReaderSpec.scala
@@ -1,0 +1,27 @@
+package org.broadinstitute.dsde.workbench.leonardo.http
+
+import org.broadinstitute.dsde.workbench.google2.ZoneName
+import org.broadinstitute.dsde.workbench.leonardo.config.PersistentDiskConfig
+import org.broadinstitute.dsde.workbench.leonardo.{BlockSize, DiskSize, DiskType}
+import org.broadinstitute.dsde.workbench.leonardo.util.TerraAppSetupChartConfig
+import org.broadinstitute.dsp.{ChartName, ChartVersion}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class ConfigReaderSpec extends AnyFlatSpec with Matchers {
+  it should "read config file correctly" in {
+    val config = ConfigReader.appConfig
+    val expectedConfig = AppConfig(
+      TerraAppSetupChartConfig(ChartName("/leonardo/terra-app-setup"), ChartVersion("0.0.2")),
+      PersistentDiskConfig(
+        DiskSize(30),
+        DiskType.Standard,
+        BlockSize(4096),
+        ZoneName("us-central1-a"),
+        DiskSize(250)
+      )
+    )
+
+    config shouldBe Right(expectedConfig)
+  }
+}

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/ConfigReaderSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/ConfigReaderSpec.scala
@@ -22,6 +22,6 @@ class ConfigReaderSpec extends AnyFlatSpec with Matchers {
       )
     )
 
-    config shouldBe Right(expectedConfig)
+    config shouldBe expectedConfig
   }
 }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/HttpRoutesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/HttpRoutesSpec.scala
@@ -368,7 +368,8 @@ class HttpRoutesSpec
       Map("foo" -> "bar"),
       Some(DiskSize(500)),
       Some(DiskType.Standard),
-      Some(BlockSize(65536))
+      Some(BlockSize(65536)),
+      None
     )
     Post("/api/google/v1/disks/googleProject1/disk1")
       .withEntity(ContentTypes.`application/json`, diskCreateRequest.asJson.spaces2) ~> routes.route ~> check {

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/TestLeoRoutes.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/TestLeoRoutes.scala
@@ -120,7 +120,7 @@ trait TestLeoRoutes {
     override val userInfo: UserInfo = timedUserInfo
   }
 
-  val runtimeService = new RuntimeServiceInterp(
+  val runtimeService = RuntimeService(
     RuntimeServiceConfig(Config.proxyConfig.proxyUrlBase,
                          imageConfig,
                          autoFreezeConfig,

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/TestLeoRoutes.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/TestLeoRoutes.scala
@@ -126,7 +126,7 @@ trait TestLeoRoutes {
                          autoFreezeConfig,
                          dataprocConfig,
                          Config.gceConfig),
-    Config.persistentDiskConfig,
+    ConfigReader.appConfig.persistentDiskConfig,
     whitelistAuthProvider,
     serviceAccountProvider,
     new MockDockerDAO,

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/TestLeoRoutes.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/TestLeoRoutes.scala
@@ -126,7 +126,7 @@ trait TestLeoRoutes {
                          autoFreezeConfig,
                          dataprocConfig,
                          Config.gceConfig),
-    ConfigReader.appConfig.persistentDiskConfig,
+    ConfigReader.appConfig.persistentDisk,
     whitelistAuthProvider,
     serviceAccountProvider,
     new MockDockerDAO,

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/DiskServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/DiskServiceInterpSpec.scala
@@ -26,7 +26,7 @@ import org.scalatest.flatspec.AnyFlatSpec
 class DiskServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with TestComponent {
   val publisherQueue = QueueFactory.makePublisherQueue()
   val diskService = new DiskServiceInterp(
-    ConfigReader.appConfig.persistentDiskConfig,
+    ConfigReader.appConfig.persistentDisk,
     whitelistAuthProvider,
     serviceAccountProvider,
     publisherQueue

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/DiskServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/DiskServiceInterpSpec.scala
@@ -36,6 +36,7 @@ class DiskServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with Test
     Map.empty,
     None,
     None,
+    None,
     None
   )
 

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/DiskServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/DiskServiceInterpSpec.scala
@@ -11,7 +11,6 @@ import cats.mtl.Ask
 import org.broadinstitute.dsde.workbench.google2.{DiskName, MachineTypeName, ZoneName}
 import org.broadinstitute.dsde.workbench.leonardo.CommonTestData._
 import org.broadinstitute.dsde.workbench.leonardo.SamResourceId.PersistentDiskSamResourceId
-import org.broadinstitute.dsde.workbench.leonardo.config.Config
 import org.broadinstitute.dsde.workbench.leonardo.db._
 import org.broadinstitute.dsde.workbench.leonardo.http.api.UpdateDiskRequest
 import org.broadinstitute.dsde.workbench.leonardo.model.ForbiddenError
@@ -27,7 +26,7 @@ import org.scalatest.flatspec.AnyFlatSpec
 class DiskServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with TestComponent {
   val publisherQueue = QueueFactory.makePublisherQueue()
   val diskService = new DiskServiceInterp(
-    Config.persistentDiskConfig,
+    ConfigReader.appConfig.persistentDiskConfig,
     whitelistAuthProvider,
     serviceAccountProvider,
     publisherQueue

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterpSpec.scala
@@ -54,7 +54,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
                            autoFreezeConfig,
                            dataprocConfig,
                            Config.gceConfig),
-      ConfigReader.appConfig.persistentDiskConfig,
+      ConfigReader.appConfig.persistentDisk,
       whitelistAuthProvider,
       serviceAccountProvider,
       new MockDockerDAO,
@@ -1454,13 +1454,13 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
                                                                       serviceAccount,
                                                                       FormattedBy.GCE,
                                                                       whitelistAuthProvider,
-                                                                      ConfigReader.appConfig.persistentDiskConfig)
+                                                                      ConfigReader.appConfig.persistentDisk)
       disk = diskResult.disk
       persistedDisk <- persistentDiskQuery.getById(disk.id).transaction
     } yield {
       diskResult.creationNeeded shouldBe true
       disk.googleProject shouldBe project
-      disk.zone shouldBe ConfigReader.appConfig.persistentDiskConfig.defaultZone
+      disk.zone shouldBe ConfigReader.appConfig.persistentDisk.defaultZone
       disk.name shouldBe diskName
       disk.googleId shouldBe None
       disk.status shouldBe DiskStatus.Creating
@@ -1469,8 +1469,8 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
       disk.auditInfo.destroyedDate shouldBe None
       disk.auditInfo.dateAccessed shouldBe context.now
       disk.size shouldBe DiskSize(500)
-      disk.diskType shouldBe ConfigReader.appConfig.persistentDiskConfig.defaultDiskType
-      disk.blockSize shouldBe ConfigReader.appConfig.persistentDiskConfig.defaultBlockSizeBytes
+      disk.diskType shouldBe ConfigReader.appConfig.persistentDisk.defaultDiskType
+      disk.blockSize shouldBe ConfigReader.appConfig.persistentDisk.defaultBlockSizeBytes
       disk.labels shouldBe DefaultDiskLabels(diskName, project, userInfo.userEmail, serviceAccount).toMap ++ Map(
         "foo" -> "bar"
       )
@@ -1497,7 +1497,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
                                       serviceAccount,
                                       FormattedBy.GCE,
                                       whitelistAuthProvider,
-                                      ConfigReader.appConfig.persistentDiskConfig)
+                                      ConfigReader.appConfig.persistentDisk)
         .attempt
     } yield {
       diskResult shouldBe (Left(
@@ -1524,7 +1524,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
                                       serviceAccount,
                                       FormattedBy.GCE,
                                       whitelistAuthProvider,
-                                      ConfigReader.appConfig.persistentDiskConfig)
+                                      ConfigReader.appConfig.persistentDisk)
       persistedDisk <- persistentDiskQuery.getById(diskResult.disk.id).transaction
     } yield {
       persistedDisk.get.zone shouldBe (targetZone)
@@ -1546,7 +1546,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
                                       serviceAccount,
                                       FormattedBy.GCE,
                                       whitelistAuthProvider,
-                                      ConfigReader.appConfig.persistentDiskConfig)
+                                      ConfigReader.appConfig.persistentDisk)
         .attempt
     } yield {
       returnedDisk shouldBe Right(PersistentDiskRequestResult(disk, false))
@@ -1568,7 +1568,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
                                       serviceAccount,
                                       FormattedBy.GCE,
                                       whitelistAuthProvider,
-                                      ConfigReader.appConfig.persistentDiskConfig)
+                                      ConfigReader.appConfig.persistentDisk)
         .unsafeRunSync()
     }
 
@@ -1596,7 +1596,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
                                       serviceAccount,
                                       FormattedBy.GCE,
                                       whitelistAuthProvider,
-                                      ConfigReader.appConfig.persistentDiskConfig)
+                                      ConfigReader.appConfig.persistentDisk)
         .attempt
     } yield {
       err shouldBe Left(DiskAlreadyAttachedException(project, savedDisk.name, t.traceId))
@@ -1618,7 +1618,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
                                       serviceAccount,
                                       FormattedBy.Galaxy,
                                       whitelistAuthProvider,
-                                      ConfigReader.appConfig.persistentDiskConfig)
+                                      ConfigReader.appConfig.persistentDisk)
         .attempt
       galaxyDisk <- makePersistentDisk(Some(DiskName("galaxyDisk")), Some(FormattedBy.Galaxy)).save()
       req = PersistentDiskRequest(galaxyDisk.name, Some(galaxyDisk.size), Some(galaxyDisk.diskType), galaxyDisk.labels)
@@ -1630,7 +1630,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
                                       serviceAccount,
                                       FormattedBy.GCE,
                                       whitelistAuthProvider,
-                                      ConfigReader.appConfig.persistentDiskConfig)
+                                      ConfigReader.appConfig.persistentDisk)
         .attempt
     } yield {
       formatGceDiskError shouldBe Left(
@@ -1656,7 +1656,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
                                                              serviceAccount,
                                                              FormattedBy.GCE,
                                                              whitelistAuthProvider,
-                                                             ConfigReader.appConfig.persistentDiskConfig)
+                                                             ConfigReader.appConfig.persistentDisk)
     } yield ()
 
     val thrown = the[ForbiddenError] thrownBy {

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterpSpec.scala
@@ -1502,7 +1502,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
     } yield {
       diskResult shouldBe (Left(
         BadRequestException(
-          s"existing disk ${req.name.value} is in zone ${zone.value} while the target zone ${targetZone.value}. They have to be in the same zone",
+          s"existing disk ${project.value}/${req.name.value} is in zone ${zone.value}, and cannot be attached to a runtime in zone ${targetZone.value}. Please create your runtime in zone us-central1-a if you'd like to use this disk; or opt to use a new disk",
           Some(context.traceId)
         )
       ))

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterpSpec.scala
@@ -54,7 +54,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
                            autoFreezeConfig,
                            dataprocConfig,
                            Config.gceConfig),
-      Config.persistentDiskConfig,
+      ConfigReader.appConfig.persistentDiskConfig,
       whitelistAuthProvider,
       serviceAccountProvider,
       new MockDockerDAO,
@@ -1454,13 +1454,13 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
                                                                       serviceAccount,
                                                                       FormattedBy.GCE,
                                                                       whitelistAuthProvider,
-                                                                      Config.persistentDiskConfig)
+                                                                      ConfigReader.appConfig.persistentDiskConfig)
       disk = diskResult.disk
       persistedDisk <- persistentDiskQuery.getById(disk.id).transaction
     } yield {
       diskResult.creationNeeded shouldBe true
       disk.googleProject shouldBe project
-      disk.zone shouldBe Config.persistentDiskConfig.zone
+      disk.zone shouldBe ConfigReader.appConfig.persistentDiskConfig.defaultZone
       disk.name shouldBe diskName
       disk.googleId shouldBe None
       disk.status shouldBe DiskStatus.Creating
@@ -1469,8 +1469,8 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
       disk.auditInfo.destroyedDate shouldBe None
       disk.auditInfo.dateAccessed shouldBe context.now
       disk.size shouldBe DiskSize(500)
-      disk.diskType shouldBe Config.persistentDiskConfig.defaultDiskType
-      disk.blockSize shouldBe Config.persistentDiskConfig.defaultBlockSizeBytes
+      disk.diskType shouldBe ConfigReader.appConfig.persistentDiskConfig.defaultDiskType
+      disk.blockSize shouldBe ConfigReader.appConfig.persistentDiskConfig.defaultBlockSizeBytes
       disk.labels shouldBe DefaultDiskLabels(diskName, project, userInfo.userEmail, serviceAccount).toMap ++ Map(
         "foo" -> "bar"
       )
@@ -1497,7 +1497,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
                                       serviceAccount,
                                       FormattedBy.GCE,
                                       whitelistAuthProvider,
-                                      Config.persistentDiskConfig)
+                                      ConfigReader.appConfig.persistentDiskConfig)
         .attempt
     } yield {
       diskResult shouldBe (Left(
@@ -1524,7 +1524,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
                                       serviceAccount,
                                       FormattedBy.GCE,
                                       whitelistAuthProvider,
-                                      Config.persistentDiskConfig)
+                                      ConfigReader.appConfig.persistentDiskConfig)
       persistedDisk <- persistentDiskQuery.getById(diskResult.disk.id).transaction
     } yield {
       persistedDisk.get.zone shouldBe (targetZone)
@@ -1546,7 +1546,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
                                       serviceAccount,
                                       FormattedBy.GCE,
                                       whitelistAuthProvider,
-                                      Config.persistentDiskConfig)
+                                      ConfigReader.appConfig.persistentDiskConfig)
         .attempt
     } yield {
       returnedDisk shouldBe Right(PersistentDiskRequestResult(disk, false))
@@ -1568,7 +1568,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
                                       serviceAccount,
                                       FormattedBy.GCE,
                                       whitelistAuthProvider,
-                                      Config.persistentDiskConfig)
+                                      ConfigReader.appConfig.persistentDiskConfig)
         .unsafeRunSync()
     }
 
@@ -1596,7 +1596,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
                                       serviceAccount,
                                       FormattedBy.GCE,
                                       whitelistAuthProvider,
-                                      Config.persistentDiskConfig)
+                                      ConfigReader.appConfig.persistentDiskConfig)
         .attempt
     } yield {
       err shouldBe Left(DiskAlreadyAttachedException(project, savedDisk.name, t.traceId))
@@ -1618,7 +1618,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
                                       serviceAccount,
                                       FormattedBy.Galaxy,
                                       whitelistAuthProvider,
-                                      Config.persistentDiskConfig)
+                                      ConfigReader.appConfig.persistentDiskConfig)
         .attempt
       galaxyDisk <- makePersistentDisk(Some(DiskName("galaxyDisk")), Some(FormattedBy.Galaxy)).save()
       req = PersistentDiskRequest(galaxyDisk.name, Some(galaxyDisk.size), Some(galaxyDisk.diskType), galaxyDisk.labels)
@@ -1630,7 +1630,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
                                       serviceAccount,
                                       FormattedBy.GCE,
                                       whitelistAuthProvider,
-                                      Config.persistentDiskConfig)
+                                      ConfigReader.appConfig.persistentDiskConfig)
         .attempt
     } yield {
       formatGceDiskError shouldBe Left(
@@ -1656,7 +1656,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
                                                              serviceAccount,
                                                              FormattedBy.GCE,
                                                              whitelistAuthProvider,
-                                                             Config.persistentDiskConfig)
+                                                             ConfigReader.appConfig.persistentDiskConfig)
     } yield ()
 
     val thrown = the[ForbiddenError] thrownBy {


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-2640

Turns out we're already persisting zone for disks, so it's actually less change than I expected.

* Persist disk's zone properly in `createRuntime` API call (this should fix the bug that @wnojopra ran into)
* Reject a request if createRuntime's zone is not the same as existing PD's zone
* Add `zone` to `createDisk` API

Tested in fiab

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
