### PR TITLE
[QA-1512] increasing number of retries

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeCreationDiskSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeCreationDiskSpec.scala
@@ -200,9 +200,9 @@ class RuntimeCreationDiskSpec
           }
         })
         _ <- deleteRuntimeWithWait(googleProject, runtimeWithDataName, deleteDisk = true)
-        getDiskAttempt = getDisk(googleProject, diskName).attempt
+        getDiskAttempt = g15etDisk(googleProject, diskName).attempt
         // Disk deletion may take some time so we're retrying to reduce flaky test failures
-        diskResp <- streamFUntilDone(getDiskAttempt, 5, 5 seconds).compile.lastOrError
+        diskResp <- streamFUntilDone(getDiskAttempt, 10, 5 seconds).compile.lastOrError
       } yield {
         runtime.diskConfig.map(_.name) shouldBe Some(diskName)
         runtime.diskConfig.map(_.size) shouldBe Some(diskSize)

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeCreationDiskSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeCreationDiskSpec.scala
@@ -139,6 +139,8 @@ class RuntimeCreationDiskSpec
     val diskName = genDiskName.sample.get
     val diskSize = genDiskSize.sample.get
 
+    logger.info(s"runtime Name ${runtimeWithDataName} googleProject ${googleProject}")
+
     val res = dependencies.use { dep =>
       implicit val client = dep.httpClient
 

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeCreationDiskSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeCreationDiskSpec.scala
@@ -200,7 +200,7 @@ class RuntimeCreationDiskSpec
           }
         })
         _ <- deleteRuntimeWithWait(googleProject, runtimeWithDataName, deleteDisk = true)
-        getDiskAttempt = g15etDisk(googleProject, diskName).attempt
+        getDiskAttempt = getDisk(googleProject, diskName).attempt
         // Disk deletion may take some time so we're retrying to reduce flaky test failures
         diskResp <- streamFUntilDone(getDiskAttempt, 10, 5 seconds).compile.lastOrError
       } yield {

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeCreationDiskSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeCreationDiskSpec.scala
@@ -201,8 +201,10 @@ class RuntimeCreationDiskSpec
         })
         _ <- deleteRuntimeWithWait(googleProject, runtimeWithDataName, deleteDisk = true)
         getDiskAttempt = getDisk(googleProject, diskName).attempt
+
+        logger.info(s"runtime Name ${runtimeWithDataName} googleProject ${googleProject}")
         // Disk deletion may take some time so we're retrying to reduce flaky test failures
