### PR TITLE
[IA-2669] make Galaxy pvc claim dynamic based on disk size

### DIFF
--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -377,8 +377,8 @@ gke {
   }
   galaxyDisk {
     nfsPersistenceName = "nfs-disk"
+    nfsMinimumDiskSizeGB = 100
     postgresPersistenceName = "postgres-disk"
-    # TODO: remove post-alpha once persistence is in place for Galaxy
     postgresDiskNameSuffix = "gxy-postres-disk"
     postgresDiskSizeGB = 10
     postgresDiskBlockSize = 4096

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
@@ -594,6 +594,7 @@ object Config {
   implicit private val appDiskConfigReader: ValueReader[GalaxyDiskConfig] = ValueReader.relative { config =>
     GalaxyDiskConfig(
       config.as[String]("nfsPersistenceName"),
+      config.as[DiskSize]("nfsMinimumDiskSizeGB"),
       config.as[String]("postgresPersistenceName"),
       config.as[String]("postgresDiskNameSuffix"),
       config.as[DiskSize]("postgresDiskSizeGB"),
@@ -646,12 +647,15 @@ object Config {
   val gkeCustomAppConfig = config.as[CustomAppConfig]("gke.customApp")
   val gkeNodepoolConfig = NodepoolConfig(gkeDefaultNodepoolConfig, gkeGalaxyNodepoolConfig)
   val gkeGalaxyDiskConfig = config.as[GalaxyDiskConfig]("gke.galaxyDisk")
-  val leoKubernetesConfig = LeoKubernetesConfig(kubeServiceAccountProviderConfig,
-                                                gkeClusterConfig,
-                                                gkeNodepoolConfig,
-                                                gkeIngressConfig,
-                                                gkeGalaxyAppConfig,
-                                                ConfigReader.appConfig.persistentDisk)
+  val leoKubernetesConfig = LeoKubernetesConfig(
+    kubeServiceAccountProviderConfig,
+    gkeClusterConfig,
+    gkeNodepoolConfig,
+    gkeIngressConfig,
+    gkeGalaxyAppConfig,
+    gkeGalaxyDiskConfig,
+    ConfigReader.appConfig.persistentDisk
+  )
 
   val pubsubConfig = config.as[PubsubConfig]("pubsub")
   val vpcConfig = config.as[VPCConfig]("vpc")

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/GalaxyDiskConfig.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/GalaxyDiskConfig.scala
@@ -1,10 +1,9 @@
 package org.broadinstitute.dsde.workbench.leonardo
 package config
-import org.broadinstitute.dsde.workbench.leonardo.{BlockSize, DiskSize}
 
 final case class GalaxyDiskConfig(nfsPersistenceName: String,
+                                  nfsMinimumDiskSizeGB: DiskSize,
                                   postgresPersistenceName: String,
-                                  // TODO: remove post-alpha once persistence is in place
                                   postgresDiskNameSuffix: String,
                                   postgresDiskSizeGB: DiskSize,
                                   postgresDiskBlockSize: BlockSize) {}

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
@@ -1240,7 +1240,8 @@ class GKEInterpreter[F[_]: Parallel: ContextShift: Timer](
       raw"""nfs.persistence.existingClaim=${namespaceName.value}-${config.galaxyDiskConfig.nfsPersistenceName}-pvc""",
       raw"""nfs.persistence.size=${nfsDisk.size.gb.toString}Gi""",
       raw"""galaxy.postgresql.persistence.existingClaim=${namespaceName.value}-${config.galaxyDiskConfig.postgresPersistenceName}-pvc""",
-      raw"""galaxy.persistence.size=200Gi"""
+      // Note Galaxy pvc claim is the nfs disk size minus 50G
+      raw"""galaxy.persistence.size=${(nfsDisk.size.gb - 50).toString}Gi"""
     ) ++ configs ++ galaxyRestoreSettings
   }
 

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/config/ConfigSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/config/ConfigSpec.scala
@@ -108,7 +108,7 @@ final class ConfigSpec extends AnyFlatSpec with Matchers {
 
   it should "read GalaxyDiskConfig properly" in {
     val expectedResult =
-      GalaxyDiskConfig("nfs-disk", "postgres-disk", "gxy-postres-disk", DiskSize(10), BlockSize(4096))
+      GalaxyDiskConfig("nfs-disk", DiskSize(100), "postgres-disk", "gxy-postres-disk", DiskSize(10), BlockSize(4096))
     Config.gkeGalaxyDiskConfig shouldBe expectedResult
   }
 }


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-2669

Previously `galaxy.persistence.size` was hard-coded to 200G. This was a carry-over from when the disk was fixed at 250G. I made this param dynamic: `diskSize - 50G`.

Also started enforcing a minimum disk size for Galaxy, currently set to 100G. Will also update UI to make the minimum consistent.

Tested in a fiab and I see the Galaxy PVC set to 450G when a 500G disk is chosen.

Friends with UI PR https://github.com/DataBiosphere/terra-ui/pull/2485

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
