### PR TITLE
IA-2603: Adding Retryable tags to certain tests

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/RuntimeFixtureSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/RuntimeFixtureSpec.scala
@@ -41,6 +41,12 @@ abstract class RuntimeFixtureSpec
 
   override type FixtureParam = ClusterFixture
 
+  override def withFixture(test: NoArgTest) =
+    if (isRetryable(test))
+      withRetry(super.withFixture(test))
+    else
+      super.withFixture(test)
+
   override def withFixture(test: OneArgTest): Outcome = {
 
     if (clusterCreationFailureMsg.nonEmpty)

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/AppCreationSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/AppCreationSpec.scala
@@ -8,7 +8,6 @@ import org.broadinstitute.dsde.workbench.leonardo.http.{ListAppResponse, Persist
 import org.broadinstitute.dsde.workbench.service.util.Tags
 import org.http4s.headers.Authorization
 import org.http4s.{AuthScheme, Credentials}
-import org.scalatest.tagobjects.Retryable
 import org.scalatest.{DoNotDiscover, ParallelTestExecution}
 
 import scala.concurrent.duration._
@@ -18,7 +17,7 @@ class AppCreationSpec extends GPAllocFixtureSpec with LeonardoTestUtils with GPA
   implicit val auth: Authorization =
     Authorization(Credentials.Token(AuthScheme.Bearer, ronCreds.makeAuthToken().value))
 
-  "create, delete an app and re-create an app with same disk" taggedAs (Tags.SmokeTest, Retryable) in { _ =>
+  "create, delete an app and re-create an app with same disk" taggedAs Tags.SmokeTest in { _ =>
     withNewProject { googleProject =>
       val appName = randomAppName
       val restoreAppName = AppName(s"restore-${appName.value}")
@@ -99,7 +98,7 @@ class AppCreationSpec extends GPAllocFixtureSpec with LeonardoTestUtils with GPA
     }
   }
 
-  "stop and start an app" taggedAs (Tags.SmokeTest, Retryable) in { _ =>
+  "stop and start an app" taggedAs Tags.SmokeTest in { _ =>
     withNewProject { googleProject =>
       val appName = randomAppName
       val diskName = Generators.genDiskName.sample.get

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/AppCreationSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/AppCreationSpec.scala
@@ -8,6 +8,7 @@ import org.broadinstitute.dsde.workbench.leonardo.http.{ListAppResponse, Persist
 import org.broadinstitute.dsde.workbench.service.util.Tags
 import org.http4s.headers.Authorization
 import org.http4s.{AuthScheme, Credentials}
+import org.scalatest.tagobjects.Retryable
 import org.scalatest.{DoNotDiscover, ParallelTestExecution}
 
 import scala.concurrent.duration._
@@ -17,7 +18,7 @@ class AppCreationSpec extends GPAllocFixtureSpec with LeonardoTestUtils with GPA
   implicit val auth: Authorization =
     Authorization(Credentials.Token(AuthScheme.Bearer, ronCreds.makeAuthToken().value))
 
-  "create, delete an app and re-create an app with same disk" taggedAs Tags.SmokeTest in { _ =>
+  "create, delete an app and re-create an app with same disk" taggedAs (Tags.SmokeTest, Retryable) in { _ =>
     withNewProject { googleProject =>
       val appName = randomAppName
       val restoreAppName = AppName(s"restore-${appName.value}")
@@ -98,7 +99,7 @@ class AppCreationSpec extends GPAllocFixtureSpec with LeonardoTestUtils with GPA
     }
   }
 
-  "stop and start an app" taggedAs Tags.SmokeTest in { _ =>
+  "stop and start an app" taggedAs (Tags.SmokeTest, Retryable) in { _ =>
     withNewProject { googleProject =>
       val appName = randomAppName
       val diskName = Generators.genDiskName.sample.get

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/AppCreationSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/AppCreationSpec.scala
@@ -18,6 +18,12 @@ class AppCreationSpec extends GPAllocFixtureSpec with LeonardoTestUtils with GPA
   implicit val auth: Authorization =
     Authorization(Credentials.Token(AuthScheme.Bearer, ronCreds.makeAuthToken().value))
 
+  override def withFixture(test: NoArgTest) =
+    if (isRetryable(test))
+      withRetry(super.withFixture(test))
+    else
+      super.withFixture(test)
+
   "create, delete an app and re-create an app with same disk" taggedAs (Tags.SmokeTest, Retryable) in { _ =>
     withNewProject { googleProject =>
       val appName = randomAppName

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/CustomAppCreationSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/CustomAppCreationSpec.scala
@@ -7,6 +7,7 @@ import org.broadinstitute.dsde.workbench.leonardo.LeonardoApiClient.defaultCreat
 import org.broadinstitute.dsde.workbench.leonardo.http.{ListAppResponse, PersistentDiskRequest}
 import org.http4s.headers.Authorization
 import org.http4s.{AuthScheme, Credentials, Uri}
+import org.scalatest.tagobjects.Retryable
 import org.scalatest.{DoNotDiscover, ParallelTestExecution}
 
 import scala.concurrent.duration._
@@ -20,7 +21,7 @@ class CustomAppCreationSpec
   implicit val auth: Authorization =
     Authorization(Credentials.Token(AuthScheme.Bearer, ronCreds.makeAuthToken().value))
 
-  "create and delete a custom app" in { _ =>
+  "create and delete a custom app" taggedAs Retryable in { _ =>
     withNewProject { googleProject =>
       val appName = randomAppName
 

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/CustomAppCreationSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/CustomAppCreationSpec.scala
@@ -21,6 +21,12 @@ class CustomAppCreationSpec
   implicit val auth: Authorization =
     Authorization(Credentials.Token(AuthScheme.Bearer, ronCreds.makeAuthToken().value))
 
+  override def withFixture(test: NoArgTest) =
+    if (isRetryable(test))
+      withRetry(super.withFixture(test))
+    else
+      super.withFixture(test)
+
   "create and delete a custom app" taggedAs Retryable in { _ =>
     withNewProject { googleProject =>
       val appName = randomAppName

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookGCEDataSyncingSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookGCEDataSyncingSpec.scala
@@ -22,6 +22,12 @@ import scala.concurrent.duration._
 class NotebookGCEDataSyncingSpec extends RuntimeFixtureSpec with NotebookTestUtils {
   override def enableWelder: Boolean = true
 
+  override def withFixture(test: NoArgTest) =
+    if (isRetryable(test))
+      withRetry(super.withFixture(test))
+    else
+      super.withFixture(test)
+
   "NotebookGCEDataSyncingSpec" - {
 
     "Welder should be up" in { runtimeFixture =>
@@ -91,7 +97,7 @@ class NotebookGCEDataSyncingSpec extends RuntimeFixtureSpec with NotebookTestUti
                 getObjectSize(gcsPath.bucketName, GcsBlobName(gcsPath.objectName.value))
                   .unsafeRunSync()
               logger.info(s"[playground mode] original remote content size is ${originalRemoteContentSize}")
-
+              logger.info(s"YOU ARE HERE")
               val originalLocalContent: NotebookContentItem =
                 Notebook.getNotebookItem(runtimeFixture.runtime.googleProject,
                                          runtimeFixture.runtime.clusterName,
@@ -137,7 +143,7 @@ class NotebookGCEDataSyncingSpec extends RuntimeFixtureSpec with NotebookTestUti
                                                     "notification_notebook")
               val areElementsHidden: Boolean = notebookPage.areElementsHidden(uiElementIds)
 
-              areElementsHidden shouldBe true
+              areElementsHidden shouldBe false
 
               val gcsLockedBy: Option[String] =
                 getLockedBy(gcsPath.bucketName, GcsBlobName(gcsPath.objectName.value)).unsafeRunSync()

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookGCEDataSyncingSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookGCEDataSyncingSpec.scala
@@ -22,12 +22,6 @@ import scala.concurrent.duration._
 class NotebookGCEDataSyncingSpec extends RuntimeFixtureSpec with NotebookTestUtils {
   override def enableWelder: Boolean = true
 
-  override def withFixture(test: NoArgTest) =
-    if (isRetryable(test))
-      withRetry(super.withFixture(test))
-    else
-      super.withFixture(test)
-
   "NotebookGCEDataSyncingSpec" - {
 
     "Welder should be up" in { runtimeFixture =>
@@ -107,7 +101,8 @@ class NotebookGCEDataSyncingSpec extends RuntimeFixtureSpec with NotebookTestUti
 
               originalRemoteContentSize shouldBe originalLocalContentSize +- 1
 
-              notebookPage.modeExists() shouldBe true
+              logger.info(s"YOU ARE HERE")
+              notebookPage.modeExists() shouldBe false
               notebookPage.getMode() shouldBe NotebookMode.SafeMode
               notebookPage.addCodeAndExecute("1+1")
               notebookPage.saveNotebook()

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookGCEDataSyncingSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookGCEDataSyncingSpec.scala
@@ -12,7 +12,6 @@ import org.scalatest.DoNotDiscover
 import org.scalatest.time.{Minutes, Seconds, Span}
 
 import scala.concurrent.duration._
-import scala.math.abs
 
 /**
  * This spec verifies data syncing functionality, including notebook edit mode, playground mode,

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookGCEDataSyncingSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookGCEDataSyncingSpec.scala
@@ -101,8 +101,7 @@ class NotebookGCEDataSyncingSpec extends RuntimeFixtureSpec with NotebookTestUti
 
               originalRemoteContentSize shouldBe originalLocalContentSize +- 1
 
-              logger.info(s"YOU ARE HERE")
-              notebookPage.modeExists() shouldBe false
+              notebookPage.modeExists() shouldBe true
               notebookPage.getMode() shouldBe NotebookMode.SafeMode
               notebookPage.addCodeAndExecute("1+1")
               notebookPage.saveNotebook()

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookGCEDataSyncingSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookGCEDataSyncingSpec.scala
@@ -12,6 +12,7 @@ import org.scalatest.DoNotDiscover
 import org.scalatest.time.{Minutes, Seconds, Span}
 
 import scala.concurrent.duration._
+import scala.math.abs
 
 /**
  * This spec verifies data syncing functionality, including notebook edit mode, playground mode,

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookGCEDataSyncingSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookGCEDataSyncingSpec.scala
@@ -10,6 +10,7 @@ import org.broadinstitute.dsde.workbench.leonardo._
 import org.broadinstitute.dsde.workbench.leonardo.notebooks.Notebook.NotebookMode
 import org.scalatest.DoNotDiscover
 import org.scalatest.time.{Minutes, Seconds, Span}
+import org.scalatest.tagobjects.Retryable
 
 import scala.concurrent.duration._
 
@@ -78,7 +79,7 @@ class NotebookGCEDataSyncingSpec extends RuntimeFixtureSpec with NotebookTestUti
       }
     }
 
-    "open notebook in playground mode should work" in { runtimeFixture =>
+    "open notebook in playground mode should work" taggedAs Retryable in { runtimeFixture =>
       val sampleNotebook = ResourceFile("bucket-tests/gcsFile2.ipynb")
       val isEditMode = false
 

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookGCEDataSyncingSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookGCEDataSyncingSpec.scala
@@ -97,7 +97,7 @@ class NotebookGCEDataSyncingSpec extends RuntimeFixtureSpec with NotebookTestUti
                 getObjectSize(gcsPath.bucketName, GcsBlobName(gcsPath.objectName.value))
                   .unsafeRunSync()
               logger.info(s"[playground mode] original remote content size is ${originalRemoteContentSize}")
-              logger.info(s"YOU ARE HERE")
+
               val originalLocalContent: NotebookContentItem =
                 Notebook.getNotebookItem(runtimeFixture.runtime.googleProject,
                                          runtimeFixture.runtime.clusterName,
@@ -143,7 +143,7 @@ class NotebookGCEDataSyncingSpec extends RuntimeFixtureSpec with NotebookTestUti
                                                     "notification_notebook")
               val areElementsHidden: Boolean = notebookPage.areElementsHidden(uiElementIds)
 
-              areElementsHidden shouldBe false
+              areElementsHidden shouldBe true
 
               val gcsLockedBy: Option[String] =
                 getLockedBy(gcsPath.bucketName, GcsBlobName(gcsPath.objectName.value)).unsafeRunSync()

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeCreationDiskSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeCreationDiskSpec.scala
@@ -30,6 +30,12 @@ class RuntimeCreationDiskSpec
   implicit val authTokenForOldApiClient = ronAuthToken
   implicit val auth: Authorization = Authorization(Credentials.Token(AuthScheme.Bearer, ronCreds.makeAuthToken().value))
 
+  override def withFixture(test: NoArgTest) =
+    if (isRetryable(test))
+      withRetry(super.withFixture(test))
+    else
+      super.withFixture(test)
+
   val zone = ZoneName("us-central1-a")
 
   val dependencies = for {

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeCreationDiskSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeCreationDiskSpec.scala
@@ -19,6 +19,7 @@ import org.scalatest.{DoNotDiscover, ParallelTestExecution}
 import scala.concurrent.duration._
 import org.broadinstitute.dsde.workbench.DoneCheckableSyntax._
 import org.http4s.Status
+import org.scalatest.tagobjects.Retryable
 
 @DoNotDiscover
 class RuntimeCreationDiskSpec
@@ -121,7 +122,7 @@ class RuntimeCreationDiskSpec
     res.unsafeRunSync()
   }
 
-  "create runtime and attach an existing persistent disk" in { googleProject =>
+  "create runtime and attach an existing persistent disk" taggedAs Retryable in { googleProject =>
     val randomeName = randomClusterName
     val runtimeName = randomeName.copy(asString = randomeName.asString + "pd-spec") // just to make sure the test runtime name is unique
     val runtimeWithDataName = randomeName.copy(asString = randomeName.asString + "pd-spec-data-persist")

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeCreationDiskSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeCreationDiskSpec.scala
@@ -19,7 +19,6 @@ import org.scalatest.{DoNotDiscover, ParallelTestExecution}
 import scala.concurrent.duration._
 import org.broadinstitute.dsde.workbench.DoneCheckableSyntax._
 import org.http4s.Status
-import org.scalatest.tagobjects.Retryable
 
 @DoNotDiscover
 class RuntimeCreationDiskSpec
@@ -122,7 +121,7 @@ class RuntimeCreationDiskSpec
     res.unsafeRunSync()
   }
 
-  "create runtime and attach an existing persistent disk" taggedAs Retryable in { googleProject =>
+  "create runtime and attach an existing persistent disk" in { googleProject =>
     val randomeName = randomClusterName
     val runtimeName = randomeName.copy(asString = randomeName.asString + "pd-spec") // just to make sure the test runtime name is unique
     val runtimeWithDataName = randomeName.copy(asString = randomeName.asString + "pd-spec-data-persist")

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeDataprocSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeDataprocSpec.scala
@@ -78,7 +78,7 @@ class RuntimeDataprocSpec
 
         // check cluster status in Dataproc
         _ <- verifyDataproc(project, runtime.clusterName, dep.dataproc, 2, 1, RegionName("europe-west1"))
-        _ = getRuntimeResponse.runtimeConfig.asInstanceOf[DataprocConfig].region shouldBe RegionName("europe-west1")
+        _ = getRuntimeResponse.runtimeConfig.asInstanceOf[DataprocConfig].region shouldBe RegionName("europe-west2")
 
         _ <- LeonardoApiClient.deleteRuntime(project, runtimeName)
       } yield ()

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeDataprocSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeDataprocSpec.scala
@@ -42,6 +42,12 @@ class RuntimeDataprocSpec
   implicit val auth: Authorization = Authorization(Credentials.Token(AuthScheme.Bearer, ronCreds.makeAuthToken().value))
   implicit val traceId = Ask.const[IO, TraceId](TraceId(UUID.randomUUID()))
 
+  override def withFixture(test: NoArgTest) =
+    if (isRetryable(test))
+      withRetry(super.withFixture(test))
+    else
+      super.withFixture(test)
+
   val dependencies = for {
     dataprocService <- googleDataprocService
     storage <- google2StorageResource

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeDataprocSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeDataprocSpec.scala
@@ -84,7 +84,7 @@ class RuntimeDataprocSpec
 
         // check cluster status in Dataproc
         _ <- verifyDataproc(project, runtime.clusterName, dep.dataproc, 2, 1, RegionName("europe-west1"))
-        _ = getRuntimeResponse.runtimeConfig.asInstanceOf[DataprocConfig].region shouldBe RegionName("europe-west2")
+        _ = getRuntimeResponse.runtimeConfig.asInstanceOf[DataprocConfig].region shouldBe RegionName("europe-west1")
 
         _ <- LeonardoApiClient.deleteRuntime(project, runtimeName)
       } yield ()

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeDataprocSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeDataprocSpec.scala
@@ -57,7 +57,6 @@ class RuntimeDataprocSpec
   "should create a Dataproc cluster in a non-default region" taggedAs Retryable in { project =>
     val runtimeName = randomClusterName
 
-    logger.info(s"YOU ARE HERE!")
     // In a europe region
     val createRuntimeRequest = defaultCreateRuntime2Request.copy(
       runtimeConfig = Some(

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeDataprocSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeDataprocSpec.scala
@@ -42,12 +42,6 @@ class RuntimeDataprocSpec
   implicit val auth: Authorization = Authorization(Credentials.Token(AuthScheme.Bearer, ronCreds.makeAuthToken().value))
   implicit val traceId = Ask.const[IO, TraceId](TraceId(UUID.randomUUID()))
 
-  override def withFixture(test: NoArgTest) =
-    if (isRetryable(test))
-      withRetry(super.withFixture(test))
-    else
-      super.withFixture(test)
-
   val dependencies = for {
     dataprocService <- googleDataprocService
     storage <- google2StorageResource
@@ -84,7 +78,7 @@ class RuntimeDataprocSpec
 
         // check cluster status in Dataproc
         _ <- verifyDataproc(project, runtime.clusterName, dep.dataproc, 2, 1, RegionName("europe-west1"))
-        _ = getRuntimeResponse.runtimeConfig.asInstanceOf[DataprocConfig].region shouldBe RegionName("europe-west1")
+        _ = getRuntimeResponse.runtimeConfig.asInstanceOf[DataprocConfig].region shouldBe RegionName("europe-west2")
 
         _ <- LeonardoApiClient.deleteRuntime(project, runtimeName)
       } yield ()

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeDataprocSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeDataprocSpec.scala
@@ -56,7 +56,7 @@ class RuntimeDataprocSpec
 
   "should create a Dataproc cluster in a non-default region" taggedAs Retryable in { project =>
     val runtimeName = randomClusterName
-    logger.info(s"YOU ARE HERE")
+
     // In a europe region
     val createRuntimeRequest = defaultCreateRuntime2Request.copy(
       runtimeConfig = Some(
@@ -84,7 +84,7 @@ class RuntimeDataprocSpec
 
         // check cluster status in Dataproc
         _ <- verifyDataproc(project, runtime.clusterName, dep.dataproc, 2, 1, RegionName("europe-west1"))
-        _ = getRuntimeResponse.runtimeConfig.asInstanceOf[DataprocConfig].region shouldBe RegionName("europe-west2")
+        _ = getRuntimeResponse.runtimeConfig.asInstanceOf[DataprocConfig].region shouldBe RegionName("europe-west1")
 
         _ <- LeonardoApiClient.deleteRuntime(project, runtimeName)
       } yield ()

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeDataprocSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeDataprocSpec.scala
@@ -28,9 +28,9 @@ import org.http4s.client.Client
 import org.http4s.headers.Authorization
 import org.http4s.{AuthScheme, Credentials}
 import org.scalatest.{DoNotDiscover, ParallelTestExecution}
-
 import java.nio.charset.{Charset, StandardCharsets}
 import java.util.UUID
+import org.scalatest.tagobjects.Retryable
 
 @DoNotDiscover
 class RuntimeDataprocSpec
@@ -48,7 +48,7 @@ class RuntimeDataprocSpec
     httpClient <- LeonardoApiClient.client
   } yield RuntimeDataprocSpecDependencies(httpClient, dataprocService, storage)
 
-  "should create a Dataproc cluster in a non-default region" in { project =>
+  "should create a Dataproc cluster in a non-default region" taggedAs Retryable in { project =>
     val runtimeName = randomClusterName
 
     // In a europe region
@@ -87,7 +87,7 @@ class RuntimeDataprocSpec
     res.unsafeRunSync()
   }
 
-  "should create a Dataproc cluster with workers and preemptible workers" in { project =>
+  "should create a Dataproc cluster with workers and preemptible workers" taggedAs Retryable in { project =>
     val runtimeName = randomClusterName
 
     // 2 workers and 5 preemptible workers
@@ -134,7 +134,7 @@ class RuntimeDataprocSpec
     res.unsafeRunSync()
   }
 
-  "should stop/start a Dataproc cluster with workers and preemptible workers" in { project =>
+  "should stop/start a Dataproc cluster with workers and preemptible workers" taggedAs Retryable in { project =>
     val runtimeName = randomClusterName
 
     val res = dependencies.use { dep =>

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeDataprocSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeDataprocSpec.scala
@@ -42,6 +42,12 @@ class RuntimeDataprocSpec
   implicit val auth: Authorization = Authorization(Credentials.Token(AuthScheme.Bearer, ronCreds.makeAuthToken().value))
   implicit val traceId = Ask.const[IO, TraceId](TraceId(UUID.randomUUID()))
 
+  override def withFixture(test: NoArgTest) =
+    if (isRetryable(test))
+      withRetry(super.withFixture(test))
+    else
+      super.withFixture(test)
+
   val dependencies = for {
     dataprocService <- googleDataprocService
     storage <- google2StorageResource
@@ -50,7 +56,7 @@ class RuntimeDataprocSpec
 
   "should create a Dataproc cluster in a non-default region" taggedAs Retryable in { project =>
     val runtimeName = randomClusterName
-
+    logger.info(s"YOU ARE HERE")
     // In a europe region
     val createRuntimeRequest = defaultCreateRuntime2Request.copy(
       runtimeConfig = Some(

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeDataprocSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeDataprocSpec.scala
@@ -57,6 +57,7 @@ class RuntimeDataprocSpec
   "should create a Dataproc cluster in a non-default region" taggedAs Retryable in { project =>
     val runtimeName = randomClusterName
 
+    logger.info(s"YOU ARE HERE!")
     // In a europe region
     val createRuntimeRequest = defaultCreateRuntime2Request.copy(
       runtimeConfig = Some(

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimePatchSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimePatchSpec.scala
@@ -18,7 +18,6 @@ import org.broadinstitute.dsde.workbench.service.util.Tags
 import org.http4s.headers.Authorization
 import org.http4s.{AuthScheme, Credentials}
 import org.scalatest.{DoNotDiscover, ParallelTestExecution}
-import org.scalatest.tagobjects.Retryable
 
 import scala.concurrent.duration._
 
@@ -179,7 +178,7 @@ class RuntimePatchSpec
       res.unsafeRunSync
   }
 
-  "Patch endpoint should perform a stop/start transition for Dataproc cluster" taggedAs (Tags.SmokeTest, Retryable) in {
+  "Patch endpoint should perform a stop/start transition for Dataproc cluster" taggedAs Tags.SmokeTest in {
     googleProject =>
       val newMasterMachineType = MachineTypeName("n1-standard-2")
       val newDiskSize = DiskSize(60)

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimePatchSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimePatchSpec.scala
@@ -18,6 +18,7 @@ import org.broadinstitute.dsde.workbench.service.util.Tags
 import org.http4s.headers.Authorization
 import org.http4s.{AuthScheme, Credentials}
 import org.scalatest.{DoNotDiscover, ParallelTestExecution}
+import org.scalatest.tagobjects.Retryable
 
 import scala.concurrent.duration._
 
@@ -178,7 +179,7 @@ class RuntimePatchSpec
       res.unsafeRunSync
   }
 
-  "Patch endpoint should perform a stop/start transition for Dataproc cluster" taggedAs Tags.SmokeTest in {
+  "Patch endpoint should perform a stop/start transition for Dataproc cluster" taggedAs (Tags.SmokeTest, Retryable) in {
     googleProject =>
       val newMasterMachineType = MachineTypeName("n1-standard-2")
       val newDiskSize = DiskSize(60)

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimePatchSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimePatchSpec.scala
@@ -31,6 +31,12 @@ class RuntimePatchSpec
   implicit val ronToken: AuthToken = ronAuthToken
   implicit val auth: Authorization = Authorization(Credentials.Token(AuthScheme.Bearer, ronCreds.makeAuthToken().value))
 
+  override def withFixture(test: NoArgTest) =
+    if (isRetryable(test))
+      withRetry(super.withFixture(test))
+    else
+      super.withFixture(test)
+
   //this is an end to end test of the pub/sub infrastructure
   "Patch endpoint should perform a stop/start transition for GCE VM" taggedAs Tags.SmokeTest in { googleProject =>
     // create a new GCE runtime


### PR DESCRIPTION
Adding retryable tag to allow for a retry in case one of these flaky tests fails. 

I think I might need to intentionally fail a test to make sure it works properly

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
