### PR TITLE
[IA-2636] add gpu to create runtime

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
@@ -238,7 +238,7 @@ trait LeonardoTestUtils
     labelCheck(cluster.labels, expectedName, expectedProject, cluster.creator, clusterRequest)
 
     if (bucketCheck) {
-      cluster.stagingBucket shouldBe 'defined
+      cluster.stagingBucket shouldBe Symbol("defined")
 
       implicit val patienceConfig: PatienceConfig = storagePatience
       googleStorageDAO.bucketExists(GcsBucketName(cluster.stagingBucket.get.value)).futureValue shouldBe true

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
@@ -238,7 +238,7 @@ trait LeonardoTestUtils
     labelCheck(cluster.labels, expectedName, expectedProject, cluster.creator, clusterRequest)
 
     if (bucketCheck) {
-      cluster.stagingBucket shouldBe Symbol("defined")
+      cluster.stagingBucket shouldBe defined
 
       implicit val patienceConfig: PatienceConfig = storagePatience
       googleStorageDAO.bucketExists(GcsBucketName(cluster.stagingBucket.get.value)).futureValue shouldBe true

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/RuntimeFixtureSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/RuntimeFixtureSpec.scala
@@ -151,7 +151,9 @@ object RuntimeFixtureSpec {
       case CloudService.GCE =>
         RuntimeConfigRequest.GceConfig(
           machineType = Some(MachineTypeName("n1-standard-4")),
-          diskSize = Some(DiskSize(100))
+          diskSize = Some(DiskSize(100)),
+          None,
+          None
         )
       case CloudService.Dataproc =>
         RuntimeConfigRequest.DataprocConfig(

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookAouSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookAouSpec.scala
@@ -15,7 +15,7 @@ class NotebookAouSpec extends RuntimeFixtureSpec with NotebookTestUtils {
       withWebDriver { implicit driver =>
         withNewNotebook(runtimeFixture.runtime, Python3) { notebookPage =>
           val result = notebookPage.executeCell("!command -v wondershaper")
-          result shouldBe Symbol("defined")
+          result shouldBe defined
           result.get should include("/usr/sbin/wondershaper")
         }
       }

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookAouSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookAouSpec.scala
@@ -15,7 +15,7 @@ class NotebookAouSpec extends RuntimeFixtureSpec with NotebookTestUtils {
       withWebDriver { implicit driver =>
         withNewNotebook(runtimeFixture.runtime, Python3) { notebookPage =>
           val result = notebookPage.executeCell("!command -v wondershaper")
-          result shouldBe 'defined
+          result shouldBe Symbol("defined")
           result.get should include("/usr/sbin/wondershaper")
         }
       }

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookBioconductorKernelSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookBioconductorKernelSpec.scala
@@ -148,7 +148,7 @@ class NotebookBioconductorKernelSpec extends RuntimeFixtureSpec with NotebookTes
       withWebDriver { implicit driver =>
         withNewNotebook(runtimeFixture.runtime, RKernel) { notebookPage =>
           val javaOutput = notebookPage.executeCell("""system('java --version', intern = TRUE)""")
-          javaOutput shouldBe Symbol("defined")
+          javaOutput shouldBe defined
           javaOutput.get should include("OpenJDK Runtime Environment")
           javaOutput.get should not include ("not found")
         }

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookBioconductorKernelSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookBioconductorKernelSpec.scala
@@ -148,7 +148,7 @@ class NotebookBioconductorKernelSpec extends RuntimeFixtureSpec with NotebookTes
       withWebDriver { implicit driver =>
         withNewNotebook(runtimeFixture.runtime, RKernel) { notebookPage =>
           val javaOutput = notebookPage.executeCell("""system('java --version', intern = TRUE)""")
-          javaOutput shouldBe 'defined
+          javaOutput shouldBe Symbol("defined")
           javaOutput.get should include("OpenJDK Runtime Environment")
           javaOutput.get should not include ("not found")
         }

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookGATKSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookGATKSpec.scala
@@ -16,26 +16,26 @@ class NotebookGATKSpec extends RuntimeFixtureSpec with NotebookTestUtils {
       withWebDriver { implicit driver =>
         withNewNotebook(runtimeFixture.runtime, Python3) { notebookPage =>
           val pythonOutput = notebookPage.executeCell("""! pip3 show tensorflow_cpu""")
-          pythonOutput shouldBe 'defined
+          pythonOutput shouldBe Symbol("defined")
           pythonOutput.get should include("Name: tensorflow-cpu")
 
           val rOutput = notebookPage.executeCell("""! R --version""")
-          rOutput shouldBe 'defined
+          rOutput shouldBe Symbol("defined")
           rOutput.get should include("R version")
           rOutput.get should not include ("not found")
 
           val gatkOutput = notebookPage.executeCell("""! gatk --version""")
-          gatkOutput shouldBe 'defined
+          gatkOutput shouldBe Symbol("defined")
           gatkOutput.get should include("Using GATK jar")
           gatkOutput.get should not include ("not found")
 
           val samtoolsOutput = notebookPage.executeCell("""! samtools --version""")
-          samtoolsOutput shouldBe 'defined
+          samtoolsOutput shouldBe Symbol("defined")
           samtoolsOutput.get should include("Using htslib")
           samtoolsOutput.get should not include ("not found")
 
           val javaOutput = notebookPage.executeCell("""! java -version""")
-          javaOutput shouldBe 'defined
+          javaOutput shouldBe Symbol("defined")
           javaOutput.get should include("openjdk version \"1.8.0_")
           javaOutput.get should include("OpenJDK Runtime Environment")
           javaOutput.get should not include ("not found")

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookGATKSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookGATKSpec.scala
@@ -16,26 +16,26 @@ class NotebookGATKSpec extends RuntimeFixtureSpec with NotebookTestUtils {
       withWebDriver { implicit driver =>
         withNewNotebook(runtimeFixture.runtime, Python3) { notebookPage =>
           val pythonOutput = notebookPage.executeCell("""! pip3 show tensorflow_cpu""")
-          pythonOutput shouldBe Symbol("defined")
+          pythonOutput shouldBe defined
           pythonOutput.get should include("Name: tensorflow-cpu")
 
           val rOutput = notebookPage.executeCell("""! R --version""")
-          rOutput shouldBe Symbol("defined")
+          rOutput shouldBe defined
           rOutput.get should include("R version")
           rOutput.get should not include ("not found")
 
           val gatkOutput = notebookPage.executeCell("""! gatk --version""")
-          gatkOutput shouldBe Symbol("defined")
+          gatkOutput shouldBe defined
           gatkOutput.get should include("Using GATK jar")
           gatkOutput.get should not include ("not found")
 
           val samtoolsOutput = notebookPage.executeCell("""! samtools --version""")
-          samtoolsOutput shouldBe Symbol("defined")
+          samtoolsOutput shouldBe defined
           samtoolsOutput.get should include("Using htslib")
           samtoolsOutput.get should not include ("not found")
 
           val javaOutput = notebookPage.executeCell("""! java -version""")
-          javaOutput shouldBe Symbol("defined")
+          javaOutput shouldBe defined
           javaOutput.get should include("openjdk version \"1.8.0_")
           javaOutput.get should include("OpenJDK Runtime Environment")
           javaOutput.get should not include ("not found")

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookHailSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookHailSpec.scala
@@ -110,7 +110,7 @@ class NotebookHailSpec extends RuntimeFixtureSpec with NotebookTestUtils {
               // Import the TSV into a Hail table
               val importResult =
                 notebookPage.executeCell(s"table = hl.import_table('${tsvUri}', impute=True)", timeout = 5.minutes)
-              importResult shouldBe Symbol("defined")
+              importResult shouldBe defined
               importResult.get should include("Finished type imputation")
 
               // Verify the Hail table
@@ -133,7 +133,7 @@ class NotebookHailSpec extends RuntimeFixtureSpec with NotebookTestUtils {
           withNewNotebook(clusterFixture.runtime, Python3) { notebookPage =>
             // Localize the CSV
             val localizeResult = notebookPage.executeCell(s"! gsutil cp ${gcsPath.toUri} .")
-            localizeResult shouldBe Symbol("defined")
+            localizeResult shouldBe defined
             localizeResult.get should include("Operation completed")
 
             // Read the CSV into a pandas DataFrame
@@ -153,7 +153,7 @@ class NotebookHailSpec extends RuntimeFixtureSpec with NotebookTestUtils {
             // Import the DataFrame into a Hail table
             val result =
               notebookPage.executeCell(s"samples = hl.Table.from_pandas(df, key = 'sample')", timeout = 5.minutes)
-            result shouldBe Symbol("defined")
+            result shouldBe defined
             result.get should not include ("FatalError")
             result.get should not include ("PythonException")
             result.get should include("Coerced sorted dataset")

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookHailSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookHailSpec.scala
@@ -110,7 +110,7 @@ class NotebookHailSpec extends RuntimeFixtureSpec with NotebookTestUtils {
               // Import the TSV into a Hail table
               val importResult =
                 notebookPage.executeCell(s"table = hl.import_table('${tsvUri}', impute=True)", timeout = 5.minutes)
-              importResult shouldBe 'defined
+              importResult shouldBe Symbol("defined")
               importResult.get should include("Finished type imputation")
 
               // Verify the Hail table
@@ -133,7 +133,7 @@ class NotebookHailSpec extends RuntimeFixtureSpec with NotebookTestUtils {
           withNewNotebook(clusterFixture.runtime, Python3) { notebookPage =>
             // Localize the CSV
             val localizeResult = notebookPage.executeCell(s"! gsutil cp ${gcsPath.toUri} .")
-            localizeResult shouldBe 'defined
+            localizeResult shouldBe Symbol("defined")
             localizeResult.get should include("Operation completed")
 
             // Read the CSV into a pandas DataFrame
@@ -153,7 +153,7 @@ class NotebookHailSpec extends RuntimeFixtureSpec with NotebookTestUtils {
             // Import the DataFrame into a Hail table
             val result =
               notebookPage.executeCell(s"samples = hl.Table.from_pandas(df, key = 'sample')", timeout = 5.minutes)
-            result shouldBe 'defined
+            result shouldBe Symbol("defined")
             result.get should not include ("FatalError")
             result.get should not include ("PythonException")
             result.get should include("Coerced sorted dataset")

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookPyKernelSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookPyKernelSpec.scala
@@ -80,7 +80,7 @@ class NotebookPyKernelSpec extends RuntimeFixtureSpec with NotebookTestUtils {
     "should include Content-Security-Policy in headers" in { runtimeFixture =>
       val headers = Notebook.getApiHeaders(runtimeFixture.runtime.googleProject, runtimeFixture.runtime.clusterName)
       val contentSecurityHeader = headers.find(_.name == "Content-Security-Policy")
-      contentSecurityHeader shouldBe Symbol("defined")
+      contentSecurityHeader shouldBe defined
       contentSecurityHeader.get.value should include("https://bvdp-saturn-dev.appspot.com")
       contentSecurityHeader.get.value should not include ("https://bvdp-saturn-prod.appspot.com")
       contentSecurityHeader.get.value should not include ("*.terra.bio")

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookPyKernelSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookPyKernelSpec.scala
@@ -80,7 +80,7 @@ class NotebookPyKernelSpec extends RuntimeFixtureSpec with NotebookTestUtils {
     "should include Content-Security-Policy in headers" in { runtimeFixture =>
       val headers = Notebook.getApiHeaders(runtimeFixture.runtime.googleProject, runtimeFixture.runtime.clusterName)
       val contentSecurityHeader = headers.find(_.name == "Content-Security-Policy")
-      contentSecurityHeader shouldBe 'defined
+      contentSecurityHeader shouldBe Symbol("defined")
       contentSecurityHeader.get.value should include("https://bvdp-saturn-dev.appspot.com")
       contentSecurityHeader.get.value should not include ("https://bvdp-saturn-prod.appspot.com")
       contentSecurityHeader.get.value should not include ("*.terra.bio")

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookRKernelSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookRKernelSpec.scala
@@ -27,7 +27,7 @@ class NotebookRKernelSpec extends RuntimeFixtureSpec with NotebookTestUtils {
 //          val output = notebookPage.executeCell("""data(iris)
 //                                                  |skim(iris)""".stripMargin)
 //
-//          output shouldBe 'defined
+//          output shouldBe Symbol("defined")
 //          output.get should not include ("<U+")
 //          output.get should include("▂▇▅▇▆▅▂▂") TODO: re-enable this once we understand why `Variable type: numeric` doesn't show any data the same way https://github.com/ropensci/skimr does
         }
@@ -72,7 +72,7 @@ class NotebookRKernelSpec extends RuntimeFixtureSpec with NotebookTestUtils {
           val installTimeout = 2.minutes
 
           val output = notebookPage.executeCell("""install.packages("httr")""", installTimeout)
-          output shouldBe 'defined
+          output shouldBe Symbol("defined")
           output.get should include("Installing package into")
           output.get should include("/home/jupyter-user/notebooks/packages")
 
@@ -98,7 +98,7 @@ class NotebookRKernelSpec extends RuntimeFixtureSpec with NotebookTestUtils {
           val installTimeout = 5.minutes
 
           val installOutput = notebookPage.executeCell("""install.packages('mlr')""", installTimeout)
-          installOutput shouldBe 'defined
+          installOutput shouldBe Symbol("defined")
           installOutput.get should include("Installing package into")
           installOutput.get should include("/home/jupyter-user/notebooks/packages")
           installOutput.get should not include ("Installation failed")
@@ -134,7 +134,7 @@ class NotebookRKernelSpec extends RuntimeFixtureSpec with NotebookTestUtils {
           val installTimeout = 5.minutes
 
           val installOutput = notebookPage.executeCell("""install.packages('qwraps2')""", installTimeout)
-          installOutput shouldBe 'defined
+          installOutput shouldBe Symbol("defined")
           installOutput.get should include("Installing package into")
           installOutput.get should include("/home/jupyter-user/notebooks/packages")
           installOutput.get should not include ("cannot find -lgfortran")

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookRKernelSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookRKernelSpec.scala
@@ -27,7 +27,7 @@ class NotebookRKernelSpec extends RuntimeFixtureSpec with NotebookTestUtils {
 //          val output = notebookPage.executeCell("""data(iris)
 //                                                  |skim(iris)""".stripMargin)
 //
-//          output shouldBe Symbol("defined")
+//          output shouldBe defined
 //          output.get should not include ("<U+")
 //          output.get should include("▂▇▅▇▆▅▂▂") TODO: re-enable this once we understand why `Variable type: numeric` doesn't show any data the same way https://github.com/ropensci/skimr does
         }
@@ -72,7 +72,7 @@ class NotebookRKernelSpec extends RuntimeFixtureSpec with NotebookTestUtils {
           val installTimeout = 2.minutes
 
           val output = notebookPage.executeCell("""install.packages("httr")""", installTimeout)
-          output shouldBe Symbol("defined")
+          output shouldBe defined
           output.get should include("Installing package into")
           output.get should include("/home/jupyter-user/notebooks/packages")
 
@@ -98,7 +98,7 @@ class NotebookRKernelSpec extends RuntimeFixtureSpec with NotebookTestUtils {
           val installTimeout = 5.minutes
 
           val installOutput = notebookPage.executeCell("""install.packages('mlr')""", installTimeout)
-          installOutput shouldBe Symbol("defined")
+          installOutput shouldBe defined
           installOutput.get should include("Installing package into")
           installOutput.get should include("/home/jupyter-user/notebooks/packages")
           installOutput.get should not include ("Installation failed")
@@ -134,7 +134,7 @@ class NotebookRKernelSpec extends RuntimeFixtureSpec with NotebookTestUtils {
           val installTimeout = 5.minutes
 
           val installOutput = notebookPage.executeCell("""install.packages('qwraps2')""", installTimeout)
-          installOutput shouldBe Symbol("defined")
+          installOutput shouldBe defined
           installOutput.get should include("Installing package into")
           installOutput.get should include("/home/jupyter-user/notebooks/packages")
           installOutput.get should not include ("cannot find -lgfortran")

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookTestUtils.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookTestUtils.scala
@@ -139,7 +139,7 @@ trait NotebookTestUtils extends LeonardoTestUtils {
     }
 
     val installOutput = notebookPage.executeCell(s"!$pip install $packageName")
-    installOutput shouldBe Symbol("defined")
+    installOutput shouldBe defined
     installOutput.get should include(s"Collecting $packageName")
     installOutput.get should include("Installing collected packages:")
     installOutput.get should include("Successfully installed")

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookTestUtils.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookTestUtils.scala
@@ -139,7 +139,7 @@ trait NotebookTestUtils extends LeonardoTestUtils {
     }
 
     val installOutput = notebookPage.executeCell(s"!$pip install $packageName")
-    installOutput shouldBe 'defined
+    installOutput shouldBe Symbol("defined")
     installOutput.get should include(s"Collecting $packageName")
     installOutput.get should include("Installing collected packages:")
     installOutput.get should include("Successfully installed")

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeCreationDiskSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeCreationDiskSpec.scala
@@ -49,7 +49,9 @@ class RuntimeCreationDiskSpec
       runtimeConfig = Some(
         RuntimeConfigRequest.GceConfig(
           None,
-          Some(DiskSize(20))
+          Some(DiskSize(20)),
+          None,
+          None
         )
       )
     )
@@ -94,7 +96,9 @@ class RuntimeCreationDiskSpec
             Some(diskSize),
             None,
             Map.empty
-          )
+          ),
+          None,
+          None
         )
       )
     )
@@ -147,7 +151,9 @@ class RuntimeCreationDiskSpec
               Some(DiskSize(500)), //this will be ignored since in this test we'll pre create a disk
               None,
               Map.empty
-            )
+            ),
+            None,
+            None
           )
         )
       )

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeGceSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeGceSpec.scala
@@ -114,8 +114,8 @@ class RuntimeGceSpec
                 |print(device_name)
                 |""".stripMargin
             val output = notebookPage.executeCell(deviceNameOutput).get
-            output should contain("GPU:0")
-            output should contain("GPU:1")
+            output.contains("GPU:0") shouldBe true
+            output.contains("GPU:1") shouldBe true
           }
         })
         _ <- LeonardoApiClient.deleteRuntime(project, runtimeName)

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeGceSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeGceSpec.scala
@@ -15,7 +15,7 @@ import org.broadinstitute.dsde.workbench.google2.{
 }
 import org.broadinstitute.dsde.workbench.leonardo.LeonardoApiClient.{defaultCreateRuntime2Request, getRuntime}
 import org.broadinstitute.dsde.workbench.leonardo.http.{PersistentDiskRequest, RuntimeConfigRequest}
-import org.broadinstitute.dsde.workbench.leonardo.notebooks.NotebookTestUtils
+import org.broadinstitute.dsde.workbench.leonardo.notebooks.{NotebookTestUtils, Python3}
 import org.broadinstitute.dsde.workbench.model.TraceId
 import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GcsObjectName, GcsPath, GoogleProject}
 import org.broadinstitute.dsde.workbench.service.Sam
@@ -60,7 +60,8 @@ class RuntimeGceSpec
             None,
             Map.empty
           ),
-          Some(targetZone)
+          Some(targetZone),
+          None
         )
       )
     )
@@ -71,6 +72,52 @@ class RuntimeGceSpec
         _ = getRuntimeResponse.runtimeConfig.asInstanceOf[RuntimeConfig.GceWithPdConfig].zone shouldBe targetZone
         disk <- LeonardoApiClient.getDisk(project, getRuntimeResponse.diskConfig.get.name)
         _ = disk.zone shouldBe targetZone
+        _ <- LeonardoApiClient.deleteRuntime(project, runtimeName)
+      } yield ()
+    }
+
+    res.unsafeRunSync()
+  }
+
+  "should be able to create a VM with GPU enabled" in { project =>
+    val runtimeName = randomClusterName
+    val diskName = genDiskName.sample.get
+
+    val toolImage = ContainerImage.fromImageUrl("us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:qi-gpu") // Use the default base image once we migrate to use gpu images by default
+    // In a europe zone
+    val createRuntimeRequest = defaultCreateRuntime2Request.copy(
+      runtimeConfig = Some(
+        RuntimeConfigRequest.GceWithPdConfig(Some(MachineTypeName("n1-standard-4")),
+                                             PersistentDiskRequest(
+                                               diskName,
+                                               None,
+                                               None,
+                                               Map.empty
+                                             ),
+                                             None,
+                                             Some(GpuConfig(GpuType.NvidiaTeslaT4, 2)))
+      ),
+      toolDockerImage = toolImage
+    )
+
+    val res = dependencies.use { deps =>
+      implicit val httpClient = deps.httpClient
+      for {
+        runtime <- LeonardoApiClient.createRuntimeWithWait(project, runtimeName, createRuntimeRequest)
+        clusterCopy = ClusterCopy.fromGetRuntimeResponseCopy(runtime)
+        _ <- IO(withWebDriver { implicit driver =>
+          withNewNotebook(clusterCopy, Python3) { notebookPage =>
+            val deviceNameOutput =
+              """
+                |import tensorflow as tf
+                |device_name = tf.test.gpu_device_name()
+                |print(device_name)
+                |""".stripMargin
+            val output = notebookPage.executeCell(deviceNameOutput).get
+            output should contain("GPU:0")
+            output should contain("GPU:1")
+          }
+        })
         _ <- LeonardoApiClient.deleteRuntime(project, runtimeName)
       } yield ()
     }

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeGceSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeGceSpec.scala
@@ -79,6 +79,7 @@ class RuntimeGceSpec
     res.unsafeRunSync()
   }
 
+  // Not enable this in automation test because we can get `ZONE_RESOURCE_POOL_EXHAUSTED` easily
   "should be able to create a VM with GPU enabled" in { project =>
     val runtimeName = randomClusterName
     val diskName = genDiskName.sample.get
@@ -110,8 +111,8 @@ class RuntimeGceSpec
             val deviceNameOutput =
               """
                 |import tensorflow as tf
-                |device_name = tf.test.gpu_device_name()
-                |print(device_name)
+                |gpus = tf.config.experimental.list_physical_devices('GPU')
+                |print(gpus)
                 |""".stripMargin
             val output = notebookPage.executeCell(deviceNameOutput).get
             output.contains("GPU:0") shouldBe true

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeGceSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeGceSpec.scala
@@ -88,15 +88,17 @@ class RuntimeGceSpec
     // In a europe zone
     val createRuntimeRequest = defaultCreateRuntime2Request.copy(
       runtimeConfig = Some(
-        RuntimeConfigRequest.GceWithPdConfig(Some(MachineTypeName("n1-standard-4")),
-                                             PersistentDiskRequest(
-                                               diskName,
-                                               None,
-                                               None,
-                                               Map.empty
-                                             ),
-                                             None,
-                                             Some(GpuConfig(GpuType.NvidiaTeslaT4, 2)))
+        RuntimeConfigRequest.GceWithPdConfig(
+          Some(MachineTypeName("n1-standard-4")),
+          PersistentDiskRequest(
+            diskName,
+            None,
+            None,
+            Map.empty
+          ),
+          Some(ZoneName("us-west1-a")),
+          Some(GpuConfig(GpuType.NvidiaTeslaT4, 2))
+        )
       ),
       toolDockerImage = toolImage
     )

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeGceSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeGceSpec.scala
@@ -80,7 +80,7 @@ class RuntimeGceSpec
   }
 
   // Not enable this in automation test because we can get `ZONE_RESOURCE_POOL_EXHAUSTED` easily
-  "should be able to create a VM with GPU enabled" in { project =>
+  "should be able to create a VM with GPU enabled" ignore { project =>
     val runtimeName = randomClusterName
     val diskName = genDiskName.sample.get
 

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimePatchSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimePatchSpec.scala
@@ -59,7 +59,9 @@ class RuntimePatchSpec
       runtimeConfig = Some(
         RuntimeConfigRequest.GceConfig(
           Some(MachineTypeName("n1-standard-4")),
-          Some(DiskSize(10))
+          Some(DiskSize(10)),
+          None,
+          None
         )
       )
     )
@@ -141,7 +143,9 @@ class RuntimePatchSpec
               Some(DiskSize(10)),
               None,
               Map.empty
-            )
+            ),
+            None,
+            None
           )
         )
       )

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimePatchSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimePatchSpec.scala
@@ -112,7 +112,7 @@ class RuntimePatchSpec
         res.diskSize shouldBe newDiskSize
       }
     }
-    res.unsafeRunSync
+    res.unsafeRunSync()
   }
 
   //this is an end to end test of the pub/sub infrastructure
@@ -186,7 +186,7 @@ class RuntimePatchSpec
           res.machineType shouldBe newMasterMachineType
         }
       }
-      res.unsafeRunSync
+      res.unsafeRunSync()
   }
 
   "Patch endpoint should perform a stop/start transition for Dataproc cluster" taggedAs (Tags.SmokeTest, Retryable) in {
@@ -279,6 +279,6 @@ class RuntimePatchSpec
           res.diskSize shouldBe newDiskSize
         }
       }
-      res.unsafeRunSync
+      res.unsafeRunSync()
   }
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/JsonCodec.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/JsonCodec.scala
@@ -105,13 +105,14 @@ object JsonCodec {
      x.cloudService,
      x.region)
   )
-  implicit val gceRuntimeConfigEncoder: Encoder[RuntimeConfig.GceConfig] = Encoder.forProduct5(
+  implicit val gceRuntimeConfigEncoder: Encoder[RuntimeConfig.GceConfig] = Encoder.forProduct6(
     "machineType",
     "diskSize",
     "cloudService",
     "bootDiskSize",
-    "zone"
-  )(x => (x.machineType, x.diskSize, x.cloudService, x.bootDiskSize, x.zone))
+    "zone",
+    "gpuConfig"
+  )(x => (x.machineType, x.diskSize, x.cloudService, x.bootDiskSize, x.zone, x.gpuConfig))
   implicit val userJupyterExtensionConfigEncoder: Encoder[UserJupyterExtensionConfig] = Encoder.forProduct4(
     "nbExtensions",
     "serverExtensions",
@@ -134,13 +135,14 @@ object JsonCodec {
     "homeDirectory",
     "timestamp"
   )(x => RuntimeImage.unapply(x).get)
-  implicit val gceWithPdConfigEncoder: Encoder[RuntimeConfig.GceWithPdConfig] = Encoder.forProduct5(
+  implicit val gceWithPdConfigEncoder: Encoder[RuntimeConfig.GceWithPdConfig] = Encoder.forProduct6(
     "machineType",
     "persistentDiskId",
     "cloudService",
     "bootDiskSize",
-    "zone"
-  )(x => (x.machineType, x.persistentDiskId, x.cloudService, x.bootDiskSize, x.zone))
+    "zone",
+    "gpuConfig"
+  )(x => (x.machineType, x.persistentDiskId, x.cloudService, x.bootDiskSize, x.zone, x.gpuConfig))
 
   implicit val runtimeConfigEncoder: Encoder[RuntimeConfig] = Encoder.instance(x =>
     x match {
@@ -357,18 +359,20 @@ object JsonCodec {
     "numOfGpus"
   )(GpuConfig.apply)
 
-  implicit val gceWithPdConfigDecoder: Decoder[RuntimeConfig.GceWithPdConfig] = Decoder.forProduct4(
+  implicit val gceWithPdConfigDecoder: Decoder[RuntimeConfig.GceWithPdConfig] = Decoder.forProduct5(
     "machineType",
     "persistentDiskId",
     "bootDiskSize",
-    "zone"
+    "zone",
+    "gpuConfig"
   )(RuntimeConfig.GceWithPdConfig.apply)
-  implicit val gceConfigDecoder: Decoder[RuntimeConfig.GceConfig] = Decoder.forProduct4(
+  implicit val gceConfigDecoder: Decoder[RuntimeConfig.GceConfig] = Decoder.forProduct5(
     "machineType",
     "diskSize",
     "bootDiskSize",
-    "zone"
-  )((mt, ds, bds, z) => RuntimeConfig.GceConfig(mt, ds, bds, z))
+    "zone",
+    "gpuConfig"
+  )((mt, ds, bds, z, gpu) => RuntimeConfig.GceConfig(mt, ds, bds, z, gpu))
 
   implicit val persistentDiskRequestDecoder: Decoder[PersistentDiskRequest] = Decoder.instance { x =>
     for {

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/runtimeRoutesModels.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/runtimeRoutesModels.scala
@@ -35,8 +35,8 @@ object RuntimeConfigRequest {
   final case class GceConfig(
     machineType: Option[MachineTypeName],
     diskSize: Option[DiskSize],
-    zone: Option[ZoneName] = None,
-    gpuConfig: Option[GpuConfig] = None
+    zone: Option[ZoneName],
+    gpuConfig: Option[GpuConfig]
   ) extends RuntimeConfigRequest {
     val cloudService: CloudService = CloudService.GCE
   }
@@ -44,8 +44,8 @@ object RuntimeConfigRequest {
   final case class GceWithPdConfig(
     machineType: Option[MachineTypeName],
     persistentDisk: PersistentDiskRequest,
-    zone: Option[ZoneName] = None,
-    gpuConfig: Option[GpuConfig] = None
+    zone: Option[ZoneName],
+    gpuConfig: Option[GpuConfig]
   ) extends RuntimeConfigRequest {
     val cloudService: CloudService = CloudService.GCE
   }

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/runtimeRoutesModels.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/runtimeRoutesModels.scala
@@ -10,6 +10,7 @@ import org.broadinstitute.dsde.workbench.leonardo.{
   ContainerRegistry,
   DataprocInstance,
   DiskSize,
+  GpuConfig,
   LabelMap,
   Runtime,
   RuntimeConfig,
@@ -22,9 +23,9 @@ import org.broadinstitute.dsde.workbench.leonardo.{
 }
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
-
 import java.net.URL
 import java.time.Instant
+
 import scala.concurrent.duration.FiniteDuration
 
 sealed trait RuntimeConfigRequest extends Product with Serializable {
@@ -34,7 +35,8 @@ object RuntimeConfigRequest {
   final case class GceConfig(
     machineType: Option[MachineTypeName],
     diskSize: Option[DiskSize],
-    zone: Option[ZoneName] = None
+    zone: Option[ZoneName] = None,
+    gpuConfig: Option[GpuConfig] = None
   ) extends RuntimeConfigRequest {
     val cloudService: CloudService = CloudService.GCE
   }
@@ -42,7 +44,8 @@ object RuntimeConfigRequest {
   final case class GceWithPdConfig(
     machineType: Option[MachineTypeName],
     persistentDisk: PersistentDiskRequest,
-    zone: Option[ZoneName] = None
+    zone: Option[ZoneName] = None,
+    gpuConfig: Option[GpuConfig] = None
   ) extends RuntimeConfigRequest {
     val cloudService: CloudService = CloudService.GCE
   }

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/runtimeModels.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/runtimeModels.scala
@@ -232,7 +232,8 @@ object RuntimeConfig {
     bootDiskSize: Option[
       DiskSize
     ], //This is optional for supporting old runtimes which only have 1 disk. All new runtime will have a boot disk
-    zone: ZoneName
+    zone: ZoneName,
+    gpuConfig: Option[GpuConfig] //This is optional since not all runtimes use gpus
   ) extends RuntimeConfig {
     val cloudService: CloudService = CloudService.GCE
   }
@@ -241,7 +242,8 @@ object RuntimeConfig {
   final case class GceWithPdConfig(machineType: MachineTypeName,
                                    persistentDiskId: Option[DiskId],
                                    bootDiskSize: DiskSize,
-                                   zone: ZoneName)
+                                   zone: ZoneName,
+                                   gpuConfig: Option[GpuConfig])
       extends RuntimeConfig {
     val cloudService: CloudService = CloudService.GCE
   }

--- a/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/JsonCodecSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/JsonCodecSpec.scala
@@ -38,7 +38,7 @@ class JsonCodecSpec extends LeonardoTestSuite with Matchers with AnyFlatSpecLike
     res shouldBe (Right(expected))
   }
 
-  it should "decode GCEConfig properly" in {
+  it should "decode GCEConfig without GPU properly" in {
     val inputString =
       """
         |{
@@ -54,7 +54,34 @@ class JsonCodecSpec extends LeonardoTestSuite with Matchers with AnyFlatSpecLike
       MachineTypeName("n1-standard-8"),
       DiskSize(500),
       None,
-      ZoneName("us-west2-b")
+      ZoneName("us-west2-b"),
+      None
+    )
+    res shouldBe (Right(expected))
+  }
+
+  it should "decode GCEConfig with GPU properly" in {
+    val inputString =
+      """
+        |{
+        |   "machineType": "n1-standard-8",
+        |   "diskSize": 500,
+        |   "cloudService": "GCE",
+        |   "zone": "us-west2-b",
+        |   "gpuConfig": {
+        |     "gpuType": "nvidia-tesla-t4"
+        |     "numOfGpus": 2
+        |   }
+        |}
+        |""".stripMargin
+
+    val res = decode[RuntimeConfig](inputString)
+    val expected = RuntimeConfig.GceConfig(
+      MachineTypeName("n1-standard-8"),
+      DiskSize(500),
+      None,
+      ZoneName("us-west2-b"),
+      Some(GpuConfig(GpuType.NvidiaTeslaT4, 2))
     )
     res shouldBe (Right(expected))
   }
@@ -76,7 +103,8 @@ class JsonCodecSpec extends LeonardoTestSuite with Matchers with AnyFlatSpecLike
       MachineTypeName("n1-standard-8"),
       None,
       DiskSize(50),
-      ZoneName("us-west2-b")
+      ZoneName("us-west2-b"),
+      None
     )
     res shouldBe (Right(expected))
   }
@@ -108,14 +136,22 @@ class JsonCodecSpec extends LeonardoTestSuite with Matchers with AnyFlatSpecLike
         |   "machineType": "n1-standard-8",
         |   "persistentDiskId": 50,
         |   "bootDiskSize": 50,
-        |   "zone": "us-west2-b"
+        |   "zone": "us-west2-b",
+        |   "gpuConfig": {
+        |     "gpuType": "nvidia-tesla-t4",
+        |     "numOfGpus": 2
+        |   }
         |}
         |""".stripMargin
 
     val res = decode[RuntimeConfig](inputString)
     res shouldBe Right(
       RuntimeConfig
-        .GceWithPdConfig(MachineTypeName("n1-standard-8"), Some(DiskId(50)), DiskSize(50), ZoneName("us-west2-b"))
+        .GceWithPdConfig(MachineTypeName("n1-standard-8"),
+                         Some(DiskId(50)),
+                         DiskSize(50),
+                         ZoneName("us-west2-b"),
+                         Some(GpuConfig(GpuType.NvidiaTeslaT4, 2)))
     )
   }
 

--- a/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/JsonCodecSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/JsonCodecSpec.scala
@@ -69,7 +69,7 @@ class JsonCodecSpec extends LeonardoTestSuite with Matchers with AnyFlatSpecLike
         |   "cloudService": "GCE",
         |   "zone": "us-west2-b",
         |   "gpuConfig": {
-        |     "gpuType": "nvidia-tesla-t4"
+        |     "gpuType": "nvidia-tesla-t4",
         |     "numOfGpus": 2
         |   }
         |}

--- a/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/RuntimeRoutesTestJsonCodec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/RuntimeRoutesTestJsonCodec.scala
@@ -45,20 +45,22 @@ object RuntimeRoutesTestJsonCodec {
      x.numberOfPreemptibleWorkers,
      x.region)
   )
-  implicit val gceRuntimeConfigRequestEncoder: Encoder[RuntimeConfigRequest.GceConfig] = Encoder.forProduct4(
+  implicit val gceRuntimeConfigRequestEncoder: Encoder[RuntimeConfigRequest.GceConfig] = Encoder.forProduct5(
     "cloudService",
     "machineType",
     "diskSize",
-    "zone"
-  )(x => (x.cloudService, x.machineType, x.diskSize, x.zone))
+    "zone",
+    "gpuConfig"
+  )(x => (x.cloudService, x.machineType, x.diskSize, x.zone, x.gpuConfig))
 
   implicit val gceWithPdRuntimeConfigRequestEncoder: Encoder[RuntimeConfigRequest.GceWithPdConfig] =
-    Encoder.forProduct4(
+    Encoder.forProduct5(
       "cloudService",
       "machineType",
       "persistentDisk",
-      "zone"
-    )(x => (x.cloudService, x.machineType, x.persistentDisk, x.zone))
+      "zone",
+      "gpuConfig"
+    )(x => (x.cloudService, x.machineType, x.persistentDisk, x.zone, x.gpuConfig))
 
   implicit val runtimeConfigRequestEncoder: Encoder[RuntimeConfigRequest] = Encoder.instance { x =>
     x match {

--- a/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changelog.xml
+++ b/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changelog.xml
@@ -76,4 +76,5 @@
     <include file="changesets/20210414_add_home_dir.xml" relativeToChangelogFile="true" />
     <include file="changesets/20210505_rename_jupyter_user_script_column.xml" relativeToChangelogFile="true" />
     <include file="changesets/20210429_rename_vm.xml" relativeToChangelogFile="true" />
+    <include file="changesets/20210517_add_gpu_config.xml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/20210517_add_gpu_config.xml
+++ b/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/20210517_add_gpu_config.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog logicalFilePath="leonardo" xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+
+    <changeSet logicalFilePath="leonardo" author="jdcanas" id="add_gpu_config">
+        <addColumn tableName="RUNTIME_CONFIG">
+            <column name="gpuType" type="VARCHAR(254)">
+                <constraints nullable="true"/>
+            </column>
+        </addColumn>
+
+        <addColumn tableName="RUNTIME_CONFIG">
+            <column name="numOfGpus" type="INT">
+                <constraints nullable="true"/>
+            </column>
+        </addColumn>
+    </changeSet>
+
+</databaseChangeLog>

--- a/http/src/main/resources/swagger/api-docs.yaml
+++ b/http/src/main/resources/swagger/api-docs.yaml
@@ -2359,6 +2359,8 @@ components:
               description: >
                 Optional, the deployment area of the GCE VM. For example, us-east1-a or europe-west2-c.
                 Defaults to us-central1-a.
+            gpuConfig:
+              $ref: "#/components/schemas/GpuConfig"
     GceWithPdConfig:
       description: Configuration for Google Compute Engine instances.
       allOf:
@@ -2384,6 +2386,8 @@ components:
               description: >
                 Optional, the deployment area of the GCE VM. For example, us-east1-a or europe-west2-c.
                 Defaults to us-central1-a.
+            gpuConfig:
+              $ref: "#/components/schemas/GpuConfig"
     DataprocConfig:
       description: Configuration for a single Dataproc cluster.
       allOf:
@@ -2672,3 +2676,18 @@ components:
         googleErrorCode:
           type: integer
           description: if the error is associated with an external API call, the error code will be propagated here
+
+    GpuConfig:
+      description: A config that describes the gpus associated with a runtime
+      type: object
+      required:
+        - gpuType
+        - numOfGpus
+
+      properties:
+        gpuType:
+          type: string
+          description: The google identifier for the gpu specs associated with this runtime, ex `nvidia-tesla-t4`. See https://cloud.google.com/compute/docs/gpus
+        numOfGpus:
+          type: integer
+          description: The number of gpus associated with this runtime

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/LeoLenses.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/LeoLenses.scala
@@ -52,7 +52,7 @@ object LeoLenses {
               )
             ),
           x.zone,
-          None //TODO: Justin's front leo will populate this properly
+          x.gpuConfig
         )
       )
     case x: RuntimeConfig.GceWithPdConfig =>
@@ -66,7 +66,7 @@ object LeoLenses {
           ),
           x.bootDiskSize,
           x.zone,
-          None //TODO: Justin's front leo will populate this properly
+          x.gpuConfig
         )
       )
     case x: RuntimeConfig.DataprocConfig =>
@@ -77,14 +77,16 @@ object LeoLenses {
         x.machineType,
         x.diskSize,
         Some(x.bootDiskSize),
-        x.zone
+        x.zone,
+        x.gpuConfig
       )
     case x: RuntimeConfigInCreateRuntimeMessage.GceWithPdConfig =>
       RuntimeConfig.GceWithPdConfig(
         x.machineType,
         Some(x.persistentDiskId),
         x.bootDiskSize,
-        x.zone
+        x.zone,
+        x.gpuConfig
       )
     case x: RuntimeConfigInCreateRuntimeMessage.DataprocConfig =>
       dataprocInCreateRuntimeMsgToDataprocRuntime(x)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
@@ -87,7 +87,8 @@ object Config {
       machineType = config.as[MachineTypeName]("machineType"),
       diskSize = config.as[DiskSize]("diskSize"),
       bootDiskSize = Some(config.as[DiskSize]("bootDiskSize")),
-      zone = config.as[ZoneName]("zone")
+      zone = config.as[ZoneName]("zone"),
+      gpuConfig = None
     )
   }
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/LeoProfile.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/LeoProfile.scala
@@ -249,6 +249,12 @@ private[leonardo] object LeoProfile extends MySQLProfile {
         _.toString,
         s => Uri.fromString(s).getOrElse(throw ColumnDecodingException(s"invalid uri $s"))
       )
+    implicit val gpuTypeColumnType: BaseColumnType[GpuType] =
+      MappedColumnType.base[GpuType, String](
+        _.asString,
+        s => GpuType.stringToObject.getOrElse(s, throw ColumnDecodingException(s"invalid gpuType $s"))
+      )
+
   }
 
   case class ColumnDecodingException(message: String) extends Exception

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/RuntimeConfigTable.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/RuntimeConfigTable.scala
@@ -25,7 +25,6 @@ class RuntimeConfigTable(tag: Tag) extends Table[RuntimeConfigRecord](tag, "RUNT
   def zone = column[Option[ZoneName]]("zone", O.Length(254))
   def region = column[Option[RegionName]]("region", O.Length(254))
   def gpuType = column[Option[GpuType]]("gpuType", O.Length(254))
-  //TODO use class instead of int when we aren't working on same branch
   def numOfGpus = column[Option[Int]]("numOfGpus")
 
   def * =

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/RuntimeRoutes.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/RuntimeRoutes.scala
@@ -251,7 +251,8 @@ object RuntimeRoutes {
         .downField("persistentDisk")
         .as[PersistentDiskRequest]
       zone <- x.downField("zone").as[Option[ZoneName]]
-    } yield RuntimeConfigRequest.GceWithPdConfig(machineType, pd, zone)
+      gpu <- x.downField("gpuConfig").as[Option[GpuConfig]]
+    } yield RuntimeConfigRequest.GceWithPdConfig(machineType, pd, zone, gpu)
   }
 
   implicit val gceConfigRequestDecoder: Decoder[RuntimeConfigRequest.GceConfig] = Decoder.instance { x =>
@@ -261,7 +262,8 @@ object RuntimeRoutes {
         .downField("diskSize")
         .as[Option[DiskSize]]
       zone <- x.downField("zone").as[Option[ZoneName]]
-    } yield RuntimeConfigRequest.GceConfig(machineType, diskSize, zone)
+      gpu <- x.downField("gpuConfig").as[Option[GpuConfig]]
+    } yield RuntimeConfigRequest.GceConfig(machineType, diskSize, zone, gpu)
   }
 
   val invalidPropertiesError =
@@ -345,12 +347,13 @@ object RuntimeRoutes {
             machineType <- x.downField("machineType").as[Option[MachineTypeName]]
             pd <- x.downField("persistentDisk").as[Option[PersistentDiskRequest]]
             zone <- x.downField("zone").as[Option[ZoneName]]
+            gpu <- x.downField("gpuConfig").as[Option[GpuConfig]]
             res <- pd match {
-              case Some(p) => RuntimeConfigRequest.GceWithPdConfig(machineType, p, zone).asRight[DecodingFailure]
+              case Some(p) => RuntimeConfigRequest.GceWithPdConfig(machineType, p, zone, gpu).asRight[DecodingFailure]
               case None =>
                 x.downField("diskSize")
                   .as[Option[DiskSize]]
-                  .map(d => RuntimeConfigRequest.GceConfig(machineType, d, zone))
+                  .map(d => RuntimeConfigRequest.GceConfig(machineType, d, zone, gpu))
             }
           } yield res
       }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterp.scala
@@ -127,7 +127,7 @@ class RuntimeServiceInterp[F[_]: Parallel](config: RuntimeServiceConfig,
                           gce.diskSize.getOrElse(config.gceConfig.runtimeConfigDefaults.diskSize),
                           bootDiskSize,
                           gce.zone.getOrElse(config.gceConfig.runtimeConfigDefaults.zone),
-                          None //TODO, Justin's ticket will take care of this
+                          gce.gpuConfig
                         ): RuntimeConfigInCreateRuntimeMessage
                       )
                     case dataproc: RuntimeConfigRequest.DataprocConfig =>
@@ -153,7 +153,7 @@ class RuntimeServiceInterp[F[_]: Parallel](config: RuntimeServiceConfig,
                             diskResult.disk.id,
                             bootDiskSize,
                             gce.zone.getOrElse(config.gceConfig.runtimeConfigDefaults.zone),
-                            None // Some(GpuConfig(GpuType.NvidiaTeslaP4, 1)) TODO, Justin's ticket will take care of this
+                            gce.gpuConfig
                           ): RuntimeConfigInCreateRuntimeMessage
                         )
                   }
@@ -633,7 +633,7 @@ class RuntimeServiceInterp[F[_]: Parallel](config: RuntimeServiceConfig,
     for {
       context <- ctx.ask
       msg <- (runtimeConfig, request) match {
-        case (RuntimeConfig.GceConfig(machineType, existngDiskSize, _, _),
+        case (RuntimeConfig.GceConfig(machineType, existngDiskSize, _, _, _),
               UpdateRuntimeConfigRequest.GceConfig(newMachineType, diskSizeInRequest)) =>
           for {
             targetDiskSize <- traverseIfChanged(diskSizeInRequest, existngDiskSize) { d =>
@@ -652,7 +652,7 @@ class RuntimeServiceInterp[F[_]: Parallel](config: RuntimeServiceConfig,
                                                targetDiskSize,
                                                context.traceId)
           } yield r
-        case (RuntimeConfig.GceWithPdConfig(machineType, diskIdOpt, _, _),
+        case (RuntimeConfig.GceWithPdConfig(machineType, diskIdOpt, _, _, _),
               UpdateRuntimeConfigRequest.GceConfig(newMachineType, diskSizeInRequest)) =>
           for {
             // should disk size be updated?

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/BaseCloudServiceRuntimeMonitor.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/BaseCloudServiceRuntimeMonitor.scala
@@ -154,7 +154,7 @@ abstract class BaseCloudServiceRuntimeMonitor[F[_]] {
             )
           case _ =>
             logger.info(ctx.loggingCtx)(
-              s"failedRuntime: moving runtime with id  ${runtimeAndRuntimeConfig.runtime.id} to Error status."
+              s"failedRuntime: moving runtime with id  ${runtimeAndRuntimeConfig.runtime.id} to Error status because ${errorDetails.longMessage}"
             ) >> clusterQuery
               .updateClusterStatus(runtimeAndRuntimeConfig.runtime.id, RuntimeStatus.Error, ctx.now)
               .transaction

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/MonitorAtBoot.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/MonitorAtBoot.scala
@@ -206,7 +206,7 @@ class MonitorAtBoot[F[_]: Timer](publisherQueue: fs2.concurrent.Queue[F, LeoPubs
                 x.diskSize,
                 bootDiskSize,
                 x.zone,
-                None //TODO: Justin's front leo will populate this properly
+                x.gpuConfig
               ): RuntimeConfigInCreateRuntimeMessage
             case x: RuntimeConfig.GceWithPdConfig =>
               for {
@@ -218,7 +218,7 @@ class MonitorAtBoot[F[_]: Timer](publisherQueue: fs2.concurrent.Queue[F, LeoPubs
                 diskId,
                 x.bootDiskSize,
                 x.zone,
-                None //TODO: Justin's front leo will populate this properly
+                x.gpuConfig
               ): RuntimeConfigInCreateRuntimeMessage
             case _: RuntimeConfig.DataprocConfig =>
               Right(

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/BaseRuntimeInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/BaseRuntimeInterpreter.scala
@@ -168,7 +168,7 @@ abstract private[util] class BaseRuntimeInterpreter[F[_]: ContextShift](
     } yield ()
 
   // Startup script to run after the runtime is resumed
-  protected def getStartupScript(runtime: Runtime,
+  protected def getStartupScript(runtimeAndRuntimeConfig: RuntimeAndRuntimeConfig,
                                  welderAction: Option[WelderAction],
                                  initBucket: GcsBucketName,
                                  blocker: Blocker,
@@ -179,7 +179,7 @@ abstract private[util] class BaseRuntimeInterpreter[F[_]: ContextShift](
     val googleKey = "startup-script" // required; see https://cloud.google.com/compute/docs/startupscript
 
     val templateConfig = RuntimeTemplateValuesConfig.fromRuntime(
-      runtime,
+      runtimeAndRuntimeConfig,
       Some(initBucket),
       None,
       config.imageConfig,
@@ -211,11 +211,12 @@ abstract private[util] class BaseRuntimeInterpreter[F[_]: ContextShift](
   }
 
   // Shutdown script to run after the runtime is paused
-  protected def getShutdownScript(runtime: Runtime, blocker: Blocker): F[Map[String, String]] = {
+  protected def getShutdownScript(runtimeAndRuntimeConfig: RuntimeAndRuntimeConfig,
+                                  blocker: Blocker): F[Map[String, String]] = {
     val googleKey = "shutdown-script" // required; see https://cloud.google.com/compute/docs/shutdownscript
 
     val templateConfig = RuntimeTemplateValuesConfig.fromRuntime(
-      runtime,
+      runtimeAndRuntimeConfig,
       None,
       None,
       config.imageConfig,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/DataprocInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/DataprocInterpreter.scala
@@ -295,7 +295,7 @@ class DataprocInterpreter[F[_]: Timer: Parallel: ContextShift](
           LeoLenses.dataprocRegion.getOption(params.runtimeAndRuntimeConfig.runtimeConfig),
           new RuntimeException("DataprocInterpreter shouldn't get a GCE request")
         )
-        metadata <- getShutdownScript(params.runtimeAndRuntimeConfig.runtime, blocker)
+        metadata <- getShutdownScript(params.runtimeAndRuntimeConfig, blocker)
         _ <- params.runtimeAndRuntimeConfig.runtime.dataprocInstances.find(_.dataprocRole == Master).traverse {
           instance =>
             googleComputeService
@@ -325,7 +325,7 @@ class DataprocInterpreter[F[_]: Timer: Parallel: ContextShift](
         LeoLenses.dataprocRegion.getOption(params.runtimeAndRuntimeConfig.runtimeConfig),
         new RuntimeException("DataprocInterpreter shouldn't get a GCE request")
       )
-      metadata <- getShutdownScript(params.runtimeAndRuntimeConfig.runtime, blocker)
+      metadata <- getShutdownScript(params.runtimeAndRuntimeConfig, blocker)
       _ <- googleDataprocService.stopCluster(
         params.runtimeAndRuntimeConfig.runtime.googleProject,
         region,
@@ -349,7 +349,7 @@ class DataprocInterpreter[F[_]: Timer: Parallel: ContextShift](
         params.runtimeAndRuntimeConfig.runtimeConfig.machineType,
         dataprocConfig.region
       )
-      metadata <- getStartupScript(params.runtimeAndRuntimeConfig.runtime,
+      metadata <- getStartupScript(params.runtimeAndRuntimeConfig,
                                    params.welderAction,
                                    params.initBucket,
                                    blocker,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GceInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GceInterpreter.scala
@@ -136,6 +136,7 @@ class GceInterpreter[F[_]: Parallel: ContextShift](
             .newBuilder()
             .setDescription("Leonardo Managed Boot Disk")
             .setSourceImage(config.gceConfig.sourceImage.asString)
+            .setDiskSizeGb(bootDiskSize.gb.toString)
             .putAllLabels(Map("leonardo" -> "true").asJava)
             .build()
         )

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GceInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GceInterpreter.scala
@@ -323,7 +323,7 @@ class GceInterpreter[F[_]: Parallel: ContextShift](
           "GceInterpreter shouldn't get a stop dataproc runtime request. Something is very wrong"
         )
       )
-      metadata <- getShutdownScript(params.runtimeAndRuntimeConfig.runtime, blocker)
+      metadata <- getShutdownScript(params.runtimeAndRuntimeConfig, blocker)
       _ <- googleComputeService.addInstanceMetadata(
         params.runtimeAndRuntimeConfig.runtime.googleProject,
         zoneParam,
@@ -349,7 +349,7 @@ class GceInterpreter[F[_]: Parallel: ContextShift](
       resourceConstraints <- getResourceConstraints(params.runtimeAndRuntimeConfig.runtime.googleProject,
                                                     zoneParam,
                                                     params.runtimeAndRuntimeConfig.runtimeConfig.machineType)
-      metadata <- getStartupScript(params.runtimeAndRuntimeConfig.runtime,
+      metadata <- getStartupScript(params.runtimeAndRuntimeConfig,
                                    params.welderAction,
                                    params.initBucket,
                                    blocker,
@@ -397,7 +397,7 @@ class GceInterpreter[F[_]: Parallel: ContextShift](
             "GceInterpreter shouldn't get a dataproc runtime creation request. Something is very wrong"
           )
         )
-        metadata <- getShutdownScript(params.runtimeAndRuntimeConfig.runtime, blocker)
+        metadata <- getShutdownScript(params.runtimeAndRuntimeConfig, blocker)
         _ <- googleComputeService
           .addInstanceMetadata(
             params.runtimeAndRuntimeConfig.runtime.googleProject,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/RuntimeTemplateValues.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/RuntimeTemplateValues.scala
@@ -2,6 +2,7 @@ package org.broadinstitute.dsde.workbench.leonardo.util
 
 import java.time.format.{DateTimeFormatter, FormatStyle}
 import java.time.{Instant, ZoneId}
+
 import org.broadinstitute.dsde.workbench.leonardo.RuntimeImageType.{CryptoDetector, Jupyter, Proxy, RStudio, Welder}
 import org.broadinstitute.dsde.workbench.leonardo.WelderAction._
 import org.broadinstitute.dsde.workbench.leonardo._
@@ -10,7 +11,7 @@ import org.broadinstitute.dsde.workbench.leonardo.monitor.RuntimeConfigInCreateR
 import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GcsObjectName, GcsPath, ServiceAccountKey}
 
 case class RuntimeTemplateValues private (googleProject: String,
-                                          gpuEnabled: Boolean,
+                                          gpuEnabled: String,
                                           clusterName: String,
                                           initBucketName: String,
                                           stagingBucketName: String,
@@ -136,7 +137,7 @@ object RuntimeTemplateValuesConfig {
       false
     )
 
-  def fromRuntime(runtime: Runtime,
+  def fromRuntime(runtimeAndRuntimeConfig: RuntimeAndRuntimeConfig,
                   initBucketName: Option[GcsBucketName],
                   serviceAccountKey: Option[ServiceAccountKey],
                   imageConfig: ImageConfig,
@@ -147,10 +148,15 @@ object RuntimeTemplateValuesConfig {
                   clusterResourceConstraints: Option[RuntimeResourceConstraints],
                   runtimeOperation: RuntimeOperation,
                   welderAction: Option[WelderAction],
-                  useGceStartupScript: Boolean): RuntimeTemplateValuesConfig =
+                  useGceStartupScript: Boolean): RuntimeTemplateValuesConfig = {
+    val runtime = runtimeAndRuntimeConfig.runtime
     RuntimeTemplateValuesConfig(
       RuntimeProjectAndName(runtime.googleProject, runtime.runtimeName),
-      false, //TODO: Justin's front leo will populate this properly
+      runtimeAndRuntimeConfig.runtimeConfig match {
+        case gce: RuntimeConfig.GceConfig       => gce.gpuConfig.isDefined
+        case gce: RuntimeConfig.GceWithPdConfig => gce.gpuConfig.isDefined
+        case _: RuntimeConfig.DataprocConfig    => false
+      },
       runtime.asyncRuntimeFields.map(_.stagingBucket),
       runtime.runtimeImages,
       initBucketName,
@@ -172,6 +178,7 @@ object RuntimeTemplateValuesConfig {
       false,
       useGceStartupScript
     )
+  }
 }
 
 object RuntimeTemplateValues {
@@ -186,7 +193,7 @@ object RuntimeTemplateValues {
         .getOrElse("/home/jupyter-user")
     RuntimeTemplateValues(
       config.runtimeProjectAndName.googleProject.value,
-      config.gpuEnabled,
+      config.gpuEnabled.toString,
       config.runtimeProjectAndName.runtimeName.asString,
       config.initBucketName.map(_.value).getOrElse(""),
       config.stagingBucketName.map(_.value).getOrElse(""),

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/CommonTestData.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/CommonTestData.scala
@@ -197,7 +197,7 @@ object CommonTestData {
     Map("lbl1" -> "true"),
     None,
     Some(UserScriptPath.Gcs(GcsPath(GcsBucketName("bucket"), GcsObjectName("script.sh")))),
-    Some(RuntimeConfigRequest.GceConfig(Some(MachineTypeName("n1-standard-4")), Some(DiskSize(100)))),
+    Some(RuntimeConfigRequest.GceConfig(Some(MachineTypeName("n1-standard-4")), Some(DiskSize(100)), None, None)),
     None,
     Some(true),
     Some(30.minutes),

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/CommonTestData.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/CommonTestData.scala
@@ -211,7 +211,8 @@ object CommonTestData {
     RuntimeConfig.GceConfig(MachineTypeName("n1-standard-4"),
                             DiskSize(500),
                             bootDiskSize = Some(DiskSize(50)),
-                            zone = ZoneName("us-west2-b"))
+                            zone = ZoneName("us-west2-b"),
+                            None)
   val defaultRuntimeConfigRequest =
     RuntimeConfigRequest.DataprocConfig(Some(0),
                                         Some(MachineTypeName("n1-standard-4")),
@@ -221,16 +222,22 @@ object CommonTestData {
                                         None,
                                         None,
                                         Map.empty[String, String])
+
+  val gpuConfig = Some(GpuConfig(GpuType.NvidiaTeslaT4, 2))
   val gceRuntimeConfig =
     RuntimeConfig.GceConfig(MachineTypeName("n1-standard-4"),
                             DiskSize(500),
                             bootDiskSize = Some(DiskSize(50)),
-                            zone = ZoneName("us-west2-b"))
+                            zone = ZoneName("us-west2-b"),
+                            None)
+
+  val gceRuntimeConfigWithGpu = gceRuntimeConfig.copy(gpuConfig = gpuConfig)
   val gceWithPdRuntimeConfig =
     RuntimeConfig.GceWithPdConfig(MachineTypeName("n1-standard-4"),
                                   Some(DiskId(1234)),
                                   DiskSize(50),
-                                  ZoneName("us-west2-b"))
+                                  ZoneName("us-west2-b"),
+                                  None)
 
   def makeCluster(index: Int): Runtime = {
     val clusterName = RuntimeName("clustername" + index.toString)

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponentSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponentSpec.scala
@@ -297,7 +297,7 @@ class ClusterComponentSpec extends AnyFlatSpecLike with TestComponent with GcsPa
 
     val retrievedCluster = dbFutureValue(clusterQuery.getClusterById(savedCluster.id))
 
-    retrievedCluster shouldBe Symbol("defined")
+    retrievedCluster shouldBe defined
     retrievedCluster.get.customEnvironmentVariables shouldBe expectedEvs
     retrievedCluster.get shouldBe savedCluster
   }
@@ -345,7 +345,7 @@ class ClusterComponentSpec extends AnyFlatSpecLike with TestComponent with GcsPa
         )
       ).attempt
     } yield {
-      retrievedRuntime shouldBe Symbol("defined")
+      retrievedRuntime shouldBe defined
       runtimeConfig.asInstanceOf[RuntimeConfig.GceWithPdConfig].persistentDiskId shouldBe Some(savedDisk.id)
       error.isLeft shouldBe true
     }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponentSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponentSpec.scala
@@ -329,7 +329,8 @@ class ClusterComponentSpec extends AnyFlatSpecLike with TestComponent with GcsPa
           RuntimeConfig.GceWithPdConfig(defaultMachineType,
                                         Some(savedDisk.id),
                                         bootDiskSize = DiskSize(50),
-                                        zone = ZoneName("us-west2-b"))
+                                        zone = ZoneName("us-west2-b"),
+                                        None)
         )
       )
       retrievedRuntime <- clusterQuery.getClusterById(savedRuntime.id).transaction
@@ -339,7 +340,8 @@ class ClusterComponentSpec extends AnyFlatSpecLike with TestComponent with GcsPa
           RuntimeConfig.GceWithPdConfig(defaultMachineType,
                                         Some(DiskId(-1)),
                                         bootDiskSize = DiskSize(50),
-                                        zone = ZoneName("us-west2-b"))
+                                        zone = ZoneName("us-west2-b"),
+                                        None)
         )
       ).attempt
     } yield {

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponentSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponentSpec.scala
@@ -297,7 +297,7 @@ class ClusterComponentSpec extends AnyFlatSpecLike with TestComponent with GcsPa
 
     val retrievedCluster = dbFutureValue(clusterQuery.getClusterById(savedCluster.id))
 
-    retrievedCluster shouldBe 'defined
+    retrievedCluster shouldBe Symbol("defined")
     retrievedCluster.get.customEnvironmentVariables shouldBe expectedEvs
     retrievedCluster.get shouldBe savedCluster
   }
@@ -345,7 +345,7 @@ class ClusterComponentSpec extends AnyFlatSpecLike with TestComponent with GcsPa
         )
       ).attempt
     } yield {
-      retrievedRuntime shouldBe 'defined
+      retrievedRuntime shouldBe Symbol("defined")
       runtimeConfig.asInstanceOf[RuntimeConfig.GceWithPdConfig].persistentDiskId shouldBe Some(savedDisk.id)
       error.isLeft shouldBe true
     }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/InstanceComponentSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/InstanceComponentSpec.scala
@@ -33,7 +33,7 @@ class InstanceComponentSpec extends AnyFlatSpecLike with TestComponent with GcsP
       instanceQuery.updateStatusAndIpForCluster(savedCluster1.id, GceInstanceStatus.Provisioning, Some(IP("4.5.6.7")))
     } shouldEqual 1
     val updated = dbFutureValue(instanceQuery.getInstanceByKey(masterInstance.key))
-    updated shouldBe 'defined
+    updated shouldBe Symbol("defined")
     updated.get.status shouldBe GceInstanceStatus.Provisioning
     updated.get.ip shouldBe Some(IP("4.5.6.7"))
   }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/InstanceComponentSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/InstanceComponentSpec.scala
@@ -33,7 +33,7 @@ class InstanceComponentSpec extends AnyFlatSpecLike with TestComponent with GcsP
       instanceQuery.updateStatusAndIpForCluster(savedCluster1.id, GceInstanceStatus.Provisioning, Some(IP("4.5.6.7")))
     } shouldEqual 1
     val updated = dbFutureValue(instanceQuery.getInstanceByKey(masterInstance.key))
-    updated shouldBe Symbol("defined")
+    updated shouldBe defined
     updated.get.status shouldBe GceInstanceStatus.Provisioning
     updated.get.ip shouldBe Some(IP("4.5.6.7"))
   }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/RuntimeConfigQueriesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/RuntimeConfigQueriesSpec.scala
@@ -6,7 +6,7 @@ import java.util.concurrent.TimeUnit
 import org.broadinstitute.dsde.workbench.google2.{MachineTypeName, RegionName, ZoneName}
 import org.broadinstitute.dsde.workbench.leonardo.CommonTestData.makePersistentDisk
 import org.broadinstitute.dsde.workbench.leonardo.http.dbioToIO
-import org.broadinstitute.dsde.workbench.leonardo.{DiskSize, LeonardoTestSuite, RuntimeConfig}
+import org.broadinstitute.dsde.workbench.leonardo.{DiskSize, GpuConfig, GpuType, LeonardoTestSuite, RuntimeConfig}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import org.scalatest.flatspec.AnyFlatSpecLike
@@ -39,13 +39,15 @@ class RuntimeConfigQueriesSpec extends AnyFlatSpecLike with TestComponent with L
       MachineTypeName("n1-standard-4"),
       DiskSize(100),
       Some(DiskSize(50)),
-      ZoneName("us-west2-b")
+      ZoneName("us-west2-b"),
+      None
     )
     val runtimeConfig2 = RuntimeConfig.GceConfig(
       MachineTypeName("n1-standard-4"),
       DiskSize(100),
       None,
-      ZoneName("us-west2-b")
+      ZoneName("us-west2-b"),
+      Some(GpuConfig(GpuType.NvidiaTeslaT4, 2))
     )
     val res = for {
       now <- testTimer.clock.realTime(TimeUnit.MILLISECONDS)
@@ -69,7 +71,8 @@ class RuntimeConfigQueriesSpec extends AnyFlatSpecLike with TestComponent with L
         MachineTypeName("n1-standard-4"),
         Some(savedDisk.id),
         DiskSize(50),
-        ZoneName("us-west2-b")
+        ZoneName("us-west2-b"),
+        Some(GpuConfig(GpuType.NvidiaTeslaT4, 2))
       )
       id <- RuntimeConfigQueries.insertRuntimeConfig(runtimeConfig, Instant.ofEpochMilli(now)).transaction
       rc <- RuntimeConfigQueries.getRuntimeConfig(id).transaction

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/RuntimeServiceDbQueriesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/RuntimeServiceDbQueriesSpec.scala
@@ -52,7 +52,8 @@ class RuntimeServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent wit
       d1RuntimeConfig = RuntimeConfig.GceWithPdConfig(defaultMachineType,
                                                       Some(d1.id),
                                                       bootDiskSize = DiskSize(50),
-                                                      zone = ZoneName("us-west2-b"))
+                                                      zone = ZoneName("us-west2-b"),
+                                                      CommonTestData.gpuConfig)
       c1 <- IO(
         makeCluster(1).saveWithRuntimeConfig(d1RuntimeConfig)
       )
@@ -61,7 +62,8 @@ class RuntimeServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent wit
       d2RuntimeConfig = RuntimeConfig.GceWithPdConfig(defaultMachineType,
                                                       Some(d2.id),
                                                       bootDiskSize = DiskSize(50),
-                                                      zone = ZoneName("us-west2-b"))
+                                                      zone = ZoneName("us-west2-b"),
+                                                      CommonTestData.gpuConfig)
       c2 <- IO(
         makeCluster(2).saveWithRuntimeConfig(d2RuntimeConfig)
       )
@@ -88,13 +90,15 @@ class RuntimeServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent wit
       c1RuntimeConfig = RuntimeConfig.GceWithPdConfig(defaultMachineType,
                                                       Some(d1.id),
                                                       bootDiskSize = DiskSize(50),
-                                                      zone = ZoneName("us-west2-b"))
+                                                      zone = ZoneName("us-west2-b"),
+                                                      CommonTestData.gpuConfig)
       c1 <- IO(makeCluster(1).saveWithRuntimeConfig(c1RuntimeConfig))
       d2 <- makePersistentDisk(Some(DiskName("d2"))).save()
       c2RuntimeConfig = RuntimeConfig.GceWithPdConfig(defaultMachineType,
                                                       Some(d2.id),
                                                       bootDiskSize = DiskSize(50),
-                                                      zone = ZoneName("us-west2-b"))
+                                                      zone = ZoneName("us-west2-b"),
+                                                      None)
       c2 <- IO(makeCluster(2).saveWithRuntimeConfig(c2RuntimeConfig))
       labels1 = Map("googleProject" -> c1.googleProject.value,
                     "clusterName" -> c1.runtimeName.asString,
@@ -135,7 +139,8 @@ class RuntimeServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent wit
       c1RuntimeConfig = RuntimeConfig.GceWithPdConfig(defaultMachineType,
                                                       Some(d1.id),
                                                       bootDiskSize = DiskSize(50),
-                                                      zone = ZoneName("us-west2-b"))
+                                                      zone = ZoneName("us-west2-b"),
+                                                      CommonTestData.gpuConfig)
       c1 <- IO(
         makeCluster(1).saveWithRuntimeConfig(c1RuntimeConfig)
       )
@@ -143,7 +148,8 @@ class RuntimeServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent wit
       c2RuntimeConfig = RuntimeConfig.GceWithPdConfig(defaultMachineType,
                                                       Some(d2.id),
                                                       bootDiskSize = DiskSize(50),
-                                                      zone = ZoneName("us-west2-b"))
+                                                      zone = ZoneName("us-west2-b"),
+                                                      None)
       c2 <- IO(
         makeCluster(2).saveWithRuntimeConfig(c2RuntimeConfig)
       )
@@ -170,7 +176,8 @@ class RuntimeServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent wit
       c1RuntimeConfig = RuntimeConfig.GceWithPdConfig(defaultMachineType,
                                                       Some(d1.id),
                                                       bootDiskSize = DiskSize(50),
-                                                      zone = ZoneName("us-west2-b"))
+                                                      zone = ZoneName("us-west2-b"),
+                                                      None)
       c1 <- IO(
         makeCluster(1)
           .copy(status = RuntimeStatus.Deleted)
@@ -180,7 +187,8 @@ class RuntimeServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent wit
       c2RuntimeConfig = RuntimeConfig.GceWithPdConfig(defaultMachineType,
                                                       Some(d2.id),
                                                       bootDiskSize = DiskSize(50),
-                                                      zone = ZoneName("us-west2-b"))
+                                                      zone = ZoneName("us-west2-b"),
+                                                      CommonTestData.gpuConfig)
       c2 <- IO(
         makeCluster(2)
           .copy(status = RuntimeStatus.Deleted)
@@ -190,13 +198,15 @@ class RuntimeServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent wit
       c3RuntimeConfig = RuntimeConfig.GceWithPdConfig(defaultMachineType,
                                                       Some(d3.id),
                                                       bootDiskSize = DiskSize(50),
-                                                      zone = ZoneName("us-west2-b"))
+                                                      zone = ZoneName("us-west2-b"),
+                                                      CommonTestData.gpuConfig)
       c3 <- IO(
         makeCluster(3).saveWithRuntimeConfig(
           RuntimeConfig.GceWithPdConfig(defaultMachineType,
                                         Some(d3.id),
                                         bootDiskSize = DiskSize(50),
-                                        zone = ZoneName("us-west2-b"))
+                                        zone = ZoneName("us-west2-b"),
+                                        CommonTestData.gpuConfig)
         )
       )
       list1 <- RuntimeServiceDbQueries.listRuntimes(Map.empty, true, None).transaction
@@ -222,7 +232,8 @@ class RuntimeServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent wit
       c1RuntimeConfig = RuntimeConfig.GceWithPdConfig(defaultMachineType,
                                                       Some(disk.id),
                                                       bootDiskSize = DiskSize(50),
-                                                      zone = ZoneName("us-west2-b"))
+                                                      zone = ZoneName("us-west2-b"),
+                                                      CommonTestData.gpuConfig)
       c1 <- IO(makeCluster(1).saveWithRuntimeConfig(c1RuntimeConfig))
       get1 <- RuntimeServiceDbQueries.getRuntime(c1.googleProject, c1.runtimeName).transaction
       get2 <- RuntimeServiceDbQueries.getRuntime(c1.googleProject, RuntimeName("does-not-exist")).transaction.attempt

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/HttpRoutesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/HttpRoutesSpec.scala
@@ -558,7 +558,8 @@ class HttpRoutesSpec
     val test =
       RuntimeConfigRequest.GceConfig(Some(MachineTypeName("n1-standard-8")),
                                      Some(DiskSize(100)),
-                                     Some(ZoneName("europe-west1-b")))
+                                     Some(ZoneName("europe-west1-b")),
+                                     None)
     decode[RuntimeConfigRequest](test.asJson.noSpaces) shouldBe Right(test)
   }
 
@@ -566,7 +567,8 @@ class HttpRoutesSpec
     val test = RuntimeConfigRequest.GceWithPdConfig(
       Some(MachineTypeName("n1-standard-8")),
       PersistentDiskRequest(DiskName("disk"), Some(DiskSize(100)), Some(DiskType.Standard), Map.empty),
-      Some(ZoneName("europe-west1-b"))
+      Some(ZoneName("europe-west1-b")),
+      None
     )
     decode[RuntimeConfigRequest](test.asJson.noSpaces) shouldBe Right(test)
   }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/RuntimeRoutesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/RuntimeRoutesSpec.scala
@@ -317,7 +317,7 @@ class RuntimeRoutesSpec extends AnyFlatSpec with Matchers with LeonardoTestSuite
       name1,
       project,
       auditInfo.copy(createdDate = date, dateAccessed = date),
-      defaultGceRuntimeConfig,
+      gceRuntimeConfigWithGpu,
       new URL("https://leo.org/proxy"),
       RuntimeStatus.Running,
       Map("foo" -> "bar"),
@@ -341,7 +341,11 @@ class RuntimeRoutesSpec extends AnyFlatSpec with Matchers with LeonardoTestSuite
         |    "diskSize" : 500,
         |    "cloudService" : "GCE",
         |    "bootDiskSize" : 50,
-        |    "zone" : "us-west2-b"
+        |    "zone" : "us-west2-b",
+        |    "gpuConfig" : {
+        |      "gpuType" : "nvidia-tesla-t4",
+        |      "numOfGpus" : 2
+        |    }
         |  },
         |  "proxyUrl" : "https://leo.org/proxy",
         |  "status" : "Running",

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/RuntimeRoutesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/RuntimeRoutesSpec.scala
@@ -481,7 +481,9 @@ class RuntimeRoutesSpec extends AnyFlatSpec with Matchers with LeonardoTestSuite
         |""".stripMargin
     val expectedResult = RuntimeConfigRequest.GceWithPdConfig(
       None,
-      PersistentDiskRequest(DiskName("qi-disk-c1"), Some(DiskSize(200)), None, Map.empty)
+      PersistentDiskRequest(DiskName("qi-disk-c1"), Some(DiskSize(200)), None, Map.empty),
+      None,
+      None
     )
     decode[RuntimeConfigRequest](jsonString) shouldBe Right(expectedResult)
   }
@@ -494,6 +496,8 @@ class RuntimeRoutesSpec extends AnyFlatSpec with Matchers with LeonardoTestSuite
         |}
         |""".stripMargin
     val expectedResult = RuntimeConfigRequest.GceConfig(
+      None,
+      None,
       None,
       None
     )
@@ -513,7 +517,9 @@ class RuntimeRoutesSpec extends AnyFlatSpec with Matchers with LeonardoTestSuite
         |""".stripMargin
     val expectedResult = RuntimeConfigRequest.GceWithPdConfig(
       None,
-      PersistentDiskRequest(DiskName("qi-disk-c1"), Some(DiskSize(30)), None, Map.empty)
+      PersistentDiskRequest(DiskName("qi-disk-c1"), Some(DiskSize(30)), None, Map.empty),
+      None,
+      None
     )
     decode[RuntimeConfigRequest](jsonString) shouldBe Right(expectedResult)
   }
@@ -615,7 +621,8 @@ class RuntimeRoutesSpec extends AnyFlatSpec with Matchers with LeonardoTestSuite
         RuntimeConfigRequest.GceConfig(
           Some(MachineTypeName("n1-standard-4")),
           Some(DiskSize(100)),
-          Some(ZoneName("us-central2-b"))
+          Some(ZoneName("us-central2-b")),
+          None
         )
       ),
       None,

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/StatusRoutesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/StatusRoutesSpec.scala
@@ -68,7 +68,7 @@ class StatusRoutesSpec
         responseAs[StatusCheckResponse].ok shouldEqual false
         responseAs[StatusCheckResponse].systems.keySet shouldEqual Set(Database, Sam)
         responseAs[StatusCheckResponse].systems(Sam).ok shouldBe false
-        responseAs[StatusCheckResponse].systems(Sam).messages shouldBe Symbol("defined")
+        responseAs[StatusCheckResponse].systems(Sam).messages shouldBe defined
         responseAs[StatusCheckResponse].systems(Database).ok shouldBe true
         responseAs[StatusCheckResponse].systems(Database).messages shouldBe None
         status shouldEqual StatusCodes.InternalServerError

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/TestLeoRoutes.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/TestLeoRoutes.scala
@@ -163,7 +163,7 @@ trait TestLeoRoutes {
   protected def validateCookie(setCookie: Option[`Set-Cookie`],
                                expectedCookie: HttpCookiePair = tokenCookie,
                                age: Long = tokenAge): Unit = {
-    setCookie shouldBe Symbol("defined")
+    setCookie shouldBe defined
     val cookie = setCookie.get.cookie
     cookie.name shouldBe expectedCookie.name
     cookie.value shouldBe expectedCookie.value
@@ -178,7 +178,7 @@ trait TestLeoRoutes {
   protected def validateRawCookie(setCookie: Option[HttpHeader],
                                   expectedCookie: HttpCookiePair = tokenCookie,
                                   age: Long = tokenAge): Unit = {
-    setCookie shouldBe Symbol("defined")
+    setCookie shouldBe defined
     setCookie.get.name shouldBe "Set-Cookie"
 
     // test execution loses some milliseconds, so round Max-Age before validation
@@ -190,7 +190,7 @@ trait TestLeoRoutes {
 
   protected def validateUnsetRawCookie(setCookie: Option[HttpHeader],
                                        expectedCookie: HttpCookiePair = tokenCookie): Unit = {
-    setCookie shouldBe Symbol("defined")
+    setCookie shouldBe defined
     setCookie.get.name shouldBe "Set-Cookie"
     setCookie.get.value shouldBe s"${tokenName}=unset; expires=Thu, 01 Jan 1970 00:00:00 GMT; Path=/; Secure; SameSite=None"
   }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/TestLeoRoutes.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/TestLeoRoutes.scala
@@ -163,7 +163,7 @@ trait TestLeoRoutes {
   protected def validateCookie(setCookie: Option[`Set-Cookie`],
                                expectedCookie: HttpCookiePair = tokenCookie,
                                age: Long = tokenAge): Unit = {
-    setCookie shouldBe 'defined
+    setCookie shouldBe Symbol("defined")
     val cookie = setCookie.get.cookie
     cookie.name shouldBe expectedCookie.name
     cookie.value shouldBe expectedCookie.value

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/DiskServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/DiskServiceInterpSpec.scala
@@ -208,7 +208,8 @@ class DiskServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with Test
           RuntimeConfig.GceWithPdConfig(MachineTypeName("n1-standard-4"),
                                         Some(disk.id),
                                         bootDiskSize = DiskSize(50),
-                                        zone = ZoneName("us-west2-b"))
+                                        zone = ZoneName("us-west2-b"),
+                                        None)
         )
       )
       err <- diskService.deleteDisk(userInfo, disk.googleProject, disk.name).attempt

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterpSpec.scala
@@ -512,7 +512,10 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
     )
     val req = emptyCreateRuntimeReq.copy(
       runtimeConfig = Some(
-        RuntimeConfigRequest.GceWithPdConfig(machineType = Some(MachineTypeName("n1-standard-4")), persistentDisk)
+        RuntimeConfigRequest.GceWithPdConfig(machineType = Some(MachineTypeName("n1-standard-4")),
+                                             persistentDisk,
+                                             None,
+                                             None)
       )
     )
 
@@ -603,12 +606,13 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
       runtimeConfig = Some(
         RuntimeConfigRequest.GceConfig(machineType = Some(MachineTypeName("n1-standard-4")),
                                        diskSize = Some(DiskSize(500)),
+                                       None,
                                        gpuConfig = gpuConfig)
       )
     )
 
     val res = for {
-      context <- ctx.ask[AppContext]
+      _ <- publisherQueue.tryDequeue1
       r <- runtimeService
         .createRuntime(
           userInfo,

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterpSpec.scala
@@ -126,7 +126,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
     val clusterRequest = emptyCreateRuntimeReq.copy(userJupyterExtensionConfig =
       Some(
         UserJupyterExtensionConfig(nbExtensions =
-          Map("notebookExtension" -> s"gs://bucket/${Stream.continually('a').take(1025).mkString}")
+          Map("notebookExtension" -> s"gs://bucket/${LazyList.continually('a').take(1025).mkString}")
         )
       )
     )
@@ -792,12 +792,12 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
       listRuntimeResponse1,
       listRuntimeResponse2
     )
-    runtimeService.listRuntimes(userInfo, None, Map("_labels" -> "foo=bar,bam=yes")).unsafeRunSync.toSet shouldBe Set(
+    runtimeService.listRuntimes(userInfo, None, Map("_labels" -> "foo=bar,bam=yes")).unsafeRunSync().toSet shouldBe Set(
       listRuntimeResponse1
     )
     runtimeService
       .listRuntimes(userInfo, None, Map("_labels" -> "foo=bar,bam=yes,vcf=no"))
-      .unsafeToFuture
+      .unsafeToFuture()
       .futureValue
       .toSet shouldBe Set(listRuntimeResponse1)
     runtimeService.listRuntimes(userInfo, None, Map("_labels" -> "a=b")).unsafeRunSync().toSet shouldBe Set(
@@ -1573,7 +1573,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
         "foo" -> "bar"
       )
 
-      persistedDisk shouldBe 'defined
+      persistedDisk shouldBe Symbol("defined")
       persistedDisk.get shouldEqual disk
     }
 

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterpSpec.scala
@@ -1573,7 +1573,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
         "foo" -> "bar"
       )
 
-      persistedDisk shouldBe Symbol("defined")
+      persistedDisk shouldBe defined
       persistedDisk.get shouldEqual disk
     }
 

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriberSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriberSpec.scala
@@ -329,7 +329,7 @@ class LeoPubsubMessageSubscriberSpec
       _ <- leoSubscriber.messageResponder(StopRuntimeMessage(runtime.id, Some(tr)))
       updatedRuntime <- clusterQuery.getClusterById(runtime.id).transaction
     } yield {
-      updatedRuntime shouldBe 'defined
+      updatedRuntime shouldBe Symbol("defined")
       updatedRuntime.get.status shouldBe RuntimeStatus.Stopping
     }
 
@@ -362,7 +362,7 @@ class LeoPubsubMessageSubscriberSpec
       _ <- leoSubscriber.messageResponder(StartRuntimeMessage(runtime.id, Some(tr)))
       updatedRuntime <- clusterQuery.getClusterById(runtime.id).transaction
     } yield {
-      updatedRuntime shouldBe 'defined
+      updatedRuntime shouldBe Symbol("defined")
       updatedRuntime.get.status shouldBe RuntimeStatus.Starting
     }
 
@@ -449,10 +449,10 @@ class LeoPubsubMessageSubscriberSpec
       )
     } yield {
       // runtime should be Stopping
-      updatedRuntime shouldBe 'defined
+      updatedRuntime shouldBe Symbol("defined")
       updatedRuntime.get.status shouldBe RuntimeStatus.Stopping
       // machine type should not be updated yet
-      updatedRuntimeConfig shouldBe 'defined
+      updatedRuntimeConfig shouldBe Symbol("defined")
       updatedRuntimeConfig.get.machineType shouldBe MachineTypeName("n1-standard-4")
     }
 
@@ -481,10 +481,10 @@ class LeoPubsubMessageSubscriberSpec
           patchInProgress <- patchQuery.isInprogress(runtime.id).transaction
         } yield {
           // runtime should be Starting after having gone through a stop -> update -> start
-          updatedRuntime shouldBe 'defined
+          updatedRuntime shouldBe Symbol("defined")
           updatedRuntime.get.status shouldBe RuntimeStatus.Starting
           // machine type should be updated
-          updatedRuntimeConfig shouldBe 'defined
+          updatedRuntimeConfig shouldBe Symbol("defined")
           updatedRuntimeConfig.get.machineType shouldBe MachineTypeName("n1-highmem-64")
           patchInProgress shouldBe false
         }
@@ -523,10 +523,10 @@ class LeoPubsubMessageSubscriberSpec
         updatedDisk <- persistentDiskQuery.getById(disk.id).transaction
       } yield {
         // runtime should be Starting after having gone through a stop -> start
-        updatedRuntime shouldBe 'defined
+        updatedRuntime shouldBe Symbol("defined")
         updatedRuntime.get.status shouldBe RuntimeStatus.Starting
         // machine type should be updated
-        updatedDisk shouldBe 'defined
+        updatedDisk shouldBe Symbol("defined")
         updatedDisk.get.size shouldBe DiskSize(200)
       }
 
@@ -561,10 +561,10 @@ class LeoPubsubMessageSubscriberSpec
       )
     } yield {
       // runtime should still be Stopped
-      updatedRuntime shouldBe 'defined
+      updatedRuntime shouldBe Symbol("defined")
       updatedRuntime.get.status shouldBe RuntimeStatus.Stopped
       // machine type and disk size should be updated
-      updatedRuntimeConfig shouldBe 'defined
+      updatedRuntimeConfig shouldBe Symbol("defined")
       updatedRuntimeConfig.get.machineType shouldBe MachineTypeName("n1-highmem-64")
       updatedRuntimeConfig.get.asInstanceOf[RuntimeConfig.GceConfig].diskSize shouldBe DiskSize(1024)
     }
@@ -582,7 +582,7 @@ class LeoPubsubMessageSubscriberSpec
       _ <- leoSubscriber.messageResponder(CreateDiskMessage.fromDisk(disk, Some(tr)))
       updatedDisk <- persistentDiskQuery.getById(disk.id).transaction
     } yield {
-      updatedDisk shouldBe 'defined
+      updatedDisk shouldBe Symbol("defined")
       updatedDisk.get.googleId.get.value shouldBe "target"
     }
 
@@ -599,7 +599,7 @@ class LeoPubsubMessageSubscriberSpec
       _ <- leoSubscriber.messageResponder(DeleteDiskMessage(disk.id, Some(tr)))
       updatedDisk <- persistentDiskQuery.getById(disk.id).transaction
     } yield {
-      updatedDisk shouldBe 'defined
+      updatedDisk shouldBe Symbol("defined")
       updatedDisk.get.status shouldBe DiskStatus.Deleting
     }
 
@@ -631,7 +631,7 @@ class LeoPubsubMessageSubscriberSpec
       _ <- leoSubscriber.messageResponder(UpdateDiskMessage(disk.id, DiskSize(550), Some(tr)))
       updatedDisk <- persistentDiskQuery.getById(disk.id).transaction
     } yield {
-      updatedDisk shouldBe 'defined
+      updatedDisk shouldBe Symbol("defined")
       //TODO: fix tests
 //      updatedDisk.get.size shouldBe DiskSize(550)
     }
@@ -992,7 +992,7 @@ class LeoPubsubMessageSubscriberSpec
         Some(tr)
       )
       queue <- InspectableQueue.bounded[IO, Task[IO]](10)
-      leoSubscriber = makeLeoSubscriber(asyncTaskQueue = queue, diskInterp = makeDetachingDiskInterp)
+      leoSubscriber = makeLeoSubscriber(asyncTaskQueue = queue, diskInterp = makeDetachingDiskInterp())
       asyncTaskProcessor = AsyncTaskProcessor(AsyncTaskProcessor.Config(10, 10), queue)
       _ <- leoSubscriber.messageHandler(Event(msg, None, timestamp, mockAckConsumer))
       _ <- withInfiniteStream(asyncTaskProcessor.process, assertions, maxRetry = 40)
@@ -1076,7 +1076,7 @@ class LeoPubsubMessageSubscriberSpec
       tr <- traceId.ask[TraceId]
       msg = DeleteAppMessage(savedApp1.id, savedApp1.appName, savedCluster1.googleProject, None, Some(tr))
       queue <- InspectableQueue.bounded[IO, Task[IO]](10)
-      leoSubscriber = makeLeoSubscriber(asyncTaskQueue = queue, diskInterp = makeDetachingDiskInterp)
+      leoSubscriber = makeLeoSubscriber(asyncTaskQueue = queue, diskInterp = makeDetachingDiskInterp())
       asyncTaskProcessor = AsyncTaskProcessor(AsyncTaskProcessor.Config(10, 10), queue)
       _ <- leoSubscriber.handleDeleteAppMessage(msg)
       _ <- withInfiniteStream(asyncTaskProcessor.process, assertions)
@@ -1117,7 +1117,7 @@ class LeoPubsubMessageSubscriberSpec
       tr <- traceId.ask[TraceId]
       msg = DeleteAppMessage(savedApp1.id, savedApp1.appName, savedCluster1.googleProject, Some(disk.id), Some(tr))
       queue <- InspectableQueue.bounded[IO, Task[IO]](10)
-      leoSubscriber = makeLeoSubscriber(asyncTaskQueue = queue, diskInterp = makeDetachingDiskInterp)
+      leoSubscriber = makeLeoSubscriber(asyncTaskQueue = queue, diskInterp = makeDetachingDiskInterp())
       asyncTaskProcessor = AsyncTaskProcessor(AsyncTaskProcessor.Config(10, 10), queue)
       _ <- leoSubscriber.handleDeleteAppMessage(msg)
       _ <- withInfiniteStream(asyncTaskProcessor.process, assertions)
@@ -1329,7 +1329,7 @@ class LeoPubsubMessageSubscriberSpec
                                          blocker,
                                          lock)
       leoSubscriber = makeLeoSubscriber(asyncTaskQueue = queue,
-                                        diskInterp = makeDetachingDiskInterp,
+                                        diskInterp = makeDetachingDiskInterp(),
                                         gkeInterpreter = gkeInterp)
       asyncTaskProcessor = AsyncTaskProcessor(AsyncTaskProcessor.Config(10, 10), queue)
       _ <- leoSubscriber.handleCreateAppMessage(msg)
@@ -1424,7 +1424,7 @@ class LeoPubsubMessageSubscriberSpec
         Some(tr)
       )
       queue <- InspectableQueue.bounded[IO, Task[IO]](10)
