### PR TITLE
[no ticket] Attempt to fix scala    steward gh action

### DIFF
--- a/.github/workflows/merge_scalasteward_prs.yml
+++ b/.github/workflows/merge_scalasteward_prs.yml
@@ -23,6 +23,8 @@ jobs:
         git config --global user.email "broadbot@broadinstitute.org"
         git config --global user.name "broadbot"
 
+        git fetch
+        git checkout develop
         git checkout -B merged-scala-steward-prs
 
         while IFS= read -r pr

--- a/.github/workflows/merge_scalasteward_prs.yml
+++ b/.github/workflows/merge_scalasteward_prs.yml
@@ -33,6 +33,7 @@ jobs:
           gh pr checkout $pr
           curBranch=`git branch --show-current`
           git checkout merged-scala-steward-prs 2>/dev/null || git checkout -b merged-scala-steward-prs
+          echo "Merging $curBranch"
           git merge -m "merging" $curBranch
         done <<< `gh pr list | grep scala-steward | cut -d$'\t'  -f 1`
         git push origin merged-scala-steward-prs


### PR DESCRIPTION
I noticed that the `scala-steward` action is failing with:
```
Switched to branch 'update/google-cloud-nio-0.122.12'
fatal: refusing to merge unrelated histories
Error: Process completed with exit code 128.
```
Ex: https://github.com/DataBiosphere/leonardo/runs/2345407318?check_suite_focus=true

Just guessing this'll fix it: e.g. start off from known head of `develop` branch.


---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
