### PR TITLE
[IA-2836] Proxy Spark web UI through Leonardo

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoApiClient.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoApiClient.scala
@@ -88,7 +88,7 @@ object LeonardoApiClient {
         None,
         Map.empty,
         None,
-        None
+        true
       )
     ),
     None,

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoApiClient.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoApiClient.scala
@@ -86,7 +86,9 @@ object LeonardoApiClient {
         None,
         None,
         None,
-        Map.empty
+        Map.empty,
+        None,
+        None
       )
     ),
     None,
@@ -588,8 +590,34 @@ object LeonardoApiClient {
         }
     } yield r
 
+  def testSparkWebUi(googleProject: GoogleProject,
+                     runtimeName: RuntimeName,
+                     path: String)(implicit client: Client[IO], authHeader: Authorization): IO[Unit] =
+    for {
+      traceIdHeader <- genTraceIdHeader()
+      refererHeader <- genRefererHeader()
+      _ <- client
+        .run(
+          Request[IO](
+            method = Method.GET,
+            headers = Headers.of(authHeader, traceIdHeader, refererHeader),
+            uri = rootUri.withPath(s"/proxy/${googleProject.value}/${runtimeName.asString}/${path}")
+          )
+        )
+        .use { resp =>
+          if (!resp.status.isSuccess) {
+            onError(s"Failed to load Spark Web UI: $path")(resp)
+              .flatMap(IO.raiseError)
+          } else
+            IO.unit
+        }
+    } yield ()
+
   private def genTraceIdHeader(): IO[Header] =
     IO(UUID.randomUUID().toString).map(uuid => Header(traceIdHeaderString, uuid))
+
+  private def genRefererHeader(): IO[Header] =
+    ProxyRedirectClient.baseUri.map(Referer.apply)
 }
 
 final case class RestError(message: String, statusCode: Status, body: Option[String]) extends NoStackTrace {

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/RuntimeFixtureSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/RuntimeFixtureSpec.scala
@@ -166,7 +166,7 @@ object RuntimeFixtureSpec {
           numberOfPreemptibleWorkers = None,
           properties = Map.empty,
           region = None,
-          componentGatewayEnabled = None
+          componentGatewayEnabled = true
         )
 
     }

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/RuntimeFixtureSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/RuntimeFixtureSpec.scala
@@ -164,7 +164,9 @@ object RuntimeFixtureSpec {
           workerDiskSize = None,
           numberOfWorkerLocalSSDs = None,
           numberOfPreemptibleWorkers = None,
-          properties = Map.empty
+          properties = Map.empty,
+          region = None,
+          componentGatewayEnabled = None
         )
 
     }

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeDataprocSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeDataprocSpec.scala
@@ -70,7 +70,7 @@ class RuntimeDataprocSpec
           Some(1),
           Map.empty,
           Some(RegionName("europe-west1")),
-          Some(true)
+          true
         )
       ),
       toolDockerImage = Some(ContainerImage(LeonardoConfig.Leonardo.hailImageUrl, ContainerRegistry.GCR))
@@ -110,7 +110,7 @@ class RuntimeDataprocSpec
           Some(5),
           Map.empty,
           None,
-          Some(true)
+          true
         )
       ),
       toolDockerImage = Some(ContainerImage(LeonardoConfig.Leonardo.hailImageUrl, ContainerRegistry.GCR))
@@ -194,7 +194,7 @@ class RuntimeDataprocSpec
               Some(5),
               Map.empty,
               None,
-              Some(true)
+              true
             )
           ),
           toolDockerImage = Some(ContainerImage(LeonardoConfig.Leonardo.hailImageUrl, ContainerRegistry.GCR))

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimePatchSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimePatchSpec.scala
@@ -219,7 +219,7 @@ class RuntimePatchSpec
             None,
             Map.empty,
             None,
-            None
+            true
           )
         )
       )

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimePatchSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimePatchSpec.scala
@@ -17,8 +17,8 @@ import org.broadinstitute.dsde.workbench.leonardo.notebooks.{NotebookTestUtils, 
 import org.broadinstitute.dsde.workbench.service.util.Tags
 import org.http4s.headers.Authorization
 import org.http4s.{AuthScheme, Credentials}
-import org.scalatest.{DoNotDiscover, ParallelTestExecution}
 import org.scalatest.tagobjects.Retryable
+import org.scalatest.{DoNotDiscover, ParallelTestExecution}
 
 import scala.concurrent.duration._
 
@@ -217,7 +217,9 @@ class RuntimePatchSpec
             None,
             None,
             None,
-            Map.empty
+            Map.empty,
+            None,
+            None
           )
         )
       )

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/JsonCodec.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/JsonCodec.scala
@@ -83,7 +83,7 @@ object JsonCodec {
     "numOfGpus"
   )(x => GpuConfig.unapply(x).get)
 