-        diskResp <- streamFUntilDone(getDiskAttempt, 20, 5 seconds).compile.lastOrError
+        diskResp <- streamFUntilDone(getDiskAttempt, 15, 5 seconds).compile.lastOrError
       } yield {
         runtime.diskConfig.map(_.name) shouldBe Some(diskName)
         runtime.diskConfig.map(_.size) shouldBe Some(diskSize)

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeCreationDiskSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeCreationDiskSpec.scala
@@ -202,7 +202,7 @@ class RuntimeCreationDiskSpec
         _ <- deleteRuntimeWithWait(googleProject, runtimeWithDataName, deleteDisk = true)
         getDiskAttempt = getDisk(googleProject, diskName).attempt
 
-        logger.info(s"runtime Name ${runtimeWithDataName} googleProject ${googleProject}")
+        _ <- logger.info(s"runtime Name ${runtimeWithDataName} googleProject ${googleProject}")
         // Disk deletion may take some time so we're retrying to reduce flaky test failures
         diskResp <- streamFUntilDone(getDiskAttempt, 15, 5 seconds).compile.lastOrError
       } yield {

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeCreationDiskSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeCreationDiskSpec.scala
@@ -139,7 +139,7 @@ class RuntimeCreationDiskSpec
     val diskName = genDiskName.sample.get
     val diskSize = genDiskSize.sample.get
 
-    logger.info(s"runtime Name ${runtimeWithDataName} googleProject ${googleProject}")
+    logger.info(s"runtime Name ${runtimeWithDataName} googleProject ${googleProject} diskname ${diskName}")
 
     val res = dependencies.use { dep =>
       implicit val client = dep.httpClient

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeCreationDiskSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeCreationDiskSpec.scala
@@ -139,7 +139,6 @@ class RuntimeCreationDiskSpec
     val diskName = genDiskName.sample.get
     val diskSize = genDiskSize.sample.get
 
-    
     val res = dependencies.use { dep =>
       implicit val client = dep.httpClient
 

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeCreationDiskSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeCreationDiskSpec.scala
@@ -202,7 +202,7 @@ class RuntimeCreationDiskSpec
         _ <- deleteRuntimeWithWait(googleProject, runtimeWithDataName, deleteDisk = true)
         getDiskAttempt = getDisk(googleProject, diskName).attempt
         // Disk deletion may take some time so we're retrying to reduce flaky test failures
-        diskResp <- streamFUntilDone(getDiskAttempt, 10, 5 seconds).compile.lastOrError
+        diskResp <- streamFUntilDone(getDiskAttempt, 20, 5 seconds).compile.lastOrError
       } yield {
         runtime.diskConfig.map(_.name) shouldBe Some(diskName)
         runtime.diskConfig.map(_.size) shouldBe Some(diskSize)

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeCreationDiskSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeCreationDiskSpec.scala
@@ -139,6 +139,8 @@ class RuntimeCreationDiskSpec
     val diskName = genDiskName.sample.get
     val diskSize = genDiskSize.sample.get
 
+    logger.info(s"runtime Name ${runtimeWithDataName} googleProject ${googleProject}")
+    
     val res = dependencies.use { dep =>
       implicit val client = dep.httpClient
 
@@ -202,7 +204,6 @@ class RuntimeCreationDiskSpec
         _ <- deleteRuntimeWithWait(googleProject, runtimeWithDataName, deleteDisk = true)
         getDiskAttempt = getDisk(googleProject, diskName).attempt
 
-        _ <- logger.info(s"runtime Name ${runtimeWithDataName} googleProject ${googleProject}")
         // Disk deletion may take some time so we're retrying to reduce flaky test failures
         diskResp <- streamFUntilDone(getDiskAttempt, 15, 5 seconds).compile.lastOrError
       } yield {

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeCreationDiskSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeCreationDiskSpec.scala
@@ -138,8 +138,6 @@ class RuntimeCreationDiskSpec
     val runtimeWithDataName = randomeName.copy(asString = randomeName.asString + "pd-spec-data-persist")
     val diskName = genDiskName.sample.get
     val diskSize = genDiskSize.sample.get
-
-    logger.info(s"runtime Name ${runtimeWithDataName} googleProject ${googleProject}")
     
     val res = dependencies.use { dep =>
       implicit val client = dep.httpClient

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeCreationDiskSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeCreationDiskSpec.scala
@@ -138,9 +138,7 @@ class RuntimeCreationDiskSpec
     val runtimeWithDataName = randomeName.copy(asString = randomeName.asString + "pd-spec-data-persist")
     val diskName = genDiskName.sample.get
     val diskSize = genDiskSize.sample.get
-
-    logger.info(s"runtime Name ${runtimeWithDataName} googleProject ${googleProject} diskname ${diskName}")
-
+    
     val res = dependencies.use { dep =>
       implicit val client = dep.httpClient
 

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeCreationDiskSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeCreationDiskSpec.scala
@@ -138,7 +138,7 @@ class RuntimeCreationDiskSpec
     val runtimeWithDataName = randomeName.copy(asString = randomeName.asString + "pd-spec-data-persist")
     val diskName = genDiskName.sample.get
     val diskSize = genDiskSize.sample.get
-    
+
     val res = dependencies.use { dep =>
       implicit val client = dep.httpClient
 

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeCreationDiskSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeCreationDiskSpec.scala
@@ -138,6 +138,7 @@ class RuntimeCreationDiskSpec
     val runtimeWithDataName = randomeName.copy(asString = randomeName.asString + "pd-spec-data-persist")
     val diskName = genDiskName.sample.get
     val diskSize = genDiskSize.sample.get
+
     
     val res = dependencies.use { dep =>
       implicit val client = dep.httpClient


### PR DESCRIPTION
Looking to address this [error signature](https://fc-jenkins.dsp-techops.broadinstitute.org/job/leonardo-fiab-test-runner/37622/testReport/junit/org.broadinstitute.dsde.workbench.leonardo.runtimes/RuntimeCreationDiskSpec/create_runtime_and_attach_an_existing_persistent_disk/). 

Just adding more retries to see if extending the amount of times we try will get rid of this flakiness. We have run into this issue before here:  https://github.com/DataBiosphere/leonardo/pull/1545

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
