### PR TITLE
[IA-2659] update default jupyter docker image

### DIFF
--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -393,7 +393,7 @@ image {
   welderGcrUri = "us.gcr.io/broad-dsp-gcr-public/welder-server"
   welderDockerHubUri = "broadinstitute/welder-server"
   welderHash = "6cfad83"
-  jupyterImage =  "us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:1.0.15"
+  jupyterImage =  "us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:1.1.1"
   legacyJupyterImage = "us.gcr.io/broad-dsp-gcr-public/leonardo-jupyter:5c51ce6935da"
   proxyImage = "broadinstitute/openidc-proxy:2.3.1_2"
   # Note: if you update this, please also update prepare_custom_leonardo_gce_image.sh and


### PR DESCRIPTION
Updating the default image to `1.1.1` for Tuesday's (4/20) Terra monolith release since the documentation/release notes for this feature are ready 

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