-  implicit val dataprocConfigEncoder: Encoder[RuntimeConfig.DataprocConfig] = Encoder.forProduct9(
+  implicit val dataprocConfigEncoder: Encoder[RuntimeConfig.DataprocConfig] = Encoder.forProduct10(
     "numberOfWorkers",
     "masterMachineType",
     "masterDiskSize",
@@ -93,7 +93,8 @@ object JsonCodec {
     "numberOfWorkerLocalSSDs",
     "numberOfPreemptibleWorkers",
     "cloudService",
-    "region"
+    "region",
+    "componentGatewayEnabled"
   )(x =>
     (x.numberOfWorkers,
      x.machineType,
@@ -103,7 +104,8 @@ object JsonCodec {
      x.numberOfWorkerLocalSSDs,
      x.numberOfPreemptibleWorkers,
      x.cloudService,
-     x.region)
+     x.region,
+     x.componentGatewayEnabled)
   )
   implicit val gceRuntimeConfigEncoder: Encoder[RuntimeConfig.GceConfig] = Encoder.forProduct6(
     "machineType",

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/JsonCodec.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/JsonCodec.scala
@@ -290,6 +290,7 @@ object JsonCodec {
       propertiesOpt <- c.downField("properties").as[Option[LabelMap]]
       properties = propertiesOpt.getOrElse(Map.empty)
       region <- c.downField("region").as[RegionName]
+      componentGatewayEnabled <- c.downField("componentGatewayEnabled").as[Boolean]
     } yield RuntimeConfig.DataprocConfig(
       numberOfWorkers,
       masterMachineType,
@@ -299,7 +300,8 @@ object JsonCodec {
       numberOfWorkerLocalSSDs,
       numberOfPreemptibleWorkers,
       properties,
-      region
+      region,
+      componentGatewayEnabled
     )
   }
 

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/runtimeRoutesModels.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/runtimeRoutesModels.scala
@@ -59,7 +59,8 @@ object RuntimeConfigRequest {
                                   numberOfWorkerLocalSSDs: Option[Int] = None, //min 0 max 8
                                   numberOfPreemptibleWorkers: Option[Int] = None,
                                   properties: Map[String, String],
-                                  region: Option[RegionName] = None)
+                                  region: Option[RegionName],
+                                  componentGatewayEnabled: Option[Boolean])
       extends RuntimeConfigRequest {
     val cloudService: CloudService = CloudService.Dataproc
   }

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/runtimeRoutesModels.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/runtimeRoutesModels.scala
@@ -60,7 +60,7 @@ object RuntimeConfigRequest {
                                   numberOfPreemptibleWorkers: Option[Int] = None,
                                   properties: Map[String, String],
                                   region: Option[RegionName],
-                                  componentGatewayEnabled: Option[Boolean])
+                                  componentGatewayEnabled: Boolean)
       extends RuntimeConfigRequest {
     val cloudService: CloudService = CloudService.Dataproc
   }

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/runtimeModels.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/runtimeModels.scala
@@ -257,7 +257,8 @@ object RuntimeConfig {
                                   numberOfWorkerLocalSSDs: Option[Int] = None, //min 0 max 8
                                   numberOfPreemptibleWorkers: Option[Int] = None,
                                   properties: Map[String, String],
-                                  region: RegionName)
+                                  region: RegionName,
+                                  componentGatewayEnabled: Boolean)
       extends RuntimeConfig {
     val cloudService: CloudService = CloudService.Dataproc
     val machineType: MachineTypeName = masterMachineType

--- a/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/JsonCodecSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/JsonCodecSpec.scala
@@ -19,7 +19,8 @@ class JsonCodecSpec extends LeonardoTestSuite with Matchers with AnyFlatSpecLike
         |   "masterDiskSize": 500,
         |   "numberOfPreemptibleWorkers": -1,
         |   "cloudService": "DATAPROC",
-        |   "region": "us-west2"
+        |   "region": "us-west2",
+        |   "componentGatewayEnabled": true
         |}
         |""".stripMargin
 
@@ -33,7 +34,8 @@ class JsonCodecSpec extends LeonardoTestSuite with Matchers with AnyFlatSpecLike
       None,
       Some(-1),
       Map.empty,
-      RegionName("us-west2")
+      RegionName("us-west2"),
+      true
     )
     res shouldBe (Right(expected))
   }

--- a/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/RuntimeRoutesTestJsonCodec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/RuntimeRoutesTestJsonCodec.scala
@@ -23,7 +23,7 @@ import java.time.Instant
 import org.broadinstitute.dsde.workbench.leonardo.SamResourceId.RuntimeSamResourceId
 
 object RuntimeRoutesTestJsonCodec {
-  implicit val dataprocConfigRequestEncoder: Encoder[RuntimeConfigRequest.DataprocConfig] = Encoder.forProduct9(
+  implicit val dataprocConfigRequestEncoder: Encoder[RuntimeConfigRequest.DataprocConfig] = Encoder.forProduct10(
     "cloudService",
     "numberOfWorkers",
     "masterMachineType",
@@ -33,7 +33,8 @@ object RuntimeRoutesTestJsonCodec {
     "workerDiskSize",
     "numberOfWorkerLocalSSDs",
     "numberOfPreemptibleWorkers",
-    "region"
+    "region",
+    "componentGatewayEnabled"
   )(x =>
     (x.cloudService,
      x.numberOfWorkers,
@@ -43,7 +44,8 @@ object RuntimeRoutesTestJsonCodec {
      x.workerDiskSize,
      x.numberOfWorkerLocalSSDs,
      x.numberOfPreemptibleWorkers,
-     x.region)
+     x.region,
+     x.componentGatewayEnabled)
   )
   implicit val gceRuntimeConfigRequestEncoder: Encoder[RuntimeConfigRequest.GceConfig] = Encoder.forProduct5(
     "cloudService",

--- a/http/src/main/resources/init-resources/cluster-site.conf
+++ b/http/src/main/resources/init-resources/cluster-site.conf
@@ -21,20 +21,20 @@
     RewriteCond %{REQUEST_URI} /proxy/[^/]*/[^/]*/gateway/.* [NC]
     RewriteRule .* http://127.0.0.1:8443%{REQUEST_URI} [P,L]
 
-    RewriteCond %{REQUEST_URI} /proxy/[^/]*/[^/]*/yarn/.* [NC]
-    RewriteRule /proxy/[^/]*/[^/]*/yarn/(.*) http://127.0.0.1:8443/yarn/$1 [P,L]
+    RewriteCond %{REQUEST_URI} /proxy/[^/]*/[^/]*/spark-yarn/.* [NC]
+    RewriteRule /proxy/[^/]*/[^/]*/spark-yarn/(.*) http://127.0.0.1:8443/yarn/$1 [P,L]
 
-    RewriteCond %{REQUEST_URI} /proxy/[^/]*/[^/]*/jobhistory/.* [NC]
-    RewriteRule /proxy/[^/]*/[^/]*/jobhistory/(.*) http://127.0.0.1:8443/jobhistory/$1 [P,L]
+    RewriteCond %{REQUEST_URI} /proxy/[^/]*/[^/]*/spark-jobhistory/.* [NC]
+    RewriteRule /proxy/[^/]*/[^/]*/spark-jobhistory/(.*) http://127.0.0.1:8443/jobhistory/$1 [P,L]
 
-    RewriteCond %{REQUEST_URI} /proxy/[^/]*/[^/]*/apphistory/.* [NC]
-    RewriteRule /proxy/[^/]*/[^/]*/apphistory/(.*) http://127.0.0.1:8443/apphistory/$1 [P,L]
+    RewriteCond %{REQUEST_URI} /proxy/[^/]*/[^/]*/spark-apphistory/.* [NC]
+    RewriteRule /proxy/[^/]*/[^/]*/spark-apphistory/(.*) http://127.0.0.1:8443/apphistory/$1 [P,L]
 
-    RewriteCond %{REQUEST_URI} /proxy/[^/]*/[^/]*/sparkhistory/.* [NC]
-    RewriteRule /proxy/[^/]*/[^/]*/sparkhistory/(.*) http://127.0.0.1:8443/sparkhistory/$1 [P,L]
+    RewriteCond %{REQUEST_URI} /proxy/[^/]*/[^/]*/spark-sparkhistory/.* [NC]
+    RewriteRule /proxy/[^/]*/[^/]*/spark-sparkhistory/(.*) http://127.0.0.1:8443/sparkhistory/$1 [P,L]
 
-    RewriteCond %{REQUEST_URI} /proxy/[^/]*/[^/]*/hdfs/.* [NC]
-    RewriteRule /proxy/[^/]*/[^/]*/hdfs/(.*) http://127.0.0.1:8443/hdfs/$1 [P,L]
+    RewriteCond %{REQUEST_URI} /proxy/[^/]*/[^/]*/spark-hdfs/.* [NC]
+    RewriteRule /proxy/[^/]*/[^/]*/spark-hdfs/(.*) http://127.0.0.1:8443/hdfs/$1 [P,L]
 
     ################
     # RStudio

--- a/http/src/main/resources/init-resources/cluster-site.conf
+++ b/http/src/main/resources/init-resources/cluster-site.conf
@@ -18,6 +18,9 @@
     ################
     # Spark Web UIs
     ################
+    RewriteCond %{REQUEST_URI} /proxy/[^/]*/[^/]*/gateway/.* [NC]
+    RewriteRule .* http://127.0.0.1:8443%{REQUEST_URI} [P,L]
+
     RewriteCond %{REQUEST_URI} /proxy/[^/]*/[^/]*/yarn/.* [NC]
     RewriteRule /proxy/[^/]*/[^/]*/yarn/(.*) http://127.0.0.1:8443/yarn/$1 [P,L]
 
@@ -25,16 +28,13 @@
     RewriteRule /proxy/[^/]*/[^/]*/jobhistory/(.*) http://127.0.0.1:8443/jobhistory/$1 [P,L]
 
     RewriteCond %{REQUEST_URI} /proxy/[^/]*/[^/]*/apphistory/.* [NC]
-    RewriteRule /proxy/[^/]*/[^/]*/jobhistory/(.*) http://127.0.0.1:8443/apphistory/$1 [P,L]
+    RewriteRule /proxy/[^/]*/[^/]*/apphistory/(.*) http://127.0.0.1:8443/apphistory/$1 [P,L]
 
     RewriteCond %{REQUEST_URI} /proxy/[^/]*/[^/]*/sparkhistory/.* [NC]
-    RewriteRule /proxy/[^/]*/[^/]*/jobhistory/(.*) http://127.0.0.1:8443/sparkhistory/$1 [P,L]
+    RewriteRule /proxy/[^/]*/[^/]*/sparkhistory/(.*) http://127.0.0.1:8443/sparkhistory/$1 [P,L]
 
     RewriteCond %{REQUEST_URI} /proxy/[^/]*/[^/]*/hdfs/.* [NC]
     RewriteRule /proxy/[^/]*/[^/]*/hdfs/(.*) http://127.0.0.1:8443/hdfs/$1 [P,L]
-
-    #ProxyPassReverse /proxy/${GOOGLE_PROJECT}/${RUNTIME_NAME}/yarn/ http://127.0.0.1:8088/
-    #ProxyPassReverse /proxy/${GOOGLE_PROJECT}/${RUNTIME_NAME}/hdfs/ http://127.0.0.1:9870/
 
     ################
     # RStudio

--- a/http/src/main/resources/init-resources/cluster-site.conf
+++ b/http/src/main/resources/init-resources/cluster-site.conf
@@ -24,6 +24,9 @@
     RewriteCond %{REQUEST_URI} /proxy/[^/]*/[^/]*/hdfs/.* [NC]
     RewriteRule /proxy/[^/]*/[^/]*/hdfs/(.*) http://127.0.0.1:9870/$1 [P,L]
 
+    ProxyPassReverse /proxy/${GOOGLE_PROJECT}/${RUNTIME_NAME}/yarn/ http://127.0.0.1:8088/
+    ProxyPassReverse /proxy/${GOOGLE_PROJECT}/${RUNTIME_NAME}/hdfs/ http://127.0.0.1:9870/
+
     ################
     # RStudio
     ################

--- a/http/src/main/resources/init-resources/cluster-site.conf
+++ b/http/src/main/resources/init-resources/cluster-site.conf
@@ -16,6 +16,15 @@
     RewriteEngine on
 
     ################
+    # Spark Web UIs
+    ################
+    RewriteCond %{REQUEST_URI} /proxy/[^/]*/[^/]*/yarn/.* [NC]
+    RewriteRule /proxy/[^/]*/[^/]*/yarn/(.*) http://127.0.0.1:8088/$1 [P,L]
+
+    RewriteCond %{REQUEST_URI} /proxy/[^/]*/[^/]*/hdfs/.* [NC]
+    RewriteRule /proxy/[^/]*/[^/]*/hdfs/(.*) http://127.0.0.1:9870/$1 [P,L]
+
+    ################
     # RStudio
     ################
     RewriteCond %{HTTP:Upgrade} =websocket

--- a/http/src/main/resources/init-resources/cluster-site.conf
+++ b/http/src/main/resources/init-resources/cluster-site.conf
@@ -21,20 +21,20 @@
     RewriteCond %{REQUEST_URI} /proxy/[^/]*/[^/]*/gateway/.* [NC]
     RewriteRule .* http://127.0.0.1:8443%{REQUEST_URI} [P,L]
 
-    RewriteCond %{REQUEST_URI} /proxy/[^/]*/[^/]*/spark-yarn/.* [NC]
-    RewriteRule /proxy/[^/]*/[^/]*/spark-yarn/(.*) http://127.0.0.1:8443/yarn/$1 [P,L]
+    RewriteCond %{REQUEST_URI} /proxy/[^/]*/[^/]*/yarn/.* [NC]
+    RewriteRule /proxy/[^/]*/[^/]*/yarn/(.*) http://127.0.0.1:8443/yarn/$1 [P,L]
 
-    RewriteCond %{REQUEST_URI} /proxy/[^/]*/[^/]*/spark-jobhistory/.* [NC]
-    RewriteRule /proxy/[^/]*/[^/]*/spark-jobhistory/(.*) http://127.0.0.1:8443/jobhistory/$1 [P,L]
+    RewriteCond %{REQUEST_URI} /proxy/[^/]*/[^/]*/jobhistory/.* [NC]
+    RewriteRule /proxy/[^/]*/[^/]*/jobhistory/(.*) http://127.0.0.1:8443/jobhistory/$1 [P,L]
 
-    RewriteCond %{REQUEST_URI} /proxy/[^/]*/[^/]*/spark-apphistory/.* [NC]
-    RewriteRule /proxy/[^/]*/[^/]*/spark-apphistory/(.*) http://127.0.0.1:8443/apphistory/$1 [P,L]
+    RewriteCond %{REQUEST_URI} /proxy/[^/]*/[^/]*/apphistory/.* [NC]
+    RewriteRule /proxy/[^/]*/[^/]*/apphistory/(.*) http://127.0.0.1:8443/apphistory/$1 [P,L]
 
-    RewriteCond %{REQUEST_URI} /proxy/[^/]*/[^/]*/spark-sparkhistory/.* [NC]
-    RewriteRule /proxy/[^/]*/[^/]*/spark-sparkhistory/(.*) http://127.0.0.1:8443/sparkhistory/$1 [P,L]
+    RewriteCond %{REQUEST_URI} /proxy/[^/]*/[^/]*/sparkhistory/.* [NC]
+    RewriteRule /proxy/[^/]*/[^/]*/sparkhistory/(.*) http://127.0.0.1:8443/sparkhistory/$1 [P,L]
 
-    RewriteCond %{REQUEST_URI} /proxy/[^/]*/[^/]*/spark-hdfs/.* [NC]
-    RewriteRule /proxy/[^/]*/[^/]*/spark-hdfs/(.*) http://127.0.0.1:8443/hdfs/$1 [P,L]
+    RewriteCond %{REQUEST_URI} /proxy/[^/]*/[^/]*/hdfs/.* [NC]
+    RewriteRule /proxy/[^/]*/[^/]*/hdfs/(.*) http://127.0.0.1:8443/hdfs/$1 [P,L]
 
     ################
     # RStudio

--- a/http/src/main/resources/init-resources/cluster-site.conf
+++ b/http/src/main/resources/init-resources/cluster-site.conf
@@ -19,13 +19,22 @@
     # Spark Web UIs
     ################
     RewriteCond %{REQUEST_URI} /proxy/[^/]*/[^/]*/yarn/.* [NC]
-    RewriteRule /proxy/[^/]*/[^/]*/yarn/(.*) http://127.0.0.1:8088/$1 [P,L]
+    RewriteRule /proxy/[^/]*/[^/]*/yarn/(.*) http://127.0.0.1:8443/yarn/$1 [P,L]
+
+    RewriteCond %{REQUEST_URI} /proxy/[^/]*/[^/]*/jobhistory/.* [NC]
+    RewriteRule /proxy/[^/]*/[^/]*/jobhistory/(.*) http://127.0.0.1:8443/jobhistory/$1 [P,L]
+
+    RewriteCond %{REQUEST_URI} /proxy/[^/]*/[^/]*/apphistory/.* [NC]
+    RewriteRule /proxy/[^/]*/[^/]*/jobhistory/(.*) http://127.0.0.1:8443/apphistory/$1 [P,L]
+
+    RewriteCond %{REQUEST_URI} /proxy/[^/]*/[^/]*/sparkhistory/.* [NC]
+    RewriteRule /proxy/[^/]*/[^/]*/jobhistory/(.*) http://127.0.0.1:8443/sparkhistory/$1 [P,L]
 
     RewriteCond %{REQUEST_URI} /proxy/[^/]*/[^/]*/hdfs/.* [NC]
-    RewriteRule /proxy/[^/]*/[^/]*/hdfs/(.*) http://127.0.0.1:9870/$1 [P,L]
+    RewriteRule /proxy/[^/]*/[^/]*/hdfs/(.*) http://127.0.0.1:8443/hdfs/$1 [P,L]
 
-    ProxyPassReverse /proxy/${GOOGLE_PROJECT}/${RUNTIME_NAME}/yarn/ http://127.0.0.1:8088/
-    ProxyPassReverse /proxy/${GOOGLE_PROJECT}/${RUNTIME_NAME}/hdfs/ http://127.0.0.1:9870/
+    #ProxyPassReverse /proxy/${GOOGLE_PROJECT}/${RUNTIME_NAME}/yarn/ http://127.0.0.1:8088/
+    #ProxyPassReverse /proxy/${GOOGLE_PROJECT}/${RUNTIME_NAME}/hdfs/ http://127.0.0.1:9870/
 
     ################
     # RStudio

--- a/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changelog.xml
+++ b/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changelog.xml
@@ -77,4 +77,5 @@
     <include file="changesets/20210505_rename_jupyter_user_script_column.xml" relativeToChangelogFile="true" />
     <include file="changesets/20210429_rename_vm.xml" relativeToChangelogFile="true" />
     <include file="changesets/20210517_add_gpu_config.xml" relativeToChangelogFile="true" />
+    <include file="changesets/20210723_add_component_gateway_enabled_flag.xml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/20210723_add_component_gateway_enabled_flag.xml
+++ b/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/20210723_add_component_gateway_enabled_flag.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog logicalFilePath="leonardo" xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+
+    <changeSet logicalFilePath="leonardo" author="rtitle" id="add_component_gateway_enabled">
+        <addColumn tableName="RUNTIME_CONFIG">
+            <column name="componentGatewayEnabled" type="boolean" defaultValueBoolean="false">
+                <constraints nullable="false"/>
+            </column>
+        </addColumn>
+    </changeSet>
+
+</databaseChangeLog>

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -60,6 +60,8 @@ dataproc {
     numberOfWorkerLocalSSDs = 0
     numberOfPreemptibleWorkers = 0
     region = "us-central1"
+    # TODO: change to true when ready to roll out Spark Web UIs for new clusters
+    componentGatewayEnabled = false
   }
   customDataprocImage = "projects/broad-dsp-gcr-public/global/images/test-1-4-51-debian10-qi-2021-07-22-11-27-42"
 

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -60,8 +60,6 @@ dataproc {
     numberOfWorkerLocalSSDs = 0
     numberOfPreemptibleWorkers = 0
     region = "us-central1"
-    # TODO: change to true when ready to roll out Spark Web UIs for new clusters
-    componentGatewayEnabled = false
   }
   customDataprocImage = "projects/broad-dsp-gcr-public/global/images/test-1-4-51-debian10-qi-2021-07-22-11-27-42"
 

--- a/http/src/main/resources/swagger/api-docs.yaml
+++ b/http/src/main/resources/swagger/api-docs.yaml
@@ -1613,7 +1613,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorReport"
-  "/proxy/{googleProject}/{runtimeName}/spark-yarn":
+  "/proxy/{googleProject}/{runtimeName}/yarn":
     get:
       summary: YARN Resource Manager
       description: >
@@ -1668,7 +1668,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorReport"
-  "/proxy/{googleProject}/{runtimeName}/spark-jobhistory":
+  "/proxy/{googleProject}/{runtimeName}/jobhistory":
     get:
       summary: MapReduce Job History
       description: >
@@ -1723,7 +1723,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorReport"
-  "/proxy/{googleProject}/{runtimeName}/spark-apphistory":
+  "/proxy/{googleProject}/{runtimeName}/apphistory":
     get:
       summary: YARN Application Timeline
       description: >
@@ -1778,7 +1778,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorReport"
-  "/proxy/{googleProject}/{runtimeName}/spark-sparkhistory":
+  "/proxy/{googleProject}/{runtimeName}/sparkhistory":
     get:
       summary: Spark History Server
       description: >
@@ -1833,7 +1833,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorReport"
-  "/proxy/{googleProject}/{runtimeName}/spark-hdfs":
+  "/proxy/{googleProject}/{runtimeName}/hdfs":
     get:
       summary: HDFS NameNode
       description: >

--- a/http/src/main/resources/swagger/api-docs.yaml
+++ b/http/src/main/resources/swagger/api-docs.yaml
@@ -1320,14 +1320,14 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorReport"
-        "420":
-          description: Runtime not ready
+        "422":
+          description: Runtime is stopped
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorReport"
-        "422":
-          description: Runtime is stopped
+        "423":
+          description: Runtime not ready
           content:
             application/json:
               schema:
@@ -1377,14 +1377,14 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorReport"
-        "420":
-          description: Runtime not ready
+        "422":
+          description: Runtime is stopped
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorReport"
-        "422":
-          description: Runtime is stopped
+        "423":
+          description: Runtime not ready
           content:
             application/json:
               schema:
@@ -1434,14 +1434,14 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorReport"
-        "420":
-          description: Runtime not ready
+        "422":
+          description: Runtime is stopped
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorReport"
-        "422":
-          description: Runtime is stopped
+        "423":
+          description: Runtime not ready
           content:
             application/json:
               schema:
@@ -1497,14 +1497,14 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorReport"
-        "420":
-          description: App not ready
+        "422":
+          description: App is stopped
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorReport"
-        "422":
-          description: App is stopped
+        "423":
+          description: App not ready
           content:
             application/json:
               schema:
@@ -1603,6 +1603,281 @@ paths:
                 $ref: "#/components/schemas/ErrorReport"
         "404":
           description: Runtime not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorReport"
+        "500":
+          description: Internal Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorReport"
+  "/proxy/{googleProject}/{runtimeName}/yarn":
+    get:
+      summary: YARN Resource Manager
+      description: >
+        Only available for Dataproc runtimes with Component Gateway enabled.
+        See https://cloud.google.com/dataproc/docs/concepts/accessing/dataproc-gateways
+      operationId: yarn
+      tags:
+        - proxy
+      parameters:
+        - in: path
+          name: googleProject
+          description: googleProject
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: runtimeName
+          description: runtimeName
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Proxy connection successful
+        "403":
+          description: Proxy connection unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorReport"
+        "404":
+          description: Runtime not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorReport"
+        "422":
+          description: Runtime is stopped
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorReport"
+        "423":
+          description: Runtime not ready
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorReport"
+        "500":
+          description: Internal Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorReport"
+  "/proxy/{googleProject}/{runtimeName}/jobhistory":
+    get:
+      summary: MapReduce Job History
+      description: >
+        Only available for Dataproc runtimes with Component Gateway enabled.
+        See https://cloud.google.com/dataproc/docs/concepts/accessing/dataproc-gateways
+      operationId: jobhistory
+      tags:
+        - proxy
+      parameters:
+        - in: path
+          name: googleProject
+          description: googleProject
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: runtimeName
+          description: runtimeName
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Proxy connection successful
+        "403":
+          description: Proxy connection unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorReport"
+        "404":
+          description: Runtime not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorReport"
+        "422":
+          description: Runtime is stopped
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorReport"
+        "423":
+          description: Runtime not ready
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorReport"
+        "500":
+          description: Internal Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorReport"
+  "/proxy/{googleProject}/{runtimeName}/apphistory":
+    get:
+      summary: YARN Application Timeline
+      description: >
+        Only available for Dataproc runtimes with Component Gateway enabled.
+        See https://cloud.google.com/dataproc/docs/concepts/accessing/dataproc-gateways
+      operationId: apphistory
+      tags:
+        - proxy
+      parameters:
+        - in: path
+          name: googleProject
+          description: googleProject
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: runtimeName
+          description: runtimeName
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Proxy connection successful
+        "403":
+          description: Proxy connection unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorReport"
+        "404":
+          description: Runtime not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorReport"
+        "422":
+          description: Runtime is stopped
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorReport"
+        "423":
+          description: Runtime not ready
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorReport"
+        "500":
+          description: Internal Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorReport"
+  "/proxy/{googleProject}/{runtimeName}/sparkhistory":
+    get:
+      summary: Spark History Server
+      description: >
+        Only available for Dataproc runtimes with Component Gateway enabled.
+        See https://cloud.google.com/dataproc/docs/concepts/accessing/dataproc-gateways
+      operationId: sparkhistory
+      tags:
+        - proxy
+      parameters:
+        - in: path
+          name: googleProject
+          description: googleProject
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: runtimeName
+          description: runtimeName
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Proxy connection successful
+        "403":
+          description: Proxy connection unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorReport"
+        "404":
+          description: Runtime not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorReport"
+        "422":
+          description: Runtime is stopped
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorReport"
+        "423":
+          description: Runtime not ready
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorReport"
+        "500":
+          description: Internal Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorReport"
+  "/proxy/{googleProject}/{runtimeName}/hdfs":
+    get:
+      summary: HDFS NameNode
+      description: >
+        Only available for Dataproc runtimes with Component Gateway enabled.
+        See https://cloud.google.com/dataproc/docs/concepts/accessing/dataproc-gateways
+      operationId: hdfs
+      tags:
+        - proxy
+      parameters:
+        - in: path
+          name: googleProject
+          description: googleProject
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: runtimeName
+          description: runtimeName
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Proxy connection successful
+        "403":
+          description: Proxy connection unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorReport"
+        "404":
+          description: Runtime not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorReport"
+        "422":
+          description: Runtime is stopped
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorReport"
+        "423":
+          description: Runtime not ready
           content:
             application/json:
               schema:
@@ -2456,6 +2731,13 @@ components:
               description: >
                 Optional, the deployment region of the cluster. For example, us-east1 or europe-west2.
                 Defaults to us-central1.
+            componentGatewayEnabled:
+              type: boolean
+              description: >
+                Optional, specifies whether to enable Dataproc Component Gateway on the cluster.
+                This can be used for accessing Spark web UIs. See
+                https://cloud.google.com/dataproc/docs/concepts/accessing/dataproc-gateways for more details.
+                Defaults to false.
     UserJupyterExtensionConfig:
       description: Specification of Jupyter Extensions to be installed on the cluster
       properties:

--- a/http/src/main/resources/swagger/api-docs.yaml
+++ b/http/src/main/resources/swagger/api-docs.yaml
@@ -4,7 +4,7 @@ info:
   description: |
     Workbench notebooks service.
   # Follow semantic versioning https://semver.org/
-  version: "1.2.0"
+  version: "1.3.0"
   license:
     name: BSD
     url: http://opensource.org/licenses/BSD-3-Clause
@@ -1613,7 +1613,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorReport"
-  "/proxy/{googleProject}/{runtimeName}/yarn":
+  "/proxy/{googleProject}/{runtimeName}/spark-yarn":
     get:
       summary: YARN Resource Manager
       description: >
@@ -1668,7 +1668,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorReport"
-  "/proxy/{googleProject}/{runtimeName}/jobhistory":
+  "/proxy/{googleProject}/{runtimeName}/spark-jobhistory":
     get:
       summary: MapReduce Job History
       description: >
@@ -1723,7 +1723,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorReport"
-  "/proxy/{googleProject}/{runtimeName}/apphistory":
+  "/proxy/{googleProject}/{runtimeName}/spark-apphistory":
     get:
       summary: YARN Application Timeline
       description: >
@@ -1778,7 +1778,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorReport"
-  "/proxy/{googleProject}/{runtimeName}/sparkhistory":
+  "/proxy/{googleProject}/{runtimeName}/spark-sparkhistory":
     get:
       summary: Spark History Server
       description: >
@@ -1833,7 +1833,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorReport"
-  "/proxy/{googleProject}/{runtimeName}/hdfs":
+  "/proxy/{googleProject}/{runtimeName}/spark-hdfs":
     get:
       summary: HDFS NameNode
       description: >

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
@@ -78,7 +78,8 @@ object Config {
         config.getAs[Int]("numberOfWorkerLocalSSDs"),
         config.getAs[Int]("numberOfPreemptibleWorkers"),
         Map.empty,
-        config.as[RegionName]("region")
+        config.as[RegionName]("region"),
+        config.getBoolean("componentGatewayEnabled")
       )
   }
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
@@ -79,7 +79,7 @@ object Config {
         config.getAs[Int]("numberOfPreemptibleWorkers"),
         Map.empty,
         config.as[RegionName]("region"),
-        config.getBoolean("componentGatewayEnabled")
+        false // Not used; default defined in RuntimeConfigRequest.DataprocConfig decoder
       )
   }
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/RuntimeRoutes.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/RuntimeRoutes.scala
@@ -299,37 +299,53 @@ object RuntimeRoutes {
         .as[Option[Int]]
         .flatMap(x => if (x.exists(_ < 0)) Left(negativeNumberDecodingFailure) else Right(x))
       region <- c.downField("region").as[Option[RegionName]]
+      componentGatewayEnabled <- c.downField("componentGatewayEnabled").as[Option[Boolean]]
       res <- numberOfWorkersInput match {
         case Some(x) if x < 0 => Left(negativeNumberDecodingFailure)
         case Some(0) =>
           Right(
             RuntimeConfigRequest
-              .DataprocConfig(Some(0), masterMachineType, masterDiskSize, None, None, None, None, properties)
+              .DataprocConfig(Some(0),
+                              masterMachineType,
+                              masterDiskSize,
+                              None,
+                              None,
+                              None,
+                              None,
+                              properties,
+                              region,
+                              componentGatewayEnabled)
           )
         case Some(1) => Left(oneWorkerSpecifiedDecodingFailure)
         case Some(x) =>
           Right(
-            RuntimeConfigRequest.DataprocConfig(Some(x),
-                                                masterMachineType,
-                                                masterDiskSize,
-                                                workerMachineType,
-                                                workerDiskSize,
-                                                numberOfWorkerLocalSSDs,
-                                                numberOfPreemptibleWorkers,
-                                                properties,
-                                                region)
+            RuntimeConfigRequest.DataprocConfig(
+              Some(x),
+              masterMachineType,
+              masterDiskSize,
+              workerMachineType,
+              workerDiskSize,
+              numberOfWorkerLocalSSDs,
+              numberOfPreemptibleWorkers,
+              properties,
+              region,
+              componentGatewayEnabled
+            )
           )
         case None =>
           Right(
-            RuntimeConfigRequest.DataprocConfig(None,
-                                                masterMachineType,
-                                                masterDiskSize,
-                                                workerMachineType,
-                                                workerDiskSize,
-                                                numberOfWorkerLocalSSDs,
-                                                numberOfPreemptibleWorkers,
-                                                properties,
-                                                region)
+            RuntimeConfigRequest.DataprocConfig(
+              None,
+              masterMachineType,
+              masterDiskSize,
+              workerMachineType,
+              workerDiskSize,
+              numberOfWorkerLocalSSDs,
+              numberOfPreemptibleWorkers,
+              properties,
+              region,
+              componentGatewayEnabled
+            )
           )
       }
     } yield res

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/RuntimeRoutes.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/RuntimeRoutes.scala
@@ -314,7 +314,7 @@ object RuntimeRoutes {
                               None,
                               properties,
                               region,
-                              componentGatewayEnabled)
+                              componentGatewayEnabled.getOrElse(false))
           )
         case Some(1) => Left(oneWorkerSpecifiedDecodingFailure)
         case Some(x) =>
@@ -329,7 +329,7 @@ object RuntimeRoutes {
               numberOfPreemptibleWorkers,
               properties,
               region,
-              componentGatewayEnabled
+              componentGatewayEnabled.getOrElse(false)
             )
           )
         case None =>
@@ -344,7 +344,7 @@ object RuntimeRoutes {
               numberOfPreemptibleWorkers,
               properties,
               region,
-              componentGatewayEnabled
+              componentGatewayEnabled.getOrElse(false)
             )
           )
       }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterp.scala
@@ -677,7 +677,7 @@ class RuntimeServiceInterp[F[_]: Parallel](config: RuntimeServiceConfig,
                                                diskUpdate,
                                                context.traceId)
           } yield r
-        case (dataprocConfig @ RuntimeConfig.DataprocConfig(_, _, _, _, _, _, _, _, _),
+        case (dataprocConfig @ RuntimeConfig.DataprocConfig(_, _, _, _, _, _, _, _, _, _),
               req @ UpdateRuntimeConfigRequest.DataprocConfig(_, _, _, _)) =>
           processUpdateDataprocConfigRequest(req, allowStop, runtime, dataprocConfig)
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/leoPubsubMessageSubscriberModels.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/leoPubsubMessageSubscriberModels.scala
@@ -59,7 +59,8 @@ object RuntimeConfigInCreateRuntimeMessage {
                                   numberOfWorkerLocalSSDs: Option[Int] = None, //min 0 max 8
                                   numberOfPreemptibleWorkers: Option[Int] = None,
                                   properties: Map[String, String],
-                                  region: RegionName)
+                                  region: RegionName,
+                                  componentGatewayEnabled: Boolean)
       extends RuntimeConfigInCreateRuntimeMessage {
     val cloudService: CloudService = CloudService.Dataproc
     val machineType: MachineTypeName = masterMachineType
@@ -83,7 +84,8 @@ object RuntimeConfigInCreateRuntimeMessage {
           None,
           None,
           dataproc.properties,
-          dataproc.region.getOrElse(default.region)
+          dataproc.region.getOrElse(default.region),
+          dataproc.componentGatewayEnabled.getOrElse(default.componentGatewayEnabled)
         )
       case Some(numWorkers) =>
         val wds = dataproc.workerDiskSize.orElse(default.workerDiskSize)
@@ -96,7 +98,8 @@ object RuntimeConfigInCreateRuntimeMessage {
           dataproc.numberOfWorkerLocalSSDs.orElse(default.numberOfWorkerLocalSSDs),
           dataproc.numberOfPreemptibleWorkers.orElse(default.numberOfPreemptibleWorkers),
           dataproc.properties,
-          dataproc.region.getOrElse(default.region)
+          dataproc.region.getOrElse(default.region),
+          dataproc.componentGatewayEnabled.getOrElse(default.componentGatewayEnabled)
         )
     }
   }
@@ -546,6 +549,7 @@ object LeoPubsubCodec {
       propertiesOpt <- c.downField("properties").as[Option[LabelMap]]
       properties = propertiesOpt.getOrElse(Map.empty)
       region <- c.downField("region").as[RegionName]
+      componentGatewayEnabled <- c.downField("componentGatewayEnabled").as[Boolean]
     } yield RuntimeConfigInCreateRuntimeMessage.DataprocConfig(
       numberOfWorkers,
       masterMachineType,
@@ -555,7 +559,8 @@ object LeoPubsubCodec {
       numberOfWorkerLocalSSDs,
       numberOfPreemptibleWorkers,
       properties,
-      region
+      region,
+      componentGatewayEnabled
     )
   }
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/leoPubsubMessageSubscriberModels.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/leoPubsubMessageSubscriberModels.scala
@@ -85,7 +85,7 @@ object RuntimeConfigInCreateRuntimeMessage {
           None,
           dataproc.properties,
           dataproc.region.getOrElse(default.region),
-          dataproc.componentGatewayEnabled.getOrElse(default.componentGatewayEnabled)
+          dataproc.componentGatewayEnabled
         )
       case Some(numWorkers) =>
         val wds = dataproc.workerDiskSize.orElse(default.workerDiskSize)
@@ -99,7 +99,7 @@ object RuntimeConfigInCreateRuntimeMessage {
           dataproc.numberOfPreemptibleWorkers.orElse(default.numberOfPreemptibleWorkers),
           dataproc.properties,
           dataproc.region.getOrElse(default.region),
-          dataproc.componentGatewayEnabled.getOrElse(default.componentGatewayEnabled)
+          dataproc.componentGatewayEnabled
         )
     }
   }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/DataprocInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/DataprocInterpreter.scala
@@ -716,7 +716,9 @@ class DataprocInterpreter[F[_]: Timer: Parallel: ContextShift](
 
     val yarnProps = Map(
       // Helps with debugging
-      "yarn:yarn.log-aggregation-enable" -> "true"
+      "yarn:yarn.log-aggregation-enable" -> "true",
+      // Allows submitting jobs through the YARN Resource Manager web UI
+      "yarn:yarn.resourcemanager.webapp.methods-allowed" -> "ALL"
     )
 
     val stackdriverProps = Map("dataproc:dataproc.monitoring.stackdriver.enable" -> "true")

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/DataprocInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/DataprocInterpreter.scala
@@ -251,9 +251,10 @@ class DataprocInterpreter[F[_]: Timer: Parallel: ContextShift](
 
         // Enables Dataproc Component Gateway. Used for enabling cluster web UIs.
         // See https://cloud.google.com/dataproc/docs/concepts/accessing/dataproc-gateways
-        endpointConfig = if (machineConfig.componentGatewayEnabled)
-          Some(EndpointConfig.newBuilder().setEnableHttpPortAccess(true).build())
-        else None
+        endpointConfig = EndpointConfig
+          .newBuilder()
+          .setEnableHttpPortAccess(machineConfig.componentGatewayEnabled)
+          .build()
 
         createClusterConfig = CreateClusterConfig(
           gceClusterConfig,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/DataprocInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/DataprocInterpreter.scala
@@ -247,6 +247,10 @@ class DataprocInterpreter[F[_]: Timer: Parallel: ContextShift](
 
         softwareConfig = getSoftwareConfig(params.runtimeProjectAndName.googleProject, machineConfig)
 
+        // Enables Dataproc Component Gateway. Used for enabling cluster web UIs.
+        // See https://cloud.google.com/dataproc/docs/concepts/accessing/dataproc-gateways
+        endpointConfig = EndpointConfig.newBuilder().setEnableHttpPortAccess(true).build()
+
         createClusterConfig = CreateClusterConfig(
           gceClusterConfig,
           nodeInitializationActions,
@@ -254,7 +258,8 @@ class DataprocInterpreter[F[_]: Timer: Parallel: ContextShift](
           workerConfig,
           secondaryWorkerConfig,
           stagingBucketName,
-          softwareConfig
+          softwareConfig,
+          Some(endpointConfig)
         )
 
         op <- googleDataprocService.createCluster(

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/CommonTestData.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/CommonTestData.scala
@@ -141,7 +141,7 @@ object CommonTestData {
     numberOfPreemptibleWorkers = None,
     properties = Map.empty,
     region = Some(singleNodeDefaultMachineConfig.region),
-    componentGatewayEnabled = Some(singleNodeDefaultMachineConfig.componentGatewayEnabled)
+    componentGatewayEnabled = singleNodeDefaultMachineConfig.componentGatewayEnabled
   )
 
   val mockSamDAO = new MockSamDAO
@@ -227,7 +227,7 @@ object CommonTestData {
       None,
       Map.empty[String, String],
       Some(RegionName("us-central1")),
-      Some(true)
+      true
     )
 
   val gpuConfig = Some(GpuConfig(GpuType.NvidiaTeslaT4, 2))

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/CommonTestData.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/CommonTestData.scala
@@ -139,7 +139,9 @@ object CommonTestData {
     workerDiskSize = None,
     numberOfWorkerLocalSSDs = None,
     numberOfPreemptibleWorkers = None,
-    properties = Map.empty
+    properties = Map.empty,
+    region = Some(singleNodeDefaultMachineConfig.region),
+    componentGatewayEnabled = Some(singleNodeDefaultMachineConfig.componentGatewayEnabled)
   )
 
   val mockSamDAO = new MockSamDAO
@@ -191,7 +193,8 @@ object CommonTestData {
                                  None,
                                  None,
                                  Map.empty,
-                                 RegionName("us-central1"))
+                                 RegionName("us-central1"),
+                                 true)
 
   val defaultCreateRuntimeRequest = CreateRuntime2Request(
     Map("lbl1" -> "true"),
@@ -214,14 +217,18 @@ object CommonTestData {
                             zone = ZoneName("us-west2-b"),
                             None)
   val defaultRuntimeConfigRequest =
-    RuntimeConfigRequest.DataprocConfig(Some(0),
-                                        Some(MachineTypeName("n1-standard-4")),
-                                        Some(DiskSize(500)),
-                                        None,
-                                        None,
-                                        None,
-                                        None,
-                                        Map.empty[String, String])
+    RuntimeConfigRequest.DataprocConfig(
+      Some(0),
+      Some(MachineTypeName("n1-standard-4")),
+      Some(DiskSize(500)),
+      None,
+      None,
+      None,
+      None,
+      Map.empty[String, String],
+      Some(RegionName("us-central1")),
+      Some(true)
+    )
 
   val gpuConfig = Some(GpuConfig(GpuType.NvidiaTeslaT4, 2))
   val gceRuntimeConfig =

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponentSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponentSpec.scala
@@ -59,7 +59,8 @@ class ClusterComponentSpec extends AnyFlatSpecLike with TestComponent with GcsPa
         Some(2),
         Some(1),
         Map.empty,
-        RegionName("test-region")
+        RegionName("test-region"),
+        true
       )
     )
     savedCluster3.copy(runtimeConfigId = RuntimeConfigId(-1)) shouldEqual cluster3
@@ -233,7 +234,8 @@ class ClusterComponentSpec extends AnyFlatSpecLike with TestComponent with GcsPa
           Some(2),
           Some(1),
           Map.empty,
-          RegionName("test-region")
+          RegionName("test-region"),
+          true
         )
       )
 
@@ -255,7 +257,8 @@ class ClusterComponentSpec extends AnyFlatSpecLike with TestComponent with GcsPa
         Some(2),
         Some(1),
         Map.empty,
-        RegionName("test-region")
+        RegionName("test-region"),
+        true
       )
     )
 
@@ -312,7 +315,8 @@ class ClusterComponentSpec extends AnyFlatSpecLike with TestComponent with GcsPa
       Some(2),
       Some(1),
       Map.empty,
-      RegionName("test-region")
+      RegionName("test-region"),
+      true
     )
 
     val savedCluster = makeCluster(1)

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/RuntimeConfigQueriesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/RuntimeConfigQueriesSpec.scala
@@ -22,7 +22,8 @@ class RuntimeConfigQueriesSpec extends AnyFlatSpecLike with TestComponent with L
       numberOfPreemptibleWorkers = Some(0),
       numberOfWorkerLocalSSDs = None,
       properties = Map("spark:spark.executor.memory" -> "10g"),
-      region = RegionName("us-central1")
+      region = RegionName("us-central1"),
+      componentGatewayEnabled = true
     )
     val res = for {
       now <- testTimer.clock.realTime(TimeUnit.MILLISECONDS)

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/HttpRoutesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/HttpRoutesSpec.scala
@@ -584,7 +584,7 @@ class HttpRoutesSpec
       Some(100),
       Map.empty,
       Some(RegionName("europe-west1")),
-      Some(true)
+      true
     )
     decode[RuntimeConfigRequest](test.asJson.noSpaces) shouldBe Right(test)
   }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/HttpRoutesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/HttpRoutesSpec.scala
@@ -583,7 +583,8 @@ class HttpRoutesSpec
       Some(0),
       Some(100),
       Map.empty,
-      Some(RegionName("europe-west1"))
+      Some(RegionName("europe-west1")),
+      Some(true)
     )
     decode[RuntimeConfigRequest](test.asJson.noSpaces) shouldBe Right(test)
   }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/RuntimeRoutesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/RuntimeRoutesSpec.scala
@@ -45,7 +45,9 @@ class RuntimeRoutesSpec extends AnyFlatSpec with Matchers with LeonardoTestSuite
       None,
       None,
       None,
-      Map("spark:spark.executor.cores" -> "4")
+      Map("spark:spark.executor.cores" -> "4"),
+      None,
+      None
     )
     decode[RuntimeConfigRequest.DataprocConfig](jsonString) shouldBe Right(expectedResult)
   }
@@ -187,7 +189,9 @@ class RuntimeRoutesSpec extends AnyFlatSpec with Matchers with LeonardoTestSuite
       None,
       None,
       None,
-      Map.empty
+      Map.empty,
+      None,
+      None
     )
     decodeResult shouldBe Right(expectedRuntimeConfig)
   }
@@ -202,7 +206,8 @@ class RuntimeRoutesSpec extends AnyFlatSpec with Matchers with LeonardoTestSuite
         |      "numberOfWorkerLocalSSDs" : 0,
         |      "service" : "DATAPROC",
         |      "numberOfPreemptibleWorkers" : 0,
-        |      "masterMachineType" : "test-master-machine-type"
+        |      "masterMachineType" : "test-master-machine-type",
+        |      "componentGatewayEnabled": true
         |}
         |""".stripMargin
 
