### PR TITLE
[PROD-533] Pass correct Accept header to Dockerhub registry API call

### DIFF
--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpDockerDAO.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpDockerDAO.scala
@@ -78,7 +78,6 @@ class HttpDockerDAO[F[_]] private (httpClient: Client[F])(implicit logger: Logge
         }
         .map(_._1)
       homeDirectory = envSet.collectFirst { case env if (env.key == "HOME") => Paths.get(env.value) }
-
       res <- F.fromEither(tool.toRight(InvalidImage(traceId, image, None)))
     } yield RuntimeImage(res, image.imageUrl, homeDirectory, now)
 
@@ -121,6 +120,7 @@ class HttpDockerDAO[F[_]] private (httpClient: Client[F])(implicit logger: Logge
               .withPath("/token")
               .withQueryParam("scope", s"repository:${parsedImage.imageName}:pull")
               .withQueryParam("service", "registry.docker.io"),
+            // must be Accept: application/json not Accept: application/vnd.docker.distribution.manifest.v2+json
             headers = Headers.of(Header("Accept", "application/json"))
           )
         )(onError)


### PR DESCRIPTION
Fix error when specifying Dockerhub images:
```
org.broadinstitute.dsde.workbench.leonardo.dao.DockerImageException: Error occurred during Docker image auto-detection: 406: Not Acceptable

Available representations: application/json
```

It seems the `/token` API now requires an `Appect: application/json` header, which we weren't passing before. [This issue](https://github.com/hpcng/singularity/issues/868) pointed me in the right direction.

This must be new behavior on the Dockerhub side, since Leo has not changed this code recently.

This also caused the `HttpDockerDAOSpec` unit tests to fail, and they are passing now.


---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
