### PR TITLE
[IA-2868] Memory updates not reflected in RStudio

### DIFF
--- a/http/src/main/resources/init-resources/jupyter-docker-compose-gce.yaml
+++ b/http/src/main/resources/init-resources/jupyter-docker-compose-gce.yaml
@@ -37,6 +37,7 @@ services:
       - /var/custom_env_vars.env
     # See https://docs.docker.com/engine/reference/run/#user-memory-constraints
     mem_limit: ${MEM_LIMIT}   # hard limit on memory consumption by the container
+    memswap_limit: ${MEM_LIMIT}
 networks:
   app_network:
     external: true

--- a/http/src/main/resources/init-resources/jupyter-docker-compose.yaml
+++ b/http/src/main/resources/init-resources/jupyter-docker-compose.yaml
@@ -51,3 +51,4 @@ services:
       - /var/custom_env_vars.env
     # See https://docs.docker.com/engine/reference/run/#user-memory-constraints
     mem_limit: ${MEM_LIMIT}   # hard limit on memory consumption by the container
+    memswap_limit: ${MEM_LIMIT}

--- a/http/src/main/resources/init-resources/rstudio-docker-compose-gce.yaml
+++ b/http/src/main/resources/init-resources/rstudio-docker-compose-gce.yaml
@@ -28,6 +28,7 @@ services:
       - /var/custom_env_vars.env
     # See https://docs.docker.com/engine/reference/run/#user-memory-constraints
     mem_limit: ${MEM_LIMIT}   # hard limit on memory consumption by the container
+    memswap_limit: ${MEM_LIMIT}
 networks:
   app_network:
     external: true

--- a/http/src/main/resources/init-resources/rstudio-docker-compose.yaml
+++ b/http/src/main/resources/init-resources/rstudio-docker-compose.yaml
@@ -25,3 +25,4 @@ services:
       - /var/custom_env_vars.env
     # See https://docs.docker.com/engine/reference/run/#user-memory-constraints
     mem_limit: ${MEM_LIMIT}   # hard limit on memory consumption by the container
+    memswap_limit: ${MEM_LIMIT}

--- a/http/src/main/resources/init-resources/startup.sh
+++ b/http/src/main/resources/init-resources/startup.sh
@@ -211,7 +211,7 @@ if [ ! -z "$JUPYTER_DOCKER_IMAGE" ] ; then
     echo "Starting Jupyter on cluster $GOOGLE_PROJECT / $CLUSTER_NAME..."
 
     # update container MEM_LIMIT to reflect VM's MEM_LIMIT
-    docker update $JUPYTER_SERVER_NAME --memory $MEM_LIMIT
+    docker update $JUPYTER_SERVER_NAME --memory $MEM_LIMIT --memory-swap $MEM_LIMIT
 
     # See IA-1901: Jupyter UI stalls indefinitely on initial R kernel connection after cluster create/resume
     # The intent of this is to "warm up" R at VM creation time to hopefully prevent issues when the Jupyter
@@ -232,7 +232,7 @@ if [ ! -z "$RSTUDIO_DOCKER_IMAGE" ] ; then
     echo "Starting RStudio on cluster $GOOGLE_PROJECT / $CLUSTER_NAME..."
 
     # update container MEM_LIMIT to reflect VM's MEM_LIMIT
-    docker update $RSTUDIO_SERVER_NAME --memory $MEM_LIMIT
+    docker update $RSTUDIO_SERVER_NAME --memory $MEM_LIMIT --memory-swap $MEM_LIMIT
 
     # Warm up R before starting the RStudio session (see above comment).
     docker exec $RSTUDIO_SERVER_NAME /bin/bash -c "R -e '1+1'" || true


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-2868

This came from UL. When a runtime PATCH call went through a stop/start to update machine type, the _old_ machine type was still being used to determine docker memory limits. Changed it to use the new value instead.

Also fixed an error with the `docker update` call (see comment below) with large memory sizes, potentially due to a newer version of docker-compose.

Tested in a fiab:

1. Create an RStudio runtime with 4 CPUs and 15G memory
2. Open RStudio, go to `Tools -> Memory -> Memory Usage Report`, see ~13G
3. In Terra UI, update the machine type to 8 CPUs and 52G memory
4. The VM goes through stop/start cycle
5. Open RStudio again, go to `Tools -> Memory -> Memory Usage Report`, see ~50G

I tried a few other updates to go larger & smaller, seems to work correctly now.

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
