### PR TITLE
[no ticket] revert the scala-steward workflow back to what it was

### DIFF
--- a/.github/workflows/merge_scalasteward_prs.yml
+++ b/.github/workflows/merge_scalasteward_prs.yml
@@ -37,7 +37,6 @@ jobs:
         * #$pr" )
           else
             echo "Unexpected exit code: ${EXIT_CODE}"
-            git rebase --abort
             UNSUCCESSFUL_PRS+=( "
         * #$pr" )
           fi

--- a/.github/workflows/merge_scalasteward_prs.yml
+++ b/.github/workflows/merge_scalasteward_prs.yml
@@ -28,18 +28,10 @@ jobs:
         while IFS= read -r pr
         do
           echo "Merging $pr"
-          git fetch origin pull/${pr}/head:pr_${pr}
-          git merge -m "merging" pr_${pr} && EXIT_CODE=$? || EXIT_CODE=$?
-
-          if [ "${EXIT_CODE}" == "0" ]
-          then
-            SUCCESSFUL_PRS+=( "
-        * #$pr" )
-          else
-            echo "Unexpected exit code: ${EXIT_CODE}"
-            UNSUCCESSFUL_PRS+=( "
-        * #$pr" )
-          fi
+          gh pr checkout $pr
+          curBranch=`git branch --show-current`
+          git checkout merged-scala-steward-prs 2>/dev/null || git checkout -b merged-scala-steward-prs
+          git merge -m "merging" $curBranch
         done <<< `gh pr list | grep scala-steward | cut -d$'\t'  -f 1`
         git push origin merged-scala-steward-prs
         gh pr create --title "[No Ticket] Bump dependencies" --body "Consolidate scala-steward PRs"


### PR DESCRIPTION
Revert the workflow to previous working version

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