-      leoSubscriber = makeLeoSubscriber(asyncTaskQueue = queue, diskInterp = makeDetachingDiskInterp)
+      leoSubscriber = makeLeoSubscriber(asyncTaskQueue = queue, diskInterp = makeDetachingDiskInterp())
       asyncTaskProcessor = AsyncTaskProcessor(AsyncTaskProcessor.Config(10, 10), queue)
       _ <- leoSubscriber.handleCreateAppMessage(msg)
       _ <- withInfiniteStream(asyncTaskProcessor.process, assertions, maxRetry = 50)
@@ -1702,7 +1702,7 @@ class LeoPubsubMessageSubscriberSpec
       tr <- traceId.ask[TraceId]
       msg = DeleteAppMessage(savedApp1.id, savedApp1.appName, savedCluster1.googleProject, None, Some(tr))
       queue <- InspectableQueue.bounded[IO, Task[IO]](10)
-      leoSubscriber = makeLeoSubscriber(asyncTaskQueue = queue, diskInterp = makeDetachingDiskInterp)
+      leoSubscriber = makeLeoSubscriber(asyncTaskQueue = queue, diskInterp = makeDetachingDiskInterp())
       asyncTaskProcessor = AsyncTaskProcessor(AsyncTaskProcessor.Config(10, 10), queue)
       // send message twice
       _ <- leoSubscriber.handleDeleteAppMessage(msg)
