### PR TITLE
[IA-2663] Helm client is slow at high concurrency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN mkdir /helm-go-lib-build && \
     cd /helm-go-lib-build && \
     git clone https://github.com/broadinstitute/helm-scala-sdk.git && \
     cd helm-scala-sdk && \
-    git checkout master && \
+    git checkout rt-set-qps-and-burst && \
     cd helm-go-lib && \
     go build -o libhelm.so -buildmode=c-shared main.go
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN mkdir /helm-go-lib-build && \
     cd /helm-go-lib-build && \
     git clone https://github.com/broadinstitute/helm-scala-sdk.git && \
     cd helm-scala-sdk && \
-    git checkout rt-set-qps-and-burst && \
+    git checkout master && \
     cd helm-go-lib && \
     go build -o libhelm.so -buildmode=c-shared main.go
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -24,7 +24,7 @@ object Dependencies {
   val workbenchOpenTelemetryV = s"0.1-$workbenchLibsHash"
   val workbenchErrorReportingV = s"0.1-$workbenchLibsHash"
 
-  val helmScalaSdkV = "0.0.2"
+  val helmScalaSdkV = "0.0.3"
 
   val excludeAkkaHttp = ExclusionRule(organization = "com.typesafe.akka", name = s"akka-http_${scalaV}")
   val excludeAkkaStream = ExclusionRule(organization = "com.typesafe.akka", name = s"akka-stream_${scalaV}")


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-2663

See https://github.com/broadinstitute/helm-scala-sdk/pull/11

Ran 1 test on perf.. I don't see the `Throttling request` messages anymore but there is a still a lag for the helm call to return. Going to try again with even higher QPS/Burst settings.

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
