### PR TITLE
[no ticket] add back headless system property to fix local automation tests

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/ProxyRedirectClient.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/ProxyRedirectClient.scala
@@ -18,8 +18,11 @@ import org.http4s.{HttpRoutes, _}
 import scala.concurrent.ExecutionContext
 
 object ProxyRedirectClient extends RestClient with LazyLogging {
-  // Note: change to "localhost" if running tests locally
-  val host = java.net.InetAddress.getLocalHost.getHostName
+  // If test is running in headless mode, hostname needs to work in a docker container
+  val host = sys.props.get("headless") match {
+    case Some("true") => java.net.InetAddress.getLocalHost.getHostName
+    case _            => "localhost"
+  }
 
   // Singleton http4s server to serve the proxy redirect page.
   // Explanation of the type:

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -192,7 +192,8 @@ object Settings {
               s"-Dlogback.configurationFile=${(Test / baseDirectory).value.getAbsolutePath}/src/test/resources/logback-test.xml",
               s"-Djava.util.logging.config.file=${(Test / baseDirectory).value.getAbsolutePath}/src/test/resources/logback-test.xml",
               s"-Dtest.name=${test.name}",
-              s"-Ddir.name=${(Test / baseDirectory).value}"))
+              s"-Ddir.name=${(Test / baseDirectory).value}",
+              s"-Dheadless=${Option(System.getProperty("headless")).getOrElse("false")}"))
         Tests.Group(
           name = test.name,
           tests = Seq(test),


### PR DESCRIPTION
I think this was inadvertently removed in the [Java 11 PR](https://github.com/DataBiosphere/leonardo/commit/96e467b83ae5a1404c5efd2582a215b71b0cd116#diff-f45415265fd14a72d0c7d579db5d9e03c9fd5278fefe931e31b1da1b57a152d8L195), which broke running tests locally in non-headless mode.


---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