@@ -1727,7 +1727,7 @@ class LeoPubsubMessageSubscriberSpec
       _ <- leoSubscriber.messageResponder(message)
       updatedDisk <- persistentDiskQuery.getById(disk.id).transaction
     } yield {
-      updatedDisk shouldBe 'defined
+      updatedDisk shouldBe Symbol("defined")
       updatedDisk.get.googleId.get.value shouldBe "target"
     }
 
@@ -1746,7 +1746,7 @@ class LeoPubsubMessageSubscriberSpec
       _ <- leoSubscriber.messageResponder(message)
       updatedDisk <- persistentDiskQuery.getById(disk.id).transaction
     } yield {
-      updatedDisk shouldBe 'defined
+      updatedDisk shouldBe Symbol("defined")
       updatedDisk.get.status shouldBe DiskStatus.Deleting
     }
 
@@ -1770,7 +1770,7 @@ class LeoPubsubMessageSubscriberSpec
 
   def makeLeoSubscriber(
     runtimeMonitor: RuntimeMonitor[IO, CloudService] = MockRuntimeMonitor,
-    asyncTaskQueue: InspectableQueue[IO, Task[IO]] = InspectableQueue.bounded[IO, Task[IO]](10).unsafeRunSync,
+    asyncTaskQueue: InspectableQueue[IO, Task[IO]] = InspectableQueue.bounded[IO, Task[IO]](10).unsafeRunSync(),
     computePollOperation: ComputePollOperation[IO] = new MockComputePollOperation,
     gkeInterpreter: GKEInterpreter[IO] = makeGKEInterp(nodepoolLock.unsafeRunSync(), appRelease = List.empty),
     diskInterp: GoogleDiskService[IO] = MockGoogleDiskService,

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriberSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriberSpec.scala
@@ -250,7 +250,8 @@ class LeoPubsubMessageSubscriberSpec
       runtimeConfig = RuntimeConfig.GceWithPdConfig(MachineTypeName("n1-standard-4"),
                                                     bootDiskSize = DiskSize(50),
                                                     persistentDiskId = Some(disk.id),
-                                                    zone = ZoneName("us-central1-a"))
+                                                    zone = ZoneName("us-central1-a"),
+                                                    gpuConfig = None)
 
       runtime <- IO(makeCluster(1).copy(status = RuntimeStatus.Deleting).saveWithRuntimeConfig(runtimeConfig))
       tr <- traceId.ask[TraceId]
