### PR TITLE
[IA-2661] Perf fixes: Increase dns cache expiry and reduce app monitoring timeouts

### DIFF
--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -465,7 +465,7 @@ runtimeDnsCache {
 }
 
 # Kubernetes expiration can be higher because the IP is at the cluster level, which is
-# consistent across app creations. Clusters are garbage collected ~1 hour after app deletion.
+# consistent across app pause/resume. Clusters are garbage collected ~1 hour after app deletion.
 kubernetesDnsCache {
   cacheExpiryTime = 10 minutes
   cacheMaxSize = 10000

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -457,8 +457,8 @@ clusterFiles {
   rstudioLicenseFile = "/etc/rstudio-license-file.lic"
 }
 
-# Expiration is low because runtimes can be recreated with the same project/name but with
-# a different IP, so we need to ensure we don't use stale cache entries.
+# The expiration is low because the IP changes when a runtime is pause/resumed,
+# so we need to ensure we don't use stale cache entries.
 runtimeDnsCache {
   cacheExpiryTime = 5 seconds
   cacheMaxSize = 10000

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -631,7 +631,8 @@ pubsub {
     }
     createApp {
       interval = 10 seconds
-      max-attempts = 60 # (10 seconds + ~20 second http4s retry) * 60 =~ 30 min
+      max-attempts = 120 # 10 seconds * 120 = 20 min
+      interruptAfter = 20 minutes
     }
     deleteApp {
       interval = 10 seconds
@@ -646,8 +647,9 @@ pubsub {
       interval = 10 seconds
     }
     startApp {
-      max-attempts = 24 # (5 seconds + ~20 second http4s retry) * 24 = ~10 min
-      interval = 5 seconds
+      max-attempts = 200 # 3 seconds * 200 is 10 min
+      interval = 3 seconds
+      interruptAfter = 10 minutes
     }
   }
 

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -457,13 +457,17 @@ clusterFiles {
   rstudioLicenseFile = "/etc/rstudio-license-file.lic"
 }
 
+# Expiration is low because runtimes can be recreated with the same project/name but with
+# a different IP, so we need to ensure we don't use stale cache entries.
 runtimeDnsCache {
-  cacheExpiryTime = 5 minutes
+  cacheExpiryTime = 5 seconds
   cacheMaxSize = 10000
 }
 
+# Kubernetes expiration can be higher because the IP is at the cluster level, which is
+# consistent across app creations. Clusters are garbage collected ~1 hour after app deletion.
 kubernetesDnsCache {
-  cacheExpiryTime = 5 minutes
+  cacheExpiryTime = 10 minutes
   cacheMaxSize = 10000
 }
 

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -458,12 +458,12 @@ clusterFiles {
 }
 
 runtimeDnsCache {
-  cacheExpiryTime = 30 minutes
+  cacheExpiryTime = 5 minutes
   cacheMaxSize = 10000
 }
 
 kubernetesDnsCache {
-  cacheExpiryTime = 30 minutes
+  cacheExpiryTime = 5 minutes
   cacheMaxSize = 10000
 }
 

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -458,12 +458,12 @@ clusterFiles {
 }
 
 runtimeDnsCache {
-  cacheExpiryTime = 5 seconds
+  cacheExpiryTime = 30 minutes
   cacheMaxSize = 10000
 }
 
 kubernetesDnsCache {
-  cacheExpiryTime = 5 seconds
+  cacheExpiryTime = 30 minutes
   cacheMaxSize = 10000
 }
 
@@ -627,7 +627,7 @@ pubsub {
     }
     createApp {
       interval = 10 seconds
-      max-attempts = 120 # 10 seconds * 120 = 20 min
+      max-attempts = 60 # (10 seconds + ~20 second http4s retry) * 60 =~ 30 min
     }
     deleteApp {
       interval = 10 seconds
@@ -642,8 +642,8 @@ pubsub {
       interval = 10 seconds
     }
     startApp {
-      max-attempts = 100 # 3 seconds * 100 is 5 min
-      interval = 3 seconds
+      max-attempts = 24 # (5 seconds + ~20 second http4s retry) * 24 = ~10 min
+      interval = 5 seconds
     }
   }
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/AppMonitorConfig.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/AppMonitorConfig.scala
@@ -1,15 +1,15 @@
 package org.broadinstitute.dsde.workbench.leonardo
 package config
 
-import org.broadinstitute.dsde.workbench.leonardo.monitor.PollMonitorConfig
+import org.broadinstitute.dsde.workbench.leonardo.monitor.{InterruptablePollMonitorConfig, PollMonitorConfig}
 
 case class AppMonitorConfig(nodepoolCreate: PollMonitorConfig,
                             clusterCreate: PollMonitorConfig,
                             nodepoolDelete: PollMonitorConfig,
                             clusterDelete: PollMonitorConfig,
                             createIngress: PollMonitorConfig,
-                            createApp: PollMonitorConfig,
+                            createApp: InterruptablePollMonitorConfig,
                             deleteApp: PollMonitorConfig,
                             scaleNodepool: PollMonitorConfig,
                             setNodepoolAutoscaling: PollMonitorConfig,
-                            startApp: PollMonitorConfig)
+                            startApp: InterruptablePollMonitorConfig)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/package.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/package.scala
@@ -1,12 +1,9 @@
 package org.broadinstitute.dsde.workbench.leonardo
 
-import java.nio.file.{Files, Path}
-import java.sql.SQLDataException
-
 import akka.http.scaladsl.model.Uri.Host
 import cats.effect.{Blocker, ContextShift, Resource, Sync}
-import cats.syntax.all._
 import cats.mtl.Ask
+import cats.syntax.all._
 import io.opencensus.scala.http.ServiceData
 import io.opencensus.trace.{AttributeValue, Span}
 import fs2._
@@ -24,6 +21,10 @@ import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.broadinstitute.dsde.workbench.model.{ErrorReportSource, TraceId}
 import shapeless._
 import slick.dbio.DBIO
+
+import java.nio.file.{Files, Path}
+import java.sql.SQLDataException
+import java.util.Objects
 
 package object http {
   val includeDeletedKey = "includeDeleted"
@@ -61,6 +62,11 @@ package object http {
   // This hostname is used by the ProxyService and also needs to be specified in the Galaxy ingress resource
   def kubernetesProxyHost(cluster: KubernetesCluster, proxyDomain: String): Host = {
     val prefix = Math.abs(cluster.getGkeClusterId.toString.hashCode).toString
+    Host(prefix + proxyDomain)
+  }
+
+  def runtimeProxyHost(googleProject: GoogleProject, runtimeName: RuntimeName, proxyDomain: String): Host = {
+    val prefix = Math.abs(Objects.hash(googleProject.value, runtimeName.asString)).toString
     Host(prefix + proxyDomain)
   }
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/package.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/package.scala
@@ -24,7 +24,6 @@ import slick.dbio.DBIO
 
 import java.nio.file.{Files, Path}
 import java.sql.SQLDataException
-import java.util.Objects
 
 package object http {
   val includeDeletedKey = "includeDeleted"
@@ -62,11 +61,6 @@ package object http {
   // This hostname is used by the ProxyService and also needs to be specified in the Galaxy ingress resource
   def kubernetesProxyHost(cluster: KubernetesCluster, proxyDomain: String): Host = {
     val prefix = Math.abs(cluster.getGkeClusterId.toString.hashCode).toString
-    Host(prefix + proxyDomain)
-  }
-
-  def runtimeProxyHost(googleProject: GoogleProject, runtimeName: RuntimeName, proxyDomain: String): Host = {
-    val prefix = Math.abs(Objects.hash(googleProject.value, runtimeName.asString)).toString
     Host(prefix + proxyDomain)
   }
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/leoPubsubMessageSubscriberModels.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/leoPubsubMessageSubscriberModels.scala
@@ -819,9 +819,7 @@ final case class PollMonitorConfig(maxAttempts: Int, interval: FiniteDuration) {
 
 final case class InterruptablePollMonitorConfig(maxAttempts: Int,
                                                 interval: FiniteDuration,
-                                                interruptAfter: FiniteDuration) {
-  def totalDuration: FiniteDuration = interruptAfter
-}
+                                                interruptAfter: FiniteDuration)
 
 final case class PersistentDiskMonitorConfig(create: PollMonitorConfig,
                                              delete: PollMonitorConfig,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/leoPubsubMessageSubscriberModels.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/leoPubsubMessageSubscriberModels.scala
@@ -817,6 +817,12 @@ final case class PollMonitorConfig(maxAttempts: Int, interval: FiniteDuration) {
   def totalDuration: FiniteDuration = interval * maxAttempts
 }
 
+final case class InterruptablePollMonitorConfig(maxAttempts: Int,
+                                                interval: FiniteDuration,
+                                                interruptAfter: FiniteDuration) {
+  def totalDuration: FiniteDuration = interruptAfter
+}
+
 final case class PersistentDiskMonitorConfig(create: PollMonitorConfig,
                                              delete: PollMonitorConfig,
                                              update: PollMonitorConfig)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
@@ -2,7 +2,6 @@ package org.broadinstitute.dsde.workbench
 package leonardo
 package util
 
-import java.util.Base64
 import _root_.org.typelevel.log4cats.StructuredLogger
 import cats.Parallel
 import cats.effect.{Async, Blocker, ConcurrentEffect, ContextShift, IO, Timer}
@@ -40,9 +39,10 @@ import org.broadinstitute.dsde.workbench.leonardo.http.service.AppNotFoundExcept
 import org.broadinstitute.dsde.workbench.leonardo.model.LeoException
 import org.broadinstitute.dsde.workbench.leonardo.monitor.PubsubHandleMessageError.PubsubKubernetesError
 import org.broadinstitute.dsde.workbench.model.{IP, TraceId, WorkbenchEmail}
-import org.broadinstitute.dsp.{AuthContext, ChartName, ChartVersion, HelmAlgebra, Release}
+import org.broadinstitute.dsp._
 import org.http4s.Uri
 
+import java.util.Base64
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 import scala.jdk.CollectionConverters._
@@ -756,7 +756,7 @@ class GKEInterpreter[F[_]: Parallel: ContextShift: Timer](
         appDao.isProxyAvailable(dbCluster.googleProject, dbApp.app.appName),
         config.monitorConfig.startApp.maxAttempts,
         config.monitorConfig.startApp.interval
-      ).compile.lastOrError
+      ).interruptAfter(config.monitorConfig.startApp.interruptAfter).compile.lastOrError
 
       _ <- if (!isDone) {
         // If starting timed out, persist an error and attempt to stop the app again.
@@ -930,9 +930,11 @@ class GKEInterpreter[F[_]: Parallel: ContextShift: Timer](
 
       // Poll galaxy until it starts up
       // TODO potentially add other status checks for pod readiness, beyond just HTTP polling the galaxy-web service
-      isDone <- streamFUntilDone(appDao.isProxyAvailable(dbCluster.googleProject, appName),
-                                 config.monitorConfig.createApp.maxAttempts,
-                                 config.monitorConfig.createApp.interval).compile.lastOrError
+      isDone <- streamFUntilDone(
+        appDao.isProxyAvailable(dbCluster.googleProject, appName),
+        config.monitorConfig.createApp.maxAttempts,
+        config.monitorConfig.createApp.interval
+      ).interruptAfter(config.monitorConfig.createApp.interruptAfter).compile.lastOrError
 
       _ <- if (!isDone) {
         val msg =
@@ -1029,7 +1031,7 @@ class GKEInterpreter[F[_]: Parallel: ContextShift: Timer](
         ),
         config.monitorConfig.createApp.maxAttempts,
         config.monitorConfig.createApp.interval
-      ).compile.lastOrError
+      ).interruptAfter(config.monitorConfig.createApp.interruptAfter).compile.lastOrError
 
       _ <- if (!last.isDone) {
         val msg =


### PR DESCRIPTION
2 fixes here:

### 1. DNS cache expiry
Perf tests showed a couple app errors like:
```
MySQL [leonardo]> select * from APP_ERROR where appId in (12308, 12367);
+------+-------+--------------+----------------------------+-----------------+--------+-----------------+------------------------------------------------------+
| id   | appId | errorMessage | timestamp                  | action          | source | googleErrorCode | traceId                                              |
+------+-------+--------------+----------------------------+-----------------+--------+-----------------+------------------------------------------------------+
| 6692 | 12308 | 5 seconds    | 2021-04-12 16:34:28.051000 | createGalaxyApp | app    |            NULL | 96b6077099bd235b82ff55e19d301148/3485759192482900616 |
| 6691 | 12367 | 5 seconds    | 2021-04-12 16:34:32.139000 | createGalaxyApp | app    |            NULL | a689e094ab503f225822acf91158c319/8959465316832708319 |
+------+-------+--------------+----------------------------+-----------------+--------+-----------------+------------------------------------------------------+
```
I suspect the `5 seconds` error is likely from the `KubernetesDnsCache` guava cache [expiry](https://github.com/DataBiosphere/leonardo/blob/develop/http/src/main/resources/reference.conf#L466). I don't think there is a good reason it needs to be so low for k8s. See comment in `reference.conf`, I'm hoping increasing it to 10 minutes improves things.

### 2. App monitoring timeouts
Other perf test errors show app creation timeouts:
```
MySQL [leonardo]> select * from APP_ERROR where appId = 12329;
+------+-------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+----------------------------+-----------------+--------+-----------------+-------------------------------------------------------+
| id   | appId | errorMessage                                                                                                                                                                                                               | timestamp                  | action          | source | googleErrorCode | traceId                                               |
+------+-------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+----------------------------+-----------------+--------+-----------------+-------------------------------------------------------+
| 6695 | 12329 | Galaxy installation has failed or timed out for app leo-perf-test-4c10bac6-3857-4a33-bf9f-fd2ac1777159 in cluster projects/perf-env-test-project-992/locations/us-central1-a/clusters/k51fd49e-7280-487d-a91a-990683311c53 | 2021-04-12 16:34:29.404000 | createGalaxyApp | app    |            NULL | a0a6dd6fe533f1738a9a8a19f50070f0/10167083808395204781 |
+------+-------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+----------------------------+-----------------+--------+-----------------+-------------------------------------------------------+
```
I noticed that the timeout takes much longer than intended because we are actually retrying the `http4s` call (which itself retries) with `streamFUntilDone`. This is annoying because it makes the gatling tests time out. So I added `InterruptableMonitorConfig` and use fs2 `Stream.interruptAfter` to `createApp` and `startApp` monitoring. (Note this isn't needed for runtimes because of how `BaseCloudServiceRuntimeMonitor` works.)


---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