@@ -218,7 +223,9 @@ class RuntimeRoutesSpec extends AnyFlatSpec with Matchers with LeonardoTestSuite
       Some(DiskSize(100)),
       Some(0),
       Some(0),
-      Map.empty
+      Map.empty,
+      None,
+      Some(true)
     )
     decodeResult shouldBe Right(expectedRuntimeConfig)
   }
@@ -287,7 +294,9 @@ class RuntimeRoutesSpec extends AnyFlatSpec with Matchers with LeonardoTestSuite
           None,
           None,
           None,
-          Map.empty
+          Map.empty,
+          None,
+          None
         )
       ),
       Some(

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/RuntimeRoutesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/RuntimeRoutesSpec.scala
@@ -47,7 +47,7 @@ class RuntimeRoutesSpec extends AnyFlatSpec with Matchers with LeonardoTestSuite
       None,
       Map("spark:spark.executor.cores" -> "4"),
       None,
-      None
+      false
     )
     decode[RuntimeConfigRequest.DataprocConfig](jsonString) shouldBe Right(expectedResult)
   }
@@ -191,7 +191,7 @@ class RuntimeRoutesSpec extends AnyFlatSpec with Matchers with LeonardoTestSuite
       None,
       Map.empty,
       None,
-      None
+      false
     )
     decodeResult shouldBe Right(expectedRuntimeConfig)
   }