@@ -283,7 +284,8 @@ class LeoPubsubMessageSubscriberSpec
       runtimeConfig = RuntimeConfig.GceWithPdConfig(MachineTypeName("n1-standard-4"),
                                                     bootDiskSize = DiskSize(50),
                                                     persistentDiskId = Some(disk.id),
-                                                    zone = ZoneName("us-cetnral1-a"))
+                                                    zone = ZoneName("us-cetnral1-a"),
+                                                    gpuConfig = None)
 
       runtime <- IO(makeCluster(1).copy(status = RuntimeStatus.Deleting).saveWithRuntimeConfig(runtimeConfig))
       tr <- traceId.ask[TraceId]

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriberSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriberSpec.scala
@@ -163,8 +163,8 @@ class LeoPubsubMessageSubscriberSpec
       _ <- leoSubscriber.messageResponder(CreateRuntimeMessage.fromRuntime(runtime, gceRuntimeConfigRequest, Some(tr)))
       updatedRuntime <- clusterQuery.getClusterById(runtime.id).transaction
     } yield {
-      updatedRuntime shouldBe Symbol("defined")
-      updatedRuntime.get.asyncRuntimeFields shouldBe Symbol("defined")
+      updatedRuntime shouldBe defined
+      updatedRuntime.get.asyncRuntimeFields shouldBe defined
       updatedRuntime.get.asyncRuntimeFields.get.stagingBucket.value should startWith("leostaging")
       updatedRuntime.get.asyncRuntimeFields.get.hostIp shouldBe None
       updatedRuntime.get.asyncRuntimeFields.get.operationName.value shouldBe "opName"
@@ -202,7 +202,7 @@ class LeoPubsubMessageSubscriberSpec
       _ <- leoSubscriber.messageResponder(CreateRuntimeMessage.fromRuntime(runtime, gceRuntimeConfigRequest, Some(tr)))
       updatedRuntime <- clusterQuery.getClusterById(runtime.id).transaction
     } yield {
-      updatedRuntime shouldBe Symbol("defined")
+      updatedRuntime shouldBe defined
       updatedRuntime.get.asyncRuntimeFields shouldBe Some(asyncFields)
       updatedRuntime.get.runtimeImages shouldBe runtime.runtimeImages
     }
