### PR TITLE
QA-1452: Extending assertion range

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookGCEDataSyncingSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookGCEDataSyncingSpec.scala
@@ -99,7 +99,7 @@ class NotebookGCEDataSyncingSpec extends RuntimeFixtureSpec with NotebookTestUti
               logger.info(s"[playground mode] original local content is ${originalLocalContent}")
               val originalLocalContentSize: Int = originalLocalContent.size
 
-              abs(originalRemoteContentSize - originalLocalContentSize)<2 shouldBe true
+              originalRemoteContentSize shouldBe originalLocalContentSize +- 1
 
               notebookPage.modeExists() shouldBe true
               notebookPage.getMode() shouldBe NotebookMode.SafeMode

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookGCEDataSyncingSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookGCEDataSyncingSpec.scala
@@ -12,7 +12,6 @@ import org.scalatest.DoNotDiscover
 import org.scalatest.time.{Minutes, Seconds, Span}
 
 import scala.concurrent.duration._
-import scala.math.abs
 
 /**
  * This spec verifies data syncing functionality, including notebook edit mode, playground mode,

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookGCEDataSyncingSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookGCEDataSyncingSpec.scala
@@ -4,7 +4,6 @@ import java.io.File
 import java.math.BigInteger
 import java.security.MessageDigest
 import java.time.Instant
-
 import org.broadinstitute.dsde.workbench.ResourceFile
 import org.broadinstitute.dsde.workbench.google2.GcsBlobName
 import org.broadinstitute.dsde.workbench.leonardo._
@@ -13,6 +12,7 @@ import org.scalatest.DoNotDiscover
 import org.scalatest.time.{Minutes, Seconds, Span}
 
 import scala.concurrent.duration._
+import scala.math.abs
 
 /**
  * This spec verifies data syncing functionality, including notebook edit mode, playground mode,
@@ -99,7 +99,7 @@ class NotebookGCEDataSyncingSpec extends RuntimeFixtureSpec with NotebookTestUti
               logger.info(s"[playground mode] original local content is ${originalLocalContent}")
               val originalLocalContentSize: Int = originalLocalContent.size
 
-              originalRemoteContentSize shouldBe originalLocalContentSize
+              abs(originalRemoteContentSize - originalLocalContentSize)<2 shouldBe true
 
               notebookPage.modeExists() shouldBe true
               notebookPage.getMode() shouldBe NotebookMode.SafeMode


### PR DESCRIPTION
[It looks like we are doing an object size comparison that ends up 1 byte off at times](https://broadworkbench.atlassian.net/browse/QA-1452). 
We are extending the range of the assertion to allow for 1 byte. I'm hesitant to have the range be too large in case there is something bigger happening.

I am going to test this a few times to see if this fixes the issue 

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