@@ -225,7 +225,7 @@ class RuntimeRoutesSpec extends AnyFlatSpec with Matchers with LeonardoTestSuite
       Some(0),
       Map.empty,
       None,
-      Some(true)
+      true
     )
     decodeResult shouldBe Right(expectedRuntimeConfig)
   }
@@ -296,7 +296,7 @@ class RuntimeRoutesSpec extends AnyFlatSpec with Matchers with LeonardoTestSuite
           None,
           Map.empty,
           None,
-          None
+          false
         )
       ),
       Some(

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterpSpec.scala
@@ -280,7 +280,9 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
           None,
           None,
           None,
-          Map.empty
+          Map.empty,
+          None,
+          None
         )
       )
     )
@@ -346,7 +348,9 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
           None,
           None,
           None,
-          Map.empty
+          Map.empty,
+          None,
+          None
         )
       )
     )

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterpSpec.scala
@@ -282,7 +282,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
           None,
           Map.empty,
           None,
-          None
+          false
         )
       )
     )
@@ -350,7 +350,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
           None,
           Map.empty,
           None,
-          None
+          false
         )
       )
     )

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/DataprocInterpreterSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/DataprocInterpreterSpec.scala
@@ -23,8 +23,8 @@ import org.broadinstitute.dsde.workbench.leonardo.config.Config
 import org.broadinstitute.dsde.workbench.leonardo.dao.MockWelderDAO
 import org.broadinstitute.dsde.workbench.leonardo.db.TestComponent
 import org.broadinstitute.dsde.workbench.leonardo.monitor.LeoPubsubMessage.CreateRuntimeMessage
