### PR TITLE
IA-2793: Fix launching GHCR image

### DIFF
--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpDockerDAO.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpDockerDAO.scala
@@ -131,8 +131,7 @@ class HttpDockerDAO[F[_]] private (httpClient: Client[F])(implicit logger: Logge
             method = Method.GET,
             uri = ghcrAuthUri
               .withPath("/token")
-              .withQueryParam("scope", s"repository:${parsedImage.imageName}:pull")
-              .withQueryParam("service", "registry.docker.io"),
+              .withQueryParam("scope", s"repository:${parsedImage.imageName}:pull"),
             // must be Accept: application/json not Accept: application/vnd.docker.distribution.manifest.v2+json
             headers = Headers.of(Header("Accept", "application/json"))
           )

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpDockerDAOSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpDockerDAOSpec.scala
@@ -32,18 +32,15 @@ class HttpDockerDAOSpec extends AnyFlatSpec with Matchers with BeforeAndAfterAll
     ContainerImage("us.gcr.io/broad-dsp-gcr-public/leonardo-jupyter:dev", GCR),
     ContainerImage("us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.4", GCR),
     ContainerImage("us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:0.0.5", GCR),
-    ContainerImage("us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:0.0.4", GCR)
+    ContainerImage("us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:0.0.4", GCR),
     // gcr with sha
     // TODO shas are currently not working
 //    GCR(
 //      "us.gcr.io/broad-dsp-gcr-public/leonardo-jupyter@sha256:fa11b7c528304726985b4ad4cb4cb4d8b9a2fbf7c5547671ef495f414564727c"
 //    ),
     // ghcr with tag
-    // TODO: disabled because these images now throw auth errors
     // Taken from workspace https://app.terra.bio/#workspaces/uk-biobank-sek/ml4h-toolkit-for-machine-learning-on-clinical-data
-//    ContainerImage("ghcr.io/broadinstitute/ml4h/ml4h_terra:20210104_224422", GHCR),
-    // ghcr no tag
-//    ContainerImage("ghcr.io/lucidtronix/ml4h/ml4h_terra", GHCR)
+    ContainerImage("ghcr.io/broadinstitute/ml4h/ml4h_terra:20210104_224422", GHCR)
   )
 
   val rstudioImages = List(


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-2793

Tested with `ghcr.io/broadinstitute/ml4h/ml4h_terra:20210104_224422`, which has come up in UL a couple times.

Root cause was we need to send a real noop token to GitHub when pulling the image manifest.

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