@@ -329,7 +329,7 @@ class LeoPubsubMessageSubscriberSpec
       _ <- leoSubscriber.messageResponder(StopRuntimeMessage(runtime.id, Some(tr)))
       updatedRuntime <- clusterQuery.getClusterById(runtime.id).transaction
     } yield {
-      updatedRuntime shouldBe Symbol("defined")
+      updatedRuntime shouldBe defined
       updatedRuntime.get.status shouldBe RuntimeStatus.Stopping
     }
 
@@ -362,7 +362,7 @@ class LeoPubsubMessageSubscriberSpec
       _ <- leoSubscriber.messageResponder(StartRuntimeMessage(runtime.id, Some(tr)))
       updatedRuntime <- clusterQuery.getClusterById(runtime.id).transaction
     } yield {
-      updatedRuntime shouldBe Symbol("defined")
+      updatedRuntime shouldBe defined
       updatedRuntime.get.status shouldBe RuntimeStatus.Starting
     }
 
@@ -449,10 +449,10 @@ class LeoPubsubMessageSubscriberSpec
       )
     } yield {
       // runtime should be Stopping
-      updatedRuntime shouldBe Symbol("defined")
+      updatedRuntime shouldBe defined
       updatedRuntime.get.status shouldBe RuntimeStatus.Stopping
       // machine type should not be updated yet
-      updatedRuntimeConfig shouldBe Symbol("defined")
+      updatedRuntimeConfig shouldBe defined
       updatedRuntimeConfig.get.machineType shouldBe MachineTypeName("n1-standard-4")
     }
 