-import org.broadinstitute.dsde.workbench.model.{TraceId, WorkbenchEmail}
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
+import org.broadinstitute.dsde.workbench.model.{TraceId, WorkbenchEmail}
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.flatspec.AnyFlatSpecLike

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/DataprocInterpreterSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/DataprocInterpreterSpec.scala
@@ -157,7 +157,8 @@ class DataprocInterpreterSpec
                                                      None,
                                                      None,
                                                      Map.empty[String, String],
-                                                     RegionName("us-central1"))
+                                                     RegionName("us-central1"),
+                                                     true)
     val resourceConstraints = dataprocInterp
       .getClusterResourceContraints(testClusterClusterProjectAndName,
                                     runtimeConfig.machineType,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -83,7 +83,15 @@ object Dependencies {
   // Exclude workbench-libs transitive dependencies so we can control the library versions individually.
   // workbench-google pulls in workbench-{util, model, metrics} and workbcan ench-metrics pulls in workbench-util.
   val workbenchModel: ModuleID =        "org.broadinstitute.dsde.workbench" %% "workbench-model"    % workbenchModelV excludeAll (excludeGoogleError, excludeGuava)
-  val workbenchGoogle: ModuleID =       "org.broadinstitute.dsde.workbench" %% "workbench-google"   % workbenchGoogleV excludeAll (excludeIoGrpc, excludeFindbugsJsr, excludeGoogleApiClient, excludeGoogleError, excludeHttpComponent, excludeGuava, excludeStatsD)
+  val workbenchGoogle: ModuleID =       "org.broadinstitute.dsde.workbench" %% "workbench-google"   % workbenchGoogleV excludeAll (
+    excludeIoGrpc,
+    excludeFindbugsJsr,
+    excludeGoogleApiClient,
+    excludeGoogleError,
+    excludeHttpComponent,
+    excludeGuava,
+    excludeStatsD,
+    excludeKms)
   val workbenchGoogle2: ModuleID =      "org.broadinstitute.dsde.workbench" %% "workbench-google2"  % workbenchGoogle2V excludeAll (
     excludeWorkbenchModel,
     excludeWorkbenchMetrics,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -20,7 +20,7 @@ object Dependencies {
   val serviceTestV = s"0.19-$workbenchLibsHash"
   val workbenchModelV = s"0.14-$workbenchLibsHash"
   val workbenchGoogleV = s"0.21-$workbenchLibsHash"
-  val workbenchGoogle2V = "0.21-30caedc3-SNAP"
+  val workbenchGoogle2V = "0.21-bc72733e-SNAP"
   val workbenchOpenTelemetryV = s"0.1-$workbenchLibsHash"
   val workbenchErrorReportingV = s"0.1-$workbenchLibsHash"
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -52,6 +52,8 @@ object Dependencies {
   val excludeFirestore = ExclusionRule(organization = "com.google.cloud", name = s"google-cloud-firestore")
   val excludeBouncyCastle = ExclusionRule(organization = "org.bouncycastle", name = s"bcprov-jdk15on")
   val excludeBouncyCastleExt = ExclusionRule(organization = "org.bouncycastle", name = s"bcprov-ext-jdk15on")
+  val excludeBouncyCastleUtil = ExclusionRule(organization = "org.bouncycastle", name = s"bcutil-jdk15on")
+  val excludeBouncyCastlePkix = ExclusionRule(organization = "org.bouncycastle", name = s"bcpkix-jdk15on")
   val excludeSundrCodegen = ExclusionRule(organization = "io.sundr", name = s"sundr-codegen")
   val excludeStatsD = ExclusionRule(organization = "com.readytalk", name = s"metrics3-statsd")
 
@@ -89,6 +91,8 @@ object Dependencies {
     excludeFirestore,
     excludeBouncyCastle,
     excludeBouncyCastleExt,
+    excludeBouncyCastleUtil,
+    excludeBouncyCastlePkix,
     excludeSundrCodegen,
     excludeGuava)
   val workbenchGoogleTest: ModuleID =   "org.broadinstitute.dsde.workbench" %% "workbench-google"   % workbenchGoogleV  % "test" classifier "tests" excludeAll (excludeWorkbenchModel, excludeGuava, excludeStatsD)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -20,7 +20,7 @@ object Dependencies {
   val serviceTestV = s"0.19-$workbenchLibsHash"
   val workbenchModelV = s"0.14-$workbenchLibsHash"
   val workbenchGoogleV = s"0.21-$workbenchLibsHash"
-  val workbenchGoogle2V = "0.21-51effcf7-SNAP"
+  val workbenchGoogle2V = "0.21-30caedc3-SNAP"
   val workbenchOpenTelemetryV = s"0.1-$workbenchLibsHash"
   val workbenchErrorReportingV = s"0.1-$workbenchLibsHash"
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -20,7 +20,7 @@ object Dependencies {
   val serviceTestV = s"0.19-$workbenchLibsHash"
   val workbenchModelV = s"0.14-$workbenchLibsHash"
   val workbenchGoogleV = s"0.21-$workbenchLibsHash"
-  val workbenchGoogle2V = s"0.21-$workbenchLibsHash"
+  val workbenchGoogle2V = "0.21-51effcf7-SNAP"
   val workbenchOpenTelemetryV = s"0.1-$workbenchLibsHash"
   val workbenchErrorReportingV = s"0.1-$workbenchLibsHash"
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -16,11 +16,11 @@ object Dependencies {
   val opencensusV = "0.28.3"
 
 
-  private val workbenchLibsHash = "89d0d9e"
+  private val workbenchLibsHash = "bf66e61"
   val serviceTestV = s"0.19-$workbenchLibsHash"
   val workbenchModelV = s"0.14-$workbenchLibsHash"
   val workbenchGoogleV = s"0.21-$workbenchLibsHash"
-  val workbenchGoogle2V = "0.21-d89d5792-SNAP"
+  val workbenchGoogle2V = s"0.21-$workbenchLibsHash"
   val workbenchOpenTelemetryV = s"0.1-$workbenchLibsHash"
   val workbenchErrorReportingV = s"0.1-$workbenchLibsHash"
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -20,7 +20,7 @@ object Dependencies {
   val serviceTestV = s"0.19-$workbenchLibsHash"
   val workbenchModelV = s"0.14-$workbenchLibsHash"
   val workbenchGoogleV = s"0.21-$workbenchLibsHash"
-  val workbenchGoogle2V = "0.21-bc72733e-SNAP"
+  val workbenchGoogle2V = "0.21-d89d5792-SNAP"
   val workbenchOpenTelemetryV = s"0.1-$workbenchLibsHash"
   val workbenchErrorReportingV = s"0.1-$workbenchLibsHash"
 
@@ -56,6 +56,9 @@ object Dependencies {
   val excludeBouncyCastlePkix = ExclusionRule(organization = "org.bouncycastle", name = s"bcpkix-jdk15on")
   val excludeSundrCodegen = ExclusionRule(organization = "io.sundr", name = s"sundr-codegen")
   val excludeStatsD = ExclusionRule(organization = "com.readytalk", name = s"metrics3-statsd")
+  val excludeKms = ExclusionRule(organization = "com.google.cloud", name = s"google-cloud-kms")
+  val excludeBigQuery = ExclusionRule(organization = "com.google.cloud", name = "google-cloud-bigquery")
+  val excludeCloudBilling = ExclusionRule(organization = "com.google.cloud", name = "google-cloud-billing")
 
   val logbackClassic: ModuleID =  "ch.qos.logback"              % "logback-classic" % "1.2.5"
   val scalaLogging: ModuleID =    "com.typesafe.scala-logging"  %% "scala-logging"  % scalaLoggingV
@@ -89,12 +92,16 @@ object Dependencies {
     excludeGoogleError,
     excludeHttpComponent,
     excludeFirestore,
+    excludeKms,
+    excludeBigQuery,
+    excludeCloudBilling,
     excludeBouncyCastle,
     excludeBouncyCastleExt,
     excludeBouncyCastleUtil,
     excludeBouncyCastlePkix,
     excludeSundrCodegen,
     excludeGuava)
+
   val workbenchGoogleTest: ModuleID =   "org.broadinstitute.dsde.workbench" %% "workbench-google"   % workbenchGoogleV  % "test" classifier "tests" excludeAll (excludeWorkbenchModel, excludeGuava, excludeStatsD)
   val workbenchGoogle2Test: ModuleID =  "org.broadinstitute.dsde.workbench" %% "workbench-google2"  % workbenchGoogle2V % "test" classifier "tests" excludeAll (excludeGuava) //for generators
   val workbenchOpenTelemetry: ModuleID =     "org.broadinstitute.dsde.workbench" %% "workbench-opentelemetry" % workbenchOpenTelemetryV excludeAll (excludeGuava)


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-2836

See design doc: https://docs.google.com/document/d/1Zr6qzICStrrJwYkfoIE7fTf9Ziu3f6JmhdA9Ao3Y8Bo/edit

Depends on https://github.com/broadinstitute/workbench-libs/pull/697

This does the following:
1. Adds `DataprocConfig.componentGatewayEnabled` field to DB, models, JSON decoders. Defaults to `false` for now.
2. If that field is true, enables [Component Gateway](https://cloud.google.com/dataproc/docs/concepts/accessing/dataproc-gateways) when creating Dataproc cluster
3. Updates proxy rules to proxy Spark web UIs (see doc for details)
4. Updates swagger
5. Adds an automation test

It seems to work in a fiab, still doing some more detailed testing of the Spark UIs themselves.

UPDATE: I ran through the [Hail GWAS tutorial](https://hail.is/docs/0.2/tutorials/01-genome-wide-association-study.html) and clicked through all the UIs and they all seem functional. 🎉 

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
