### PR TITLE
[no ticket] attempt to fix flakey createDiskSpec

### DIFF
--- a/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/DiskModelGenerators.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/DiskModelGenerators.scala
@@ -3,7 +3,7 @@ package org.broadinstitute.dsde.workbench.leonardo
 import org.scalacheck.{Arbitrary, Gen}
 
 object DiskModelGenerators {
-  val genDiskSize: Gen[DiskSize] = Gen.chooseNum(5, 500).map(DiskSize)
+  val genDiskSize: Gen[DiskSize] = Gen.chooseNum(10, 500).map(DiskSize)
 
   implicit val arbDiskSize: Arbitrary[DiskSize] = Arbitrary(genDiskSize)
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/DiskModelGenerators.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/DiskModelGenerators.scala
@@ -3,7 +3,7 @@ package org.broadinstitute.dsde.workbench.leonardo
 import org.scalacheck.{Arbitrary, Gen}
 
 object DiskModelGenerators {
-  val genDiskSize: Gen[DiskSize] = Gen.chooseNum(10, 500).map(DiskSize)
+  val genDiskSize: Gen[DiskSize] = Gen.chooseNum(5, 500).map(DiskSize)
 
   implicit val arbDiskSize: Arbitrary[DiskSize] = Arbitrary(genDiskSize)
 }

--- a/http/src/main/resources/init-resources/cloud-init.yml
+++ b/http/src/main/resources/init-resources/cloud-init.yml
@@ -3,6 +3,7 @@
 bootcmd:
 - fsck.ext4 -tvy /dev/sdb
 - mkdir -p /mnt/disks/work
+- chmod a+rwx /mnt/disks/work
 - mount -t ext4 -O discard,defaults /dev/sdb /mnt/disks/work
 
 write_files:

--- a/http/src/main/resources/init-resources/gce-init.sh
+++ b/http/src/main/resources/init-resources/gce-init.sh
@@ -520,6 +520,8 @@ docker image prune -a -f &
 
 log 'All done!'
 
+chmod a+rwx ${WORK_DIRECTORY}
+
 ELAPSED_TIME=$(($END_TIME - $START_TIME))
 log "gce-init.sh took $(display_time $ELAPSED_TIME)"
 log "Step timings: ${STEP_TIMINGS[@]}"


### PR DESCRIPTION
checked a few in the runtimes that errored in failed tests last night. Increase the pd size a bit to see if it makes tests more reliable

```
Default
2021-05-25 02:57:36.403 EDT
"[E 06:57:36.028 NotebookApp] Error while saving file: Untitled.ipynb [Errno 28] No space left on device "
```

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
