### PR TITLE
[IA-2811] QA-1492 Make GCE images public

### DIFF
--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -446,6 +446,12 @@ pipeline {
     
                                             # Daisy doesn't clean it up all so we remove the bucket manually
                                             gsutil rm -r $GCE_IMAGE_BUCKET
+
+                                            # Make the image public
+                                            gcloud beta compute images add-iam-policy-binding \\
+                                                projects/$GOOGLE_PROJECT/global/images/${customGceImageBaseName}-${imageID} \\
+                                                --member='allAuthenticatedUsers' \\
+                                                --role='roles/compute.imageUser'
                                         """
                                     }
                                 }

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -448,9 +448,9 @@ pipeline {
                                             gsutil rm -r $GCE_IMAGE_BUCKET
 
                                             # Make the image public
-                                            gcloud beta compute images add-iam-policy-binding \\
-                                                projects/$GOOGLE_PROJECT/global/images/${customGceImageBaseName}-${imageID} \\
-                                                --member='allAuthenticatedUsers' \\
+                                            gcloud beta compute images add-iam-policy-binding \
+                                                projects/$GOOGLE_PROJECT/global/images/${customGceImageBaseName}-${imageID} \
+                                                --member='allAuthenticatedUsers' \
                                                 --role='roles/compute.imageUser'
                                         """
                                     }


### PR DESCRIPTION
[JIRA ticket](https://broadworkbench.atlassian.net/browse/IA-2811)

This PR fixes a bug that [A previous PR](https://github.com/DataBiosphere/leonardo/pull/2108/files#diff-6c263717a24af2836fc1795f59bdea6b8616d61bd499edb331d6c9d253478e34L445) introduced causing Jenkins jobs generating custom GCE images to not make the images public, which in turn caused runtime creation failures.