@@ -481,10 +481,10 @@ class LeoPubsubMessageSubscriberSpec
           patchInProgress <- patchQuery.isInprogress(runtime.id).transaction
         } yield {
           // runtime should be Starting after having gone through a stop -> update -> start
-          updatedRuntime shouldBe Symbol("defined")
+          updatedRuntime shouldBe defined
           updatedRuntime.get.status shouldBe RuntimeStatus.Starting
           // machine type should be updated
-          updatedRuntimeConfig shouldBe Symbol("defined")
+          updatedRuntimeConfig shouldBe defined
           updatedRuntimeConfig.get.machineType shouldBe MachineTypeName("n1-highmem-64")
           patchInProgress shouldBe false
         }
@@ -523,10 +523,10 @@ class LeoPubsubMessageSubscriberSpec
         updatedDisk <- persistentDiskQuery.getById(disk.id).transaction
       } yield {
         // runtime should be Starting after having gone through a stop -> start
-        updatedRuntime shouldBe Symbol("defined")
+        updatedRuntime shouldBe defined
         updatedRuntime.get.status shouldBe RuntimeStatus.Starting
         // machine type should be updated
-        updatedDisk shouldBe Symbol("defined")
+        updatedDisk shouldBe defined
         updatedDisk.get.size shouldBe DiskSize(200)
       }
 
