### PR TITLE
[IA-2630] Poll group updates in DataprocInterpreter

### DIFF
--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/DataprocInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/DataprocInterpreter.scala
@@ -682,7 +682,8 @@ class DataprocInterpreter[F[_]: Timer: Parallel: ContextShift](
     val poll = for {
       ctx <- ev.ask
       d: DoneCheckable[Boolean] = (_: Boolean) == addToGroup
-      isMember <- Timer[F].sleep(2 seconds) >> streamFUntilDone(checkIsMember, 30, 2 seconds)(implicitly, d).compile.lastOrError
+      isMember <- Timer[F].sleep(5 seconds) >>
+        streamFUntilDone(checkIsMember, 30, 2 seconds)(implicitly, d).compile.lastOrError
       _ <- if (!d.isDone(isMember)) F.raiseError(GoogleGroupMembershipException(groupEmail, ctx.traceId))
       else F.unit
     } yield ()

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/DataprocInterpreterSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/DataprocInterpreterSpec.scala
@@ -176,7 +176,7 @@ class DataprocInterpreterSpec
                                                             MockGoogleDiskService,
                                                             mockGoogleDirectoryDAO,
                                                             erroredIamDAO,
-                                                            FakeGoogleResourceService,
+                                                            MockGoogleResourceService,
                                                             MockWelderDAO,
                                                             blocker)
 
@@ -231,6 +231,11 @@ class DataprocInterpreterSpec
 
       Future.failed(testException)
     }
+  }
+
+  private object MockGoogleResourceService extends FakeGoogleResourceService {
+    override def getProjectNumber(project: GoogleProject)(implicit ev: Ask[IO, TraceId]): IO[Option[Long]] =
+      IO(Some(1234567890))
   }
 
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -16,7 +16,7 @@ object Dependencies {
   val opencensusV = "0.28.3"
 
 
-  private val workbenchLibsHash = "db20f46-SNAP"
+  private val workbenchLibsHash = "e17afdf"
   val serviceTestV = s"0.18-$workbenchLibsHash"
   val workbenchModelV = s"0.14-$workbenchLibsHash"
   val workbenchGoogleV = s"0.21-$workbenchLibsHash"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -16,7 +16,7 @@ object Dependencies {
   val opencensusV = "0.28.3"
 
 
-  private val workbenchLibsHash = "197294d"
+  private val workbenchLibsHash = "db20f46-SNAP"
   val serviceTestV = s"0.18-$workbenchLibsHash"
   val workbenchModelV = s"0.14-$workbenchLibsHash"
   val workbenchGoogleV = s"0.21-$workbenchLibsHash"


### PR DESCRIPTION
JIRA: https://broadworkbench.atlassian.net/browse/IA-2630
Depends on: https://github.com/broadinstitute/workbench-libs/pull/630

Attempt to fix errors like:
```
Required 'compute.images.useReadOnly' permission for 'projects/broad-dsp-gcr-public/global/images/custom-leo-image-dataproc-1-4-51-debian10-d26876f'
```

I think the cause is delays on the GCP side for group additions to the Dataproc custom image group to take effect. I added some polling after the group addition in `DataprocInterpreter`. 

I decided not to retry the Dataproc cluster creation as specified in the ticket because it's an asynchronous error, and we don't currently have a pattern for `create -> error -> delete -> recreate -> etc` during monitoring. If this PR doesn't fix it, we could revisit this. 


---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