@@ -561,10 +561,10 @@ class LeoPubsubMessageSubscriberSpec
       )
     } yield {
       // runtime should still be Stopped
-      updatedRuntime shouldBe Symbol("defined")
+      updatedRuntime shouldBe defined
       updatedRuntime.get.status shouldBe RuntimeStatus.Stopped
       // machine type and disk size should be updated
-      updatedRuntimeConfig shouldBe Symbol("defined")
+      updatedRuntimeConfig shouldBe defined
       updatedRuntimeConfig.get.machineType shouldBe MachineTypeName("n1-highmem-64")
       updatedRuntimeConfig.get.asInstanceOf[RuntimeConfig.GceConfig].diskSize shouldBe DiskSize(1024)
     }
@@ -582,7 +582,7 @@ class LeoPubsubMessageSubscriberSpec
       _ <- leoSubscriber.messageResponder(CreateDiskMessage.fromDisk(disk, Some(tr)))
       updatedDisk <- persistentDiskQuery.getById(disk.id).transaction
     } yield {
-      updatedDisk shouldBe Symbol("defined")
+      updatedDisk shouldBe defined
       updatedDisk.get.googleId.get.value shouldBe "target"
     }
 
@@ -599,7 +599,7 @@ class LeoPubsubMessageSubscriberSpec
       _ <- leoSubscriber.messageResponder(DeleteDiskMessage(disk.id, Some(tr)))
       updatedDisk <- persistentDiskQuery.getById(disk.id).transaction
     } yield {
-      updatedDisk shouldBe Symbol("defined")
+      updatedDisk shouldBe defined
       updatedDisk.get.status shouldBe DiskStatus.Deleting
     }
 
@@ -631,7 +631,7 @@ class LeoPubsubMessageSubscriberSpec
       _ <- leoSubscriber.messageResponder(UpdateDiskMessage(disk.id, DiskSize(550), Some(tr)))
       updatedDisk <- persistentDiskQuery.getById(disk.id).transaction
     } yield {
-      updatedDisk shouldBe Symbol("defined")
+      updatedDisk shouldBe defined
       //TODO: fix tests
 //      updatedDisk.get.size shouldBe DiskSize(550)
     }
@@ -1727,7 +1727,7 @@ class LeoPubsubMessageSubscriberSpec
       _ <- leoSubscriber.messageResponder(message)
       updatedDisk <- persistentDiskQuery.getById(disk.id).transaction
     } yield {
-      updatedDisk shouldBe Symbol("defined")
+      updatedDisk shouldBe defined
       updatedDisk.get.googleId.get.value shouldBe "target"
     }
 
@@ -1746,7 +1746,7 @@ class LeoPubsubMessageSubscriberSpec
       _ <- leoSubscriber.messageResponder(message)
       updatedDisk <- persistentDiskQuery.getById(disk.id).transaction
     } yield {
-      updatedDisk shouldBe Symbol("defined")
+      updatedDisk shouldBe defined
       updatedDisk.get.status shouldBe DiskStatus.Deleting
     }
 

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/RuntimeTemplateValuesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/RuntimeTemplateValuesSpec.scala
@@ -8,7 +8,7 @@ class RuntimeTemplateValuesSpec extends LeonardoTestSuite with AnyFlatSpecLike {
 
   "RuntimeTemplateValues" should "generate correct template values from a Runtime" in {
     val config = RuntimeTemplateValuesConfig.fromRuntime(
-      CommonTestData.testCluster,
+      RuntimeAndRuntimeConfig(CommonTestData.testCluster, CommonTestData.gceRuntimeConfigWithGpu),
       Some(CommonTestData.initBucketName),
       None,
       CommonTestData.imageConfig,
@@ -39,6 +39,7 @@ class RuntimeTemplateValuesSpec extends LeonardoTestSuite with AnyFlatSpecLike {
       result.disableDelocalization shouldBe "false"
       result.googleClientId shouldBe "clientId"
       result.googleProject shouldBe CommonTestData.testCluster.googleProject.value
+      result.gpuEnabled shouldBe "true"
       result.jupyterCombinedExtensions shouldBe ""
       result.jupyterDockerCompose shouldBe GcsPath(CommonTestData.initBucketName,
                                                    GcsObjectName("test-jupyter-docker-compose.yaml")).toUri

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/VPCInterpreterSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/VPCInterpreterSpec.scala
@@ -89,7 +89,7 @@ class VPCInterpreterSpec extends AnyFlatSpecLike with LeonardoTestSuite {
     computeService.firewallMap.size shouldBe 3
     vpcConfig.firewallsToAdd.foreach { fwConfig =>
       val fw = computeService.firewallMap.get(FirewallRuleName(s"${fwConfig.namePrefix}-us-central1"))
-      fw shouldBe 'defined
+      fw shouldBe Symbol("defined")
       fw.get.getNetwork shouldBe s"projects/${project.value}/global/networks/${vpcConfig.networkName.value}"
       fw.get.getTargetTagsList.asScala shouldBe List(vpcConfig.networkTag.value)
       fw.get.getAllowedList.asScala.map(_.getIPProtocol).toSet shouldBe fwConfig.allowed.map(_.protocol).toSet

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/VPCInterpreterSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/VPCInterpreterSpec.scala
@@ -89,7 +89,7 @@ class VPCInterpreterSpec extends AnyFlatSpecLike with LeonardoTestSuite {
     computeService.firewallMap.size shouldBe 3
     vpcConfig.firewallsToAdd.foreach { fwConfig =>
       val fw = computeService.firewallMap.get(FirewallRuleName(s"${fwConfig.namePrefix}-us-central1"))
-      fw shouldBe Symbol("defined")
+      fw shouldBe defined
       fw.get.getNetwork shouldBe s"projects/${project.value}/global/networks/${vpcConfig.networkName.value}"
       fw.get.getTargetTagsList.asScala shouldBe List(vpcConfig.networkTag.value)
       fw.get.getAllowedList.asScala.map(_.getIPProtocol).toSet shouldBe fwConfig.allowed.map(_.protocol).toSet

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -106,7 +106,7 @@ object Dependencies {
   val mysql: ModuleID =           "mysql"               % "mysql-connector-java"  % "8.0.22"
   val liquibase: ModuleID =       "org.liquibase"       % "liquibase-core"        % "4.3.5"
   val sealerate: ModuleID =       "ca.mrvisser"         %% "sealerate"            % "0.0.6"
-  val googleCloudNio: ModuleID =  "com.google.cloud"    % "google-cloud-nio"      % "0.123.0" % Test // brought in for FakeStorageInterpreter
+  val googleCloudNio: ModuleID =  "com.google.cloud"    % "google-cloud-nio"      % "0.123.1" % Test // brought in for FakeStorageInterpreter
 
   val http4sCirce =       "org.http4s"        %% "http4s-circe"         % http4sVersion
   val circeYaml =         "io.circe"          %% "circe-yaml"           % "0.14.0"


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-2636

1. Add API for supporting GPU
2. address some straightforward deprecation warnings
3. Add automation test for creating GPU enabled VM
4. Add error details to log. e.g.
```
failedRuntime: moving runtime with id  108 to Error status because Can't retrieve instance yet. Possibly runtime creation failed in Google
```
5. Modification to `createRuntime` flow: if we still get `NOT FOUND` from google after 60 seconds, we abort the process. This is because it's most likely runtime creation already failed in this case in google. One such case is `ZONE_RESOURCE_POOL_EXHAUSTED ` error

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
