### PR TITLE
IA-2881 IA-2878 Update to latest wb-libs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,9 +13,9 @@ RUN mkdir /helm-go-lib-build && \
     cd helm-go-lib && \
     go build -o libhelm.so -buildmode=c-shared main.go
 
-# TODO: Revert this to blessed image
-FROM ghcr.io/graalvm/graalvm-ce:ol8-java11-21.0.0.2
-# FROM us.gcr.io/broad-dsp-gcr-public/base/jre:11-debian
+# Use this graalvm image if we need to use jstack etc
+# FROM ghcr.io/graalvm/graalvm-ce:ol8-java11-21.0.0.2
+FROM us.gcr.io/broad-dsp-gcr-public/base/jre:11-debian
 
 EXPOSE 8080
 EXPOSE 5050

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,9 @@ RUN mkdir /helm-go-lib-build && \
     cd helm-go-lib && \
     go build -o libhelm.so -buildmode=c-shared main.go
 
-FROM us.gcr.io/broad-dsp-gcr-public/base/jre:11-debian
+# TODO: Revert this to blessed image
+FROM ghcr.io/graalvm/graalvm-ce:ol8-java11-21.0.0.2
+# FROM us.gcr.io/broad-dsp-gcr-public/base/jre:11-debian
 
 EXPOSE 8080
 EXPOSE 5050

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeoPubsubSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeoPubsubSpec.scala
@@ -1,7 +1,8 @@
 package org.broadinstitute.dsde.workbench.leonardo
 
 import cats.effect.IO
-import fs2.concurrent.InspectableQueue
+import cats.effect.std.Queue
+import cats.effect.unsafe.implicits.global
 import org.broadinstitute.dsde.workbench.google2.GooglePublisher
 import org.scalatest.time.{Minutes, Span}
 import org.scalatest.DoNotDiscover
@@ -17,21 +18,21 @@ class LeoPubsubSpec extends AnyFlatSpec with LeonardoTestUtils {
 
     publisher
       .use(_ => IO.unit)
-      .unsafeRunSync()
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "publish" in {
     val publisher = GooglePublisher.resource[IO](LeonardoConfig.Leonardo.publisherConfig)
-    val queue = InspectableQueue.bounded[IO, String](100).unsafeRunSync()
+    val queue = Queue.bounded[IO, String](100).unsafeRunSync()(cats.effect.unsafe.implicits.global)
 
     publisher
-      .use(publisher => (queue.dequeue through publisher.publish).compile.drain)
+      .use(publisher => (fs2.Stream.fromQueueUnterminated(queue) through publisher.publish).compile.drain)
       .unsafeRunAsync(_ => ())
 
-    queue.enqueue1("automation-test-message").unsafeRunSync()
+    queue.offer("automation-test-message").unsafeRunSync()(cats.effect.unsafe.implicits.global)
 
     eventually(timeout(Span(2, Minutes))) {
-      val size = queue.getSize.unsafeRunSync()
+      val size = queue.size.unsafeRunSync()(cats.effect.unsafe.implicits.global)
       size shouldBe 0
     }
   }

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeoPubsubSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeoPubsubSpec.scala
@@ -18,21 +18,21 @@ class LeoPubsubSpec extends AnyFlatSpec with LeonardoTestUtils {
 
     publisher
       .use(_ => IO.unit)
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+      .unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   it should "publish" in {
     val publisher = GooglePublisher.resource[IO](LeonardoConfig.Leonardo.publisherConfig)
-    val queue = Queue.bounded[IO, String](100).unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    val queue = Queue.bounded[IO, String](100).unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
 
     publisher
       .use(publisher => (fs2.Stream.fromQueueUnterminated(queue) through publisher.publish).compile.drain)
       .unsafeRunAsync(_ => ())
 
-    queue.offer("automation-test-message").unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    queue.offer("automation-test-message").unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
 
     eventually(timeout(Span(2, Minutes))) {
-      val size = queue.size.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+      val size = queue.size.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
       size shouldBe 0
     }
   }

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoSuite.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoSuite.scala
@@ -221,10 +221,8 @@ trait GPAllocBeforeAndAfterAll extends GPAllocUtils with BeforeAndAfterAll {
             case Right(_) =>
               loggerIO.info(s"Deleted initial runtime ${project.value} / ${initalRuntimeName.asString}")
             case Left(err) =>
-              IO(
-                loggerIO.warn(err)(
-                  s"Failed to delete initial runtime ${project.value} / ${initalRuntimeName.asString} with error"
-                )
+              loggerIO.warn(err)(
+                s"Failed to delete initial runtime ${project.value} / ${initalRuntimeName.asString} with error"
               )
           }
         } yield ()

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoSuite.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoSuite.scala
@@ -120,7 +120,7 @@ trait GPAllocUtils extends BillingFixtures with LeonardoTestUtils {
       _ <- unclaimProject(googleProjectAndWorkspaceName.workspaceName)
     } yield t
 
-    test.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    test.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 }
 
@@ -152,7 +152,7 @@ trait GPAllocBeforeAndAfterAll extends GPAllocUtils with BeforeAndAfterAll {
       _ <- loggerIO.info(s"Serving proxy redirect page at ${ProxyRedirectClient.baseUri.renderString}")
     } yield ()
 
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   override def afterAll(): Unit = {
@@ -174,7 +174,7 @@ trait GPAllocBeforeAndAfterAll extends GPAllocUtils with BeforeAndAfterAll {
       _ <- IO(super.afterAll())
     } yield ()
 
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   // NOTE: createInitialRuntime / deleteInitialRuntime exists so we can ensure that project-level

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoSuite.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoSuite.scala
@@ -51,6 +51,7 @@ object GPAllocFixtureSpec {
   val shouldUnclaimProjectsKey = "leonardo.shouldUnclaimProjects"
   val gpallocErrorPrefix = "Failed To Claim Project: "
   val initalRuntimeName = RuntimeName("initial-runtime")
+  val proxyRedirectServerPortKey = "proxyRedirectServerPort"
 }
 
 case class GoogleProjectAndWorkspaceName(
@@ -119,7 +120,7 @@ trait GPAllocUtils extends BillingFixtures with LeonardoTestUtils {
       _ <- unclaimProject(googleProjectAndWorkspaceName.workspaceName)
     } yield t
 
-    test.unsafeRunSync()
+    test.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 }
 
@@ -146,11 +147,12 @@ trait GPAllocBeforeAndAfterAll extends GPAllocUtils with BeforeAndAfterAll {
             googleProjectAndWorkspaceName.googleProject
           )
       }
-      proxyRedirectServer <- ProxyRedirectClient.baseUri
-      _ <- loggerIO.info(s"Serving proxy redirect page at ${proxyRedirectServer.renderString}")
+      port <- ProxyRedirectClient.startServer()
+      _ <- IO(sys.props.put(proxyRedirectServerPortKey, port.toString))
+      _ <- loggerIO.info(s"Serving proxy redirect page at ${ProxyRedirectClient.baseUri.renderString}")
     } yield ()
 
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   override def afterAll(): Unit = {
@@ -167,12 +169,12 @@ trait GPAllocBeforeAndAfterAll extends GPAllocUtils with BeforeAndAfterAll {
         }
       } else loggerIO.info(s"Not going to release project: ${workspaceNamespaceProp} due to error happened")
       _ <- IO(sys.props.subtractAll(List(googleProjectKey, workspaceNamespaceKey, workspaceNameKey)))
-      _ <- ProxyRedirectClient.stopServer()
+      _ <- ProxyRedirectClient.stopServer(sys.props.get(proxyRedirectServerPortKey).get.toInt)
       _ <- loggerIO.info(s"Stopped proxy redirect server")
       _ <- IO(super.afterAll())
     } yield ()
 
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   // NOTE: createInitialRuntime / deleteInitialRuntime exists so we can ensure that project-level
@@ -180,50 +182,54 @@ trait GPAllocBeforeAndAfterAll extends GPAllocUtils with BeforeAndAfterAll {
   // We can remove this once https://broadworkbench.atlassian.net/browse/IA-2121 is done.
 
   private def createInitialRuntime(project: GoogleProject): IO[Unit] =
-    LeonardoApiClient.client.use { implicit c =>
-      implicit val authHeader = Authorization(Token(AuthScheme.Bearer, ronCreds.makeAuthToken().value))
-      for {
-        res <- LeonardoApiClient
-          .createRuntimeWithWait(
-            project,
-            initalRuntimeName,
-            LeonardoApiClient.defaultCreateRuntime2Request
-          )
-          .attempt
-        _ <- res match {
-          case Right(_) =>
-            loggerIO.info(s"Created initial runtime ${project.value} / ${initalRuntimeName.asString}")
-          case Left(err) =>
-            loggerIO
-              .warn(err)(
-                s"Failed to create initial runtime ${project.value} / ${initalRuntimeName.asString} with error"
-              )
-        }
-      } yield ()
-    }
+    if (isHeadless) {
+      LeonardoApiClient.client.use { implicit c =>
+        implicit val authHeader = Authorization(Token(AuthScheme.Bearer, ronCreds.makeAuthToken().value))
+        for {
+          res <- LeonardoApiClient
+            .createRuntimeWithWait(
+              project,
+              initalRuntimeName,
+              LeonardoApiClient.defaultCreateRuntime2Request
+            )
+            .attempt
+          _ <- res match {
+            case Right(_) =>
+              loggerIO.info(s"Created initial runtime ${project.value} / ${initalRuntimeName.asString}")
+            case Left(err) =>
+              loggerIO
+                .warn(err)(
+                  s"Failed to create initial runtime ${project.value} / ${initalRuntimeName.asString} with error"
+                )
+          }
+        } yield ()
+      }
+    } else IO.unit
 
   private def deleteInitialRuntime(project: GoogleProject): IO[Unit] =
-    LeonardoApiClient.client.use { implicit c =>
-      implicit val authHeader = Authorization(Token(AuthScheme.Bearer, ronCreds.makeAuthToken().value))
-      for {
-        res <- LeonardoApiClient
-          .deleteRuntime(
-            project,
-            initalRuntimeName
-          )
-          .attempt
-        _ <- res match {
-          case Right(_) =>
-            loggerIO.info(s"Deleted initial runtime ${project.value} / ${initalRuntimeName.asString}")
-          case Left(err) =>
-            IO(
-              loggerIO.warn(err)(
-                s"Failed to delete initial runtime ${project.value} / ${initalRuntimeName.asString} with error"
-              )
+    if (isHeadless) {
+      LeonardoApiClient.client.use { implicit c =>
+        implicit val authHeader = Authorization(Token(AuthScheme.Bearer, ronCreds.makeAuthToken().value))
+        for {
+          res <- LeonardoApiClient
+            .deleteRuntime(
+              project,
+              initalRuntimeName
             )
-        }
-      } yield ()
-    }
+            .attempt
+          _ <- res match {
+            case Right(_) =>
+              loggerIO.info(s"Deleted initial runtime ${project.value} / ${initalRuntimeName.asString}")
+            case Left(err) =>
+              IO(
+                loggerIO.warn(err)(
+                  s"Failed to delete initial runtime ${project.value} / ${initalRuntimeName.asString} with error"
+                )
+              )
+          }
+        } yield ()
+      }
+    } else IO.unit
 }
 
 final class LeonardoSuite

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
@@ -1,8 +1,8 @@
 package org.broadinstitute.dsde.workbench.leonardo
 
 import akka.actor.ActorSystem
+import cats.effect.IO
 import cats.effect.std.Semaphore
-import cats.effect.{IO, Ref}
 import cats.effect.unsafe.implicits.global
 import cats.syntax.all._
 import com.typesafe.scalalogging.LazyLogging
@@ -28,8 +28,7 @@ import org.broadinstitute.dsde.workbench.util._
 import org.broadinstitute.dsde.workbench.{DoneCheckable, ResourceFile}
 import org.http4s.client.Client
 import org.http4s.headers.Authorization
-import org.http4s.server.Server
-import org.scalatest.{Suite, TestSuite}
+import org.scalatest.TestSuite
 import org.scalatest.concurrent.PatienceConfiguration.Timeout
 import org.scalatest.concurrent.{Eventually, ScalaFutures}
 import org.scalatest.matchers.should.Matchers

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
@@ -93,12 +93,12 @@ trait LeonardoTestUtils
   val googleDiskService =
     GoogleDiskService.resource[IO](LeonardoConfig.GCS.pathToQAJson, Semaphore[IO](10).unsafeRunSync())
   val concurrentClusterCreationPermits: Semaphore[IO] = Semaphore[IO](5).unsafeRunSync()(
-    cats.effect.unsafe.implicits.global
+    cats.effect.unsafe.IORuntime.global
   ) //Since we're using the same google project, we can reach bucket creation quota limit
 
   val googleComputeService =
     GoogleComputeService.resource(LeonardoConfig.GCS.pathToQAJson,
-                                  Semaphore[IO](10).unsafeRunSync()(cats.effect.unsafe.implicits.global))
+                                  Semaphore[IO](10).unsafeRunSync()(cats.effect.unsafe.IORuntime.global))
   val googleDataprocService = for {
     compute <- googleComputeService
     dp <- GoogleDataprocService
@@ -318,7 +318,7 @@ trait LeonardoTestUtils
       } yield resp
     }
 
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   def monitorCreateRuntime(
@@ -451,7 +451,7 @@ trait LeonardoTestUtils
       LeonardoApiClient.startRuntimeWithWait(googleProject, runtimeName)
     }
 
-    waitForRunning.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    waitForRunning.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
 
     logger.info(s"Checking if ${googleProject.value}/${runtimeName.asString} is proxyable yet")
     val getResult = Try(Notebook.getApi(googleProject, runtimeName))
@@ -549,7 +549,7 @@ trait LeonardoTestUtils
       } else IO(logger.info(s"not going to delete runtime ${googleProject}/${cluster.clusterName}"))
     } yield t
 
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   def withNewErroredRuntime[T](

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/ProxyRedirectClient.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/ProxyRedirectClient.scala
@@ -36,7 +36,7 @@ object ProxyRedirectClient {
   def startServer(): IO[Int] =
     for {
       serverAndShutDown <- ProxyRedirectClient.server
-      port = serverAndShutDown._1.address.port.value
+      port = serverAndShutDown._1.address.getPort //TODO: use this when upgraded to http4s 1.+ .port.value
       _ <- serverRef.modify(mp => (mp, mp + (port -> serverAndShutDown)))
     } yield port
 

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/ProxyRedirectClient.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/ProxyRedirectClient.scala
@@ -1,42 +1,59 @@
 package org.broadinstitute.dsde.workbench.leonardo
 
-import cats.effect.concurrent.Ref
-import cats.effect.{Blocker, ContextShift, IO, Timer}
+import cats.effect.{IO, Ref}
+import cats.implicits._
 import fs2._
+import org.broadinstitute.dsde.workbench.leonardo.GPAllocFixtureSpec.proxyRedirectServerPortKey
+import org.http4s.blaze.server.BlazeServerBuilder
 import org.http4s.client.Client
 import org.http4s.dsl.io._
-import org.http4s.headers.`Content-Type`
+import org.http4s.headers.{`Content-Type`, Referer}
 import org.http4s.implicits._
 import org.http4s.server.Server
-import org.http4s.server.blaze._
-import org.http4s.{HttpRoutes, _}
+import org.http4s._
 
 import java.util.concurrent.Executors
 import scala.concurrent.ExecutionContext
 
 // This is for setting `REFERER` header in automation tests
 object ProxyRedirectClient {
+  // serverRef is Singleton http4s server to serve the proxy redirect page.
+  // Explanation of the type:
+  //   `Ref` is a cats-effect reference, used to cache a single instance of the server
+  //   `Server[IO]` is the actual server instance
+  //   `IO[Unit]` is used to shut down the server. See documentation for http4s `ServerBuilder.allocated`.
+  //
+  // There might be more than one server running if there's more than one test using `GPAllocBeforeAndAfterAll`
+  private val serverRef: Ref[IO, Map[Int, (Server, IO[Unit])]] =
+    Ref.of[IO, Map[Int, (Server, IO[Unit])]](Map.empty).unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
+
   // If test is running in headless mode, hostname needs to work in a docker container
   val host = sys.props.get("headless") match {
     case Some("true") => java.net.InetAddress.getLocalHost.getHostName
     case _            => "localhost"
   }
 
-  // Singleton http4s server to serve the proxy redirect page.
-  // Explanation of the type:
-  //   `Ref` is a cats-effect reference, used to cache a single instance of the server
-  //   `Server[IO]` is the actual server instance
-  //   `IO[Unit]` is used to shut down the server. See documentation for http4s `ServerBuilder.allocated`.
-  private val singletonServer: IO[Ref[IO, (Server[IO], IO[Unit])]] = server.flatMap(s => Ref.of(s))
-
-  def baseUri: IO[Uri] =
+  def startServer(): IO[Int] =
     for {
-      server <- singletonServer
-      uri <- server.get.map(s => Uri.unsafeFromString(s"http://${host}:${s._1.address.getPort}"))
-    } yield uri
+      serverAndShutDown <- ProxyRedirectClient.server
+      port = serverAndShutDown._1.address.port.value
+      _ <- serverRef.modify(mp => (mp, mp + (port -> serverAndShutDown)))
+    } yield port
+
+  def stopServer(port: Int): IO[Unit] =
+    for {
+      ref <- serverRef.get
+      _ <- ref.get(port).traverse(_._2)
+    } yield ()
+
+  def baseUri: Uri =
+    Uri.unsafeFromString(s"http://${host}:${sys.props.get(proxyRedirectServerPortKey).get.toInt}")
+
+  def genRefererHeader(): IO[Referer] =
+    IO.pure(Referer(baseUri))
 
   def get(rurl: String): IO[Uri] =
-    baseUri.map(_.withPath("proxyRedirectClient").withQueryParam("rurl", rurl))
+    IO.pure(baseUri.withPath(Uri.Path.unsafeFromString("proxyRedirectClient")).withQueryParam("rurl", rurl))
 
   // Tests the server connection by making a simple GET request
   def testConnection(rurl: String)(implicit client: Client[IO]): IO[Unit] =
@@ -58,40 +75,37 @@ object ProxyRedirectClient {
         }
     } yield r
 
-  def stopServer(): IO[Unit] =
-    singletonServer.flatMap(server => server.get.flatMap(_._2))
-
   private def onError(message: String)(response: Response[IO]): IO[Throwable] =
     for {
       body <- response.bodyText.compile.foldMonoid
     } yield RestError(message, response.status, Some(body))
 
   // Loads redirect-proxy-page.html and replaces templated values
-  private def getContent(rurl: String, blocker: Blocker)(implicit cs: ContextShift[IO]): Stream[IO, Byte] =
-    io.readInputStream(IO(getClass.getClassLoader.getResourceAsStream("redirect-proxy-page.html")), 4096, blocker)
-      .through(text.utf8Decode)
+  private def getContent(rurl: String): Stream[IO, Byte] =
+    io.readInputStream(IO(getClass.getClassLoader.getResourceAsStream("redirect-proxy-page.html")), 4096)
+      .through(text.utf8.decode)
       .through(text.lines)
       .map(_.replace("""$(rurl)""", s"""'$rurl'"""))
       .intersperse("\n")
-      .through(text.utf8Encode)
+      .through(text.utf8.encode)
 
-  private def server: IO[(Server[IO], IO[Unit])] =
+  private def server: IO[(Server, IO[Unit])] =
     for {
       // Instantiate a dedicated execution context for this server
       blockingEc <- IO(Executors.newCachedThreadPool).map(ExecutionContext.fromExecutor)
-      blocker = Blocker.liftExecutionContext(blockingEc)
-      implicit0(timer: Timer[IO]) = IO.timer(blockingEc)
-      implicit0(cs: ContextShift[IO]) = IO.contextShift(blockingEc)
       route = HttpRoutes
         .of[IO] {
           case GET -> Root / "proxyRedirectClient" :? Rurl(rurl) =>
-            Ok(getContent(rurl, blocker), `Content-Type`(MediaType.text.html))
+            Ok(getContent(rurl), `Content-Type`(MediaType.text.html))
         }
         .orNotFound
       // Note this uses `bindAny` which will bind to an arbitrary port. We can't use a dedicated port
       // because multiple test suites may be running on the same host in different class loaders.
       server <- BlazeServerBuilder[IO](blockingEc).bindAny("0.0.0.0").withHttpApp(route).allocated
-    } yield server
+    } yield {
+
+      server
+    }
 
   private object Rurl extends QueryParamDecoderMatcher[String]("rurl")
 }

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/RuntimeFixtureSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/RuntimeFixtureSpec.scala
@@ -106,7 +106,7 @@ abstract class RuntimeFixtureSpec
       }
     }
 
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   /**

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/RuntimeFixtureSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/RuntimeFixtureSpec.scala
@@ -106,7 +106,7 @@ abstract class RuntimeFixtureSpec
       }
     }
 
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   /**

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/AppCreationSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/AppCreationSpec.scala
@@ -1,6 +1,7 @@
 package org.broadinstitute.dsde.workbench.leonardo
 package apps
 
+import cats.effect.IO
 import org.broadinstitute.dsde.workbench.DoneCheckable
 import org.broadinstitute.dsde.workbench.google2.{streamFUntilDone, streamUntilDoneOrTimeout, Generators}
 import org.broadinstitute.dsde.workbench.leonardo.LeonardoApiClient._

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/AppCreationSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/AppCreationSpec.scala
@@ -55,19 +55,19 @@ class AppCreationSpec extends GPAllocFixtureSpec with LeonardoTestUtils with GPA
           _ = getAppResponse.status should (be(AppStatus.Provisioning) or be(AppStatus.Precreating))
 
           // Verify the app eventually becomes Running
-          _ <- testTimer.sleep(120 seconds)
+          _ <- IO.sleep(120 seconds)
           monitorCreateResult <- streamUntilDoneOrTimeout(
             getApp,
             120,
             10 seconds,
             s"AppCreationSpec: app ${googleProject.value}/${appName.value} did not finish creating after 20 minutes"
-          )(implicitly, implicitly, appInStateOrError(AppStatus.Running))
+          )(implicitly, appInStateOrError(AppStatus.Running))
           _ <- loggerIO.info(
             s"AppCreationSpec: app ${googleProject.value}/${appName.value} monitor result: ${monitorCreateResult}"
           )
           _ = monitorCreateResult.status shouldBe AppStatus.Running
 
-          _ <- testTimer.sleep(1 minute)
+          _ <- IO.sleep(1 minute)
 
           // Delete the app
           _ <- LeonardoApiClient.deleteApp(googleProject, appName, false)
@@ -100,8 +100,7 @@ class AppCreationSpec extends GPAllocFixtureSpec with LeonardoTestUtils with GPA
               )
               _ <- LeonardoApiClient.createAppWithWait(googleProject, restoreAppName, createAppRequest)(client,
                                                                                                         auth,
-                                                                                                        loggerIO,
-                                                                                                        testTimer)
+                                                                                                        loggerIO)
               _ <- LeonardoApiClient.deleteAppWithWait(googleProject, restoreAppName)
             } yield ()
           }
@@ -139,13 +138,13 @@ class AppCreationSpec extends GPAllocFixtureSpec with LeonardoTestUtils with GPA
           _ = getAppResponse.status should (be(AppStatus.Provisioning) or be(AppStatus.Precreating))
 
           // Verify the app eventually becomes Running
-          _ <- testTimer.sleep(90 seconds)
+          _ <- IO.sleep(90 seconds)
           monitorCreateResult <- streamUntilDoneOrTimeout(
             getApp,
             120,
             10 seconds,
             s"AppCreationSpec: app ${googleProject.value}/${appName.value} did not finish creating after 20 minutes"
-          )(implicitly, implicitly, appInStateOrError(AppStatus.Running))
+          )(implicitly, appInStateOrError(AppStatus.Running))
           _ <- loggerIO.info(
             s"AppCreationSpec: app ${googleProject.value}/${appName.value} monitor result: ${monitorCreateResult}"
           )
@@ -159,13 +158,13 @@ class AppCreationSpec extends GPAllocFixtureSpec with LeonardoTestUtils with GPA
           _ = getAppResponse.status should (be(AppStatus.Stopping) or be(AppStatus.PreStopping))
 
           // Verify the app eventually becomes Stopped
-          _ <- testTimer.sleep(60 seconds)
+          _ <- IO.sleep(60 seconds)
           monitorStopResult <- streamUntilDoneOrTimeout(
             getApp,
             180,
             10 seconds,
             s"AppCreationSpec: app ${googleProject.value}/${appName.value} did not finish stopping after 30 minutes"
-          )(implicitly, implicitly, appInStateOrError(AppStatus.Stopped))
+          )(implicitly, appInStateOrError(AppStatus.Stopped))
           _ <- loggerIO.info(
             s"AppCreationSpec: app ${googleProject.value}/${appName.value} stop result: $monitorStopResult"
           )
@@ -179,23 +178,23 @@ class AppCreationSpec extends GPAllocFixtureSpec with LeonardoTestUtils with GPA
           _ = getAppResponse.status should (be(AppStatus.Starting) or be(AppStatus.PreStarting))
 
           // Verify the app eventually becomes Running
-          _ <- testTimer.sleep(30 seconds)
+          _ <- IO.sleep(30 seconds)
           monitorStartResult <- streamUntilDoneOrTimeout(
             getApp,
             120,
             10 seconds,
             s"AppCreationSpec: app ${googleProject.value}/${appName.value} did not finish starting after 20 minutes"
-          )(implicitly, implicitly, appInStateOrError(AppStatus.Running))
+          )(implicitly, appInStateOrError(AppStatus.Running))
           _ <- loggerIO.info(
             s"AppCreationSpec: app ${googleProject.value}/${appName.value} start result: $monitorStartResult"
           )
           _ = monitorStartResult.status shouldBe AppStatus.Running
 
-          _ <- testTimer.sleep(1 minute)
+          _ <- IO.sleep(1 minute)
 
           // Delete the app
           _ <- LeonardoApiClient.deleteApp(googleProject, appName, true)
-          _ <- testTimer.sleep(30 seconds)
+          _ <- IO.sleep(30 seconds)
 
           // Verify getApp again
           getAppResponse <- getApp

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/lab/Lab.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/lab/Lab.scala
@@ -2,10 +2,9 @@ package org.broadinstitute.dsde.workbench.leonardo.lab
 
 import akka.http.scaladsl.model.Uri
 import akka.http.scaladsl.model.headers.{Cookie, HttpCookiePair, Referer}
-import cats.effect.{IO, Timer}
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.workbench.auth.AuthToken
-import org.broadinstitute.dsde.workbench.leonardo.notebooks.Notebook.{contentsPath, handleContentItemResponse}
+import org.broadinstitute.dsde.workbench.leonardo.notebooks.Notebook //.{contentsPath, handleContentItemResponse}
 import org.broadinstitute.dsde.workbench.leonardo.{ContentItem, LeonardoConfig, ProxyRedirectClient, RuntimeName}
 import org.broadinstitute.dsde.workbench.model.google._
 import org.broadinstitute.dsde.workbench.service.RestClient
@@ -15,7 +14,8 @@ object Lab extends RestClient with LazyLogging {
 
   private val url = LeonardoConfig.Leonardo.apiUrl
 
-  private val refererUrl = ProxyRedirectClient.baseUri.map(_.renderString).unsafeRunSync()
+  private val refererUrl =
+    ProxyRedirectClient.baseUri.renderString
 
   def labPath(googleProject: GoogleProject, clusterName: RuntimeName): String =
     s"notebooks/${googleProject.value}/${clusterName.asString}/lab"
@@ -28,8 +28,7 @@ object Lab extends RestClient with LazyLogging {
   }
 
   def get(googleProject: GoogleProject, clusterName: RuntimeName)(implicit token: AuthToken,
-                                                                  webDriver: WebDriver,
-                                                                  timer: Timer[IO]): LabLauncherPage = {
+                                                                  webDriver: WebDriver): LabLauncherPage = {
     val path = labPath(googleProject, clusterName)
     logger.info(s"Get jupyter lab: GET /$path")
     new LabLauncherPage(url + path)
@@ -39,10 +38,11 @@ object Lab extends RestClient with LazyLogging {
                      clusterName: RuntimeName,
                      contentPath: String,
                      includeContent: Boolean = true)(implicit token: AuthToken): ContentItem = {
-    val path = contentsPath(googleProject, clusterName, contentPath) + (if (includeContent) "?content=1" else "")
+    val path =
+      Notebook.contentsPath(googleProject, clusterName, contentPath) + (if (includeContent) "?content=1" else "")
     logger.info(s"Get lab notebook contents: GET /$path")
     val cookie = Cookie(HttpCookiePair("LeoToken", token.value))
     val referer = Referer(Uri(refererUrl))
-    handleContentItemResponse(parseResponse(getRequest(url + path, httpHeaders = List(cookie, referer))))
+    Notebook.handleContentItemResponse(parseResponse(getRequest(url + path, httpHeaders = List(cookie, referer))))
   }
 }

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/lab/Lab.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/lab/Lab.scala
@@ -4,7 +4,7 @@ import akka.http.scaladsl.model.Uri
 import akka.http.scaladsl.model.headers.{Cookie, HttpCookiePair, Referer}
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.workbench.auth.AuthToken
-import org.broadinstitute.dsde.workbench.leonardo.notebooks.Notebook //.{contentsPath, handleContentItemResponse}
+import org.broadinstitute.dsde.workbench.leonardo.notebooks.Notebook
 import org.broadinstitute.dsde.workbench.leonardo.{ContentItem, LeonardoConfig, ProxyRedirectClient, RuntimeName}
 import org.broadinstitute.dsde.workbench.model.google._
 import org.broadinstitute.dsde.workbench.service.RestClient

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/lab/LabLauncherPage.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/lab/LabLauncherPage.scala
@@ -1,7 +1,6 @@
 package org.broadinstitute.dsde.workbench.leonardo.lab
 
 import org.broadinstitute.dsde.workbench.auth.AuthToken
-import org.broadinstitute.dsde.workbench.leonardo.ProxyRedirectClient
 import org.openqa.selenium.WebDriver
 
 import scala.concurrent.duration._

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/lab/LabLauncherPage.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/lab/LabLauncherPage.scala
@@ -1,7 +1,7 @@
 package org.broadinstitute.dsde.workbench.leonardo.lab
 
-import cats.effect.{IO, Timer}
 import org.broadinstitute.dsde.workbench.auth.AuthToken
+import org.broadinstitute.dsde.workbench.leonardo.ProxyRedirectClient
 import org.openqa.selenium.WebDriver
 
 import scala.concurrent.duration._
@@ -10,11 +10,6 @@ import scala.util.{Failure, Success, Try}
 sealed trait LabKernel {
   def string: String
   def cssSelectorString: String
-}
-
-case object Python2 extends LabKernel {
-  def string: String = "Python 2"
-  override def cssSelectorString: String = "[title='Python 2'][data-category='Notebook']"
 }
 
 case object Python3 extends LabKernel {
@@ -37,10 +32,10 @@ case object RKernel extends LabKernel {
   override def cssSelectorString: String = "[title='R'][data-category='Notebook']"
 }
 
-class LabLauncherPage(override val url: String)(implicit override val authToken: AuthToken,
-                                                override val webDriver: WebDriver,
-                                                override val timer: Timer[IO])
-    extends LabPage {
+class LabLauncherPage(override val url: String)(
+  implicit override val authToken: AuthToken,
+  override val webDriver: WebDriver
+) extends LabPage {
 
   override def open(implicit webDriver: WebDriver): LabLauncherPage = super.open.asInstanceOf[LabLauncherPage]
 

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/lab/LabNotebookPage.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/lab/LabNotebookPage.scala
@@ -1,25 +1,24 @@
 package org.broadinstitute.dsde.workbench.leonardo.lab
 
-import cats.effect.{IO, Timer}
 import com.typesafe.scalalogging.LazyLogging
 import org.apache.commons.text.StringEscapeUtils
 import org.broadinstitute.dsde.workbench.auth.AuthToken
-import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
+import org.broadinstitute.dsde.workbench.leonardo.{KernelNotReadyException, ProxyRedirectClient}
+import org.openqa.selenium.{By, TimeoutException, WebDriver, WebElement}
 import org.scalatest.concurrent.Eventually
 import org.scalatest.concurrent.PatienceConfiguration.{Interval, Timeout}
 import org.scalatest.exceptions.TestFailedDueToTimeoutException
+import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
 import org.scalatest.time.{Seconds, Span}
-import org.broadinstitute.dsde.workbench.leonardo.KernelNotReadyException
-import org.openqa.selenium.{By, TimeoutException, WebDriver, WebElement}
 
-import scala.jdk.CollectionConverters._
 import scala.concurrent.duration._
+import scala.jdk.CollectionConverters._
 import scala.util.{Failure, Success, Try}
 
-class LabNotebookPage(override val url: String)(implicit override val authToken: AuthToken,
-                                                override val webDriver: WebDriver,
-                                                override val timer: Timer[IO])
-    extends LabPage
+class LabNotebookPage(override val url: String)(
+  implicit override val authToken: AuthToken,
+  override val webDriver: WebDriver
+) extends LabPage
     with Toolbar
     with NotebookCell
     with Eventually

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/lab/LabNotebookPage.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/lab/LabNotebookPage.scala
@@ -3,7 +3,7 @@ package org.broadinstitute.dsde.workbench.leonardo.lab
 import com.typesafe.scalalogging.LazyLogging
 import org.apache.commons.text.StringEscapeUtils
 import org.broadinstitute.dsde.workbench.auth.AuthToken
-import org.broadinstitute.dsde.workbench.leonardo.{KernelNotReadyException, ProxyRedirectClient}
+import org.broadinstitute.dsde.workbench.leonardo.KernelNotReadyException
 import org.openqa.selenium.{By, TimeoutException, WebDriver, WebElement}
 import org.scalatest.concurrent.Eventually
 import org.scalatest.concurrent.PatienceConfiguration.{Interval, Timeout}

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/lab/LabTestUtils.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/lab/LabTestUtils.scala
@@ -3,13 +3,13 @@ package org.broadinstitute.dsde.workbench.leonardo.lab
 import org.broadinstitute.dsde.workbench.auth.AuthToken
 import org.broadinstitute.dsde.workbench.leonardo._
 import org.openqa.selenium.WebDriver
-import org.scalatest.Suite
+import org.scalatest.TestSuite
 
 import scala.concurrent._
 import scala.concurrent.duration._
 
 trait LabTestUtils extends LeonardoTestUtils {
-  this: Suite =>
+  this: TestSuite =>
 
   private def whenKernelNotReady(t: Throwable): Boolean = t match {
     case _: KernelNotReadyException => true
@@ -20,11 +20,11 @@ trait LabTestUtils extends LeonardoTestUtils {
 
   def withLabLauncherPage[T](cluster: ClusterCopy)(testCode: LabLauncherPage => T)(implicit webDriver: WebDriver,
                                                                                    token: AuthToken): T = {
-    val labLauncherPage = lab.Lab.get(cluster.googleProject, cluster.clusterName)
+    val labLauncherPage = Lab.get(cluster.googleProject, cluster.clusterName)
     testCode(labLauncherPage.open)
   }
 
-  def withNewLabNotebook[T](cluster: ClusterCopy, kernel: LabKernel = lab.Python2, timeout: FiniteDuration = 2.minutes)(
+  def withNewLabNotebook[T](cluster: ClusterCopy, kernel: LabKernel = Python3, timeout: FiniteDuration = 2.minutes)(
     testCode: LabNotebookPage => T
   )(implicit webDriver: WebDriver, token: AuthToken): T =
     withLabLauncherPage(cluster) { labLauncherPage =>

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/Notebook.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/Notebook.scala
@@ -1,12 +1,11 @@
 package org.broadinstitute.dsde.workbench.leonardo.notebooks
 
-import java.io.File
-
 import akka.http.scaladsl.model.headers._
 import akka.http.scaladsl.model.{HttpHeader, Uri}
-import cats.effect.{IO, Timer}
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.workbench.auth.AuthToken
+import org.broadinstitute.dsde.workbench.leonardo.GPAllocFixtureSpec.proxyRedirectServerPortKey
+import org.broadinstitute.dsde.workbench.leonardo.ProxyRedirectClient.host
 import org.broadinstitute.dsde.workbench.leonardo.{
   ContentItem,
   LeonardoConfig,
@@ -18,6 +17,8 @@ import org.broadinstitute.dsde.workbench.model.google._
 import org.broadinstitute.dsde.workbench.service.RestClient
 import org.openqa.selenium.WebDriver
 
+import java.io.File
+
 /**
  * Leonardo API service client.
  */
@@ -25,7 +26,7 @@ object Notebook extends RestClient with LazyLogging {
 
   private val url = LeonardoConfig.Leonardo.apiUrl
 
-  private val refererUrl = ProxyRedirectClient.baseUri.map(_.renderString).unsafeRunSync()
+  private val refererUrl = ProxyRedirectClient.baseUri.renderString
 
   def handleContentItemResponse(response: String): ContentItem =
     mapper.readValue(response, classOf[ContentItem])
@@ -47,8 +48,7 @@ object Notebook extends RestClient with LazyLogging {
     s"${notebooksBasePath(googleProject, clusterName)}/api/localize${if (async) "?async=true" else ""}"
 
   def get(googleProject: GoogleProject, clusterName: RuntimeName)(implicit token: AuthToken,
-                                                                  webDriver: WebDriver,
-                                                                  timer: Timer[IO]): NotebooksListPage = {
+                                                                  webDriver: WebDriver): NotebooksListPage = {
     val path = notebooksBasePath(googleProject, clusterName)
     logger.info(s"Get notebook: GET /$path")
     new NotebooksListPage(url + path)
@@ -108,7 +108,8 @@ object Notebook extends RestClient with LazyLogging {
     logger.info(s"Get notebook contents: GET /$path")
     val cookie = Cookie(HttpCookiePair("LeoToken", token.value))
     val referer = Referer(Uri(refererUrl))
-    handleContentItemResponse(parseResponse(getRequest(url + path, httpHeaders = List(cookie, referer))))
+    val resp = getRequest(url + path, httpHeaders = List(cookie, referer))
+    handleContentItemResponse(parseResponse(resp))
   }
 
   def getNotebookItem(googleProject: GoogleProject,
@@ -130,30 +131,30 @@ object Notebook extends RestClient with LazyLogging {
     logger.info(s"Set cookie: GET /$path")
     parseResponse(getRequest(url + path, httpHeaders = List(Authorization(OAuth2BearerToken(token.value)), referer)))
   }
+}
 
-  sealed trait NotebookMode extends Product with Serializable {
-    def asString: String
+sealed trait NotebookMode extends Product with Serializable {
+  def asString: String
+}
+
+object NotebookMode {
+  final case object SafeMode extends NotebookMode {
+    def asString: String = "playground"
   }
 
-  object NotebookMode {
-    final case object SafeMode extends NotebookMode {
-      def asString: String = "playground"
-    }
-
-    final case object EditMode extends NotebookMode {
-      def asString: String = "edit"
-    }
-
-    final case object NoMode extends NotebookMode {
-      def asString: String = ""
-    }
-
-    def getModeFromString(message: String): NotebookMode =
-      message match {
-        case message if message.toLowerCase().contains(SafeMode.asString) => SafeMode
-        case message if message.toLowerCase().contains(EditMode.asString) => EditMode
-        case _                                                            => NoMode
-      }
-
+  final case object EditMode extends NotebookMode {
+    def asString: String = "edit"
   }
+
+  final case object NoMode extends NotebookMode {
+    def asString: String = ""
+  }
+
+  def getModeFromString(message: String): NotebookMode =
+    message match {
+      case message if message.toLowerCase().contains(SafeMode.asString) => SafeMode
+      case message if message.toLowerCase().contains(EditMode.asString) => EditMode
+      case _                                                            => NoMode
+    }
+
 }

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/Notebook.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/Notebook.scala
@@ -4,8 +4,6 @@ import akka.http.scaladsl.model.headers._
 import akka.http.scaladsl.model.{HttpHeader, Uri}
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.workbench.auth.AuthToken
-import org.broadinstitute.dsde.workbench.leonardo.GPAllocFixtureSpec.proxyRedirectServerPortKey
-import org.broadinstitute.dsde.workbench.leonardo.ProxyRedirectClient.host
 import org.broadinstitute.dsde.workbench.leonardo.{
   ContentItem,
   LeonardoConfig,

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookGCEDataSyncingSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookGCEDataSyncingSpec.scala
@@ -1,5 +1,7 @@
 package org.broadinstitute.dsde.workbench.leonardo.notebooks
 
+import cats.effect.unsafe.implicits.global
+
 import java.io.File
 import java.math.BigInteger
 import java.security.MessageDigest
@@ -7,7 +9,7 @@ import java.time.Instant
 import org.broadinstitute.dsde.workbench.ResourceFile
 import org.broadinstitute.dsde.workbench.google2.GcsBlobName
 import org.broadinstitute.dsde.workbench.leonardo._
-import org.broadinstitute.dsde.workbench.leonardo.notebooks.Notebook.NotebookMode
+import org.broadinstitute.dsde.workbench.leonardo.notebooks.NotebookMode
 import org.scalatest.DoNotDiscover
 import org.scalatest.time.{Minutes, Seconds, Span}
 import org.scalatest.tagobjects.Retryable

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookPage.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookPage.scala
@@ -1,11 +1,9 @@
 package org.broadinstitute.dsde.workbench.leonardo.notebooks
 
 import cats.data.NonEmptyList
-import cats.effect.{IO, Timer}
 import org.apache.commons.text.StringEscapeUtils
 import org.broadinstitute.dsde.workbench.auth.AuthToken
 import org.broadinstitute.dsde.workbench.leonardo.KernelNotReadyException
-import org.broadinstitute.dsde.workbench.leonardo.notebooks.Notebook.NotebookMode
 import org.openqa.selenium.interactions.Actions
 import org.openqa.selenium.{By, WebDriver, WebElement}
 import org.scalatest.concurrent.Eventually
@@ -18,10 +16,10 @@ import scala.concurrent.duration._
 import scala.jdk.CollectionConverters._
 import scala.util.Try
 
-class NotebookPage(override val url: String)(implicit override val webDriver: WebDriver,
-                                             override val authToken: AuthToken,
-                                             override val timer: Timer[IO])
-    extends JupyterPage
+class NotebookPage(override val url: String)(
+  implicit override val webDriver: WebDriver,
+  override val authToken: AuthToken
+) extends JupyterPage
     with Eventually {
 
   override def open(implicit webDriver: WebDriver): NotebookPage = super.open.asInstanceOf[NotebookPage]
@@ -422,7 +420,6 @@ class NotebookPage(override val url: String)(implicit override val webDriver: We
     click on (await enabled confirmKernelDiedButton)
     await notVisible jupyterModal
   }
-
 }
 
 // Notebook cells can have multiple output blocks. This class captures all cell outputs.

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookTestUtils.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookTestUtils.scala
@@ -1,8 +1,5 @@
 package org.broadinstitute.dsde.workbench.leonardo.notebooks
 
-import java.io.File
-import java.time.Instant
-
 import cats.data.NonEmptyList
 import cats.effect.IO
 import com.google.cloud.Identity
@@ -13,15 +10,16 @@ import org.broadinstitute.dsde.workbench.leonardo._
 import org.broadinstitute.dsde.workbench.model.google._
 import org.broadinstitute.dsde.workbench.service.Sam
 import org.openqa.selenium.WebDriver
-import org.scalatest.Suite
+import org.scalatest.TestSuite
 
+import java.io.File
+import java.time.Instant
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
 
 trait NotebookTestUtils extends LeonardoTestUtils {
-  this: Suite =>
-
+  this: TestSuite =>
   private def whenKernelNotReady(t: Throwable): Boolean = t match {
     case _: KernelNotReadyException => true
     case _                          => false

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebooksListPage.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebooksListPage.scala
@@ -1,11 +1,9 @@
 package org.broadinstitute.dsde.workbench.leonardo.notebooks
 
-import java.io.File
-
-import cats.effect.{IO, Timer}
 import org.broadinstitute.dsde.workbench.auth.AuthToken
 import org.openqa.selenium.WebDriver
 
+import java.io.File
 import scala.concurrent.duration.{FiniteDuration, _}
 import scala.util.Try
 
@@ -39,10 +37,10 @@ case object RKernel extends NotebookKernel {
   override def cssSelectorString: String = super.cssSelectorString + "[title='Create a new notebook with R']"
 }
 
-class NotebooksListPage(override val url: String)(implicit override val webDriver: WebDriver,
-                                                  override val authToken: AuthToken,
-                                                  override val timer: Timer[IO])
-    extends JupyterPage {
+class NotebooksListPage(override val url: String)(
+  implicit override val webDriver: WebDriver,
+  override val authToken: AuthToken
+) extends JupyterPage {
 
   override def open(implicit webDriver: WebDriver): NotebooksListPage = super.open.asInstanceOf[NotebooksListPage]
 
@@ -114,5 +112,4 @@ class NotebooksListPage(override val url: String)(implicit override val webDrive
     val newListPage = new NotebooksListPage(currentUrl)
     testCode(newListPage)
   }
-
 }

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/Welder.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/Welder.scala
@@ -3,7 +3,7 @@ package org.broadinstitute.dsde.workbench.leonardo.notebooks
 import akka.http.scaladsl.model.Uri
 import akka.http.scaladsl.model.headers.{Cookie, HttpCookiePair, Referer}
 import akka.http.scaladsl.unmarshalling.Unmarshal
-import cats.effect.{ContextShift, IO}
+import cats.effect.IO
 import com.typesafe.scalalogging.LazyLogging
 import io.circe.Decoder
 import org.broadinstitute.dsde.workbench.auth.AuthToken
@@ -11,8 +11,6 @@ import org.broadinstitute.dsde.workbench.leonardo._
 import org.broadinstitute.dsde.workbench.leonardo.notebooks.WelderJsonCodec._
 import org.broadinstitute.dsde.workbench.model.google.{GoogleProject, _}
 import org.broadinstitute.dsde.workbench.service.RestClient
-
-import scala.concurrent.ExecutionContext.global
 
 /**
  * Welder API service client.
@@ -22,10 +20,9 @@ object Welder extends RestClient with LazyLogging {
   val localSafeModeBaseDirectory = "safe"
   val localBaseDirectory = "edit"
 
-  implicit val cs: ContextShift[IO] = IO.contextShift(global)
   private val url = LeonardoConfig.Leonardo.apiUrl
 
-  private val refererUrl = ProxyRedirectClient.baseUri.map(_.renderString).unsafeRunSync()
+  private val refererUrl = ProxyRedirectClient.baseUri.renderString
 
   case class Metadata(syncMode: String,
                       syncStatus: Option[String],

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/rstudio/RStudio.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/rstudio/RStudio.scala
@@ -2,7 +2,6 @@ package org.broadinstitute.dsde.workbench.leonardo.rstudio
 
 import akka.http.scaladsl.model.Uri
 import akka.http.scaladsl.model.headers.Referer
-import cats.effect.{IO, Timer}
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.workbench.auth.AuthToken
 import org.broadinstitute.dsde.workbench.leonardo.{LeonardoConfig, ProxyRedirectClient, RuntimeName}
@@ -17,13 +16,14 @@ object RStudio extends RestClient with LazyLogging {
 
   private val url = LeonardoConfig.Leonardo.apiUrl
 
-  private val refererUrl = ProxyRedirectClient.baseUri.map(_.renderString).unsafeRunSync()
+  private val refererUrl =
+    ProxyRedirectClient.baseUri.renderString
 
-  def rstudioPath(googleProject: GoogleProject, clusterName: RuntimeName): String =
+  private def rstudioPath(googleProject: GoogleProject, clusterName: RuntimeName): String =
     s"proxy/${googleProject.value}/${clusterName.asString}/rstudio/"
 
-  def get(googleProject: GoogleProject,
-          clusterName: RuntimeName)(implicit token: AuthToken, webDriver: WebDriver, timer: Timer[IO]): RStudioPage = {
+  def get(googleProject: GoogleProject, clusterName: RuntimeName)(implicit token: AuthToken,
+                                                                  webDriver: WebDriver): RStudioPage = {
     val path = rstudioPath(googleProject, clusterName)
     logger.info(s"Get rstudio: GET /$path")
     new RStudioPage(url + path)

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/rstudio/RStudioPage.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/rstudio/RStudioPage.scala
@@ -1,17 +1,16 @@
 package org.broadinstitute.dsde.workbench.leonardo.rstudio
 
-import cats.effect.{IO, Timer}
 import org.broadinstitute.dsde.workbench.auth.AuthToken
+import scala.concurrent.duration._
 import org.broadinstitute.dsde.workbench.page.ProxyRedirectPage
 import org.openqa.selenium.{Keys, WebDriver}
 
-import scala.concurrent.duration.{FiniteDuration, _}
 import scala.util.Try
 
-class RStudioPage(override val url: String)(implicit val webDriver: WebDriver,
-                                            override val authToken: AuthToken,
-                                            override val timer: Timer[IO])
-    extends ProxyRedirectPage[RStudioPage] {
+class RStudioPage(override val url: String)(
+  implicit val webDriver: WebDriver,
+  override val authToken: AuthToken
+) extends ProxyRedirectPage[RStudioPage] {
 
   val renderedApp: Query = cssSelector("[id='rstudio_rstudio_logo']")
 

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/rstudio/RStudioTestUtils.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/rstudio/RStudioTestUtils.scala
@@ -3,13 +3,13 @@ package org.broadinstitute.dsde.workbench.leonardo.rstudio
 import org.broadinstitute.dsde.workbench.auth.AuthToken
 import org.broadinstitute.dsde.workbench.leonardo._
 import org.openqa.selenium.WebDriver
-import org.scalatest.Suite
+import org.scalatest.TestSuite
 
 import scala.concurrent._
 import scala.concurrent.duration._
 
 trait RStudioTestUtils extends LeonardoTestUtils {
-  this: Suite =>
+  this: TestSuite =>
 
   implicit val ec: ExecutionContextExecutor = ExecutionContext.global
 

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeCreationDiskSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeCreationDiskSpec.scala
@@ -5,7 +5,7 @@ import cats.effect.IO
 import cats.effect.unsafe.implicits.global
 import org.broadinstitute.dsde.workbench.DoneCheckableSyntax._
 import org.broadinstitute.dsde.workbench.google2.Generators.genDiskName
-import org.broadinstitute.dsde.workbench.google2.{streamFUntilDone, DiskName, GoogleDiskService, ZoneName}
+import org.broadinstitute.dsde.workbench.google2.{streamFUntilDone, DiskName, GoogleDiskService}
 import org.broadinstitute.dsde.workbench.leonardo.DiskModelGenerators._
 import org.broadinstitute.dsde.workbench.leonardo.LeonardoApiClient._
 import org.broadinstitute.dsde.workbench.leonardo.http.{PersistentDiskRequest, RuntimeConfigRequest}
@@ -76,7 +76,7 @@ class RuntimeCreationDiskSpec
         _ <- LeonardoApiClient.deleteRuntimeWithWait(googleProject, runtimeName)
       } yield ()
     }
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   "create runtime with SSD disk" in { googleProject =>
@@ -156,7 +156,7 @@ class RuntimeCreationDiskSpec
         ) //assume we won't have multiple disks with same name in the same project in tests
       }
     }
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   "create runtime and attach an existing persistent disk" taggedAs Retryable in { googleProject =>
@@ -248,7 +248,7 @@ class RuntimeCreationDiskSpec
       }
     }
 
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 }
 

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeCreationDiskSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeCreationDiskSpec.scala
@@ -179,7 +179,7 @@ class RuntimeCreationDiskSpec
               None,
               Map.empty
             ),
-            None,
+            defaultCreateDiskRequest.zone,
             None
           )
         )

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeDataprocSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeDataprocSpec.scala
@@ -92,7 +92,7 @@ class RuntimeDataprocSpec
       } yield ()
     }
 
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   "should create a Dataproc cluster with workers and preemptible workers" taggedAs Retryable in { project =>
@@ -141,7 +141,7 @@ class RuntimeDataprocSpec
       } yield ()
     }
 
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   "should stop/start a Dataproc cluster with workers and preemptible workers" taggedAs Retryable in { project =>
@@ -280,7 +280,7 @@ class RuntimeDataprocSpec
       } yield ()
     }
 
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   private def verifyDataproc(project: GoogleProject,

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeDataprocSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeDataprocSpec.scala
@@ -28,6 +28,7 @@ import org.http4s.client.Client
 import org.http4s.headers.Authorization
 import org.http4s.{AuthScheme, Credentials}
 import org.scalatest.{DoNotDiscover, ParallelTestExecution}
+
 import java.nio.charset.{Charset, StandardCharsets}
 import java.util.UUID
 import org.scalatest.tagobjects.Retryable
@@ -91,7 +92,7 @@ class RuntimeDataprocSpec
       } yield ()
     }
 
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   "should create a Dataproc cluster with workers and preemptible workers" taggedAs Retryable in { project =>
@@ -140,7 +141,7 @@ class RuntimeDataprocSpec
       } yield ()
     }
 
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   "should stop/start a Dataproc cluster with workers and preemptible workers" taggedAs Retryable in { project =>
@@ -279,7 +280,7 @@ class RuntimeDataprocSpec
       } yield ()
     }
 
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   private def verifyDataproc(project: GoogleProject,

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeGceSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeGceSpec.scala
@@ -3,6 +3,7 @@ package runtimes
 
 import cats.data.NonEmptyList
 import cats.effect.IO
+import cats.effect.unsafe.implicits.global
 import cats.mtl.Ask
 import com.google.cloud.Identity
 import org.broadinstitute.dsde.workbench.google2.Generators.genDiskName
@@ -76,7 +77,7 @@ class RuntimeGceSpec
       } yield ()
     }
 
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   // Not enable this in automation test because we can get `ZONE_RESOURCE_POOL_EXHAUSTED` easily
@@ -125,7 +126,7 @@ class RuntimeGceSpec
       } yield ()
     }
 
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   "should run a user script and startup script for Jupyter" in { project =>

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeGceSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeGceSpec.scala
@@ -77,7 +77,7 @@ class RuntimeGceSpec
       } yield ()
     }
 
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   // Not enable this in automation test because we can get `ZONE_RESOURCE_POOL_EXHAUSTED` easily
@@ -126,7 +126,7 @@ class RuntimeGceSpec
       } yield ()
     }
 
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   "should run a user script and startup script for Jupyter" in { project =>

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimePatchSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimePatchSpec.scala
@@ -111,7 +111,7 @@ class RuntimePatchSpec
         res.diskSize shouldBe newDiskSize
       }
     }
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   //this is an end to end test of the pub/sub infrastructure
@@ -185,7 +185,7 @@ class RuntimePatchSpec
           res.machineType shouldBe newMasterMachineType
         }
       }
-      res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+      res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   "Patch endpoint should perform a stop/start transition for Dataproc cluster" taggedAs (Tags.SmokeTest, Retryable) in {
@@ -278,6 +278,6 @@ class RuntimePatchSpec
           res.diskSize shouldBe newDiskSize
         }
       }
-      res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+      res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 }

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimePatchSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimePatchSpec.scala
@@ -1,8 +1,7 @@
 package org.broadinstitute.dsde.workbench.leonardo
 package runtimes
 
-import cats.effect.{IO, Sync}
-import cats.syntax.all._
+import cats.effect.IO
 import org.broadinstitute.dsde.workbench.DoneCheckable
 import org.broadinstitute.dsde.workbench.auth.AuthToken
 import org.broadinstitute.dsde.workbench.google2.{streamFUntilDone, streamUntilDoneOrTimeout, DiskName, MachineTypeName}
@@ -76,17 +75,17 @@ class RuntimePatchSpec
       for {
         _ <- createRuntimeWithWait(googleProject, runtimeName, createRuntimeRequest)
         _ <- updateRuntime(googleProject, runtimeName, updateRuntimeRequest)
-        _ <- testTimer.sleep(30 seconds) //We need this because DB update happens in subscriber for update API.
+        _ <- IO.sleep(30 seconds) //We need this because DB update happens in subscriber for update API.
         ioa = LeonardoApiClient.getRuntime(googleProject, runtimeName)
         getRuntimeResult <- ioa
         _ = getRuntimeResult.status shouldBe ClusterStatus.Stopping
-        monitorStoppingResult <- testTimer.sleep(30 seconds) >> streamFUntilDone(ioa, 20, 10 seconds)(
-          testTimer,
+        monitorStoppingResult <- IO.sleep(30 seconds) >> streamFUntilDone(ioa, 20, 10 seconds)(
+          implicitly,
           stoppingDoneCheckable
         ).compile.lastOrError
         _ = monitorStoppingResult.status shouldBe ClusterStatus.Starting
-        monitoringStartingResult <- testTimer.sleep(50 seconds) >> streamFUntilDone(ioa, 30, 10 seconds)(
-          testTimer,
+        monitoringStartingResult <- IO.sleep(50 seconds) >> streamFUntilDone(ioa, 30, 10 seconds)(
+          implicitly,
           startingDoneCheckable
         ).compile.lastOrError
         clusterCopy = ClusterCopy.fromGetRuntimeResponseCopy(getRuntimeResult)
@@ -112,7 +111,7 @@ class RuntimePatchSpec
         res.diskSize shouldBe newDiskSize
       }
     }
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   //this is an end to end test of the pub/sub infrastructure
@@ -157,11 +156,11 @@ class RuntimePatchSpec
         for {
           _ <- createRuntimeWithWait(googleProject, runtimeName, createRuntimeRequest)
           _ <- updateRuntime(googleProject, runtimeName, updateRuntimeRequest)
-          _ <- testTimer.sleep(70 seconds) //We need this because DB update happens in subscriber for update API.
+          _ <- IO.sleep(70 seconds) //We need this because DB update happens in subscriber for update API.
           ioa = LeonardoApiClient.getRuntime(googleProject, runtimeName)
           getRuntimeResult <- ioa
-          monitoringStartingResult <- testTimer.sleep(50 seconds) >> streamFUntilDone(ioa, 30, 10 seconds)(
-            testTimer,
+          monitoringStartingResult <- IO.sleep(50 seconds) >> streamFUntilDone(ioa, 30, 10 seconds)(
+            implicitly,
             startingDoneCheckable
           ).compile.lastOrError
           clusterCopy = ClusterCopy.fromGetRuntimeResponseCopy(getRuntimeResult)
@@ -186,7 +185,7 @@ class RuntimePatchSpec
           res.machineType shouldBe newMasterMachineType
         }
       }
-      res.unsafeRunSync()
+      res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   "Patch endpoint should perform a stop/start transition for Dataproc cluster" taggedAs (Tags.SmokeTest, Retryable) in {
@@ -233,29 +232,27 @@ class RuntimePatchSpec
         for {
           _ <- createRuntimeWithWait(googleProject, runtimeName, createRuntimeRequest)
           _ <- updateRuntime(googleProject, runtimeName, updateRuntimeRequest)
-          _ <- testTimer.sleep(30 seconds) //We need this because DB update happens in subscriber for update API.
+          _ <- IO.sleep(30 seconds) //We need this because DB update happens in subscriber for update API.
           ioa = LeonardoApiClient.getRuntime(googleProject, runtimeName)
           getRuntimeResult <- ioa
           _ = getRuntimeResult.status shouldBe ClusterStatus.Stopping
-          monitorStoppingResult <- testTimer.sleep(30 seconds) >> streamUntilDoneOrTimeout(
+          monitorStoppingResult <- IO.sleep(30 seconds) >> streamUntilDoneOrTimeout(
             ioa,
             30,
             10 seconds,
             s"Stopping ${googleProject}/${runtimeName} timed out"
           )(
-            implicitly[Sync[IO]],
-            testTimer,
+            implicitly,
             stoppingDoneCheckable
           )
           _ = monitorStoppingResult.status shouldBe ClusterStatus.Starting
-          monitringStartingResult <- testTimer.sleep(50 seconds) >> streamUntilDoneOrTimeout(
+          monitringStartingResult <- IO.sleep(50 seconds) >> streamUntilDoneOrTimeout(
             ioa,
             30,
             10 seconds,
             s"starting ${googleProject}/${runtimeName} timed out"
           )(
-            implicitly[Sync[IO]],
-            testTimer,
+            implicitly,
             startingDoneCheckable
           )
           clusterCopy = ClusterCopy.fromGetRuntimeResponseCopy(getRuntimeResult)
@@ -281,6 +278,6 @@ class RuntimePatchSpec
           res.diskSize shouldBe newDiskSize
         }
       }
-      res.unsafeRunSync()
+      res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 }

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeStatusTransitionsSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeStatusTransitionsSpec.scala
@@ -32,7 +32,6 @@ class RuntimeStatusTransitionsSpec extends GPAllocFixtureSpec with ParallelTestE
 
       // create a runtime, but don't wait
       createNewRuntime(billingProject, runtimeName, runtimeRequest, monitor = false)
-
       // runtime status should be Creating
       val creatingRuntime = Leonardo.cluster.getRuntime(billingProject, runtimeName)
       creatingRuntime.status shouldBe ClusterStatus.Creating
@@ -62,7 +61,7 @@ class RuntimeStatusTransitionsSpec extends GPAllocFixtureSpec with ParallelTestE
       // Can't recreate while runtime is deleting
       val caught3 =
         the[RestError] thrownBy createNewRuntime(billingProject, runtimeName, runtimeRequest, monitor = false)
-      caught.statusCode shouldBe (org.http4s.Status.Conflict)
+      caught3.statusCode shouldBe (org.http4s.Status.Conflict)
 
       // Wait for the runtime to be deleted
       monitorDeleteRuntime(billingProject, runtimeName)

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/page/ProxyRedirectPage.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/page/ProxyRedirectPage.scala
@@ -62,7 +62,7 @@ trait ProxyRedirectPage[P <: Page] extends Page with PageUtil[P] with WebBrowser
 
     } yield res
 
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
 }

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/page/ProxyRedirectPage.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/page/ProxyRedirectPage.scala
@@ -1,7 +1,6 @@
 package org.broadinstitute.dsde.workbench.page
 
-import cats.effect.{IO, Timer}
-import cats.implicits._
+import cats.effect.IO
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.workbench.auth.AuthToken
 import org.broadinstitute.dsde.workbench.leonardo.{LeonardoApiClient, ProxyRedirectClient}
@@ -13,7 +12,6 @@ import scala.concurrent.duration._
 
 trait ProxyRedirectPage[P <: Page] extends Page with PageUtil[P] with WebBrowserUtil with LazyLogging { self: P =>
   implicit val authToken: AuthToken
-  implicit val timer: Timer[IO]
 
   override def open(implicit webDriver: WebDriver): P = {
     val res = for {
@@ -64,7 +62,7 @@ trait ProxyRedirectPage[P <: Page] extends Page with PageUtil[P] with WebBrowser
 
     } yield res
 
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
 }

--- a/build.sbt
+++ b/build.sbt
@@ -20,5 +20,3 @@ lazy val automation = project.in(file("automation"))
   .dependsOn(core % "test->test;compile->compile")
 
 ThisBuild / scalafixDependencies += "org.scalatest" %% "autofix" % "3.1.0.1"
-
-ThisBuild / scalacOptions += "-P:semanticdb:synthetics:on"

--- a/build.sbt
+++ b/build.sbt
@@ -20,3 +20,5 @@ lazy val automation = project.in(file("automation"))
   .dependsOn(core % "test->test;compile->compile")
 
 ThisBuild / scalafixDependencies += "org.scalatest" %% "autofix" % "3.1.0.1"
+
+ThisBuild / scalacOptions += "-P:semanticdb:synthetics:on"

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/KeyLock.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/KeyLock.scala
@@ -2,11 +2,8 @@ package org.broadinstitute.dsde.workbench.leonardo
 
 import cats.syntax.all._
 import cats.effect.Async
-import cats.effect.std.{Dispatcher, Semaphore}
-import com.google.common.cache.{CacheBuilder, CacheLoader}
-
-import java.util.concurrent.TimeUnit
-import scala.concurrent.duration.FiniteDuration
+import cats.effect.std.Semaphore
+import scalacache.caffeine.CaffeineCache
 
 /**
  * A functional lock which works on a per-key basis.
@@ -15,33 +12,21 @@ abstract class KeyLock[F[_]: Async, K] {
   def withKeyLock[A](key: K)(fa: F[A]): F[A]
 }
 object KeyLock {
-  def apply[F[_], K <: AnyRef](expiryTime: FiniteDuration, maxSize: Int, dispatcher: Dispatcher[F])(
+  def apply[F[_], K <: AnyRef](cache: CaffeineCache[F, Semaphore[F]])(
     implicit F: Async[F]
-  ): F[KeyLock[F, K]] =
-    F.delay(new KeyLockImpl(expiryTime, maxSize, dispatcher))
+  ): KeyLock[F, K] =
+    new KeyLockImpl(cache)
 
   // A KeyLock implementation backed by a guava cache
-  final private class KeyLockImpl[F[_], K <: AnyRef](expiryTime: FiniteDuration,
-                                                     maxSize: Int,
-                                                     dispatcher: Dispatcher[F])(
+  final private class KeyLockImpl[F[_], K <: AnyRef](cache: CaffeineCache[F, Semaphore[F]])(
     implicit F: Async[F]
   ) extends KeyLock[F, K] {
 
-    private val cache = CacheBuilder
-      .newBuilder()
-      .expireAfterWrite(expiryTime.toSeconds, TimeUnit.SECONDS)
-      .maximumSize(maxSize)
-      .recordStats
-      .build(
-        new CacheLoader[K, Semaphore[F]] {
-          def load(key: K): Semaphore[F] =
-            dispatcher.unsafeRunSync(Semaphore(1L))
-        }
-      )
-
     override def withKeyLock[A](key: K)(fa: F[A]): F[A] =
       for {
-        lock <- F.delay(cache.get(key))
+        lock <- cache.cachingF(key)(None) {
+          Semaphore(1L)
+        }
         res <- lock.permit.use(_ => fa)
       } yield res
   }

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/gceModels.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/gceModels.scala
@@ -2,22 +2,41 @@ package org.broadinstitute.dsde.workbench.leonardo
 
 import enumeratum.{Enum, EnumEntry}
 import ca.mrvisser.sealerate
+import com.google.cloud.compute.v1.Instance.Status
 
 /** Google Compute Instance Status
  *  See: https://cloud.google.com/compute/docs/instances/checking-instance-status */
-sealed trait GceInstanceStatus extends EnumEntry with Product with Serializable
+sealed trait GceInstanceStatus extends EnumEntry with Product with Serializable {
+  def instanceStatus: Status
+}
 object GceInstanceStatus extends Enum[GceInstanceStatus] {
   val values = findValues
 
   // NOTE: Remember to update the definition of this enum in Swagger when you add new ones
-  case object Provisioning extends GceInstanceStatus // Resources are being allocated for the instance. The instance is not running yet.
-  case object Staging extends GceInstanceStatus // Resources have been acquired and the instance is being prepared for first boot.
-  case object Running extends GceInstanceStatus // The instance is booting up or running. You can connect to the instance shortly after it enters this state.
-  case object Stopping extends GceInstanceStatus //The instance is being stopped. This can be because a user has made a request to stop the instance or there was a failure. This is a temporary status and the instance will move to TERMINATED once the instance has stopped.
-  case object Stopped extends GceInstanceStatus
-  case object Suspending extends GceInstanceStatus
-  case object Suspended extends GceInstanceStatus
-  case object Terminated extends GceInstanceStatus
+  case object Provisioning extends GceInstanceStatus {
+    override def instanceStatus: Status = Status.PROVISIONING
+  } // Resources are being allocated for the instance. The instance is not running yet.
+  case object Staging extends GceInstanceStatus {
+    override def instanceStatus: Status = Status.STAGING
+  } // Resources have been acquired and the instance is being prepared for first boot.
+  case object Running extends GceInstanceStatus {
+    override def instanceStatus: Status = Status.RUNNING
+  } // The instance is booting up or running. You can connect to the instance shortly after it enters this state.
+  case object Stopping extends GceInstanceStatus {
+    override def instanceStatus: Status = Status.STOPPING
+  } //The instance is being stopped. This can be because a user has made a request to stop the instance or there was a failure. This is a temporary status and the instance will move to TERMINATED once the instance has stopped.
+  case object Stopped extends GceInstanceStatus {
+    override def instanceStatus: Status = Status.STOPPED
+  }
+  case object Suspending extends GceInstanceStatus {
+    override def instanceStatus: Status = Status.SUSPENDING
+  }
+  case object Suspended extends GceInstanceStatus {
+    override def instanceStatus: Status = Status.SUSPENDED
+  }
+  case object Terminated extends GceInstanceStatus {
+    override def instanceStatus: Status = Status.TERMINATED
+  }
 }
 
 sealed abstract class GpuType extends Product with Serializable {

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/models.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/models.scala
@@ -1,20 +1,14 @@
 package org.broadinstitute.dsde.workbench.leonardo
 
-import java.time.Instant
-import java.util.UUID
-
-import cats.effect.{Sync, Timer}
-import cats.syntax.all._
+import cats.effect.Sync
 import cats.mtl.Ask
+import cats.syntax.all._
 import io.opencensus.trace.Span
 import org.broadinstitute.dsde.workbench.model.TraceId
 
-/**
- * @param traceId Unique identifier to connect logs for the same request or transaction together
- * @param now
- * @param requestUri API request if this is context for an API request
- * @param span span for a request if this is context for an API request
- */
+import java.time.Instant
+import java.util.UUID
+
 final case class AppContext(traceId: TraceId, now: Instant, requestUri: String = "", span: Option[Span] = None) {
   override def toString: String = s"${traceId.asString}"
 
@@ -22,15 +16,15 @@ final case class AppContext(traceId: TraceId, now: Instant, requestUri: String =
 }
 
 object AppContext {
-  def generate[F[_]: Sync](span: Option[Span] = None, requestUri: String)(implicit timer: Timer[F]): F[AppContext] =
+  def generate[F[_]: Sync](span: Option[Span] = None, requestUri: String): F[AppContext] =
     for {
       traceId <- span.fold(Sync[F].delay(UUID.randomUUID().toString))(s =>
         Sync[F].pure(s.getContext.getTraceId.toLowerBase16())
       )
-      now <- nowInstant[F]
+      now <- Sync[F].realTimeInstant
     } yield AppContext(TraceId(traceId), now, requestUri, span)
 
-  def lift[F[_]: Sync: Timer](span: Option[Span] = None, requestUri: String): F[Ask[F, AppContext]] =
+  def lift[F[_]: Sync](span: Option[Span] = None, requestUri: String): F[Ask[F, AppContext]] =
     for {
       context <- AppContext.generate[F](span, requestUri)
     } yield Ask.const[F, AppContext](

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/package.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/package.scala
@@ -1,22 +1,23 @@
 package org.broadinstitute.dsde.workbench
 
-import java.time.Instant
-
-import cats.syntax.all._
-import cats.{Applicative, Functor}
-import cats.effect.Timer
+import cats.Applicative
+import cats.effect.Sync
 import cats.mtl.Ask
+import cats.syntax.all._
 import org.broadinstitute.dsde.workbench.model.TraceId
+import org.typelevel.ci._
+
+import java.time.Instant
 
 package object leonardo {
   type LabelMap = Map[String, String]
   //this value is the default for autopause, if none is specified. An autopauseThreshold of 0 indicates no autopause
   val autoPauseOffValue = 0
-  val traceIdHeaderString = "X-Cloud-Trace-Context"
+  val traceIdHeaderString = ci"X-Cloud-Trace-Context"
 
   // convenience to get now as a F[Instant] using a Timer
-  def nowInstant[F[_]: Timer: Functor]: F[Instant] =
-    Timer[F].clock.instantNow
+  def nowInstant[F[_]: Sync]: F[Instant] =
+    Sync[F].realTimeInstant
 
   // converts an Ask[F, RuntimeServiceContext] to an  Ask[F, TraceId]
   // (you'd think Ask would have a `map` function)

--- a/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/AsyncTaskProcessorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/AsyncTaskProcessorSpec.scala
@@ -23,7 +23,7 @@ class AsyncTaskProcessorSpec extends AnyFlatSpec with Matchers with LeonardoTest
   ignore should "execute tasks concurrently" in {
     val start = Instant.now()
     val res = Stream.eval(Deferred[IO, Unit]).flatMap { signalToStop =>
-      val traceId = appContext.ask.unsafeRunSync()(cats.effect.unsafe.implicits.global).traceId
+      val traceId = appContext.ask.unsafeRunSync()(cats.effect.unsafe.IORuntime.global).traceId
 
       def io(x: Int): IO[Unit] =
         for {
@@ -45,7 +45,7 @@ class AsyncTaskProcessorSpec extends AnyFlatSpec with Matchers with LeonardoTest
       stream.interruptWhen(signalToStop.get.attempt.map(_.map(_ => ())))
     }
 
-    res.compile.drain.timeout(1 minutes).unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.compile.drain.timeout(1 minutes).unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
     val end = Instant.now()
     // If tasks are executed sequentially, then each sleep takes 2 seconds, which will result int at least 20 seconds latency
     // stream terminates where queue becomes empty, but queue becomes empty before all items are processed,

--- a/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/AsyncTaskProcessorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/AsyncTaskProcessorSpec.scala
@@ -1,11 +1,11 @@
 package org.broadinstitute.dsde.workbench.leonardo
 
 import java.time.Instant
-
 import cats.effect.IO
-import cats.effect.concurrent.Deferred
+import cats.effect.Deferred
 import fs2.Stream
-import fs2.concurrent.InspectableQueue
+import cats.effect.std.Queue
+import cats.effect.unsafe.implicits.global
 import org.broadinstitute.dsde.workbench.leonardo.AsyncTaskProcessor.{Config, Task}
 
 import scala.concurrent.duration._
@@ -14,7 +14,7 @@ import org.scalatest.matchers.should.Matchers
 
 class AsyncTaskProcessorSpec extends AnyFlatSpec with Matchers with LeonardoTestSuite {
   val config = Config(20, 5)
-  val queue = InspectableQueue.bounded[IO, Task[IO]](config.queueBound).unsafeRunSync()
+  val queue = Queue.bounded[IO, Task[IO]](config.queueBound).unsafeRunSync()
   val asyncTaskProcessor = new AsyncTaskProcessor[IO](
     config,
     queue
@@ -23,14 +23,14 @@ class AsyncTaskProcessorSpec extends AnyFlatSpec with Matchers with LeonardoTest
   ignore should "execute tasks concurrently" in {
     val start = Instant.now()
     val res = Stream.eval(Deferred[IO, Unit]).flatMap { signalToStop =>
-      val traceId = appContext.ask.unsafeRunSync().traceId
+      val traceId = appContext.ask.unsafeRunSync()(cats.effect.unsafe.implicits.global).traceId
 
       def io(x: Int): IO[Unit] =
         for {
           _ <- if (x == 1 || x == 4) IO.sleep(10 seconds) else IO.sleep(15 seconds)
 // Leaving the commented out code here since it's easier to see what's going on with it
 //          _ <- IO(println(s"executing ${x} " + Instant.now()))
-          size <- queue.getSize
+          size <- queue.size
 //          _ <- if (size == 0)
 //            signalToStop.complete(())
 //          else IO.unit
@@ -41,11 +41,11 @@ class AsyncTaskProcessorSpec extends AnyFlatSpec with Matchers with LeonardoTest
         .covary[IO]
         .map(x => Task(traceId, io(x), None, Instant.now()))
 
-      val stream = tasks.through(queue.enqueue) ++ asyncTaskProcessor.process
+      val stream = tasks.through(in => in.evalMap(queue.offer(_))) ++ asyncTaskProcessor.process
       stream.interruptWhen(signalToStop.get.attempt.map(_.map(_ => ())))
     }
 
-    res.compile.drain.timeout(1 minutes).unsafeRunSync()
+    res.compile.drain.timeout(1 minutes).unsafeRunSync()(cats.effect.unsafe.implicits.global)
     val end = Instant.now()
     // If tasks are executed sequentially, then each sleep takes 2 seconds, which will result int at least 20 seconds latency
     // stream terminates where queue becomes empty, but queue becomes empty before all items are processed,

--- a/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/KeyLockSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/KeyLockSpec.scala
@@ -1,6 +1,7 @@
 package org.broadinstitute.dsde.workbench.leonardo
 
 import cats.effect.IO
+import cats.effect.std.Dispatcher
 import org.scalatest.flatspec.AnyFlatSpecLike
 import org.scalatest.matchers.should.Matchers
 
@@ -9,36 +10,40 @@ import scala.concurrent.duration._
 class KeyLockSpec extends LeonardoTestSuite with Matchers with AnyFlatSpecLike {
 
   "KeyLock" should "perform operations using withKeyLock" in {
-    val res = for {
-      test <- KeyLock[IO, String](1 minute, 10, blocker)
-      key1 = "key1"
-      key2 = "key2"
-      r1 <- test.withKeyLock(key1)(IO(10))
-      r2 <- test.withKeyLock(key2)(IO(20))
-      r3 <- test.withKeyLock(key1)(IO(30))
-    } yield {
-      r1 shouldBe 10
-      r2 shouldBe 20
-      r3 shouldBe 30
+    val res = Dispatcher[IO].use { d =>
+      for {
+        test <- KeyLock[IO, String](1 minute, 10, d)
+        key1 = "key1"
+        key2 = "key2"
+        r1 <- test.withKeyLock(key1)(IO(10))
+        r2 <- test.withKeyLock(key2)(IO(20))
+        r3 <- test.withKeyLock(key1)(IO(30))
+      } yield {
+        r1 shouldBe 10
+        r2 shouldBe 20
+        r3 shouldBe 30
+      }
     }
 
-    res.timeout(5 seconds).unsafeRunSync()
+    res.timeout(5 seconds).unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "block on withKeyLock for the same key" in {
-    val res = for {
-      test <- KeyLock[IO, String](1 minute, 10, blocker)
-      key = "key"
-      timeoutErr <- test
-        .withKeyLock(key)(
-          test.withKeyLock(key)(IO(10))
-        )
-        .timeout(1 second)
-        .attempt
-    } yield {
-      timeoutErr.isLeft shouldBe true
+    val res = Dispatcher[IO].use { d =>
+      for {
+        test <- KeyLock[IO, String](1 minute, 10, d)
+        key = "key"
+        timeoutErr <- test
+          .withKeyLock(key)(
+            test.withKeyLock(key)(IO(10))
+          )
+          .timeout(1 second)
+          .attempt
+      } yield {
+        timeoutErr.isLeft shouldBe true
+      }
     }
 
-    res.timeout(5 seconds).unsafeRunSync()
+    res.timeout(5 seconds).unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/KeyLockSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/KeyLockSpec.scala
@@ -25,7 +25,7 @@ class KeyLockSpec extends LeonardoTestSuite with Matchers with AnyFlatSpecLike {
         r3 shouldBe 30
       }
 
-    res.timeout(5 seconds).unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.timeout(5 seconds).unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   it should "block on withKeyLock for the same key" in {
@@ -45,6 +45,6 @@ class KeyLockSpec extends LeonardoTestSuite with Matchers with AnyFlatSpecLike {
         timeoutErr.isLeft shouldBe true
       }
 
-    res.timeout(5 seconds).unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.timeout(5 seconds).unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestSuite.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestSuite.scala
@@ -1,31 +1,26 @@
 package org.broadinstitute.dsde.workbench.leonardo
 
-import cats.syntax.all._
-import cats.effect.concurrent.{Deferred, Semaphore}
-import cats.effect.{Blocker, ContextShift, IO, Timer}
-import org.typelevel.log4cats.StructuredLogger
-import org.typelevel.log4cats.slf4j.Slf4jLogger
-import org.broadinstitute.dsde.workbench.openTelemetry.FakeOpenTelemetryMetricsInterpreter
-import org.scalatest.{Assertion, Assertions}
+import cats.effect.std.{Dispatcher, Semaphore}
+import cats.effect.{Deferred, IO}
 import fs2.Stream
 import org.broadinstitute.dsde.workbench.google2.GKEModels.KubernetesClusterId
+import org.broadinstitute.dsde.workbench.openTelemetry.FakeOpenTelemetryMetricsInterpreter
+import org.scalatest.matchers.should.Matchers
 import org.scalatest.prop.Configuration
+import org.scalatest.{Assertion, Assertions}
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+import org.typelevel.log4cats.StructuredLogger
+import org.typelevel.log4cats.slf4j.Slf4jLogger
 
 import scala.concurrent.duration._
-import scala.concurrent.ExecutionContext.global
-import org.scalatest.matchers.should.Matchers
 
 trait LeonardoTestSuite extends Matchers {
   implicit val metrics = FakeOpenTelemetryMetricsInterpreter
-  implicit val testTimer: Timer[IO] = IO.timer(global)
-  implicit val cs: ContextShift[IO] = IO.contextShift(global)
   implicit val loggerIO: StructuredLogger[IO] = Slf4jLogger.getLogger[IO]
-  implicit val appContext = AppContext.lift[IO](None, "").unsafeRunSync()
+  implicit val appContext = AppContext.lift[IO](None, "").unsafeRunSync()(cats.effect.unsafe.implicits.global)
 
-  val blocker = Blocker.liftExecutionContext(global)
-  val semaphore = Semaphore[IO](10).unsafeRunSync()
-  val nodepoolLock = KeyLock[IO, KubernetesClusterId](1 minute, 10, blocker)
+  val semaphore = Semaphore[IO](10).unsafeRunSync()(cats.effect.unsafe.implicits.global)
+  val nodepoolLock = Dispatcher[IO].evalMap(d => KeyLock[IO, KubernetesClusterId](1 minute, 10, d))
 
   def withInfiniteStream(stream: Stream[IO, Unit], validations: IO[Assertion], maxRetry: Int = 30): IO[Assertion] = {
     val process = Stream.eval(Deferred[IO, Assertion]).flatMap { signalToStop =>
@@ -36,7 +31,7 @@ trait LeonardoTestSuite extends Matchers {
             .complete(Assertions.fail(s"time out after ${maxRetry} retries", acc.throwable.orNull))
             .as(None)
         else
-          testTimer.sleep(1 seconds) >> validations.attempt.flatMap {
+          IO.sleep(1 seconds) >> validations.attempt.flatMap {
             case Left(e)  => IO.pure(Some(((), Accumulator(acc.maxRetry - 1, Some(e)))))
             case Right(a) => signalToStop.complete(a).as(None)
           }

--- a/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestSuite.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestSuite.scala
@@ -20,9 +20,9 @@ import scala.concurrent.duration._
 trait LeonardoTestSuite extends Matchers {
   implicit val metrics = FakeOpenTelemetryMetricsInterpreter
   implicit val loggerIO: StructuredLogger[IO] = Slf4jLogger.getLogger[IO]
-  implicit val appContext = AppContext.lift[IO](None, "").unsafeRunSync()(cats.effect.unsafe.implicits.global)
+  implicit val appContext = AppContext.lift[IO](None, "").unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
 
-  val semaphore = Semaphore[IO](10).unsafeRunSync()(cats.effect.unsafe.implicits.global)
+  val semaphore = Semaphore[IO](10).unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   val underlyingCache =
     Caffeine
       .newBuilder()

--- a/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/DiskRoutesTestJsonCodec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/DiskRoutesTestJsonCodec.scala
@@ -9,17 +9,19 @@ import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 
 object DiskRoutesTestJsonCodec {
-  implicit val createDiskRequestEncoder: Encoder[CreateDiskRequest] = Encoder.forProduct4(
+  implicit val createDiskRequestEncoder: Encoder[CreateDiskRequest] = Encoder.forProduct5(
     "labels",
     "size",
     "diskType",
-    "blockSize"
+    "blockSize",
+    "zone"
   )(x =>
     (
       x.labels,
       x.size,
       x.diskType,
-      x.blockSize
+      x.blockSize,
+      x.zone
     )
   )
 

--- a/http/src/main/resources/logback.xml
+++ b/http/src/main/resources/logback.xml
@@ -28,11 +28,6 @@
         <syslogHost>127.0.0.1</syslogHost>
         <facility>AUDIT</facility>
         <suffixPattern>[%level] [%d{HH:mm:ss.SSS}] [%thread] %logger{36} - %msg%n</suffixPattern>
-<!--        <encoder class="net.logstash.logback.encoder.LogstashEncoder">-->
-<!--            <fieldNames>-->
-<!--                <level>severity</level>-->
-<!--            </fieldNames>-->
-<!--        </encoder>-->
     </appender>
 
     <logger name="org.broadinstitute.dsde" level="info" additivity="false">
@@ -41,7 +36,7 @@
         <appender-ref ref="SYSLOG"/>
     </logger>
 
-    <logger name="akka" level="info" additivity="false">
+    <logger name="akka" level="debug" additivity="false">
         <appender-ref ref="file"/>
         <appender-ref ref="console"/>
         <appender-ref ref="SYSLOG"/>

--- a/http/src/main/resources/logback.xml
+++ b/http/src/main/resources/logback.xml
@@ -54,6 +54,11 @@
 <!--        <appender-ref ref="console"/>-->
 <!--    </logger>-->
 
+    <logger name="org.http4s.client" level="DEBUG" additivity="false">
+        <appender-ref ref="file"/>
+        <appender-ref ref="console"/>
+    </logger>
+
     <logger name="slick.jdbc.JdbcBackend" level="INFO" additivity="false">
         <appender-ref ref="file"/>
         <appender-ref ref="console"/>

--- a/http/src/main/resources/logback.xml
+++ b/http/src/main/resources/logback.xml
@@ -59,7 +59,7 @@
         <appender-ref ref="console"/>
     </logger>
 
-    <root level="debug">
+    <root level="info">
         <appender-ref ref="file"/>
         <appender-ref ref="console"/>
         <appender-ref ref="SYSLOG"/>

--- a/http/src/main/resources/logback.xml
+++ b/http/src/main/resources/logback.xml
@@ -54,7 +54,7 @@
 <!--        <appender-ref ref="console"/>-->
 <!--    </logger>-->
 
-    <root level="info">
+    <root level="debug">
         <appender-ref ref="file"/>
         <appender-ref ref="console"/>
         <appender-ref ref="SYSLOG"/>

--- a/http/src/main/resources/logback.xml
+++ b/http/src/main/resources/logback.xml
@@ -36,7 +36,7 @@
         <appender-ref ref="SYSLOG"/>
     </logger>
 
-    <logger name="akka" level="debug" additivity="false">
+    <logger name="akka" level="info" additivity="false">
         <appender-ref ref="file"/>
         <appender-ref ref="console"/>
         <appender-ref ref="SYSLOG"/>
@@ -53,16 +53,6 @@
 <!--        <appender-ref ref="file"/>-->
 <!--        <appender-ref ref="console"/>-->
 <!--    </logger>-->
-
-    <logger name="org.http4s.client" level="DEBUG" additivity="false">
-        <appender-ref ref="file"/>
-        <appender-ref ref="console"/>
-    </logger>
-
-    <logger name="slick.jdbc.JdbcBackend" level="INFO" additivity="false">
-        <appender-ref ref="file"/>
-        <appender-ref ref="console"/>
-    </logger>
 
     <root level="info">
         <appender-ref ref="file"/>

--- a/http/src/main/resources/logback.xml
+++ b/http/src/main/resources/logback.xml
@@ -54,6 +54,11 @@
 <!--        <appender-ref ref="console"/>-->
 <!--    </logger>-->
 
+    <logger name="slick.jdbc.JdbcBackend" level="INFO" additivity="false">
+        <appender-ref ref="file"/>
+        <appender-ref ref="console"/>
+    </logger>
+
     <root level="debug">
         <appender-ref ref="file"/>
         <appender-ref ref="console"/>

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -545,7 +545,7 @@ proxy {
   proxyPort = 443
   dnsPollPeriod = 15 seconds
   tokenCacheExpiryTime = 60 minutes
-  tokenCacheMaxSize = 1000
+  tokenCacheMaxSize = 5000
   internalIdCacheExpiryTime = 2 minutes
   internalIdCacheMaxSize = 1000
 }

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -504,14 +504,14 @@ clusterFiles {
 # so we need to ensure we don't use stale cache entries.
 runtimeDnsCache {
   cacheExpiryTime = 5 seconds
-  cacheMaxSize = 10000
+  cacheMaxSize = 1000
 }
 
 # Kubernetes expiration can be higher because the IP is at the cluster level, which is
 # consistent across app pause/resume. Clusters are garbage collected ~1 hour after app deletion.
 kubernetesDnsCache {
   cacheExpiryTime = 10 minutes
-  cacheMaxSize = 10000
+  cacheMaxSize = 1000
 }
 
 mysql {
@@ -545,9 +545,9 @@ proxy {
   proxyPort = 443
   dnsPollPeriod = 15 seconds
   tokenCacheExpiryTime = 60 minutes
-  tokenCacheMaxSize = 20000
+  tokenCacheMaxSize = 1000
   internalIdCacheExpiryTime = 2 minutes
-  internalIdCacheMaxSize = 20000
+  internalIdCacheMaxSize = 1000
 }
 
 # The fields here will be combined to build a Content-Security-Policy header

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/auth/SamAuthProvider.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/auth/SamAuthProvider.scala
@@ -45,6 +45,8 @@ class SamAuthProvider[F[_]: Logger: OpenTelemetryMetrics](samDao: SamDAO[F],
       new CacheLoader[AuthCacheKey, java.lang.Boolean] {
         override def load(key: AuthCacheKey): java.lang.Boolean = {
           implicit val traceId = Ask.const[F, TraceId](TraceId(UUID.randomUUID()))
+//          dispatcher.unsafeRunSync(checkPermission(key.samResourceType, key.samResource, key.action, key.authorization))
+          println("1111111: missing cache; calling SAM for permission")
           dispatcher.unsafeRunSync(checkPermission(key.samResourceType, key.samResource, key.action, key.authorization))
         }
       }
@@ -59,7 +61,7 @@ class SamAuthProvider[F[_]: Logger: OpenTelemetryMetrics](samDao: SamDAO[F],
   ): F[Boolean] = {
     val authHeader = Authorization(Credentials.Token(AuthScheme.Bearer, userInfo.accessToken.token))
     if (config.authCacheEnabled && sr.cacheableActions.contains(action)) {
-      F.blocking(
+      F.delay(
         authCache
           .get(
             AuthCacheKey(sr.resourceType, sr.resourceIdAsString(samResource), authHeader, sr.actionAsString(action))

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
@@ -428,14 +428,6 @@ object Config {
         c.getInt("max-concurrent-tasks")
       )
   }
-  implicit private val leoPubsubMessageSubscriberConfigReader: ValueReader[LeoPubsubMessageSubscriberConfig] =
-    ValueReader.relative { config =>
-      LeoPubsubMessageSubscriberConfig(
-        config.getInt("concurrency"),
-        config.as[FiniteDuration]("timeout"),
-        config.as[PersistentDiskMonitorConfig]("persistent-disk-monitor")
-      )
-    }
 
   val dateAccessUpdaterConfig = config.as[DateAccessedUpdaterConfig]("dateAccessedUpdater")
   val applicationConfig = config.as[ApplicationConfig]("application")
@@ -645,6 +637,17 @@ object Config {
   val gkeCustomAppConfig = config.as[CustomAppConfig]("gke.customApp")
   val gkeNodepoolConfig = NodepoolConfig(gkeDefaultNodepoolConfig, gkeGalaxyNodepoolConfig)
   val gkeGalaxyDiskConfig = config.as[GalaxyDiskConfig]("gke.galaxyDisk")
+
+  implicit private val leoPubsubMessageSubscriberConfigReader: ValueReader[LeoPubsubMessageSubscriberConfig] =
+    ValueReader.relative { config =>
+      LeoPubsubMessageSubscriberConfig(
+        config.getInt("concurrency"),
+        config.as[FiniteDuration]("timeout"),
+        config.as[PersistentDiskMonitorConfig]("persistent-disk-monitor"),
+        gkeGalaxyDiskConfig
+      )
+    }
+
   val leoKubernetesConfig = LeoKubernetesConfig(
     kubeServiceAccountProviderConfig,
     gkeClusterConfig,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpAppDAO.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpAppDAO.scala
@@ -1,7 +1,7 @@
 package org.broadinstitute.dsde.workbench.leonardo
 package dao
 
-import cats.effect.{Concurrent, ContextShift, Timer}
+import cats.effect.Async
 import cats.syntax.all._
 import org.broadinstitute.dsde.workbench.google2.KubernetesSerializableName.ServiceName
 import org.broadinstitute.dsde.workbench.leonardo.dao.HostStatus.HostReady
@@ -10,9 +10,7 @@ import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.http4s.client.Client
 import org.http4s.{Method, Request, Uri}
 
-class HttpAppDAO[F[_]: Timer: ContextShift: Concurrent](val kubernetesDnsCache: KubernetesDnsCache[F],
-                                                        client: Client[F])
-    extends AppDAO[F] {
+class HttpAppDAO[F[_]: Async](val kubernetesDnsCache: KubernetesDnsCache[F], client: Client[F]) extends AppDAO[F] {
 
   def isProxyAvailable(googleProject: GoogleProject, appName: AppName, serviceName: ServiceName): F[Boolean] =
     Proxy.getAppTargetHost[F](kubernetesDnsCache, googleProject, appName) flatMap {
@@ -27,7 +25,7 @@ class HttpAppDAO[F[_]: Timer: ContextShift: Concurrent](val kubernetesDnsCache: 
             )
           )
           .handleError(_ => false)
-      case _ => Concurrent[F].pure(false)
+      case _ => Async[F].pure(false)
     }
 }
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpAppDescriptorDAO.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpAppDescriptorDAO.scala
@@ -1,7 +1,7 @@
 package org.broadinstitute.dsde.workbench.leonardo
 package dao
 
-import cats.effect.Effect
+import cats.effect.Concurrent
 import cats.implicits._
 import cats.mtl.Ask
 import org.typelevel.log4cats.StructuredLogger
@@ -12,7 +12,7 @@ import org.broadinstitute.dsde.workbench.leonardo.dao.HttpAppDescriptorDAO._
 import org.http4s.{Method, Request, Response, Uri}
 import org.http4s.client.Client
 
-class HttpAppDescriptorDAO[F[_]](httpClient: Client[F])(implicit logger: StructuredLogger[F], F: Effect[F])
+class HttpAppDescriptorDAO[F[_]](httpClient: Client[F])(implicit logger: StructuredLogger[F], F: Concurrent[F])
     extends AppDescriptorDAO[F] {
   override def getDescriptor(path: Uri)(implicit ev: Ask[F, AppContext]): F[AppDescriptor] =
     for {

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpJupyterDAO.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpJupyterDAO.scala
@@ -1,6 +1,6 @@
 package org.broadinstitute.dsde.workbench.leonardo.dao
 
-import cats.effect.{Concurrent, ContextShift, Timer}
+import cats.effect.Async
 import cats.syntax.all._
 import io.circe.Decoder
 import org.broadinstitute.dsde.workbench.leonardo.RuntimeName
@@ -15,8 +15,8 @@ import org.http4s.{Method, Request, Uri}
 import org.typelevel.log4cats.Logger
 
 //Jupyter server API doc https://github.com/jupyter/jupyter/wiki/Jupyter-Notebook-Server-API
-class HttpJupyterDAO[F[_]: Timer: ContextShift](val runtimeDnsCache: RuntimeDnsCache[F], client: Client[F])(
-  implicit F: Concurrent[F],
+class HttpJupyterDAO[F[_]](val runtimeDnsCache: RuntimeDnsCache[F], client: Client[F])(
+  implicit F: Async[F],
   logger: Logger[F]
 ) extends JupyterDAO[F] {
   def isProxyAvailable(googleProject: GoogleProject, runtimeName: RuntimeName): F[Boolean] =

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpRStudioDAO.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpRStudioDAO.scala
@@ -1,6 +1,6 @@
 package org.broadinstitute.dsde.workbench.leonardo.dao
 
-import cats.effect.{Concurrent, ContextShift, Timer}
+import cats.effect.Async
 import cats.syntax.all._
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.workbench.leonardo.RuntimeName
@@ -10,7 +10,7 @@ import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.http4s.client.Client
 import org.http4s.{Method, Request, Uri}
 
-class HttpRStudioDAO[F[_]: Timer: ContextShift: Concurrent](val runtimeDnsCache: RuntimeDnsCache[F], client: Client[F])
+class HttpRStudioDAO[F[_]: Async](val runtimeDnsCache: RuntimeDnsCache[F], client: Client[F])
     extends RStudioDAO[F]
     with LazyLogging {
   def isProxyAvailable(googleProject: GoogleProject, runtimeName: RuntimeName): F[Boolean] =
@@ -26,7 +26,7 @@ class HttpRStudioDAO[F[_]: Timer: ContextShift: Concurrent](val runtimeDnsCache:
             )
           )
           .handleError(_ => false)
-      case _ => Concurrent[F].pure(false)
+      case _ => Async[F].pure(false)
     }
 }
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpSamDAO.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpSamDAO.scala
@@ -6,15 +6,14 @@ import java.net.URLEncoder
 import java.nio.charset.StandardCharsets.UTF_8
 import java.util.UUID
 import java.util.concurrent.TimeUnit
-
 import _root_.fs2._
 import _root_.org.typelevel.log4cats.Logger
 import _root_.io.circe._
 import _root_.io.circe.syntax._
 import akka.http.scaladsl.model.StatusCode._
 import akka.http.scaladsl.model.{StatusCode, StatusCodes}
-import cats.effect.implicits._
-import cats.effect.{Blocker, ContextShift, Effect, Resource, Timer}
+import cats.effect.std.Dispatcher
+import cats.effect.{Async, Resource}
 import cats.syntax.all._
 import cats.mtl.Ask
 import com.google.api.services.plus.PlusScopes
@@ -42,10 +41,9 @@ import scala.jdk.CollectionConverters._
 import scala.concurrent.duration._
 import scala.util.control.NoStackTrace
 
-class HttpSamDAO[F[_]: Effect](httpClient: Client[F], config: HttpSamDaoConfig, blocker: Blocker)(
+class HttpSamDAO[F[_]](httpClient: Client[F], config: HttpSamDaoConfig, dispatcher: Dispatcher[F])(
   implicit logger: Logger[F],
-  cs: ContextShift[F],
-  timer: Timer[F],
+  F: Async[F],
   metrics: OpenTelemetryMetrics[F]
 ) extends SamDAO[F]
     with Http4sClientDsl[F] {
@@ -60,22 +58,21 @@ class HttpSamDAO[F[_]: Effect](httpClient: Client[F], config: HttpSamDaoConfig, 
       new CacheLoader[UserEmailAndProject, Option[String]] {
         def load(userEmailAndProject: UserEmailAndProject): Option[String] = {
           implicit val traceId = Ask.const[F, TraceId](TraceId(UUID.randomUUID()))
-          getPetAccessToken(userEmailAndProject.userEmail, userEmailAndProject.googleProject).toIO
-            .unsafeRunSync()
+          dispatcher.unsafeRunSync(getPetAccessToken(userEmailAndProject.userEmail, userEmailAndProject.googleProject))
         }
       }
     )
 
   val recordCacheMetricsProcess: Stream[F, Unit] =
     CacheMetrics("petTokenCache")
-      .process(() => Effect[F].delay(petTokenCache.size), () => Effect[F].delay(petTokenCache.stats))
+      .process(() => F.delay(petTokenCache.size), () => F.delay(petTokenCache.stats))
 
   def getStatus(implicit ev: Ask[F, TraceId]): F[StatusCheckResponse] =
     metrics.incrementCounter("sam/status") >>
       httpClient.expectOr[StatusCheckResponse](
         Request[F](
           method = Method.GET,
-          uri = config.samUri.withPath(s"/status")
+          uri = config.samUri.withPath(Uri.Path.unsafeFromString(s"/status"))
         )
       )(onError)
 
@@ -92,9 +89,9 @@ class HttpSamDAO[F[_]: Effect](httpClient: Client[F], config: HttpSamDaoConfig, 
           method = Method.GET,
           uri = config.samUri
             .withPath(
-              s"/api/resources/v2/${resourceType.asString}/${resource}/action/${action}"
+              Uri.Path.unsafeFromString(s"/api/resources/v2/${resourceType.asString}/${resource}/action/${action}")
             ),
-          headers = Headers.of(authHeader)
+          headers = Headers(authHeader)
         )
       )(onError)
     } yield res
@@ -109,8 +106,12 @@ class HttpSamDAO[F[_]: Effect](httpClient: Client[F], config: HttpSamDaoConfig, 
         Request[F](
           method = Method.GET,
           uri = config.samUri
-            .withPath(s"/api/resources/v2/${sr.resourceType.asString}/${sr.resourceIdAsString(resource)}/actions"),
-          headers = Headers.of(authHeader)
+            .withPath(
+              Uri.Path.unsafeFromString(
+                s"/api/resources/v2/${sr.resourceType.asString}/${sr.resourceIdAsString(resource)}/actions"
+              )
+            ),
+          headers = Headers(authHeader)
         )
       )(onError)
   }
@@ -123,8 +124,8 @@ class HttpSamDAO[F[_]: Effect](httpClient: Client[F], config: HttpSamDaoConfig, 
       resp <- httpClient.expectOr[List[ListResourceResponse[R]]](
         Request[F](
           method = Method.GET,
-          uri = config.samUri.withPath(s"/api/resources/v2/${sr.resourceType.asString}"),
-          headers = Headers.of(authHeader)
+          uri = config.samUri.withPath(Uri.Path.unsafeFromString(s"/api/resources/v2/${sr.resourceType.asString}")),
+          headers = Headers(authHeader)
         )
       )(onError)
     } yield resp.flatMap(r => r.samPolicyNames.map(pn => (r.samResourceId, pn)))
@@ -137,12 +138,12 @@ class HttpSamDAO[F[_]: Effect](httpClient: Client[F], config: HttpSamDaoConfig, 
       traceId <- ev.ask
       token <- getCachedPetAccessToken(creatorEmail, googleProject).flatMap(
         _.fold(
-          Effect[F].raiseError[String](
+          F.raiseError[String](
             AuthProviderException(traceId,
                                   s"No pet SA found for ${creatorEmail} in ${googleProject}",
                                   StatusCodes.Unauthorized)
           )
-        )(s => Effect[F].pure(s))
+        )(s => F.pure(s))
       )
       authHeader = Authorization(Credentials.Token(AuthScheme.Bearer, token))
       _ <- logger.info(
@@ -154,15 +155,18 @@ class HttpSamDAO[F[_]: Effect](httpClient: Client[F], config: HttpSamDaoConfig, 
           Request[F](
             method = Method.POST,
             uri = config.samUri
-              .withPath(s"/api/resources/v2/${sr.resourceType.asString}/${sr.resourceIdAsString(resource)}"),
-            headers = Headers.of(authHeader)
+              .withPath(
+                Uri.Path
+                  .unsafeFromString(s"/api/resources/v2/${sr.resourceType.asString}/${sr.resourceIdAsString(resource)}")
+              ),
+            headers = Headers(authHeader)
           )
         )
         .use { resp =>
           if (resp.status.isSuccess)
-            Effect[F].unit
+            F.unit
           else
-            onError(resp).flatMap(Effect[F].raiseError[Unit])
+            onError(resp).flatMap(F.raiseError[Unit])
         }
     } yield ()
 
@@ -175,12 +179,12 @@ class HttpSamDAO[F[_]: Effect](httpClient: Client[F], config: HttpSamDaoConfig, 
       traceId <- ev.ask
       token <- getCachedPetAccessToken(creatorEmail, googleProject).flatMap(
         _.fold(
-          Effect[F].raiseError[String](
+          F.raiseError[String](
             AuthProviderException(traceId,
                                   s"No pet SA found for ${creatorEmail} in ${googleProject}",
                                   StatusCodes.Unauthorized)
           )
-        )(s => Effect[F].pure(s))
+        )(s => F.pure(s))
       )
       authHeader = Authorization(Credentials.Token(AuthScheme.Bearer, token))
       _ <- logger.info(
@@ -196,16 +200,16 @@ class HttpSamDAO[F[_]: Effect](httpClient: Client[F], config: HttpSamDaoConfig, 
           Request[F](
             method = Method.POST,
             uri = config.samUri
-              .withPath(s"/api/resources/v2/${sr.resourceType.asString}"),
-            headers = Headers.of(authHeader, `Content-Type`(MediaType.application.json)),
+              .withPath(Uri.Path.unsafeFromString(s"/api/resources/v2/${sr.resourceType.asString}")),
+            headers = Headers(authHeader, `Content-Type`(MediaType.application.json)),
             body = Stream.emits(CreateSamResourceRequest(resource, policies, parent).asJson.noSpaces.getBytes)
           )
         )
         .use { resp =>
           if (resp.status.isSuccess)
-            Effect[F].unit
+            F.unit
           else
-            onError(resp).flatMap(Effect[F].raiseError[Unit])
+            onError(resp).flatMap(F.raiseError[Unit])
         }
     } yield ()
 
@@ -217,12 +221,12 @@ class HttpSamDAO[F[_]: Effect](httpClient: Client[F], config: HttpSamDaoConfig, 
       traceId <- ev.ask
       token <- getCachedPetAccessToken(creatorEmail, googleProject).flatMap(
         _.fold(
-          Effect[F].raiseError[String](
+          F.raiseError[String](
             AuthProviderException(traceId,
                                   s"No pet SA found for ${creatorEmail} in ${googleProject}",
                                   StatusCodes.Unauthorized)
           )
-        )(s => Effect[F].pure(s))
+        )(s => F.pure(s))
       )
       authHeader = Authorization(Credentials.Token(AuthScheme.Bearer, token))
       _ <- metrics.incrementCounter(s"sam/deleteResource/${sr.resourceType.asString}")
@@ -231,8 +235,11 @@ class HttpSamDAO[F[_]: Effect](httpClient: Client[F], config: HttpSamDaoConfig, 
           Request[F](
             method = Method.DELETE,
             uri = config.samUri
-              .withPath(s"/api/resources/v2/${sr.resourceType.asString}/${sr.resourceIdAsString(resource)}"),
-            headers = Headers.of(authHeader)
+              .withPath(
+                Uri.Path
+                  .unsafeFromString(s"/api/resources/v2/${sr.resourceType.asString}/${sr.resourceIdAsString(resource)}")
+              ),
+            headers = Headers(authHeader)
           )
         )
         .use { resp =>
@@ -241,8 +248,8 @@ class HttpSamDAO[F[_]: Effect](httpClient: Client[F], config: HttpSamDaoConfig, 
               logger.info(
                 s"Fail to delete ${googleProject}/${sr.resourceIdAsString(resource)} because ${sr.resourceType.asString} doesn't exist in SAM"
               )
-            case s if (s.isSuccess) => Effect[F].unit
-            case _                  => onError(resp).flatMap(Effect[F].raiseError[Unit])
+            case s if (s.isSuccess) => F.unit
+            case _                  => onError(resp).flatMap(F.raiseError[Unit])
           }
         }
     } yield ()
@@ -254,8 +261,9 @@ class HttpSamDAO[F[_]: Effect](httpClient: Client[F], config: HttpSamDaoConfig, 
       httpClient.expectOptionOr[WorkbenchEmail](
         Request[F](
           method = Method.GET,
-          uri = config.samUri.withPath(s"/api/google/v1/user/petServiceAccount/${googleProject.value}"),
-          headers = Headers.of(authorization)
+          uri = config.samUri
+            .withPath(Uri.Path.unsafeFromString(s"/api/google/v1/user/petServiceAccount/${googleProject.value}")),
+          headers = Headers(authorization)
         )
       )(onError)
 
@@ -267,8 +275,11 @@ class HttpSamDAO[F[_]: Effect](httpClient: Client[F], config: HttpSamDaoConfig, 
           Request[F](
             method = Method.GET,
             uri = config.samUri
-              .withPath(s"/api/google/v1/user/proxyGroup/${URLEncoder.encode(userEmail.value, UTF_8.name)}"),
-            headers = Headers.of(authHeader)
+              .withPath(
+                Uri.Path
+                  .unsafeFromString(s"/api/google/v1/user/proxyGroup/${URLEncoder.encode(userEmail.value, UTF_8.name)}")
+              ),
+            headers = Headers(authHeader)
           )
         )(onError)
     }
@@ -277,7 +288,7 @@ class HttpSamDAO[F[_]: Effect](httpClient: Client[F], config: HttpSamDaoConfig, 
     implicit ev: Ask[F, TraceId]
   ): F[Option[String]] =
     if (config.petCacheEnabled) {
-      blocker.blockOn(Effect[F].delay(petTokenCache.get(UserEmailAndProject(userEmail, googleProject))))
+      F.delay(petTokenCache.get(UserEmailAndProject(userEmail, googleProject)))
     } else {
       getPetAccessToken(userEmail, googleProject)
     }
@@ -288,7 +299,7 @@ class HttpSamDAO[F[_]: Effect](httpClient: Client[F], config: HttpSamDaoConfig, 
         config.serviceAccountProviderConfig.leoServiceAccountJsonFile.toAbsolutePath.toString
       )
       scopedCredential = credential.createScoped(saScopes.asJava)
-      _ <- Resource.eval(Effect[F].delay(scopedCredential.refresh))
+      _ <- Resource.eval(F.delay(scopedCredential.refresh))
     } yield scopedCredential.getAccessToken.getTokenValue
 
   private def getPetAccessToken(userEmail: WorkbenchEmail, googleProject: GoogleProject)(
@@ -303,15 +314,16 @@ class HttpSamDAO[F[_]: Effect](httpClient: Client[F], config: HttpSamDaoConfig, 
           Request[F](
             method = Method.GET,
             uri = config.samUri.withPath(
-              s"/api/google/v1/petServiceAccount/${googleProject.value}/${URLEncoder.encode(userEmail.value, UTF_8.name)}"
+              Uri.Path.unsafeFromString(
+                s"/api/google/v1/petServiceAccount/${googleProject.value}/${URLEncoder.encode(userEmail.value, UTF_8.name)}"
+              )
             ),
-            headers = Headers.of(leoAuth)
+            headers = Headers(leoAuth)
           )
         )(onError)
         token <- userPetKey.traverse { key =>
           val keyStream = new ByteArrayInputStream(key.toString().getBytes)
-          Effect[F]
-            .delay(ServiceAccountCredentials.fromStream(keyStream).createScoped(saScopes.asJava))
+          F.delay(ServiceAccountCredentials.fromStream(keyStream).createScoped(saScopes.asJava))
             .map(_.refreshAccessToken.getTokenValue)
         }
       } yield token
@@ -332,12 +344,12 @@ class HttpSamDAO[F[_]: Effect](httpClient: Client[F], config: HttpSamDaoConfig, 
       _ <- metrics.incrementCounter("sam/getSubjectId")
       token <- getCachedPetAccessToken(userEmail, googleProject).flatMap(
         _.fold(
-          Effect[F].raiseError[String](
+          F.raiseError[String](
             AuthProviderException(traceId,
                                   s"No pet SA found for ${userEmail} in ${googleProject}",
                                   StatusCodes.Unauthorized)
           )
-        )(s => Effect[F].pure(s))
+        )(s => F.pure(s))
       )
       resp <- getUserSubjectIdFromToken(token)
     } yield resp
@@ -349,10 +361,8 @@ class HttpSamDAO[F[_]: Effect](httpClient: Client[F], config: HttpSamDaoConfig, 
       resp <- httpClient.expectOptionOr[GetGoogleSubjectIdResponse](
         Request[F](
           method = Method.GET,
-          uri = config.samUri.withPath(
-            s"/register/user/v2/self/info"
-          ),
-          headers = Headers.of(authHeader)
+          uri = config.samUri.withPath(Uri.Path.unsafeFromString(s"/register/user/v2/self/info")),
+          headers = Headers(authHeader)
         )
       )(onError)
     } yield resp.map(_.userSubjectId)
@@ -360,15 +370,12 @@ class HttpSamDAO[F[_]: Effect](httpClient: Client[F], config: HttpSamDaoConfig, 
 }
 
 object HttpSamDAO {
-  def apply[F[_]: Effect](
+  def apply[F[_]: Async](
     httpClient: Client[F],
     config: HttpSamDaoConfig,
-    blocker: Blocker
-  )(implicit logger: Logger[F],
-    contextShift: ContextShift[F],
-    timer: Timer[F],
-    metrics: OpenTelemetryMetrics[F]): HttpSamDAO[F] =
-    new HttpSamDAO[F](httpClient, config, blocker)
+    dispatcher: Dispatcher[F]
+  )(implicit logger: Logger[F], metrics: OpenTelemetryMetrics[F]): HttpSamDAO[F] =
+    new HttpSamDAO[F](httpClient, config, dispatcher)
 
   implicit val samRoleEncoder: Encoder[SamRole] = Encoder.encodeString.contramap(_.asString)
   implicit val projectActionEncoder: Encoder[ProjectAction] = Encoder.encodeString.contramap(_.asString)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpWelderDAO.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpWelderDAO.scala
@@ -1,7 +1,7 @@
 package org.broadinstitute.dsde.workbench.leonardo
 package dao
 
-import cats.effect.{Concurrent, ContextShift, Timer}
+import cats.effect.Async
 import cats.syntax.all._
 import org.broadinstitute.dsde.workbench.leonardo.dao.HostStatus.HostReady
 import org.broadinstitute.dsde.workbench.leonardo.dns.RuntimeDnsCache
@@ -11,7 +11,7 @@ import org.http4s.client.Client
 import org.http4s.{Method, Request, Uri}
 import org.typelevel.log4cats.Logger
 
-class HttpWelderDAO[F[_]: Concurrent: Timer: ContextShift: Logger](
+class HttpWelderDAO[F[_]: Async: Logger](
   val runtimeDnsCache: RuntimeDnsCache[F],
   client: Client[F]
 )(

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/ProxyDAO.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/ProxyDAO.scala
@@ -2,8 +2,8 @@ package org.broadinstitute.dsde.workbench.leonardo
 package dao
 
 import akka.http.scaladsl.model.Uri.Host
+import cats.effect.Async
 import cats.effect.implicits._
-import cats.effect.{Concurrent, ContextShift, Timer}
 import org.broadinstitute.dsde.workbench.leonardo.dns._
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 
@@ -18,13 +18,13 @@ object HostStatus {
 }
 
 object Proxy {
-  def getRuntimeTargetHost[F[_]: Timer: ContextShift: Concurrent](runtimeDnsCache: RuntimeDnsCache[F],
-                                                                  googleProject: GoogleProject,
-                                                                  runtimeName: RuntimeName): F[HostStatus] =
+  def getRuntimeTargetHost[F[_]: Async](runtimeDnsCache: RuntimeDnsCache[F],
+                                        googleProject: GoogleProject,
+                                        runtimeName: RuntimeName): F[HostStatus] =
     runtimeDnsCache.getHostStatus(RuntimeDnsCacheKey(googleProject, runtimeName)).timeout(5 seconds)
 
-  def getAppTargetHost[F[_]: Timer: ContextShift: Concurrent](kubernetesDnsCache: KubernetesDnsCache[F],
-                                                              googleProject: GoogleProject,
-                                                              appName: AppName): F[HostStatus] =
+  def getAppTargetHost[F[_]: Async](kubernetesDnsCache: KubernetesDnsCache[F],
+                                    googleProject: GoogleProject,
+                                    appName: AppName): F[HostStatus] =
     kubernetesDnsCache.getHostStatus(KubernetesDnsCacheKey(googleProject, appName)).timeout(5 seconds)
 }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/google/GoogleOAuth2Interpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/google/GoogleOAuth2Interpreter.scala
@@ -18,7 +18,7 @@ class GoogleOAuth2Interpreter[F[_]: Async: StructuredLogger](client: Oauth2, blo
   override def getUserInfoFromToken(accessToken: String)(implicit ev: Ask[F, TraceId]): F[UserInfo] =
     for {
       tokenInfo <- blockAndLogF(
-        Async[F].delay(client.tokeninfo().setAccessToken(accessToken).execute()).adaptError {
+        Async[F].blocking(client.tokeninfo().setAccessToken(accessToken).execute()).adaptError {
           case _ =>
             // Rethrow AuthenticationError if unable to look up the token
             // Do this before logging the error because tokeninfo errors are verbose

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/google/GoogleOAuth2Interpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/google/GoogleOAuth2Interpreter.scala
@@ -3,8 +3,8 @@ package dao
 package google
 
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
-import cats.effect.concurrent.Semaphore
-import cats.effect.{Async, Blocker, ContextShift, Timer}
+import cats.effect.std.Semaphore
+import cats.effect.{Async}
 import cats.syntax.all._
 import cats.mtl.Ask
 import com.google.api.services.oauth2.Oauth2
@@ -13,9 +13,7 @@ import org.broadinstitute.dsde.workbench.google2.withLogging
 import org.broadinstitute.dsde.workbench.leonardo.model.AuthenticationError
 import org.broadinstitute.dsde.workbench.model.{TraceId, UserInfo, WorkbenchEmail, WorkbenchUserId}
 
-class GoogleOAuth2Interpreter[F[_]: Async: Timer: StructuredLogger: ContextShift](client: Oauth2,
-                                                                                  blocker: Blocker,
-                                                                                  blockerBound: Semaphore[F])
+class GoogleOAuth2Interpreter[F[_]: Async: StructuredLogger](client: Oauth2, blockerBound: Semaphore[F])
     extends GoogleOAuth2Service[F] {
   override def getUserInfoFromToken(accessToken: String)(implicit ev: Ask[F, TraceId]): F[UserInfo] =
     for {
@@ -37,6 +35,6 @@ class GoogleOAuth2Interpreter[F[_]: Async: Timer: StructuredLogger: ContextShift
   private def blockAndLogF[A](fa: F[A], action: String)(implicit ev: Ask[F, TraceId]): F[A] =
     for {
       traceId <- ev.ask
-      res <- withLogging(blockerBound.withPermit(blocker.blockOn(fa)), Some(traceId), action)
+      res <- withLogging(blockerBound.permit.use(_ => fa), Some(traceId), action)
     } yield res
 }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/google/GoogleOAuth2Service.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/google/GoogleOAuth2Service.scala
@@ -2,20 +2,19 @@ package org.broadinstitute.dsde.workbench.leonardo
 package dao
 package google
 
-import cats.effect.concurrent.Semaphore
-import cats.effect.{Async, Blocker, ContextShift, Resource, Sync, Timer}
+import cats.effect.std.Semaphore
+import cats.effect.{Async, Resource, Sync}
 import cats.mtl.Ask
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport
 import com.google.api.services.oauth2.Oauth2
-import org.typelevel.log4cats.StructuredLogger
 import org.broadinstitute.dsde.workbench.model.{TraceId, UserInfo}
+import org.typelevel.log4cats.StructuredLogger
 
 trait GoogleOAuth2Service[F[_]] {
   def getUserInfoFromToken(accessToken: String)(implicit ev: Ask[F, TraceId]): F[UserInfo]
 }
 object GoogleOAuth2Service {
-  def resource[F[_]: Async: ContextShift: Timer: StructuredLogger](
-    blocker: Blocker,
+  def resource[F[_]: Async: StructuredLogger](
     blockerBound: Semaphore[F]
   ): Resource[F, GoogleOAuth2Service[F]] =
     for {
@@ -25,5 +24,5 @@ object GoogleOAuth2Service {
       client = new Oauth2.Builder(httpTransport, jsonFactory, null)
         .setApplicationName("leonardo")
         .build()
-    } yield new GoogleOAuth2Interpreter[F](client, blocker, blockerBound)
+    } yield new GoogleOAuth2Interpreter[F](client, blockerBound)
 }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/DbReference.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/DbReference.scala
@@ -59,7 +59,7 @@ object DbReference extends LazyLogging {
         Async[F].delay(initWithLiquibase(dbConnection, config)) >> Logger[F].info("Applied liquidbase changelog")
       else Async[F].unit
       _ <- Resource.eval(initLiquibase)
-    } yield new DbRef[F](dbConfig, db, concurrentDbAccessPermits)
+    } yield new DbRef[F](db, concurrentDbAccessPermits)
   }
 }
 
@@ -70,10 +70,9 @@ trait DbReference[F[_]] {
   ): F[T]
 }
 
-private[db] class DbRef[F[_]](dbConfig: DatabaseConfig[JdbcProfile],
-                              database: JdbcBackend#DatabaseDef,
-                              concurrentDbAccessPermits: Semaphore[F])(implicit F: Async[F])
-    extends DbReference[F] {
+private[db] class DbRef[F[_]](database: JdbcBackend#DatabaseDef, concurrentDbAccessPermits: Semaphore[F])(
+  implicit F: Async[F]
+) extends DbReference[F] {
   import LeoProfile.api._
 
   val dataAccess = DataAccess

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dns/KubernetesDnsCache.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dns/KubernetesDnsCache.scala
@@ -4,7 +4,7 @@ import akka.http.scaladsl.model.Uri.Host
 import cats.effect.{Async, Ref}
 import cats.syntax.all._
 import org.broadinstitute.dsde.workbench.leonardo.AppName
-import org.broadinstitute.dsde.workbench.leonardo.config.{CacheConfig, ProxyConfig}
+import org.broadinstitute.dsde.workbench.leonardo.config.ProxyConfig
 import org.broadinstitute.dsde.workbench.leonardo.dao.HostStatus
 import org.broadinstitute.dsde.workbench.leonardo.dao.HostStatus.{HostNotFound, HostNotReady, HostReady}
 import org.broadinstitute.dsde.workbench.leonardo.db.{DbReference, KubernetesServiceDbQueries}
@@ -28,11 +28,9 @@ final case class KubernetesDnsCacheKey(googleProject: GoogleProject, appName: Ap
 final class KubernetesDnsCache[F[_]: Logger: OpenTelemetryMetrics](
   proxyConfig: ProxyConfig,
   dbRef: DbReference[F],
-  cacheConfig: CacheConfig,
   hostToIpMapping: Ref[F, Map[Host, IP]],
   hostStatusCache: Cache[F, HostStatus]
 )(implicit F: Async[F], ec: ExecutionContext) {
-  //  TODO: Set ttl to cacheConfig.cacheExpiryTime properly once https://github.com/cb372/scalacache/issues/522 in scalacache is fixed
   def getHostStatus(key: KubernetesDnsCacheKey): F[HostStatus] =
     hostStatusCache.cachingF(key)(None)(getHostStatusHelper(key))
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dns/RuntimeDnsCache.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dns/RuntimeDnsCache.scala
@@ -2,22 +2,18 @@ package org.broadinstitute.dsde.workbench.leonardo.dns
 
 import akka.http.scaladsl.model.Uri.Host
 import cats.effect.{Async, Ref}
-import cats.effect.std.Dispatcher
 import cats.syntax.all._
-import com.google.common.cache.{CacheBuilder, CacheLoader, CacheStats}
-import fs2.Stream
 import org.broadinstitute.dsde.workbench.leonardo.config.{CacheConfig, ProxyConfig}
 import org.broadinstitute.dsde.workbench.leonardo.dao.HostStatus
 import org.broadinstitute.dsde.workbench.leonardo.dao.HostStatus._
 import org.broadinstitute.dsde.workbench.leonardo.db.{clusterQuery, DbReference}
-import org.broadinstitute.dsde.workbench.leonardo.util.CacheMetrics
 import org.broadinstitute.dsde.workbench.leonardo.{GoogleId, Runtime, RuntimeName}
 import org.broadinstitute.dsde.workbench.model.IP
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.broadinstitute.dsde.workbench.openTelemetry.OpenTelemetryMetrics
 import org.typelevel.log4cats.Logger
+import scalacache.Cache
 
-import java.util.concurrent.TimeUnit
 import scala.concurrent.ExecutionContext
 
 final case class RuntimeDnsCacheKey(googleProject: GoogleProject, runtimeName: RuntimeName)
@@ -34,44 +30,26 @@ class RuntimeDnsCache[F[_]: Logger: OpenTelemetryMetrics](
   dbRef: DbReference[F],
   cacheConfig: CacheConfig,
   hostToIpMapping: Ref[F, Map[Host, IP]],
-  dispatcher: Dispatcher[F]
+  runtimeDnsCache: Cache[F, HostStatus]
 )(implicit F: Async[F], ec: ExecutionContext) {
-
+  //  TODO: Set ttl to cacheConfig.tokenCacheExpiryTime properly once https://github.com/cb372/scalacache/issues/522 in scalacache is fixed
   def getHostStatus(key: RuntimeDnsCacheKey): F[HostStatus] =
-    F.blocking(projectClusterToHostStatus.get(key))
-  def size: Long = projectClusterToHostStatus.size
-  def stats: CacheStats = projectClusterToHostStatus.stats
+    runtimeDnsCache.cachingF(key)(None)(getHostStatusHelper(key))
 
-  private val projectClusterToHostStatus = CacheBuilder
-    .newBuilder()
-    .expireAfterWrite(cacheConfig.cacheExpiryTime.toSeconds, TimeUnit.SECONDS)
-    .maximumSize(cacheConfig.cacheMaxSize)
-    .recordStats
-    .build(
-      new CacheLoader[RuntimeDnsCacheKey, HostStatus] {
-        def load(key: RuntimeDnsCacheKey): HostStatus = {
-          val res = for {
-            _ <- Logger[F]
-              .debug(s"DNS Cache miss for ${key.googleProject} / ${key.runtimeName}...loading from DB...")
-            runtimeOpt <- dbRef.inTransaction {
-              clusterQuery.getActiveClusterByNameMinimal(key.googleProject, key.runtimeName)
-            }
-            hostStatus <- runtimeOpt match {
-              case Some(runtime) =>
-                hostStatusByProjectAndCluster(runtime)
-              case None =>
-                F.pure[HostStatus](HostNotFound)
-            }
-          } yield hostStatus
-
-          dispatcher.unsafeRunSync(res)
-        }
+  private def getHostStatusHelper(key: RuntimeDnsCacheKey): F[HostStatus] =
+    for {
+      _ <- Logger[F]
+        .debug(s"DNS Cache miss for ${key.googleProject} / ${key.runtimeName}...loading from DB...")
+      runtimeOpt <- dbRef.inTransaction {
+        clusterQuery.getActiveClusterByNameMinimal(key.googleProject, key.runtimeName)
       }
-    )
-
-  val recordCacheMetricsProcess: Stream[F, Unit] =
-    CacheMetrics("runtimeDnsCache")
-      .process(() => F.blocking(projectClusterToHostStatus.size), () => F.blocking(projectClusterToHostStatus.stats))
+      hostStatus <- runtimeOpt match {
+        case Some(runtime) =>
+          hostStatusByProjectAndCluster(runtime)
+        case None =>
+          F.pure[HostStatus](HostNotFound)
+      }
+    } yield hostStatus
 
   private def host(googleId: GoogleId): Host =
     Host(googleId.value + proxyConfig.proxyDomain)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dns/RuntimeDnsCache.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dns/RuntimeDnsCache.scala
@@ -3,7 +3,7 @@ package org.broadinstitute.dsde.workbench.leonardo.dns
 import akka.http.scaladsl.model.Uri.Host
 import cats.effect.{Async, Ref}
 import cats.syntax.all._
-import org.broadinstitute.dsde.workbench.leonardo.config.{CacheConfig, ProxyConfig}
+import org.broadinstitute.dsde.workbench.leonardo.config.ProxyConfig
 import org.broadinstitute.dsde.workbench.leonardo.dao.HostStatus
 import org.broadinstitute.dsde.workbench.leonardo.dao.HostStatus._
 import org.broadinstitute.dsde.workbench.leonardo.db.{clusterQuery, DbReference}
@@ -28,11 +28,9 @@ final case class RuntimeDnsCacheKey(googleProject: GoogleProject, runtimeName: R
 class RuntimeDnsCache[F[_]: Logger: OpenTelemetryMetrics](
   proxyConfig: ProxyConfig,
   dbRef: DbReference[F],
-  cacheConfig: CacheConfig,
   hostToIpMapping: Ref[F, Map[Host, IP]],
   runtimeDnsCache: Cache[F, HostStatus]
 )(implicit F: Async[F], ec: ExecutionContext) {
-  //  TODO: Set ttl to cacheConfig.tokenCacheExpiryTime properly once https://github.com/cb372/scalacache/issues/522 in scalacache is fixed
   def getHostStatus(key: RuntimeDnsCacheKey): F[HostStatus] =
     runtimeDnsCache.cachingF(key)(None)(getHostStatusHelper(key))
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/Boot.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/Boot.scala
@@ -52,7 +52,7 @@ import org.broadinstitute.dsde.workbench.model.{IP, TraceId, UserInfo}
 import org.broadinstitute.dsde.workbench.openTelemetry.OpenTelemetryMetrics
 import org.broadinstitute.dsp.{HelmAlgebra, HelmInterpreter}
 import org.http4s.blaze.client
-import org.http4s.client.middleware.{Retry, RetryPolicy, Logger => Http4sLogger}
+import org.http4s.client.middleware.{Logger => Http4sLogger}
 import org.typelevel.log4cats.StructuredLogger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 
@@ -353,7 +353,7 @@ object Boot extends IOApp {
       kubernetesDnsCache = new KubernetesDnsCache(proxyConfig, dbRef, hostToIpMapping, kubernetesDnsCaffineCache)
 
       // Set up SSL context and http clients
-      retryPolicy = RetryPolicy[F](RetryPolicy.exponentialBackoff(30 seconds, 5))
+//      retryPolicy = RetryPolicy[F](RetryPolicy.exponentialBackoff(30 seconds, 5))
       sslContext <- Resource.eval(SslContextReader.getSSLContext())
       httpClient <- client
         .BlazeClientBuilder[F](blocker)
@@ -363,7 +363,7 @@ object Boot extends IOApp {
         // hostname resolution, so it's okay to use for all clients.
         .withCustomDnsResolver(proxyResolver.resolveHttp4s)
         .resource
-        .map(Retry(retryPolicy))
+//        .map(Retry(retryPolicy))
       httpClientWithLogging = Http4sLogger[F](logHeaders = true, logBody = false)(httpClient)
 
       // Note the Sam client intentionally doesn't use httpClientWithLogging because the logs are

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/Boot.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/Boot.scala
@@ -197,7 +197,7 @@ object Boot extends IOApp {
                 case t: Throwable =>
                   logger
                     .error(t)("FATAL - failure starting http server")
-                    .unsafeToFuture()(cats.effect.unsafe.implicits.global)
+                    .unsafeToFuture()(cats.effect.unsafe.IORuntime.global)
               }
           }
         }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/Boot.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/Boot.scala
@@ -353,7 +353,7 @@ object Boot extends IOApp {
         .withCustomDnsResolver(proxyResolver.resolveHttp4s)
         .resource
         .map(Retry(retryPolicy))
-      httpClientWithLogging = Http4sLogger[F](logHeaders = true, logBody = false)(httpClient)
+      httpClientWithLogging = Http4sLogger[F](logHeaders = true, logBody = true)(httpClient)
 
       // Note the Sam client intentionally doesn't use httpClientWithLogging because the logs are
       // too verbose. We send OpenTelemetry metrics instead for instrumenting Sam calls.

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/Boot.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/Boot.scala
@@ -6,7 +6,7 @@ import akka.http.scaladsl.Http
 import akka.http.scaladsl.model.Uri.Host
 import cats.Parallel
 import cats.effect._
-import cats.effect.concurrent.{Ref, Semaphore}
+import cats.effect.std.{Dispatcher, Queue, Semaphore}
 import cats.mtl.Ask
 import cats.syntax.all._
 import com.google.api.services.compute.ComputeScopes
@@ -14,7 +14,6 @@ import com.google.api.services.container.ContainerScopes
 import com.google.auth.oauth2.GoogleCredentials
 import com.google.devtools.clouderrorreporting.v1beta1.ProjectName
 import fs2.Stream
-import fs2.concurrent.InspectableQueue
 import org.broadinstitute.dsde.workbench.errorReporting.ErrorReporting
 import org.broadinstitute.dsde.workbench.google.GoogleCredentialModes.Json
 import org.broadinstitute.dsde.workbench.google.{HttpGoogleDirectoryDAO, HttpGoogleIamDAO}
@@ -44,22 +43,19 @@ import org.broadinstitute.dsde.workbench.leonardo.dns.{KubernetesDnsCache, Proxy
 import org.broadinstitute.dsde.workbench.leonardo.http.api.{HttpRoutes, StandardUserInfoDirectives}
 import org.broadinstitute.dsde.workbench.leonardo.http.service.{DiskServiceInterp, LeoAppServiceInterp, _}
 import org.broadinstitute.dsde.workbench.leonardo.model.ServiceAccountProvider
-import org.broadinstitute.dsde.workbench.leonardo.monitor.LeoPubsubCodec._
+import org.broadinstitute.dsde.workbench.leonardo.monitor.LeoPubsubCodec.leoPubsubMessageDecoder
 import org.broadinstitute.dsde.workbench.leonardo.monitor.NonLeoMessageSubscriber.nonLeoMessageDecoder
 import org.broadinstitute.dsde.workbench.leonardo.monitor._
 import org.broadinstitute.dsde.workbench.leonardo.util._
 import org.broadinstitute.dsde.workbench.model.{IP, TraceId}
 import org.broadinstitute.dsde.workbench.openTelemetry.OpenTelemetryMetrics
-import org.broadinstitute.dsde.workbench.util2.ExecutionContexts
 import org.broadinstitute.dsp.{HelmAlgebra, HelmInterpreter}
-import org.http4s.client.blaze
+import org.http4s.blaze.client
 import org.http4s.client.middleware.{Retry, RetryPolicy, Logger => Http4sLogger}
 import org.typelevel.log4cats.StructuredLogger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 
 import java.nio.file.Paths
-import java.time.Instant
-import java.util.concurrent.TimeUnit
 import javax.net.ssl.SSLContext
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
@@ -89,8 +85,7 @@ object Boot extends IOApp {
       )
       val bucketHelper = new BucketHelper(bucketHelperConfig,
                                           googleDependencies.googleStorageService,
-                                          appDependencies.serviceAccountProvider,
-                                          appDependencies.blocker)
+                                          appDependencies.serviceAccountProvider)
       val vpcInterp =
         new VPCInterpreter(vpcInterpreterConfig,
                            googleDependencies.googleResourceService,
@@ -107,8 +102,7 @@ object Boot extends IOApp {
         googleDependencies.googleDirectoryDAO,
         googleDependencies.googleIamDAO,
         googleDependencies.googleResourceService,
-        appDependencies.welderDAO,
-        appDependencies.blocker
+        appDependencies.welderDAO
       )
 
       val gceInterp = new GceInterpreter(
@@ -117,8 +111,7 @@ object Boot extends IOApp {
         vpcInterp,
         googleDependencies.googleComputeService,
         googleDependencies.googleDiskService,
-        appDependencies.welderDAO,
-        appDependencies.blocker
+        appDependencies.welderDAO
       )
       implicit val runtimeInstances = new RuntimeInstances(dataprocInterp, gceInterp)
 
@@ -134,10 +127,9 @@ object Boot extends IOApp {
         appDependencies.dateAccessedUpdaterQueue,
         googleDependencies.googleOauth2DAO,
         appDependencies.proxyResolver,
-        appDependencies.samDAO,
-        appDependencies.blocker
+        appDependencies.samDAO
       )
-      val statusService = new StatusService(appDependencies.samDAO, appDependencies.dbReference, applicationConfig)
+      val statusService = new StatusService(appDependencies.samDAO, appDependencies.dbReference)
       val runtimeServiceConfig = RuntimeServiceConfig(
         proxyConfig.proxyUrlBase,
         imageConfig,
@@ -181,9 +173,9 @@ object Boot extends IOApp {
         refererConfig
       )
       val httpServer = for {
-        start <- Timer[IO].clock.realTime(TimeUnit.MILLISECONDS)
+        start <- IO.realTimeInstant
         implicit0(ctx: Ask[IO, AppContext]) = Ask.const[IO, AppContext](
-          AppContext(TraceId(s"Boot_${start}"), Instant.ofEpochMilli(start), "")
+          AppContext(TraceId(s"Boot_${start}"), start)
         )
 
         _ <- if (leoExecutionModeConfig == LeoExecutionModeConfig.BackLeoOnly) {
@@ -196,7 +188,9 @@ object Boot extends IOApp {
               .bindFlow(httpRoutes.route)
               .onError {
                 case t: Throwable =>
-                  logger.error(t)("FATAL - failure starting http server").unsafeToFuture()
+                  logger
+                    .error(t)("FATAL - failure starting http server")
+                    .unsafeToFuture()(cats.effect.unsafe.implicits.global)
               }
           }
         }
@@ -250,7 +244,6 @@ object Boot extends IOApp {
             googleDependencies.googleIamDAO,
             googleDependencies.googleDiskService,
             appDependencies.appDescriptorDAO,
-            appDependencies.blocker,
             appDependencies.nodepoolLock
           )
 
@@ -322,39 +315,38 @@ object Boot extends IOApp {
     }
   }
 
-  private def createDependencies[F[_]: StructuredLogger: Parallel: Concurrent: ContextShift: Timer](
+  private def createDependencies[F[_]: StructuredLogger: Parallel](
     pathToCredentialJson: String
-  )(implicit ec: ExecutionContext, as: ActorSystem, F: ConcurrentEffect[F]): Resource[F, AppDependencies[F]] =
+  )(implicit ec: ExecutionContext, as: ActorSystem, F: Async[F]): Resource[F, AppDependencies[F]] =
     for {
-      blockingEc <- ExecutionContexts.cachedThreadPool[F]
       semaphore <- Resource.eval(Semaphore[F](applicationConfig.concurrency))
-      blocker = Blocker.liftExecutionContext(blockingEc)
-
+      blocker <- org.broadinstitute.dsde.workbench.util2.ExecutionContexts.cachedThreadPool
       // This is for sending custom metrics to stackdriver. all custom metrics starts with `OpenCensus/leonardo/`.
       // Typing in `leonardo` in metrics explorer will show all leonardo custom metrics.
       // As best practice, we should have all related metrics under same prefix separated by `/`
       implicit0(openTelemetry: OpenTelemetryMetrics[F]) <- OpenTelemetryMetrics
-        .resource[F](applicationConfig.leoServiceAccountJsonFile, applicationConfig.applicationName, blocker)
+        .resource[F](applicationConfig.leoServiceAccountJsonFile, applicationConfig.applicationName)
 
       // Set up database reference
       concurrentDbAccessPermits <- Resource.eval(Semaphore[F](dbConcurrency))
-      implicit0(dbRef: DbReference[F]) <- DbReference.init(liquibaseConfig, concurrentDbAccessPermits, blocker)
+      implicit0(dbRef: DbReference[F]) <- DbReference.init(liquibaseConfig, concurrentDbAccessPermits)
 
       // Set up DNS caches
       hostToIpMapping <- Resource.eval(Ref.of(Map.empty[Host, IP]))
-      proxyResolver = ProxyResolver(hostToIpMapping)
-      runtimeDnsCache = new RuntimeDnsCache(proxyConfig, dbRef, runtimeDnsCacheConfig, hostToIpMapping, blocker)
-      kubernetesDnsCache = new KubernetesDnsCache(proxyConfig,
-                                                  dbRef,
-                                                  kubernetesDnsCacheConfig,
-                                                  hostToIpMapping,
-                                                  blocker)
+      proxyResolver <- Dispatcher[F].map(d => ProxyResolver(hostToIpMapping, d))
+      runtimeDnsCache <- Dispatcher[F].map(d =>
+        new RuntimeDnsCache(proxyConfig, dbRef, runtimeDnsCacheConfig, hostToIpMapping, d)
+      )
+      kubernetesDnsCache <- Dispatcher[F].map(d =>
+        new KubernetesDnsCache(proxyConfig, dbRef, kubernetesDnsCacheConfig, hostToIpMapping, d)
+      )
 
       // Set up SSL context and http clients
       retryPolicy = RetryPolicy[F](RetryPolicy.exponentialBackoff(30 seconds, 5))
       sslContext <- Resource.eval(SslContextReader.getSSLContext())
-      httpClient <- blaze
-        .BlazeClientBuilder[F](blockingEc, Some(sslContext))
+      httpClient <- client
+        .BlazeClientBuilder[F](blocker)
+        .withSslContext(sslContext)
         // Note a custom resolver is needed for making requests through the Leo proxy
         // (for example HttpJupyterDAO). Otherwise the proxyResolver falls back to default
         // hostname resolution, so it's okay to use for all clients.
@@ -365,7 +357,7 @@ object Boot extends IOApp {
 
       // Note the Sam client intentionally doesn't use httpClientWithLogging because the logs are
       // too verbose. We send OpenTelemetry metrics instead for instrumenting Sam calls.
-      samDao = HttpSamDAO[F](httpClient, httpSamDaoConfig, blocker)
+      samDao <- Dispatcher[F].map(d => HttpSamDAO[F](httpClient, httpSamDaoConfig, d))
       jupyterDao = new HttpJupyterDAO[F](runtimeDnsCache, httpClientWithLogging)
       welderDao = new HttpWelderDAO[F](runtimeDnsCache, httpClientWithLogging)
       rstudioDAO = new HttpRStudioDAO(runtimeDnsCache, httpClientWithLogging)
@@ -375,14 +367,14 @@ object Boot extends IOApp {
 
       // Set up identity providers
       serviceAccountProvider = new PetClusterServiceAccountProvider(samDao)
-      authProvider = new SamAuthProvider(samDao, samAuthConfig, serviceAccountProvider, blocker)
+      authProvider <- Dispatcher[F].map(d => new SamAuthProvider(samDao, samAuthConfig, serviceAccountProvider, d))
 
       // Set up GCP credentials
       credential <- credentialResource(pathToCredentialJson)
       scopedCredential = credential.createScoped(Seq(ComputeScopes.COMPUTE).asJava)
       kubernetesScopedCredential = credential.createScoped(Seq(ContainerScopes.CLOUD_PLATFORM).asJava)
       credentialJson <- Resource.eval(
-        readFileToString(applicationConfig.leoServiceAccountJsonFile, blocker)
+        readFileToString(applicationConfig.leoServiceAccountJsonFile)
       )
       json = Json(credentialJson)
       jsonWithServiceAccountUser = Json(credentialJson, Option(googleGroupsConfig.googleAdminEmail))
@@ -392,11 +384,11 @@ object Boot extends IOApp {
       googleDirectoryDAO = new HttpGoogleDirectoryDAO(applicationConfig.applicationName,
                                                       jsonWithServiceAccountUser,
                                                       workbenchMetricsBaseName)
-      googleResourceService <- GoogleResourceService.resource[F](Paths.get(pathToCredentialJson), blocker, semaphore)
-      googleStorage <- GoogleStorageService.resource[F](pathToCredentialJson, blocker, Some(semaphore))
+      googleResourceService <- GoogleResourceService.resource[F](Paths.get(pathToCredentialJson), semaphore)
+      googleStorage <- GoogleStorageService.resource[F](pathToCredentialJson, Some(semaphore))
       googlePublisher <- GooglePublisher.resource[F](publisherConfig)
       cryptoMiningUserPublisher <- GooglePublisher.resource[F](cryptominingTopicPublisherConfig)
-      gkeService <- GKEService.resource(Paths.get(pathToCredentialJson), blocker, semaphore)
+      gkeService <- GKEService.resource(Paths.get(pathToCredentialJson), semaphore)
 
       // Retry 400 responses from Google, as those can occur when resources aren't ready yet
       // (e.g. if the subnet isn't ready when creating an instance).
@@ -405,7 +397,6 @@ object Boot extends IOApp {
 
       googleComputeService <- GoogleComputeService.fromCredential(
         scopedCredential,
-        blocker,
         semaphore,
         googleComputeRetryPolicy
       )
@@ -419,47 +410,45 @@ object Boot extends IOApp {
         .resource(
           googleComputeService,
           pathToCredentialJson,
-          blocker,
           semaphore,
           dataprocConfig.supportedRegions,
           googleDataprocRetryPolicy
         )
 
-      _ <- OpenTelemetryMetrics.registerTracing[F](Paths.get(pathToCredentialJson), blocker)
-      googleDiskService <- GoogleDiskService.resource(pathToCredentialJson, blocker, semaphore)
-      computePollOperation <- ComputePollOperation.resourceFromCredential(scopedCredential, blocker, semaphore)
+      _ <- OpenTelemetryMetrics.registerTracing[F](Paths.get(pathToCredentialJson))
+      googleDiskService <- GoogleDiskService.resource(pathToCredentialJson, semaphore)
+      computePollOperation <- ComputePollOperation.resourceFromCredential(scopedCredential, semaphore)
       errorReporting <- ErrorReporting.fromCredential(scopedCredential,
                                                       applicationConfig.applicationName,
                                                       ProjectName.of(applicationConfig.leoGoogleProject.value))
-      googleOauth2DAO <- GoogleOAuth2Service.resource(blocker, semaphore)
-      nodepoolLock <- Resource.eval(
+      googleOauth2DAO <- GoogleOAuth2Service.resource(semaphore)
+      nodepoolLock <- Dispatcher[F].evalMap(d =>
         KeyLock[F, KubernetesClusterId](gkeClusterConfig.nodepoolLockCacheExpiryTime,
                                         gkeClusterConfig.nodepoolLockCacheMaxSize,
-                                        blocker)
+                                        d)
       )
 
       // Set up PubSub queues
-      asyncTasksQueue <- Resource.eval(InspectableQueue.bounded[F, Task[F]](asyncTaskProcessorConfig.queueBound))
-      publisherQueue <- Resource.eval(InspectableQueue.bounded[F, LeoPubsubMessage](pubsubConfig.queueSize))
+      publisherQueue <- Resource.eval(Queue.bounded[F, LeoPubsubMessage](pubsubConfig.queueSize))
       leoPublisher = new LeoPublisher(publisherQueue, googlePublisher)
       dataAccessedUpdater <- Resource.eval(
-        InspectableQueue.bounded[F, UpdateDateAccessMessage](dateAccessUpdaterConfig.queueSize)
+        Queue.bounded[F, UpdateDateAccessMessage](dateAccessUpdaterConfig.queueSize)
       )
-      subscriberQueue <- Resource.eval(InspectableQueue.bounded[F, Event[LeoPubsubMessage]](pubsubConfig.queueSize))
+      subscriberQueue <- Resource.eval(Queue.bounded[F, Event[LeoPubsubMessage]](pubsubConfig.queueSize))
       subscriber <- GoogleSubscriber.resource(subscriberConfig, subscriberQueue)
       nonLeoMessageSubscriberQueue <- Resource.eval(
-        InspectableQueue.bounded[F, Event[NonLeoMessage]](pubsubConfig.queueSize)
+        Queue.bounded[F, Event[NonLeoMessage]](pubsubConfig.queueSize)
       )
       nonLeoMessageSubscriber <- GoogleSubscriber.resource(nonLeoMessageSubscriberConfig, nonLeoMessageSubscriberQueue)
-      asyncTasksQueue <- Resource.eval(InspectableQueue.bounded[F, Task[F]](asyncTaskProcessorConfig.queueBound))
+      asyncTasksQueue <- Resource.eval(Queue.bounded[F, Task[F]](asyncTaskProcessorConfig.queueBound))
 
       // Set up k8s and helm clients
       kubeService <- org.broadinstitute.dsde.workbench.google2.KubernetesService
-        .resource(Paths.get(pathToCredentialJson), gkeService, blocker, semaphore)
+        .resource(Paths.get(pathToCredentialJson), gkeService)
       // Use a low concurrency for helm because it can generate very chatty network traffic
       // (especially for Galaxy) and cause issues at high concurrency.
       helmConcurrency <- Resource.eval(Semaphore[F](20L))
-      helmClient = new HelmInterpreter[F](blocker, helmConcurrency)
+      helmClient = new HelmInterpreter[F](helmConcurrency)
 
       googleDependencies = GoogleDependencies(
         googleStorage,
@@ -491,7 +480,6 @@ object Boot extends IOApp {
       rstudioDAO,
       serviceAccountProvider,
       authProvider,
-      blocker,
       semaphore,
       leoPublisher,
       publisherQueue,
@@ -540,14 +528,13 @@ final case class AppDependencies[F[_]](
   rStudioDAO: RStudioDAO[F],
   serviceAccountProvider: ServiceAccountProvider[F],
   authProvider: SamAuthProvider[F],
-  blocker: Blocker,
   semaphore: Semaphore[F],
   leoPublisher: LeoPublisher[F],
-  publisherQueue: fs2.concurrent.InspectableQueue[F, LeoPubsubMessage],
-  dateAccessedUpdaterQueue: fs2.concurrent.InspectableQueue[F, UpdateDateAccessMessage],
+  publisherQueue: Queue[F, LeoPubsubMessage],
+  dateAccessedUpdaterQueue: Queue[F, UpdateDateAccessMessage],
   subscriber: GoogleSubscriber[F, LeoPubsubMessage],
   nonLeoMessageGoogleSubscriber: GoogleSubscriber[F, NonLeoMessage],
-  asyncTasksQueue: InspectableQueue[F, Task[F]],
+  asyncTasksQueue: Queue[F, Task[F]],
   helmClient: HelmAlgebra[F],
   appDAO: AppDAO[F],
   nodepoolLock: KeyLock[F, KubernetesClusterId],

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/Boot.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/Boot.scala
@@ -293,7 +293,7 @@ object Boot extends IOApp {
 
         val frontLeoOnlyProcesses = List(
           dateAccessedUpdater.process // We only need to update dateAccessed in front leo
-        ) ++ appDependencies.recordCacheMetrics
+        ) // ++ appDependencies.recordCacheMetrics TODO: uncomment this
 
         val extraProcesses = leoExecutionModeConfig match {
           case LeoExecutionModeConfig.BackLeoOnly  => backLeoOnlyProcesses

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/Boot.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/Boot.scala
@@ -373,7 +373,7 @@ object Boot extends IOApp {
         F.delay(s.close)
       )
 
-      samDao = HttpSamDAO[F](httpClient, httpSamDaoConfig, petTokenCache)
+      samDao = HttpSamDAO[F](Retry(retryPolicy)(httpClient), httpSamDaoConfig, petTokenCache)
       jupyterDao = new HttpJupyterDAO[F](runtimeDnsCache, httpClientWithLogging)
       welderDao = new HttpWelderDAO[F](runtimeDnsCache, httpClientWithLogging)
       rstudioDAO = new HttpRStudioDAO(runtimeDnsCache, httpClientWithLogging)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/Boot.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/Boot.scala
@@ -341,11 +341,7 @@ object Boot extends IOApp {
       runtimeDnsCaffineCache <- Resource.make(F.delay(CaffeineCache[F, HostStatus](underlyingRuntimeDnsCache)))(s =>
         F.delay(s.close)
       )
-      runtimeDnsCache = new RuntimeDnsCache(proxyConfig,
-                                            dbRef,
-                                            runtimeDnsCacheConfig,
-                                            hostToIpMapping,
-                                            runtimeDnsCaffineCache)
+      runtimeDnsCache = new RuntimeDnsCache(proxyConfig, dbRef, hostToIpMapping, runtimeDnsCaffineCache)
       underlyingkubernetesDnsCache = buildCache[scalacache.Entry[HostStatus]](
         kubernetesDnsCacheConfig.cacheMaxSize,
         kubernetesDnsCacheConfig.cacheExpiryTime
@@ -354,11 +350,7 @@ object Boot extends IOApp {
       kubernetesDnsCaffineCache <- Resource.make(F.delay(CaffeineCache[F, HostStatus](underlyingkubernetesDnsCache)))(
         s => F.delay(s.close)
       )
-      kubernetesDnsCache = new KubernetesDnsCache(proxyConfig,
-                                                  dbRef,
-                                                  kubernetesDnsCacheConfig,
-                                                  hostToIpMapping,
-                                                  kubernetesDnsCaffineCache)
+      kubernetesDnsCache = new KubernetesDnsCache(proxyConfig, dbRef, hostToIpMapping, kubernetesDnsCaffineCache)
 
       // Set up SSL context and http clients
       retryPolicy = RetryPolicy[F](RetryPolicy.exponentialBackoff(30 seconds, 5))

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/Boot.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/Boot.scala
@@ -322,7 +322,6 @@ object Boot extends IOApp {
   )(implicit ec: ExecutionContext, as: ActorSystem, F: Async[F]): Resource[F, AppDependencies[F]] =
     for {
       semaphore <- Resource.eval(Semaphore[F](applicationConfig.concurrency))
-      blocker <- org.broadinstitute.dsde.workbench.util2.ExecutionContexts.cachedThreadPool
       // This is for sending custom metrics to stackdriver. all custom metrics starts with `OpenCensus/leonardo/`.
       // Typing in `leonardo` in metrics explorer will show all leonardo custom metrics.
       // As best practice, we should have all related metrics under same prefix separated by `/`
@@ -357,7 +356,7 @@ object Boot extends IOApp {
       retryPolicy = RetryPolicy[F](RetryPolicy.exponentialBackoff(30 seconds, 5))
       sslContext <- Resource.eval(SslContextReader.getSSLContext())
       httpClient <- client
-        .BlazeClientBuilder[F](blocker)
+        .BlazeClientBuilder[F]
         .withSslContext(sslContext)
         // Note a custom resolver is needed for making requests through the Leo proxy
         // (for example HttpJupyterDAO). Otherwise the proxyResolver falls back to default

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/HttpRoutes.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/HttpRoutes.scala
@@ -10,7 +10,7 @@ import akka.http.scaladsl.server.RouteResult.Complete
 import akka.http.scaladsl.server.directives.{DebuggingDirectives, LogEntry, LoggingMagnet}
 import akka.http.scaladsl.server.{Directive0, ExceptionHandler, RejectionHandler, Route, ValidationRejection}
 import akka.stream.scaladsl.Sink
-import cats.effect.{ContextShift, IO}
+import cats.effect.IO
 import com.typesafe.scalalogging.LazyLogging
 import io.circe.Encoder
 import org.broadinstitute.dsde.workbench.leonardo.config.{RefererConfig, SwaggerConfig}
@@ -40,7 +40,7 @@ class HttpRoutes(
   userInfoDirectives: UserInfoDirectives,
   contentSecurityPolicy: String,
   refererConfig: RefererConfig
-)(implicit ec: ExecutionContext, ac: ActorSystem, cs: ContextShift[IO], metrics: OpenTelemetryMetrics[IO])
+)(implicit ec: ExecutionContext, ac: ActorSystem, metrics: OpenTelemetryMetrics[IO])
     extends LazyLogging {
   private val swaggerRoutes = new SwaggerRoutes(swaggerConfig)
   private val statusRoutes = new StatusRoutes(statusService)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/ProxyRoutes.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/ProxyRoutes.scala
@@ -145,7 +145,7 @@ class ProxyRoutes(proxyService: ProxyService, corsSupport: CorsSupport, refererC
   private def extractUserInfoOpt(implicit ev: Ask[IO, TraceId]): Directive1[Option[UserInfo]] =
     (extractTokenFromHeader orElse extractTokenFromCookie).flatMap {
       case Some(token) =>
-        onSuccess(proxyService.getCachedUserInfoFromToken(token).unsafeToFuture()(cats.effect.unsafe.implicits.global))
+        onSuccess(proxyService.getCachedUserInfoFromToken(token).unsafeToFuture()(cats.effect.unsafe.IORuntime.global))
           .map(_.some)
       case None => provide(None)
     }
@@ -156,7 +156,7 @@ class ProxyRoutes(proxyService: ProxyService, corsSupport: CorsSupport, refererC
   private def extractUserInfo(implicit ev: Ask[IO, TraceId]): Directive1[UserInfo] =
     (extractTokenFromHeader orElse extractTokenFromCookie).flatMap {
       case Some(token) =>
-        onSuccess(proxyService.getCachedUserInfoFromToken(token).unsafeToFuture()(cats.effect.unsafe.implicits.global))
+        onSuccess(proxyService.getCachedUserInfoFromToken(token).unsafeToFuture()(cats.effect.unsafe.IORuntime.global))
       case None => failWith(AuthenticationError())
     }
 
@@ -167,7 +167,7 @@ class ProxyRoutes(proxyService: ProxyService, corsSupport: CorsSupport, refererC
   private def extractUserInfoFromHeader(implicit ev: Ask[IO, TraceId]): Directive1[Option[UserInfo]] =
     extractTokenFromHeader flatMap {
       case Some(token) =>
-        onSuccess(proxyService.getCachedUserInfoFromToken(token).unsafeToFuture()(cats.effect.unsafe.implicits.global))
+        onSuccess(proxyService.getCachedUserInfoFromToken(token).unsafeToFuture()(cats.effect.unsafe.IORuntime.global))
           .map(_.some)
       case None => provide(None)
     }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/package.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/package.scala
@@ -19,7 +19,7 @@ import scala.concurrent.Future
 
 package object api {
   implicit def ioMarshaller[A, B](implicit m: Marshaller[Future[A], B]): Marshaller[IO[A], B] =
-    Marshaller(implicit ec => (x => m(x.unsafeToFuture()(cats.effect.unsafe.implicits.global))))
+    Marshaller(implicit ec => (x => m(x.unsafeToFuture()(cats.effect.unsafe.IORuntime.global))))
 
   val googleProjectSegment = Segment.map(GoogleProject)
   val runtimeNameSegment = Segment.map(RuntimeName)
@@ -48,5 +48,5 @@ package object api {
 
 object ImplicitConversions {
   implicit def ioToFuture[A](ioa: IO[A]): Future[A] =
-    ioa.unsafeToFuture()(cats.effect.unsafe.implicits.global)
+    ioa.unsafeToFuture()(cats.effect.unsafe.IORuntime.global)
 }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/ProxyService.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/ProxyService.scala
@@ -93,7 +93,6 @@ class ProxyService(
   dbRef: DbReference[IO],
   loggerIO: StructuredLogger[IO])
     extends LazyLogging {
-  implicit val gtc = googleTokenCache
   val httpsConnectionContext = ConnectionContext.httpsClient(sslContext)
   val clientConnectionSettings =
     ClientConnectionSettings(system).withTransport(ClientTransport.withCustomResolver(proxyResolver.resolveAkka))

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/ProxyService.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/ProxyService.scala
@@ -112,7 +112,6 @@ class ProxyService(
   /* Ask the cache for the corresponding user info given a token */
   def getCachedUserInfoFromToken(token: String)(implicit ev: Ask[IO, TraceId]): IO[UserInfo] =
     for {
-//    TODO: Set ttl to proxyConfig.tokenCacheExpiryTime properly once https://github.com/cb372/scalacache/issues/522 in scalacache is fixed
       cache <- googleTokenCache.cachingF(token)(None)(getUserInfo(token)).adaptError {
         case e: AuthenticationError => e
         case _                      =>
@@ -145,7 +144,6 @@ class ProxyService(
   ): IO[RuntimeSamResourceId] =
     for {
       ctx <- ev.ask[AppContext]
-      //    TODO: Set ttl to proxyConfig.tokenCacheExpiryTime properly once https://github.com/cb372/scalacache/issues/522 in scalacache is fixed
       cacheResult <- samResourceCache.cachingF(key)(None)(
         getSamResourceFromDb(key)
       )
@@ -168,7 +166,6 @@ class ProxyService(
   ): IO[AppSamResourceId] =
     for {
       ctx <- ev.ask[AppContext]
-//    TODO: Set ttl to proxyConfig.tokenCacheExpiryTime properly once https://github.com/cb372/scalacache/issues/522 in scalacache is fixed
       cacheResult <- samResourceCache.cachingF(key)(None)(
         getSamResourceFromDb(key)
       )

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/ProxyService.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/ProxyService.scala
@@ -12,12 +12,10 @@ import akka.http.scaladsl.unmarshalling.Unmarshal
 import akka.http.scaladsl.{ClientTransport, ConnectionContext, Http}
 import akka.stream.scaladsl.{Flow, Keep, Sink, Source}
 import cats.effect.IO
+import cats.effect.std.Queue
 import cats.mtl.Ask
 import cats.syntax.all._
-import com.google.common.cache.{CacheBuilder, CacheLoader}
 import com.typesafe.scalalogging.LazyLogging
-import fs2.Stream
-import cats.effect.std.Queue
 import org.broadinstitute.dsde.workbench.google2.KubernetesSerializableName.ServiceName
 import org.broadinstitute.dsde.workbench.leonardo.SamResourceId._
 import org.broadinstitute.dsde.workbench.leonardo.config.ProxyConfig
@@ -30,20 +28,16 @@ import org.broadinstitute.dsde.workbench.leonardo.http.service.ProxyService._
 import org.broadinstitute.dsde.workbench.leonardo.http.service.SamResourceCacheKey.{AppCacheKey, RuntimeCacheKey}
 import org.broadinstitute.dsde.workbench.leonardo.model._
 import org.broadinstitute.dsde.workbench.leonardo.monitor.UpdateDateAccessMessage
-import org.broadinstitute.dsde.workbench.leonardo.util.CacheMetrics
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.broadinstitute.dsde.workbench.model.{TraceId, UserInfo}
-import org.broadinstitute.dsde.workbench.openTelemetry.OpenTelemetryMetrics
 import org.broadinstitute.dsde.workbench.util.toScalaDuration
 import org.typelevel.log4cats.StructuredLogger
+import scalacache.Cache
 
 import java.time.Instant
-import java.util.UUID
-import java.util.concurrent.TimeUnit
 import javax.net.ssl.SSLContext
 import scala.collection.immutable
 import scala.concurrent.{ExecutionContext, Future}
-
 final case class HostContext(status: HostStatus, description: String)
 
 sealed trait SamResourceCacheKey extends Product with Serializable {
@@ -91,14 +85,15 @@ class ProxyService(
   dateAccessUpdaterQueue: Queue[IO, UpdateDateAccessMessage],
   googleOauth2Service: GoogleOAuth2Service[IO],
   proxyResolver: ProxyResolver[IO],
-  samDAO: SamDAO[IO]
+  samDAO: SamDAO[IO],
+  googleTokenCache: Cache[IO, (UserInfo, Instant)],
+  samResourceCache: Cache[IO, Option[String]]
 )(implicit val system: ActorSystem,
   executionContext: ExecutionContext,
   dbRef: DbReference[IO],
-  metrics: OpenTelemetryMetrics[IO],
   loggerIO: StructuredLogger[IO])
     extends LazyLogging {
-
+  implicit val gtc = googleTokenCache
   val httpsConnectionContext = ConnectionContext.httpsClient(sslContext)
   val clientConnectionSettings =
     ClientConnectionSettings(system).withTransport(ClientTransport.withCustomResolver(proxyResolver.resolveAkka))
@@ -106,38 +101,19 @@ class ProxyService(
   final val requestTimeout = toScalaDuration(system.settings.config.getDuration("akka.http.server.request-timeout"))
   logger.info(s"Leo proxy request timeout is $requestTimeout")
 
-  /* Cache for the bearer token and corresponding google user email */
-  private[leonardo] val googleTokenCache = CacheBuilder
-    .newBuilder()
-    .expireAfterWrite(proxyConfig.tokenCacheExpiryTime.toSeconds, TimeUnit.SECONDS)
-    .maximumSize(proxyConfig.tokenCacheMaxSize)
-    .recordStats()
-    .build(
-      new CacheLoader[String, (UserInfo, Instant)] {
-        def load(key: String): (UserInfo, Instant) = {
-          implicit val traceId = Ask.const[IO, TraceId](TraceId(UUID.randomUUID()))
-          // UserInfo only stores a _relative_ expiration time to when the tokeninfo call was made
-          // (e.g. tokenExpiresIn). So we also cache the _absolute_ expiration by doing
-          // (now + tokenExpiresIn).
-          val res = for {
-            now <- IO.realTimeInstant
-            userInfo <- googleOauth2Service.getUserInfoFromToken(key)
-            userOpt <- samDAO.getUserSubjectIdFromToken(key)
-            _ <- IO.fromOption(userOpt)(AuthenticationError(Some(userInfo.userEmail)))
-          } yield (userInfo, now.plusSeconds(userInfo.tokenExpiresIn.toInt))
-          res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
-        }
-      }
-    )
-
-  val recordGoogleTokenCacheMetricsProcess: Stream[IO, Unit] =
-    CacheMetrics[IO]("googleTokenCache")
-      .process(() => IO(googleTokenCache.size), () => IO(googleTokenCache.stats))
+  private[leonardo] def getUserInfo(token: String)(implicit ev: Ask[IO, TraceId]): IO[(UserInfo, Instant)] =
+    for {
+      now <- IO.realTimeInstant
+      userInfo <- googleOauth2Service.getUserInfoFromToken(token)
+      userOpt <- samDAO.getUserSubjectIdFromToken(token)
+      _ <- IO.fromOption(userOpt)(AuthenticationError(Some(userInfo.userEmail)))
+    } yield (userInfo, now.plusSeconds(userInfo.tokenExpiresIn.toInt))
 
   /* Ask the cache for the corresponding user info given a token */
-  def getCachedUserInfoFromToken(token: String): IO[UserInfo] =
+  def getCachedUserInfoFromToken(token: String)(implicit ev: Ask[IO, TraceId]): IO[UserInfo] =
     for {
-      cache <- IO.blocking(googleTokenCache.get(token)).adaptError {
+//    TODO: Set ttl to proxyConfig.tokenCacheExpiryTime properly once https://github.com/cb372/scalacache/issues/522 in scalacache is fixed
+      cache <- googleTokenCache.cachingF(token)(None)(getUserInfo(token)).adaptError {
         case e: AuthenticationError => e
         case _                      =>
           // Rethrow AuthenticationError if unable to look up the token
@@ -153,39 +129,26 @@ class ProxyService(
       }
     } yield res
 
-  /* Cache for the sam resource from the database */
-  private[leonardo] val samResourceCache = CacheBuilder
-    .newBuilder()
-    .expireAfterWrite(proxyConfig.internalIdCacheExpiryTime.toSeconds, TimeUnit.SECONDS)
-    .maximumSize(proxyConfig.internalIdCacheMaxSize)
-    .recordStats()
-    .build(
-      new CacheLoader[SamResourceCacheKey, Option[String]] {
-        def load(key: SamResourceCacheKey): Option[String] = {
-          val io = key match {
-            case RuntimeCacheKey(googleProject, name) =>
-              clusterQuery.getActiveClusterInternalIdByName(googleProject, name).map(_.map(_.resourceId)).transaction
-            case AppCacheKey(googleProject, name) =>
-              KubernetesServiceDbQueries
-                .getActiveFullAppByName(googleProject, name)
-                .map(_.map(_.app.samResourceId.resourceId))
-                .transaction
-          }
-          io.unsafeRunSync()(cats.effect.unsafe.implicits.global)
-        }
-      }
-    )
-
-  val recordSamResourceCacheMetricsProcess: Stream[IO, Unit] =
-    CacheMetrics[IO]("samResourceCache")
-      .process(() => IO(samResourceCache.size), () => IO(samResourceCache.stats))
+  private[leonardo] def getSamResourceFromDb(samResourceCacheKey: SamResourceCacheKey): IO[Option[String]] =
+    samResourceCacheKey match {
+      case RuntimeCacheKey(googleProject, name) =>
+        clusterQuery.getActiveClusterInternalIdByName(googleProject, name).map(_.map(_.resourceId)).transaction
+      case AppCacheKey(googleProject, name) =>
+        KubernetesServiceDbQueries
+          .getActiveFullAppByName(googleProject, name)
+          .map(_.map(_.app.samResourceId.resourceId))
+          .transaction
+    }
 
   def getCachedRuntimeSamResource(key: RuntimeCacheKey)(
     implicit ev: Ask[IO, AppContext]
   ): IO[RuntimeSamResourceId] =
     for {
       ctx <- ev.ask[AppContext]
-      cacheResult <- IO.blocking(samResourceCache.get(key))
+      //    TODO: Set ttl to proxyConfig.tokenCacheExpiryTime properly once https://github.com/cb372/scalacache/issues/522 in scalacache is fixed
+      cacheResult <- samResourceCache.cachingF(key)(None)(
+        getSamResourceFromDb(key)
+      )
       resourceId = cacheResult.map(RuntimeSamResourceId)
       res <- resourceId match {
         case Some(samResource) => IO.pure(samResource)
@@ -205,7 +168,10 @@ class ProxyService(
   ): IO[AppSamResourceId] =
     for {
       ctx <- ev.ask[AppContext]
-      cacheResult <- IO.blocking(samResourceCache.get(key))
+//    TODO: Set ttl to proxyConfig.tokenCacheExpiryTime properly once https://github.com/cb372/scalacache/issues/522 in scalacache is fixed
+      cacheResult <- samResourceCache.cachingF(key)(None)(
+        getSamResourceFromDb(key)
+      )
       resourceId = cacheResult.map(AppSamResourceId)
       res <- resourceId match {
         case Some(samResource) => IO.pure(samResource)
@@ -225,7 +191,7 @@ class ProxyService(
     } yield res
 
   def invalidateAccessToken(token: String): IO[Unit] =
-    IO.blocking(googleTokenCache.invalidate(token))
+    googleTokenCache.remove(token)
 
   def proxyRequest(userInfo: UserInfo, googleProject: GoogleProject, runtimeName: RuntimeName, request: HttpRequest)(
     implicit ev: Ask[IO, AppContext]
@@ -301,9 +267,6 @@ class ProxyService(
   ): IO[HttpResponse] =
     for {
       ctx <- ev.ask[AppContext]
-      _ <- loggerIO.debug(ctx.loggingCtx)(
-        s"Received proxy request for ${hostContext.description}: ${runtimeDnsCache.stats} / ${runtimeDnsCache.size}"
-      )
       res <- hostContext.status match {
         case HostReady(targetHost) =>
           // If this is a WebSocket request (e.g. wss://leo:8080/...) then akka-http injects a

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/ProxyService.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/ProxyService.scala
@@ -125,7 +125,7 @@ class ProxyService(
             userOpt <- samDAO.getUserSubjectIdFromToken(key)
             _ <- IO.fromOption(userOpt)(AuthenticationError(Some(userInfo.userEmail)))
           } yield (userInfo, now.plusSeconds(userInfo.tokenExpiresIn.toInt))
-          res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+          res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
         }
       }
     )

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeService.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeService.scala
@@ -4,6 +4,7 @@ package service
 
 import cats.Parallel
 import cats.effect.Async
+import cats.effect.std.Queue
 import cats.mtl.Ask
 import org.broadinstitute.dsde.workbench.google2.{ComputePollOperation, GoogleComputeService, GoogleStorageService}
 import org.broadinstitute.dsde.workbench.leonardo.config.PersistentDiskConfig
@@ -60,7 +61,7 @@ object RuntimeService {
                             googleStorageService: GoogleStorageService[F],
                             googleComputeService: GoogleComputeService[F],
                             computePollOperation: ComputePollOperation[F],
-                            publisherQueue: fs2.concurrent.Queue[F, LeoPubsubMessage])(
+                            publisherQueue: Queue[F, LeoPubsubMessage])(
     implicit F: Async[F],
     log: StructuredLogger[F],
     dbReference: DbReference[F],

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterp.scala
@@ -639,12 +639,11 @@ class RuntimeServiceInterp[F[_]: Parallel](config: RuntimeServiceConfig,
           for {
             targetDiskSize <- traverseIfChanged(diskSizeInRequest, existngDiskSize) { d =>
               if (d.gb < existngDiskSize.gb)
-                Async[F]
-                  .raiseError[DiskUpdate.NoPdSizeUpdate](
-                    RuntimeDiskSizeCannotBeDecreasedException(runtime.projectNameString)
-                  )
+                F.raiseError[DiskUpdate](
+                  RuntimeDiskSizeCannotBeDecreasedException(runtime.projectNameString)
+                )
               else
-                Async[F].pure(DiskUpdate.NoPdSizeUpdate(d))
+                F.pure(DiskUpdate.NoPdSizeUpdate(d): DiskUpdate)
             }
             r <- processUpdateGceConfigRequest(newMachineType,
                                                allowStop,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/StatusService.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/StatusService.scala
@@ -39,7 +39,7 @@ class StatusService(
 
   private def checkStatus(): Map[Subsystem, Future[SubsystemStatus]] =
     Map(
-      Sam -> checkSam.unsafeToFuture()(cats.effect.unsafe.implicits.global),
+      Sam -> checkSam.unsafeToFuture()(cats.effect.unsafe.IORuntime.global),
       Database -> checkDatabase
     ).map(logFailures.tupled)
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/BaseCloudServiceRuntimeMonitor.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/BaseCloudServiceRuntimeMonitor.scala
@@ -62,6 +62,7 @@ abstract class BaseCloudServiceRuntimeMonitor[F[_]] {
             monitorContext,
             s
           )
+          _ <- logger.info(s"Continue polling for ${runtimeId}? ${res._2}") //TODO: remove this
         } yield res
       }
     } yield ()

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/BaseCloudServiceRuntimeMonitor.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/BaseCloudServiceRuntimeMonitor.scala
@@ -57,6 +57,7 @@ abstract class BaseCloudServiceRuntimeMonitor[F[_]] {
           _ <- s.newTransition.traverse(newStatus => monitorContextRef.modify(x => (x.copy(action = newStatus), ())))
           monitorContext <- monitorContextRef.get
           _ <- F.sleep(monitorConfig.pollStatus.interval)
+          _ <- logger.info("pollinggggggggggggggg") //TODO: remove this
           res <- handler(
             monitorContext,
             s
@@ -219,7 +220,7 @@ abstract class BaseCloudServiceRuntimeMonitor[F[_]] {
     ip: Option[IP] = None
   ): F[CheckResult] =
     for {
-      now <- nowInstant[F]
+      now <- F.realTimeInstant
       ctx = AppContext(monitorContext.traceId, now)
       implicit0(traceId: Ask[F, AppContext]) = Ask.const[F, AppContext](
         ctx

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/BaseCloudServiceRuntimeMonitor.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/BaseCloudServiceRuntimeMonitor.scala
@@ -57,14 +57,10 @@ abstract class BaseCloudServiceRuntimeMonitor[F[_]] {
           _ <- s.newTransition.traverse(newStatus => monitorContextRef.modify(x => (x.copy(action = newStatus), ())))
           monitorContext <- monitorContextRef.get
           _ <- F.sleep(monitorConfig.pollStatus.interval)
-          _ <- logger.info(s"pollinggggggggggggggg ${runtimeId}") //TODO: remove this
           res <- handler(
             monitorContext,
             s
           )
-          _ <- logger.info(monitorContext.loggingContext)(
-            s"Continue polling for ${runtimeId}? ${res._2}"
-          ) //TODO: remove this
         } yield res
       }
     } yield ()
@@ -462,7 +458,7 @@ abstract class BaseCloudServiceRuntimeMonitor[F[_]] {
           } yield images.toList
         }
       checkTools = imageTypes.traverseFilter { imageType =>
-        logger.info(ctx.loggingCtx)(s"Checking if ${imageType} is up") >> RuntimeContainerServiceType.imageTypeToRuntimeContainerServiceType
+        RuntimeContainerServiceType.imageTypeToRuntimeContainerServiceType
           .get(imageType)
           .traverse(
             _.isProxyAvailable(runtimeAndRuntimeConfig.runtime.googleProject,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/BaseCloudServiceRuntimeMonitor.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/BaseCloudServiceRuntimeMonitor.scala
@@ -1,8 +1,7 @@
 package org.broadinstitute.dsde.workbench.leonardo.monitor
 
 import cats.Parallel
-import cats.effect.concurrent.Ref
-import cats.effect.{ConcurrentEffect, Sync, Timer}
+import cats.effect.{Async, Ref, Sync}
 import cats.mtl.Ask
 import cats.syntax.all._
 import com.google.cloud.storage.BucketInfo
@@ -30,9 +29,8 @@ import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 
 abstract class BaseCloudServiceRuntimeMonitor[F[_]] {
-  implicit def F: ConcurrentEffect[F]
+  implicit def F: Async[F]
   implicit def parallel: Parallel[F]
-  implicit def timer: Timer[F]
   implicit def dbRef: DbReference[F]
   implicit def ec: ExecutionContext
   implicit def runtimeToolToToolDao: RuntimeContainerServiceType => ToolDAO[F, RuntimeContainerServiceType]
@@ -50,7 +48,7 @@ abstract class BaseCloudServiceRuntimeMonitor[F[_]] {
     for {
       // building up a stream that will terminate when gce runtime is ready
       traceId <- Stream.eval(ev.ask)
-      startMonitoring <- Stream.eval(nowInstant[F])
+      startMonitoring <- Stream.eval(F.realTimeInstant)
       monitorContextRef <- Stream.eval(
         Ref.of[F, MonitorContext](MonitorContext(startMonitoring, runtimeId, traceId, runtimeStatus))
       )
@@ -58,7 +56,7 @@ abstract class BaseCloudServiceRuntimeMonitor[F[_]] {
         for {
           _ <- s.newTransition.traverse(newStatus => monitorContextRef.modify(x => (x.copy(action = newStatus), ())))
           monitorContext <- monitorContextRef.get
-          _ <- Timer[F].sleep(monitorConfig.pollStatus.interval)
+          _ <- F.sleep(monitorConfig.pollStatus.interval)
           res <- handler(
             monitorContext,
             s
@@ -74,7 +72,7 @@ abstract class BaseCloudServiceRuntimeMonitor[F[_]] {
 
   private[monitor] def handler(monitorContext: MonitorContext, monitorState: MonitorState): F[CheckResult] =
     for {
-      now <- nowInstant
+      now <- F.realTimeInstant
       ctx = AppContext(monitorContext.traceId, now)
       implicit0(ct: Ask[F, AppContext]) = Ask.const[F, AppContext](
         ctx

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/BaseCloudServiceRuntimeMonitor.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/BaseCloudServiceRuntimeMonitor.scala
@@ -57,12 +57,14 @@ abstract class BaseCloudServiceRuntimeMonitor[F[_]] {
           _ <- s.newTransition.traverse(newStatus => monitorContextRef.modify(x => (x.copy(action = newStatus), ())))
           monitorContext <- monitorContextRef.get
           _ <- F.sleep(monitorConfig.pollStatus.interval)
-          _ <- logger.info("pollinggggggggggggggg") //TODO: remove this
+          _ <- logger.info(s"pollinggggggggggggggg ${runtimeId}") //TODO: remove this
           res <- handler(
             monitorContext,
             s
           )
-          _ <- logger.info(s"Continue polling for ${runtimeId}? ${res._2}") //TODO: remove this
+          _ <- logger.info(monitorContext.loggingContext)(
+            s"Continue polling for ${runtimeId}? ${res._2}"
+          ) //TODO: remove this
         } yield res
       }
     } yield ()
@@ -460,7 +462,7 @@ abstract class BaseCloudServiceRuntimeMonitor[F[_]] {
           } yield images.toList
         }
       checkTools = imageTypes.traverseFilter { imageType =>
-        RuntimeContainerServiceType.imageTypeToRuntimeContainerServiceType
+        logger.info(ctx.loggingCtx)(s"Checking if ${imageType} is up") >> RuntimeContainerServiceType.imageTypeToRuntimeContainerServiceType
           .get(imageType)
           .traverse(
             _.isProxyAvailable(runtimeAndRuntimeConfig.runtime.googleProject,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterToolMonitor.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterToolMonitor.scala
@@ -2,7 +2,8 @@ package org.broadinstitute.dsde.workbench.leonardo
 package monitor
 
 import akka.actor.{Actor, Props, Timers}
-import cats.effect.{ContextShift, IO}
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
 import cats.syntax.all._
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.workbench.leonardo.config.ClusterToolConfig
@@ -20,8 +21,7 @@ object ClusterToolMonitor {
     dbRef: DbReference[IO],
     metrics: OpenTelemetryMetrics[IO]
   )(implicit clusterToolToToolDao: RuntimeContainerServiceType => ToolDAO[IO, RuntimeContainerServiceType],
-    ec: ExecutionContext,
-    cs: ContextShift[IO]): Props =
+    ec: ExecutionContext): Props =
     Props(new ClusterToolMonitor(config, dbRef, metrics))
 
   sealed trait ClusterToolMonitorMessage
@@ -39,8 +39,7 @@ class ClusterToolMonitor(
   dbRef: DbReference[IO],
   metrics: OpenTelemetryMetrics[IO]
 )(implicit clusterToolToToolDao: RuntimeContainerServiceType => ToolDAO[IO, RuntimeContainerServiceType],
-  ec: ExecutionContext,
-  cs: ContextShift[IO])
+  ec: ExecutionContext)
     extends Actor
     with Timers
     with LazyLogging {

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
@@ -1,18 +1,14 @@
 package org.broadinstitute.dsde.workbench.leonardo
 package monitor
 
-import java.time.Instant
-import java.util.concurrent.TimeoutException
-
 import _root_.org.typelevel.log4cats.StructuredLogger
-import cats.Parallel
+import cats.effect.Async
 import cats.effect.implicits._
-import cats.effect.{ConcurrentEffect, ContextShift, Timer}
+import cats.effect.std.Queue
 import cats.mtl.Ask
 import cats.syntax.all._
-import com.google.cloud.compute.v1.Disk
+import com.google.cloud.compute.v1.{Disk, Operation}
 import fs2.Stream
-import fs2.concurrent.InspectableQueue
 import org.broadinstitute.dsde.workbench.DoneCheckable
 import org.broadinstitute.dsde.workbench.errorReporting.ErrorReporting
 import org.broadinstitute.dsde.workbench.errorReporting.ReportWorthySyntax._
@@ -36,25 +32,31 @@ import org.broadinstitute.dsde.workbench.leonardo.http.{cloudServiceSyntax, _}
 import org.broadinstitute.dsde.workbench.leonardo.model.{LeoAuthProvider, LeoException}
 import org.broadinstitute.dsde.workbench.leonardo.monitor.LeoPubsubMessage._
 import org.broadinstitute.dsde.workbench.leonardo.monitor.PubsubHandleMessageError._
+import org.broadinstitute.dsde.workbench.leonardo.util.GKEAlgebra.{
+  getGalaxyPostgresDiskName,
+  getOldStyleGalaxyPostgresDiskName
+}
 import org.broadinstitute.dsde.workbench.leonardo.util._
 import org.broadinstitute.dsde.workbench.model.google.{GcsObjectName, GcsPath, GoogleProject}
 import org.broadinstitute.dsde.workbench.model.{ErrorReport, TraceId, WorkbenchException}
 
+import java.time.Instant
+import java.util.concurrent.TimeoutException
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 import scala.jdk.CollectionConverters._
 
-class LeoPubsubMessageSubscriber[F[_]: Timer: ContextShift: Parallel](
+class LeoPubsubMessageSubscriber[F[_]](
   config: LeoPubsubMessageSubscriberConfig,
   subscriber: GoogleSubscriber[F, LeoPubsubMessage],
-  asyncTasks: InspectableQueue[F, Task[F]],
+  asyncTasks: Queue[F, Task[F]],
   googleDiskService: GoogleDiskService[F],
   computePollOperation: ComputePollOperation[F],
   authProvider: LeoAuthProvider[F],
-  gkeInterp: GKEInterpreter[F],
+  gkeAlg: GKEAlgebra[F],
   errorReporting: ErrorReporting[F]
 )(implicit executionContext: ExecutionContext,
-  F: ConcurrentEffect[F],
+  F: Async[F],
   logger: StructuredLogger[F],
   dbRef: DbReference[F],
   runtimeInstances: RuntimeInstances[F],
@@ -98,6 +100,7 @@ class LeoPubsubMessageSubscriber[F[_]: Timer: ContextShift: Parallel](
       res <- messageResponder(event.msg)
         .timeout(config.timeout)
         .attempt // set timeout to 55 seconds because subscriber's ack deadline is 1 minute
+      ctx <- appContext.ask
       _ <- res match {
         case Left(e) =>
           e match {
@@ -105,7 +108,9 @@ class LeoPubsubMessageSubscriber[F[_]: Timer: ContextShift: Parallel](
               for {
                 _ <- ee match {
                   case ee: PubsubKubernetesError =>
-                    handleKubernetesError(ee)
+                    logger.error(ctx.loggingCtx, e)(s"Encountered an error for app ${ee.appId}, ${ee.getMessage}") >> handleKubernetesError(
+                      ee
+                    )
                   case _ => F.unit
                 }
                 _ <- if (ee.isRetryable)
@@ -167,7 +172,7 @@ class LeoPubsubMessageSubscriber[F[_]: Timer: ContextShift: Parallel](
       taskToRun = for {
         _ <- msg.runtimeConfig.cloudService.process(msg.runtimeId, RuntimeStatus.Creating).compile.drain
       } yield ()
-      _ <- asyncTasks.enqueue1(
+      _ <- asyncTasks.offer(
         Task(
           ctx.traceId,
           taskToRun,
@@ -213,13 +218,13 @@ class LeoPubsubMessageSubscriber[F[_]: Timer: ContextShift: Parallel](
           now <- nowInstant
           diskOpt <- persistentDiskQuery.getPersistentDiskRecord(id).transaction
           disk <- F.fromEither(diskOpt.toRight(new RuntimeException(s"disk not found for ${id}")))
-
           deleteDiskOp <- googleDiskService.deleteDisk(runtime.googleProject, disk.zone, disk.name)
-          whenDone = persistentDiskQuery.delete(id, now).transaction.void >> authProvider.notifyResourceDeleted(
-            disk.samResource,
-            disk.creator,
-            disk.googleProject
-          )
+          whenDone = persistentDiskQuery.delete(id, now).transaction.void >> authProvider
+            .notifyResourceDeleted(
+              disk.samResource,
+              disk.creator,
+              disk.googleProject
+            )
           whenTimeout = F.raiseError[Unit](
             new RuntimeException(s"Fail to delete ${disk.name} in a timely manner")
           )
@@ -244,7 +249,7 @@ class LeoPubsubMessageSubscriber[F[_]: Timer: ContextShift: Parallel](
             .void
         )
       }
-      _ <- asyncTasks.enqueue1(
+      _ <- asyncTasks.offer(
         Task(
           ctx.traceId,
           fa,
@@ -281,7 +286,7 @@ class LeoPubsubMessageSubscriber[F[_]: Timer: ContextShift: Parallel](
         case None =>
           runtimeConfig.cloudService.process(runtime.id, RuntimeStatus.Stopping).compile.drain
       }
-      _ <- asyncTasks.enqueue1(
+      _ <- asyncTasks.offer(
         Task(
           ctx.traceId,
           poll,
@@ -313,7 +318,7 @@ class LeoPubsubMessageSubscriber[F[_]: Timer: ContextShift: Parallel](
                                  new RuntimeException(s"init bucket not found for ${runtime.projectNameString} in DB"))
       _ <- runtimeConfig.cloudService.interpreter
         .startRuntime(StartRuntimeParams(RuntimeAndRuntimeConfig(runtime, runtimeConfig), bucketName))
-      _ <- asyncTasks.enqueue1(
+      _ <- asyncTasks.offer(
         Task(
           ctx.traceId,
           runtimeConfig.cloudService.process(msg.runtimeId, RuntimeStatus.Starting).compile.drain,
@@ -420,7 +425,7 @@ class LeoPubsubMessageSubscriber[F[_]: Timer: ContextShift: Parallel](
             )
             _ <- startAndUpdateRuntime(runtime, runtimeConfig, msg.newMachineType)(ctxStarting)
           } yield ()
-          _ <- asyncTasks.enqueue1(
+          _ <- asyncTasks.offer(
             Task(ctx.traceId,
                  task,
                  Some(
@@ -438,7 +443,7 @@ class LeoPubsubMessageSubscriber[F[_]: Timer: ContextShift: Parallel](
               .updateMachineType(UpdateMachineTypeParams(RuntimeAndRuntimeConfig(runtime, runtimeConfig), m, ctx.now))
           )
           _ <- if (hasResizedCluster) {
-            asyncTasks.enqueue1(
+            asyncTasks.offer(
               Task(
                 ctx.traceId,
                 runtimeConfig.cloudService.process(runtime.id, RuntimeStatus.Updating).compile.drain,
@@ -497,15 +502,15 @@ class LeoPubsubMessageSubscriber[F[_]: Timer: ContextShift: Parallel](
           Disk
             .newBuilder()
             .setName(msg.name.value)
-            .setSizeGb(msg.size.gb.toString)
+            .setSizeGb(msg.size.gb)
             .setZone(msg.zone.value)
             .setType(msg.diskType.googleString(msg.googleProject, msg.zone))
-            .setPhysicalBlockSizeBytes(msg.blockSize.bytes.toString)
+            .setPhysicalBlockSizeBytes(msg.blockSize.bytes)
             .putAllLabels(Map("leonardo" -> "true").asJava)
             .build()
         )
       _ <- operationOpt.traverse(operation =>
-        persistentDiskQuery.updateGoogleId(msg.diskId, GoogleId(operation.getTargetId), ctx.now).transaction[F]
+        persistentDiskQuery.updateGoogleId(msg.diskId, GoogleId(operation.getTargetId.toString), ctx.now).transaction[F]
       )
       task = operationOpt.traverse_(operation =>
         computePollOperation
@@ -534,7 +539,7 @@ class LeoPubsubMessageSubscriber[F[_]: Timer: ContextShift: Parallel](
       )
       _ <- if (sync) task
       else {
-        asyncTasks.enqueue1(
+        asyncTasks.offer(
           Task(ctx.traceId,
                task,
                Some(logError(s"${ctx.traceId.asString} | ${msg.diskId.value}", "Creating Disk")),
@@ -566,7 +571,11 @@ class LeoPubsubMessageSubscriber[F[_]: Timer: ContextShift: Parallel](
     val create = for {
       ctx <- ev.ask
       _ <- logger.info(ctx.loggingCtx)(s"Beginning postgres disk creation for app ${appName.value}")
-      operationOpt <- googleDiskService.createDisk(project, zone, gkeInterp.buildGalaxyPostgresDisk(zone, dataDiskName))
+      operationOpt <- googleDiskService.createDisk(
+        project,
+        zone,
+        GKEAlgebra.buildGalaxyPostgresDisk(zone, dataDiskName, config.galaxyDiskConfig)
+      )
       whenDone = logger.info(ctx.loggingCtx)(
         s"Completed postgres disk creation for app ${appName.value} in project ${project.value}"
       )
@@ -642,7 +651,7 @@ class LeoPubsubMessageSubscriber[F[_]: Timer: ContextShift: Parallel](
       }
       _ <- if (sync) task
       else {
-        asyncTasks.enqueue1(
+        asyncTasks.offer(
           Task(ctx.traceId,
                task,
                Some(logError(s"${ctx.traceId.asString} | ${diskId.value}", "Deleting Disk")),
@@ -665,7 +674,7 @@ class LeoPubsubMessageSubscriber[F[_]: Timer: ContextShift: Parallel](
       _ <- logger.info(ctx.loggingCtx)(
         s"Beginning postres disk deletion for app ${appName.value} in project ${project.value}"
       )
-      operation <- gkeInterp.deleteGalaxyPostgresDisk(dataDiskName, namespaceName, project, zone)
+      operation <- deleteGalaxyPostgresDisk(dataDiskName, namespaceName, project, zone)
       whenDone = logger.info(ctx.loggingCtx)(
         s"Completed postgres disk deletion for app ${appName.value} in project ${project.value}"
       )
@@ -717,7 +726,7 @@ class LeoPubsubMessageSubscriber[F[_]: Timer: ContextShift: Parallel](
           ), //Should save disk creation error if we have error column in DB
           F.unit
         )
-      _ <- asyncTasks.enqueue1(
+      _ <- asyncTasks.offer(
         Task(ctx.traceId,
              task,
              Some(logError(s"${ctx.traceId.asString} | ${msg.diskId.value}", "Updating Disk")),
@@ -768,7 +777,7 @@ class LeoPubsubMessageSubscriber[F[_]: Timer: ContextShift: Parallel](
         case Some(ClusterNodepoolAction.CreateClusterAndNodepool(clusterId, defaultNodepoolId, nodepoolId)) =>
           for {
             // initial the createCluster call synchronously
-            createClusterResultOpt <- gkeInterp
+            createClusterResultOpt <- gkeAlg
               .createCluster(
                 CreateClusterParams(clusterId, msg.project, List(defaultNodepoolId, nodepoolId))
               )
@@ -792,7 +801,7 @@ class LeoPubsubMessageSubscriber[F[_]: Timer: ContextShift: Parallel](
               }
             // monitor cluster creation asynchronously
             monitorOp = createClusterResultOpt.traverse_(createClusterResult =>
-              gkeInterp
+              gkeAlg
                 .pollCluster(PollClusterParams(clusterId, msg.project, createClusterResult))
                 .adaptError {
                   case e =>
@@ -817,7 +826,7 @@ class LeoPubsubMessageSubscriber[F[_]: Timer: ContextShift: Parallel](
         case Some(ClusterNodepoolAction.CreateNodepool(nodepoolId)) =>
           // create nodepool asynchronously
           F.pure(
-            gkeInterp
+            gkeAlg
               .createAndPollNodepool(CreateNodepoolParams(nodepoolId, msg.project))
               .adaptError {
                 case e =>
@@ -878,7 +887,7 @@ class LeoPubsubMessageSubscriber[F[_]: Timer: ContextShift: Parallel](
         _ <- List(createDiskOp, createSecondDiskOp, createClusterOrNodepoolOp).parSequence_
 
         // create and monitor app
-        _ <- gkeInterp
+        _ <- gkeAlg
           .createAndPollApp(CreateAppParams(msg.appId, msg.project, msg.appName))
           .onError {
             case e =>
@@ -896,7 +905,7 @@ class LeoPubsubMessageSubscriber[F[_]: Timer: ContextShift: Parallel](
           }
       } yield ()
 
-      _ <- asyncTasks.enqueue1(
+      _ <- asyncTasks.offer(
         Task(ctx.traceId, task, Some(handleKubernetesError), ctx.now)
       )
     } yield ()
@@ -916,15 +925,33 @@ class LeoPubsubMessageSubscriber[F[_]: Timer: ContextShift: Parallel](
       dbApp <- F.fromOption(dbAppOpt, AppNotFoundException(msg.project, msg.appName, ctx.traceId))
       zone = ZoneName("us-central1-a")
 
+      getPostgresDiskOp = dbApp.app.appResources.disk.flatTraverse { d =>
+        for {
+          postgresDiskOpt <- googleDiskService
+            .getDisk(
+              msg.project,
+              zone,
+              getGalaxyPostgresDiskName(d.name, config.galaxyDiskConfig.postgresDiskNameSuffix)
+            )
+          res <- postgresDiskOpt match {
+            case Some(disk) => F.pure(disk.some)
+            case None =>
+              googleDiskService.getDisk(
+                msg.project,
+                zone,
+                getOldStyleGalaxyPostgresDiskName(dbApp.app.appResources.namespace.name,
+                                                  config.galaxyDiskConfig.postgresDiskNameSuffix)
+              )
+          }
+        } yield res
+      }
       // The app must be deleted before the nodepool and disk, to future proof against the app potentially flushing the postgres db somewhere
       task = for {
+        postgresDiskOpt <- getPostgresDiskOp
+
         // we record the last disk detach timestamp here, before it is removed from galaxy
         // this is needed before we can delete disks
-        postgresOriginalDetachTimestampOpt <- dbApp.app.appResources.disk.flatTraverse { d =>
-          gkeInterp
-            .getGalaxyPostgresDisk(d.name, dbApp.app.appResources.namespace.name, msg.project, zone)
-            .map(_.map(_.getLastDetachTimestamp))
-        }
+        postgresOriginalDetachTimestampOpt = postgresDiskOpt.map(_.getLastDetachTimestamp)
 
         dataDiskOriginalDetachTimestampOpt <- dbApp.app.appResources.disk.flatTraverse { d =>
           googleDiskService
@@ -935,7 +962,7 @@ class LeoPubsubMessageSubscriber[F[_]: Timer: ContextShift: Parallel](
             )
             .map(_.map(_.getLastDetachTimestamp))
         }
-        _ <- gkeInterp
+        _ <- gkeAlg
           .deleteAndPollApp(DeleteAppParams(msg.appId, msg.project, msg.appName, errorAfterDelete))
           .adaptError {
             case e =>
@@ -951,10 +978,7 @@ class LeoPubsubMessageSubscriber[F[_]: Timer: ContextShift: Parallel](
         // detach/delete disk when we need to delete disk
         _ <- msg.diskId.traverse_ { diskId =>
           // we now use the detach timestamp recorded prior to helm uninstall so we can observe when galaxy actually 'detaches' the disk from google's perspective
-          val getPostgresDisk = gkeInterp.getGalaxyPostgresDisk(dbApp.app.appResources.disk.get.name,
-                                                                dbApp.app.appResources.namespace.name,
-                                                                msg.project,
-                                                                zone)
+          val getPostgresDisk = getPostgresDiskOp
           val getDataDisk = dbApp.app.appResources.disk.flatTraverse { d =>
             googleDiskService
               .getDisk(
@@ -1042,7 +1066,7 @@ class LeoPubsubMessageSubscriber[F[_]: Timer: ContextShift: Parallel](
 
       _ <- if (sync) task
       else
-        asyncTasks.enqueue1(
+        asyncTasks.offer(
           Task(ctx.traceId, task, Some(handleKubernetesError), ctx.now)
         )
     } yield ()
@@ -1065,7 +1089,7 @@ class LeoPubsubMessageSubscriber[F[_]: Timer: ContextShift: Parallel](
         s"Beginning clean up for cluster $clusterId in project $project due to an error during cluster creation"
       )
       _ <- kubernetesClusterQuery.markPendingDeletion(clusterId).transaction
-      _ <- gkeInterp.deleteAndPollCluster(DeleteClusterParams(clusterId, project)).handleErrorWith { e =>
+      _ <- gkeAlg.deleteAndPollCluster(DeleteClusterParams(clusterId, project)).handleErrorWith { e =>
         // we do not want to bubble up errors with cluster clean-up
         logger.error(ctx.loggingCtx, e)(
           s"An error occurred during resource clean up for cluster ${clusterId} in project ${project}"
@@ -1105,7 +1129,7 @@ class LeoPubsubMessageSubscriber[F[_]: Timer: ContextShift: Parallel](
   private[monitor] def handleStopAppMessage(msg: StopAppMessage)(implicit ev: Ask[F, AppContext]): F[Unit] =
     for {
       ctx <- ev.ask
-      stopApp = gkeInterp
+      stopApp = gkeAlg
         .stopAndPollApp(StopAppParams(msg.appId, msg.appName, msg.project))
         .adaptError {
           case e =>
@@ -1117,8 +1141,7 @@ class LeoPubsubMessageSubscriber[F[_]: Timer: ContextShift: Parallel](
               None
             )
         }
-
-      _ <- asyncTasks.enqueue1(Task(ctx.traceId, stopApp, Some(handleKubernetesError), ctx.now))
+      _ <- asyncTasks.offer(Task(ctx.traceId, stopApp, Some(handleKubernetesError), ctx.now))
     } yield ()
 
   private[monitor] def handleStartAppMessage(
@@ -1126,7 +1149,7 @@ class LeoPubsubMessageSubscriber[F[_]: Timer: ContextShift: Parallel](
   )(implicit ev: Ask[F, AppContext]): F[Unit] =
     for {
       ctx <- ev.ask
-      startApp = gkeInterp
+      startApp = gkeAlg
         .startAndPollApp(StartAppParams(msg.appId, msg.appName, msg.project))
         .adaptError {
           case e =>
@@ -1139,14 +1162,13 @@ class LeoPubsubMessageSubscriber[F[_]: Timer: ContextShift: Parallel](
             )
         }
 
-      _ <- asyncTasks.enqueue1(Task(ctx.traceId, startApp, Some(handleKubernetesError), ctx.now))
+      _ <- asyncTasks.offer(Task(ctx.traceId, startApp, Some(handleKubernetesError), ctx.now))
     } yield ()
 
   private def handleKubernetesError(e: Throwable)(implicit ev: Ask[F, AppContext]): F[Unit] = ev.ask.flatMap { ctx =>
     e match {
       case e: PubsubKubernetesError =>
         for {
-          _ <- logger.error(ctx.loggingCtx, e)(s"Encountered an error for app ${e.appId}, ${e.getMessage}")
           _ <- e.appId.traverse(id => appErrorQuery.save(id, e.dbError).transaction)
           _ <- e.appId.traverse(id => appQuery.markAsErrored(id).transaction)
           _ <- e.clusterId.traverse(clusterId =>
@@ -1202,4 +1224,28 @@ class LeoPubsubMessageSubscriber[F[_]: Timer: ContextShift: Parallel](
 
   private def logError(projectAndName: String, action: String)(implicit ev: Ask[F, AppContext]): Throwable => F[Unit] =
     t => ev.ask.flatMap(ctx => logger.error(ctx.loggingCtx, t)(s"Fail to monitor ${projectAndName} for ${action}"))
+
+  private[leonardo] def deleteGalaxyPostgresDisk(
+    diskName: DiskName,
+    namespaceName: NamespaceName,
+    project: GoogleProject,
+    zone: ZoneName
+  )(implicit traceId: Ask[F, AppContext]): F[Option[Operation]] =
+    for {
+      postgresDiskOpt <- googleDiskService
+        .deleteDisk(
+          project,
+          zone,
+          getGalaxyPostgresDiskName(diskName, config.galaxyDiskConfig.postgresDiskNameSuffix)
+        )
+      res <- postgresDiskOpt match {
+        case Some(operation) => F.pure(Some(operation))
+        case None =>
+          googleDiskService.deleteDisk(
+            project,
+            zone,
+            GKEAlgebra.getOldStyleGalaxyPostgresDiskName(namespaceName, config.galaxyDiskConfig.postgresDiskNameSuffix)
+          )
+      }
+    } yield res
 }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/RuntimeMonitor.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/RuntimeMonitor.scala
@@ -1,10 +1,7 @@
 package org.broadinstitute.dsde.workbench.leonardo
 package monitor
 
-import java.time.Instant
-import java.util.concurrent.TimeUnit
-
-import cats.effect.{Async, Timer}
+import cats.effect.Async
 import cats.mtl.Ask
 import cats.syntax.all._
 import com.google.cloud.compute.v1.Instance
@@ -15,6 +12,7 @@ import org.broadinstitute.dsde.workbench.model.TraceId
 import org.broadinstitute.dsde.workbench.model.google.{GcsPath, GoogleProject}
 import org.broadinstitute.dsde.workbench.openTelemetry.OpenTelemetryMetrics
 
+import java.time.Instant
 import scala.collection.immutable.Set
 import scala.concurrent.duration._
 import scala.jdk.CollectionConverters._
@@ -41,7 +39,7 @@ object RuntimeMonitor {
     else if (runtime.labels.contains(Config.uiConfig.allOfUsLabel)) RuntimeUI.AoU
     else RuntimeUI.Other
 
-  private[monitor] def recordStatusTransitionMetrics[F[_]: Timer: Async](
+  private[monitor] def recordStatusTransitionMetrics[F[_]: Async](
     startTime: Instant,
     runtimeUI: RuntimeUI,
     origStatus: RuntimeStatus,
@@ -49,9 +47,9 @@ object RuntimeMonitor {
     cloudService: CloudService
   )(implicit openTelemetry: OpenTelemetryMetrics[F]): F[Unit] =
     for {
-      endTime <- Timer[F].clock.realTime(TimeUnit.MILLISECONDS)
+      endTime <- Async[F].realTimeInstant
       metricsName = s"monitor/transition/${origStatus}_to_${finalStatus}"
-      duration = (endTime - startTime.toEpochMilli).millis
+      duration = (endTime.toEpochMilli - startTime.toEpochMilli).millis
       tags = Map("cloudService" -> cloudService.asString, "ui_client" -> runtimeUI.asString)
       _ <- openTelemetry.incrementCounter(metricsName, 1, tags)
       distributionBucket = List(0.5 minutes,
@@ -82,17 +80,17 @@ object RuntimeMonitor {
     }
   }
 
-  private[monitor] def recordClusterCreationMetrics[F[_]: Timer: Async](
+  private[monitor] def recordClusterCreationMetrics[F[_]: Async](
     createdDate: Instant,
     images: Set[RuntimeImage],
     imageConfig: ImageConfig,
     cloudService: CloudService
   )(implicit openTelemetry: OpenTelemetryMetrics[F]): F[Unit] =
     for {
-      endTime <- Timer[F].clock.realTime(TimeUnit.MILLISECONDS)
+      endTime <- Async[F].realTimeInstant
       toolImageInfo = findToolImageInfo(images, imageConfig)
       metricsName = s"monitor/runtimeCreation"
-      duration = (endTime - createdDate.toEpochMilli).milliseconds
+      duration = (endTime.toEpochMilli - createdDate.toEpochMilli).milliseconds
       tags = Map("cloudService" -> cloudService.asString, "image" -> toolImageInfo)
       _ <- openTelemetry.incrementCounter(metricsName, 1, tags)
       distributionBucket = List(1 minutes,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/leoPubsubMessageSubscriberModels.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/leoPubsubMessageSubscriberModels.scala
@@ -11,6 +11,7 @@ import org.broadinstitute.dsde.workbench.google2.JsonCodec.{traceIdDecoder, trac
 import org.broadinstitute.dsde.workbench.google2.KubernetesSerializableName.NamespaceName
 import org.broadinstitute.dsde.workbench.google2.{DiskName, MachineTypeName, RegionName, ZoneName}
 import org.broadinstitute.dsde.workbench.leonardo.JsonCodec._
+import org.broadinstitute.dsde.workbench.leonardo.config.GalaxyDiskConfig
 import org.broadinstitute.dsde.workbench.leonardo.http.{
   dataprocInCreateRuntimeMsgToDataprocRuntime,
   RuntimeConfigRequest
@@ -838,6 +839,7 @@ final case class PersistentDiskMonitorConfig(create: PollMonitorConfig,
 
 final case class LeoPubsubMessageSubscriberConfig(concurrency: Int,
                                                   timeout: FiniteDuration,
-                                                  persistentDiskMonitorConfig: PersistentDiskMonitorConfig)
+                                                  persistentDiskMonitorConfig: PersistentDiskMonitorConfig,
+                                                  galaxyDiskConfig: GalaxyDiskConfig)
 
 final case class DiskDetachStatus(disk: Option[Disk], originalDetachTimestampOpt: Option[String])

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/CacheMetrics.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/CacheMetrics.scala
@@ -1,16 +1,15 @@
 package org.broadinstitute.dsde.workbench.leonardo.util
 
-import cats.effect.{Async, Effect, Timer}
+import cats.effect.Async
 import cats.syntax.all._
 import com.google.common.cache.CacheStats
 import fs2.Stream
-import org.typelevel.log4cats.Logger
 import org.broadinstitute.dsde.workbench.openTelemetry.OpenTelemetryMetrics
+import org.typelevel.log4cats.Logger
 
 import scala.concurrent.duration._
 
 class CacheMetrics[F[_]] private (name: String, interval: FiniteDuration)(implicit F: Async[F],
-                                                                          timer: Timer[F],
                                                                           metrics: OpenTelemetryMetrics[F],
                                                                           logger: Logger[F]) {
   def process(sizeF: () => F[Long], statsF: () => F[CacheStats]): Stream[F, Unit] =
@@ -32,7 +31,7 @@ class CacheMetrics[F[_]] private (name: String, interval: FiniteDuration)(implic
     } yield ()
 }
 object CacheMetrics {
-  def apply[F[_]: Timer: Effect: OpenTelemetryMetrics: Logger](name: String,
-                                                               interval: FiniteDuration = 1 minute): CacheMetrics[F] =
+  def apply[F[_]: Async: OpenTelemetryMetrics: Logger](name: String,
+                                                       interval: FiniteDuration = 1 minute): CacheMetrics[F] =
     new CacheMetrics(name, interval)
 }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/CacheMetrics.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/CacheMetrics.scala
@@ -2,8 +2,8 @@ package org.broadinstitute.dsde.workbench.leonardo.util
 
 import cats.effect.Async
 import cats.syntax.all._
-import com.google.common.cache.CacheStats
 import fs2.Stream
+import com.github.benmanes.caffeine.cache.stats.CacheStats
 import org.broadinstitute.dsde.workbench.openTelemetry.OpenTelemetryMetrics
 import org.typelevel.log4cats.Logger
 
@@ -15,6 +15,11 @@ class CacheMetrics[F[_]] private (name: String, interval: FiniteDuration)(implic
   def process(sizeF: () => F[Long], statsF: () => F[CacheStats]): Stream[F, Unit] =
     (Stream.sleep[F](interval) ++ Stream.eval(recordMetrics(sizeF, statsF))).repeat
 
+  def processWithUnderlyingCache[K, V](
+    underlyingCache: com.github.benmanes.caffeine.cache.Cache[K, V]
+  ): Stream[F, Unit] =
+    process(() => F.delay(underlyingCache.estimatedSize()), () => F.delay(underlyingCache.stats()))
+
   private def recordMetrics(sizeF: () => F[Long], statsF: () => F[CacheStats]): F[Unit] =
     for {
       size <- sizeF()
@@ -25,7 +30,7 @@ class CacheMetrics[F[_]] private (name: String, interval: FiniteDuration)(implic
       _ <- metrics.gauge(s"cache/$name/hitCount", stats.hitCount.toDouble)
       _ <- metrics.gauge(s"cache/$name/missCount", stats.missCount.toDouble)
       _ <- metrics.gauge(s"cache/$name/loadSuccessCount", stats.loadSuccessCount.toDouble)
-      _ <- metrics.gauge(s"cache/$name/loadExceptionCount", stats.loadExceptionCount.toDouble)
+      _ <- metrics.gauge(s"cache/$name/averageLoadPenalty", stats.averageLoadPenalty())
       _ <- metrics.gauge(s"cache/$name/totalLoadTime", stats.totalLoadTime.toDouble)
       _ <- metrics.gauge(s"cache/$name/evictionCount", stats.evictionCount.toDouble)
     } yield ()

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/CacheMetrics.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/CacheMetrics.scala
@@ -18,7 +18,7 @@ class CacheMetrics[F[_]] private (name: String, interval: FiniteDuration)(implic
   def processWithUnderlyingCache[K, V](
     underlyingCache: com.github.benmanes.caffeine.cache.Cache[K, V]
   ): Stream[F, Unit] =
-    process(() => F.delay(underlyingCache.estimatedSize()), () => F.delay(underlyingCache.stats()))
+    process(() => F.blocking(underlyingCache.estimatedSize()), () => F.blocking(underlyingCache.stats()))
 
   private def recordMetrics(sizeF: () => F[Long], statsF: () => F[CacheStats]): F[Unit] =
     for {

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/DataprocInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/DataprocInterpreter.scala
@@ -665,15 +665,15 @@ class DataprocInterpreter[F[_]: Parallel](
     implicit ev: Ask[F, AppContext]
   ): F[Unit] = {
     val checkIsMember = retry(
-      F.fromFuture(F.delay(googleDirectoryDAO.isGroupMember(groupEmail, memberEmail))),
+      F.fromFuture(F.blocking(googleDirectoryDAO.isGroupMember(groupEmail, memberEmail))),
       when409
     )
     val addMemberToGroup = retry(
-      F.fromFuture(F.delay(googleDirectoryDAO.addMemberToGroup(groupEmail, memberEmail))),
+      F.fromFuture(F.blocking(googleDirectoryDAO.addMemberToGroup(groupEmail, memberEmail))),
       when409
     )
     val removeMemberFromGroup = retry(
-      F.fromFuture(F.delay(googleDirectoryDAO.removeMemberFromGroup(groupEmail, memberEmail))),
+      F.fromFuture(F.blocking(googleDirectoryDAO.removeMemberFromGroup(groupEmail, memberEmail))),
       when409
     )
     for {

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GceInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GceInterpreter.scala
@@ -1,12 +1,10 @@
 package org.broadinstitute.dsde.workbench.leonardo
 package util
 
-import cats.Parallel
-import cats.effect.{Async, Blocker, ContextShift}
+import cats.effect.Async
 import cats.mtl.Ask
 import cats.syntax.all._
 import com.google.cloud.compute.v1.{Operation, _}
-import org.typelevel.log4cats.StructuredLogger
 import org.broadinstitute.dsde.workbench.google2.{
   GoogleComputeService,
   GoogleDiskService,
@@ -28,6 +26,7 @@ import org.broadinstitute.dsde.workbench.leonardo.util.RuntimeInterpreterConfig.
 import org.broadinstitute.dsde.workbench.model.TraceId
 import org.broadinstitute.dsde.workbench.model.google.{generateUniqueBucketName, GcsObjectName, GcsPath, GoogleProject}
 import org.broadinstitute.dsde.workbench.openTelemetry.OpenTelemetryMetrics
+import org.typelevel.log4cats.StructuredLogger
 
 import scala.concurrent.ExecutionContext
 import scala.jdk.CollectionConverters._
@@ -41,14 +40,13 @@ final case class InstanceResourceConstraintsException(project: GoogleProject, ma
 final case class MissingServiceAccountException(projectAndName: RuntimeProjectAndName)
     extends LeoException(s"Cannot create instance ${projectAndName}: service account required", traceId = None)
 
-class GceInterpreter[F[_]: Parallel: ContextShift](
+class GceInterpreter[F[_]](
   config: GceInterpreterConfig,
   bucketHelper: BucketHelper[F],
   vpcAlg: VPCAlgebra[F],
   googleComputeService: GoogleComputeService[F],
   googleDiskService: GoogleDiskService[F],
-  welderDao: WelderDAO[F],
-  blocker: Blocker
+  welderDao: WelderDAO[F]
 )(implicit val executionContext: ExecutionContext,
   metrics: OpenTelemetryMetrics[F],
   dbRef: DbReference[F],
@@ -136,7 +134,7 @@ class GceInterpreter[F[_]: Parallel: ContextShift](
             .newBuilder()
             .setDescription("Leonardo Managed Boot Disk")
             .setSourceImage(config.gceConfig.sourceImage.asString)
-            .setDiskSizeGb(bootDiskSize.gb.toString)
+            .setDiskSizeGb(bootDiskSize.gb)
             .putAllLabels(Map("leonardo" -> "true").asJava)
             .build()
         )
@@ -172,7 +170,7 @@ class GceInterpreter[F[_]: Parallel: ContextShift](
                 AttachedDiskInitializeParams
                   .newBuilder()
                   .setDiskName(persistentDisk.name.value)
-                  .setDiskSizeGb(persistentDisk.size.gb.toString)
+                  .setDiskSizeGb(persistentDisk.size.gb)
                   .putAllLabels(Map("leonardo" -> "true").asJava)
                   .setDiskType(
                     persistentDisk.diskType.googleString(params.runtimeProjectAndName.googleProject,
@@ -191,7 +189,7 @@ class GceInterpreter[F[_]: Parallel: ContextShift](
             .setInitializeParams(
               AttachedDiskInitializeParams
                 .newBuilder()
-                .setDiskSizeGb(x.diskSize.gb.toString)
+                .setDiskSizeGb(x.diskSize.gb)
                 .build()
             )
             .setAutoDelete(true)
@@ -296,7 +294,12 @@ class GceInterpreter[F[_]: Parallel: ContextShift](
                 .setAcceleratorCount(gc.numOfGpus)
                 .build()
             )
-            .setScheduling(Scheduling.newBuilder().setOnHostMaintenance("TERMINATE").build())
+            .setScheduling(
+              Scheduling
+                .newBuilder()
+                .setOnHostMaintenance(com.google.cloud.compute.v1.Scheduling.OnHostMaintenance.TERMINATE)
+                .build()
+            )
             //.setShieldedInstanceConfig(???)  // investigate shielded VM on Albano's recommendation
             .build()
         case None => instanceBuilder.build()
@@ -307,7 +310,7 @@ class GceInterpreter[F[_]: Parallel: ContextShift](
 
       res = operation.map(o =>
         CreateGoogleRuntimeResponse(
-          AsyncRuntimeFields(GoogleId(o.getTargetId), OperationName(o.getName), stagingBucketName, None),
+          AsyncRuntimeFields(GoogleId(o.getTargetId.toString), OperationName(o.getName), stagingBucketName, None),
           initBucketName,
           BootSource.VmImage(config.gceConfig.sourceImage)
         )
@@ -324,7 +327,7 @@ class GceInterpreter[F[_]: Parallel: ContextShift](
           "GceInterpreter shouldn't get a stop dataproc runtime request. Something is very wrong"
         )
       )
-      metadata <- getShutdownScript(params.runtimeAndRuntimeConfig, blocker)
+      metadata <- getShutdownScript(params.runtimeAndRuntimeConfig)
       _ <- googleComputeService.addInstanceMetadata(
         params.runtimeAndRuntimeConfig.runtime.googleProject,
         zoneParam,
@@ -353,7 +356,6 @@ class GceInterpreter[F[_]: Parallel: ContextShift](
       metadata <- getStartupScript(params.runtimeAndRuntimeConfig,
                                    params.welderAction,
                                    params.initBucket,
-                                   blocker,
                                    resourceConstraints,
                                    true)
       // remove the startup-script-url metadata entry if present which is only used at creation time
@@ -398,7 +400,7 @@ class GceInterpreter[F[_]: Parallel: ContextShift](
             "GceInterpreter shouldn't get a dataproc runtime creation request. Something is very wrong"
           )
         )
-        metadata <- getShutdownScript(params.runtimeAndRuntimeConfig, blocker)
+        metadata <- getShutdownScript(params.runtimeAndRuntimeConfig)
         _ <- googleComputeService
           .addInstanceMetadata(
             params.runtimeAndRuntimeConfig.runtime.googleProject,
@@ -469,7 +471,7 @@ object GceInterpreter {
   def instanceStatusToRuntimeStatus(instance: Option[Instance]): RuntimeStatus =
     instance.fold[RuntimeStatus](RuntimeStatus.Deleted)(s =>
       GceInstanceStatus
-        .withNameInsensitiveOption(s.getStatus)
+        .withNameInsensitiveOption(s.getStatus.name)
         .map(RuntimeStatus.fromGceInstanceStatus)
         .getOrElse(RuntimeStatus.Unknown)
     )

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/TemplateHelper.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/TemplateHelper.scala
@@ -1,43 +1,40 @@
 package org.broadinstitute.dsde.workbench.leonardo.util
 
 import java.nio.file.Path
-
 import cats.effect._
 import fs2._
+import fs2.io.file.Files
 import org.broadinstitute.dsde.workbench.leonardo.RuntimeResource
 import org.broadinstitute.dsde.workbench.leonardo.config.ClusterResourcesConfig
 
 object TemplateHelper {
 
-  def templateFile[F[_]: ContextShift: Sync](replacementMap: Map[String, String],
-                                             path: Path,
-                                             blocker: Blocker): Stream[F, Byte] =
-    fileStream(path, blocker)
-      .through(text.utf8Decode)
+  def templateFile[F[_]: Sync: Files](replacementMap: Map[String, String], path: Path): Stream[F, Byte] =
+    fileStream(path)
+      .through(text.utf8.decode)
       .through(text.lines)
       .map(template(replacementMap))
       .intersperse("\n")
-      .through(text.utf8Encode)
+      .through(text.utf8.encode)
 
-  def templateResource[F[_]: ContextShift: Sync](replacementMap: Map[String, String],
-                                                 clusterResource: RuntimeResource,
-                                                 blocker: Blocker): Stream[F, Byte] =
-    resourceStream(clusterResource, blocker)
-      .through(text.utf8Decode)
+  def templateResource[F[_]: Sync](replacementMap: Map[String, String],
+                                   clusterResource: RuntimeResource): Stream[F, Byte] =
+    resourceStream(clusterResource)
+      .through(text.utf8.decode)
       .through(text.lines)
       .map(template(replacementMap))
       .intersperse("\n")
-      .through(text.utf8Encode)
+      .through(text.utf8.encode)
 
-  def fileStream[F[_]: ContextShift: Sync](path: Path, blocker: Blocker): Stream[F, Byte] =
-    io.file.readAll[F](path, blocker, 4096)
+  def fileStream[F[_]: Sync: Files](path: Path): Stream[F, Byte] =
+    Files[F].readAll(fs2.io.file.Path.fromNioPath(path))
 
-  def resourceStream[F[_]: ContextShift: Sync](clusterResource: RuntimeResource, blocker: Blocker): Stream[F, Byte] = {
+  def resourceStream[F[_]: Sync](clusterResource: RuntimeResource): Stream[F, Byte] = {
     val inputStream =
       Sync[F].delay(
         getClass.getClassLoader.getResourceAsStream(s"${ClusterResourcesConfig.basePath}/${clusterResource.asString}")
       )
-    io.readInputStream[F](inputStream, 4096, blocker)
+    io.readInputStream[F](inputStream, 4096)
   }
 
   private def template(replacementMap: Map[String, String])(str: String): String =

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/VPCInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/VPCInterpreter.scala
@@ -2,9 +2,9 @@ package org.broadinstitute.dsde.workbench.leonardo.util
 
 import _root_.org.typelevel.log4cats.StructuredLogger
 import cats.Parallel
-import cats.effect.{Async, ContextShift, Timer}
-import cats.syntax.all._
+import cats.effect.Async
 import cats.mtl.Ask
+import cats.syntax.all._
 import com.google.cloud.compute.v1._
 import org.broadinstitute.dsde.workbench.google2.util.RetryPredicates
 import org.broadinstitute.dsde.workbench.google2.{
@@ -43,7 +43,7 @@ final case class FirewallNotReadyException(project: GoogleProject, firewall: Fir
     extends LeoException(s"Firewall ${firewall.value} in project ${project.value} not ready within the specified time",
                          traceId = None)
 
-final class VPCInterpreter[F[_]: Parallel: ContextShift: StructuredLogger: Timer](
+final class VPCInterpreter[F[_]: StructuredLogger: Parallel](
   config: VPCInterpreterConfig,
   googleResourceService: GoogleResourceService[F],
   googleComputeService: GoogleComputeService[F],

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/CloudTraceSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/CloudTraceSpec.scala
@@ -41,7 +41,7 @@ class CloudTraceSpec
           }
         }
       }
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
 
     1 shouldBe (1)
   }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/CloudTraceSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/CloudTraceSpec.scala
@@ -1,11 +1,11 @@
 package org.broadinstitute.dsde.workbench.leonardo
 
 import java.nio.file.Paths
-
 import akka.http.scaladsl.client.RequestBuilding
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import cats.effect.IO
+import cats.effect.unsafe.implicits.global
 import io.opencensus.scala.akka.http.TracingDirective.traceRequestForService
 import org.broadinstitute.dsde.workbench.leonardo.http.serviceData
 import org.broadinstitute.dsde.workbench.openTelemetry.OpenTelemetryMetrics
@@ -32,7 +32,7 @@ class CloudTraceSpec
 
     val credentialFilePath = Paths.get("Your SA Path")
     val res = OpenTelemetryMetrics
-      .registerTracing(credentialFilePath, blocker)
+      .registerTracing[IO](credentialFilePath)
       .use { _ =>
         val req = Post("/route")
         IO {
@@ -41,7 +41,7 @@ class CloudTraceSpec
           }
         }
       }
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
 
     1 shouldBe (1)
   }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/CommonTestData.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/CommonTestData.scala
@@ -3,9 +3,11 @@ package org.broadinstitute.dsde.workbench.leonardo
 import akka.http.scaladsl.model.Uri.Host
 import akka.http.scaladsl.model.headers.{HttpCookiePair, OAuth2BearerToken}
 import cats.effect.IO
-import cats.effect.concurrent.Ref
+import cats.effect.Ref
+import cats.effect.unsafe.implicits.global
 import cats.mtl.Ask
 import com.google.auth.oauth2.{AccessToken, GoogleCredentials}
+import com.google.cloud.compute.v1.Instance.Status
 import com.google.cloud.compute.v1._
 import com.typesafe.config.ConfigFactory
 import net.ceedubs.ficus.Ficus._
@@ -334,7 +336,7 @@ object CommonTestData {
 
   val readyInstance = Instance
     .newBuilder()
-    .setStatus("Running")
+    .setStatus(Status.RUNNING)
     .setMetadata(
       Metadata
         .newBuilder()

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/KubernetesTestData.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/KubernetesTestData.scala
@@ -96,7 +96,7 @@ object KubernetesTestData {
     )
   }
 
-  def makeKubeCluster(index: Int): KubernetesCluster = {
+  def makeKubeCluster(index: Int, withDefaultNodepool: Boolean = true): KubernetesCluster = {
     val name = KubernetesClusterName("kubecluster" + index)
     val uniqueProject = GoogleProject(project.value + index)
     KubernetesCluster(
@@ -110,7 +110,7 @@ object KubernetesTestData {
       auditInfo,
       None,
       List(),
-      List(makeNodepool(index, KubernetesClusterLeoId(-1), "cluster", true))
+      List(makeNodepool(index, KubernetesClusterLeoId(-1), "cluster", withDefaultNodepool))
     )
   }
 

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/TestUtils.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/TestUtils.scala
@@ -207,5 +207,6 @@ object TestUtils extends Matchers {
                  userJupyterExtensionConfig = None)
   }
 
-  def sslContext(implicit as: ActorSystem): SSLContext = SslContextReader.getSSLContext[IO]().unsafeRunSync()
+  def sslContext(implicit as: ActorSystem): SSLContext =
+    SslContextReader.getSSLContext[IO]().unsafeRunSync()(cats.effect.unsafe.implicits.global)
 }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/TestUtils.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/TestUtils.scala
@@ -208,5 +208,5 @@ object TestUtils extends Matchers {
   }
 
   def sslContext(implicit as: ActorSystem): SSLContext =
-    SslContextReader.getSSLContext[IO]().unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    SslContextReader.getSSLContext[IO]().unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
 }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/auth/SamAuthProviderSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/auth/SamAuthProviderSpec.scala
@@ -3,21 +3,23 @@ package auth
 
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import cats.data.NonEmptyList
-import cats.effect.std.Dispatcher
-import cats.effect.{IO, Resource}
+import cats.effect.IO
 import cats.effect.unsafe.implicits.global
 import cats.syntax.all._
+import com.github.benmanes.caffeine.cache.Caffeine
 import org.broadinstitute.dsde.workbench.leonardo.CommonTestData._
-import org.broadinstitute.dsde.workbench.leonardo.KubernetesTestData._
-import org.broadinstitute.dsde.workbench.leonardo.dao._
 import org.broadinstitute.dsde.workbench.leonardo.JsonCodec._
+import org.broadinstitute.dsde.workbench.leonardo.KubernetesTestData._
 import org.broadinstitute.dsde.workbench.leonardo.SamResourceId._
+import org.broadinstitute.dsde.workbench.leonardo.dao._
 import org.broadinstitute.dsde.workbench.model.{UserInfo, WorkbenchUserId}
 import org.scalatest._
 import org.scalatest.flatspec.AnyFlatSpec
+import scalacache.Cache
+import scalacache.caffeine.CaffeineCache
 
-import scala.concurrent.duration._
 import scala.jdk.CollectionConverters._
+import scala.concurrent.duration._
 
 class SamAuthProviderSpec extends AnyFlatSpec with LeonardoTestSuite with BeforeAndAfter {
   val samAuthProviderConfigWithoutCache: SamAuthProviderConfig = SamAuthProviderConfig(false)
@@ -37,445 +39,358 @@ class SamAuthProviderSpec extends AnyFlatSpec with LeonardoTestSuite with Before
   val projectOwnerAuthHeader = MockSamDAO.userEmailToAuthorization(MockSamDAO.projectOwnerEmail)
   val authHeader = MockSamDAO.userEmailToAuthorization(userInfo.userEmail)
 
+  val underlyingCaffeineCache = Caffeine.newBuilder().maximumSize(10000L).build[String, scalacache.Entry[Boolean]]()
+  implicit val authCache: Cache[IO, Boolean] = CaffeineCache[IO, Boolean](underlyingCaffeineCache)
   var mockSam: MockSamDAO = _
-  var samAuthProviderResource: Resource[IO, SamAuthProvider[IO]] = for {
-    dispatcher <- Dispatcher[IO]
-    samDao = setUpMockSam()
-  } yield new SamAuthProvider(samDao, samAuthProviderConfigWithoutCache, serviceAccountProvider, dispatcher)
+  var samAuthProvider: SamAuthProvider[IO] = _
+  var samAuthProviderWithCache: SamAuthProvider[IO] = _
 
-  var samAuthProviderWithCacheResource: Resource[IO, SamAuthProvider[IO]] = for {
-    dispatcher <- Dispatcher[IO]
-    samDao = setUpMockSam()
-  } yield new SamAuthProvider(samDao, samAuthProviderConfigWithCache, serviceAccountProvider, dispatcher)
-
-//
-//  before {
-//    setUpMockSam()
-//    samAuthProvider = new SamAuthProvider(mockSam, samAuthProviderConfigWithoutCache, serviceAccountProvider)
-//    samAuthProviderWithCache = new SamAuthProvider(mockSam, samAuthProviderConfigWithCache, serviceAccountProvider)
-//
-//  }
+  before {
+    setUpMockSam()
+    samAuthProvider = new SamAuthProvider(mockSam, samAuthProviderConfigWithoutCache, serviceAccountProvider)
+    samAuthProviderWithCache = new SamAuthProvider(mockSam, samAuthProviderConfigWithCache, serviceAccountProvider)
+  }
 
   "SamAuthProvider" should "check resource permissions" in {
-    samAuthProviderResource
-      .use { samAuthProvider =>
-        IO {
-          // positive tests
-          ProjectAction.allActions.foreach { a =>
-            samAuthProvider
-              .hasPermission(ProjectSamResourceId(project), a, projectOwnerUserInfo)
-              .unsafeRunSync() shouldBe true
-          }
-          RuntimeAction.allActions.foreach { a =>
-            samAuthProvider.hasPermission(runtimeSamResource, a, userInfo).unsafeRunSync() shouldBe true
-          }
-          PersistentDiskAction.allActions.foreach { a =>
-            samAuthProvider.hasPermission(diskSamResource, a, userInfo).unsafeRunSync() shouldBe true
-          }
-          AppAction.allActions.foreach { a =>
-            samAuthProvider.hasPermission(appSamId, a, userInfo).unsafeRunSync() shouldBe true
-          }
-          MockSamDAO.appManagerActions.foreach { a =>
-            samAuthProvider.hasPermission(appSamId, a, projectOwnerUserInfo).unsafeRunSync() shouldBe true
-          }
+    // positive tests
+    ProjectAction.allActions.foreach { a =>
+      samAuthProvider
+        .hasPermission(ProjectSamResourceId(project), a, projectOwnerUserInfo)
+        .unsafeRunSync() shouldBe true
+    }
+    RuntimeAction.allActions.foreach { a =>
+      samAuthProvider.hasPermission(runtimeSamResource, a, userInfo).unsafeRunSync() shouldBe true
+    }
+    PersistentDiskAction.allActions.foreach { a =>
+      samAuthProvider.hasPermission(diskSamResource, a, userInfo).unsafeRunSync() shouldBe true
+    }
+    AppAction.allActions.foreach { a =>
+      samAuthProvider.hasPermission(appSamId, a, userInfo).unsafeRunSync() shouldBe true
+    }
+    MockSamDAO.appManagerActions.foreach { a =>
+      samAuthProvider.hasPermission(appSamId, a, projectOwnerUserInfo).unsafeRunSync() shouldBe true
+    }
 
-          // negative tests
-          ProjectAction.allActions.foreach { a =>
-            samAuthProvider
-              .hasPermission(ProjectSamResourceId(project), a, unauthorizedUserInfo)
-              .unsafeRunSync() shouldBe false
-          }
-          RuntimeAction.allActions.foreach { a =>
-            samAuthProvider.hasPermission(runtimeSamResource, a, unauthorizedUserInfo).unsafeRunSync() shouldBe false
-            samAuthProvider.hasPermission(runtimeSamResource, a, projectOwnerUserInfo).unsafeRunSync() shouldBe false
-          }
-          PersistentDiskAction.allActions.foreach { a =>
-            samAuthProvider.hasPermission(diskSamResource, a, unauthorizedUserInfo).unsafeRunSync() shouldBe false
-            samAuthProvider.hasPermission(diskSamResource, a, projectOwnerUserInfo).unsafeRunSync() shouldBe false
-          }
-          AppAction.allActions.foreach { a =>
-            samAuthProvider.hasPermission(appSamId, a, unauthorizedUserInfo).unsafeRunSync() shouldBe false
-          }
-        }
-      }
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
-
+    // negative tests
+    ProjectAction.allActions.foreach { a =>
+      samAuthProvider
+        .hasPermission(ProjectSamResourceId(project), a, unauthorizedUserInfo)
+        .unsafeRunSync() shouldBe false
+    }
+    RuntimeAction.allActions.foreach { a =>
+      samAuthProvider.hasPermission(runtimeSamResource, a, unauthorizedUserInfo).unsafeRunSync() shouldBe false
+      samAuthProvider.hasPermission(runtimeSamResource, a, projectOwnerUserInfo).unsafeRunSync() shouldBe false
+    }
+    PersistentDiskAction.allActions.foreach { a =>
+      samAuthProvider.hasPermission(diskSamResource, a, unauthorizedUserInfo).unsafeRunSync() shouldBe false
+      samAuthProvider.hasPermission(diskSamResource, a, projectOwnerUserInfo).unsafeRunSync() shouldBe false
+    }
+    AppAction.allActions.foreach { a =>
+      samAuthProvider.hasPermission(appSamId, a, unauthorizedUserInfo).unsafeRunSync() shouldBe false
+    }
   }
 
   it should "check resource permissions with project fallback" in {
-    samAuthProviderResource
-      .use { samAuthProvider =>
-        IO {
-          // positive tests
-          List(
-            (RuntimeAction.GetRuntimeStatus, ProjectAction.GetRuntimeStatus),
-            (RuntimeAction.DeleteRuntime, ProjectAction.DeleteRuntime),
-            (RuntimeAction.StopStartRuntime, ProjectAction.StopStartRuntime)
-          ).foreach {
-            case (runtimeAction, projectAction) =>
-              // project fallback should work as the user
-              samAuthProvider
-                .hasPermissionWithProjectFallback(runtimeSamResource, runtimeAction, projectAction, userInfo, project)
-                .unsafeRunSync() shouldBe true
+    // positive tests
+    List(
+      (RuntimeAction.GetRuntimeStatus, ProjectAction.GetRuntimeStatus),
+      (RuntimeAction.DeleteRuntime, ProjectAction.DeleteRuntime),
+      (RuntimeAction.StopStartRuntime, ProjectAction.StopStartRuntime)
+    ).foreach {
+      case (runtimeAction, projectAction) =>
+        // project fallback should work as the user
+        samAuthProvider
+          .hasPermissionWithProjectFallback(runtimeSamResource, runtimeAction, projectAction, userInfo, project)
+          .unsafeRunSync() shouldBe true
 
-              // project fallback should work as the project owner
-              samAuthProvider
-                .hasPermissionWithProjectFallback(runtimeSamResource,
-                                                  runtimeAction,
-                                                  projectAction,
-                                                  projectOwnerUserInfo,
-                                                  project)
-                .unsafeRunSync() shouldBe true
+        // project fallback should work as the project owner
+        samAuthProvider
+          .hasPermissionWithProjectFallback(runtimeSamResource,
+                                            runtimeAction,
+                                            projectAction,
+                                            projectOwnerUserInfo,
+                                            project)
+          .unsafeRunSync() shouldBe true
 
-          }
-          List(
-            (PersistentDiskAction.ReadPersistentDisk, ProjectAction.ReadPersistentDisk),
-            (PersistentDiskAction.DeletePersistentDisk, ProjectAction.DeletePersistentDisk)
-          ).foreach {
-            case (diskAction, projectAction) =>
-              // project fallback should work as the user
-              samAuthProvider
-                .hasPermissionWithProjectFallback(diskSamResource, diskAction, projectAction, userInfo, project)
-                .unsafeRunSync() shouldBe true
+    }
+    List(
+      (PersistentDiskAction.ReadPersistentDisk, ProjectAction.ReadPersistentDisk),
+      (PersistentDiskAction.DeletePersistentDisk, ProjectAction.DeletePersistentDisk)
+    ).foreach {
+      case (diskAction, projectAction) =>
+        // project fallback should work as the user
+        samAuthProvider
+          .hasPermissionWithProjectFallback(diskSamResource, diskAction, projectAction, userInfo, project)
+          .unsafeRunSync() shouldBe true
 
-              // project fallback should work as the project owner
-              samAuthProvider
-                .hasPermissionWithProjectFallback(diskSamResource,
-                                                  diskAction,
-                                                  projectAction,
-                                                  projectOwnerUserInfo,
-                                                  project)
-                .unsafeRunSync() shouldBe true
-          }
+        // project fallback should work as the project owner
+        samAuthProvider
+          .hasPermissionWithProjectFallback(diskSamResource, diskAction, projectAction, projectOwnerUserInfo, project)
+          .unsafeRunSync() shouldBe true
+    }
 
-          // negative tests
-          List(
-            (RuntimeAction.GetRuntimeStatus, ProjectAction.GetRuntimeStatus),
-            (RuntimeAction.DeleteRuntime, ProjectAction.DeleteRuntime),
-            (RuntimeAction.StopStartRuntime, ProjectAction.StopStartRuntime)
-          ).foreach {
-            case (runtimeAction, projectAction) =>
-              samAuthProvider
-                .hasPermissionWithProjectFallback(runtimeSamResource,
-                                                  runtimeAction,
-                                                  projectAction,
-                                                  unauthorizedUserInfo,
-                                                  project)
-                .unsafeRunSync() shouldBe false
-          }
-          List(
-            (PersistentDiskAction.ReadPersistentDisk, ProjectAction.ReadPersistentDisk),
-            (PersistentDiskAction.DeletePersistentDisk, ProjectAction.DeletePersistentDisk)
-          ).foreach {
-            case (diskAction, projectAction) =>
-              samAuthProvider
-                .hasPermissionWithProjectFallback(diskSamResource,
-                                                  diskAction,
-                                                  projectAction,
-                                                  unauthorizedUserInfo,
-                                                  project)
-                .unsafeRunSync() shouldBe false
-          }
-        }
-      }
+    // negative tests
+    List(
+      (RuntimeAction.GetRuntimeStatus, ProjectAction.GetRuntimeStatus),
+      (RuntimeAction.DeleteRuntime, ProjectAction.DeleteRuntime),
+      (RuntimeAction.StopStartRuntime, ProjectAction.StopStartRuntime)
+    ).foreach {
+      case (runtimeAction, projectAction) =>
+        samAuthProvider
+          .hasPermissionWithProjectFallback(runtimeSamResource,
+                                            runtimeAction,
+                                            projectAction,
+                                            unauthorizedUserInfo,
+                                            project)
+          .unsafeRunSync() shouldBe false
+    }
+    List(
+      (PersistentDiskAction.ReadPersistentDisk, ProjectAction.ReadPersistentDisk),
+      (PersistentDiskAction.DeletePersistentDisk, ProjectAction.DeletePersistentDisk)
+    ).foreach {
+      case (diskAction, projectAction) =>
+        samAuthProvider
+          .hasPermissionWithProjectFallback(diskSamResource, diskAction, projectAction, unauthorizedUserInfo, project)
+          .unsafeRunSync() shouldBe false
+    }
   }
 
   it should "get actions" in {
-    samAuthProviderResource
-      .use { samAuthProvider =>
-        IO {
-          // positive tests
-          samAuthProvider
-            .getActions(ProjectSamResourceId(project), projectOwnerUserInfo)
-            .unsafeRunSync()
-            .toSet shouldBe ProjectAction.allActions
-          samAuthProvider
-            .getActions(runtimeSamResource, userInfo)
-            .unsafeRunSync()
-            .toSet shouldBe RuntimeAction.allActions
-          samAuthProvider
-            .getActions(diskSamResource, userInfo)
-            .unsafeRunSync()
-            .toSet shouldBe PersistentDiskAction.allActions
-          samAuthProvider.getActions(appSamId, userInfo).unsafeRunSync().toSet shouldBe AppAction.allActions
-          samAuthProvider
-            .getActions(appSamId, projectOwnerUserInfo)
-            .unsafeRunSync()
-            .toSet shouldBe MockSamDAO.appManagerActions
+    // positive tests
+    samAuthProvider
+      .getActions(ProjectSamResourceId(project), projectOwnerUserInfo)
+      .unsafeRunSync()
+      .toSet shouldBe ProjectAction.allActions
+    samAuthProvider
+      .getActions(runtimeSamResource, userInfo)
+      .unsafeRunSync()
+      .toSet shouldBe RuntimeAction.allActions
+    samAuthProvider
+      .getActions(diskSamResource, userInfo)
+      .unsafeRunSync()
+      .toSet shouldBe PersistentDiskAction.allActions
+    samAuthProvider.getActions(appSamId, userInfo).unsafeRunSync().toSet shouldBe AppAction.allActions
+    samAuthProvider
+      .getActions(appSamId, projectOwnerUserInfo)
+      .unsafeRunSync()
+      .toSet shouldBe MockSamDAO.appManagerActions
 
-          // negative tests
-          samAuthProvider
-            .getActions(ProjectSamResourceId(project), unauthorizedUserInfo)
-            .unsafeRunSync() shouldBe List.empty
-          samAuthProvider.getActions(runtimeSamResource, unauthorizedUserInfo).unsafeRunSync() shouldBe List.empty
-          samAuthProvider.getActions(runtimeSamResource, projectOwnerUserInfo).unsafeRunSync() shouldBe List.empty
-          samAuthProvider.getActions(diskSamResource, unauthorizedUserInfo).unsafeRunSync() shouldBe List.empty
-          samAuthProvider.getActions(diskSamResource, projectOwnerUserInfo).unsafeRunSync() shouldBe List.empty
-          samAuthProvider.getActions(appSamId, unauthorizedUserInfo).unsafeRunSync() shouldBe List.empty
-        }
-      }
+    // negative tests
+    samAuthProvider
+      .getActions(ProjectSamResourceId(project), unauthorizedUserInfo)
+      .unsafeRunSync() shouldBe List.empty
+    samAuthProvider.getActions(runtimeSamResource, unauthorizedUserInfo).unsafeRunSync() shouldBe List.empty
+    samAuthProvider.getActions(runtimeSamResource, projectOwnerUserInfo).unsafeRunSync() shouldBe List.empty
+    samAuthProvider.getActions(diskSamResource, unauthorizedUserInfo).unsafeRunSync() shouldBe List.empty
+    samAuthProvider.getActions(diskSamResource, projectOwnerUserInfo).unsafeRunSync() shouldBe List.empty
+    samAuthProvider.getActions(appSamId, unauthorizedUserInfo).unsafeRunSync() shouldBe List.empty
   }
 
   it should "get actions with project fallback" in {
-    samAuthProviderResource
-      .use { samAuthProvider =>
-        IO {
-          // positive tests
-          samAuthProvider
-            .getActionsWithProjectFallback(runtimeSamResource, project, userInfo)
-            .unsafeRunSync()
-            .leftMap(_.toSet) shouldBe (RuntimeAction.allActions, List.empty)
-          samAuthProvider
-            .getActionsWithProjectFallback(runtimeSamResource, project, projectOwnerUserInfo)
-            .unsafeRunSync()
-            .map(_.toSet) shouldBe (List.empty, ProjectAction.allActions)
-          samAuthProvider
-            .getActionsWithProjectFallback(diskSamResource, project, userInfo)
-            .unsafeRunSync()
-            .leftMap(_.toSet) shouldBe (PersistentDiskAction.allActions, List.empty)
-          samAuthProvider
-            .getActionsWithProjectFallback(diskSamResource, project, projectOwnerUserInfo)
-            .unsafeRunSync()
-            .map(_.toSet) shouldBe (List.empty, ProjectAction.allActions)
+    // positive tests
+    samAuthProvider
+      .getActionsWithProjectFallback(runtimeSamResource, project, userInfo)
+      .unsafeRunSync()
+      .leftMap(_.toSet) shouldBe (RuntimeAction.allActions, List.empty)
+    samAuthProvider
+      .getActionsWithProjectFallback(runtimeSamResource, project, projectOwnerUserInfo)
+      .unsafeRunSync()
+      .map(_.toSet) shouldBe (List.empty, ProjectAction.allActions)
+    samAuthProvider
+      .getActionsWithProjectFallback(diskSamResource, project, userInfo)
+      .unsafeRunSync()
+      .leftMap(_.toSet) shouldBe (PersistentDiskAction.allActions, List.empty)
+    samAuthProvider
+      .getActionsWithProjectFallback(diskSamResource, project, projectOwnerUserInfo)
+      .unsafeRunSync()
+      .map(_.toSet) shouldBe (List.empty, ProjectAction.allActions)
 
-          // negative tests
-          samAuthProvider
-            .getActionsWithProjectFallback(runtimeSamResource, project, unauthorizedUserInfo)
-            .unsafeRunSync() shouldBe (List.empty, List.empty)
-          samAuthProvider
-            .getActionsWithProjectFallback(diskSamResource, project, unauthorizedUserInfo)
-            .unsafeRunSync() shouldBe (List.empty, List.empty)
-        }
-      }
+    // negative tests
+    samAuthProvider
+      .getActionsWithProjectFallback(runtimeSamResource, project, unauthorizedUserInfo)
+      .unsafeRunSync() shouldBe (List.empty, List.empty)
+    samAuthProvider
+      .getActionsWithProjectFallback(diskSamResource, project, unauthorizedUserInfo)
+      .unsafeRunSync() shouldBe (List.empty, List.empty)
   }
 
   it should "cache hasPermission results" in {
-    samAuthProviderWithCacheResource
-      .use { samAuthProviderWithCache =>
-        IO {
-          // cache should be empty
-          samAuthProviderWithCache.authCache.size shouldBe 0
+//     cache should be empty
+    underlyingCaffeineCache.asMap().size shouldBe 0
 
-          // these actions should be cached
-          List(ProjectAction.GetRuntimeStatus, ProjectAction.ReadPersistentDisk).foreach { a =>
-            samAuthProviderWithCache
-              .hasPermission(ProjectSamResourceId(project), a, projectOwnerUserInfo)
-              .unsafeRunSync() shouldBe true
-          }
-          List(RuntimeAction.GetRuntimeStatus, RuntimeAction.ConnectToRuntime).foreach { a =>
-            samAuthProviderWithCache
-              .hasPermission(runtimeSamResource, a, userInfo)
-              .unsafeRunSync() shouldBe true
-            samAuthProviderWithCache
-              .hasPermission(runtimeSamResource, a, userInfo)
-              .unsafeRunSync() shouldBe true
-          }
-          List(PersistentDiskAction.ReadPersistentDisk).foreach { a =>
-            samAuthProviderWithCache
-              .hasPermission(diskSamResource, a, userInfo)
-              .unsafeRunSync() shouldBe true
-          }
-          List(AppAction.ConnectToApp, AppAction.GetAppStatus).foreach { a =>
-            samAuthProviderWithCache.hasPermission(appSamId, a, userInfo).unsafeRunSync() shouldBe true
-          }
+    // these actions should be cached
+    List(ProjectAction.GetRuntimeStatus, ProjectAction.ReadPersistentDisk).foreach { a =>
+      samAuthProviderWithCache
+        .hasPermission(ProjectSamResourceId(project), a, projectOwnerUserInfo)
+        .unsafeRunSync() shouldBe true
+    }
+    List(RuntimeAction.GetRuntimeStatus, RuntimeAction.ConnectToRuntime).foreach { a =>
+      samAuthProviderWithCache
+        .hasPermission(runtimeSamResource, a, userInfo)
+        .unsafeRunSync() shouldBe true
+      samAuthProviderWithCache
+        .hasPermission(runtimeSamResource, a, userInfo)
+        .unsafeRunSync() shouldBe true
+    }
+    List(PersistentDiskAction.ReadPersistentDisk).foreach { a =>
+      samAuthProviderWithCache
+        .hasPermission(diskSamResource, a, userInfo)
+        .unsafeRunSync() shouldBe true
+    }
+    List(AppAction.ConnectToApp, AppAction.GetAppStatus).foreach { a =>
+      samAuthProviderWithCache.hasPermission(appSamId, a, userInfo).unsafeRunSync() shouldBe true
+    }
 
-          // these actions should not be cached
-          List(
-            ProjectAction.CreateApp,
-            ProjectAction.CreatePersistentDisk,
-            ProjectAction.CreateRuntime,
-            ProjectAction.DeletePersistentDisk,
-            ProjectAction.DeleteRuntime,
-            ProjectAction.StopStartRuntime
-          ).foreach { a =>
-            samAuthProviderWithCache
-              .hasPermission(ProjectSamResourceId(project), a, projectOwnerUserInfo)
-              .unsafeRunSync() shouldBe true
-          }
-          List(RuntimeAction.ModifyRuntime, RuntimeAction.DeleteRuntime, RuntimeAction.StopStartRuntime).foreach { a =>
-            samAuthProviderWithCache
-              .hasPermission(runtimeSamResource, a, userInfo)
-              .unsafeRunSync() shouldBe true
-          }
-          List(PersistentDiskAction.DeletePersistentDisk,
-               PersistentDiskAction.ModifyPersistentDisk,
-               PersistentDiskAction.AttachPersistentDisk).foreach { a =>
-            samAuthProviderWithCache
-              .hasPermission(diskSamResource, a, userInfo)
-              .unsafeRunSync() shouldBe true
-          }
-          List(AppAction.DeleteApp, AppAction.UpdateApp).foreach { a =>
-            samAuthProviderWithCache
-              .hasPermission(appSamId, a, userInfo)
-              .unsafeRunSync() shouldBe true
-          }
+    // these actions should not be cached
+    List(
+      ProjectAction.CreateApp,
+      ProjectAction.CreatePersistentDisk,
+      ProjectAction.CreateRuntime,
+      ProjectAction.DeletePersistentDisk,
+      ProjectAction.DeleteRuntime,
+      ProjectAction.StopStartRuntime
+    ).foreach { a =>
+      samAuthProviderWithCache
+        .hasPermission(ProjectSamResourceId(project), a, projectOwnerUserInfo)
+        .unsafeRunSync() shouldBe true
+    }
+    List(RuntimeAction.ModifyRuntime, RuntimeAction.DeleteRuntime, RuntimeAction.StopStartRuntime).foreach { a =>
+      samAuthProviderWithCache
+        .hasPermission(runtimeSamResource, a, userInfo)
+        .unsafeRunSync() shouldBe true
+    }
+    List(PersistentDiskAction.DeletePersistentDisk,
+         PersistentDiskAction.ModifyPersistentDisk,
+         PersistentDiskAction.AttachPersistentDisk).foreach { a =>
+      samAuthProviderWithCache
+        .hasPermission(diskSamResource, a, userInfo)
+        .unsafeRunSync() shouldBe true
+    }
+    List(AppAction.DeleteApp, AppAction.UpdateApp).foreach { a =>
+      samAuthProviderWithCache
+        .hasPermission(appSamId, a, userInfo)
+        .unsafeRunSync() shouldBe true
+    }
 
-          // check cache
-          samAuthProviderWithCache.authCache.size shouldBe 7
-          samAuthProviderWithCache.authCache.asMap().asScala.keySet shouldBe
-            Set(
-              AuthCacheKey(SamResourceType.Project,
-                           project.value,
-                           projectOwnerAuthHeader,
-                           ProjectAction.GetRuntimeStatus.asString),
-              AuthCacheKey(SamResourceType.Project,
-                           project.value,
-                           projectOwnerAuthHeader,
-                           ProjectAction.ReadPersistentDisk.asString),
-              AuthCacheKey(SamResourceType.Runtime,
-                           runtimeSamResource.resourceId,
-                           authHeader,
-                           RuntimeAction.ConnectToRuntime.asString),
-              AuthCacheKey(SamResourceType.Runtime,
-                           runtimeSamResource.resourceId,
-                           authHeader,
-                           RuntimeAction.GetRuntimeStatus.asString),
-              AuthCacheKey(SamResourceType.PersistentDisk,
-                           diskSamResource.resourceId,
-                           authHeader,
-                           PersistentDiskAction.ReadPersistentDisk.asString),
-              AuthCacheKey(SamResourceType.App, appSamId.resourceId, authHeader, AppAction.GetAppStatus.asString),
-              AuthCacheKey(SamResourceType.App, appSamId.resourceId, authHeader, AppAction.ConnectToApp.asString)
-            )
-          samAuthProviderWithCache.authCache.asMap().asScala.values.toSet shouldBe Set(true)
-        }
-      }
+    // check cache
+    val cacheMap = underlyingCaffeineCache.asMap()
+    cacheMap.size shouldBe 9
+    cacheMap.asScala.values.map(_.value).toSet shouldBe Set(true)
   }
 
   it should "create a resource" in {
-    samAuthProviderResource
-      .use { samAuthProvider =>
-        IO {
-          val newRuntime = RuntimeSamResourceId("new_runtime")
-          samAuthProvider.notifyResourceCreated(newRuntime, userEmail, project).unsafeRunSync()
-          mockSam.runtimes.get((newRuntime, authHeader)) shouldBe Some(
-            RuntimeAction.allActions
-          )
+    val newRuntime = RuntimeSamResourceId("new_runtime")
+    samAuthProvider.notifyResourceCreated(newRuntime, userEmail, project).unsafeRunSync()
+    mockSam.runtimes.get((newRuntime, authHeader)) shouldBe Some(
+      RuntimeAction.allActions
+    )
 
-          val newDisk = PersistentDiskSamResourceId("new_disk")
-          samAuthProvider.notifyResourceCreated(newDisk, userEmail, project).unsafeRunSync()
-          mockSam.persistentDisks.get((newDisk, authHeader)) shouldBe Some(
-            PersistentDiskAction.allActions
-          )
+    val newDisk = PersistentDiskSamResourceId("new_disk")
+    samAuthProvider.notifyResourceCreated(newDisk, userEmail, project).unsafeRunSync()
+    mockSam.persistentDisks.get((newDisk, authHeader)) shouldBe Some(
+      PersistentDiskAction.allActions
+    )
 
-          val newApp = AppSamResourceId("new_app")
-          samAuthProvider.notifyResourceCreated(newApp, userEmail, project).unsafeRunSync()
-          mockSam.apps.get((newApp, authHeader)) shouldBe Some(
-            AppAction.allActions
-          )
-          mockSam.apps.get((newApp, projectOwnerAuthHeader)) shouldBe Some(
-            MockSamDAO.appManagerActions
-          )
-        }
-      }
+    val newApp = AppSamResourceId("new_app")
+    samAuthProvider.notifyResourceCreated(newApp, userEmail, project).unsafeRunSync()
+    mockSam.apps.get((newApp, authHeader)) shouldBe Some(
+      AppAction.allActions
+    )
+    mockSam.apps.get((newApp, projectOwnerAuthHeader)) shouldBe Some(
+      MockSamDAO.appManagerActions
+    )
   }
 
   it should "delete a resource" in {
-    samAuthProviderResource
-      .use { samAuthProvider =>
-        IO {
-          samAuthProvider.notifyResourceDeleted(runtimeSamResource, userEmail, project).unsafeRunSync()
-          mockSam.runtimes.get((runtimeSamResource, authHeader)) shouldBe None
+    samAuthProvider.notifyResourceDeleted(runtimeSamResource, userEmail, project).unsafeRunSync()
+    mockSam.runtimes.get((runtimeSamResource, authHeader)) shouldBe None
 
-          samAuthProvider.notifyResourceDeleted(diskSamResource, userEmail, project).unsafeRunSync()
-          mockSam.persistentDisks.get((diskSamResource, authHeader)) shouldBe None
+    samAuthProvider.notifyResourceDeleted(diskSamResource, userEmail, project).unsafeRunSync()
+    mockSam.persistentDisks.get((diskSamResource, authHeader)) shouldBe None
 
-          samAuthProvider.notifyResourceDeleted(appSamId, userEmail, project).unsafeRunSync()
-          mockSam.apps.get((appSamId, authHeader)) shouldBe None
-          mockSam.apps.get((appSamId, projectOwnerAuthHeader)) shouldBe None
-        }
-      }
+    samAuthProvider.notifyResourceDeleted(appSamId, userEmail, project).unsafeRunSync()
+    mockSam.apps.get((appSamId, authHeader)) shouldBe None
+    mockSam.apps.get((appSamId, projectOwnerAuthHeader)) shouldBe None
   }
 
   it should "filter user visible resources" in {
-    samAuthProviderResource
-      .use { samAuthProvider =>
-        IO {
-          // positive tests
-          val newRuntime = RuntimeSamResourceId("new_runtime")
-          mockSam.createResource(newRuntime, userEmail2, project).unsafeRunSync()
-          samAuthProvider
-            .filterUserVisible(NonEmptyList.of(runtimeSamResource, newRuntime), userInfo)
-            .unsafeRunSync() shouldBe List(
-            runtimeSamResource
-          )
+    // positive tests
+    val newRuntime = RuntimeSamResourceId("new_runtime")
+    mockSam.createResource(newRuntime, userEmail2, project).unsafeRunSync()
+    samAuthProvider
+      .filterUserVisible(NonEmptyList.of(runtimeSamResource, newRuntime), userInfo)
+      .unsafeRunSync() shouldBe List(
+      runtimeSamResource
+    )
 
-          val newDisk = PersistentDiskSamResourceId("new_disk")
-          mockSam.createResource(newDisk, userEmail2, project).unsafeRunSync()
-          samAuthProvider
-            .filterUserVisible(NonEmptyList.of(diskSamResource, newDisk), userInfo)
-            .unsafeRunSync() shouldBe List(
-            diskSamResource
-          )
+    val newDisk = PersistentDiskSamResourceId("new_disk")
+    mockSam.createResource(newDisk, userEmail2, project).unsafeRunSync()
+    samAuthProvider
+      .filterUserVisible(NonEmptyList.of(diskSamResource, newDisk), userInfo)
+      .unsafeRunSync() shouldBe List(
+      diskSamResource
+    )
 
-          val newApp = AppSamResourceId("new_app")
-          mockSam.createResourceWithParent(newApp, userEmail2, project).unsafeRunSync()
-          samAuthProvider.filterUserVisible(NonEmptyList.of(appSamId, newApp), userInfo).unsafeRunSync() shouldBe List(
-            appSamId
-          )
-          samAuthProvider
-            .filterUserVisible(NonEmptyList.of(appSamId, newApp), projectOwnerUserInfo)
-            .unsafeRunSync() shouldBe List(
-            appSamId,
-            newApp
-          )
+    val newApp = AppSamResourceId("new_app")
+    mockSam.createResourceWithParent(newApp, userEmail2, project).unsafeRunSync()
+    samAuthProvider.filterUserVisible(NonEmptyList.of(appSamId, newApp), userInfo).unsafeRunSync() shouldBe List(
+      appSamId
+    )
+    samAuthProvider
+      .filterUserVisible(NonEmptyList.of(appSamId, newApp), projectOwnerUserInfo)
+      .unsafeRunSync() shouldBe List(
+      appSamId,
+      newApp
+    )
 
-          // negative tests
-          samAuthProvider
-            .filterUserVisible(NonEmptyList.of(runtimeSamResource, newRuntime), unauthorizedUserInfo)
-            .unsafeRunSync() shouldBe List.empty
-          samAuthProvider
-            .filterUserVisible(NonEmptyList.of(runtimeSamResource, newRuntime), projectOwnerUserInfo)
-            .unsafeRunSync() shouldBe List.empty
-          samAuthProvider
-            .filterUserVisible(NonEmptyList.of(diskSamResource, newDisk), unauthorizedUserInfo)
-            .unsafeRunSync() shouldBe List.empty
-          samAuthProvider
-            .filterUserVisible(NonEmptyList.of(diskSamResource, newDisk), projectOwnerUserInfo)
-            .unsafeRunSync() shouldBe List.empty
-          samAuthProvider
-            .filterUserVisible(NonEmptyList.of(appSamId, newApp), unauthorizedUserInfo)
-            .unsafeRunSync() shouldBe List.empty
-        }
-      }
+    // negative tests
+    samAuthProvider
+      .filterUserVisible(NonEmptyList.of(runtimeSamResource, newRuntime), unauthorizedUserInfo)
+      .unsafeRunSync() shouldBe List.empty
+    samAuthProvider
+      .filterUserVisible(NonEmptyList.of(runtimeSamResource, newRuntime), projectOwnerUserInfo)
+      .unsafeRunSync() shouldBe List.empty
+    samAuthProvider
+      .filterUserVisible(NonEmptyList.of(diskSamResource, newDisk), unauthorizedUserInfo)
+      .unsafeRunSync() shouldBe List.empty
+    samAuthProvider
+      .filterUserVisible(NonEmptyList.of(diskSamResource, newDisk), projectOwnerUserInfo)
+      .unsafeRunSync() shouldBe List.empty
+    samAuthProvider
+      .filterUserVisible(NonEmptyList.of(appSamId, newApp), unauthorizedUserInfo)
+      .unsafeRunSync() shouldBe List.empty
   }
 
   it should "filter user visible resources with project fallback" in {
-    samAuthProviderResource
-      .use { samAuthProvider =>
-        IO {
-          // positive tests
-          val newRuntime = RuntimeSamResourceId("new_runtime")
-          mockSam.createResource(newRuntime, userEmail2, project).unsafeRunSync()
-          samAuthProvider
-            .filterUserVisibleWithProjectFallback(NonEmptyList.of((project, runtimeSamResource), (project, newRuntime)),
-                                                  userInfo)
-            .unsafeRunSync() shouldBe List((project, runtimeSamResource))
-          samAuthProvider
-            .filterUserVisibleWithProjectFallback(NonEmptyList.of((project, runtimeSamResource), (project, newRuntime)),
-                                                  projectOwnerUserInfo)
-            .unsafeRunSync() shouldBe List((project, runtimeSamResource), (project, newRuntime))
+    // positive tests
+    val newRuntime = RuntimeSamResourceId("new_runtime")
+    mockSam.createResource(newRuntime, userEmail2, project).unsafeRunSync()
+    samAuthProvider
+      .filterUserVisibleWithProjectFallback(NonEmptyList.of((project, runtimeSamResource), (project, newRuntime)),
+                                            userInfo)
+      .unsafeRunSync() shouldBe List((project, runtimeSamResource))
+    samAuthProvider
+      .filterUserVisibleWithProjectFallback(NonEmptyList.of((project, runtimeSamResource), (project, newRuntime)),
+                                            projectOwnerUserInfo)
+      .unsafeRunSync() shouldBe List((project, runtimeSamResource), (project, newRuntime))
 
-          val newDisk = PersistentDiskSamResourceId("new_disk")
-          mockSam.createResource(newDisk, userEmail2, project).unsafeRunSync()
-          samAuthProvider
-            .filterUserVisibleWithProjectFallback(NonEmptyList.of((project, diskSamResource), (project, newDisk)),
-                                                  userInfo)
-            .unsafeRunSync() shouldBe List((project, diskSamResource))
-          samAuthProvider
-            .filterUserVisibleWithProjectFallback(NonEmptyList.of((project, diskSamResource), (project, newDisk)),
-                                                  projectOwnerUserInfo)
-            .unsafeRunSync() shouldBe List((project, diskSamResource), (project, newDisk))
+    val newDisk = PersistentDiskSamResourceId("new_disk")
+    mockSam.createResource(newDisk, userEmail2, project).unsafeRunSync()
+    samAuthProvider
+      .filterUserVisibleWithProjectFallback(NonEmptyList.of((project, diskSamResource), (project, newDisk)), userInfo)
+      .unsafeRunSync() shouldBe List((project, diskSamResource))
+    samAuthProvider
+      .filterUserVisibleWithProjectFallback(NonEmptyList.of((project, diskSamResource), (project, newDisk)),
+                                            projectOwnerUserInfo)
+      .unsafeRunSync() shouldBe List((project, diskSamResource), (project, newDisk))
 
-          // negative tests
-          samAuthProvider
-            .filterUserVisible(NonEmptyList.of(runtimeSamResource, newRuntime), unauthorizedUserInfo)
-            .unsafeRunSync() shouldBe List.empty
-          samAuthProvider
-            .filterUserVisible(NonEmptyList.of(diskSamResource, newDisk), unauthorizedUserInfo)
-            .unsafeRunSync() shouldBe List.empty
-        }
-      }
+    // negative tests
+    samAuthProvider
+      .filterUserVisible(NonEmptyList.of(runtimeSamResource, newRuntime), unauthorizedUserInfo)
+      .unsafeRunSync() shouldBe List.empty
+    samAuthProvider
+      .filterUserVisible(NonEmptyList.of(diskSamResource, newDisk), unauthorizedUserInfo)
+      .unsafeRunSync() shouldBe List.empty
   }
 
   private def setUpMockSam(): SamDAO[IO] = {

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/auth/SamAuthProviderSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/auth/SamAuthProviderSpec.scala
@@ -3,7 +3,9 @@ package auth
 
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import cats.data.NonEmptyList
-import cats.effect.IO
+import cats.effect.std.Dispatcher
+import cats.effect.{IO, Resource}
+import cats.effect.unsafe.implicits.global
 import cats.syntax.all._
 import org.broadinstitute.dsde.workbench.leonardo.CommonTestData._
 import org.broadinstitute.dsde.workbench.leonardo.KubernetesTestData._
@@ -36,376 +38,447 @@ class SamAuthProviderSpec extends AnyFlatSpec with LeonardoTestSuite with Before
   val authHeader = MockSamDAO.userEmailToAuthorization(userInfo.userEmail)
 
   var mockSam: MockSamDAO = _
-  var samAuthProvider: SamAuthProvider[IO] = _
-  var samAuthProviderWithCache: SamAuthProvider[IO] = _
+  var samAuthProviderResource: Resource[IO, SamAuthProvider[IO]] = for {
+    dispatcher <- Dispatcher[IO]
+    samDao = setUpMockSam()
+  } yield new SamAuthProvider(samDao, samAuthProviderConfigWithoutCache, serviceAccountProvider, dispatcher)
 
-  before {
-    setUpMockSam()
-    samAuthProvider = new SamAuthProvider(mockSam, samAuthProviderConfigWithoutCache, serviceAccountProvider, blocker)
-    samAuthProviderWithCache =
-      new SamAuthProvider(mockSam, samAuthProviderConfigWithCache, serviceAccountProvider, blocker)
+  var samAuthProviderWithCacheResource: Resource[IO, SamAuthProvider[IO]] = for {
+    dispatcher <- Dispatcher[IO]
+    samDao = setUpMockSam()
+  } yield new SamAuthProvider(samDao, samAuthProviderConfigWithCache, serviceAccountProvider, dispatcher)
 
-  }
+//
+//  before {
+//    setUpMockSam()
+//    samAuthProvider = new SamAuthProvider(mockSam, samAuthProviderConfigWithoutCache, serviceAccountProvider)
+//    samAuthProviderWithCache = new SamAuthProvider(mockSam, samAuthProviderConfigWithCache, serviceAccountProvider)
+//
+//  }
 
   "SamAuthProvider" should "check resource permissions" in {
-    // positive tests
-    ProjectAction.allActions.foreach { a =>
-      samAuthProvider
-        .hasPermission(ProjectSamResourceId(project), a, projectOwnerUserInfo)
-        .unsafeRunSync() shouldBe true
-    }
-    RuntimeAction.allActions.foreach { a =>
-      samAuthProvider.hasPermission(runtimeSamResource, a, userInfo).unsafeRunSync() shouldBe true
-    }
-    PersistentDiskAction.allActions.foreach { a =>
-      samAuthProvider.hasPermission(diskSamResource, a, userInfo).unsafeRunSync() shouldBe true
-    }
-    AppAction.allActions.foreach { a =>
-      samAuthProvider.hasPermission(appSamId, a, userInfo).unsafeRunSync() shouldBe true
-    }
-    MockSamDAO.appManagerActions.foreach { a =>
-      samAuthProvider.hasPermission(appSamId, a, projectOwnerUserInfo).unsafeRunSync() shouldBe true
-    }
+    samAuthProviderResource
+      .use { samAuthProvider =>
+        IO {
+          // positive tests
+          ProjectAction.allActions.foreach { a =>
+            samAuthProvider
+              .hasPermission(ProjectSamResourceId(project), a, projectOwnerUserInfo)
+              .unsafeRunSync() shouldBe true
+          }
+          RuntimeAction.allActions.foreach { a =>
+            samAuthProvider.hasPermission(runtimeSamResource, a, userInfo).unsafeRunSync() shouldBe true
+          }
+          PersistentDiskAction.allActions.foreach { a =>
+            samAuthProvider.hasPermission(diskSamResource, a, userInfo).unsafeRunSync() shouldBe true
+          }
+          AppAction.allActions.foreach { a =>
+            samAuthProvider.hasPermission(appSamId, a, userInfo).unsafeRunSync() shouldBe true
+          }
+          MockSamDAO.appManagerActions.foreach { a =>
+            samAuthProvider.hasPermission(appSamId, a, projectOwnerUserInfo).unsafeRunSync() shouldBe true
+          }
 
-    // negative tests
-    ProjectAction.allActions.foreach { a =>
-      samAuthProvider
-        .hasPermission(ProjectSamResourceId(project), a, unauthorizedUserInfo)
-        .unsafeRunSync() shouldBe false
-    }
-    RuntimeAction.allActions.foreach { a =>
-      samAuthProvider.hasPermission(runtimeSamResource, a, unauthorizedUserInfo).unsafeRunSync() shouldBe false
-      samAuthProvider.hasPermission(runtimeSamResource, a, projectOwnerUserInfo).unsafeRunSync() shouldBe false
-    }
-    PersistentDiskAction.allActions.foreach { a =>
-      samAuthProvider.hasPermission(diskSamResource, a, unauthorizedUserInfo).unsafeRunSync() shouldBe false
-      samAuthProvider.hasPermission(diskSamResource, a, projectOwnerUserInfo).unsafeRunSync() shouldBe false
-    }
-    AppAction.allActions.foreach { a =>
-      samAuthProvider.hasPermission(appSamId, a, unauthorizedUserInfo).unsafeRunSync() shouldBe false
-    }
+          // negative tests
+          ProjectAction.allActions.foreach { a =>
+            samAuthProvider
+              .hasPermission(ProjectSamResourceId(project), a, unauthorizedUserInfo)
+              .unsafeRunSync() shouldBe false
+          }
+          RuntimeAction.allActions.foreach { a =>
+            samAuthProvider.hasPermission(runtimeSamResource, a, unauthorizedUserInfo).unsafeRunSync() shouldBe false
+            samAuthProvider.hasPermission(runtimeSamResource, a, projectOwnerUserInfo).unsafeRunSync() shouldBe false
+          }
+          PersistentDiskAction.allActions.foreach { a =>
+            samAuthProvider.hasPermission(diskSamResource, a, unauthorizedUserInfo).unsafeRunSync() shouldBe false
+            samAuthProvider.hasPermission(diskSamResource, a, projectOwnerUserInfo).unsafeRunSync() shouldBe false
+          }
+          AppAction.allActions.foreach { a =>
+            samAuthProvider.hasPermission(appSamId, a, unauthorizedUserInfo).unsafeRunSync() shouldBe false
+          }
+        }
+      }
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+
   }
 
   it should "check resource permissions with project fallback" in {
-    // positive tests
-    List(
-      (RuntimeAction.GetRuntimeStatus, ProjectAction.GetRuntimeStatus),
-      (RuntimeAction.DeleteRuntime, ProjectAction.DeleteRuntime),
-      (RuntimeAction.StopStartRuntime, ProjectAction.StopStartRuntime)
-    ).foreach {
-      case (runtimeAction, projectAction) =>
-        // project fallback should work as the user
-        samAuthProvider
-          .hasPermissionWithProjectFallback(runtimeSamResource, runtimeAction, projectAction, userInfo, project)
-          .unsafeRunSync() shouldBe true
+    samAuthProviderResource
+      .use { samAuthProvider =>
+        IO {
+          // positive tests
+          List(
+            (RuntimeAction.GetRuntimeStatus, ProjectAction.GetRuntimeStatus),
+            (RuntimeAction.DeleteRuntime, ProjectAction.DeleteRuntime),
+            (RuntimeAction.StopStartRuntime, ProjectAction.StopStartRuntime)
+          ).foreach {
+            case (runtimeAction, projectAction) =>
+              // project fallback should work as the user
+              samAuthProvider
+                .hasPermissionWithProjectFallback(runtimeSamResource, runtimeAction, projectAction, userInfo, project)
+                .unsafeRunSync() shouldBe true
 
-        // project fallback should work as the project owner
-        samAuthProvider
-          .hasPermissionWithProjectFallback(runtimeSamResource,
-                                            runtimeAction,
-                                            projectAction,
-                                            projectOwnerUserInfo,
-                                            project)
-          .unsafeRunSync() shouldBe true
+              // project fallback should work as the project owner
+              samAuthProvider
+                .hasPermissionWithProjectFallback(runtimeSamResource,
+                                                  runtimeAction,
+                                                  projectAction,
+                                                  projectOwnerUserInfo,
+                                                  project)
+                .unsafeRunSync() shouldBe true
 
-    }
-    List(
-      (PersistentDiskAction.ReadPersistentDisk, ProjectAction.ReadPersistentDisk),
-      (PersistentDiskAction.DeletePersistentDisk, ProjectAction.DeletePersistentDisk)
-    ).foreach {
-      case (diskAction, projectAction) =>
-        // project fallback should work as the user
-        samAuthProvider
-          .hasPermissionWithProjectFallback(diskSamResource, diskAction, projectAction, userInfo, project)
-          .unsafeRunSync() shouldBe true
+          }
+          List(
+            (PersistentDiskAction.ReadPersistentDisk, ProjectAction.ReadPersistentDisk),
+            (PersistentDiskAction.DeletePersistentDisk, ProjectAction.DeletePersistentDisk)
+          ).foreach {
+            case (diskAction, projectAction) =>
+              // project fallback should work as the user
+              samAuthProvider
+                .hasPermissionWithProjectFallback(diskSamResource, diskAction, projectAction, userInfo, project)
+                .unsafeRunSync() shouldBe true
 
-        // project fallback should work as the project owner
-        samAuthProvider
-          .hasPermissionWithProjectFallback(diskSamResource, diskAction, projectAction, projectOwnerUserInfo, project)
-          .unsafeRunSync() shouldBe true
-    }
+              // project fallback should work as the project owner
+              samAuthProvider
+                .hasPermissionWithProjectFallback(diskSamResource,
+                                                  diskAction,
+                                                  projectAction,
+                                                  projectOwnerUserInfo,
+                                                  project)
+                .unsafeRunSync() shouldBe true
+          }
 
-    // negative tests
-    List(
-      (RuntimeAction.GetRuntimeStatus, ProjectAction.GetRuntimeStatus),
-      (RuntimeAction.DeleteRuntime, ProjectAction.DeleteRuntime),
-      (RuntimeAction.StopStartRuntime, ProjectAction.StopStartRuntime)
-    ).foreach {
-      case (runtimeAction, projectAction) =>
-        samAuthProvider
-          .hasPermissionWithProjectFallback(runtimeSamResource,
-                                            runtimeAction,
-                                            projectAction,
-                                            unauthorizedUserInfo,
-                                            project)
-          .unsafeRunSync() shouldBe false
-    }
-    List(
-      (PersistentDiskAction.ReadPersistentDisk, ProjectAction.ReadPersistentDisk),
-      (PersistentDiskAction.DeletePersistentDisk, ProjectAction.DeletePersistentDisk)
-    ).foreach {
-      case (diskAction, projectAction) =>
-        samAuthProvider
-          .hasPermissionWithProjectFallback(diskSamResource, diskAction, projectAction, unauthorizedUserInfo, project)
-          .unsafeRunSync() shouldBe false
-    }
+          // negative tests
+          List(
+            (RuntimeAction.GetRuntimeStatus, ProjectAction.GetRuntimeStatus),
+            (RuntimeAction.DeleteRuntime, ProjectAction.DeleteRuntime),
+            (RuntimeAction.StopStartRuntime, ProjectAction.StopStartRuntime)
+          ).foreach {
+            case (runtimeAction, projectAction) =>
+              samAuthProvider
+                .hasPermissionWithProjectFallback(runtimeSamResource,
+                                                  runtimeAction,
+                                                  projectAction,
+                                                  unauthorizedUserInfo,
+                                                  project)
+                .unsafeRunSync() shouldBe false
+          }
+          List(
+            (PersistentDiskAction.ReadPersistentDisk, ProjectAction.ReadPersistentDisk),
+            (PersistentDiskAction.DeletePersistentDisk, ProjectAction.DeletePersistentDisk)
+          ).foreach {
+            case (diskAction, projectAction) =>
+              samAuthProvider
+                .hasPermissionWithProjectFallback(diskSamResource,
+                                                  diskAction,
+                                                  projectAction,
+                                                  unauthorizedUserInfo,
+                                                  project)
+                .unsafeRunSync() shouldBe false
+          }
+        }
+      }
   }
 
   it should "get actions" in {
-    // positive tests
-    samAuthProvider
-      .getActions(ProjectSamResourceId(project), projectOwnerUserInfo)
-      .unsafeRunSync()
-      .toSet shouldBe ProjectAction.allActions
-    samAuthProvider.getActions(runtimeSamResource, userInfo).unsafeRunSync().toSet shouldBe RuntimeAction.allActions
-    samAuthProvider.getActions(diskSamResource, userInfo).unsafeRunSync().toSet shouldBe PersistentDiskAction.allActions
-    samAuthProvider.getActions(appSamId, userInfo).unsafeRunSync().toSet shouldBe AppAction.allActions
-    samAuthProvider
-      .getActions(appSamId, projectOwnerUserInfo)
-      .unsafeRunSync()
-      .toSet shouldBe MockSamDAO.appManagerActions
+    samAuthProviderResource
+      .use { samAuthProvider =>
+        IO {
+          // positive tests
+          samAuthProvider
+            .getActions(ProjectSamResourceId(project), projectOwnerUserInfo)
+            .unsafeRunSync()
+            .toSet shouldBe ProjectAction.allActions
+          samAuthProvider
+            .getActions(runtimeSamResource, userInfo)
+            .unsafeRunSync()
+            .toSet shouldBe RuntimeAction.allActions
+          samAuthProvider
+            .getActions(diskSamResource, userInfo)
+            .unsafeRunSync()
+            .toSet shouldBe PersistentDiskAction.allActions
+          samAuthProvider.getActions(appSamId, userInfo).unsafeRunSync().toSet shouldBe AppAction.allActions
+          samAuthProvider
+            .getActions(appSamId, projectOwnerUserInfo)
+            .unsafeRunSync()
+            .toSet shouldBe MockSamDAO.appManagerActions
 
-    // negative tests
-    samAuthProvider.getActions(ProjectSamResourceId(project), unauthorizedUserInfo).unsafeRunSync() shouldBe List.empty
-    samAuthProvider.getActions(runtimeSamResource, unauthorizedUserInfo).unsafeRunSync() shouldBe List.empty
-    samAuthProvider.getActions(runtimeSamResource, projectOwnerUserInfo).unsafeRunSync() shouldBe List.empty
-    samAuthProvider.getActions(diskSamResource, unauthorizedUserInfo).unsafeRunSync() shouldBe List.empty
-    samAuthProvider.getActions(diskSamResource, projectOwnerUserInfo).unsafeRunSync() shouldBe List.empty
-    samAuthProvider.getActions(appSamId, unauthorizedUserInfo).unsafeRunSync() shouldBe List.empty
+          // negative tests
+          samAuthProvider
+            .getActions(ProjectSamResourceId(project), unauthorizedUserInfo)
+            .unsafeRunSync() shouldBe List.empty
+          samAuthProvider.getActions(runtimeSamResource, unauthorizedUserInfo).unsafeRunSync() shouldBe List.empty
+          samAuthProvider.getActions(runtimeSamResource, projectOwnerUserInfo).unsafeRunSync() shouldBe List.empty
+          samAuthProvider.getActions(diskSamResource, unauthorizedUserInfo).unsafeRunSync() shouldBe List.empty
+          samAuthProvider.getActions(diskSamResource, projectOwnerUserInfo).unsafeRunSync() shouldBe List.empty
+          samAuthProvider.getActions(appSamId, unauthorizedUserInfo).unsafeRunSync() shouldBe List.empty
+        }
+      }
   }
 
   it should "get actions with project fallback" in {
-    // positive tests
-    samAuthProvider
-      .getActionsWithProjectFallback(runtimeSamResource, project, userInfo)
-      .unsafeRunSync()
-      .leftMap(_.toSet) shouldBe (RuntimeAction.allActions, List.empty)
-    samAuthProvider
-      .getActionsWithProjectFallback(runtimeSamResource, project, projectOwnerUserInfo)
-      .unsafeRunSync()
-      .map(_.toSet) shouldBe (List.empty, ProjectAction.allActions)
-    samAuthProvider
-      .getActionsWithProjectFallback(diskSamResource, project, userInfo)
-      .unsafeRunSync()
-      .leftMap(_.toSet) shouldBe (PersistentDiskAction.allActions, List.empty)
-    samAuthProvider
-      .getActionsWithProjectFallback(diskSamResource, project, projectOwnerUserInfo)
-      .unsafeRunSync()
-      .map(_.toSet) shouldBe (List.empty, ProjectAction.allActions)
+    samAuthProviderResource
+      .use { samAuthProvider =>
+        IO {
+          // positive tests
+          samAuthProvider
+            .getActionsWithProjectFallback(runtimeSamResource, project, userInfo)
+            .unsafeRunSync()
+            .leftMap(_.toSet) shouldBe (RuntimeAction.allActions, List.empty)
+          samAuthProvider
+            .getActionsWithProjectFallback(runtimeSamResource, project, projectOwnerUserInfo)
+            .unsafeRunSync()
+            .map(_.toSet) shouldBe (List.empty, ProjectAction.allActions)
+          samAuthProvider
+            .getActionsWithProjectFallback(diskSamResource, project, userInfo)
+            .unsafeRunSync()
+            .leftMap(_.toSet) shouldBe (PersistentDiskAction.allActions, List.empty)
+          samAuthProvider
+            .getActionsWithProjectFallback(diskSamResource, project, projectOwnerUserInfo)
+            .unsafeRunSync()
+            .map(_.toSet) shouldBe (List.empty, ProjectAction.allActions)
 
-    // negative tests
-    samAuthProvider
-      .getActionsWithProjectFallback(runtimeSamResource, project, unauthorizedUserInfo)
-      .unsafeRunSync() shouldBe (List.empty, List.empty)
-    samAuthProvider
-      .getActionsWithProjectFallback(diskSamResource, project, unauthorizedUserInfo)
-      .unsafeRunSync() shouldBe (List.empty, List.empty)
+          // negative tests
+          samAuthProvider
+            .getActionsWithProjectFallback(runtimeSamResource, project, unauthorizedUserInfo)
+            .unsafeRunSync() shouldBe (List.empty, List.empty)
+          samAuthProvider
+            .getActionsWithProjectFallback(diskSamResource, project, unauthorizedUserInfo)
+            .unsafeRunSync() shouldBe (List.empty, List.empty)
+        }
+      }
   }
 
   it should "cache hasPermission results" in {
-    // cache should be empty
-    samAuthProviderWithCache.authCache.size shouldBe 0
+    samAuthProviderWithCacheResource
+      .use { samAuthProviderWithCache =>
+        IO {
+          // cache should be empty
+          samAuthProviderWithCache.authCache.size shouldBe 0
 
-    // these actions should be cached
-    List(ProjectAction.GetRuntimeStatus, ProjectAction.ReadPersistentDisk).foreach { a =>
-      samAuthProviderWithCache
-        .hasPermission(ProjectSamResourceId(project), a, projectOwnerUserInfo)
-        .unsafeRunSync() shouldBe true
-    }
-    List(RuntimeAction.GetRuntimeStatus, RuntimeAction.ConnectToRuntime).foreach { a =>
-      samAuthProviderWithCache
-        .hasPermission(runtimeSamResource, a, userInfo)
-        .unsafeRunSync() shouldBe true
-      samAuthProviderWithCache
-        .hasPermission(runtimeSamResource, a, userInfo)
-        .unsafeRunSync() shouldBe true
-    }
-    List(PersistentDiskAction.ReadPersistentDisk).foreach { a =>
-      samAuthProviderWithCache
-        .hasPermission(diskSamResource, a, userInfo)
-        .unsafeRunSync() shouldBe true
-    }
-    List(AppAction.ConnectToApp, AppAction.GetAppStatus).foreach { a =>
-      samAuthProviderWithCache.hasPermission(appSamId, a, userInfo).unsafeRunSync() shouldBe true
-    }
+          // these actions should be cached
+          List(ProjectAction.GetRuntimeStatus, ProjectAction.ReadPersistentDisk).foreach { a =>
+            samAuthProviderWithCache
+              .hasPermission(ProjectSamResourceId(project), a, projectOwnerUserInfo)
+              .unsafeRunSync() shouldBe true
+          }
+          List(RuntimeAction.GetRuntimeStatus, RuntimeAction.ConnectToRuntime).foreach { a =>
+            samAuthProviderWithCache
+              .hasPermission(runtimeSamResource, a, userInfo)
+              .unsafeRunSync() shouldBe true
+            samAuthProviderWithCache
+              .hasPermission(runtimeSamResource, a, userInfo)
+              .unsafeRunSync() shouldBe true
+          }
+          List(PersistentDiskAction.ReadPersistentDisk).foreach { a =>
+            samAuthProviderWithCache
+              .hasPermission(diskSamResource, a, userInfo)
+              .unsafeRunSync() shouldBe true
+          }
+          List(AppAction.ConnectToApp, AppAction.GetAppStatus).foreach { a =>
+            samAuthProviderWithCache.hasPermission(appSamId, a, userInfo).unsafeRunSync() shouldBe true
+          }
 
-    // these actions should not be cached
-    List(
-      ProjectAction.CreateApp,
-      ProjectAction.CreatePersistentDisk,
-      ProjectAction.CreateRuntime,
-      ProjectAction.DeletePersistentDisk,
-      ProjectAction.DeleteRuntime,
-      ProjectAction.StopStartRuntime
-    ).foreach { a =>
-      samAuthProviderWithCache
-        .hasPermission(ProjectSamResourceId(project), a, projectOwnerUserInfo)
-        .unsafeRunSync() shouldBe true
-    }
-    List(RuntimeAction.ModifyRuntime, RuntimeAction.DeleteRuntime, RuntimeAction.StopStartRuntime).foreach { a =>
-      samAuthProviderWithCache
-        .hasPermission(runtimeSamResource, a, userInfo)
-        .unsafeRunSync() shouldBe true
-    }
-    List(PersistentDiskAction.DeletePersistentDisk,
-         PersistentDiskAction.ModifyPersistentDisk,
-         PersistentDiskAction.AttachPersistentDisk).foreach { a =>
-      samAuthProviderWithCache
-        .hasPermission(diskSamResource, a, userInfo)
-        .unsafeRunSync() shouldBe true
-    }
-    List(AppAction.DeleteApp, AppAction.UpdateApp).foreach { a =>
-      samAuthProviderWithCache
-        .hasPermission(appSamId, a, userInfo)
-        .unsafeRunSync() shouldBe true
-    }
+          // these actions should not be cached
+          List(
+            ProjectAction.CreateApp,
+            ProjectAction.CreatePersistentDisk,
+            ProjectAction.CreateRuntime,
+            ProjectAction.DeletePersistentDisk,
+            ProjectAction.DeleteRuntime,
+            ProjectAction.StopStartRuntime
+          ).foreach { a =>
+            samAuthProviderWithCache
+              .hasPermission(ProjectSamResourceId(project), a, projectOwnerUserInfo)
+              .unsafeRunSync() shouldBe true
+          }
+          List(RuntimeAction.ModifyRuntime, RuntimeAction.DeleteRuntime, RuntimeAction.StopStartRuntime).foreach { a =>
+            samAuthProviderWithCache
+              .hasPermission(runtimeSamResource, a, userInfo)
+              .unsafeRunSync() shouldBe true
+          }
+          List(PersistentDiskAction.DeletePersistentDisk,
+               PersistentDiskAction.ModifyPersistentDisk,
+               PersistentDiskAction.AttachPersistentDisk).foreach { a =>
+            samAuthProviderWithCache
+              .hasPermission(diskSamResource, a, userInfo)
+              .unsafeRunSync() shouldBe true
+          }
+          List(AppAction.DeleteApp, AppAction.UpdateApp).foreach { a =>
+            samAuthProviderWithCache
+              .hasPermission(appSamId, a, userInfo)
+              .unsafeRunSync() shouldBe true
+          }
 
-    // check cache
-    samAuthProviderWithCache.authCache.size shouldBe 7
-    samAuthProviderWithCache.authCache.asMap().asScala.keySet shouldBe
-      Set(
-        AuthCacheKey(SamResourceType.Project,
-                     project.value,
-                     projectOwnerAuthHeader,
-                     ProjectAction.GetRuntimeStatus.asString),
-        AuthCacheKey(SamResourceType.Project,
-                     project.value,
-                     projectOwnerAuthHeader,
-                     ProjectAction.ReadPersistentDisk.asString),
-        AuthCacheKey(SamResourceType.Runtime,
-                     runtimeSamResource.resourceId,
-                     authHeader,
-                     RuntimeAction.ConnectToRuntime.asString),
-        AuthCacheKey(SamResourceType.Runtime,
-                     runtimeSamResource.resourceId,
-                     authHeader,
-                     RuntimeAction.GetRuntimeStatus.asString),
-        AuthCacheKey(SamResourceType.PersistentDisk,
-                     diskSamResource.resourceId,
-                     authHeader,
-                     PersistentDiskAction.ReadPersistentDisk.asString),
-        AuthCacheKey(SamResourceType.App, appSamId.resourceId, authHeader, AppAction.GetAppStatus.asString),
-        AuthCacheKey(SamResourceType.App, appSamId.resourceId, authHeader, AppAction.ConnectToApp.asString)
-      )
-    samAuthProviderWithCache.authCache.asMap().asScala.values.toSet shouldBe Set(true)
+          // check cache
+          samAuthProviderWithCache.authCache.size shouldBe 7
+          samAuthProviderWithCache.authCache.asMap().asScala.keySet shouldBe
+            Set(
+              AuthCacheKey(SamResourceType.Project,
+                           project.value,
+                           projectOwnerAuthHeader,
+                           ProjectAction.GetRuntimeStatus.asString),
+              AuthCacheKey(SamResourceType.Project,
+                           project.value,
+                           projectOwnerAuthHeader,
+                           ProjectAction.ReadPersistentDisk.asString),
+              AuthCacheKey(SamResourceType.Runtime,
+                           runtimeSamResource.resourceId,
+                           authHeader,
+                           RuntimeAction.ConnectToRuntime.asString),
+              AuthCacheKey(SamResourceType.Runtime,
+                           runtimeSamResource.resourceId,
+                           authHeader,
+                           RuntimeAction.GetRuntimeStatus.asString),
+              AuthCacheKey(SamResourceType.PersistentDisk,
+                           diskSamResource.resourceId,
+                           authHeader,
+                           PersistentDiskAction.ReadPersistentDisk.asString),
+              AuthCacheKey(SamResourceType.App, appSamId.resourceId, authHeader, AppAction.GetAppStatus.asString),
+              AuthCacheKey(SamResourceType.App, appSamId.resourceId, authHeader, AppAction.ConnectToApp.asString)
+            )
+          samAuthProviderWithCache.authCache.asMap().asScala.values.toSet shouldBe Set(true)
+        }
+      }
   }
 
   it should "create a resource" in {
-    val newRuntime = RuntimeSamResourceId("new_runtime")
-    samAuthProvider.notifyResourceCreated(newRuntime, userEmail, project).unsafeRunSync()
-    mockSam.runtimes.get((newRuntime, authHeader)) shouldBe Some(
-      RuntimeAction.allActions
-    )
+    samAuthProviderResource
+      .use { samAuthProvider =>
+        IO {
+          val newRuntime = RuntimeSamResourceId("new_runtime")
+          samAuthProvider.notifyResourceCreated(newRuntime, userEmail, project).unsafeRunSync()
+          mockSam.runtimes.get((newRuntime, authHeader)) shouldBe Some(
+            RuntimeAction.allActions
+          )
 
-    val newDisk = PersistentDiskSamResourceId("new_disk")
-    samAuthProvider.notifyResourceCreated(newDisk, userEmail, project).unsafeRunSync()
-    mockSam.persistentDisks.get((newDisk, authHeader)) shouldBe Some(
-      PersistentDiskAction.allActions
-    )
+          val newDisk = PersistentDiskSamResourceId("new_disk")
+          samAuthProvider.notifyResourceCreated(newDisk, userEmail, project).unsafeRunSync()
+          mockSam.persistentDisks.get((newDisk, authHeader)) shouldBe Some(
+            PersistentDiskAction.allActions
+          )
 
-    val newApp = AppSamResourceId("new_app")
-    samAuthProvider.notifyResourceCreated(newApp, userEmail, project).unsafeRunSync()
-    mockSam.apps.get((newApp, authHeader)) shouldBe Some(
-      AppAction.allActions
-    )
-    mockSam.apps.get((newApp, projectOwnerAuthHeader)) shouldBe Some(
-      MockSamDAO.appManagerActions
-    )
+          val newApp = AppSamResourceId("new_app")
+          samAuthProvider.notifyResourceCreated(newApp, userEmail, project).unsafeRunSync()
+          mockSam.apps.get((newApp, authHeader)) shouldBe Some(
+            AppAction.allActions
+          )
+          mockSam.apps.get((newApp, projectOwnerAuthHeader)) shouldBe Some(
+            MockSamDAO.appManagerActions
+          )
+        }
+      }
   }
 
   it should "delete a resource" in {
-    samAuthProvider.notifyResourceDeleted(runtimeSamResource, userEmail, project).unsafeRunSync()
-    mockSam.runtimes.get((runtimeSamResource, authHeader)) shouldBe None
+    samAuthProviderResource
+      .use { samAuthProvider =>
+        IO {
+          samAuthProvider.notifyResourceDeleted(runtimeSamResource, userEmail, project).unsafeRunSync()
+          mockSam.runtimes.get((runtimeSamResource, authHeader)) shouldBe None
 
-    samAuthProvider.notifyResourceDeleted(diskSamResource, userEmail, project).unsafeRunSync()
-    mockSam.persistentDisks.get((diskSamResource, authHeader)) shouldBe None
+          samAuthProvider.notifyResourceDeleted(diskSamResource, userEmail, project).unsafeRunSync()
+          mockSam.persistentDisks.get((diskSamResource, authHeader)) shouldBe None
 
-    samAuthProvider.notifyResourceDeleted(appSamId, userEmail, project).unsafeRunSync()
-    mockSam.apps.get((appSamId, authHeader)) shouldBe None
-    mockSam.apps.get((appSamId, projectOwnerAuthHeader)) shouldBe None
+          samAuthProvider.notifyResourceDeleted(appSamId, userEmail, project).unsafeRunSync()
+          mockSam.apps.get((appSamId, authHeader)) shouldBe None
+          mockSam.apps.get((appSamId, projectOwnerAuthHeader)) shouldBe None
+        }
+      }
   }
 
   it should "filter user visible resources" in {
-    // positive tests
-    val newRuntime = RuntimeSamResourceId("new_runtime")
-    mockSam.createResource(newRuntime, userEmail2, project).unsafeRunSync()
-    samAuthProvider
-      .filterUserVisible(NonEmptyList.of(runtimeSamResource, newRuntime), userInfo)
-      .unsafeRunSync() shouldBe List(
-      runtimeSamResource
-    )
+    samAuthProviderResource
+      .use { samAuthProvider =>
+        IO {
+          // positive tests
+          val newRuntime = RuntimeSamResourceId("new_runtime")
+          mockSam.createResource(newRuntime, userEmail2, project).unsafeRunSync()
+          samAuthProvider
+            .filterUserVisible(NonEmptyList.of(runtimeSamResource, newRuntime), userInfo)
+            .unsafeRunSync() shouldBe List(
+            runtimeSamResource
+          )
 
-    val newDisk = PersistentDiskSamResourceId("new_disk")
-    mockSam.createResource(newDisk, userEmail2, project).unsafeRunSync()
-    samAuthProvider
-      .filterUserVisible(NonEmptyList.of(diskSamResource, newDisk), userInfo)
-      .unsafeRunSync() shouldBe List(
-      diskSamResource
-    )
+          val newDisk = PersistentDiskSamResourceId("new_disk")
+          mockSam.createResource(newDisk, userEmail2, project).unsafeRunSync()
+          samAuthProvider
+            .filterUserVisible(NonEmptyList.of(diskSamResource, newDisk), userInfo)
+            .unsafeRunSync() shouldBe List(
+            diskSamResource
+          )
 
-    val newApp = AppSamResourceId("new_app")
-    mockSam.createResourceWithParent(newApp, userEmail2, project).unsafeRunSync()
-    samAuthProvider.filterUserVisible(NonEmptyList.of(appSamId, newApp), userInfo).unsafeRunSync() shouldBe List(
-      appSamId
-    )
-    samAuthProvider
-      .filterUserVisible(NonEmptyList.of(appSamId, newApp), projectOwnerUserInfo)
-      .unsafeRunSync() shouldBe List(
-      appSamId,
-      newApp
-    )
+          val newApp = AppSamResourceId("new_app")
+          mockSam.createResourceWithParent(newApp, userEmail2, project).unsafeRunSync()
+          samAuthProvider.filterUserVisible(NonEmptyList.of(appSamId, newApp), userInfo).unsafeRunSync() shouldBe List(
+            appSamId
+          )
+          samAuthProvider
+            .filterUserVisible(NonEmptyList.of(appSamId, newApp), projectOwnerUserInfo)
+            .unsafeRunSync() shouldBe List(
+            appSamId,
+            newApp
+          )
 
-    // negative tests
-    samAuthProvider
-      .filterUserVisible(NonEmptyList.of(runtimeSamResource, newRuntime), unauthorizedUserInfo)
-      .unsafeRunSync() shouldBe List.empty
-    samAuthProvider
-      .filterUserVisible(NonEmptyList.of(runtimeSamResource, newRuntime), projectOwnerUserInfo)
-      .unsafeRunSync() shouldBe List.empty
-    samAuthProvider
-      .filterUserVisible(NonEmptyList.of(diskSamResource, newDisk), unauthorizedUserInfo)
-      .unsafeRunSync() shouldBe List.empty
-    samAuthProvider
-      .filterUserVisible(NonEmptyList.of(diskSamResource, newDisk), projectOwnerUserInfo)
-      .unsafeRunSync() shouldBe List.empty
-    samAuthProvider
-      .filterUserVisible(NonEmptyList.of(appSamId, newApp), unauthorizedUserInfo)
-      .unsafeRunSync() shouldBe List.empty
+          // negative tests
+          samAuthProvider
+            .filterUserVisible(NonEmptyList.of(runtimeSamResource, newRuntime), unauthorizedUserInfo)
+            .unsafeRunSync() shouldBe List.empty
+          samAuthProvider
+            .filterUserVisible(NonEmptyList.of(runtimeSamResource, newRuntime), projectOwnerUserInfo)
+            .unsafeRunSync() shouldBe List.empty
+          samAuthProvider
+            .filterUserVisible(NonEmptyList.of(diskSamResource, newDisk), unauthorizedUserInfo)
+            .unsafeRunSync() shouldBe List.empty
+          samAuthProvider
+            .filterUserVisible(NonEmptyList.of(diskSamResource, newDisk), projectOwnerUserInfo)
+            .unsafeRunSync() shouldBe List.empty
+          samAuthProvider
+            .filterUserVisible(NonEmptyList.of(appSamId, newApp), unauthorizedUserInfo)
+            .unsafeRunSync() shouldBe List.empty
+        }
+      }
   }
 
   it should "filter user visible resources with project fallback" in {
-    // positive tests
-    val newRuntime = RuntimeSamResourceId("new_runtime")
-    mockSam.createResource(newRuntime, userEmail2, project).unsafeRunSync()
-    samAuthProvider
-      .filterUserVisibleWithProjectFallback(NonEmptyList.of((project, runtimeSamResource), (project, newRuntime)),
-                                            userInfo)
-      .unsafeRunSync() shouldBe List((project, runtimeSamResource))
-    samAuthProvider
-      .filterUserVisibleWithProjectFallback(NonEmptyList.of((project, runtimeSamResource), (project, newRuntime)),
-                                            projectOwnerUserInfo)
-      .unsafeRunSync() shouldBe List((project, runtimeSamResource), (project, newRuntime))
+    samAuthProviderResource
+      .use { samAuthProvider =>
+        IO {
+          // positive tests
+          val newRuntime = RuntimeSamResourceId("new_runtime")
+          mockSam.createResource(newRuntime, userEmail2, project).unsafeRunSync()
+          samAuthProvider
+            .filterUserVisibleWithProjectFallback(NonEmptyList.of((project, runtimeSamResource), (project, newRuntime)),
+                                                  userInfo)
+            .unsafeRunSync() shouldBe List((project, runtimeSamResource))
+          samAuthProvider
+            .filterUserVisibleWithProjectFallback(NonEmptyList.of((project, runtimeSamResource), (project, newRuntime)),
+                                                  projectOwnerUserInfo)
+            .unsafeRunSync() shouldBe List((project, runtimeSamResource), (project, newRuntime))
 
-    val newDisk = PersistentDiskSamResourceId("new_disk")
-    mockSam.createResource(newDisk, userEmail2, project).unsafeRunSync()
-    samAuthProvider
-      .filterUserVisibleWithProjectFallback(NonEmptyList.of((project, diskSamResource), (project, newDisk)), userInfo)
-      .unsafeRunSync() shouldBe List((project, diskSamResource))
-    samAuthProvider
-      .filterUserVisibleWithProjectFallback(NonEmptyList.of((project, diskSamResource), (project, newDisk)),
-                                            projectOwnerUserInfo)
-      .unsafeRunSync() shouldBe List((project, diskSamResource), (project, newDisk))
+          val newDisk = PersistentDiskSamResourceId("new_disk")
+          mockSam.createResource(newDisk, userEmail2, project).unsafeRunSync()
+          samAuthProvider
+            .filterUserVisibleWithProjectFallback(NonEmptyList.of((project, diskSamResource), (project, newDisk)),
+                                                  userInfo)
+            .unsafeRunSync() shouldBe List((project, diskSamResource))
+          samAuthProvider
+            .filterUserVisibleWithProjectFallback(NonEmptyList.of((project, diskSamResource), (project, newDisk)),
+                                                  projectOwnerUserInfo)
+            .unsafeRunSync() shouldBe List((project, diskSamResource), (project, newDisk))
 
-    // negative tests
-    samAuthProvider
-      .filterUserVisible(NonEmptyList.of(runtimeSamResource, newRuntime), unauthorizedUserInfo)
-      .unsafeRunSync() shouldBe List.empty
-    samAuthProvider
-      .filterUserVisible(NonEmptyList.of(diskSamResource, newDisk), unauthorizedUserInfo)
-      .unsafeRunSync() shouldBe List.empty
+          // negative tests
+          samAuthProvider
+            .filterUserVisible(NonEmptyList.of(runtimeSamResource, newRuntime), unauthorizedUserInfo)
+            .unsafeRunSync() shouldBe List.empty
+          samAuthProvider
+            .filterUserVisible(NonEmptyList.of(diskSamResource, newDisk), unauthorizedUserInfo)
+            .unsafeRunSync() shouldBe List.empty
+        }
+      }
   }
 
-  private def setUpMockSam(): Unit = {
+  private def setUpMockSam(): SamDAO[IO] = {
     mockSam = new MockSamDAO
     // set up mock sam with a project, runtime, disk, and app
     mockSam.createResource(ProjectSamResourceId(project), MockSamDAO.projectOwnerEmail, project).unsafeRunSync()
@@ -429,5 +502,6 @@ class SamAuthProviderSpec extends AnyFlatSpec with LeonardoTestSuite with Before
     mockSam.apps.get((appSamId, projectOwnerAuthHeader)) shouldBe Some(
       MockSamDAO.appManagerActions
     )
+    mockSam
   }
 }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/config/ConfigSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/config/ConfigSpec.scala
@@ -25,6 +25,14 @@ final class ConfigSpec extends AnyFlatSpec with Matchers {
         PollMonitorConfig(5, 3 seconds),
         PollMonitorConfig(5, 3 seconds),
         PollMonitorConfig(5, 3 seconds)
+      ),
+      GalaxyDiskConfig(
+        "nfs-disk",
+        DiskSize(100),
+        "postgres-disk",
+        "gxy-postres-disk",
+        DiskSize(10),
+        BlockSize(4096)
       )
     )
 

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HTTPAppDescriptorDAOSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HTTPAppDescriptorDAOSpec.scala
@@ -9,7 +9,7 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.http4s.client.Client
 import org.http4s._
-import org.http4s.client.blaze.BlazeClientBuilder
+import org.http4s.blaze.client.BlazeClientBuilder
 
 import scala.concurrent.ExecutionContext.global
 
@@ -45,7 +45,7 @@ class HTTPAppDescriptorDAOSpec extends AnyFlatSpec with Matchers with BeforeAndA
 
     withStubbedAppDescriptorDAO(
       rstudioRespYaml, { dao =>
-        val descriptor = dao.getDescriptor(dummyRequestURI).unsafeRunSync()
+        val descriptor = dao.getDescriptor(dummyRequestURI).unsafeRunSync()(cats.effect.unsafe.implicits.global)
         descriptor.author shouldBe "workbench-interactive-analysis@broadinstitute.org"
         descriptor.description should include("RStudio")
         descriptor.name shouldBe "rstudio"
@@ -80,7 +80,7 @@ class HTTPAppDescriptorDAOSpec extends AnyFlatSpec with Matchers with BeforeAndA
 
     val appDAOResource = new HttpAppDescriptorDAO[IO](clientWithLogging)
 
-    IO(testCode(appDAOResource)).unsafeRunSync()
+    IO(testCode(appDAOResource)).unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   //allows http retrieval
@@ -90,6 +90,6 @@ class HTTPAppDescriptorDAOSpec extends AnyFlatSpec with Matchers with BeforeAndA
       clientWithLogging = Logger[IO](logHeaders = true, logBody = false)(client)
     } yield new HttpAppDescriptorDAO[IO](clientWithLogging)
 
-    daoResource.use(dao => IO(testCode(dao))).unsafeRunSync()
+    daoResource.use(dao => IO(testCode(dao))).unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HTTPAppDescriptorDAOSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HTTPAppDescriptorDAOSpec.scala
@@ -45,7 +45,7 @@ class HTTPAppDescriptorDAOSpec extends AnyFlatSpec with Matchers with BeforeAndA
 
     withStubbedAppDescriptorDAO(
       rstudioRespYaml, { dao =>
-        val descriptor = dao.getDescriptor(dummyRequestURI).unsafeRunSync()(cats.effect.unsafe.implicits.global)
+        val descriptor = dao.getDescriptor(dummyRequestURI).unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
         descriptor.author shouldBe "workbench-interactive-analysis@broadinstitute.org"
         descriptor.description should include("RStudio")
         descriptor.name shouldBe "rstudio"
@@ -80,7 +80,7 @@ class HTTPAppDescriptorDAOSpec extends AnyFlatSpec with Matchers with BeforeAndA
 
     val appDAOResource = new HttpAppDescriptorDAO[IO](clientWithLogging)
 
-    IO(testCode(appDAOResource)).unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    IO(testCode(appDAOResource)).unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   //allows http retrieval
@@ -90,6 +90,6 @@ class HTTPAppDescriptorDAOSpec extends AnyFlatSpec with Matchers with BeforeAndA
       clientWithLogging = Logger[IO](logHeaders = true, logBody = false)(client)
     } yield new HttpAppDescriptorDAO[IO](clientWithLogging)
 
-    daoResource.use(dao => IO(testCode(dao))).unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    daoResource.use(dao => IO(testCode(dao))).unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpDockerDAOSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpDockerDAOSpec.scala
@@ -89,7 +89,7 @@ class HttpDockerDAOSpec extends AnyFlatSpec with Matchers with BeforeAndAfterAll
     } yield {
       response shouldBe Left(ImageParseException(ctx.traceId, image))
     }
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   it should s"detect invalid GCR image if image doesn't have proper environment variables set" in withDockerDAO {
@@ -101,7 +101,7 @@ class HttpDockerDAOSpec extends AnyFlatSpec with Matchers with BeforeAndAfterAll
       } yield {
         response shouldBe Left(InvalidImage(ctx.traceId, image, None))
       }
-      res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+      res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   it should s"detect invalid dockerhub image if image doesn't have proper environment variables set" in withDockerDAO {
@@ -113,7 +113,7 @@ class HttpDockerDAOSpec extends AnyFlatSpec with Matchers with BeforeAndAfterAll
       } yield {
         response shouldBe Left(InvalidImage(ctx.traceId, image, None))
       }
-      res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+      res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   it should "detect invalid ghcr image if image doesn't have proper environment variables set" in withDockerDAO {
@@ -125,7 +125,7 @@ class HttpDockerDAOSpec extends AnyFlatSpec with Matchers with BeforeAndAfterAll
       } yield {
         response.isLeft shouldBe true
       }
-      res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+      res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   it should "correctly decode 'container_config' field from Docker API response if it exists" in {

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpJupyterDAOSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpJupyterDAOSpec.scala
@@ -5,7 +5,6 @@ import cats.effect.IO
 import com.github.benmanes.caffeine.cache.Caffeine
 import io.circe.parser
 import org.broadinstitute.dsde.workbench.leonardo.CommonTestData._
-import org.broadinstitute.dsde.workbench.leonardo.config.Config
 import org.broadinstitute.dsde.workbench.leonardo.dao.ExecutionState.Idle
 import org.broadinstitute.dsde.workbench.leonardo.dao.HttpJupyterDAO.sessionDecoder
 import org.broadinstitute.dsde.workbench.leonardo.db.TestComponent
@@ -67,11 +66,7 @@ class HttpJupyterDAOSpec extends AnyFlatSpec with Matchers with LeonardoTestSuit
 
   it should "return true for isAllKernelsIdle if host is down" in {
     val clusterDnsCache =
-      new RuntimeDnsCache(proxyConfig,
-                          testDbRef,
-                          Config.runtimeDnsCacheConfig,
-                          hostToIpMapping,
-                          runtimeDnsCaffeineCache)
+      new RuntimeDnsCache(proxyConfig, testDbRef, hostToIpMapping, runtimeDnsCaffeineCache)
 
     val jupyterDAO = new HttpJupyterDAO(clusterDnsCache, FakeHttpClient.client)
     val res = jupyterDAO.isAllKernelsIdle(GoogleProject("project1"), RuntimeName("rt"))

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpJupyterDAOSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpJupyterDAOSpec.scala
@@ -70,6 +70,6 @@ class HttpJupyterDAOSpec extends AnyFlatSpec with Matchers with LeonardoTestSuit
 
     val jupyterDAO = new HttpJupyterDAO(clusterDnsCache, FakeHttpClient.client)
     val res = jupyterDAO.isAllKernelsIdle(GoogleProject("project1"), RuntimeName("rt"))
-    res.map(r => r shouldBe true).unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.map(r => r shouldBe true).unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpSamDAOSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpSamDAOSpec.scala
@@ -153,7 +153,7 @@ class HttpSamDAOSpec extends AnyFlatSpec with LeonardoTestSuite with BeforeAndAf
       }
     }
 
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 }
 

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpSamDAOSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpSamDAOSpec.scala
@@ -1,12 +1,12 @@
 package org.broadinstitute.dsde.workbench.leonardo
 package dao
 
-import java.nio.file.Paths
 import cats.effect.IO
 import cats.effect.std.Dispatcher
 import cats.effect.unsafe.implicits.global
-import org.typelevel.log4cats.slf4j.Slf4jLogger
+import com.github.benmanes.caffeine.cache.Caffeine
 import io.circe.parser._
+import org.broadinstitute.dsde.workbench.leonardo.config.Config.httpSamDaoConfig
 import org.broadinstitute.dsde.workbench.leonardo.model.ServiceAccountProviderConfig
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
 import org.broadinstitute.dsde.workbench.util.health.Subsystems.{GoogleGroups, GoogleIam, GooglePubSub, OpenDJ}
@@ -17,7 +17,10 @@ import org.http4s.client.Client
 import org.http4s.client.middleware.{Retry, RetryPolicy}
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.flatspec.AnyFlatSpec
+import org.typelevel.log4cats.slf4j.Slf4jLogger
+import scalacache.caffeine.CaffeineCache
 
+import java.nio.file.Paths
 import scala.concurrent.duration._
 import scala.util.control.NoStackTrace
 
@@ -28,6 +31,11 @@ class HttpSamDAOSpec extends AnyFlatSpec with LeonardoTestSuite with BeforeAndAf
                                 10,
                                 ServiceAccountProviderConfig(Paths.get("test"), WorkbenchEmail("test")))
   implicit def unsafeLogger = Slf4jLogger.getLogger[IO]
+  val underlyingPetTokenCache = Caffeine
+    .newBuilder()
+    .maximumSize(httpSamDaoConfig.petCacheMaxSize)
+    .build[String, scalacache.Entry[Option[String]]]()
+  val petTokenCache = CaffeineCache[IO, Option[String]](underlyingPetTokenCache)
 
   "HttpSamDAO" should "get Sam ok status" in {
     val okResponse =
@@ -56,7 +64,7 @@ class HttpSamDAOSpec extends AnyFlatSpec with LeonardoTestSuite with BeforeAndAf
     )
 
     val res = Dispatcher[IO].use { d =>
-      val samDao = new HttpSamDAO(okSam, config, d)
+      val samDao = new HttpSamDAO(okSam, config, petTokenCache)
       val expectedResponse = StatusCheckResponse(
         true,
         Map(
@@ -73,27 +81,22 @@ class HttpSamDAOSpec extends AnyFlatSpec with LeonardoTestSuite with BeforeAndAf
   }
 
   it should "get Sam ok status with no systems" in {
-    val res = Dispatcher[IO].use { d =>
-      val okResponse =
-        """
-          |{
-          |  "ok": true,
-          |  "systems": {
-          |  }
-          |}
-          |""".stripMargin
-      val okSam = Client.fromHttpApp[IO](
-        HttpApp(_ => IO.fromEither(parse(okResponse)).flatMap(r => IO(Response(status = Status.Ok).withEntity(r))))
-      )
+    val okResponse =
+      """
+        |{
+        |  "ok": true,
+        |  "systems": {
+        |  }
+        |}
+        |""".stripMargin
+    val okSam = Client.fromHttpApp[IO](
+      HttpApp(_ => IO.fromEither(parse(okResponse)).flatMap(r => IO(Response(status = Status.Ok).withEntity(r))))
+    )
 
-      val samDao = new HttpSamDAO(okSam, config, d)
-      val expectedResponse = StatusCheckResponse(true, Map.empty)
+    val samDao = new HttpSamDAO(okSam, config, petTokenCache)
+    val expectedResponse = StatusCheckResponse(true, Map.empty)
 
-      samDao.getStatus.map(s => s shouldBe expectedResponse)
-    }
-
-    res.unsafeRunSync
-
+    samDao.getStatus.map(s => s shouldBe expectedResponse)
   }
 
   it should "get Sam unhealthy status with no systems" in {
@@ -117,7 +120,7 @@ class HttpSamDAOSpec extends AnyFlatSpec with LeonardoTestSuite with BeforeAndAf
     )
 
     val res = Dispatcher[IO].use { d =>
-      val samDao = new HttpSamDAO(okSam, config, d)
+      val samDao = new HttpSamDAO(okSam, config, petTokenCache)
       val expectedResponse =
         StatusCheckResponse(false,
                             Map(GoogleIam -> SubsystemStatus(true, None),
@@ -141,7 +144,7 @@ class HttpSamDAOSpec extends AnyFlatSpec with LeonardoTestSuite with BeforeAndAf
     val clientWithRetry = Retry(retryPolicy)(errorSam)
 
     val res = Dispatcher[IO].use { d =>
-      val samDao = new HttpSamDAO(clientWithRetry, config, d)
+      val samDao = new HttpSamDAO(clientWithRetry, config, petTokenCache)
 
       for {
         result <- samDao.getStatus.attempt

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/AppComponentSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/AppComponentSpec.scala
@@ -39,7 +39,7 @@ class AppComponentSpec extends AnyFlatSpecLike with TestComponent {
     val savedCluster1 = makeKubeCluster(1).save()
     val savedNodepool1 = makeNodepool(1, savedCluster1.id).save()
 
-    val disk = makePersistentDisk(None).save().unsafeRunSync()
+    val disk = makePersistentDisk(None).save().unsafeRunSync()(cats.effect.unsafe.implicits.global)
     val basicApp = makeApp(1, savedNodepool1.id)
     val complexApp = basicApp.copy(appResources =
       basicApp.appResources.copy(

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/AppComponentSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/AppComponentSpec.scala
@@ -39,7 +39,7 @@ class AppComponentSpec extends AnyFlatSpecLike with TestComponent {
     val savedCluster1 = makeKubeCluster(1).save()
     val savedNodepool1 = makeNodepool(1, savedCluster1.id).save()
 
-    val disk = makePersistentDisk(None).save().unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    val disk = makePersistentDisk(None).save().unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
     val basicApp = makeApp(1, savedNodepool1.id)
     val complexApp = basicApp.copy(appResources =
       basicApp.appResources.copy(

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/AppServiceDbQueriesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/AppServiceDbQueriesSpec.scala
@@ -73,7 +73,7 @@ class AppServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent {
     val savedCluster1 = makeKubeCluster(1).save()
     val savedNodepool1 = makeNodepool(1, savedCluster1.id).save()
 
-    val disk = makePersistentDisk(None).save().unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    val disk = makePersistentDisk(None).save().unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
     val basicApp = makeApp(1, savedNodepool1.id)
     val complexApp = basicApp.copy(appResources =
       basicApp.appResources.copy(
@@ -274,11 +274,11 @@ class AppServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent {
     val saveResult2IO = KubernetesServiceDbQueries.saveOrGetClusterForApp(saveCluster2).transaction
 
     the[KubernetesAppCreationException] thrownBy {
-      saveResult1IO.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+      saveResult1IO.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
     }
 
     the[KubernetesAppCreationException] thrownBy {
-      saveResult2IO.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+      saveResult2IO.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
     }
   }
 
@@ -302,7 +302,7 @@ class AppServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent {
     val saveResult = KubernetesServiceDbQueries
       .saveOrGetClusterForApp(saveCluster2)
       .transaction
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+      .unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
     // We are verifying it saved a new cluster here.
     // We don't know the ID, but the method not returning the original DELETED cluster is sufficient
     saveResult.minimalCluster.id should not be savedCluster1.id
@@ -356,8 +356,8 @@ class AppServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent {
     val now = Instant.now()
     val error1 = AppError("error1", now, ErrorAction.CreateApp, ErrorSource.App, Some(1))
     val error2 = AppError("error2", now, ErrorAction.DeleteApp, ErrorSource.Nodepool, Some(2))
-    appErrorQuery.save(savedApp1.id, error1).transaction.unsafeRunSync()(cats.effect.unsafe.implicits.global)
-    appErrorQuery.save(savedApp1.id, error2).transaction.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    appErrorQuery.save(savedApp1.id, error1).transaction.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
+    appErrorQuery.save(savedApp1.id, error2).transaction.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
 
     val getApp = dbFutureValue {
       KubernetesServiceDbQueries.getActiveFullAppByName(savedCluster1.googleProject, savedApp1.appName)
@@ -376,7 +376,7 @@ class AppServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent {
     KubernetesServiceDbQueries
       .hasClusterOperationInProgress(savedCluster1.id)
       .transaction
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global) shouldBe true
+      .unsafeRunSync()(cats.effect.unsafe.IORuntime.global) shouldBe true
   }
 
   it should "list Error'd apps if the underlying cluster is deleted" in {

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/AppServiceDbQueriesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/AppServiceDbQueriesSpec.scala
@@ -3,7 +3,6 @@ package http
 package db
 
 import java.time.Instant
-
 import org.broadinstitute.dsde.workbench.leonardo.CommonTestData._
 import org.broadinstitute.dsde.workbench.leonardo.KubernetesTestData._
 import org.broadinstitute.dsde.workbench.leonardo.TestUtils._
@@ -74,7 +73,7 @@ class AppServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent {
     val savedCluster1 = makeKubeCluster(1).save()
     val savedNodepool1 = makeNodepool(1, savedCluster1.id).save()
 
-    val disk = makePersistentDisk(None).save().unsafeRunSync()
+    val disk = makePersistentDisk(None).save().unsafeRunSync()(cats.effect.unsafe.implicits.global)
     val basicApp = makeApp(1, savedNodepool1.id)
     val complexApp = basicApp.copy(appResources =
       basicApp.appResources.copy(
@@ -275,11 +274,11 @@ class AppServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent {
     val saveResult2IO = KubernetesServiceDbQueries.saveOrGetClusterForApp(saveCluster2).transaction
 
     the[KubernetesAppCreationException] thrownBy {
-      saveResult1IO.unsafeRunSync()
+      saveResult1IO.unsafeRunSync()(cats.effect.unsafe.implicits.global)
     }
 
     the[KubernetesAppCreationException] thrownBy {
-      saveResult2IO.unsafeRunSync()
+      saveResult2IO.unsafeRunSync()(cats.effect.unsafe.implicits.global)
     }
   }
 
@@ -300,7 +299,10 @@ class AppServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent {
       )
       .get
 
-    val saveResult = KubernetesServiceDbQueries.saveOrGetClusterForApp(saveCluster2).transaction.unsafeRunSync()
+    val saveResult = KubernetesServiceDbQueries
+      .saveOrGetClusterForApp(saveCluster2)
+      .transaction
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
     // We are verifying it saved a new cluster here.
     // We don't know the ID, but the method not returning the original DELETED cluster is sufficient
     saveResult.minimalCluster.id should not be savedCluster1.id
@@ -354,8 +356,8 @@ class AppServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent {
     val now = Instant.now()
     val error1 = AppError("error1", now, ErrorAction.CreateApp, ErrorSource.App, Some(1))
     val error2 = AppError("error2", now, ErrorAction.DeleteApp, ErrorSource.Nodepool, Some(2))
-    appErrorQuery.save(savedApp1.id, error1).transaction.unsafeRunSync()
-    appErrorQuery.save(savedApp1.id, error2).transaction.unsafeRunSync()
+    appErrorQuery.save(savedApp1.id, error1).transaction.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    appErrorQuery.save(savedApp1.id, error2).transaction.unsafeRunSync()(cats.effect.unsafe.implicits.global)
 
     val getApp = dbFutureValue {
       KubernetesServiceDbQueries.getActiveFullAppByName(savedCluster1.googleProject, savedApp1.appName)
@@ -371,7 +373,10 @@ class AppServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent {
     val savedNodepool2 = makeNodepool(2, savedCluster1.id).copy(status = NodepoolStatus.Running).save()
     val app2 = makeApp(1, savedNodepool2.id).copy(status = AppStatus.Running).save()
 
-    KubernetesServiceDbQueries.hasClusterOperationInProgress(savedCluster1.id).transaction.unsafeRunSync() shouldBe true
+    KubernetesServiceDbQueries
+      .hasClusterOperationInProgress(savedCluster1.id)
+      .transaction
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global) shouldBe true
   }
 
   it should "list Error'd apps if the underlying cluster is deleted" in {

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponentSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponentSpec.scala
@@ -284,7 +284,7 @@ class ClusterComponentSpec extends AnyFlatSpecLike with TestComponent with GcsPa
     patchQuery
       .save(RuntimePatchDetails(savedCluster4.id, savedCluster4.status), Some(MachineTypeName("machineType")))
       .transaction
-      .unsafeRunSync()
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
 
     val expectedRuntimeToMonitor = List(
       RuntimeToMonitor(savedCluster1.id, CloudService.Dataproc, RuntimeStatus.Starting, false),
@@ -354,7 +354,7 @@ class ClusterComponentSpec extends AnyFlatSpecLike with TestComponent with GcsPa
       error.isLeft shouldBe true
     }
 
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "save and get deletedFrom" in isolatedDbTest {
@@ -368,6 +368,6 @@ class ClusterComponentSpec extends AnyFlatSpecLike with TestComponent with GcsPa
       deletedFrom shouldBe Some("zombieMonitor")
     }
 
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponentSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponentSpec.scala
@@ -284,7 +284,7 @@ class ClusterComponentSpec extends AnyFlatSpecLike with TestComponent with GcsPa
     patchQuery
       .save(RuntimePatchDetails(savedCluster4.id, savedCluster4.status), Some(MachineTypeName("machineType")))
       .transaction
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+      .unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
 
     val expectedRuntimeToMonitor = List(
       RuntimeToMonitor(savedCluster1.id, CloudService.Dataproc, RuntimeStatus.Starting, false),
@@ -354,7 +354,7 @@ class ClusterComponentSpec extends AnyFlatSpecLike with TestComponent with GcsPa
       error.isLeft shouldBe true
     }
 
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   it should "save and get deletedFrom" in isolatedDbTest {
@@ -368,6 +368,6 @@ class ClusterComponentSpec extends AnyFlatSpecLike with TestComponent with GcsPa
       deletedFrom shouldBe Some("zombieMonitor")
     }
 
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/FollowupComponentSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/FollowupComponentSpec.scala
@@ -26,6 +26,6 @@ class PatchComponentSpec extends AnyFlatSpecLike with TestComponent {
       r3 shouldBe (1)
       r4 shouldBe (Some(MachineTypeName("machineType2")))
     }
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/FollowupComponentSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/FollowupComponentSpec.scala
@@ -26,6 +26,6 @@ class PatchComponentSpec extends AnyFlatSpecLike with TestComponent {
       r3 shouldBe (1)
       r4 shouldBe (Some(MachineTypeName("machineType2")))
     }
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/PersistentDiskComponentSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/PersistentDiskComponentSpec.scala
@@ -33,7 +33,7 @@ class PersistentDiskComponentSpec extends AnyFlatSpecLike with TestComponent {
       d3 shouldEqual None
     }
 
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   it should "get by name" in isolatedDbTest {
@@ -50,7 +50,7 @@ class PersistentDiskComponentSpec extends AnyFlatSpecLike with TestComponent {
       d2 shouldEqual None
     }
 
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   it should "update status" in isolatedDbTest {
@@ -65,7 +65,7 @@ class PersistentDiskComponentSpec extends AnyFlatSpecLike with TestComponent {
       d2.get.auditInfo.dateAccessed should not equal savedDisk.auditInfo.dateAccessed
     }
 
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   it should "delete records" in isolatedDbTest {
@@ -81,7 +81,7 @@ class PersistentDiskComponentSpec extends AnyFlatSpecLike with TestComponent {
       d2.get.auditInfo.destroyedDate should not equal savedDisk.auditInfo.destroyedDate
     }
 
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
 }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/RuntimeConfigQueriesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/RuntimeConfigQueriesSpec.scala
@@ -30,7 +30,7 @@ class RuntimeConfigQueriesSpec extends AnyFlatSpecLike with TestComponent with L
     } yield {
       rc shouldBe runtimeConfig
     }
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   it should "save gceConfig properly" in isolatedDbTest {
@@ -59,7 +59,7 @@ class RuntimeConfigQueriesSpec extends AnyFlatSpecLike with TestComponent with L
       rc shouldBe runtimeConfig1
       rc2 shouldBe runtimeConfig2
     }
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   it should "save gceWithPdConfig properly" in isolatedDbTest {
@@ -78,6 +78,6 @@ class RuntimeConfigQueriesSpec extends AnyFlatSpecLike with TestComponent with L
     } yield {
       rc shouldBe runtimeConfig
     }
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/RuntimeConfigQueriesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/RuntimeConfigQueriesSpec.scala
@@ -1,15 +1,13 @@
 package org.broadinstitute.dsde.workbench.leonardo.db
 
-import java.time.Instant
-import java.util.concurrent.TimeUnit
-
+import cats.effect.IO
 import org.broadinstitute.dsde.workbench.google2.{MachineTypeName, RegionName, ZoneName}
 import org.broadinstitute.dsde.workbench.leonardo.CommonTestData.makePersistentDisk
 import org.broadinstitute.dsde.workbench.leonardo.http.dbioToIO
 import org.broadinstitute.dsde.workbench.leonardo.{DiskSize, GpuConfig, GpuType, LeonardoTestSuite, RuntimeConfig}
+import org.scalatest.flatspec.AnyFlatSpecLike
 
 import scala.concurrent.ExecutionContext.Implicits.global
-import org.scalatest.flatspec.AnyFlatSpecLike
 
 class RuntimeConfigQueriesSpec extends AnyFlatSpecLike with TestComponent with LeonardoTestSuite {
   "RuntimeConfigQueries" should "save cluster with properties properly" in isolatedDbTest {
@@ -26,13 +24,13 @@ class RuntimeConfigQueriesSpec extends AnyFlatSpecLike with TestComponent with L
       componentGatewayEnabled = true
     )
     val res = for {
-      now <- testTimer.clock.realTime(TimeUnit.MILLISECONDS)
-      id <- RuntimeConfigQueries.insertRuntimeConfig(runtimeConfig, Instant.ofEpochMilli(now)).transaction
+      now <- IO.realTimeInstant
+      id <- RuntimeConfigQueries.insertRuntimeConfig(runtimeConfig, now).transaction
       rc <- RuntimeConfigQueries.getRuntimeConfig(id).transaction
     } yield {
       rc shouldBe runtimeConfig
     }
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "save gceConfig properly" in isolatedDbTest {
@@ -51,22 +49,22 @@ class RuntimeConfigQueriesSpec extends AnyFlatSpecLike with TestComponent with L
       Some(GpuConfig(GpuType.NvidiaTeslaT4, 2))
     )
     val res = for {
-      now <- testTimer.clock.realTime(TimeUnit.MILLISECONDS)
-      id <- RuntimeConfigQueries.insertRuntimeConfig(runtimeConfig1, Instant.ofEpochMilli(now)).transaction
+      now <- IO.realTimeInstant
+      id <- RuntimeConfigQueries.insertRuntimeConfig(runtimeConfig1, now).transaction
       rc <- RuntimeConfigQueries.getRuntimeConfig(id).transaction
 
-      id2 <- RuntimeConfigQueries.insertRuntimeConfig(runtimeConfig2, Instant.ofEpochMilli(now)).transaction
+      id2 <- RuntimeConfigQueries.insertRuntimeConfig(runtimeConfig2, now).transaction
       rc2 <- RuntimeConfigQueries.getRuntimeConfig(id2).transaction
     } yield {
       rc shouldBe runtimeConfig1
       rc2 shouldBe runtimeConfig2
     }
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "save gceWithPdConfig properly" in isolatedDbTest {
     val res = for {
-      now <- testTimer.clock.realTime(TimeUnit.MILLISECONDS)
+      now <- IO.realTimeInstant
       savedDisk <- makePersistentDisk(None).save()
       runtimeConfig = RuntimeConfig.GceWithPdConfig(
         MachineTypeName("n1-standard-4"),
@@ -75,11 +73,11 @@ class RuntimeConfigQueriesSpec extends AnyFlatSpecLike with TestComponent with L
         ZoneName("us-west2-b"),
         Some(GpuConfig(GpuType.NvidiaTeslaT4, 2))
       )
-      id <- RuntimeConfigQueries.insertRuntimeConfig(runtimeConfig, Instant.ofEpochMilli(now)).transaction
+      id <- RuntimeConfigQueries.insertRuntimeConfig(runtimeConfig, now).transaction
       rc <- RuntimeConfigQueries.getRuntimeConfig(id).transaction
     } yield {
       rc shouldBe runtimeConfig
     }
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/RuntimeServiceDbQueriesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/RuntimeServiceDbQueriesSpec.scala
@@ -3,7 +3,6 @@ package http
 package db
 
 import java.time.Instant
-import java.util.concurrent.TimeUnit
 
 import cats.effect.IO
 import org.broadinstitute.dsde.workbench.google2.{DiskName, ZoneName}
@@ -41,12 +40,12 @@ class RuntimeServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent wit
       statusAfterDeletion shouldBe Some(RuntimeStatus.Deleting)
     }
 
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "list runtimes" in isolatedDbTest {
     val res = for {
-      start <- testTimer.clock.monotonic(TimeUnit.MILLISECONDS)
+      start <- IO.realTimeInstant
       list1 <- RuntimeServiceDbQueries.listRuntimes(Map.empty, false, None).transaction
       d1 <- makePersistentDisk(Some(DiskName("d1"))).save()
       d1RuntimeConfig = RuntimeConfig.GceWithPdConfig(defaultMachineType,
@@ -68,8 +67,8 @@ class RuntimeServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent wit
         makeCluster(2).saveWithRuntimeConfig(d2RuntimeConfig)
       )
       list3 <- RuntimeServiceDbQueries.listRuntimes(Map.empty, false, None).transaction
-      end <- testTimer.clock.monotonic(TimeUnit.MILLISECONDS)
-      elapsed = (end - start).millis
+      end <- IO.realTimeInstant
+      elapsed = (end.toEpochMilli - start.toEpochMilli).millis
       _ <- loggerIO.info(s"listClusters took $elapsed")
     } yield {
       list1 shouldEqual List.empty
@@ -80,12 +79,12 @@ class RuntimeServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent wit
       elapsed should be < maxElapsed
     }
 
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "list runtimes by labels" in isolatedDbTest {
     val res = for {
-      start <- testTimer.clock.monotonic(TimeUnit.MILLISECONDS)
+      start <- IO.realTimeInstant
       d1 <- makePersistentDisk(Some(DiskName("d1"))).save()
       c1RuntimeConfig = RuntimeConfig.GceWithPdConfig(defaultMachineType,
                                                       Some(d1.id),
@@ -115,8 +114,8 @@ class RuntimeServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent wit
       list5 <- RuntimeServiceDbQueries
         .listRuntimes(Map("googleProject" -> c1.googleProject.value), false, None)
         .transaction
-      end <- testTimer.clock.monotonic(TimeUnit.MILLISECONDS)
-      elapsed = (end - start).millis
+      end <- IO.realTimeInstant
+      elapsed = (end.toEpochMilli - start.toEpochMilli).millis
       _ <- loggerIO.info(s"listClusters took $elapsed")
     } yield {
       list1 shouldEqual List.empty
@@ -129,12 +128,12 @@ class RuntimeServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent wit
       elapsed should be < maxElapsed
     }
 
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "list runtimes by project" in isolatedDbTest {
     val res = for {
-      start <- testTimer.clock.monotonic(TimeUnit.MILLISECONDS)
+      start <- IO.realTimeInstant
       d1 <- makePersistentDisk(Some(DiskName("d1"))).save()
       c1RuntimeConfig = RuntimeConfig.GceWithPdConfig(defaultMachineType,
                                                       Some(d1.id),
@@ -155,8 +154,8 @@ class RuntimeServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent wit
       )
       list1 <- RuntimeServiceDbQueries.listRuntimes(Map.empty, false, Some(project)).transaction
       list2 <- RuntimeServiceDbQueries.listRuntimes(Map.empty, false, Some(project2)).transaction
-      end <- testTimer.clock.monotonic(TimeUnit.MILLISECONDS)
-      elapsed = (end - start).millis
+      end <- IO.realTimeInstant
+      elapsed = (end.toEpochMilli - start.toEpochMilli).millis
       _ <- loggerIO.info(s"listClusters took $elapsed")
     } yield {
       val c1Expected = toListRuntimeResponse(c1, Map.empty, c1RuntimeConfig)
@@ -166,12 +165,12 @@ class RuntimeServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent wit
       elapsed should be < maxElapsed
     }
 
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "list runtimes including deleted" in isolatedDbTest {
     val res = for {
-      start <- testTimer.clock.monotonic(TimeUnit.MILLISECONDS)
+      start <- IO.realTimeInstant
       d1 <- makePersistentDisk(Some(DiskName("d1"))).save()
       c1RuntimeConfig = RuntimeConfig.GceWithPdConfig(defaultMachineType,
                                                       Some(d1.id),
@@ -211,8 +210,8 @@ class RuntimeServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent wit
       )
       list1 <- RuntimeServiceDbQueries.listRuntimes(Map.empty, true, None).transaction
       list2 <- RuntimeServiceDbQueries.listRuntimes(Map.empty, false, None).transaction
-      end <- testTimer.clock.monotonic(TimeUnit.MILLISECONDS)
-      elapsed = (end - start).millis
+      end <- IO.realTimeInstant
+      elapsed = (end.toEpochMilli - start.toEpochMilli).millis
       _ <- loggerIO.info(s"listClusters took $elapsed")
     } yield {
       val c1Expected = toListRuntimeResponse(c1, Map.empty, c1RuntimeConfig)
@@ -223,7 +222,7 @@ class RuntimeServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent wit
       elapsed should be < maxElapsed
     }
 
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "get a runtime" in isolatedDbTest {
@@ -242,7 +241,7 @@ class RuntimeServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent wit
       get2.isLeft shouldBe true
     }
 
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   private def toListRuntimeResponse(

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/RuntimeServiceDbQueriesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/RuntimeServiceDbQueriesSpec.scala
@@ -40,7 +40,7 @@ class RuntimeServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent wit
       statusAfterDeletion shouldBe Some(RuntimeStatus.Deleting)
     }
 
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   it should "list runtimes" in isolatedDbTest {
@@ -79,7 +79,7 @@ class RuntimeServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent wit
       elapsed should be < maxElapsed
     }
 
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   it should "list runtimes by labels" in isolatedDbTest {
@@ -128,7 +128,7 @@ class RuntimeServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent wit
       elapsed should be < maxElapsed
     }
 
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   it should "list runtimes by project" in isolatedDbTest {
@@ -165,7 +165,7 @@ class RuntimeServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent wit
       elapsed should be < maxElapsed
     }
 
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   it should "list runtimes including deleted" in isolatedDbTest {
@@ -222,7 +222,7 @@ class RuntimeServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent wit
       elapsed should be < maxElapsed
     }
 
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   it should "get a runtime" in isolatedDbTest {
@@ -241,7 +241,7 @@ class RuntimeServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent wit
       get2.isLeft shouldBe true
     }
 
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   private def toListRuntimeResponse(

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/TestComponent.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/TestComponent.scala
@@ -42,7 +42,7 @@ trait TestComponent extends LeonardoTestSuite with ScalaFutures with GcsPathUtil
     LiquibaseConfig("org/broadinstitute/dsde/workbench/leonardo/liquibase/changelog.xml", true)
 
   // Not using beforeAll because the dbRef is needed before beforeAll is called
-  implicit protected lazy val testDbRef: DbRef[IO] = initDbRef.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+  implicit protected lazy val testDbRef: DbRef[IO] = initDbRef.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
 
   override def afterAll(): Unit = {
     testDbRef.close()
@@ -69,13 +69,13 @@ trait TestComponent extends LeonardoTestSuite with ScalaFutures with GcsPathUtil
     } yield new DbRef[IO](db, concurrentPermits)
 
   def dbFutureValue[T](f: DBIO[T]): T =
-    testDbRef.inTransaction(f).timeout(30 seconds).unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    testDbRef.inTransaction(f).timeout(30 seconds).unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   def dbFailure[T](f: DBIO[T]): Throwable =
     testDbRef
       .inTransaction(f)
       .attempt
       .timeout(30 seconds)
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+      .unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
       .swap
       .toOption
       .get

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/TestComponent.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/TestComponent.scala
@@ -66,7 +66,7 @@ trait TestComponent extends LeonardoTestSuite with ScalaFutures with GcsPathUtil
           sys.props.put(initWithLiquibaseProp, "done")
         )
       else IO.unit
-    } yield new DbRef[IO](dbConfig, db, concurrentPermits)
+    } yield new DbRef[IO](db, concurrentPermits)
 
   def dbFutureValue[T](f: DBIO[T]): T =
     testDbRef.inTransaction(f).timeout(30 seconds).unsafeRunSync()(cats.effect.unsafe.implicits.global)

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dns/RuntimeDnsCacheSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dns/RuntimeDnsCacheSpec.scala
@@ -67,17 +67,17 @@ class RuntimeDnsCacheSpec
     eventually {
       runtimeDnsCache
         .getHostStatus(cacheKeyForClusterBeingCreated)
-        .unsafeRunSync()(cats.effect.unsafe.implicits.global) shouldEqual HostNotReady
+        .unsafeRunSync()(cats.effect.unsafe.IORuntime.global) shouldEqual HostNotReady
     }
     eventually {
       runtimeDnsCache
         .getHostStatus(cacheKeyForRunningCluster)
-        .unsafeRunSync()(cats.effect.unsafe.implicits.global) shouldEqual HostReady(runningClusterHost)
+        .unsafeRunSync()(cats.effect.unsafe.IORuntime.global) shouldEqual HostReady(runningClusterHost)
     }
     eventually(
       runtimeDnsCache
         .getHostStatus(cacheKeyForStoppedCluster)
-        .unsafeRunSync()(cats.effect.unsafe.implicits.global) shouldEqual HostPaused
+        .unsafeRunSync()(cats.effect.unsafe.IORuntime.global) shouldEqual HostPaused
     )
     val cacheMap = underlyingRuntimeDnsCache.asMap()
     cacheMap.size() shouldBe 3
@@ -86,18 +86,18 @@ class RuntimeDnsCacheSpec
     underlyingRuntimeDnsCache.stats.evictionCount shouldBe 0
 
     hostToIpMapping.get
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+      .unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
       .get(runningClusterHost) shouldBe runningCluster.asyncRuntimeFields.flatMap(_.hostIp)
     hostToIpMapping.get
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+      .unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
       .get(clusterBeingCreatedHost) shouldBe None
-    hostToIpMapping.get.unsafeRunSync()(cats.effect.unsafe.implicits.global).get(stoppedClusterHost) shouldBe None
+    hostToIpMapping.get.unsafeRunSync()(cats.effect.unsafe.IORuntime.global).get(stoppedClusterHost) shouldBe None
 
     val cacheKeys = Set(cacheKeyForClusterBeingCreated, cacheKeyForRunningCluster, cacheKeyForStoppedCluster)
 
     // Check that the cache entries are eventually evicted and get re-loaded upon re-reading
     eventually {
-      cacheKeys.foreach(x => runtimeDnsCache.getHostStatus(x).unsafeRunSync()(cats.effect.unsafe.implicits.global))
+      cacheKeys.foreach(x => runtimeDnsCache.getHostStatus(x).unsafeRunSync()(cats.effect.unsafe.IORuntime.global))
 //      underlyingRuntimeDnsCache.stats.evictionCount shouldBe 3
     }
     val secondCacheMap = underlyingRuntimeDnsCache.asMap()

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dns/RuntimeDnsCacheSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dns/RuntimeDnsCacheSpec.scala
@@ -51,7 +51,7 @@ class RuntimeDnsCacheSpec
     s"${stoppedCluster.asyncRuntimeFields.map(_.googleId).get.value.toString}.jupyter.firecloud.org"
   )
   val underlyingRuntimeDnsCache =
-    Caffeine.newBuilder().maximumSize(10000L).build[String, scalacache.Entry[HostStatus]]()
+    Caffeine.newBuilder().maximumSize(10000L).recordStats().build[String, scalacache.Entry[HostStatus]]()
   val runtimeDnsCaffeineCache: Cache[IO, HostStatus] = CaffeineCache[IO, HostStatus](underlyingRuntimeDnsCache)
   val runtimeDnsCache =
     new RuntimeDnsCache[IO](proxyConfig,
@@ -86,9 +86,9 @@ class RuntimeDnsCacheSpec
     )
     val cacheMap = underlyingRuntimeDnsCache.asMap()
     cacheMap.size() shouldBe 3
-//    underlyingRuntimeDnsCache.stats.missCount shouldBe 3
+    underlyingRuntimeDnsCache.stats.missCount shouldBe 3
 //    underlyingRuntimeDnsCache.stats.loadCount shouldBe 3
-//    underlyingRuntimeDnsCache.stats.evictionCount shouldBe 0
+    underlyingRuntimeDnsCache.stats.evictionCount shouldBe 0
 
     hostToIpMapping.get
       .unsafeRunSync()(cats.effect.unsafe.implicits.global)
@@ -107,7 +107,6 @@ class RuntimeDnsCacheSpec
     }
     val secondCacheMap = underlyingRuntimeDnsCache.asMap()
     secondCacheMap.size() shouldBe 3
-//    underlyingRuntimeDnsCache.estimatedSize() shouldBe 3
 //    underlyingRuntimeDnsCache.stats.missCount shouldBe 6
 //    underlyingRuntimeDnsCache.stats.loadCount shouldBe 6
   }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dns/RuntimeDnsCacheSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dns/RuntimeDnsCacheSpec.scala
@@ -54,11 +54,7 @@ class RuntimeDnsCacheSpec
     Caffeine.newBuilder().maximumSize(10000L).recordStats().build[String, scalacache.Entry[HostStatus]]()
   val runtimeDnsCaffeineCache: Cache[IO, HostStatus] = CaffeineCache[IO, HostStatus](underlyingRuntimeDnsCache)
   val runtimeDnsCache =
-    new RuntimeDnsCache[IO](proxyConfig,
-                            testDbRef,
-                            Config.runtimeDnsCacheConfig,
-                            hostToIpMapping,
-                            runtimeDnsCaffeineCache)
+    new RuntimeDnsCache[IO](proxyConfig, testDbRef, hostToIpMapping, runtimeDnsCaffeineCache)
 
   it should "update maps and return clusters" in isolatedDbTest {
     // save the clusters to the db

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dns/RuntimeDnsCacheSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dns/RuntimeDnsCacheSpec.scala
@@ -5,7 +5,6 @@ import cats.effect.IO
 import com.github.benmanes.caffeine.cache.Caffeine
 import org.broadinstitute.dsde.workbench.leonardo.CommonTestData._
 import org.broadinstitute.dsde.workbench.leonardo.TestUtils.clusterEq
-import org.broadinstitute.dsde.workbench.leonardo.config.Config
 import org.broadinstitute.dsde.workbench.leonardo.dao.HostStatus
 import org.broadinstitute.dsde.workbench.leonardo.dao.HostStatus.{HostNotReady, HostPaused, HostReady}
 import org.broadinstitute.dsde.workbench.leonardo.db.TestComponent

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/HttpRoutesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/HttpRoutesSpec.scala
@@ -3,7 +3,8 @@ package http
 package api
 
 import akka.http.scaladsl.model.{ContentTypes, StatusCodes}
-import akka.http.scaladsl.testkit.ScalatestRouteTest
+import akka.http.scaladsl.testkit.{RouteTestTimeout, ScalatestRouteTest}
+import akka.testkit.TestDuration
 import cats.effect.IO
 import cats.mtl.Ask
 import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
@@ -40,6 +41,7 @@ class HttpRoutesSpec
     with TestLeoRoutes {
   val clusterName = "test"
   val googleProject = "dsp-leo-test"
+  implicit val timeout = RouteTestTimeout(20.seconds.dilated)
 
   val routes =
     new HttpRoutes(

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/HttpRoutesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/HttpRoutesSpec.scala
@@ -41,7 +41,6 @@ class HttpRoutesSpec
     with TestLeoRoutes {
   val clusterName = "test"
   val googleProject = "dsp-leo-test"
-  implicit val timeout = RouteTestTimeout(20.seconds.dilated)
 
   val routes =
     new HttpRoutes(

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/HttpRoutesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/HttpRoutesSpec.scala
@@ -4,7 +4,7 @@ package api
 
 import akka.http.scaladsl.model.{ContentTypes, StatusCodes}
 import akka.http.scaladsl.testkit.ScalatestRouteTest
-import cats.effect.IO
+import cats.effect.{IO, Resource}
 import cats.mtl.Ask
 import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
 import io.circe.parser.decode
@@ -50,77 +50,114 @@ class HttpRoutesSpec
   val clusterName = "test"
   val googleProject = "dsp-leo-test"
 
-  val routes = new HttpRoutes(
-    swaggerConfig,
-    statusService,
-    proxyService,
-    MockRuntimeServiceInterp,
-    MockDiskServiceInterp,
-    MockAppService,
-    timedUserInfoDirectives,
-    contentSecurityPolicy,
-    refererConfig
+  val routesResource = proxyServiceResource.map(p =>
+    new HttpRoutes(
+      swaggerConfig,
+      statusService,
+      p,
+      MockRuntimeServiceInterp,
+      MockDiskServiceInterp,
+      MockAppService,
+      timedUserInfoDirectives,
+      contentSecurityPolicy,
+      refererConfig
+    )
   )
 
   "RuntimeRoutes" should "create runtime" in {
-    Post("/api/google/v1/runtimes/googleProject1/runtime1")
-      .withEntity(ContentTypes.`application/json`, defaultCreateRuntimeRequest.asJson.spaces2) ~> routes.route ~> check {
-      status shouldEqual StatusCodes.Accepted
-      validateRawCookie(header("Set-Cookie"))
-    }
+    routesResource
+      .use { routes =>
+        IO(
+          Post("/api/google/v1/runtimes/googleProject1/runtime1")
+            .withEntity(ContentTypes.`application/json`, defaultCreateRuntimeRequest.asJson.spaces2) ~> routes.route ~> check {
+            status shouldEqual StatusCodes.Accepted
+            validateRawCookie(header("Set-Cookie"))
+          }
+        )
+      }
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "create a runtime with default parameters" in {
-    Post("/api/google/v1/runtimes/googleProject1/runtime1")
-      .withEntity(ContentTypes.`application/json`, "{}") ~> routes.route ~> check {
-      status shouldEqual StatusCodes.Accepted
-      validateRawCookie(header("Set-Cookie"))
-    }
+    routesResource
+      .use { routes =>
+        IO(
+          Post("/api/google/v1/runtimes/googleProject1/runtime1")
+            .withEntity(ContentTypes.`application/json`, "{}") ~> routes.route ~> check {
+            status shouldEqual StatusCodes.Accepted
+            validateRawCookie(header("Set-Cookie"))
+          }
+        )
+      }
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should s"reject create a cluster if cluster name is invalid" in {
     val invalidClusterName = "MyCluster"
-    Post(s"/api/google/v1/runtimes/googleProject1/$invalidClusterName", defaultCreateRuntimeRequest.asJson.spaces2) ~> httpRoutes.route ~> check {
-      val expectedResponse =
-        """Invalid name MyCluster. Only lowercase alphanumeric characters, numbers and dashes are allowed in leo names"""
-      responseEntity.toStrict(5 seconds).futureValue.data.utf8String shouldBe expectedResponse
+    httpRoutesResource
+      .use { httpRoutes =>
+        IO(
+          Post(s"/api/google/v1/runtimes/googleProject1/$invalidClusterName",
+               defaultCreateRuntimeRequest.asJson.spaces2) ~> httpRoutes.route ~> check {
+            val expectedResponse =
+              """Invalid name MyCluster. Only lowercase alphanumeric characters, numbers and dashes are allowed in leo names"""
+            responseEntity.toStrict(5 seconds).futureValue.data.utf8String shouldBe expectedResponse
 
-      status shouldEqual StatusCodes.BadRequest
-    }
+            status shouldEqual StatusCodes.BadRequest
+          }
+        )
+      }
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "get a runtime" in {
-    Get("/api/google/v1/runtimes/googleProject/runtime1") ~> routes.route ~> check {
-      status shouldEqual StatusCodes.OK
-      responseAs[GetRuntimeResponse].id shouldBe CommonTestData.testCluster.id
-      validateRawCookie(header("Set-Cookie"))
-    }
+    routesResource
+      .use { routes =>
+        IO(Get("/api/google/v1/runtimes/googleProject/runtime1") ~> routes.route ~> check {
+          status shouldEqual StatusCodes.OK
+          responseAs[GetRuntimeResponse].id shouldBe CommonTestData.testCluster.id
+          validateRawCookie(header("Set-Cookie"))
+        })
+      }
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "return 404 when getting a non-existent runtime" in {
-    Get("/api/google/v1/runtimes/googleProject/runtime-non-existent") ~> httpRoutes.route ~> check {
-      status shouldEqual StatusCodes.NotFound
-    }
+    httpRoutesResource
+      .use { httpRoutes =>
+        IO(Get("/api/google/v1/runtimes/googleProject/runtime-non-existent") ~> httpRoutes.route ~> check {
+          status shouldEqual StatusCodes.NotFound
+        })
+      }
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "list runtimes with a project" in {
-    Get("/api/google/v1/runtimes/googleProject") ~> routes.route ~> check {
-      status shouldEqual StatusCodes.OK
-      responseAs[Vector[ListRuntimeResponse2]].map(_.id) shouldBe Vector(CommonTestData.testCluster.id)
-      validateRawCookie(header("Set-Cookie"))
-    }
+    routesResource
+      .use { routes =>
+        IO(Get("/api/google/v1/runtimes/googleProject") ~> routes.route ~> check {
+          status shouldEqual StatusCodes.OK
+          responseAs[Vector[ListRuntimeResponse2]].map(_.id) shouldBe Vector(CommonTestData.testCluster.id)
+          validateRawCookie(header("Set-Cookie"))
+        })
+      }
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "list runtimes without a project" in {
-    Get("/api/google/v1/runtimes") ~> routes.route ~> check {
-      status shouldEqual StatusCodes.OK
-      val response = responseAs[Vector[ListRuntimeResponse2]]
-      response.map(_.id) shouldBe Vector(CommonTestData.testCluster.id)
-      response.map(_.runtimeConfig.asInstanceOf[RuntimeConfig.GceConfig]) shouldBe Vector(
-        CommonTestData.defaultGceRuntimeConfig
-      )
-      validateRawCookie(header("Set-Cookie"))
-    }
+    routesResource
+      .use { routes =>
+        IO(Get("/api/google/v1/runtimes") ~> routes.route ~> check {
+          status shouldEqual StatusCodes.OK
+          val response = responseAs[Vector[ListRuntimeResponse2]]
+          response.map(_.id) shouldBe Vector(CommonTestData.testCluster.id)
+          response.map(_.runtimeConfig.asInstanceOf[RuntimeConfig.GceConfig]) shouldBe Vector(
+            CommonTestData.defaultGceRuntimeConfig
+          )
+          validateRawCookie(header("Set-Cookie"))
+        })
+      }
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "list runtimes with labels" in isolatedDbTest {
@@ -140,74 +177,90 @@ class HttpRoutesSpec
         } getOrElse Map.empty
       )
 
-    for (i <- 1 to 10) {
-      Post(s"/api/google/v1/runtimes/${googleProject}/${clusterName}-$i", runtimesWithLabels(i).asJson) ~> httpRoutes.route ~> check {
-        status shouldEqual StatusCodes.Accepted
+    httpRoutesResource
+      .use { httpRoutes =>
+        IO {
+          for (i <- 1 to 10) {
+            Post(s"/api/google/v1/runtimes/${googleProject}/${clusterName}-$i", runtimesWithLabels(i).asJson) ~> httpRoutes.route ~> check {
+              status shouldEqual StatusCodes.Accepted
+            }
+          }
+
+          Get("/api/google/v1/runtimes?label6=value6") ~> httpRoutes.route ~> check {
+            status shouldEqual StatusCodes.OK
+
+            val responseClusters = responseAs[List[ListRuntimeResponse2]]
+            responseClusters should have size 1
+
+            val cluster = responseClusters.head
+            cluster.googleProject shouldEqual GoogleProject(googleProject)
+            cluster.clusterName shouldEqual RuntimeName(s"${clusterName}-6")
+            cluster.labels shouldEqual Map(
+              "clusterName" -> s"${clusterName}-6",
+              "runtimeName" -> s"${clusterName}-6",
+              "creator" -> "user1@example.com",
+              "googleProject" -> googleProject,
+              "tool" -> "Jupyter",
+              "label6" -> "value6"
+            ) ++ serviceAccountLabels
+
+            //validateCookie { header[`Set-Cookie`] }
+            validateRawCookie(header("Set-Cookie"))
+          }
+
+          Get("/api/google/v1/runtimes?_labels=label4%3Dvalue4") ~> httpRoutes.route ~> check {
+            status shouldEqual StatusCodes.OK
+
+            val responseClusters = responseAs[List[ListRuntimeResponse2]]
+            responseClusters should have size 1
+
+            val cluster = responseClusters.head
+            cluster.googleProject.value shouldEqual googleProject
+            cluster.clusterName shouldEqual RuntimeName(s"${clusterName}-4")
+            cluster.labels shouldEqual Map(
+              "clusterName" -> s"${clusterName}-4",
+              "runtimeName" -> s"${clusterName}-4",
+              "creator" -> "user1@example.com",
+              "googleProject" -> googleProject,
+              "tool" -> "Jupyter",
+              "label4" -> "value4"
+            ) ++ serviceAccountLabels
+
+            //validateCookie { header[`Set-Cookie`] }
+            validateRawCookie(header("Set-Cookie"))
+          }
+
+          Get("/api/google/v1/runtimes?_labels=bad") ~> httpRoutes.route ~> check {
+            status shouldEqual StatusCodes.BadRequest
+          }
+        }
       }
-    }
-
-    Get("/api/google/v1/runtimes?label6=value6") ~> httpRoutes.route ~> check {
-      status shouldEqual StatusCodes.OK
-
-      val responseClusters = responseAs[List[ListRuntimeResponse2]]
-      responseClusters should have size 1
-
-      val cluster = responseClusters.head
-      cluster.googleProject shouldEqual GoogleProject(googleProject)
-      cluster.clusterName shouldEqual RuntimeName(s"${clusterName}-6")
-      cluster.labels shouldEqual Map(
-        "clusterName" -> s"${clusterName}-6",
-        "runtimeName" -> s"${clusterName}-6",
-        "creator" -> "user1@example.com",
-        "googleProject" -> googleProject,
-        "tool" -> "Jupyter",
-        "label6" -> "value6"
-      ) ++ serviceAccountLabels
-
-      //validateCookie { header[`Set-Cookie`] }
-      validateRawCookie(header("Set-Cookie"))
-    }
-
-    Get("/api/google/v1/runtimes?_labels=label4%3Dvalue4") ~> httpRoutes.route ~> check {
-      status shouldEqual StatusCodes.OK
-
-      val responseClusters = responseAs[List[ListRuntimeResponse2]]
-      responseClusters should have size 1
-
-      val cluster = responseClusters.head
-      cluster.googleProject.value shouldEqual googleProject
-      cluster.clusterName shouldEqual RuntimeName(s"${clusterName}-4")
-      cluster.labels shouldEqual Map(
-        "clusterName" -> s"${clusterName}-4",
-        "runtimeName" -> s"${clusterName}-4",
-        "creator" -> "user1@example.com",
-        "googleProject" -> googleProject,
-        "tool" -> "Jupyter",
-        "label4" -> "value4"
-      ) ++ serviceAccountLabels
-
-      //validateCookie { header[`Set-Cookie`] }
-      validateRawCookie(header("Set-Cookie"))
-    }
-
-    Get("/api/google/v1/runtimes?_labels=bad") ~> httpRoutes.route ~> check {
-      status shouldEqual StatusCodes.BadRequest
-    }
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "list runtimes with parameters" in {
-    Get("/api/google/v1/runtimes?project=foo&creator=bar") ~> routes.route ~> check {
-      status shouldEqual StatusCodes.OK
-      responseAs[Vector[ListRuntimeResponse2]].map(_.id) shouldBe Vector(CommonTestData.testCluster.id)
-      validateRawCookie(header("Set-Cookie"))
-    }
+    routesResource
+      .use { routes =>
+        IO {
+          Get("/api/google/v1/runtimes?project=foo&creator=bar") ~> routes.route ~> check {
+            status shouldEqual StatusCodes.OK
+            responseAs[Vector[ListRuntimeResponse2]].map(_.id) shouldBe Vector(CommonTestData.testCluster.id)
+            validateRawCookie(header("Set-Cookie"))
+          }
+        }
+      }
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "delete a runtime" in {
-    Delete("/api/google/v1/runtimes/googleProject1/runtime1") ~> routes.route ~> check {
-      status shouldEqual StatusCodes.Accepted
-      validateRawCookie(header("Set-Cookie"))
-    }
+    routesResource
+      .use { routes =>
+        IO(Delete("/api/google/v1/runtimes/googleProject1/runtime1") ~> routes.route ~> check {
+          status shouldEqual StatusCodes.Accepted
+          validateRawCookie(header("Set-Cookie"))
+        })
+      }
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "delete a runtime and disk if deleteDisk is true" in {
@@ -220,17 +273,24 @@ class HttpRoutesSpec
         deleteRuntimeRequest shouldBe expectedDeleteRuntime
       }
     }
-    val routes = fakeRoutes(runtimeService)
-    Delete("/api/google/v1/runtimes/googleProject1/runtime1?deleteDisk=true") ~> routes.route ~> check {
-      status shouldEqual StatusCodes.Accepted
-      validateRawCookie(header("Set-Cookie"))
-    }
+    fakeRoutes(runtimeService)
+      .use { routes =>
+        IO(Delete("/api/google/v1/runtimes/googleProject1/runtime1?deleteDisk=true") ~> routes.route ~> check {
+          status shouldEqual StatusCodes.Accepted
+          validateRawCookie(header("Set-Cookie"))
+        })
+      }
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "return 404 when deleting a non-existent runtime" in {
-    Delete("/api/google/v1/runtimes/googleProject/runtime-non-existent") ~> httpRoutes.route ~> check {
-      status shouldEqual StatusCodes.NotFound
-    }
+    httpRoutesResource
+      .use { httpRoutes =>
+        IO(Delete("/api/google/v1/runtimes/googleProject/runtime-non-existent") ~> httpRoutes.route ~> check {
+          status shouldEqual StatusCodes.NotFound
+        })
+      }
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "keep disk when deleting runtime if deleteDisk is false" in {
@@ -243,11 +303,15 @@ class HttpRoutesSpec
         deleteRuntimeRequest shouldBe expectedDeleteRuntime
       }
     }
-    val routes = fakeRoutes(runtimeService)
-    Delete("/api/google/v1/runtimes/googleProject1/runtime1?deleteDisk=false") ~> routes.route ~> check {
-      status shouldEqual StatusCodes.Accepted
-      validateRawCookie(header("Set-Cookie"))
-    }
+    fakeRoutes(runtimeService)
+      .use { routes =>
+        IO(Delete("/api/google/v1/runtimes/googleProject1/runtime1?deleteDisk=false") ~> routes.route ~> check {
+          status shouldEqual StatusCodes.Accepted
+          validateRawCookie(header("Set-Cookie"))
+        })
+      }
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+
   }
 
   it should "not delete disk when deleting a runtime with PD enabled if deleteDisk is not set" in {
@@ -260,11 +324,15 @@ class HttpRoutesSpec
         deleteRuntimeRequest shouldBe expectedDeleteRuntime
       }
     }
-    val routes = fakeRoutes(runtimeService)
-    Delete("/api/google/v1/runtimes/googleProject1/runtime1") ~> routes.route ~> check {
-      status shouldEqual StatusCodes.Accepted
-      validateRawCookie(header("Set-Cookie"))
-    }
+    fakeRoutes(runtimeService)
+      .use(routes =>
+        IO(Delete("/api/google/v1/runtimes/googleProject1/runtime1") ~> routes.route ~> check {
+          status shouldEqual StatusCodes.Accepted
+          validateRawCookie(header("Set-Cookie"))
+        })
+      )
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+
   }
 
   it should "not delete disk when deleting a kubernetes app with PD enabled if deleteDisk is not set" in {
@@ -277,37 +345,61 @@ class HttpRoutesSpec
         request shouldBe expectedDeleteApp
       }
     }
-    val routes = fakeRoutes(kubernetesService)
-    Delete("/api/google/v1/apps/googleProject1/app1") ~> routes.route ~> check {
-      status shouldEqual StatusCodes.Accepted
-      validateRawCookie(header("Set-Cookie"))
-    }
+    fakeRoutes(kubernetesService)
+      .use { routes =>
+        IO(Delete("/api/google/v1/apps/googleProject1/app1") ~> routes.route ~> check {
+          status shouldEqual StatusCodes.Accepted
+          validateRawCookie(header("Set-Cookie"))
+        })
+      }
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+
   }
 
   it should "stop a runtime" in {
-    Post("/api/google/v1/runtimes/googleProject1/runtime1/stop") ~> routes.route ~> check {
-      status shouldEqual StatusCodes.Accepted
-      validateRawCookie(header("Set-Cookie"))
-    }
+    routesResource
+      .use { routes =>
+        IO {
+          Post("/api/google/v1/runtimes/googleProject1/runtime1/stop") ~> routes.route ~> check {
+            status shouldEqual StatusCodes.Accepted
+            validateRawCookie(header("Set-Cookie"))
+          }
+        }
+      }
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "return 404 when stopping a non-existent runtime" in {
-    Post("/api/google/v1/runtimes/googleProject1/runtime-non-existent/stop") ~> httpRoutes.route ~> check {
-      status shouldEqual StatusCodes.NotFound
-    }
+    httpRoutesResource
+      .use { httpRoutes =>
+        IO(Post("/api/google/v1/runtimes/googleProject1/runtime-non-existent/stop") ~> httpRoutes.route ~> check {
+          status shouldEqual StatusCodes.NotFound
+        })
+      }
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "start a runtime" in {
-    Post("/api/google/v1/runtimes/googleProject1/runtime1/start") ~> routes.route ~> check {
-      status shouldEqual StatusCodes.Accepted
-      validateRawCookie(header("Set-Cookie"))
-    }
+    routesResource
+      .use { routes =>
+        IO {
+          Post("/api/google/v1/runtimes/googleProject1/runtime1/start") ~> routes.route ~> check {
+            status shouldEqual StatusCodes.Accepted
+            validateRawCookie(header("Set-Cookie"))
+          }
+        }
+      }
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "return 404 when startting a non-existent runtime" in {
-    Post("/api/google/v1/runtimes/googleProject1/runtime-non-existent/start") ~> httpRoutes.route ~> check {
-      status shouldEqual StatusCodes.NotFound
-    }
+    httpRoutesResource
+      .use { httpRoutes =>
+        IO(Post("/api/google/v1/runtimes/googleProject1/runtime-non-existent/start") ~> httpRoutes.route ~> check {
+          status shouldEqual StatusCodes.NotFound
+        })
+      }
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "update a runtime" in {
@@ -319,48 +411,66 @@ class HttpRoutesSpec
       Map.empty,
       Set.empty
     )
-    Patch("/api/google/v1/runtimes/googleProject1/runtime1")
-      .withEntity(ContentTypes.`application/json`, request.asJson.spaces2) ~> routes.route ~> check {
-      status shouldEqual StatusCodes.Accepted
-      validateRawCookie(header("Set-Cookie"))
-    }
+    routesResource
+      .use { routes =>
+        IO {
+          Patch("/api/google/v1/runtimes/googleProject1/runtime1")
+            .withEntity(ContentTypes.`application/json`, request.asJson.spaces2) ~> routes.route ~> check {
+            status shouldEqual StatusCodes.Accepted
+            validateRawCookie(header("Set-Cookie"))
+          }
+        }
+      }
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "update a runtime with default parameters" in {
-    Patch("/api/google/v1/runtimes/googleProject1/runtime1")
-      .withEntity(ContentTypes.`application/json`, "{}") ~> routes.route ~> check {
-      status shouldEqual StatusCodes.Accepted
-      validateRawCookie(header("Set-Cookie"))
-    }
+    routesResource
+      .use { routes =>
+        IO {
+          Patch("/api/google/v1/runtimes/googleProject1/runtime1")
+            .withEntity(ContentTypes.`application/json`, "{}") ~> routes.route ~> check {
+            status shouldEqual StatusCodes.Accepted
+            validateRawCookie(header("Set-Cookie"))
+          }
+        }
+      }
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "not handle patch with invalid runtime config" in {
-    val negative =
-      UpdateRuntimeRequest(Some(UpdateRuntimeConfigRequest.GceConfig(None, Some(DiskSize(-100)))),
-                           false,
-                           None,
-                           None,
-                           Map.empty,
-                           Set.empty)
-    Patch("/api/google/v1/runtimes/googleProject1/runtime1")
-      .withEntity(ContentTypes.`application/json`, negative.asJson.spaces2) ~> routes.route ~> check {
-      status shouldBe StatusCodes.BadRequest
-      val resp = responseEntity.toStrict(5 seconds).futureValue.data.utf8String
-      resp shouldBe "The request content was malformed:\nDecodingFailure at .runtimeConfig.diskSize: Minimum required disk size is 5GB"
-    }
-    val oneWorker =
-      UpdateRuntimeRequest(Some(UpdateRuntimeConfigRequest.DataprocConfig(None, None, Some(1), None)),
-                           false,
-                           None,
-                           None,
-                           Map.empty,
-                           Set.empty)
-    Patch("/api/google/v1/runtimes/googleProject1/runtime1")
-      .withEntity(ContentTypes.`application/json`, oneWorker.asJson.spaces2) ~> routes.route ~> check {
-      status shouldBe StatusCodes.BadRequest
-      val resp = responseEntity.toStrict(5 seconds).futureValue.data.utf8String
-      resp shouldBe "The request content was malformed:\nDecodingFailure at : Google Dataproc does not support clusters with 1 non-preemptible worker. Must be 0, 2 or more."
-    }
+    routesResource
+      .use { routes =>
+        IO {
+          val negative =
+            UpdateRuntimeRequest(Some(UpdateRuntimeConfigRequest.GceConfig(None, Some(DiskSize(-100)))),
+                                 false,
+                                 None,
+                                 None,
+                                 Map.empty,
+                                 Set.empty)
+          Patch("/api/google/v1/runtimes/googleProject1/runtime1")
+            .withEntity(ContentTypes.`application/json`, negative.asJson.spaces2) ~> routes.route ~> check {
+            status shouldBe StatusCodes.BadRequest
+            val resp = responseEntity.toStrict(5 seconds).futureValue.data.utf8String
+            resp shouldBe "The request content was malformed:\nDecodingFailure at .runtimeConfig.diskSize: Minimum required disk size is 5GB"
+          }
+          val oneWorker =
+            UpdateRuntimeRequest(Some(UpdateRuntimeConfigRequest.DataprocConfig(None, None, Some(1), None)),
+                                 false,
+                                 None,
+                                 None,
+                                 Map.empty,
+                                 Set.empty)
+          Patch("/api/google/v1/runtimes/googleProject1/runtime1")
+            .withEntity(ContentTypes.`application/json`, oneWorker.asJson.spaces2) ~> routes.route ~> check {
+            status shouldBe StatusCodes.BadRequest
+            val resp = responseEntity.toStrict(5 seconds).futureValue.data.utf8String
+            resp shouldBe "The request content was malformed:\nDecodingFailure at : Google Dataproc does not support clusters with 1 non-preemptible worker. Must be 0, 2 or more."
+          }
+        }
+      }
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   "DiskRoutes" should "create a disk" in {
@@ -371,184 +481,276 @@ class HttpRoutesSpec
       Some(BlockSize(65536)),
       None
     )
-    Post("/api/google/v1/disks/googleProject1/disk1")
-      .withEntity(ContentTypes.`application/json`, diskCreateRequest.asJson.spaces2) ~> routes.route ~> check {
-      status shouldEqual StatusCodes.Accepted
-      validateRawCookie(header("Set-Cookie"))
-    }
+    routesResource
+      .use { routes =>
+        IO(
+          Post("/api/google/v1/disks/googleProject1/disk1")
+            .withEntity(ContentTypes.`application/json`, diskCreateRequest.asJson.spaces2) ~> routes.route ~> check {
+            status shouldEqual StatusCodes.Accepted
+            validateRawCookie(header("Set-Cookie"))
+          }
+        )
+      }
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "create a disk with default parameters" in {
-    Post("/api/google/v1/disks/googleProject1/disk1")
-      .withEntity(ContentTypes.`application/json`, "{}") ~> routes.route ~> check {
-      status shouldEqual StatusCodes.Accepted
-      validateRawCookie(header("Set-Cookie"))
-    }
+    routesResource
+      .use { routes =>
+        IO(
+          Post("/api/google/v1/disks/googleProject1/disk1")
+            .withEntity(ContentTypes.`application/json`, "{}") ~> routes.route ~> check {
+            status shouldEqual StatusCodes.Accepted
+            validateRawCookie(header("Set-Cookie"))
+          }
+        )
+      }
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "get a disk" in {
-    Get("/api/google/v1/disks/googleProject/disk1") ~> routes.route ~> check {
-      status shouldEqual StatusCodes.OK
-      responseAs[GetPersistentDiskResponse].name shouldBe CommonTestData.diskName
-      validateRawCookie(header("Set-Cookie"))
-    }
+    routesResource
+      .use { routes =>
+        IO(Get("/api/google/v1/disks/googleProject/disk1") ~> routes.route ~> check {
+          status shouldEqual StatusCodes.OK
+          responseAs[GetPersistentDiskResponse].name shouldBe CommonTestData.diskName
+          validateRawCookie(header("Set-Cookie"))
+        })
+      }
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "list all disks" in {
-    Get("/api/google/v1/disks") ~> routes.route ~> check {
-      status shouldEqual StatusCodes.OK
-      responseAs[Vector[ListPersistentDiskResponse]].map(_.name) shouldBe Vector(CommonTestData.diskName)
-      validateRawCookie(header("Set-Cookie"))
-    }
+    routesResource
+      .use { routes =>
+        IO(Get("/api/google/v1/disks") ~> routes.route ~> check {
+          status shouldEqual StatusCodes.OK
+          responseAs[Vector[ListPersistentDiskResponse]].map(_.name) shouldBe Vector(CommonTestData.diskName)
+          validateRawCookie(header("Set-Cookie"))
+        })
+      }
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "list all disks within a project" in {
-    Get("/api/google/v1/disks/googleProject") ~> routes.route ~> check {
-      status shouldEqual StatusCodes.OK
-      responseAs[Vector[ListPersistentDiskResponse]].map(_.name) shouldBe Vector(CommonTestData.diskName)
-      validateRawCookie(header("Set-Cookie"))
-    }
+    routesResource
+      .use { routes =>
+        IO(Get("/api/google/v1/disks/googleProject") ~> routes.route ~> check {
+          status shouldEqual StatusCodes.OK
+          responseAs[Vector[ListPersistentDiskResponse]].map(_.name) shouldBe Vector(CommonTestData.diskName)
+          validateRawCookie(header("Set-Cookie"))
+        })
+      }
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "list disks with parameters" in {
-    Get("/api/google/v1/disks?project=foo&creator=bar") ~> routes.route ~> check {
-      status shouldEqual StatusCodes.OK
-      responseAs[Vector[ListPersistentDiskResponse]].map(_.name) shouldBe Vector(CommonTestData.diskName)
-      validateRawCookie(header("Set-Cookie"))
-    }
+    routesResource
+      .use { routes =>
+        IO {
+          Get("/api/google/v1/disks?project=foo&creator=bar") ~> routes.route ~> check {
+            status shouldEqual StatusCodes.OK
+            responseAs[Vector[ListPersistentDiskResponse]].map(_.name) shouldBe Vector(CommonTestData.diskName)
+            validateRawCookie(header("Set-Cookie"))
+          }
+        }
+      }
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "delete a disk" in {
-    Delete("/api/google/v1/disks/googleProject1/disk1") ~> routes.route ~> check {
-      status shouldEqual StatusCodes.Accepted
-      validateRawCookie(header("Set-Cookie"))
-    }
+    routesResource
+      .use { routes =>
+        IO(Delete("/api/google/v1/disks/googleProject1/disk1") ~> routes.route ~> check {
+          status shouldEqual StatusCodes.Accepted
+          validateRawCookie(header("Set-Cookie"))
+        })
+      }
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "update a disk" in {
-    val request = UpdateDiskRequest(
-      Map("foo" -> "bar"),
-      DiskSize(1024)
-    )
-    Patch("/api/google/v1/disks/googleProject1/disk1", request.asJson) ~> routes.route ~> check {
-      status shouldEqual StatusCodes.Accepted
-      validateRawCookie(header("Set-Cookie"))
-    }
+    routesResource
+      .use { routes =>
+        IO {
+          val request = UpdateDiskRequest(
+            Map("foo" -> "bar"),
+            DiskSize(1024)
+          )
+          Patch("/api/google/v1/disks/googleProject1/disk1", request.asJson) ~> routes.route ~> check {
+            status shouldEqual StatusCodes.Accepted
+            validateRawCookie(header("Set-Cookie"))
+          }
+        }
+      }
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   "HttpRoutes" should "not handle unrecognized routes" in {
-    Post("/api/google/v1/runtime/googleProject1/runtime1/unhandled") ~> routes.route ~> check {
-      status shouldBe StatusCodes.NotFound
-      val resp = responseEntity.toStrict(5 seconds).futureValue.data.utf8String
-      resp shouldBe "\"API not found. Make sure you're calling the correct endpoint with correct method\""
-    }
-    Get("/api/google/v1/badruntime/googleProject1/runtime1") ~> routes.route ~> check {
-      status shouldBe StatusCodes.NotFound
-      val resp = responseEntity.toStrict(5 seconds).futureValue.data.utf8String
-      resp shouldBe "\"API not found. Make sure you're calling the correct endpoint with correct method\""
-    }
-    Get("/api/google/v2/runtime/googleProject1/runtime1") ~> routes.route ~> check {
-      status shouldBe StatusCodes.NotFound
-      val resp = responseEntity.toStrict(5 seconds).futureValue.data.utf8String
-      resp shouldBe "\"API not found. Make sure you're calling the correct endpoint with correct method\""
-    }
-    Post("/api/google/v1/runtime/googleProject1/runtime1") ~> routes.route ~> check {
-      status shouldBe StatusCodes.NotFound
-      val resp = responseEntity.toStrict(5 seconds).futureValue.data.utf8String
-      resp shouldBe "\"API not found. Make sure you're calling the correct endpoint with correct method\""
-    }
-    Post("/api/google/v1/disk/googleProject1/disk1") ~> routes.route ~> check {
-      status shouldBe StatusCodes.NotFound
-      val resp = responseEntity.toStrict(5 seconds).futureValue.data.utf8String
-      resp shouldBe "\"API not found. Make sure you're calling the correct endpoint with correct method\""
-    }
-    Get("/api/google/v1/disks/googleProject1/disk1/foo") ~> routes.route ~> check {
-      status shouldBe StatusCodes.NotFound
-      val resp = responseEntity.toStrict(5 seconds).futureValue.data.utf8String
-      resp shouldBe "\"API not found. Make sure you're calling the correct endpoint with correct method\""
-    }
+    routesResource
+      .use { routes =>
+        IO {
+          Post("/api/google/v1/runtime/googleProject1/runtime1/unhandled") ~> routes.route ~> check {
+            status shouldBe StatusCodes.NotFound
+            val resp = responseEntity.toStrict(5 seconds).futureValue.data.utf8String
+            resp shouldBe "\"API not found. Make sure you're calling the correct endpoint with correct method\""
+          }
+          Get("/api/google/v1/badruntime/googleProject1/runtime1") ~> routes.route ~> check {
+            status shouldBe StatusCodes.NotFound
+            val resp = responseEntity.toStrict(5 seconds).futureValue.data.utf8String
+            resp shouldBe "\"API not found. Make sure you're calling the correct endpoint with correct method\""
+          }
+          Get("/api/google/v2/runtime/googleProject1/runtime1") ~> routes.route ~> check {
+            status shouldBe StatusCodes.NotFound
+            val resp = responseEntity.toStrict(5 seconds).futureValue.data.utf8String
+            resp shouldBe "\"API not found. Make sure you're calling the correct endpoint with correct method\""
+          }
+          Post("/api/google/v1/runtime/googleProject1/runtime1") ~> routes.route ~> check {
+            status shouldBe StatusCodes.NotFound
+            val resp = responseEntity.toStrict(5 seconds).futureValue.data.utf8String
+            resp shouldBe "\"API not found. Make sure you're calling the correct endpoint with correct method\""
+          }
+          Post("/api/google/v1/disk/googleProject1/disk1") ~> routes.route ~> check {
+            status shouldBe StatusCodes.NotFound
+            val resp = responseEntity.toStrict(5 seconds).futureValue.data.utf8String
+            resp shouldBe "\"API not found. Make sure you're calling the correct endpoint with correct method\""
+          }
+          Get("/api/google/v1/disks/googleProject1/disk1/foo") ~> routes.route ~> check {
+            status shouldBe StatusCodes.NotFound
+            val resp = responseEntity.toStrict(5 seconds).futureValue.data.utf8String
+            resp shouldBe "\"API not found. Make sure you're calling the correct endpoint with correct method\""
+          }
+        }
+      }
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   "Kubernetes Routes" should "create an app" in {
-    Post("/api/google/v1/apps/googleProject1/app1")
-      .withEntity(ContentTypes.`application/json`, createAppRequest.asJson.spaces2) ~> routes.route ~> check {
-      status shouldEqual StatusCodes.Accepted
-      validateRawCookie(header("Set-Cookie"))
-    }
+    routesResource
+      .use { routes =>
+        IO(
+          Post("/api/google/v1/apps/googleProject1/app1")
+            .withEntity(ContentTypes.`application/json`, createAppRequest.asJson.spaces2) ~> routes.route ~> check {
+            status shouldEqual StatusCodes.Accepted
+            validateRawCookie(header("Set-Cookie"))
+          }
+        )
+      }
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "list apps with project" in {
-    Get("/api/google/v1/apps/googleProject1") ~> routes.route ~> check {
-      status shouldEqual StatusCodes.OK
-      validateRawCookie(header("Set-Cookie"))
-      responseAs[Vector[ListAppResponse]] shouldBe listAppResponse
-    }
+    routesResource
+      .use { routes =>
+        IO {
+          Get("/api/google/v1/apps/googleProject1") ~> routes.route ~> check {
+            status shouldEqual StatusCodes.OK
+            validateRawCookie(header("Set-Cookie"))
+            responseAs[Vector[ListAppResponse]] shouldBe listAppResponse
+          }
+        }
+      }
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "list apps with no project" in {
-    Get("/api/google/v1/apps/") ~> routes.route ~> check {
-      status shouldEqual StatusCodes.OK
-      validateRawCookie(header("Set-Cookie"))
-    }
+    routesResource
+      .use { routes =>
+        IO(Get("/api/google/v1/apps/") ~> routes.route ~> check {
+          status shouldEqual StatusCodes.OK
+          validateRawCookie(header("Set-Cookie"))
+        })
+      }
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "list apps with labels" in {
-    Get("/api/google/v1/apps?project=foo&creator=bar&includeDeleted=true") ~> routes.route ~> check {
-      status shouldEqual StatusCodes.OK
-      validateRawCookie(header("Set-Cookie"))
-    }
+    routesResource
+      .use { routes =>
+        IO(Get("/api/google/v1/apps?project=foo&creator=bar&includeDeleted=true") ~> routes.route ~> check {
+          status shouldEqual StatusCodes.OK
+          validateRawCookie(header("Set-Cookie"))
+        })
+      }
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "get app" in {
-    Get("/api/google/v1/apps/googleProject1/app1") ~> routes.route ~> check {
-      status shouldEqual StatusCodes.OK
-      validateRawCookie(header("Set-Cookie"))
-      responseAs[GetAppResponse] shouldBe getAppResponse
-    }
+    routesResource
+      .use { routes =>
+        IO(Get("/api/google/v1/apps/googleProject1/app1") ~> routes.route ~> check {
+          status shouldEqual StatusCodes.OK
+          validateRawCookie(header("Set-Cookie"))
+          responseAs[GetAppResponse] shouldBe getAppResponse
+        })
+      }
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "delete app" in {
-    Delete("/api/google/v1/apps/googleProject1/app1") ~> routes.route ~> check {
-      status shouldEqual StatusCodes.Accepted
-      validateRawCookie(header("Set-Cookie"))
-    }
+    routesResource
+      .use { routes =>
+        IO(Delete("/api/google/v1/apps/googleProject1/app1") ~> routes.route ~> check {
+          status shouldEqual StatusCodes.Accepted
+          validateRawCookie(header("Set-Cookie"))
+        })
+      }
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "validate app name" in {
-    Get("/api/google/v1/apps/googleProject1/1badApp") ~> routes.route ~> check {
-      status.intValue shouldBe 400
-    }
+    routesResource
+      .use { routes =>
+        IO(Get("/api/google/v1/apps/googleProject1/1badApp") ~> routes.route ~> check {
+          status.intValue shouldBe 400
+        })
+      }
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "validate create app request" in {
-    Post("/api/google/v1/apps/googleProject1/app1")
-      .withEntity(
-        ContentTypes.`application/json`,
-        createAppRequest
-          .copy(kubernetesRuntimeConfig =
-            createAppRequest.kubernetesRuntimeConfig.map(c => c.copy(numNodes = NumNodes(-1)))
-          )
-          .asJson
-          .spaces2
-      ) ~> httpRoutes.route ~> check {
-      status shouldBe StatusCodes.BadRequest
-      val resp = responseEntity.toStrict(5 seconds).futureValue.data.utf8String
-      resp shouldBe "The request content was malformed:\nDecodingFailure at .kubernetesRuntimeConfig.numNodes: Minimum number of nodes is 1"
-    }
+    httpRoutesResource
+      .use { httpRoutes =>
+        IO {
+          Post("/api/google/v1/apps/googleProject1/app1")
+            .withEntity(
+              ContentTypes.`application/json`,
+              createAppRequest
+                .copy(kubernetesRuntimeConfig =
+                  createAppRequest.kubernetesRuntimeConfig.map(c => c.copy(numNodes = NumNodes(-1)))
+                )
+                .asJson
+                .spaces2
+            ) ~> httpRoutes.route ~> check {
+            status shouldBe StatusCodes.BadRequest
+            val resp = responseEntity.toStrict(5 seconds).futureValue.data.utf8String
+            resp shouldBe "The request content was malformed:\nDecodingFailure at .kubernetesRuntimeConfig.numNodes: Minimum number of nodes is 1"
+          }
+        }
+      }
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "stop an app" in {
-    Post("/api/google/v1/apps/googleProject1/app1/stop") ~> routes.route ~> check {
-      status shouldEqual StatusCodes.Accepted
-      validateRawCookie(header("Set-Cookie"))
-    }
+    routesResource
+      .use { routes =>
+        IO(Post("/api/google/v1/apps/googleProject1/app1/stop") ~> routes.route ~> check {
+          status shouldEqual StatusCodes.Accepted
+          validateRawCookie(header("Set-Cookie"))
+        })
+      }
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "start an app" in {
-    Post("/api/google/v1/apps/googleProject1/app1/start") ~> routes.route ~> check {
-      status shouldEqual StatusCodes.Accepted
-      validateRawCookie(header("Set-Cookie"))
-    }
+    routesResource
+      .use { routes =>
+        IO(Post("/api/google/v1/apps/googleProject1/app1/start") ~> routes.route ~> check {
+          status shouldEqual StatusCodes.Accepted
+          validateRawCookie(header("Set-Cookie"))
+        })
+      }
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   // Validate encoding/decoding of RuntimeConfigRequest types
@@ -589,31 +791,35 @@ class HttpRoutesSpec
     decode[RuntimeConfigRequest](test.asJson.noSpaces) shouldBe Right(test)
   }
 
-  def fakeRoutes(runtimeService: RuntimeService[IO]): HttpRoutes =
-    new HttpRoutes(
-      swaggerConfig,
-      statusService,
-      proxyService,
-      runtimeService,
-      MockDiskServiceInterp,
-      MockAppService,
-      timedUserInfoDirectives,
-      contentSecurityPolicy,
-      refererConfig
-    )
+  def fakeRoutes(runtimeService: RuntimeService[IO]): Resource[IO, HttpRoutes] = proxyServiceResource.map {
+    proxyService =>
+      new HttpRoutes(
+        swaggerConfig,
+        statusService,
+        proxyService,
+        runtimeService,
+        MockDiskServiceInterp,
+        MockAppService,
+        timedUserInfoDirectives,
+        contentSecurityPolicy,
+        refererConfig
+      )
+  }
 
-  def fakeRoutes(kubernetesService: AppService[IO]): HttpRoutes =
-    new HttpRoutes(
-      swaggerConfig,
-      statusService,
-      proxyService,
-      runtimeService,
-      MockDiskServiceInterp,
-      kubernetesService,
-      timedUserInfoDirectives,
-      contentSecurityPolicy,
-      refererConfig
-    )
+  def fakeRoutes(kubernetesService: AppService[IO]): Resource[IO, HttpRoutes] = proxyServiceResource.map {
+    proxyService =>
+      new HttpRoutes(
+        swaggerConfig,
+        statusService,
+        proxyService,
+        runtimeService,
+        MockDiskServiceInterp,
+        kubernetesService,
+        timedUserInfoDirectives,
+        contentSecurityPolicy,
+        refererConfig
+      )
+  }
 }
 
 object HttpRoutesSpec {

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/HttpRoutesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/HttpRoutesSpec.scala
@@ -3,8 +3,7 @@ package http
 package api
 
 import akka.http.scaladsl.model.{ContentTypes, StatusCodes}
-import akka.http.scaladsl.testkit.{RouteTestTimeout, ScalatestRouteTest}
-import akka.testkit.TestDuration
+import akka.http.scaladsl.testkit.ScalatestRouteTest
 import cats.effect.IO
 import cats.mtl.Ask
 import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/HttpRoutesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/HttpRoutesSpec.scala
@@ -4,7 +4,7 @@ package api
 
 import akka.http.scaladsl.model.{ContentTypes, StatusCodes}
 import akka.http.scaladsl.testkit.ScalatestRouteTest
-import cats.effect.{IO, Resource}
+import cats.effect.IO
 import cats.mtl.Ask
 import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
 import io.circe.parser.decode
@@ -14,29 +14,20 @@ import org.broadinstitute.dsde.workbench.google2.{DiskName, MachineTypeName, Reg
 import org.broadinstitute.dsde.workbench.leonardo.CommonTestData._
 import org.broadinstitute.dsde.workbench.leonardo.JsonCodec._
 import org.broadinstitute.dsde.workbench.leonardo.KubernetesTestData._
+import org.broadinstitute.dsde.workbench.leonardo.SamResourceId.RuntimeSamResourceId
 import org.broadinstitute.dsde.workbench.leonardo.db.TestComponent
 import org.broadinstitute.dsde.workbench.leonardo.http.AppRoutesTestJsonCodec._
 import org.broadinstitute.dsde.workbench.leonardo.http.DiskRoutesTestJsonCodec._
 import org.broadinstitute.dsde.workbench.leonardo.http.RuntimeRoutesTestJsonCodec._
 import org.broadinstitute.dsde.workbench.leonardo.http.api.HttpRoutesSpec._
 import org.broadinstitute.dsde.workbench.leonardo.http.api.RuntimeRoutes._
-import org.broadinstitute.dsde.workbench.leonardo.http.service.{
-  AppService,
-  BaseMockRuntimeServiceInterp,
-  DeleteRuntimeRequest,
-  MockAppService,
-  MockDiskServiceInterp,
-  MockRuntimeServiceInterp,
-  RuntimeService
-}
+import org.broadinstitute.dsde.workbench.leonardo.http.service._
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
 import java.net.URL
-import org.broadinstitute.dsde.workbench.leonardo.SamResourceId.RuntimeSamResourceId
-
 import scala.concurrent.duration._
 
 class HttpRoutesSpec
@@ -50,11 +41,11 @@ class HttpRoutesSpec
   val clusterName = "test"
   val googleProject = "dsp-leo-test"
 
-  val routesResource = proxyServiceResource.map(p =>
+  val routes =
     new HttpRoutes(
       swaggerConfig,
       statusService,
-      p,
+      proxyService,
       MockRuntimeServiceInterp,
       MockDiskServiceInterp,
       MockAppService,
@@ -62,102 +53,66 @@ class HttpRoutesSpec
       contentSecurityPolicy,
       refererConfig
     )
-  )
 
   "RuntimeRoutes" should "create runtime" in {
-    routesResource
-      .use { routes =>
-        IO(
-          Post("/api/google/v1/runtimes/googleProject1/runtime1")
-            .withEntity(ContentTypes.`application/json`, defaultCreateRuntimeRequest.asJson.spaces2) ~> routes.route ~> check {
-            status shouldEqual StatusCodes.Accepted
-            validateRawCookie(header("Set-Cookie"))
-          }
-        )
-      }
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    Post("/api/google/v1/runtimes/googleProject1/runtime1")
+      .withEntity(ContentTypes.`application/json`, defaultCreateRuntimeRequest.asJson.spaces2) ~> routes.route ~> check {
+      status shouldEqual StatusCodes.Accepted
+      validateRawCookie(header("Set-Cookie"))
+    }
   }
 
   it should "create a runtime with default parameters" in {
-    routesResource
-      .use { routes =>
-        IO(
-          Post("/api/google/v1/runtimes/googleProject1/runtime1")
-            .withEntity(ContentTypes.`application/json`, "{}") ~> routes.route ~> check {
-            status shouldEqual StatusCodes.Accepted
-            validateRawCookie(header("Set-Cookie"))
-          }
-        )
-      }
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    Post("/api/google/v1/runtimes/googleProject1/runtime1")
+      .withEntity(ContentTypes.`application/json`, "{}") ~> routes.route ~> check {
+      status shouldEqual StatusCodes.Accepted
+      validateRawCookie(header("Set-Cookie"))
+    }
   }
 
   it should s"reject create a cluster if cluster name is invalid" in {
     val invalidClusterName = "MyCluster"
-    httpRoutesResource
-      .use { httpRoutes =>
-        IO(
-          Post(s"/api/google/v1/runtimes/googleProject1/$invalidClusterName",
-               defaultCreateRuntimeRequest.asJson.spaces2) ~> httpRoutes.route ~> check {
-            val expectedResponse =
-              """Invalid name MyCluster. Only lowercase alphanumeric characters, numbers and dashes are allowed in leo names"""
-            responseEntity.toStrict(5 seconds).futureValue.data.utf8String shouldBe expectedResponse
+    Post(s"/api/google/v1/runtimes/googleProject1/$invalidClusterName", defaultCreateRuntimeRequest.asJson.spaces2) ~> httpRoutes.route ~> check {
+      val expectedResponse =
+        """Invalid name MyCluster. Only lowercase alphanumeric characters, numbers and dashes are allowed in leo names"""
+      responseEntity.toStrict(5 seconds).futureValue.data.utf8String shouldBe expectedResponse
 
-            status shouldEqual StatusCodes.BadRequest
-          }
-        )
-      }
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+      status shouldEqual StatusCodes.BadRequest
+    }
   }
 
   it should "get a runtime" in {
-    routesResource
-      .use { routes =>
-        IO(Get("/api/google/v1/runtimes/googleProject/runtime1") ~> routes.route ~> check {
-          status shouldEqual StatusCodes.OK
-          responseAs[GetRuntimeResponse].id shouldBe CommonTestData.testCluster.id
-          validateRawCookie(header("Set-Cookie"))
-        })
-      }
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    Get("/api/google/v1/runtimes/googleProject/runtime1") ~> routes.route ~> check {
+      status shouldEqual StatusCodes.OK
+      responseAs[GetRuntimeResponse].id shouldBe CommonTestData.testCluster.id
+      validateRawCookie(header("Set-Cookie"))
+    }
   }
 
   it should "return 404 when getting a non-existent runtime" in {
-    httpRoutesResource
-      .use { httpRoutes =>
-        IO(Get("/api/google/v1/runtimes/googleProject/runtime-non-existent") ~> httpRoutes.route ~> check {
-          status shouldEqual StatusCodes.NotFound
-        })
-      }
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    Get("/api/google/v1/runtimes/googleProject/runtime-non-existent") ~> httpRoutes.route ~> check {
+      status shouldEqual StatusCodes.NotFound
+    }
   }
 
   it should "list runtimes with a project" in {
-    routesResource
-      .use { routes =>
-        IO(Get("/api/google/v1/runtimes/googleProject") ~> routes.route ~> check {
-          status shouldEqual StatusCodes.OK
-          responseAs[Vector[ListRuntimeResponse2]].map(_.id) shouldBe Vector(CommonTestData.testCluster.id)
-          validateRawCookie(header("Set-Cookie"))
-        })
-      }
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    Get("/api/google/v1/runtimes/googleProject") ~> routes.route ~> check {
+      status shouldEqual StatusCodes.OK
+      responseAs[Vector[ListRuntimeResponse2]].map(_.id) shouldBe Vector(CommonTestData.testCluster.id)
+      validateRawCookie(header("Set-Cookie"))
+    }
   }
 
   it should "list runtimes without a project" in {
-    routesResource
-      .use { routes =>
-        IO(Get("/api/google/v1/runtimes") ~> routes.route ~> check {
-          status shouldEqual StatusCodes.OK
-          val response = responseAs[Vector[ListRuntimeResponse2]]
-          response.map(_.id) shouldBe Vector(CommonTestData.testCluster.id)
-          response.map(_.runtimeConfig.asInstanceOf[RuntimeConfig.GceConfig]) shouldBe Vector(
-            CommonTestData.defaultGceRuntimeConfig
-          )
-          validateRawCookie(header("Set-Cookie"))
-        })
-      }
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    Get("/api/google/v1/runtimes") ~> routes.route ~> check {
+      status shouldEqual StatusCodes.OK
+      val response = responseAs[Vector[ListRuntimeResponse2]]
+      response.map(_.id) shouldBe Vector(CommonTestData.testCluster.id)
+      response.map(_.runtimeConfig.asInstanceOf[RuntimeConfig.GceConfig]) shouldBe Vector(
+        CommonTestData.defaultGceRuntimeConfig
+      )
+      validateRawCookie(header("Set-Cookie"))
+    }
   }
 
   it should "list runtimes with labels" in isolatedDbTest {
@@ -177,90 +132,74 @@ class HttpRoutesSpec
         } getOrElse Map.empty
       )
 
-    httpRoutesResource
-      .use { httpRoutes =>
-        IO {
-          for (i <- 1 to 10) {
-            Post(s"/api/google/v1/runtimes/${googleProject}/${clusterName}-$i", runtimesWithLabels(i).asJson) ~> httpRoutes.route ~> check {
-              status shouldEqual StatusCodes.Accepted
-            }
-          }
-
-          Get("/api/google/v1/runtimes?label6=value6") ~> httpRoutes.route ~> check {
-            status shouldEqual StatusCodes.OK
-
-            val responseClusters = responseAs[List[ListRuntimeResponse2]]
-            responseClusters should have size 1
-
-            val cluster = responseClusters.head
-            cluster.googleProject shouldEqual GoogleProject(googleProject)
-            cluster.clusterName shouldEqual RuntimeName(s"${clusterName}-6")
-            cluster.labels shouldEqual Map(
-              "clusterName" -> s"${clusterName}-6",
-              "runtimeName" -> s"${clusterName}-6",
-              "creator" -> "user1@example.com",
-              "googleProject" -> googleProject,
-              "tool" -> "Jupyter",
-              "label6" -> "value6"
-            ) ++ serviceAccountLabels
-
-            //validateCookie { header[`Set-Cookie`] }
-            validateRawCookie(header("Set-Cookie"))
-          }
-
-          Get("/api/google/v1/runtimes?_labels=label4%3Dvalue4") ~> httpRoutes.route ~> check {
-            status shouldEqual StatusCodes.OK
-
-            val responseClusters = responseAs[List[ListRuntimeResponse2]]
-            responseClusters should have size 1
-
-            val cluster = responseClusters.head
-            cluster.googleProject.value shouldEqual googleProject
-            cluster.clusterName shouldEqual RuntimeName(s"${clusterName}-4")
-            cluster.labels shouldEqual Map(
-              "clusterName" -> s"${clusterName}-4",
-              "runtimeName" -> s"${clusterName}-4",
-              "creator" -> "user1@example.com",
-              "googleProject" -> googleProject,
-              "tool" -> "Jupyter",
-              "label4" -> "value4"
-            ) ++ serviceAccountLabels
-
-            //validateCookie { header[`Set-Cookie`] }
-            validateRawCookie(header("Set-Cookie"))
-          }
-
-          Get("/api/google/v1/runtimes?_labels=bad") ~> httpRoutes.route ~> check {
-            status shouldEqual StatusCodes.BadRequest
-          }
-        }
+    for (i <- 1 to 10) {
+      Post(s"/api/google/v1/runtimes/${googleProject}/${clusterName}-$i", runtimesWithLabels(i).asJson) ~> httpRoutes.route ~> check {
+        status shouldEqual StatusCodes.Accepted
       }
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    }
+
+    Get("/api/google/v1/runtimes?label6=value6") ~> httpRoutes.route ~> check {
+      status shouldEqual StatusCodes.OK
+
+      val responseClusters = responseAs[List[ListRuntimeResponse2]]
+      responseClusters should have size 1
+
+      val cluster = responseClusters.head
+      cluster.googleProject shouldEqual GoogleProject(googleProject)
+      cluster.clusterName shouldEqual RuntimeName(s"${clusterName}-6")
+      cluster.labels shouldEqual Map(
+        "clusterName" -> s"${clusterName}-6",
+        "runtimeName" -> s"${clusterName}-6",
+        "creator" -> "user1@example.com",
+        "googleProject" -> googleProject,
+        "tool" -> "Jupyter",
+        "label6" -> "value6"
+      ) ++ serviceAccountLabels
+
+      //validateCookie { header[`Set-Cookie`] }
+      validateRawCookie(header("Set-Cookie"))
+    }
+
+    Get("/api/google/v1/runtimes?_labels=label4%3Dvalue4") ~> httpRoutes.route ~> check {
+      status shouldEqual StatusCodes.OK
+
+      val responseClusters = responseAs[List[ListRuntimeResponse2]]
+      responseClusters should have size 1
+
+      val cluster = responseClusters.head
+      cluster.googleProject.value shouldEqual googleProject
+      cluster.clusterName shouldEqual RuntimeName(s"${clusterName}-4")
+      cluster.labels shouldEqual Map(
+        "clusterName" -> s"${clusterName}-4",
+        "runtimeName" -> s"${clusterName}-4",
+        "creator" -> "user1@example.com",
+        "googleProject" -> googleProject,
+        "tool" -> "Jupyter",
+        "label4" -> "value4"
+      ) ++ serviceAccountLabels
+
+      //validateCookie { header[`Set-Cookie`] }
+      validateRawCookie(header("Set-Cookie"))
+    }
+
+    Get("/api/google/v1/runtimes?_labels=bad") ~> httpRoutes.route ~> check {
+      status shouldEqual StatusCodes.BadRequest
+    }
   }
 
   it should "list runtimes with parameters" in {
-    routesResource
-      .use { routes =>
-        IO {
-          Get("/api/google/v1/runtimes?project=foo&creator=bar") ~> routes.route ~> check {
-            status shouldEqual StatusCodes.OK
-            responseAs[Vector[ListRuntimeResponse2]].map(_.id) shouldBe Vector(CommonTestData.testCluster.id)
-            validateRawCookie(header("Set-Cookie"))
-          }
-        }
-      }
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    Get("/api/google/v1/runtimes?project=foo&creator=bar") ~> routes.route ~> check {
+      status shouldEqual StatusCodes.OK
+      responseAs[Vector[ListRuntimeResponse2]].map(_.id) shouldBe Vector(CommonTestData.testCluster.id)
+      validateRawCookie(header("Set-Cookie"))
+    }
   }
 
   it should "delete a runtime" in {
-    routesResource
-      .use { routes =>
-        IO(Delete("/api/google/v1/runtimes/googleProject1/runtime1") ~> routes.route ~> check {
-          status shouldEqual StatusCodes.Accepted
-          validateRawCookie(header("Set-Cookie"))
-        })
-      }
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    Delete("/api/google/v1/runtimes/googleProject1/runtime1") ~> routes.route ~> check {
+      status shouldEqual StatusCodes.Accepted
+      validateRawCookie(header("Set-Cookie"))
+    }
   }
 
   it should "delete a runtime and disk if deleteDisk is true" in {
@@ -273,24 +212,16 @@ class HttpRoutesSpec
         deleteRuntimeRequest shouldBe expectedDeleteRuntime
       }
     }
-    fakeRoutes(runtimeService)
-      .use { routes =>
-        IO(Delete("/api/google/v1/runtimes/googleProject1/runtime1?deleteDisk=true") ~> routes.route ~> check {
-          status shouldEqual StatusCodes.Accepted
-          validateRawCookie(header("Set-Cookie"))
-        })
-      }
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    Delete("/api/google/v1/runtimes/googleProject1/runtime1?deleteDisk=true") ~> fakeRoutes(runtimeService).route ~> check {
+      status shouldEqual StatusCodes.Accepted
+      validateRawCookie(header("Set-Cookie"))
+    }
   }
 
   it should "return 404 when deleting a non-existent runtime" in {
-    httpRoutesResource
-      .use { httpRoutes =>
-        IO(Delete("/api/google/v1/runtimes/googleProject/runtime-non-existent") ~> httpRoutes.route ~> check {
-          status shouldEqual StatusCodes.NotFound
-        })
-      }
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    Delete("/api/google/v1/runtimes/googleProject/runtime-non-existent") ~> httpRoutes.route ~> check {
+      status shouldEqual StatusCodes.NotFound
+    }
   }
 
   it should "keep disk when deleting runtime if deleteDisk is false" in {
@@ -303,14 +234,10 @@ class HttpRoutesSpec
         deleteRuntimeRequest shouldBe expectedDeleteRuntime
       }
     }
-    fakeRoutes(runtimeService)
-      .use { routes =>
-        IO(Delete("/api/google/v1/runtimes/googleProject1/runtime1?deleteDisk=false") ~> routes.route ~> check {
-          status shouldEqual StatusCodes.Accepted
-          validateRawCookie(header("Set-Cookie"))
-        })
-      }
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    Delete("/api/google/v1/runtimes/googleProject1/runtime1?deleteDisk=false") ~> fakeRoutes(runtimeService).route ~> check {
+      status shouldEqual StatusCodes.Accepted
+      validateRawCookie(header("Set-Cookie"))
+    }
 
   }
 
@@ -324,15 +251,10 @@ class HttpRoutesSpec
         deleteRuntimeRequest shouldBe expectedDeleteRuntime
       }
     }
-    fakeRoutes(runtimeService)
-      .use(routes =>
-        IO(Delete("/api/google/v1/runtimes/googleProject1/runtime1") ~> routes.route ~> check {
-          status shouldEqual StatusCodes.Accepted
-          validateRawCookie(header("Set-Cookie"))
-        })
-      )
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
-
+    Delete("/api/google/v1/runtimes/googleProject1/runtime1") ~> fakeRoutes(runtimeService).route ~> check {
+      status shouldEqual StatusCodes.Accepted
+      validateRawCookie(header("Set-Cookie"))
+    }
   }
 
   it should "not delete disk when deleting a kubernetes app with PD enabled if deleteDisk is not set" in {
@@ -345,61 +267,36 @@ class HttpRoutesSpec
         request shouldBe expectedDeleteApp
       }
     }
-    fakeRoutes(kubernetesService)
-      .use { routes =>
-        IO(Delete("/api/google/v1/apps/googleProject1/app1") ~> routes.route ~> check {
-          status shouldEqual StatusCodes.Accepted
-          validateRawCookie(header("Set-Cookie"))
-        })
-      }
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
-
+    Delete("/api/google/v1/apps/googleProject1/app1") ~> fakeRoutes(kubernetesService).route ~> check {
+      status shouldEqual StatusCodes.Accepted
+      validateRawCookie(header("Set-Cookie"))
+    }
   }
 
   it should "stop a runtime" in {
-    routesResource
-      .use { routes =>
-        IO {
-          Post("/api/google/v1/runtimes/googleProject1/runtime1/stop") ~> routes.route ~> check {
-            status shouldEqual StatusCodes.Accepted
-            validateRawCookie(header("Set-Cookie"))
-          }
-        }
-      }
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    Post("/api/google/v1/runtimes/googleProject1/runtime1/stop") ~> routes.route ~> check {
+      status shouldEqual StatusCodes.Accepted
+      validateRawCookie(header("Set-Cookie"))
+    }
   }
 
   it should "return 404 when stopping a non-existent runtime" in {
-    httpRoutesResource
-      .use { httpRoutes =>
-        IO(Post("/api/google/v1/runtimes/googleProject1/runtime-non-existent/stop") ~> httpRoutes.route ~> check {
-          status shouldEqual StatusCodes.NotFound
-        })
-      }
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    Post("/api/google/v1/runtimes/googleProject1/runtime-non-existent/stop") ~> httpRoutes.route ~> check {
+      status shouldEqual StatusCodes.NotFound
+    }
   }
 
   it should "start a runtime" in {
-    routesResource
-      .use { routes =>
-        IO {
-          Post("/api/google/v1/runtimes/googleProject1/runtime1/start") ~> routes.route ~> check {
-            status shouldEqual StatusCodes.Accepted
-            validateRawCookie(header("Set-Cookie"))
-          }
-        }
-      }
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    Post("/api/google/v1/runtimes/googleProject1/runtime1/start") ~> routes.route ~> check {
+      status shouldEqual StatusCodes.Accepted
+      validateRawCookie(header("Set-Cookie"))
+    }
   }
 
   it should "return 404 when startting a non-existent runtime" in {
-    httpRoutesResource
-      .use { httpRoutes =>
-        IO(Post("/api/google/v1/runtimes/googleProject1/runtime-non-existent/start") ~> httpRoutes.route ~> check {
-          status shouldEqual StatusCodes.NotFound
-        })
-      }
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    Post("/api/google/v1/runtimes/googleProject1/runtime-non-existent/start") ~> httpRoutes.route ~> check {
+      status shouldEqual StatusCodes.NotFound
+    }
   }
 
   it should "update a runtime" in {
@@ -411,66 +308,48 @@ class HttpRoutesSpec
       Map.empty,
       Set.empty
     )
-    routesResource
-      .use { routes =>
-        IO {
-          Patch("/api/google/v1/runtimes/googleProject1/runtime1")
-            .withEntity(ContentTypes.`application/json`, request.asJson.spaces2) ~> routes.route ~> check {
-            status shouldEqual StatusCodes.Accepted
-            validateRawCookie(header("Set-Cookie"))
-          }
-        }
-      }
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    Patch("/api/google/v1/runtimes/googleProject1/runtime1")
+      .withEntity(ContentTypes.`application/json`, request.asJson.spaces2) ~> routes.route ~> check {
+      status shouldEqual StatusCodes.Accepted
+      validateRawCookie(header("Set-Cookie"))
+    }
   }
 
   it should "update a runtime with default parameters" in {
-    routesResource
-      .use { routes =>
-        IO {
-          Patch("/api/google/v1/runtimes/googleProject1/runtime1")
-            .withEntity(ContentTypes.`application/json`, "{}") ~> routes.route ~> check {
-            status shouldEqual StatusCodes.Accepted
-            validateRawCookie(header("Set-Cookie"))
-          }
-        }
-      }
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    Patch("/api/google/v1/runtimes/googleProject1/runtime1")
+      .withEntity(ContentTypes.`application/json`, "{}") ~> routes.route ~> check {
+      status shouldEqual StatusCodes.Accepted
+      validateRawCookie(header("Set-Cookie"))
+    }
   }
 
   it should "not handle patch with invalid runtime config" in {
-    routesResource
-      .use { routes =>
-        IO {
-          val negative =
-            UpdateRuntimeRequest(Some(UpdateRuntimeConfigRequest.GceConfig(None, Some(DiskSize(-100)))),
-                                 false,
-                                 None,
-                                 None,
-                                 Map.empty,
-                                 Set.empty)
-          Patch("/api/google/v1/runtimes/googleProject1/runtime1")
-            .withEntity(ContentTypes.`application/json`, negative.asJson.spaces2) ~> routes.route ~> check {
-            status shouldBe StatusCodes.BadRequest
-            val resp = responseEntity.toStrict(5 seconds).futureValue.data.utf8String
-            resp shouldBe "The request content was malformed:\nDecodingFailure at .runtimeConfig.diskSize: Minimum required disk size is 5GB"
-          }
-          val oneWorker =
-            UpdateRuntimeRequest(Some(UpdateRuntimeConfigRequest.DataprocConfig(None, None, Some(1), None)),
-                                 false,
-                                 None,
-                                 None,
-                                 Map.empty,
-                                 Set.empty)
-          Patch("/api/google/v1/runtimes/googleProject1/runtime1")
-            .withEntity(ContentTypes.`application/json`, oneWorker.asJson.spaces2) ~> routes.route ~> check {
-            status shouldBe StatusCodes.BadRequest
-            val resp = responseEntity.toStrict(5 seconds).futureValue.data.utf8String
-            resp shouldBe "The request content was malformed:\nDecodingFailure at : Google Dataproc does not support clusters with 1 non-preemptible worker. Must be 0, 2 or more."
-          }
-        }
-      }
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    val negative =
+      UpdateRuntimeRequest(Some(UpdateRuntimeConfigRequest.GceConfig(None, Some(DiskSize(-100)))),
+                           false,
+                           None,
+                           None,
+                           Map.empty,
+                           Set.empty)
+    Patch("/api/google/v1/runtimes/googleProject1/runtime1")
+      .withEntity(ContentTypes.`application/json`, negative.asJson.spaces2) ~> routes.route ~> check {
+      status shouldBe StatusCodes.BadRequest
+      val resp = responseEntity.toStrict(5 seconds).futureValue.data.utf8String
+      resp shouldBe "The request content was malformed:\nDecodingFailure at .runtimeConfig.diskSize: Minimum required disk size is 5GB"
+    }
+    val oneWorker =
+      UpdateRuntimeRequest(Some(UpdateRuntimeConfigRequest.DataprocConfig(None, None, Some(1), None)),
+                           false,
+                           None,
+                           None,
+                           Map.empty,
+                           Set.empty)
+    Patch("/api/google/v1/runtimes/googleProject1/runtime1")
+      .withEntity(ContentTypes.`application/json`, oneWorker.asJson.spaces2) ~> routes.route ~> check {
+      status shouldBe StatusCodes.BadRequest
+      val resp = responseEntity.toStrict(5 seconds).futureValue.data.utf8String
+      resp shouldBe "The request content was malformed:\nDecodingFailure at : Google Dataproc does not support clusters with 1 non-preemptible worker. Must be 0, 2 or more."
+    }
   }
 
   "DiskRoutes" should "create a disk" in {
@@ -481,276 +360,184 @@ class HttpRoutesSpec
       Some(BlockSize(65536)),
       None
     )
-    routesResource
-      .use { routes =>
-        IO(
-          Post("/api/google/v1/disks/googleProject1/disk1")
-            .withEntity(ContentTypes.`application/json`, diskCreateRequest.asJson.spaces2) ~> routes.route ~> check {
-            status shouldEqual StatusCodes.Accepted
-            validateRawCookie(header("Set-Cookie"))
-          }
-        )
-      }
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    Post("/api/google/v1/disks/googleProject1/disk1")
+      .withEntity(ContentTypes.`application/json`, diskCreateRequest.asJson.spaces2) ~> routes.route ~> check {
+      status shouldEqual StatusCodes.Accepted
+      validateRawCookie(header("Set-Cookie"))
+    }
   }
 
   it should "create a disk with default parameters" in {
-    routesResource
-      .use { routes =>
-        IO(
-          Post("/api/google/v1/disks/googleProject1/disk1")
-            .withEntity(ContentTypes.`application/json`, "{}") ~> routes.route ~> check {
-            status shouldEqual StatusCodes.Accepted
-            validateRawCookie(header("Set-Cookie"))
-          }
-        )
-      }
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    Post("/api/google/v1/disks/googleProject1/disk1")
+      .withEntity(ContentTypes.`application/json`, "{}") ~> routes.route ~> check {
+      status shouldEqual StatusCodes.Accepted
+      validateRawCookie(header("Set-Cookie"))
+    }
   }
 
   it should "get a disk" in {
-    routesResource
-      .use { routes =>
-        IO(Get("/api/google/v1/disks/googleProject/disk1") ~> routes.route ~> check {
-          status shouldEqual StatusCodes.OK
-          responseAs[GetPersistentDiskResponse].name shouldBe CommonTestData.diskName
-          validateRawCookie(header("Set-Cookie"))
-        })
-      }
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    Get("/api/google/v1/disks/googleProject/disk1") ~> routes.route ~> check {
+      status shouldEqual StatusCodes.OK
+      responseAs[GetPersistentDiskResponse].name shouldBe CommonTestData.diskName
+      validateRawCookie(header("Set-Cookie"))
+    }
   }
 
   it should "list all disks" in {
-    routesResource
-      .use { routes =>
-        IO(Get("/api/google/v1/disks") ~> routes.route ~> check {
-          status shouldEqual StatusCodes.OK
-          responseAs[Vector[ListPersistentDiskResponse]].map(_.name) shouldBe Vector(CommonTestData.diskName)
-          validateRawCookie(header("Set-Cookie"))
-        })
-      }
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    Get("/api/google/v1/disks") ~> routes.route ~> check {
+      status shouldEqual StatusCodes.OK
+      responseAs[Vector[ListPersistentDiskResponse]].map(_.name) shouldBe Vector(CommonTestData.diskName)
+      validateRawCookie(header("Set-Cookie"))
+    }
   }
 
   it should "list all disks within a project" in {
-    routesResource
-      .use { routes =>
-        IO(Get("/api/google/v1/disks/googleProject") ~> routes.route ~> check {
-          status shouldEqual StatusCodes.OK
-          responseAs[Vector[ListPersistentDiskResponse]].map(_.name) shouldBe Vector(CommonTestData.diskName)
-          validateRawCookie(header("Set-Cookie"))
-        })
-      }
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    Get("/api/google/v1/disks/googleProject") ~> routes.route ~> check {
+      status shouldEqual StatusCodes.OK
+      responseAs[Vector[ListPersistentDiskResponse]].map(_.name) shouldBe Vector(CommonTestData.diskName)
+      validateRawCookie(header("Set-Cookie"))
+    }
   }
 
   it should "list disks with parameters" in {
-    routesResource
-      .use { routes =>
-        IO {
-          Get("/api/google/v1/disks?project=foo&creator=bar") ~> routes.route ~> check {
-            status shouldEqual StatusCodes.OK
-            responseAs[Vector[ListPersistentDiskResponse]].map(_.name) shouldBe Vector(CommonTestData.diskName)
-            validateRawCookie(header("Set-Cookie"))
-          }
-        }
-      }
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    Get("/api/google/v1/disks?project=foo&creator=bar") ~> routes.route ~> check {
+      status shouldEqual StatusCodes.OK
+      responseAs[Vector[ListPersistentDiskResponse]].map(_.name) shouldBe Vector(CommonTestData.diskName)
+      validateRawCookie(header("Set-Cookie"))
+    }
   }
 
   it should "delete a disk" in {
-    routesResource
-      .use { routes =>
-        IO(Delete("/api/google/v1/disks/googleProject1/disk1") ~> routes.route ~> check {
-          status shouldEqual StatusCodes.Accepted
-          validateRawCookie(header("Set-Cookie"))
-        })
-      }
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    Delete("/api/google/v1/disks/googleProject1/disk1") ~> routes.route ~> check {
+      status shouldEqual StatusCodes.Accepted
+      validateRawCookie(header("Set-Cookie"))
+    }
   }
 
   it should "update a disk" in {
-    routesResource
-      .use { routes =>
-        IO {
-          val request = UpdateDiskRequest(
-            Map("foo" -> "bar"),
-            DiskSize(1024)
-          )
-          Patch("/api/google/v1/disks/googleProject1/disk1", request.asJson) ~> routes.route ~> check {
-            status shouldEqual StatusCodes.Accepted
-            validateRawCookie(header("Set-Cookie"))
-          }
-        }
-      }
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    val request = UpdateDiskRequest(
+      Map("foo" -> "bar"),
+      DiskSize(1024)
+    )
+    Patch("/api/google/v1/disks/googleProject1/disk1", request.asJson) ~> routes.route ~> check {
+      status shouldEqual StatusCodes.Accepted
+      validateRawCookie(header("Set-Cookie"))
+    }
   }
 
   "HttpRoutes" should "not handle unrecognized routes" in {
-    routesResource
-      .use { routes =>
-        IO {
-          Post("/api/google/v1/runtime/googleProject1/runtime1/unhandled") ~> routes.route ~> check {
-            status shouldBe StatusCodes.NotFound
-            val resp = responseEntity.toStrict(5 seconds).futureValue.data.utf8String
-            resp shouldBe "\"API not found. Make sure you're calling the correct endpoint with correct method\""
-          }
-          Get("/api/google/v1/badruntime/googleProject1/runtime1") ~> routes.route ~> check {
-            status shouldBe StatusCodes.NotFound
-            val resp = responseEntity.toStrict(5 seconds).futureValue.data.utf8String
-            resp shouldBe "\"API not found. Make sure you're calling the correct endpoint with correct method\""
-          }
-          Get("/api/google/v2/runtime/googleProject1/runtime1") ~> routes.route ~> check {
-            status shouldBe StatusCodes.NotFound
-            val resp = responseEntity.toStrict(5 seconds).futureValue.data.utf8String
-            resp shouldBe "\"API not found. Make sure you're calling the correct endpoint with correct method\""
-          }
-          Post("/api/google/v1/runtime/googleProject1/runtime1") ~> routes.route ~> check {
-            status shouldBe StatusCodes.NotFound
-            val resp = responseEntity.toStrict(5 seconds).futureValue.data.utf8String
-            resp shouldBe "\"API not found. Make sure you're calling the correct endpoint with correct method\""
-          }
-          Post("/api/google/v1/disk/googleProject1/disk1") ~> routes.route ~> check {
-            status shouldBe StatusCodes.NotFound
-            val resp = responseEntity.toStrict(5 seconds).futureValue.data.utf8String
-            resp shouldBe "\"API not found. Make sure you're calling the correct endpoint with correct method\""
-          }
-          Get("/api/google/v1/disks/googleProject1/disk1/foo") ~> routes.route ~> check {
-            status shouldBe StatusCodes.NotFound
-            val resp = responseEntity.toStrict(5 seconds).futureValue.data.utf8String
-            resp shouldBe "\"API not found. Make sure you're calling the correct endpoint with correct method\""
-          }
-        }
-      }
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    Post("/api/google/v1/runtime/googleProject1/runtime1/unhandled") ~> routes.route ~> check {
+      status shouldBe StatusCodes.NotFound
+      val resp = responseEntity.toStrict(5 seconds).futureValue.data.utf8String
+      resp shouldBe "\"API not found. Make sure you're calling the correct endpoint with correct method\""
+    }
+    Get("/api/google/v1/badruntime/googleProject1/runtime1") ~> routes.route ~> check {
+      status shouldBe StatusCodes.NotFound
+      val resp = responseEntity.toStrict(5 seconds).futureValue.data.utf8String
+      resp shouldBe "\"API not found. Make sure you're calling the correct endpoint with correct method\""
+    }
+    Get("/api/google/v2/runtime/googleProject1/runtime1") ~> routes.route ~> check {
+      status shouldBe StatusCodes.NotFound
+      val resp = responseEntity.toStrict(5 seconds).futureValue.data.utf8String
+      resp shouldBe "\"API not found. Make sure you're calling the correct endpoint with correct method\""
+    }
+    Post("/api/google/v1/runtime/googleProject1/runtime1") ~> routes.route ~> check {
+      status shouldBe StatusCodes.NotFound
+      val resp = responseEntity.toStrict(5 seconds).futureValue.data.utf8String
+      resp shouldBe "\"API not found. Make sure you're calling the correct endpoint with correct method\""
+    }
+    Post("/api/google/v1/disk/googleProject1/disk1") ~> routes.route ~> check {
+      status shouldBe StatusCodes.NotFound
+      val resp = responseEntity.toStrict(5 seconds).futureValue.data.utf8String
+      resp shouldBe "\"API not found. Make sure you're calling the correct endpoint with correct method\""
+    }
+    Get("/api/google/v1/disks/googleProject1/disk1/foo") ~> routes.route ~> check {
+      status shouldBe StatusCodes.NotFound
+      val resp = responseEntity.toStrict(5 seconds).futureValue.data.utf8String
+      resp shouldBe "\"API not found. Make sure you're calling the correct endpoint with correct method\""
+    }
   }
 
   "Kubernetes Routes" should "create an app" in {
-    routesResource
-      .use { routes =>
-        IO(
-          Post("/api/google/v1/apps/googleProject1/app1")
-            .withEntity(ContentTypes.`application/json`, createAppRequest.asJson.spaces2) ~> routes.route ~> check {
-            status shouldEqual StatusCodes.Accepted
-            validateRawCookie(header("Set-Cookie"))
-          }
-        )
-      }
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    Post("/api/google/v1/apps/googleProject1/app1")
+      .withEntity(ContentTypes.`application/json`, createAppRequest.asJson.spaces2) ~> routes.route ~> check {
+      status shouldEqual StatusCodes.Accepted
+      validateRawCookie(header("Set-Cookie"))
+    }
   }
 
   it should "list apps with project" in {
-    routesResource
-      .use { routes =>
-        IO {
-          Get("/api/google/v1/apps/googleProject1") ~> routes.route ~> check {
-            status shouldEqual StatusCodes.OK
-            validateRawCookie(header("Set-Cookie"))
-            responseAs[Vector[ListAppResponse]] shouldBe listAppResponse
-          }
-        }
-      }
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    Get("/api/google/v1/apps/googleProject1") ~> routes.route ~> check {
+      status shouldEqual StatusCodes.OK
+      validateRawCookie(header("Set-Cookie"))
+      responseAs[Vector[ListAppResponse]] shouldBe listAppResponse
+    }
   }
 
   it should "list apps with no project" in {
-    routesResource
-      .use { routes =>
-        IO(Get("/api/google/v1/apps/") ~> routes.route ~> check {
-          status shouldEqual StatusCodes.OK
-          validateRawCookie(header("Set-Cookie"))
-        })
-      }
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    Get("/api/google/v1/apps/") ~> routes.route ~> check {
+      status shouldEqual StatusCodes.OK
+      validateRawCookie(header("Set-Cookie"))
+    }
   }
 
   it should "list apps with labels" in {
-    routesResource
-      .use { routes =>
-        IO(Get("/api/google/v1/apps?project=foo&creator=bar&includeDeleted=true") ~> routes.route ~> check {
-          status shouldEqual StatusCodes.OK
-          validateRawCookie(header("Set-Cookie"))
-        })
-      }
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    Get("/api/google/v1/apps?project=foo&creator=bar&includeDeleted=true") ~> routes.route ~> check {
+      status shouldEqual StatusCodes.OK
+      validateRawCookie(header("Set-Cookie"))
+    }
   }
 
   it should "get app" in {
-    routesResource
-      .use { routes =>
-        IO(Get("/api/google/v1/apps/googleProject1/app1") ~> routes.route ~> check {
-          status shouldEqual StatusCodes.OK
-          validateRawCookie(header("Set-Cookie"))
-          responseAs[GetAppResponse] shouldBe getAppResponse
-        })
-      }
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    Get("/api/google/v1/apps/googleProject1/app1") ~> routes.route ~> check {
+      status shouldEqual StatusCodes.OK
+      validateRawCookie(header("Set-Cookie"))
+      responseAs[GetAppResponse] shouldBe getAppResponse
+    }
   }
 
   it should "delete app" in {
-    routesResource
-      .use { routes =>
-        IO(Delete("/api/google/v1/apps/googleProject1/app1") ~> routes.route ~> check {
-          status shouldEqual StatusCodes.Accepted
-          validateRawCookie(header("Set-Cookie"))
-        })
-      }
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    Delete("/api/google/v1/apps/googleProject1/app1") ~> routes.route ~> check {
+      status shouldEqual StatusCodes.Accepted
+      validateRawCookie(header("Set-Cookie"))
+    }
   }
 
   it should "validate app name" in {
-    routesResource
-      .use { routes =>
-        IO(Get("/api/google/v1/apps/googleProject1/1badApp") ~> routes.route ~> check {
-          status.intValue shouldBe 400
-        })
-      }
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    Get("/api/google/v1/apps/googleProject1/1badApp") ~> routes.route ~> check {
+      status.intValue shouldBe 400
+    }
   }
 
   it should "validate create app request" in {
-    httpRoutesResource
-      .use { httpRoutes =>
-        IO {
-          Post("/api/google/v1/apps/googleProject1/app1")
-            .withEntity(
-              ContentTypes.`application/json`,
-              createAppRequest
-                .copy(kubernetesRuntimeConfig =
-                  createAppRequest.kubernetesRuntimeConfig.map(c => c.copy(numNodes = NumNodes(-1)))
-                )
-                .asJson
-                .spaces2
-            ) ~> httpRoutes.route ~> check {
-            status shouldBe StatusCodes.BadRequest
-            val resp = responseEntity.toStrict(5 seconds).futureValue.data.utf8String
-            resp shouldBe "The request content was malformed:\nDecodingFailure at .kubernetesRuntimeConfig.numNodes: Minimum number of nodes is 1"
-          }
-        }
-      }
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    Post("/api/google/v1/apps/googleProject1/app1")
+      .withEntity(
+        ContentTypes.`application/json`,
+        createAppRequest
+          .copy(kubernetesRuntimeConfig =
+            createAppRequest.kubernetesRuntimeConfig.map(c => c.copy(numNodes = NumNodes(-1)))
+          )
+          .asJson
+          .spaces2
+      ) ~> httpRoutes.route ~> check {
+      status shouldBe StatusCodes.BadRequest
+      val resp = responseEntity.toStrict(5 seconds).futureValue.data.utf8String
+      resp shouldBe "The request content was malformed:\nDecodingFailure at .kubernetesRuntimeConfig.numNodes: Minimum number of nodes is 1"
+    }
   }
 
   it should "stop an app" in {
-    routesResource
-      .use { routes =>
-        IO(Post("/api/google/v1/apps/googleProject1/app1/stop") ~> routes.route ~> check {
-          status shouldEqual StatusCodes.Accepted
-          validateRawCookie(header("Set-Cookie"))
-        })
-      }
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    Post("/api/google/v1/apps/googleProject1/app1/stop") ~> routes.route ~> check {
+      status shouldEqual StatusCodes.Accepted
+      validateRawCookie(header("Set-Cookie"))
+    }
   }
 
   it should "start an app" in {
-    routesResource
-      .use { routes =>
-        IO(Post("/api/google/v1/apps/googleProject1/app1/start") ~> routes.route ~> check {
-          status shouldEqual StatusCodes.Accepted
-          validateRawCookie(header("Set-Cookie"))
-        })
-      }
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    Post("/api/google/v1/apps/googleProject1/app1/start") ~> routes.route ~> check {
+      status shouldEqual StatusCodes.Accepted
+      validateRawCookie(header("Set-Cookie"))
+    }
   }
 
   // Validate encoding/decoding of RuntimeConfigRequest types
@@ -791,35 +578,31 @@ class HttpRoutesSpec
     decode[RuntimeConfigRequest](test.asJson.noSpaces) shouldBe Right(test)
   }
 
-  def fakeRoutes(runtimeService: RuntimeService[IO]): Resource[IO, HttpRoutes] = proxyServiceResource.map {
-    proxyService =>
-      new HttpRoutes(
-        swaggerConfig,
-        statusService,
-        proxyService,
-        runtimeService,
-        MockDiskServiceInterp,
-        MockAppService,
-        timedUserInfoDirectives,
-        contentSecurityPolicy,
-        refererConfig
-      )
-  }
+  def fakeRoutes(runtimeService: RuntimeService[IO]): HttpRoutes =
+    new HttpRoutes(
+      swaggerConfig,
+      statusService,
+      proxyService,
+      runtimeService,
+      MockDiskServiceInterp,
+      MockAppService,
+      timedUserInfoDirectives,
+      contentSecurityPolicy,
+      refererConfig
+    )
 
-  def fakeRoutes(kubernetesService: AppService[IO]): Resource[IO, HttpRoutes] = proxyServiceResource.map {
-    proxyService =>
-      new HttpRoutes(
-        swaggerConfig,
-        statusService,
-        proxyService,
-        runtimeService,
-        MockDiskServiceInterp,
-        kubernetesService,
-        timedUserInfoDirectives,
-        contentSecurityPolicy,
-        refererConfig
-      )
-  }
+  def fakeRoutes(kubernetesService: AppService[IO]): HttpRoutes =
+    new HttpRoutes(
+      swaggerConfig,
+      statusService,
+      proxyService,
+      runtimeService,
+      MockDiskServiceInterp,
+      kubernetesService,
+      timedUserInfoDirectives,
+      contentSecurityPolicy,
+      refererConfig
+    )
 }
 
 object HttpRoutesSpec {

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/ProxyRoutesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/ProxyRoutesSpec.scala
@@ -5,25 +5,19 @@ package api
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.model.HttpMethods._
 import akka.http.scaladsl.model._
-import akka.http.scaladsl.model.headers.{ContentDispositionTypes, `Content-Disposition`, _}
+import akka.http.scaladsl.model.headers._
 import akka.http.scaladsl.model.ws.{TextMessage, WebSocketRequest}
 import akka.http.scaladsl.testkit.{RouteTestTimeout, ScalatestRouteTest}
 import akka.stream.scaladsl.{Keep, Sink, Source}
-import cats.effect.{IO, Resource}
+import cats.effect.IO
+import cats.effect.std.Queue
 import cats.mtl.Ask
 import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
-import cats.effect.std.Queue
 import org.broadinstitute.dsde.workbench.leonardo.CommonTestData._
 import org.broadinstitute.dsde.workbench.leonardo.KubernetesTestData._
 import org.broadinstitute.dsde.workbench.leonardo.config.ProxyConfig
 import org.broadinstitute.dsde.workbench.leonardo.dao.google.MockGoogleOAuth2Service
-import org.broadinstitute.dsde.workbench.leonardo.dao.{
-  JupyterDAO,
-  MockJupyterDAO,
-  MockSamDAO,
-  TerminalName,
-  UserSubjectId
-}
+import org.broadinstitute.dsde.workbench.leonardo.dao._
 import org.broadinstitute.dsde.workbench.leonardo.db.TestComponent
 import org.broadinstitute.dsde.workbench.leonardo.http.service.SamResourceCacheKey.{AppCacheKey, RuntimeCacheKey}
 import org.broadinstitute.dsde.workbench.leonardo.http.service.TestProxy.{dataDecoder, Data}
@@ -31,7 +25,7 @@ import org.broadinstitute.dsde.workbench.leonardo.http.service.{MockDiskServiceI
 import org.broadinstitute.dsde.workbench.leonardo.monitor.UpdateDateAccessMessage
 import org.broadinstitute.dsde.workbench.model.TraceId
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
-import org.mockito.Mockito.{verify, _}
+import org.mockito.Mockito._
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.time.{Seconds, Span}
@@ -76,313 +70,232 @@ class ProxyRoutesSpec
     super.afterAll()
   }
 
-  val httpRoutesResourceWithProxyService = proxyServiceResource.map { proxyService =>
-    proxyService.samResourceCache.put(RuntimeCacheKey(GoogleProject(googleProject), RuntimeName(clusterName)),
-                                      Some(runtimeSamResource.resourceId))
-    proxyService.samResourceCache.put(AppCacheKey(GoogleProject(googleProject), AppName(appName)),
-                                      Some(appSamId.resourceId))
-    (proxyService,
-     new HttpRoutes(
-       swaggerConfig,
-       statusService,
-       proxyService,
-       runtimeService,
-       MockDiskServiceInterp,
-       leoKubernetesService,
-       userInfoDirectives,
-       contentSecurityPolicy,
-       refererConfig
-     ))
+  before {
+    val res = for {
+      _ <- googleTokenCache.removeAll
+      _ <- samResourceCache.put(
+        RuntimeCacheKey(GoogleProject(googleProject), RuntimeName(clusterName))
+      )(
+        Some(runtimeSamResource.resourceId),
+        None
+      )
+      _ <- samResourceCache.put(
+        AppCacheKey(GoogleProject(googleProject), AppName(appName))
+      )(
+        Some(appSamId.resourceId),
+        None
+      )
+    } yield ()
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
-  override val httpRoutesResource = httpRoutesResourceWithProxyService.map(_._2)
-
   "runtime proxy routes" should "listen on /proxy/{project}/{name} id1" in {
-    httpRoutesResource
-      .use { httpRoutes =>
-        IO {
-          Get(s"/proxy/$googleProject/$clusterName")
-            .addHeader(Cookie(tokenCookie))
-            .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
-            handled shouldBe true
-            status shouldEqual StatusCodes.OK
-            validateCors()
-          }
-          Get(s"/proxy/$googleProject/$clusterName/foo")
-            .addHeader(Cookie(tokenCookie))
-            .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
-            handled shouldBe true
-            status shouldEqual StatusCodes.OK
-            validateCors()
-          }
-          Get(s"/proxy/")
-            .addHeader(Cookie(tokenCookie))
-            .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
-            status shouldBe StatusCodes.MethodNotAllowed
-            val resp = responseEntity.toStrict(5 seconds).futureValue.data.utf8String
-            resp shouldBe "HTTP method not allowed, supported methods: OPTIONS"
-          }
-          Get(s"/api/proxy")
-            .addHeader(Cookie(tokenCookie))
-            .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
-            status shouldBe StatusCodes.NotFound
-            val resp = responseEntity.toStrict(5 seconds).futureValue.data.utf8String
-            resp shouldBe "\"API not found. Make sure you're calling the correct endpoint with correct method\""
-          }
-        }
-      }
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    Get(s"/proxy/$googleProject/$clusterName")
+      .addHeader(Cookie(tokenCookie))
+      .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
+      handled shouldBe true
+      status shouldEqual StatusCodes.OK
+      validateCors()
+    }
+    Get(s"/proxy/$googleProject/$clusterName/foo")
+      .addHeader(Cookie(tokenCookie))
+      .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
+      handled shouldBe true
+      status shouldEqual StatusCodes.OK
+      validateCors()
+    }
+    Get(s"/proxy/")
+      .addHeader(Cookie(tokenCookie))
+      .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
+      status shouldBe StatusCodes.MethodNotAllowed
+      val resp = responseEntity.toStrict(5 seconds).futureValue.data.utf8String
+      resp shouldBe "HTTP method not allowed, supported methods: OPTIONS"
+    }
+    Get(s"/api/proxy")
+      .addHeader(Cookie(tokenCookie))
+      .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
+      status shouldBe StatusCodes.NotFound
+      val resp = responseEntity.toStrict(5 seconds).futureValue.data.utf8String
+      resp shouldBe "\"API not found. Make sure you're calling the correct endpoint with correct method\""
+    }
   }
 
   it should "404 for non-existent runtimes" in {
-    httpRoutesResourceWithProxyService
-      .use {
-        case (proxyService, httpRoutes) =>
-          val newName = "aDifferentClusterName"
-          // should 404 since the internal id cannot be looked up
-          IO {
-            Get(s"/proxy/$googleProject/$newName")
-              .addHeader(Cookie(tokenCookie))
-              .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
-              status shouldEqual StatusCodes.NotFound
-            }
-            // should still 404 even if a cache entry is present
-            proxyService.samResourceCache.put(RuntimeCacheKey(GoogleProject(googleProject), RuntimeName(newName)),
-                                              Some(runtimeSamResource.resourceId))
-            Get(s"/proxy/$googleProject/$newName")
-              .addHeader(Cookie(tokenCookie))
-              .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
-              status shouldEqual StatusCodes.NotFound
-            }
-          }
-      }
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    val newName = "aDifferentClusterName"
+    // should 404 since the internal id cannot be looked up
+    Get(s"/proxy/$googleProject/$newName")
+      .addHeader(Cookie(tokenCookie))
+      .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
+      status shouldEqual StatusCodes.NotFound
+    }
+    // should still 404 even if a cache entry is present
+    samResourceCache
+      .put(
+        proxyService.getSamResourceFromDb(RuntimeCacheKey(GoogleProject(googleProject), RuntimeName(newName)))
+      )(Some(runtimeSamResource.resourceId), None)
+      .unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
+    Get(s"/proxy/$googleProject/$newName")
+      .addHeader(Cookie(tokenCookie))
+      .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
+      status shouldEqual StatusCodes.NotFound
+    }
   }
 
   it should "set CORS headers in runtime proxy requests" in {
-    httpRoutesResource
-      .use { httpRoutes =>
-        IO {
-          Get(s"/proxy/$googleProject/$clusterName")
-            .addHeader(Cookie(tokenCookie))
-            .addHeader(Origin("http://example.com"))
-            .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
-            handled shouldBe true
-            status shouldEqual StatusCodes.OK
-            validateCors(origin = Some("http://example.com"))
-          }
-        }
-      }
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    Get(s"/proxy/$googleProject/$clusterName")
+      .addHeader(Cookie(tokenCookie))
+      .addHeader(Origin("http://example.com"))
+      .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
+      handled shouldBe true
+      status shouldEqual StatusCodes.OK
+      validateCors(origin = Some("http://example.com"))
+    }
   }
 
   it should "reject non-cookied runtime proxy requests" in {
-    httpRoutesResource
-      .use { httpRoutes =>
-        IO(
-          Get(s"/proxy/$googleProject/$clusterName")
-            .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
-            handled shouldBe true
-            status shouldEqual StatusCodes.Unauthorized
-          }
-        )
-      }
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    Get(s"/proxy/$googleProject/$clusterName").addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
+      handled shouldBe true
+      status shouldEqual StatusCodes.Unauthorized
+    }
   }
 
   it should "404 when using a non-white-listed user in a runtime proxy request" in {
-    httpRoutesResource
-      .use { httpRoutes =>
-        IO(
-          Get(s"/proxy/$googleProject/$clusterName")
-            .addHeader(Cookie(unauthorizedTokenCookie))
-            .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
-            status shouldEqual StatusCodes.NotFound
-          }
-        )
-      }
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    Get(s"/proxy/$googleProject/$clusterName")
+      .addHeader(Cookie(unauthorizedTokenCookie))
+      .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
+      status shouldEqual StatusCodes.NotFound
+    }
   }
 
   it should "401 when using an expired token in a runtime proxy request" in {
-    httpRoutesResource
-      .use { httpRoutes =>
-        IO(
-          Get(s"/proxy/$googleProject/$clusterName")
-            .addHeader(Cookie(expiredTokenCookie))
-            .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
-            status shouldEqual StatusCodes.Unauthorized
-          }
-        )
-      }
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    Get(s"/proxy/$googleProject/$clusterName")
+      .addHeader(Cookie(expiredTokenCookie))
+      .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
+      status shouldEqual StatusCodes.Unauthorized
+    }
   }
 
   it should s"pass through paths in runtime proxy requests" in {
-    val queue = Queue.bounded[IO, UpdateDateAccessMessage](100).unsafeRunSync()(cats.effect.unsafe.implicits.global)
-
-    val proxyServiceResource = for {
-      runtimeDnsCache <- runtimeDnsCacheResource
-      kubernetesDnsCache <- kubernetesDnsCacheResource
-    } yield new MockProxyService(proxyConfig,
-                                 MockJupyterDAO,
-                                 whitelistAuthProvider,
-                                 runtimeDnsCache,
-                                 kubernetesDnsCache,
-                                 MockGoogleOAuth2Service,
-                                 queue = Some(queue))
-
-    proxyServiceResource
-      .use { proxyService =>
-        proxyService.samResourceCache.put(RuntimeCacheKey(GoogleProject(googleProject), RuntimeName(clusterName)),
-                                          Some(runtimeSamResource.resourceId))
-        val proxyRoutes = new ProxyRoutes(proxyService, corsSupport, refererConfig)
-        IO {
-          Get(s"/proxy/$googleProject/$clusterName")
-            .addHeader(Cookie(tokenCookie))
-            .addHeader(Referer(Uri(validRefererUri))) ~> proxyRoutes.route ~> check {
-            status shouldEqual StatusCodes.OK
-            responseAs[Data].path shouldEqual s"/proxy/$googleProject/$clusterName"
-            val message = queue.tryTake.unsafeRunSync()(cats.effect.unsafe.implicits.global).get
-            message.googleProject.value shouldBe googleProject
-            message.runtimeName.asString shouldBe clusterName
-          }
-        }
-      }
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
-
+    val queue = Queue.bounded[IO, UpdateDateAccessMessage](100).unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
+    val proxyService =
+      new MockProxyService(proxyConfig,
+                           MockJupyterDAO,
+                           whitelistAuthProvider,
+                           runtimeDnsCache,
+                           kubernetesDnsCache,
+                           googleTokenCache,
+                           samResourceCache,
+                           MockGoogleOAuth2Service,
+                           queue = Some(queue))
+    samResourceCache.put(
+      proxyService.getSamResourceFromDb(RuntimeCacheKey(GoogleProject(googleProject), RuntimeName(clusterName)))
+    )(Some(runtimeSamResource.resourceId), None)
+    val proxyRoutes = new ProxyRoutes(proxyService, corsSupport, refererConfig)
+    Get(s"/proxy/$googleProject/$clusterName")
+      .addHeader(Cookie(tokenCookie))
+      .addHeader(Referer(Uri(validRefererUri))) ~> proxyRoutes.route ~> check {
+      status shouldEqual StatusCodes.OK
+      responseAs[Data].path shouldEqual s"/proxy/$googleProject/$clusterName"
+      val message = queue.tryTake.unsafeRunSync()(cats.effect.unsafe.IORuntime.global).get
+      message.googleProject.value shouldBe googleProject
+      message.runtimeName.asString shouldBe clusterName
+    }
   }
 
   it should "pass through query string params in runtime proxy requests" in {
-    httpRoutesResource
-      .use { httpRoutes =>
-        IO(
-          Get(s"/proxy/$googleProject/$clusterName")
-            .addHeader(Cookie(tokenCookie))
-            .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
-            responseAs[Data].qs shouldBe None
-          }
-        ) >> IO(
-          Get(s"/proxy/$googleProject/$clusterName?foo=bar&baz=biz")
-            .addHeader(Cookie(tokenCookie))
-            .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
-            responseAs[Data].qs shouldEqual Some("foo=bar&baz=biz")
-          }
-        )
-      }
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    Get(s"/proxy/$googleProject/$clusterName")
+      .addHeader(Cookie(tokenCookie))
+      .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
+      responseAs[Data].qs shouldBe None
+    }
+    Get(s"/proxy/$googleProject/$clusterName?foo=bar&baz=biz")
+      .addHeader(Cookie(tokenCookie))
+      .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
+      responseAs[Data].qs shouldEqual Some("foo=bar&baz=biz")
+    }
   }
 
   it should "pass through encoded query string params in runtime proxy requests" in {
-    httpRoutesResource
-      .use { httpRoutes =>
-        IO(
-          Get(s"/proxy/$googleProject/$clusterName?foo=This%20is%20an%20encoded%20param.&baz=biz")
-            .addHeader(Cookie(tokenCookie))
-            .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
-            responseAs[Data].qs shouldEqual Some("foo=This is an encoded param.&baz=biz")
-          }
-        )
-      }
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    Get(s"/proxy/$googleProject/$clusterName?foo=This%20is%20an%20encoded%20param.&baz=biz")
+      .addHeader(Cookie(tokenCookie))
+      .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
+      responseAs[Data].qs shouldEqual Some("foo=This is an encoded param.&baz=biz")
+    }
   }
 
   it should "pass through http methods in runtime proxy requests" in {
-    httpRoutesResource
-      .use { httpRoutes =>
-        IO {
-          Get(s"/proxy/$googleProject/$clusterName")
-            .addHeader(Cookie(tokenCookie))
-            .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
-            responseAs[Data].method shouldBe "GET"
-          }
-          Post(s"/proxy/$googleProject/$clusterName")
-            .addHeader(Cookie(tokenCookie))
-            .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
-            responseAs[Data].method shouldBe "POST"
-          }
-          Put(s"/proxy/$googleProject/$clusterName")
-            .addHeader(Cookie(tokenCookie))
-            .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
-            responseAs[Data].method shouldBe "PUT"
-          }
-        }
-      }
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    Get(s"/proxy/$googleProject/$clusterName")
+      .addHeader(Cookie(tokenCookie))
+      .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
+      responseAs[Data].method shouldBe "GET"
+    }
+    Post(s"/proxy/$googleProject/$clusterName")
+      .addHeader(Cookie(tokenCookie))
+      .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
+      responseAs[Data].method shouldBe "POST"
+    }
+    Put(s"/proxy/$googleProject/$clusterName")
+      .addHeader(Cookie(tokenCookie))
+      .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
+      responseAs[Data].method shouldBe "PUT"
+    }
   }
 
   it should "pass through headers in runtime proxy requests" in {
-    httpRoutesResource
-      .use { httpRoutes =>
-        IO {
-          Get(s"/proxy/$googleProject/$clusterName")
-            .addHeader(Cookie(tokenCookie))
-            .addHeader(RawHeader("foo", "bar"))
-            .addHeader(RawHeader("baz", "biz"))
-            .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
-            responseAs[Data].headers.toList should contain allElementsOf Map("foo" -> "bar", "baz" -> "biz").toList
-          }
-        }
-      }
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    Get(s"/proxy/$googleProject/$clusterName")
+      .addHeader(Cookie(tokenCookie))
+      .addHeader(RawHeader("foo", "bar"))
+      .addHeader(RawHeader("baz", "biz"))
+      .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
+      responseAs[Data].headers.toList should contain allElementsOf Map("foo" -> "bar", "baz" -> "biz").toList
+    }
   }
 
   it should "remove utf-8'' from content-disposition header filenames" in {
-    httpRoutesResource
-      .use { httpRoutes =>
-        // The TestProxy adds the Content-Disposition header to the response, we can't do it from here
-        IO {
-          Get(s"/proxy/$googleProject/$clusterName/content-disposition-test")
-            .addHeader(Cookie(tokenCookie))
-            .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
-            responseAs[HttpResponse].headers should contain(
-              `Content-Disposition`(ContentDispositionTypes.attachment, Map("filename" -> "notebook.ipynb"))
-            )
-          }
-        }
-      }
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    // The TestProxy adds the Content-Disposition header to the response, we can't do it from here
+    Get(s"/proxy/$googleProject/$clusterName/content-disposition-test")
+      .addHeader(Cookie(tokenCookie))
+      .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
+      responseAs[HttpResponse].headers should contain(
+        `Content-Disposition`(ContentDispositionTypes.attachment, Map("filename" -> "notebook.ipynb"))
+      )
+    }
   }
 
-  it should "proxy websockets" in {
-    websocketProxyResource.use { _ =>
-      IO {
-        // See comments in ProxyService.handleHttpRequest for more high-level information on Flows, Sources, and Sinks.
+  it should "proxy websockets" in withWebsocketProxy {
+    // See comments in ProxyService.handleHttpRequest for more high-level information on Flows, Sources, and Sinks.
 
-        // Sink for incoming data from the WebSocket
-        val incoming = Sink.head[String]
+    // Sink for incoming data from the WebSocket
+    val incoming = Sink.head[String]
 
-        // Source outgoing data over the WebSocket
-        val outgoing = Source.single(TextMessage("Leonardo"))
+    // Source outgoing data over the WebSocket
+    val outgoing = Source.single(TextMessage("Leonardo"))
 
-        // Flow to hit the proxy server
-        val webSocketFlow = Http()
-          .webSocketClientFlow(
-            WebSocketRequest(Uri(s"ws://localhost:9000/proxy/$googleProject/$clusterName/websocket"),
-                             immutable.Seq(Cookie(tokenCookie)))
-          )
-          .map {
-            case m: TextMessage.Strict => m.text
-            case _                     => throw new IllegalArgumentException("ProxyRoutesSpec only supports strict messages")
-          }
-
-        // Glue together the source, sink, and flow. This materializes the Flow and actually initiates the HTTP request.
-        // Returns a tuple of:
-        //  - `upgradeResponse` is a Future[WebSocketUpgradeResponse] that completes or fails when the connection succeeds or fails.
-        //  - `result` is a Future[String] with the stream completion from the incoming sink.
-        val (upgradeResponse, result) =
-          outgoing
-            .viaMat(webSocketFlow)(Keep.right)
-            .toMat(incoming)(Keep.both)
-            .run()
-
-        // The connection future should have returned the HTTP 101 status code
-        upgradeResponse.futureValue.response.status shouldBe StatusCodes.SwitchingProtocols
-        // The stream completion future should have greeted Leonardo
-        result.futureValue shouldBe "Hello Leonardo!"
+    // Flow to hit the proxy server
+    val webSocketFlow = Http()
+      .webSocketClientFlow(
+        WebSocketRequest(Uri(s"ws://localhost:9000/proxy/$googleProject/$clusterName/websocket"),
+                         immutable.Seq(Cookie(tokenCookie)))
+      )
+      .map {
+        case m: TextMessage.Strict => m.text
+        case _                     => throw new IllegalArgumentException("ProxyRoutesSpec only supports strict messages")
       }
-    }
 
+    // Glue together the source, sink, and flow. This materializes the Flow and actually initiates the HTTP request.
+    // Returns a tuple of:
+    //  - `upgradeResponse` is a Future[WebSocketUpgradeResponse] that completes or fails when the connection succeeds or fails.
+    //  - `result` is a Future[String] with the stream completion from the incoming sink.
+    val (upgradeResponse, result) =
+      outgoing
+        .viaMat(webSocketFlow)(Keep.right)
+        .toMat(incoming)(Keep.both)
+        .run()
+
+    // The connection future should have returned the HTTP 101 status code
+    upgradeResponse.futureValue.response.status shouldBe StatusCodes.SwitchingProtocols
+    // The stream completion future should have greeted Leonardo
+    result.futureValue shouldBe "Hello Leonardo!"
   }
 
   it should "create a new terminal when trying to access a terminal that was not created yet" in {
@@ -395,218 +308,143 @@ class ProxyRoutesSpec
       jupyterDAO.createTerminal(GoogleProject(googleProject), RuntimeName(clusterName))
     } thenReturn IO.unit
 
-    createHttpRoute(jupyterDAO)
-      .use { httpRoutes =>
-        IO {
-          Get(s"/proxy/$googleProject/$clusterName/jupyter/terminals/1")
-            .addHeader(Authorization(OAuth2BearerToken(tokenCookie.value)))
-            .addHeader(Origin("http://example.com"))
-            .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
-            status shouldEqual StatusCodes.OK
-            verify(jupyterDAO, times(1)).terminalExists(GoogleProject(googleProject),
-                                                        RuntimeName(clusterName),
-                                                        TerminalName("1"))
-            verify(jupyterDAO, times(1)).createTerminal(GoogleProject(googleProject), RuntimeName(clusterName))
-          }
-        }
-      }
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    val httpRoutes = createHttpRoute(jupyterDAO)
 
+    Get(s"/proxy/$googleProject/$clusterName/jupyter/terminals/1")
+      .addHeader(Authorization(OAuth2BearerToken(tokenCookie.value)))
+      .addHeader(Origin("http://example.com"))
+      .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
+      status shouldEqual StatusCodes.OK
+      verify(jupyterDAO, times(1)).terminalExists(GoogleProject(googleProject),
+                                                  RuntimeName(clusterName),
+                                                  TerminalName("1"))
+      verify(jupyterDAO, times(1)).createTerminal(GoogleProject(googleProject), RuntimeName(clusterName))
+    }
   }
 
   "app proxy routes" should "listen on /proxy/google/v1/apps/{project}/{name}/{service}" in {
-    httpRoutesResource
-      .use { httpRoutes =>
-        IO {
-          Get(s"/proxy/google/v1/apps/$googleProject/$appName/$serviceName")
-            .addHeader(Cookie(tokenCookie))
-            .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
-            handled shouldBe true
-            status shouldEqual StatusCodes.OK
-            validateCors()
-          }
-          Get(s"/proxy/google/v1/apps/$googleProject/$appName/$serviceName/foo")
-            .addHeader(Cookie(tokenCookie))
-            .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
-            handled shouldBe true
-            status shouldEqual StatusCodes.OK
-            validateCors()
-          }
-        }
-      }
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    Get(s"/proxy/google/v1/apps/$googleProject/$appName/$serviceName")
+      .addHeader(Cookie(tokenCookie))
+      .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
+      handled shouldBe true
+      status shouldEqual StatusCodes.OK
+      validateCors()
+    }
+    Get(s"/proxy/google/v1/apps/$googleProject/$appName/$serviceName/foo")
+      .addHeader(Cookie(tokenCookie))
+      .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
+      handled shouldBe true
+      status shouldEqual StatusCodes.OK
+      validateCors()
+    }
   }
 
   it should "404 for non-existent apps" in {
     val newName = "killerApp"
     // should 404 since the internal id cannot be looked up
-    httpRoutesResource
-      .use { httpRoutes =>
-        IO(
-          Get(s"/proxy/google/v1/apps/$newName/$serviceName")
-            .addHeader(Cookie(tokenCookie))
-            .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
-            status shouldEqual StatusCodes.NotFound
-          }
-        )
-      }
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    Get(s"/proxy/google/v1/apps/$newName/$serviceName")
+      .addHeader(Cookie(tokenCookie))
+      .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
+      status shouldEqual StatusCodes.NotFound
+    }
   }
 
   it should "set CORS headers in app proxy requests" in {
-    httpRoutesResource
-      .use { httpRoutes =>
-        IO(
-          Get(s"/proxy/google/v1/apps/$googleProject/$appName/$serviceName")
-            .addHeader(Cookie(tokenCookie))
-            .addHeader(Origin("http://example.com"))
-            .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
-            handled shouldBe true
-            status shouldEqual StatusCodes.OK
-            validateCors(origin = Some("http://example.com"))
-          }
-        )
-      }
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    Get(s"/proxy/google/v1/apps/$googleProject/$appName/$serviceName")
+      .addHeader(Cookie(tokenCookie))
+      .addHeader(Origin("http://example.com"))
+      .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
+      handled shouldBe true
+      status shouldEqual StatusCodes.OK
+      validateCors(origin = Some("http://example.com"))
+    }
   }
 
   it should "reject non-cookied requests in app proxy requests" in {
-    httpRoutesResource
-      .use { httpRoutes =>
-        IO(
-          Get(s"/proxy/google/v1/apps/$googleProject/$appName/$serviceName")
-            .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
-            handled shouldBe true
-            status shouldEqual StatusCodes.Unauthorized
-          }
-        )
-      }
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    Get(s"/proxy/google/v1/apps/$googleProject/$appName/$serviceName")
+      .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
+      handled shouldBe true
+      status shouldEqual StatusCodes.Unauthorized
+    }
   }
 
   it should s"401 when using an expired token in app proxy requests" in {
-    httpRoutesResource
-      .use { httpRoutes =>
-        IO(
-          Get(s"/proxy/google/v1/apps/$googleProject/$appName/$serviceName")
-            .addHeader(Cookie(expiredTokenCookie))
-            .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
-            status shouldEqual StatusCodes.Unauthorized
-          }
-        )
-      }
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    Get(s"/proxy/google/v1/apps/$googleProject/$appName/$serviceName")
+      .addHeader(Cookie(expiredTokenCookie))
+      .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
+      status shouldEqual StatusCodes.Unauthorized
+    }
   }
 
   it should s"pass through paths in app proxy requests" in {
-    httpRoutesResource
-      .use { httpRoutes =>
-        IO(
-          Get(s"/proxy/google/v1/apps/$googleProject/$appName/$serviceName")
-            .addHeader(Cookie(tokenCookie))
-            .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
-            status shouldEqual StatusCodes.OK
-            responseAs[Data].path shouldEqual s"/proxy/google/v1/apps/$googleProject/$appName/$serviceName"
-          }
-        )
-      }
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    Get(s"/proxy/google/v1/apps/$googleProject/$appName/$serviceName")
+      .addHeader(Cookie(tokenCookie))
+      .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
+      status shouldEqual StatusCodes.OK
+      responseAs[Data].path shouldEqual s"/proxy/google/v1/apps/$googleProject/$appName/$serviceName"
+    }
   }
 
   it should "pass through query string params in app proxy requests" in {
-    httpRoutesResource
-      .use { httpRoutes =>
-        IO(
-          Get(s"/proxy/google/v1/apps/$googleProject/$appName/$serviceName?foo=bar&baz=biz")
-            .addHeader(Cookie(tokenCookie))
-            .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
-            responseAs[Data].qs shouldEqual Some("foo=bar&baz=biz")
-          }
-        )
-      }
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    Get(s"/proxy/google/v1/apps/$googleProject/$appName/$serviceName?foo=bar&baz=biz")
+      .addHeader(Cookie(tokenCookie))
+      .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
+      responseAs[Data].qs shouldEqual Some("foo=bar&baz=biz")
+    }
   }
 
   it should "pass through encoded query string params in app proxy requests" in {
-    httpRoutesResource
-      .use { httpRoutes =>
-        IO(
-          Get(
-            s"/proxy/google/v1/apps/$googleProject/$appName/$serviceName?foo=This%20is%20an%20encoded%20param.&baz=biz"
-          ).addHeader(Cookie(tokenCookie))
-            .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
-            responseAs[Data].qs shouldEqual Some("foo=This is an encoded param.&baz=biz")
-          }
-        )
-      }
+    Get(s"/proxy/google/v1/apps/$googleProject/$appName/$serviceName?foo=This%20is%20an%20encoded%20param.&baz=biz")
+      .addHeader(Cookie(tokenCookie))
+      .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
+      responseAs[Data].qs shouldEqual Some("foo=This is an encoded param.&baz=biz")
+    }
   }
 
   it should "pass through http methods in app proxy requests" in {
-    httpRoutesResource
-      .use { httpRoutes =>
-        IO(
-          Get(s"/proxy/google/v1/apps/$googleProject/$appName/$serviceName")
-            .addHeader(Cookie(tokenCookie))
-            .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
-            responseAs[Data].method shouldBe "GET"
-          }
-        ) >> IO(
-          Post(s"/proxy/google/v1/apps/$googleProject/$appName/$serviceName")
-            .addHeader(Cookie(tokenCookie))
-            .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
-            responseAs[Data].method shouldBe "POST"
-          }
-        ) >> IO(
-          Put(s"/proxy/google/v1/apps/$googleProject/$appName/$serviceName")
-            .addHeader(Cookie(tokenCookie))
-            .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
-            responseAs[Data].method shouldBe "PUT"
-          }
-        )
-      }
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    Get(s"/proxy/google/v1/apps/$googleProject/$appName/$serviceName")
+      .addHeader(Cookie(tokenCookie))
+      .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
+      responseAs[Data].method shouldBe "GET"
+    }
+    Post(s"/proxy/google/v1/apps/$googleProject/$appName/$serviceName")
+      .addHeader(Cookie(tokenCookie))
+      .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
+      responseAs[Data].method shouldBe "POST"
+    }
+    Put(s"/proxy/google/v1/apps/$googleProject/$appName/$serviceName")
+      .addHeader(Cookie(tokenCookie))
+      .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
+      responseAs[Data].method shouldBe "PUT"
+    }
   }
 
   it should "pass through headers in app proxy requests" in {
-    httpRoutesResource
-      .use { httpRoutes =>
-        IO(
-          Get(s"/proxy/google/v1/apps/$googleProject/$appName/$serviceName")
-            .addHeader(Cookie(tokenCookie))
-            .addHeader(RawHeader("foo", "bar"))
-            .addHeader(RawHeader("baz", "biz"))
-            .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
-            responseAs[Data].headers.toList should contain allElementsOf Map("foo" -> "bar", "baz" -> "biz").toList
-          }
-        )
-      }
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    Get(s"/proxy/google/v1/apps/$googleProject/$appName/$serviceName")
+      .addHeader(Cookie(tokenCookie))
+      .addHeader(RawHeader("foo", "bar"))
+      .addHeader(RawHeader("baz", "biz"))
+      .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
+      responseAs[Data].headers.toList should contain allElementsOf Map("foo" -> "bar", "baz" -> "biz").toList
+    }
   }
 
   "setCookie" should "set a cookie given a valid Authorization header" in {
-    httpRoutesResourceWithProxyService
-      .use {
-        case (proxyService, httpRoutes) =>
-          IO {
-            // cache should not initially contain the token
-            proxyService.googleTokenCache.asMap().containsKey(tokenCookie.value) shouldBe false
-            // login request with Authorization header should succeed and return a Set-Cookie header
-            Get(s"/proxy/$googleProject/$clusterName/setCookie")
-              .addHeader(Authorization(OAuth2BearerToken(tokenCookie.value)))
-              .addHeader(Origin("http://example.com"))
-              .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
-              validateRawCookie(setCookie = header("Set-Cookie"), age = 3600)
-              status shouldEqual StatusCodes.NoContent
-              validateCors(origin = Some("http://example.com"))
-            }
+    // login request with Authorization header should succeed and return a Set-Cookie header
+    Get(s"/proxy/$googleProject/$clusterName/setCookie")
+      .addHeader(Authorization(OAuth2BearerToken(tokenCookie.value)))
+      .addHeader(Origin("http://example.com"))
+      .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
+      validateRawCookie(setCookie = header("Set-Cookie"), age = 3600)
+      status shouldEqual StatusCodes.NoContent
+      validateCors(origin = Some("http://example.com"))
+    }
 
-            // cache should now contain the token
-            proxyService.googleTokenCache.asMap().containsKey(tokenCookie.value) shouldBe true
-
-          }
-      }
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
-
+    // cache should now contain the token
+    googleTokenCache
+      .get(tokenCookie.value)
+      .map(_.isDefined)
+      .unsafeRunSync()(cats.effect.unsafe.IORuntime.global) shouldBe true
   }
 
   it should "reject setCookie if user is not registered" in {
@@ -614,180 +452,143 @@ class ProxyRoutesSpec
       override def getUserSubjectIdFromToken(token: String)(implicit ev: Ask[IO, TraceId]): IO[Option[UserSubjectId]] =
         IO.pure(None)
     }
-    val httpRoutesWithProxyService = for {
-      runtimeDnsCache <- runtimeDnsCacheResource
-      kubernetesDnsCache <- kubernetesDnsCacheResource
-    } yield {
-      val proxyService = new MockProxyService(proxyConfig,
-                                              MockJupyterDAO,
-                                              whitelistAuthProvider,
-                                              runtimeDnsCache,
-                                              kubernetesDnsCache,
-                                              MockGoogleOAuth2Service,
-                                              samDAO = Some(samDao))
-      (proxyService,
-       new HttpRoutes(
-         swaggerConfig,
-         statusService,
-         proxyService,
-         runtimeService,
-         MockDiskServiceInterp,
-         leoKubernetesService,
-         userInfoDirectives,
-         contentSecurityPolicy,
-         refererConfig
-       ))
+    val proxyService =
+      new MockProxyService(proxyConfig,
+                           MockJupyterDAO,
+                           whitelistAuthProvider,
+                           runtimeDnsCache,
+                           kubernetesDnsCache,
+                           googleTokenCache,
+                           samResourceCache,
+                           MockGoogleOAuth2Service,
+                           samDAO = Some(samDao))
+    val httpRoutes = new HttpRoutes(
+      swaggerConfig,
+      statusService,
+      proxyService,
+      runtimeService,
+      MockDiskServiceInterp,
+      leoKubernetesService,
+      userInfoDirectives,
+      contentSecurityPolicy,
+      refererConfig
+    )
+    // cache should not initially contain the token
+    googleTokenCache
+      .get(tokenCookie.value)
+      .map(_.isDefined)
+      .unsafeRunSync()(cats.effect.unsafe.IORuntime.global) shouldBe false
+    // login request with Authorization header should succeed and return a Set-Cookie header
+    Get(s"/proxy/$googleProject/$clusterName/setCookie")
+      .addHeader(Authorization(OAuth2BearerToken(tokenCookie.value)))
+      .addHeader(Origin("http://example.com"))
+      .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
+      status shouldEqual StatusCodes.Unauthorized
     }
-
-    httpRoutesWithProxyService
-      .use {
-        case (proxyService, httpRoutes) =>
-          IO {
-            // cache should not initially contain the token
-            proxyService.googleTokenCache.asMap().containsKey(tokenCookie.value) shouldBe false
-            // login request with Authorization header should succeed and return a Set-Cookie header
-            Get(s"/proxy/$googleProject/$clusterName/setCookie")
-              .addHeader(Authorization(OAuth2BearerToken(tokenCookie.value)))
-              .addHeader(Origin("http://example.com"))
-              .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
-              status shouldEqual StatusCodes.Unauthorized
-            }
-          }
-      }
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
-
   }
 
   it should "handle preflight OPTIONS requests" in {
-    httpRoutesResource
-      .use { httpRoutes =>
-        IO {
-          Options(s"/proxy/$googleProject/$clusterName/setCookie")
-            .addHeader(Authorization(OAuth2BearerToken(tokenCookie.value)))
-            .addHeader(Origin("http://example.com"))
-            .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
-            handled shouldBe true
-            status shouldEqual StatusCodes.NoContent
-            header[`Set-Cookie`] shouldBe None
-            validateCors(origin = Some("http://example.com"), optionsRequest = true)
-          }
-        }
-      }
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    Options(s"/proxy/$googleProject/$clusterName/setCookie")
+      .addHeader(Authorization(OAuth2BearerToken(tokenCookie.value)))
+      .addHeader(Origin("http://example.com"))
+      .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
+      handled shouldBe true
+      status shouldEqual StatusCodes.NoContent
+      header[`Set-Cookie`] shouldBe None
+      validateCors(origin = Some("http://example.com"), optionsRequest = true)
+    }
   }
 
   it should "unset the cookie when not given an Authorization header" in {
-    httpRoutesResource
-      .use { httpRoutes =>
-        IO(
-          Get(s"/proxy/$googleProject/$clusterName/setCookie")
-            .addHeader(Origin("http://example.com"))
-            .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
-            handled shouldBe true
-            validateUnsetRawCookie(setCookie = header("Set-Cookie"))
-            status shouldEqual StatusCodes.NoContent
-            validateCors(origin = Some("http://example.com"))
-          }
-        )
-      }
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    Get(s"/proxy/$googleProject/$clusterName/setCookie")
+      .addHeader(Origin("http://example.com"))
+      .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
+      handled shouldBe true
+      validateUnsetRawCookie(setCookie = header("Set-Cookie"))
+      status shouldEqual StatusCodes.NoContent
+      validateCors(origin = Some("http://example.com"))
+    }
   }
 
   it should "401 when using an expired token" in {
-    httpRoutesResource
-      .use { httpRoutes =>
-        IO {
-          Get(s"/proxy/$googleProject/$clusterName")
-            .addHeader(Authorization(OAuth2BearerToken(expiredTokenCookie.value)))
-            .addHeader(Origin("http://example.com"))
-            .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
-            status shouldEqual StatusCodes.Unauthorized
-          }
-        }
-      }
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
-
+    Get(s"/proxy/$googleProject/$clusterName")
+      .addHeader(Authorization(OAuth2BearerToken(expiredTokenCookie.value)))
+      .addHeader(Origin("http://example.com"))
+      .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
+      status shouldEqual StatusCodes.Unauthorized
+    }
   }
 
   "invalidateToken" should "remove a token from cache" in {
-    httpRoutesResourceWithProxyService
-      .use {
-        case (proxyService, httpRoutes) =>
-          IO {
-            proxyService.googleTokenCache.asMap().containsKey(tokenCookie.value) shouldBe false
+    // regular request with a cookie should succeed but NOT return a Set-Cookie header
+    Get(s"/proxy/$googleProject/$clusterName")
+      .addHeader(Cookie(tokenCookie))
+      .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
+      handled shouldBe true
+      status shouldEqual StatusCodes.OK
+      header[`Set-Cookie`] shouldBe None
+    }
 
-            // regular request with a cookie should succeed but NOT return a Set-Cookie header
-            Get(s"/proxy/$googleProject/$clusterName")
-              .addHeader(Cookie(tokenCookie))
-              .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
-              handled shouldBe true
-              status shouldEqual StatusCodes.OK
-              header[`Set-Cookie`] shouldBe None
-            }
+    // cache should now contain the token
+    googleTokenCache
+      .get(tokenCookie.value)
+      .map(_.isDefined)
+      .unsafeRunSync()(cats.effect.unsafe.IORuntime.global) shouldBe true
 
-            // cache should now contain the token
-            proxyService.googleTokenCache.asMap().containsKey(tokenCookie.value) shouldBe true
+    // log out, passing a cookie
+    Get(s"/proxy/invalidateToken")
+      .addHeader(Cookie(tokenCookie))
+      .addHeader(Origin("http://example.com"))
+      .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
+      handled shouldBe true
+      validateUnsetRawCookie(setCookie = header("Set-Cookie"))
+      status shouldEqual StatusCodes.NoContent
+      validateCors(origin = Some("http://example.com"))
+    }
 
-            // log out, passing a cookie
-            Get(s"/proxy/invalidateToken")
-              .addHeader(Cookie(tokenCookie))
-              .addHeader(Origin("http://example.com"))
-              .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
-              handled shouldBe true
-              validateUnsetRawCookie(setCookie = header("Set-Cookie"))
-              status shouldEqual StatusCodes.NoContent
-              validateCors(origin = Some("http://example.com"))
-            }
-
-            // cache should not contain the token
-            proxyService.googleTokenCache.asMap().containsKey(tokenCookie.value) shouldBe false
-          }
-      }
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    // cache should not contain the token
+    googleTokenCache
+      .get(tokenCookie.value)
+      .map(_.isDefined)
+      .unsafeRunSync()(cats.effect.unsafe.IORuntime.global) shouldBe false
   }
 
-  def createHttpRoute(jupyterDAO: JupyterDAO[IO]): Resource[IO, HttpRoutes] =
-    for {
-      runtimeDnsCache <- runtimeDnsCacheResource
-      kubernetesDnsCache <- kubernetesDnsCacheResource
-    } yield {
-      val proxyService =
-        new MockProxyService(proxyConfig,
-                             jupyterDAO,
-                             whitelistAuthProvider,
-                             runtimeDnsCache,
-                             kubernetesDnsCache,
-                             MockGoogleOAuth2Service)
-      proxyService.samResourceCache
-        .put(RuntimeCacheKey(GoogleProject(googleProject), RuntimeName(clusterName)),
-             Some(runtimeSamResource.resourceId))
-      proxyService.samResourceCache
-        .put(AppCacheKey(GoogleProject(googleProject), AppName(appName)), Some(appSamId.resourceId))
+  def createHttpRoute(jupyterDAO: JupyterDAO[IO]): HttpRoutes = {
+    val proxyService =
+      new MockProxyService(proxyConfig,
+                           jupyterDAO,
+                           whitelistAuthProvider,
+                           runtimeDnsCache,
+                           kubernetesDnsCache,
+                           googleTokenCache,
+                           samResourceCache,
+                           MockGoogleOAuth2Service)
 
-      new HttpRoutes(
-        swaggerConfig,
-        statusService,
-        proxyService,
-        runtimeService,
-        MockDiskServiceInterp,
-        leoKubernetesService,
-        userInfoDirectives,
-        contentSecurityPolicy,
-        refererConfig
-      )
-    }
+    new HttpRoutes(
+      swaggerConfig,
+      statusService,
+      proxyService,
+      runtimeService,
+      MockDiskServiceInterp,
+      leoKubernetesService,
+      userInfoDirectives,
+      contentSecurityPolicy,
+      refererConfig
+    )
+  }
 
   /**
    * Akka-http TestKit doesn't seem to support websocket servers.
    * So for websocket tests, manually create a server binding on port 9000 for the proxy.
    */
-  def websocketProxyResource: Resource[IO, Unit] =
-    for {
-      httpRoutes <- httpRoutesResource
-      _ <- Resource.make(IO.fromFuture(IO(Http().bindAndHandle(httpRoutes.route, "0.0.0.0", 9000))))(binding =>
-        IO.fromFuture(IO(binding.unbind())).void
-      )
-    } yield ()
+  def withWebsocketProxy[T](testCode: => T): T = {
+    val bindingFuture = Http().bindAndHandle(httpRoutes.route, "0.0.0.0", 9000)
+    try {
+      testCode
+    } finally {
+      bindingFuture.flatMap(_.unbind())
+    }
+  }
 
   private def validateCors(origin: Option[String] = None, optionsRequest: Boolean = false): Unit = {
     // Issue 272: CORS headers should not be double set
@@ -808,31 +609,19 @@ class ProxyRoutesSpec
   }
 
   it should "401 when Referer is not a valid URI" in {
-    httpRoutesResource
-      .use { httpRoutes =>
-        IO(
-          Get(s"/proxy/$googleProject/$clusterName")
-            .addHeader(Referer(Uri("https://notAGoodExample.com"))) ~> httpRoutes.route ~> check {
-            status shouldEqual StatusCodes.Unauthorized
-          }
-        )
-      }
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    Get(s"/proxy/$googleProject/$clusterName")
+      .addHeader(Referer(Uri("https://notAGoodExample.com"))) ~> httpRoutes.route ~> check {
+      status shouldEqual StatusCodes.Unauthorized
+    }
   }
 
   it should "handle wildcards in referer allow list" in {
-    httpRoutesResource
-      .use { httpRoutes =>
-        IO(
-          Get(s"/proxy/$googleProject/$clusterName")
-            .addHeader(Cookie(tokenCookie))
-            .addHeader(Referer(Uri("http://foo:9099"))) ~> httpRoutes.route ~> check {
-            handled shouldBe true
-            status shouldEqual StatusCodes.OK
-            validateCors()
-          }
-        )
-      }
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    Get(s"/proxy/$googleProject/$clusterName")
+      .addHeader(Cookie(tokenCookie))
+      .addHeader(Referer(Uri("http://foo:9099"))) ~> httpRoutes.route ~> check {
+      handled shouldBe true
+      status shouldEqual StatusCodes.OK
+      validateCors()
+    }
   }
 }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/ProxyRoutesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/ProxyRoutesSpec.scala
@@ -9,10 +9,10 @@ import akka.http.scaladsl.model.headers.{ContentDispositionTypes, `Content-Dispo
 import akka.http.scaladsl.model.ws.{TextMessage, WebSocketRequest}
 import akka.http.scaladsl.testkit.{RouteTestTimeout, ScalatestRouteTest}
 import akka.stream.scaladsl.{Keep, Sink, Source}
-import cats.effect.IO
+import cats.effect.{IO, Resource}
 import cats.mtl.Ask
 import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
-import fs2.concurrent.InspectableQueue
+import cats.effect.std.Queue
 import org.broadinstitute.dsde.workbench.leonardo.CommonTestData._
 import org.broadinstitute.dsde.workbench.leonardo.KubernetesTestData._
 import org.broadinstitute.dsde.workbench.leonardo.config.ProxyConfig
@@ -76,215 +76,313 @@ class ProxyRoutesSpec
     super.afterAll()
   }
 
-  before {
-    proxyService.googleTokenCache.invalidateAll()
+  val httpRoutesResourceWithProxyService = proxyServiceResource.map { proxyService =>
     proxyService.samResourceCache.put(RuntimeCacheKey(GoogleProject(googleProject), RuntimeName(clusterName)),
                                       Some(runtimeSamResource.resourceId))
     proxyService.samResourceCache.put(AppCacheKey(GoogleProject(googleProject), AppName(appName)),
                                       Some(appSamId.resourceId))
+    (proxyService,
+     new HttpRoutes(
+       swaggerConfig,
+       statusService,
+       proxyService,
+       runtimeService,
+       MockDiskServiceInterp,
+       leoKubernetesService,
+       userInfoDirectives,
+       contentSecurityPolicy,
+       refererConfig
+     ))
   }
 
+  override val httpRoutesResource = httpRoutesResourceWithProxyService.map(_._2)
+
   "runtime proxy routes" should "listen on /proxy/{project}/{name} id1" in {
-    Get(s"/proxy/$googleProject/$clusterName")
-      .addHeader(Cookie(tokenCookie))
-      .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
-      handled shouldBe true
-      status shouldEqual StatusCodes.OK
-      validateCors()
-    }
-    Get(s"/proxy/$googleProject/$clusterName/foo")
-      .addHeader(Cookie(tokenCookie))
-      .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
-      handled shouldBe true
-      status shouldEqual StatusCodes.OK
-      validateCors()
-    }
-    Get(s"/proxy/")
-      .addHeader(Cookie(tokenCookie))
-      .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
-      status shouldBe StatusCodes.MethodNotAllowed
-      val resp = responseEntity.toStrict(5 seconds).futureValue.data.utf8String
-      resp shouldBe "HTTP method not allowed, supported methods: OPTIONS"
-    }
-    Get(s"/api/proxy")
-      .addHeader(Cookie(tokenCookie))
-      .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
-      status shouldBe StatusCodes.NotFound
-      val resp = responseEntity.toStrict(5 seconds).futureValue.data.utf8String
-      resp shouldBe "\"API not found. Make sure you're calling the correct endpoint with correct method\""
-    }
+    httpRoutesResource
+      .use { httpRoutes =>
+        IO {
+          Get(s"/proxy/$googleProject/$clusterName")
+            .addHeader(Cookie(tokenCookie))
+            .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
+            handled shouldBe true
+            status shouldEqual StatusCodes.OK
+            validateCors()
+          }
+          Get(s"/proxy/$googleProject/$clusterName/foo")
+            .addHeader(Cookie(tokenCookie))
+            .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
+            handled shouldBe true
+            status shouldEqual StatusCodes.OK
+            validateCors()
+          }
+          Get(s"/proxy/")
+            .addHeader(Cookie(tokenCookie))
+            .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
+            status shouldBe StatusCodes.MethodNotAllowed
+            val resp = responseEntity.toStrict(5 seconds).futureValue.data.utf8String
+            resp shouldBe "HTTP method not allowed, supported methods: OPTIONS"
+          }
+          Get(s"/api/proxy")
+            .addHeader(Cookie(tokenCookie))
+            .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
+            status shouldBe StatusCodes.NotFound
+            val resp = responseEntity.toStrict(5 seconds).futureValue.data.utf8String
+            resp shouldBe "\"API not found. Make sure you're calling the correct endpoint with correct method\""
+          }
+        }
+      }
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "404 for non-existent runtimes" in {
-    val newName = "aDifferentClusterName"
-    // should 404 since the internal id cannot be looked up
-    Get(s"/proxy/$googleProject/$newName")
-      .addHeader(Cookie(tokenCookie))
-      .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
-      status shouldEqual StatusCodes.NotFound
-    }
-    // should still 404 even if a cache entry is present
-    proxyService.samResourceCache.put(RuntimeCacheKey(GoogleProject(googleProject), RuntimeName(newName)),
-                                      Some(runtimeSamResource.resourceId))
-    Get(s"/proxy/$googleProject/$newName")
-      .addHeader(Cookie(tokenCookie))
-      .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
-      status shouldEqual StatusCodes.NotFound
-    }
+    httpRoutesResourceWithProxyService
+      .use {
+        case (proxyService, httpRoutes) =>
+          val newName = "aDifferentClusterName"
+          // should 404 since the internal id cannot be looked up
+          IO {
+            Get(s"/proxy/$googleProject/$newName")
+              .addHeader(Cookie(tokenCookie))
+              .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
+              status shouldEqual StatusCodes.NotFound
+            }
+            // should still 404 even if a cache entry is present
+            proxyService.samResourceCache.put(RuntimeCacheKey(GoogleProject(googleProject), RuntimeName(newName)),
+                                              Some(runtimeSamResource.resourceId))
+            Get(s"/proxy/$googleProject/$newName")
+              .addHeader(Cookie(tokenCookie))
+              .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
+              status shouldEqual StatusCodes.NotFound
+            }
+          }
+      }
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "set CORS headers in runtime proxy requests" in {
-    Get(s"/proxy/$googleProject/$clusterName")
-      .addHeader(Cookie(tokenCookie))
-      .addHeader(Origin("http://example.com"))
-      .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
-      handled shouldBe true
-      status shouldEqual StatusCodes.OK
-      validateCors(origin = Some("http://example.com"))
-    }
+    httpRoutesResource
+      .use { httpRoutes =>
+        IO {
+          Get(s"/proxy/$googleProject/$clusterName")
+            .addHeader(Cookie(tokenCookie))
+            .addHeader(Origin("http://example.com"))
+            .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
+            handled shouldBe true
+            status shouldEqual StatusCodes.OK
+            validateCors(origin = Some("http://example.com"))
+          }
+        }
+      }
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "reject non-cookied runtime proxy requests" in {
-    Get(s"/proxy/$googleProject/$clusterName").addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
-      handled shouldBe true
-      status shouldEqual StatusCodes.Unauthorized
-    }
+    httpRoutesResource
+      .use { httpRoutes =>
+        IO(
+          Get(s"/proxy/$googleProject/$clusterName")
+            .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
+            handled shouldBe true
+            status shouldEqual StatusCodes.Unauthorized
+          }
+        )
+      }
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "404 when using a non-white-listed user in a runtime proxy request" in {
-    Get(s"/proxy/$googleProject/$clusterName")
-      .addHeader(Cookie(unauthorizedTokenCookie))
-      .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
-      status shouldEqual StatusCodes.NotFound
-    }
+    httpRoutesResource
+      .use { httpRoutes =>
+        IO(
+          Get(s"/proxy/$googleProject/$clusterName")
+            .addHeader(Cookie(unauthorizedTokenCookie))
+            .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
+            status shouldEqual StatusCodes.NotFound
+          }
+        )
+      }
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "401 when using an expired token in a runtime proxy request" in {
-    Get(s"/proxy/$googleProject/$clusterName")
-      .addHeader(Cookie(expiredTokenCookie))
-      .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
-      status shouldEqual StatusCodes.Unauthorized
-    }
+    httpRoutesResource
+      .use { httpRoutes =>
+        IO(
+          Get(s"/proxy/$googleProject/$clusterName")
+            .addHeader(Cookie(expiredTokenCookie))
+            .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
+            status shouldEqual StatusCodes.Unauthorized
+          }
+        )
+      }
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should s"pass through paths in runtime proxy requests" in {
-    val queue = InspectableQueue.bounded[IO, UpdateDateAccessMessage](100).unsafeRunSync
-    val proxyService =
-      new MockProxyService(proxyConfig,
-                           MockJupyterDAO,
-                           whitelistAuthProvider,
-                           runtimeDnsCache,
-                           kubernetesDnsCache,
-                           MockGoogleOAuth2Service,
-                           queue = Some(queue))
-    proxyService.samResourceCache.put(RuntimeCacheKey(GoogleProject(googleProject), RuntimeName(clusterName)),
-                                      Some(runtimeSamResource.resourceId))
-    val proxyRoutes = new ProxyRoutes(proxyService, corsSupport, refererConfig)
-    Get(s"/proxy/$googleProject/$clusterName")
-      .addHeader(Cookie(tokenCookie))
-      .addHeader(Referer(Uri(validRefererUri))) ~> proxyRoutes.route ~> check {
-      status shouldEqual StatusCodes.OK
-      responseAs[Data].path shouldEqual s"/proxy/$googleProject/$clusterName"
-      val message = queue.tryDequeue1.unsafeRunSync().get
-      message.googleProject.value shouldBe googleProject
-      message.runtimeName.asString shouldBe clusterName
-    }
+    val queue = Queue.bounded[IO, UpdateDateAccessMessage](100).unsafeRunSync()(cats.effect.unsafe.implicits.global)
+
+    val proxyServiceResource = for {
+      runtimeDnsCache <- runtimeDnsCacheResource
+      kubernetesDnsCache <- kubernetesDnsCacheResource
+    } yield new MockProxyService(proxyConfig,
+                                 MockJupyterDAO,
+                                 whitelistAuthProvider,
+                                 runtimeDnsCache,
+                                 kubernetesDnsCache,
+                                 MockGoogleOAuth2Service,
+                                 queue = Some(queue))
+
+    proxyServiceResource
+      .use { proxyService =>
+        proxyService.samResourceCache.put(RuntimeCacheKey(GoogleProject(googleProject), RuntimeName(clusterName)),
+                                          Some(runtimeSamResource.resourceId))
+        val proxyRoutes = new ProxyRoutes(proxyService, corsSupport, refererConfig)
+        IO {
+          Get(s"/proxy/$googleProject/$clusterName")
+            .addHeader(Cookie(tokenCookie))
+            .addHeader(Referer(Uri(validRefererUri))) ~> proxyRoutes.route ~> check {
+            status shouldEqual StatusCodes.OK
+            responseAs[Data].path shouldEqual s"/proxy/$googleProject/$clusterName"
+            val message = queue.tryTake.unsafeRunSync()(cats.effect.unsafe.implicits.global).get
+            message.googleProject.value shouldBe googleProject
+            message.runtimeName.asString shouldBe clusterName
+          }
+        }
+      }
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+
   }
 
   it should "pass through query string params in runtime proxy requests" in {
-    Get(s"/proxy/$googleProject/$clusterName")
-      .addHeader(Cookie(tokenCookie))
-      .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
-      responseAs[Data].qs shouldBe None
-    }
-    Get(s"/proxy/$googleProject/$clusterName?foo=bar&baz=biz")
-      .addHeader(Cookie(tokenCookie))
-      .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
-      responseAs[Data].qs shouldEqual Some("foo=bar&baz=biz")
-    }
+    httpRoutesResource
+      .use { httpRoutes =>
+        IO(
+          Get(s"/proxy/$googleProject/$clusterName")
+            .addHeader(Cookie(tokenCookie))
+            .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
+            responseAs[Data].qs shouldBe None
+          }
+        ) >> IO(
+          Get(s"/proxy/$googleProject/$clusterName?foo=bar&baz=biz")
+            .addHeader(Cookie(tokenCookie))
+            .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
+            responseAs[Data].qs shouldEqual Some("foo=bar&baz=biz")
+          }
+        )
+      }
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "pass through encoded query string params in runtime proxy requests" in {
-    Get(s"/proxy/$googleProject/$clusterName?foo=This%20is%20an%20encoded%20param.&baz=biz")
-      .addHeader(Cookie(tokenCookie))
-      .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
-      responseAs[Data].qs shouldEqual Some("foo=This is an encoded param.&baz=biz")
-    }
+    httpRoutesResource
+      .use { httpRoutes =>
+        IO(
+          Get(s"/proxy/$googleProject/$clusterName?foo=This%20is%20an%20encoded%20param.&baz=biz")
+            .addHeader(Cookie(tokenCookie))
+            .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
+            responseAs[Data].qs shouldEqual Some("foo=This is an encoded param.&baz=biz")
+          }
+        )
+      }
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "pass through http methods in runtime proxy requests" in {
-    Get(s"/proxy/$googleProject/$clusterName")
-      .addHeader(Cookie(tokenCookie))
-      .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
-      responseAs[Data].method shouldBe "GET"
-    }
-    Post(s"/proxy/$googleProject/$clusterName")
-      .addHeader(Cookie(tokenCookie))
-      .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
-      responseAs[Data].method shouldBe "POST"
-    }
-    Put(s"/proxy/$googleProject/$clusterName")
-      .addHeader(Cookie(tokenCookie))
-      .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
-      responseAs[Data].method shouldBe "PUT"
-    }
+    httpRoutesResource
+      .use { httpRoutes =>
+        IO {
+          Get(s"/proxy/$googleProject/$clusterName")
+            .addHeader(Cookie(tokenCookie))
+            .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
+            responseAs[Data].method shouldBe "GET"
+          }
+          Post(s"/proxy/$googleProject/$clusterName")
+            .addHeader(Cookie(tokenCookie))
+            .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
+            responseAs[Data].method shouldBe "POST"
+          }
+          Put(s"/proxy/$googleProject/$clusterName")
+            .addHeader(Cookie(tokenCookie))
+            .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
+            responseAs[Data].method shouldBe "PUT"
+          }
+        }
+      }
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "pass through headers in runtime proxy requests" in {
-    Get(s"/proxy/$googleProject/$clusterName")
-      .addHeader(Cookie(tokenCookie))
-      .addHeader(RawHeader("foo", "bar"))
-      .addHeader(RawHeader("baz", "biz"))
-      .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
-      responseAs[Data].headers.toList should contain allElementsOf Map("foo" -> "bar", "baz" -> "biz").toList
-    }
+    httpRoutesResource
+      .use { httpRoutes =>
+        IO {
+          Get(s"/proxy/$googleProject/$clusterName")
+            .addHeader(Cookie(tokenCookie))
+            .addHeader(RawHeader("foo", "bar"))
+            .addHeader(RawHeader("baz", "biz"))
+            .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
+            responseAs[Data].headers.toList should contain allElementsOf Map("foo" -> "bar", "baz" -> "biz").toList
+          }
+        }
+      }
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "remove utf-8'' from content-disposition header filenames" in {
-    // The TestProxy adds the Content-Disposition header to the response, we can't do it from here
-    Get(s"/proxy/$googleProject/$clusterName/content-disposition-test")
-      .addHeader(Cookie(tokenCookie))
-      .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
-      responseAs[HttpResponse].headers should contain(
-        `Content-Disposition`(ContentDispositionTypes.attachment, Map("filename" -> "notebook.ipynb"))
-      )
-    }
+    httpRoutesResource
+      .use { httpRoutes =>
+        // The TestProxy adds the Content-Disposition header to the response, we can't do it from here
+        IO {
+          Get(s"/proxy/$googleProject/$clusterName/content-disposition-test")
+            .addHeader(Cookie(tokenCookie))
+            .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
+            responseAs[HttpResponse].headers should contain(
+              `Content-Disposition`(ContentDispositionTypes.attachment, Map("filename" -> "notebook.ipynb"))
+            )
+          }
+        }
+      }
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
-  it should "proxy websockets" in withWebsocketProxy {
-    // See comments in ProxyService.handleHttpRequest for more high-level information on Flows, Sources, and Sinks.
+  it should "proxy websockets" in {
+    websocketProxyResource.use { _ =>
+      IO {
+        // See comments in ProxyService.handleHttpRequest for more high-level information on Flows, Sources, and Sinks.
 
-    // Sink for incoming data from the WebSocket
-    val incoming = Sink.head[String]
+        // Sink for incoming data from the WebSocket
+        val incoming = Sink.head[String]
 
-    // Source outgoing data over the WebSocket
-    val outgoing = Source.single(TextMessage("Leonardo"))
+        // Source outgoing data over the WebSocket
+        val outgoing = Source.single(TextMessage("Leonardo"))
 
-    // Flow to hit the proxy server
-    val webSocketFlow = Http()
-      .webSocketClientFlow(
-        WebSocketRequest(Uri(s"ws://localhost:9000/proxy/$googleProject/$clusterName/websocket"),
-                         immutable.Seq(Cookie(tokenCookie)))
-      )
-      .map {
-        case m: TextMessage.Strict => m.text
-        case _                     => throw new IllegalArgumentException("ProxyRoutesSpec only supports strict messages")
+        // Flow to hit the proxy server
+        val webSocketFlow = Http()
+          .webSocketClientFlow(
+            WebSocketRequest(Uri(s"ws://localhost:9000/proxy/$googleProject/$clusterName/websocket"),
+                             immutable.Seq(Cookie(tokenCookie)))
+          )
+          .map {
+            case m: TextMessage.Strict => m.text
+            case _                     => throw new IllegalArgumentException("ProxyRoutesSpec only supports strict messages")
+          }
+
+        // Glue together the source, sink, and flow. This materializes the Flow and actually initiates the HTTP request.
+        // Returns a tuple of:
+        //  - `upgradeResponse` is a Future[WebSocketUpgradeResponse] that completes or fails when the connection succeeds or fails.
+        //  - `result` is a Future[String] with the stream completion from the incoming sink.
+        val (upgradeResponse, result) =
+          outgoing
+            .viaMat(webSocketFlow)(Keep.right)
+            .toMat(incoming)(Keep.both)
+            .run()
+
+        // The connection future should have returned the HTTP 101 status code
+        upgradeResponse.futureValue.response.status shouldBe StatusCodes.SwitchingProtocols
+        // The stream completion future should have greeted Leonardo
+        result.futureValue shouldBe "Hello Leonardo!"
       }
+    }
 
-    // Glue together the source, sink, and flow. This materializes the Flow and actually initiates the HTTP request.
-    // Returns a tuple of:
-    //  - `upgradeResponse` is a Future[WebSocketUpgradeResponse] that completes or fails when the connection succeeds or fails.
-    //  - `result` is a Future[String] with the stream completion from the incoming sink.
-    val (upgradeResponse, result) =
-      outgoing
-        .viaMat(webSocketFlow)(Keep.right)
-        .toMat(incoming)(Keep.both)
-        .run()
-
-    // The connection future should have returned the HTTP 101 status code
-    upgradeResponse.futureValue.response.status shouldBe StatusCodes.SwitchingProtocols
-    // The stream completion future should have greeted Leonardo
-    result.futureValue shouldBe "Hello Leonardo!"
   }
 
   it should "create a new terminal when trying to access a terminal that was not created yet" in {
@@ -297,142 +395,218 @@ class ProxyRoutesSpec
       jupyterDAO.createTerminal(GoogleProject(googleProject), RuntimeName(clusterName))
     } thenReturn IO.unit
 
-    val httpRoutes = createHttpRoute(jupyterDAO)
+    createHttpRoute(jupyterDAO)
+      .use { httpRoutes =>
+        IO {
+          Get(s"/proxy/$googleProject/$clusterName/jupyter/terminals/1")
+            .addHeader(Authorization(OAuth2BearerToken(tokenCookie.value)))
+            .addHeader(Origin("http://example.com"))
+            .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
+            status shouldEqual StatusCodes.OK
+            verify(jupyterDAO, times(1)).terminalExists(GoogleProject(googleProject),
+                                                        RuntimeName(clusterName),
+                                                        TerminalName("1"))
+            verify(jupyterDAO, times(1)).createTerminal(GoogleProject(googleProject), RuntimeName(clusterName))
+          }
+        }
+      }
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
 
-    Get(s"/proxy/$googleProject/$clusterName/jupyter/terminals/1")
-      .addHeader(Authorization(OAuth2BearerToken(tokenCookie.value)))
-      .addHeader(Origin("http://example.com"))
-      .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
-      status shouldEqual StatusCodes.OK
-      verify(jupyterDAO, times(1)).terminalExists(GoogleProject(googleProject),
-                                                  RuntimeName(clusterName),
-                                                  TerminalName("1"))
-      verify(jupyterDAO, times(1)).createTerminal(GoogleProject(googleProject), RuntimeName(clusterName))
-    }
   }
 
   "app proxy routes" should "listen on /proxy/google/v1/apps/{project}/{name}/{service}" in {
-    Get(s"/proxy/google/v1/apps/$googleProject/$appName/$serviceName")
-      .addHeader(Cookie(tokenCookie))
-      .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
-      handled shouldBe true
-      status shouldEqual StatusCodes.OK
-      validateCors()
-    }
-    Get(s"/proxy/google/v1/apps/$googleProject/$appName/$serviceName/foo")
-      .addHeader(Cookie(tokenCookie))
-      .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
-      handled shouldBe true
-      status shouldEqual StatusCodes.OK
-      validateCors()
-    }
+    httpRoutesResource
+      .use { httpRoutes =>
+        IO {
+          Get(s"/proxy/google/v1/apps/$googleProject/$appName/$serviceName")
+            .addHeader(Cookie(tokenCookie))
+            .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
+            handled shouldBe true
+            status shouldEqual StatusCodes.OK
+            validateCors()
+          }
+          Get(s"/proxy/google/v1/apps/$googleProject/$appName/$serviceName/foo")
+            .addHeader(Cookie(tokenCookie))
+            .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
+            handled shouldBe true
+            status shouldEqual StatusCodes.OK
+            validateCors()
+          }
+        }
+      }
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "404 for non-existent apps" in {
     val newName = "killerApp"
     // should 404 since the internal id cannot be looked up
-    Get(s"/proxy/google/v1/apps/$newName/$serviceName")
-      .addHeader(Cookie(tokenCookie))
-      .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
-      status shouldEqual StatusCodes.NotFound
-    }
+    httpRoutesResource
+      .use { httpRoutes =>
+        IO(
+          Get(s"/proxy/google/v1/apps/$newName/$serviceName")
+            .addHeader(Cookie(tokenCookie))
+            .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
+            status shouldEqual StatusCodes.NotFound
+          }
+        )
+      }
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "set CORS headers in app proxy requests" in {
-    Get(s"/proxy/google/v1/apps/$googleProject/$appName/$serviceName")
-      .addHeader(Cookie(tokenCookie))
-      .addHeader(Origin("http://example.com"))
-      .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
-      handled shouldBe true
-      status shouldEqual StatusCodes.OK
-      validateCors(origin = Some("http://example.com"))
-    }
+    httpRoutesResource
+      .use { httpRoutes =>
+        IO(
+          Get(s"/proxy/google/v1/apps/$googleProject/$appName/$serviceName")
+            .addHeader(Cookie(tokenCookie))
+            .addHeader(Origin("http://example.com"))
+            .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
+            handled shouldBe true
+            status shouldEqual StatusCodes.OK
+            validateCors(origin = Some("http://example.com"))
+          }
+        )
+      }
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "reject non-cookied requests in app proxy requests" in {
-    Get(s"/proxy/google/v1/apps/$googleProject/$appName/$serviceName")
-      .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
-      handled shouldBe true
-      status shouldEqual StatusCodes.Unauthorized
-    }
+    httpRoutesResource
+      .use { httpRoutes =>
+        IO(
+          Get(s"/proxy/google/v1/apps/$googleProject/$appName/$serviceName")
+            .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
+            handled shouldBe true
+            status shouldEqual StatusCodes.Unauthorized
+          }
+        )
+      }
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should s"401 when using an expired token in app proxy requests" in {
-    Get(s"/proxy/google/v1/apps/$googleProject/$appName/$serviceName")
-      .addHeader(Cookie(expiredTokenCookie))
-      .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
-      status shouldEqual StatusCodes.Unauthorized
-    }
+    httpRoutesResource
+      .use { httpRoutes =>
+        IO(
+          Get(s"/proxy/google/v1/apps/$googleProject/$appName/$serviceName")
+            .addHeader(Cookie(expiredTokenCookie))
+            .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
+            status shouldEqual StatusCodes.Unauthorized
+          }
+        )
+      }
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should s"pass through paths in app proxy requests" in {
-    Get(s"/proxy/google/v1/apps/$googleProject/$appName/$serviceName")
-      .addHeader(Cookie(tokenCookie))
-      .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
-      status shouldEqual StatusCodes.OK
-      responseAs[Data].path shouldEqual s"/proxy/google/v1/apps/$googleProject/$appName/$serviceName"
-    }
+    httpRoutesResource
+      .use { httpRoutes =>
+        IO(
+          Get(s"/proxy/google/v1/apps/$googleProject/$appName/$serviceName")
+            .addHeader(Cookie(tokenCookie))
+            .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
+            status shouldEqual StatusCodes.OK
+            responseAs[Data].path shouldEqual s"/proxy/google/v1/apps/$googleProject/$appName/$serviceName"
+          }
+        )
+      }
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "pass through query string params in app proxy requests" in {
-    Get(s"/proxy/google/v1/apps/$googleProject/$appName/$serviceName?foo=bar&baz=biz")
-      .addHeader(Cookie(tokenCookie))
-      .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
-      responseAs[Data].qs shouldEqual Some("foo=bar&baz=biz")
-    }
+    httpRoutesResource
+      .use { httpRoutes =>
+        IO(
+          Get(s"/proxy/google/v1/apps/$googleProject/$appName/$serviceName?foo=bar&baz=biz")
+            .addHeader(Cookie(tokenCookie))
+            .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
+            responseAs[Data].qs shouldEqual Some("foo=bar&baz=biz")
+          }
+        )
+      }
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "pass through encoded query string params in app proxy requests" in {
-    Get(s"/proxy/google/v1/apps/$googleProject/$appName/$serviceName?foo=This%20is%20an%20encoded%20param.&baz=biz")
-      .addHeader(Cookie(tokenCookie))
-      .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
-      responseAs[Data].qs shouldEqual Some("foo=This is an encoded param.&baz=biz")
-    }
+    httpRoutesResource
+      .use { httpRoutes =>
+        IO(
+          Get(
+            s"/proxy/google/v1/apps/$googleProject/$appName/$serviceName?foo=This%20is%20an%20encoded%20param.&baz=biz"
+          ).addHeader(Cookie(tokenCookie))
+            .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
+            responseAs[Data].qs shouldEqual Some("foo=This is an encoded param.&baz=biz")
+          }
+        )
+      }
   }
 
   it should "pass through http methods in app proxy requests" in {
-    Get(s"/proxy/google/v1/apps/$googleProject/$appName/$serviceName")
-      .addHeader(Cookie(tokenCookie))
-      .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
-      responseAs[Data].method shouldBe "GET"
-    }
-    Post(s"/proxy/google/v1/apps/$googleProject/$appName/$serviceName")
-      .addHeader(Cookie(tokenCookie))
-      .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
-      responseAs[Data].method shouldBe "POST"
-    }
-    Put(s"/proxy/google/v1/apps/$googleProject/$appName/$serviceName")
-      .addHeader(Cookie(tokenCookie))
-      .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
-      responseAs[Data].method shouldBe "PUT"
-    }
+    httpRoutesResource
+      .use { httpRoutes =>
+        IO(
+          Get(s"/proxy/google/v1/apps/$googleProject/$appName/$serviceName")
+            .addHeader(Cookie(tokenCookie))
+            .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
+            responseAs[Data].method shouldBe "GET"
+          }
+        ) >> IO(
+          Post(s"/proxy/google/v1/apps/$googleProject/$appName/$serviceName")
+            .addHeader(Cookie(tokenCookie))
+            .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
+            responseAs[Data].method shouldBe "POST"
+          }
+        ) >> IO(
+          Put(s"/proxy/google/v1/apps/$googleProject/$appName/$serviceName")
+            .addHeader(Cookie(tokenCookie))
+            .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
+            responseAs[Data].method shouldBe "PUT"
+          }
+        )
+      }
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "pass through headers in app proxy requests" in {
-    Get(s"/proxy/google/v1/apps/$googleProject/$appName/$serviceName")
-      .addHeader(Cookie(tokenCookie))
-      .addHeader(RawHeader("foo", "bar"))
-      .addHeader(RawHeader("baz", "biz"))
-      .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
-      responseAs[Data].headers.toList should contain allElementsOf Map("foo" -> "bar", "baz" -> "biz").toList
-    }
+    httpRoutesResource
+      .use { httpRoutes =>
+        IO(
+          Get(s"/proxy/google/v1/apps/$googleProject/$appName/$serviceName")
+            .addHeader(Cookie(tokenCookie))
+            .addHeader(RawHeader("foo", "bar"))
+            .addHeader(RawHeader("baz", "biz"))
+            .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
+            responseAs[Data].headers.toList should contain allElementsOf Map("foo" -> "bar", "baz" -> "biz").toList
+          }
+        )
+      }
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   "setCookie" should "set a cookie given a valid Authorization header" in {
-    // cache should not initially contain the token
-    proxyService.googleTokenCache.asMap().containsKey(tokenCookie.value) shouldBe false
-    // login request with Authorization header should succeed and return a Set-Cookie header
-    Get(s"/proxy/$googleProject/$clusterName/setCookie")
-      .addHeader(Authorization(OAuth2BearerToken(tokenCookie.value)))
-      .addHeader(Origin("http://example.com"))
-      .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
-      validateRawCookie(setCookie = header("Set-Cookie"), age = 3600)
-      status shouldEqual StatusCodes.NoContent
-      validateCors(origin = Some("http://example.com"))
-    }
+    httpRoutesResourceWithProxyService
+      .use {
+        case (proxyService, httpRoutes) =>
+          IO {
+            // cache should not initially contain the token
+            proxyService.googleTokenCache.asMap().containsKey(tokenCookie.value) shouldBe false
+            // login request with Authorization header should succeed and return a Set-Cookie header
+            Get(s"/proxy/$googleProject/$clusterName/setCookie")
+              .addHeader(Authorization(OAuth2BearerToken(tokenCookie.value)))
+              .addHeader(Origin("http://example.com"))
+              .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
+              validateRawCookie(setCookie = header("Set-Cookie"), age = 3600)
+              status shouldEqual StatusCodes.NoContent
+              validateCors(origin = Some("http://example.com"))
+            }
 
-    // cache should now contain the token
-    proxyService.googleTokenCache.asMap().containsKey(tokenCookie.value) shouldBe true
+            // cache should now contain the token
+            proxyService.googleTokenCache.asMap().containsKey(tokenCookie.value) shouldBe true
+
+          }
+      }
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+
   }
 
   it should "reject setCookie if user is not registered" in {
@@ -440,137 +614,180 @@ class ProxyRoutesSpec
       override def getUserSubjectIdFromToken(token: String)(implicit ev: Ask[IO, TraceId]): IO[Option[UserSubjectId]] =
         IO.pure(None)
     }
-    val proxyService =
-      new MockProxyService(proxyConfig,
-                           MockJupyterDAO,
-                           whitelistAuthProvider,
-                           runtimeDnsCache,
-                           kubernetesDnsCache,
-                           MockGoogleOAuth2Service,
-                           samDAO = Some(samDao))
-    val httpRoutes = new HttpRoutes(
-      swaggerConfig,
-      statusService,
-      proxyService,
-      runtimeService,
-      MockDiskServiceInterp,
-      leoKubernetesService,
-      userInfoDirectives,
-      contentSecurityPolicy,
-      refererConfig
-    )
-    // cache should not initially contain the token
-    proxyService.googleTokenCache.asMap().containsKey(tokenCookie.value) shouldBe false
-    // login request with Authorization header should succeed and return a Set-Cookie header
-    Get(s"/proxy/$googleProject/$clusterName/setCookie")
-      .addHeader(Authorization(OAuth2BearerToken(tokenCookie.value)))
-      .addHeader(Origin("http://example.com"))
-      .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
-      status shouldEqual StatusCodes.Unauthorized
+    val httpRoutesWithProxyService = for {
+      runtimeDnsCache <- runtimeDnsCacheResource
+      kubernetesDnsCache <- kubernetesDnsCacheResource
+    } yield {
+      val proxyService = new MockProxyService(proxyConfig,
+                                              MockJupyterDAO,
+                                              whitelistAuthProvider,
+                                              runtimeDnsCache,
+                                              kubernetesDnsCache,
+                                              MockGoogleOAuth2Service,
+                                              samDAO = Some(samDao))
+      (proxyService,
+       new HttpRoutes(
+         swaggerConfig,
+         statusService,
+         proxyService,
+         runtimeService,
+         MockDiskServiceInterp,
+         leoKubernetesService,
+         userInfoDirectives,
+         contentSecurityPolicy,
+         refererConfig
+       ))
     }
+
+    httpRoutesWithProxyService
+      .use {
+        case (proxyService, httpRoutes) =>
+          IO {
+            // cache should not initially contain the token
+            proxyService.googleTokenCache.asMap().containsKey(tokenCookie.value) shouldBe false
+            // login request with Authorization header should succeed and return a Set-Cookie header
+            Get(s"/proxy/$googleProject/$clusterName/setCookie")
+              .addHeader(Authorization(OAuth2BearerToken(tokenCookie.value)))
+              .addHeader(Origin("http://example.com"))
+              .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
+              status shouldEqual StatusCodes.Unauthorized
+            }
+          }
+      }
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+
   }
 
   it should "handle preflight OPTIONS requests" in {
-    Options(s"/proxy/$googleProject/$clusterName/setCookie")
-      .addHeader(Authorization(OAuth2BearerToken(tokenCookie.value)))
-      .addHeader(Origin("http://example.com"))
-      .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
-      handled shouldBe true
-      status shouldEqual StatusCodes.NoContent
-      header[`Set-Cookie`] shouldBe None
-      validateCors(origin = Some("http://example.com"), optionsRequest = true)
-    }
+    httpRoutesResource
+      .use { httpRoutes =>
+        IO {
+          Options(s"/proxy/$googleProject/$clusterName/setCookie")
+            .addHeader(Authorization(OAuth2BearerToken(tokenCookie.value)))
+            .addHeader(Origin("http://example.com"))
+            .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
+            handled shouldBe true
+            status shouldEqual StatusCodes.NoContent
+            header[`Set-Cookie`] shouldBe None
+            validateCors(origin = Some("http://example.com"), optionsRequest = true)
+          }
+        }
+      }
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "unset the cookie when not given an Authorization header" in {
-    Get(s"/proxy/$googleProject/$clusterName/setCookie")
-      .addHeader(Origin("http://example.com"))
-      .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
-      handled shouldBe true
-      validateUnsetRawCookie(setCookie = header("Set-Cookie"))
-      status shouldEqual StatusCodes.NoContent
-      validateCors(origin = Some("http://example.com"))
-    }
+    httpRoutesResource
+      .use { httpRoutes =>
+        IO(
+          Get(s"/proxy/$googleProject/$clusterName/setCookie")
+            .addHeader(Origin("http://example.com"))
+            .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
+            handled shouldBe true
+            validateUnsetRawCookie(setCookie = header("Set-Cookie"))
+            status shouldEqual StatusCodes.NoContent
+            validateCors(origin = Some("http://example.com"))
+          }
+        )
+      }
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "401 when using an expired token" in {
-    Get(s"/proxy/$googleProject/$clusterName")
-      .addHeader(Authorization(OAuth2BearerToken(expiredTokenCookie.value)))
-      .addHeader(Origin("http://example.com"))
-      .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
-      status shouldEqual StatusCodes.Unauthorized
-    }
+    httpRoutesResource
+      .use { httpRoutes =>
+        IO {
+          Get(s"/proxy/$googleProject/$clusterName")
+            .addHeader(Authorization(OAuth2BearerToken(expiredTokenCookie.value)))
+            .addHeader(Origin("http://example.com"))
+            .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
+            status shouldEqual StatusCodes.Unauthorized
+          }
+        }
+      }
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+
   }
 
   "invalidateToken" should "remove a token from cache" in {
-    // cache should not initially contain the token
-    proxyService.googleTokenCache.asMap().containsKey(tokenCookie.value) shouldBe false
+    httpRoutesResourceWithProxyService
+      .use {
+        case (proxyService, httpRoutes) =>
+          IO {
+            proxyService.googleTokenCache.asMap().containsKey(tokenCookie.value) shouldBe false
 
-    // regular request with a cookie should succeed but NOT return a Set-Cookie header
-    Get(s"/proxy/$googleProject/$clusterName")
-      .addHeader(Cookie(tokenCookie))
-      .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
-      handled shouldBe true
-      status shouldEqual StatusCodes.OK
-      header[`Set-Cookie`] shouldBe None
-    }
+            // regular request with a cookie should succeed but NOT return a Set-Cookie header
+            Get(s"/proxy/$googleProject/$clusterName")
+              .addHeader(Cookie(tokenCookie))
+              .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
+              handled shouldBe true
+              status shouldEqual StatusCodes.OK
+              header[`Set-Cookie`] shouldBe None
+            }
 
-    // cache should now contain the token
-    proxyService.googleTokenCache.asMap().containsKey(tokenCookie.value) shouldBe true
+            // cache should now contain the token
+            proxyService.googleTokenCache.asMap().containsKey(tokenCookie.value) shouldBe true
 
-    // log out, passing a cookie
-    Get(s"/proxy/invalidateToken")
-      .addHeader(Cookie(tokenCookie))
-      .addHeader(Origin("http://example.com"))
-      .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
-      handled shouldBe true
-      validateUnsetRawCookie(setCookie = header("Set-Cookie"))
-      status shouldEqual StatusCodes.NoContent
-      validateCors(origin = Some("http://example.com"))
-    }
+            // log out, passing a cookie
+            Get(s"/proxy/invalidateToken")
+              .addHeader(Cookie(tokenCookie))
+              .addHeader(Origin("http://example.com"))
+              .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
+              handled shouldBe true
+              validateUnsetRawCookie(setCookie = header("Set-Cookie"))
+              status shouldEqual StatusCodes.NoContent
+              validateCors(origin = Some("http://example.com"))
+            }
 
-    // cache should not contain the token
-    proxyService.googleTokenCache.asMap().containsKey(tokenCookie.value) shouldBe false
+            // cache should not contain the token
+            proxyService.googleTokenCache.asMap().containsKey(tokenCookie.value) shouldBe false
+          }
+      }
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
-  def createHttpRoute(jupyterDAO: JupyterDAO[IO]): HttpRoutes = {
-    val proxyService =
-      new MockProxyService(proxyConfig,
-                           jupyterDAO,
-                           whitelistAuthProvider,
-                           runtimeDnsCache,
-                           kubernetesDnsCache,
-                           MockGoogleOAuth2Service)
-    proxyService.samResourceCache
-      .put(RuntimeCacheKey(GoogleProject(googleProject), RuntimeName(clusterName)), Some(runtimeSamResource.resourceId))
-    proxyService.samResourceCache
-      .put(AppCacheKey(GoogleProject(googleProject), AppName(appName)), Some(appSamId.resourceId))
+  def createHttpRoute(jupyterDAO: JupyterDAO[IO]): Resource[IO, HttpRoutes] =
+    for {
+      runtimeDnsCache <- runtimeDnsCacheResource
+      kubernetesDnsCache <- kubernetesDnsCacheResource
+    } yield {
+      val proxyService =
+        new MockProxyService(proxyConfig,
+                             jupyterDAO,
+                             whitelistAuthProvider,
+                             runtimeDnsCache,
+                             kubernetesDnsCache,
+                             MockGoogleOAuth2Service)
+      proxyService.samResourceCache
+        .put(RuntimeCacheKey(GoogleProject(googleProject), RuntimeName(clusterName)),
+             Some(runtimeSamResource.resourceId))
+      proxyService.samResourceCache
+        .put(AppCacheKey(GoogleProject(googleProject), AppName(appName)), Some(appSamId.resourceId))
 
-    new HttpRoutes(
-      swaggerConfig,
-      statusService,
-      proxyService,
-      runtimeService,
-      MockDiskServiceInterp,
-      leoKubernetesService,
-      userInfoDirectives,
-      contentSecurityPolicy,
-      refererConfig
-    )
-  }
+      new HttpRoutes(
+        swaggerConfig,
+        statusService,
+        proxyService,
+        runtimeService,
+        MockDiskServiceInterp,
+        leoKubernetesService,
+        userInfoDirectives,
+        contentSecurityPolicy,
+        refererConfig
+      )
+    }
 
   /**
    * Akka-http TestKit doesn't seem to support websocket servers.
    * So for websocket tests, manually create a server binding on port 9000 for the proxy.
    */
-  def withWebsocketProxy[T](testCode: => T): T = {
-    val bindingFuture = Http().bindAndHandle(httpRoutes.route, "0.0.0.0", 9000)
-    try {
-      testCode
-    } finally {
-      bindingFuture.flatMap(_.unbind())
-    }
-  }
+  def websocketProxyResource: Resource[IO, Unit] =
+    for {
+      httpRoutes <- httpRoutesResource
+      _ <- Resource.make(IO.fromFuture(IO(Http().bindAndHandle(httpRoutes.route, "0.0.0.0", 9000))))(binding =>
+        IO.fromFuture(IO(binding.unbind())).void
+      )
+    } yield ()
 
   private def validateCors(origin: Option[String] = None, optionsRequest: Boolean = false): Unit = {
     // Issue 272: CORS headers should not be double set
@@ -591,19 +808,31 @@ class ProxyRoutesSpec
   }
 
   it should "401 when Referer is not a valid URI" in {
-    Get(s"/proxy/$googleProject/$clusterName")
-      .addHeader(Referer(Uri("https://notAGoodExample.com"))) ~> httpRoutes.route ~> check {
-      status shouldEqual StatusCodes.Unauthorized
-    }
+    httpRoutesResource
+      .use { httpRoutes =>
+        IO(
+          Get(s"/proxy/$googleProject/$clusterName")
+            .addHeader(Referer(Uri("https://notAGoodExample.com"))) ~> httpRoutes.route ~> check {
+            status shouldEqual StatusCodes.Unauthorized
+          }
+        )
+      }
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "handle wildcards in referer allow list" in {
-    Get(s"/proxy/$googleProject/$clusterName")
-      .addHeader(Cookie(tokenCookie))
-      .addHeader(Referer(Uri("http://foo:9099"))) ~> httpRoutes.route ~> check {
-      handled shouldBe true
-      status shouldEqual StatusCodes.OK
-      validateCors()
-    }
+    httpRoutesResource
+      .use { httpRoutes =>
+        IO(
+          Get(s"/proxy/$googleProject/$clusterName")
+            .addHeader(Cookie(tokenCookie))
+            .addHeader(Referer(Uri("http://foo:9099"))) ~> httpRoutes.route ~> check {
+            handled shouldBe true
+            status shouldEqual StatusCodes.OK
+            validateCors()
+          }
+        )
+      }
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/ProxyRoutesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/ProxyRoutesSpec.scala
@@ -7,7 +7,7 @@ import akka.http.scaladsl.model.HttpMethods._
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.headers._
 import akka.http.scaladsl.model.ws.{TextMessage, WebSocketRequest}
-import akka.http.scaladsl.testkit.{RouteTestTimeout, ScalatestRouteTest}
+import akka.http.scaladsl.testkit.ScalatestRouteTest
 import akka.stream.scaladsl.{Keep, Sink, Source}
 import cats.effect.IO
 import cats.effect.std.Queue
@@ -16,8 +16,8 @@ import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
 import org.broadinstitute.dsde.workbench.leonardo.CommonTestData._
 import org.broadinstitute.dsde.workbench.leonardo.KubernetesTestData._
 import org.broadinstitute.dsde.workbench.leonardo.config.ProxyConfig
-import org.broadinstitute.dsde.workbench.leonardo.dao.google.MockGoogleOAuth2Service
 import org.broadinstitute.dsde.workbench.leonardo.dao._
+import org.broadinstitute.dsde.workbench.leonardo.dao.google.MockGoogleOAuth2Service
 import org.broadinstitute.dsde.workbench.leonardo.db.TestComponent
 import org.broadinstitute.dsde.workbench.leonardo.http.service.SamResourceCacheKey.{AppCacheKey, RuntimeCacheKey}
 import org.broadinstitute.dsde.workbench.leonardo.http.service.TestProxy.{dataDecoder, Data}
@@ -48,7 +48,6 @@ class ProxyRoutesSpec
     with TestLeoRoutes
     with MockitoSugar {
   implicit val patience = PatienceConfig(timeout = scaled(Span(30, Seconds)))
-  implicit val routeTimeout = RouteTestTimeout(10 seconds)
   override def proxyConfig: ProxyConfig = CommonTestData.proxyConfig
 
   val clusterName = "test"

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/StatusRoutesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/StatusRoutesSpec.scala
@@ -58,7 +58,7 @@ class StatusRoutesSpec
         IO.pure(StatusCheckResponse(false, Map(OpenDJ -> SubsystemStatus(false, Some(List("OpenDJ is down. Panic!"))))))
     }
     val statusService =
-      new StatusService(badSam, testDbRef, applicationConfig, pollInterval = 1.second)
+      new StatusService(badSam, testDbRef, pollInterval = 1.second)
     val statusRoute = new StatusRoutes(statusService) with MockUserInfoDirectives {
       override val userInfo: UserInfo = defaultUserInfo
     }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/TestLeoRoutes.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/TestLeoRoutes.scala
@@ -100,21 +100,13 @@ trait TestLeoRoutes {
     Caffeine.newBuilder().maximumSize(10000L).build[String, scalacache.Entry[HostStatus]]()
   val runtimeDnsCaffeineCache: Cache[IO, HostStatus] = CaffeineCache[IO, HostStatus](underlyingRuntimeDnsCache)
   val runtimeDnsCache =
-    new RuntimeDnsCache[IO](proxyConfig,
-                            testDbRef,
-                            Config.runtimeDnsCacheConfig,
-                            hostToIpMapping,
-                            runtimeDnsCaffeineCache)
+    new RuntimeDnsCache[IO](proxyConfig, testDbRef, hostToIpMapping, runtimeDnsCaffeineCache)
 
   val underlyingKubernetesDnsCache =
     Caffeine.newBuilder().maximumSize(10000L).build[String, scalacache.Entry[HostStatus]]()
   val kubernetesDnsCaffeineCache: Cache[IO, HostStatus] = CaffeineCache[IO, HostStatus](underlyingKubernetesDnsCache)
   val kubernetesDnsCache =
-    new KubernetesDnsCache[IO](proxyConfig,
-                               testDbRef,
-                               Config.kubernetesDnsCacheConfig,
-                               hostToIpMapping,
-                               kubernetesDnsCaffeineCache)
+    new KubernetesDnsCache[IO](proxyConfig, testDbRef, hostToIpMapping, kubernetesDnsCaffeineCache)
 
   val underlyingGoogleTokenCache =
     Caffeine.newBuilder().maximumSize(10000L).build[String, scalacache.Entry[(UserInfo, Instant)]]()

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/TestLeoRoutes.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/TestLeoRoutes.scala
@@ -4,7 +4,7 @@ package api
 
 import akka.http.scaladsl.model.HttpHeader
 import akka.http.scaladsl.model.headers.{`Set-Cookie`, HttpCookiePair}
-import akka.http.scaladsl.testkit.ScalatestRouteTest
+import akka.http.scaladsl.testkit.{RouteTestTimeout, ScalatestRouteTest}
 import cats.effect.IO
 import com.github.benmanes.caffeine.cache.Caffeine
 import org.broadinstitute.dsde.workbench.google.GoogleStorageDAO
@@ -33,6 +33,8 @@ import scala.concurrent.duration._
 import scala.util.matching.Regex
 trait TestLeoRoutes {
   this: ScalatestRouteTest with Matchers with ScalaFutures with LeonardoTestSuite with TestComponent =>
+  implicit val timeout = RouteTestTimeout(20 seconds)
+
   // Set up the mock directoryDAO to have the Google group used to grant permission to users
   // to pull the custom dataproc image
   val mockGoogleDirectoryDAO = {

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/AppServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/AppServiceInterpSpec.scala
@@ -3,7 +3,7 @@ package http
 package service
 
 import cats.effect.IO
-import fs2.concurrent.InspectableQueue
+import cats.effect.std.Queue
 import org.broadinstitute.dsde.workbench.google2.mock.FakeGooglePublisher
 import org.broadinstitute.dsde.workbench.google2.{DiskName, MachineTypeName}
 import org.broadinstitute.dsde.workbench.leonardo.CommonTestData._
@@ -36,7 +36,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with TestComponent {
 
   //used when we care about queue state
-  def makeInterp(queue: InspectableQueue[IO, LeoPubsubMessage]) =
+  def makeInterp(queue: Queue[IO, LeoPubsubMessage]) =
     new LeoAppServiceInterp[IO](whitelistAuthProvider, serviceAccountProvider, leoKubernetesConfig, queue)
   val kubeServiceInterp = new LeoAppServiceInterp[IO](whitelistAuthProvider,
                                                       serviceAccountProvider,
@@ -55,7 +55,7 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
     val customEnvVars = Map("WORKSPACE_NAME" -> "testWorkspace")
     val appReq = createAppRequest.copy(diskConfig = Some(createDiskConfig), customEnvironmentVariables = customEnvVars)
 
-    kubeServiceInterp.createApp(userInfo, project, appName, appReq).unsafeRunSync()
+    kubeServiceInterp.createApp(userInfo, project, appName, appReq).unsafeRunSync()(cats.effect.unsafe.implicits.global)
 
     val clusters = dbFutureValue {
       KubernetesServiceDbQueries.listFullApps(Some(project))
@@ -90,7 +90,7 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
     val customEnvVars = Map("WORKSPACE_NAME" -> "testWorkspace")
     val appReq = createAppRequest.copy(diskConfig = Some(createDiskConfig), customEnvironmentVariables = customEnvVars)
 
-    kubeServiceInterp.createApp(userInfo, project, appName, appReq).unsafeRunSync()
+    kubeServiceInterp.createApp(userInfo, project, appName, appReq).unsafeRunSync()(cats.effect.unsafe.implicits.global)
     val appResult = dbFutureValue {
       KubernetesServiceDbQueries.getActiveFullAppByName(project, appName)
     }
@@ -100,7 +100,9 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
     val createDiskConfig2 = PersistentDiskRequest(DiskName("disk2"), None, None, Map.empty)
     val appReq2 =
       createAppRequest.copy(diskConfig = Some(createDiskConfig2), customEnvironmentVariables = customEnvVars)
-    kubeServiceInterp.createApp(userInfo, project, appName2, appReq2).unsafeRunSync()
+    kubeServiceInterp
+      .createApp(userInfo, project, appName2, appReq2)
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
 
     val clusters = dbFutureValue {
       KubernetesServiceDbQueries.listFullApps(Some(project))
@@ -156,15 +158,23 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
       defaultAppReq.copy(kubernetesRuntimeConfig = Some(nodepoolConfigWithAutoscalingDisabled),
                          diskConfig = Some(diskConfig4))
 
-    kubeServiceInterp.createApp(userInfo, project, appName1, defaultAppReq).unsafeRunSync()
+    kubeServiceInterp
+      .createApp(userInfo, project, appName1, defaultAppReq)
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
     val appResult = dbFutureValue {
       KubernetesServiceDbQueries.getActiveFullAppByName(project, appName1)
     }
     dbFutureValue(kubernetesClusterQuery.updateStatus(appResult.get.cluster.id, KubernetesClusterStatus.Running))
 
-    kubeServiceInterp.createApp(userInfo, project, appName2, appReqWithMoreNodes).unsafeRunSync()
-    kubeServiceInterp.createApp(userInfo, project, appName3, appReqWithMoreCpuAndMem).unsafeRunSync()
-    kubeServiceInterp.createApp(userInfo, project, appName4, appReqWithAutoscalingDisabled).unsafeRunSync()
+    kubeServiceInterp
+      .createApp(userInfo, project, appName2, appReqWithMoreNodes)
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    kubeServiceInterp
+      .createApp(userInfo, project, appName3, appReqWithMoreCpuAndMem)
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    kubeServiceInterp
+      .createApp(userInfo, project, appName4, appReqWithAutoscalingDisabled)
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
 
     val clusters = dbFutureValue {
       KubernetesServiceDbQueries.listFullApps(Some(project))
@@ -195,7 +205,7 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
     val publisherQueue = QueueFactory.makePublisherQueue()
     val kubeServiceInterp = makeInterp(publisherQueue)
 
-    kubeServiceInterp.createApp(userInfo, project, appName, appReq).unsafeRunSync()
+    kubeServiceInterp.createApp(userInfo, project, appName, appReq).unsafeRunSync()(cats.effect.unsafe.implicits.global)
 
     val getApp = dbFutureValue {
       KubernetesServiceDbQueries.getActiveFullAppByName(project, appName)
@@ -209,7 +219,7 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
     defaultNodepools.length shouldBe 1
     val defaultNodepool = defaultNodepools.head
 
-    val message = publisherQueue.dequeue1.unsafeRunSync()
+    val message = publisherQueue.take.unsafeRunSync()(cats.effect.unsafe.implicits.global)
     message.messageType shouldBe LeoPubsubMessageType.CreateApp
     val createAppMessage = message.asInstanceOf[CreateAppMessage]
     createAppMessage.appId shouldBe getApp.app.id
@@ -225,7 +235,7 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
     val disk = makePersistentDisk(None)
       .copy(googleProject = project)
       .save()
-      .unsafeRunSync()
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
 
     val appName = AppName("app1")
     val createDiskConfig = PersistentDiskRequest(disk.name, None, None, Map.empty)
@@ -233,7 +243,10 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
 
     val publisherQueue = QueueFactory.makePublisherQueue()
     val kubeServiceInterp = makeInterp(publisherQueue)
-    val res = kubeServiceInterp.createApp(userInfo, project, appName, appReq).attempt.unsafeRunSync()
+    val res = kubeServiceInterp
+      .createApp(userInfo, project, appName, appReq)
+      .attempt
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
 
     res.swap.toOption.get.getMessage shouldBe ("Disk is not formatted yet. Only disks previously used by galaxy app can be re-used to create a new galaxy app")
   }
@@ -248,7 +261,7 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
                                   galaxyRestore = Some(GalaxyRestore(PvcId("pv-id"), PvcId("pv-id2"), app.id)))
       .copy(googleProject = project)
       .save()
-      .unsafeRunSync()
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
 
     val appName = AppName("app1")
     val createDiskConfig = PersistentDiskRequest(disk.name, None, None, Map.empty)
@@ -257,7 +270,10 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
 
     val publisherQueue = QueueFactory.makePublisherQueue()
     val kubeServiceInterp = makeInterp(publisherQueue)
-    val res = kubeServiceInterp.createApp(userInfo, project, appName, appReq).attempt.unsafeRunSync()
+    val res = kubeServiceInterp
+      .createApp(userInfo, project, appName, appReq)
+      .attempt
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
     res.swap.toOption.get.getMessage shouldBe ("workspace name has to be the same as last used app in order to restore data from existing disk")
   }
 
@@ -271,7 +287,7 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
                                   formattedBy = Some(FormattedBy.Galaxy))
       .copy(googleProject = project)
       .save()
-      .unsafeRunSync()
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
 
     val appName = AppName("app1")
     val createDiskConfig = PersistentDiskRequest(disk.name, None, None, Map.empty)
@@ -280,9 +296,9 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
 
     val publisherQueue = QueueFactory.makePublisherQueue()
     val kubeServiceInterp = makeInterp(publisherQueue)
-    kubeServiceInterp.createApp(userInfo, project, appName, appReq).unsafeRunSync()
+    kubeServiceInterp.createApp(userInfo, project, appName, appReq).unsafeRunSync()(cats.effect.unsafe.implicits.global)
 
-    val message = publisherQueue.dequeue1.unsafeRunSync()
+    val message = publisherQueue.take.unsafeRunSync()(cats.effect.unsafe.implicits.global)
     message.messageType shouldBe LeoPubsubMessageType.CreateApp
     message.asInstanceOf[CreateAppMessage].createDisk shouldBe None
 
@@ -298,7 +314,7 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
     val disk = makePersistentDisk(None, formattedBy = Some(FormattedBy.Galaxy))
       .copy(googleProject = project)
       .save()
-      .unsafeRunSync()
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
 
     val appName = AppName("app1")
     val createDiskConfig = PersistentDiskRequest(disk.name, None, None, Map.empty)
@@ -306,7 +322,10 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
 
     val publisherQueue = QueueFactory.makePublisherQueue()
     val kubeServiceInterp = makeInterp(publisherQueue)
-    val res = kubeServiceInterp.createApp(userInfo, project, appName, appReq).attempt.unsafeRunSync()
+    val res = kubeServiceInterp
+      .createApp(userInfo, project, appName, appReq)
+      .attempt
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
 
     res.swap.toOption.get.getMessage shouldBe ("Existing disk found, but no restore info found in DB")
   }
@@ -316,7 +335,9 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
     val appReq = createAppRequest.copy(diskConfig = None, appType = AppType.Galaxy)
 
     an[AppRequiresDiskException] should be thrownBy {
-      kubeServiceInterp.createApp(userInfo, project, appName, appReq).unsafeRunSync()
+      kubeServiceInterp
+        .createApp(userInfo, project, appName, appReq)
+        .unsafeRunSync()(cats.effect.unsafe.implicits.global)
     }
   }
 
@@ -330,14 +351,16 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
                                   galaxyRestore = Some(GalaxyRestore(PvcId("pv-id"), PvcId("pv-id2"), app.id)))
       .copy(googleProject = project)
       .save()
-      .unsafeRunSync()
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
     val appName1 = AppName("app1")
     val appName2 = AppName("app2")
 
     val createDiskConfig = PersistentDiskRequest(disk.name, None, None, Map.empty)
     val appReq = createAppRequest.copy(diskConfig = Some(createDiskConfig))
 
-    kubeServiceInterp.createApp(userInfo, project, appName1, appReq).unsafeRunSync()
+    kubeServiceInterp
+      .createApp(userInfo, project, appName1, appReq)
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
     val appResult = dbFutureValue {
       KubernetesServiceDbQueries.getActiveFullAppByName(project, appName1)
     }
@@ -348,7 +371,9 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
     dbFutureValue(kubernetesClusterQuery.updateStatus(appResult.get.cluster.id, KubernetesClusterStatus.Running))
 
     a[DiskAlreadyAttachedException] should be thrownBy {
-      kubeServiceInterp.createApp(userInfo, project, appName2, appReq).unsafeRunSync()
+      kubeServiceInterp
+        .createApp(userInfo, project, appName2, appReq)
+        .unsafeRunSync()(cats.effect.unsafe.implicits.global)
     }
   }
 
@@ -357,10 +382,12 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
     val createDiskConfig = PersistentDiskRequest(diskName, None, None, Map.empty)
     val appReq = createAppRequest.copy(diskConfig = Some(createDiskConfig))
 
-    kubeServiceInterp.createApp(userInfo, project, appName, appReq).unsafeRunSync()
+    kubeServiceInterp.createApp(userInfo, project, appName, appReq).unsafeRunSync()(cats.effect.unsafe.implicits.global)
 
     an[AppAlreadyExistsException] should be thrownBy {
-      kubeServiceInterp.createApp(userInfo, project, appName, appReq).unsafeRunSync()
+      kubeServiceInterp
+        .createApp(userInfo, project, appName, appReq)
+        .unsafeRunSync()(cats.effect.unsafe.implicits.global)
     }
   }
 
@@ -370,7 +397,9 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
     val appReq = createAppRequest.copy(diskConfig = Some(createDiskConfig))
 
     a[BadRequestException] should be thrownBy {
-      kubeServiceInterp.createApp(userInfo, project, appName, appReq).unsafeRunSync()
+      kubeServiceInterp
+        .createApp(userInfo, project, appName, appReq)
+        .unsafeRunSync()(cats.effect.unsafe.implicits.global)
     }
   }
 
@@ -381,7 +410,7 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
     val createDiskConfig = PersistentDiskRequest(diskName, None, None, Map.empty)
     val appReq = createAppRequest.copy(diskConfig = Some(createDiskConfig))
 
-    kubeServiceInterp.createApp(userInfo, project, appName, appReq).unsafeRunSync()
+    kubeServiceInterp.createApp(userInfo, project, appName, appReq).unsafeRunSync()(cats.effect.unsafe.implicits.global)
 
     val appResultPreStatusUpdate = dbFutureValue {
       KubernetesServiceDbQueries.getActiveFullAppByName(project, appName)
@@ -398,7 +427,7 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
     appResultPreDelete.get.app.auditInfo.destroyedDate shouldBe None
 
     val params = DeleteAppRequest(userInfo, project, appName, false)
-    kubeServiceInterp.deleteApp(params).unsafeRunSync()
+    kubeServiceInterp.deleteApp(params).unsafeRunSync()(cats.effect.unsafe.implicits.global)
     val clusterPostDelete = dbFutureValue {
       KubernetesServiceDbQueries.listFullApps(Some(project), includeDeleted = true)
     }
@@ -410,9 +439,9 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
     app.status shouldEqual AppStatus.Predeleting
 
     //throw away create message
-    publisherQueue.dequeue1.unsafeRunSync()
+    publisherQueue.take.unsafeRunSync()(cats.effect.unsafe.implicits.global)
 
-    val message = publisherQueue.dequeue1.unsafeRunSync()
+    val message = publisherQueue.take.unsafeRunSync()(cats.effect.unsafe.implicits.global)
     message.messageType shouldBe LeoPubsubMessageType.DeleteApp
     val deleteAppMessage = message.asInstanceOf[DeleteAppMessage]
     deleteAppMessage.appId shouldBe app.id
@@ -425,7 +454,7 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
     val createDiskConfig = PersistentDiskRequest(diskName, None, None, Map.empty)
     val appReq = createAppRequest.copy(diskConfig = Some(createDiskConfig))
 
-    kubeServiceInterp.createApp(userInfo, project, appName, appReq).unsafeRunSync()
+    kubeServiceInterp.createApp(userInfo, project, appName, appReq).unsafeRunSync()(cats.effect.unsafe.implicits.global)
 
     val appResultPreDelete = dbFutureValue {
       KubernetesServiceDbQueries.getActiveFullAppByName(project, appName)
@@ -437,7 +466,7 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
 
     val params = DeleteAppRequest(userInfo, project, appName, false)
     an[AppCannotBeDeletedException] should be thrownBy {
-      kubeServiceInterp.deleteApp(params).unsafeRunSync()
+      kubeServiceInterp.deleteApp(params).unsafeRunSync()(cats.effect.unsafe.implicits.global)
     }
   }
 
@@ -448,7 +477,7 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
     val createDiskConfig = PersistentDiskRequest(diskName, None, None, Map.empty)
     val appReq = createAppRequest.copy(diskConfig = Some(createDiskConfig))
 
-    kubeServiceInterp.createApp(userInfo, project, appName, appReq).unsafeRunSync()
+    kubeServiceInterp.createApp(userInfo, project, appName, appReq).unsafeRunSync()(cats.effect.unsafe.implicits.global)
 
     val appResultPreStatusUpdate = dbFutureValue {
       KubernetesServiceDbQueries.getActiveFullAppByName(project, appName)
@@ -473,7 +502,7 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
 
     // Call deleteApp
     val params = DeleteAppRequest(userInfo, project, appName, true)
-    kubeServiceInterp.deleteApp(params).unsafeRunSync()
+    kubeServiceInterp.deleteApp(params).unsafeRunSync()(cats.effect.unsafe.implicits.global)
 
     // Verify database state
     val clusterPostDelete = dbFutureValue {
@@ -490,10 +519,10 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
     disk shouldBe None
 
     // throw away create message
-    publisherQueue.dequeue1.unsafeRunSync() shouldBe a[CreateAppMessage]
+    publisherQueue.take.unsafeRunSync()(cats.effect.unsafe.implicits.global) shouldBe a[CreateAppMessage]
 
     // Verify no DeleteAppMessage message generated
-    publisherQueue.tryDequeue1.unsafeRunSync() shouldBe None
+    publisherQueue.tryTake.unsafeRunSync()(cats.effect.unsafe.implicits.global) shouldBe None
   }
 
   it should "list apps" in isolatedDbTest {
@@ -506,17 +535,24 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
     val createDiskConfig2 = PersistentDiskRequest(diskName2, None, None, Map.empty)
     val appReq2 = createAppRequest.copy(diskConfig = Some(createDiskConfig2))
 
-    kubeServiceInterp.createApp(userInfo, project, appName1, appReq1).unsafeRunSync()
+    kubeServiceInterp
+      .createApp(userInfo, project, appName1, appReq1)
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
 
     val appResult = dbFutureValue {
       KubernetesServiceDbQueries.getActiveFullAppByName(project, appName1)
     }
     dbFutureValue(kubernetesClusterQuery.updateStatus(appResult.get.cluster.id, KubernetesClusterStatus.Running))
 
-    kubeServiceInterp.createApp(userInfo, project, appName2, appReq2).unsafeRunSync()
-    kubeServiceInterp.createApp(userInfo, project2, appName3, appReq1).unsafeRunSync()
+    kubeServiceInterp
+      .createApp(userInfo, project, appName2, appReq2)
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    kubeServiceInterp
+      .createApp(userInfo, project2, appName3, appReq1)
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
 
-    val listAllApps = kubeServiceInterp.listApp(userInfo, None, Map()).unsafeRunSync()
+    val listAllApps =
+      kubeServiceInterp.listApp(userInfo, None, Map()).unsafeRunSync()(cats.effect.unsafe.implicits.global)
     listAllApps.length shouldEqual 3
     listAllApps.map(_.appName) should contain(appName1)
     listAllApps.map(_.appName) should contain(appName2)
@@ -524,17 +560,21 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
     listAllApps.map(_.diskName).sortBy(_.get.value) shouldBe Vector(Some(diskName), Some(diskName), Some(diskName2))
       .sortBy(_.get.value)
 
-    val listProject1Apps = kubeServiceInterp.listApp(userInfo, Some(project), Map()).unsafeRunSync()
+    val listProject1Apps =
+      kubeServiceInterp.listApp(userInfo, Some(project), Map()).unsafeRunSync()(cats.effect.unsafe.implicits.global)
     listProject1Apps.length shouldBe 2
     listProject1Apps.map(_.appName) should contain(appName1)
     listProject1Apps.map(_.appName) should contain(appName2)
 
-    val listProject2Apps = kubeServiceInterp.listApp(userInfo, Some(project2), Map()).unsafeRunSync()
+    val listProject2Apps =
+      kubeServiceInterp.listApp(userInfo, Some(project2), Map()).unsafeRunSync()(cats.effect.unsafe.implicits.global)
     listProject2Apps.length shouldBe 1
     listProject2Apps.map(_.appName) should contain(appName3)
 
     val listProject3Apps =
-      kubeServiceInterp.listApp(userInfo, Some(GoogleProject("fakeProject")), Map()).unsafeRunSync()
+      kubeServiceInterp
+        .listApp(userInfo, Some(GoogleProject("fakeProject")), Map())
+        .unsafeRunSync()(cats.effect.unsafe.implicits.global)
     listProject3Apps.length shouldBe 0
   }
 
@@ -551,7 +591,9 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
     val createDiskConfig2 = PersistentDiskRequest(diskName2, None, None, Map.empty)
     val appReq2 = createAppRequest.copy(diskConfig = Some(createDiskConfig2), labels = labels)
 
-    kubeServiceInterp.createApp(userInfo, project, appName1, appReq1).unsafeRunSync()
+    kubeServiceInterp
+      .createApp(userInfo, project, appName1, appReq1)
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
 
     val app1Result = dbFutureValue {
       KubernetesServiceDbQueries.getActiveFullAppByName(project, appName1)
@@ -559,7 +601,9 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
 
     dbFutureValue(kubernetesClusterQuery.updateStatus(app1Result.get.cluster.id, KubernetesClusterStatus.Running))
 
-    kubeServiceInterp.createApp(userInfo, project, appName2, appReq2).unsafeRunSync()
+    kubeServiceInterp
+      .createApp(userInfo, project, appName2, appReq2)
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
 
     val app2Result = dbFutureValue {
       KubernetesServiceDbQueries.getActiveFullAppByName(project, appName2)
@@ -567,17 +611,22 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
     app2Result.map(_.app.labels).get.toList should contain(label1)
     app2Result.map(_.app.labels).get.toList should contain(label2)
 
-    kubeServiceInterp.createApp(userInfo, project2, appName3, appReq1).unsafeRunSync()
+    kubeServiceInterp
+      .createApp(userInfo, project2, appName3, appReq1)
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
 
-    val listLabelApp = kubeServiceInterp.listApp(userInfo, None, labels).unsafeRunSync()
+    val listLabelApp =
+      kubeServiceInterp.listApp(userInfo, None, labels).unsafeRunSync()(cats.effect.unsafe.implicits.global)
     listLabelApp.length shouldEqual 1
     listLabelApp.map(_.appName) should contain(appName2)
 
-    val listPartialLabelApp1 = kubeServiceInterp.listApp(userInfo, None, Map(label1)).unsafeRunSync()
+    val listPartialLabelApp1 =
+      kubeServiceInterp.listApp(userInfo, None, Map(label1)).unsafeRunSync()(cats.effect.unsafe.implicits.global)
     listPartialLabelApp1.length shouldEqual 1
     listPartialLabelApp1.map(_.appName) should contain(appName2)
 
-    val listPartialLabelApp2 = kubeServiceInterp.listApp(userInfo, None, Map(label2)).unsafeRunSync()
+    val listPartialLabelApp2 =
+      kubeServiceInterp.listApp(userInfo, None, Map(label2)).unsafeRunSync()(cats.effect.unsafe.implicits.global)
     listPartialLabelApp2.length shouldEqual 1
     listPartialLabelApp2.map(_.appName) should contain(appName2)
   }
@@ -601,7 +650,7 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
       listResponse.map(_.appName).toSet shouldBe Set(app1.appName, app2.appName)
     }
 
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "get app" in isolatedDbTest {
@@ -614,40 +663,49 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
     val createDiskConfig2 = PersistentDiskRequest(diskName2, None, None, Map.empty)
     val appReq2 = createAppRequest.copy(diskConfig = Some(createDiskConfig2))
 
-    kubeServiceInterp.createApp(userInfo, project, appName1, appReq1).unsafeRunSync()
+    kubeServiceInterp
+      .createApp(userInfo, project, appName1, appReq1)
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
 
     val appResult = dbFutureValue {
       KubernetesServiceDbQueries.getActiveFullAppByName(project, appName1)
     }
     dbFutureValue(kubernetesClusterQuery.updateStatus(appResult.get.cluster.id, KubernetesClusterStatus.Running))
 
-    kubeServiceInterp.createApp(userInfo, project, appName2, appReq2).unsafeRunSync()
+    kubeServiceInterp
+      .createApp(userInfo, project, appName2, appReq2)
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
 
     val diskName3 = DiskName("newDiskName2")
     val createDiskConfig3 = PersistentDiskRequest(diskName3, None, None, Map.empty)
     kubeServiceInterp
       .createApp(userInfo, project2, appName3, appReq1.copy(diskConfig = Some(createDiskConfig3)))
-      .unsafeRunSync()
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
 
-    val getApp1 = kubeServiceInterp.getApp(userInfo, project, appName1).unsafeRunSync()
+    val getApp1 =
+      kubeServiceInterp.getApp(userInfo, project, appName1).unsafeRunSync()(cats.effect.unsafe.implicits.global)
     getApp1.diskName shouldBe Some(diskName)
 
-    val getApp2 = kubeServiceInterp.getApp(userInfo, project, appName2).unsafeRunSync()
+    val getApp2 =
+      kubeServiceInterp.getApp(userInfo, project, appName2).unsafeRunSync()(cats.effect.unsafe.implicits.global)
     getApp2.diskName shouldBe Some(diskName2)
 
-    val getApp3 = kubeServiceInterp.getApp(userInfo, project2, appName3).unsafeRunSync()
+    val getApp3 =
+      kubeServiceInterp.getApp(userInfo, project2, appName3).unsafeRunSync()(cats.effect.unsafe.implicits.global)
     getApp3.diskName shouldBe Some(diskName3)
   }
 
   it should "error on get app if an app does not exist" in isolatedDbTest {
     an[AppNotFoundException] should be thrownBy {
-      kubeServiceInterp.getApp(userInfo, project, AppName("schrodingersApp")).unsafeRunSync()
+      kubeServiceInterp
+        .getApp(userInfo, project, AppName("schrodingersApp"))
+        .unsafeRunSync()(cats.effect.unsafe.implicits.global)
     }
   }
 
   it should "stop an app" in isolatedDbTest {
     val res = for {
-      publisherQueue <- InspectableQueue.bounded[IO, LeoPubsubMessage](10)
+      publisherQueue <- Queue.bounded[IO, LeoPubsubMessage](10)
       kubeServiceInterp = makeInterp(publisherQueue)
 
       savedCluster <- IO(makeKubeCluster(1).copy(status = KubernetesClusterStatus.Running).save())
@@ -660,7 +718,7 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
           dbAppOpt <- KubernetesServiceDbQueries
             .getActiveFullAppByName(savedCluster.googleProject, savedApp.appName)
             .transaction
-          msg <- publisherQueue.tryDequeue1
+          msg <- publisherQueue.tryTake
         } yield {
           dbAppOpt.isDefined shouldBe true
           dbAppOpt.get.app.status shouldBe AppStatus.Stopping
@@ -674,12 +732,12 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
       }
     } yield ()
 
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "start an app" in isolatedDbTest {
     val res = for {
-      publisherQueue <- InspectableQueue.bounded[IO, LeoPubsubMessage](10)
+      publisherQueue <- Queue.bounded[IO, LeoPubsubMessage](10)
       kubeServiceInterp = makeInterp(publisherQueue)
 
       savedCluster <- IO(makeKubeCluster(1).copy(status = KubernetesClusterStatus.Running).save())
@@ -692,7 +750,7 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
           dbAppOpt <- KubernetesServiceDbQueries
             .getActiveFullAppByName(savedCluster.googleProject, savedApp.appName)
             .transaction
-          msg <- publisherQueue.tryDequeue1
+          msg <- publisherQueue.tryTake
         } yield {
           dbAppOpt.isDefined shouldBe true
           dbAppOpt.get.app.status shouldBe AppStatus.Starting
@@ -706,11 +764,11 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
       }
     } yield ()
 
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   private def withLeoPublisher(
-    publisherQueue: InspectableQueue[IO, LeoPubsubMessage]
+    publisherQueue: Queue[IO, LeoPubsubMessage]
   )(validations: IO[Assertion]): IO[Assertion] = {
     val leoPublisher = new LeoPublisher[IO](publisherQueue, new FakeGooglePublisher)
     withInfiniteStream(leoPublisher.process, validations)

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/AppServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/AppServiceInterpSpec.scala
@@ -55,7 +55,7 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
     val customEnvVars = Map("WORKSPACE_NAME" -> "testWorkspace")
     val appReq = createAppRequest.copy(diskConfig = Some(createDiskConfig), customEnvironmentVariables = customEnvVars)
 
-    kubeServiceInterp.createApp(userInfo, project, appName, appReq).unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    kubeServiceInterp.createApp(userInfo, project, appName, appReq).unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
 
     val clusters = dbFutureValue {
       KubernetesServiceDbQueries.listFullApps(Some(project))
@@ -90,7 +90,7 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
     val customEnvVars = Map("WORKSPACE_NAME" -> "testWorkspace")
     val appReq = createAppRequest.copy(diskConfig = Some(createDiskConfig), customEnvironmentVariables = customEnvVars)
 
-    kubeServiceInterp.createApp(userInfo, project, appName, appReq).unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    kubeServiceInterp.createApp(userInfo, project, appName, appReq).unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
     val appResult = dbFutureValue {
       KubernetesServiceDbQueries.getActiveFullAppByName(project, appName)
     }
@@ -102,7 +102,7 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
       createAppRequest.copy(diskConfig = Some(createDiskConfig2), customEnvironmentVariables = customEnvVars)
     kubeServiceInterp
       .createApp(userInfo, project, appName2, appReq2)
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+      .unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
 
     val clusters = dbFutureValue {
       KubernetesServiceDbQueries.listFullApps(Some(project))
@@ -160,7 +160,7 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
 
     kubeServiceInterp
       .createApp(userInfo, project, appName1, defaultAppReq)
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+      .unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
     val appResult = dbFutureValue {
       KubernetesServiceDbQueries.getActiveFullAppByName(project, appName1)
     }
@@ -168,13 +168,13 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
 
     kubeServiceInterp
       .createApp(userInfo, project, appName2, appReqWithMoreNodes)
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+      .unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
     kubeServiceInterp
       .createApp(userInfo, project, appName3, appReqWithMoreCpuAndMem)
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+      .unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
     kubeServiceInterp
       .createApp(userInfo, project, appName4, appReqWithAutoscalingDisabled)
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+      .unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
 
     val clusters = dbFutureValue {
       KubernetesServiceDbQueries.listFullApps(Some(project))
@@ -205,7 +205,7 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
     val publisherQueue = QueueFactory.makePublisherQueue()
     val kubeServiceInterp = makeInterp(publisherQueue)
 
-    kubeServiceInterp.createApp(userInfo, project, appName, appReq).unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    kubeServiceInterp.createApp(userInfo, project, appName, appReq).unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
 
     val getApp = dbFutureValue {
       KubernetesServiceDbQueries.getActiveFullAppByName(project, appName)
@@ -219,7 +219,7 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
     defaultNodepools.length shouldBe 1
     val defaultNodepool = defaultNodepools.head
 
-    val message = publisherQueue.take.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    val message = publisherQueue.take.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
     message.messageType shouldBe LeoPubsubMessageType.CreateApp
     val createAppMessage = message.asInstanceOf[CreateAppMessage]
     createAppMessage.appId shouldBe getApp.app.id
@@ -235,7 +235,7 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
     val disk = makePersistentDisk(None)
       .copy(googleProject = project)
       .save()
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+      .unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
 
     val appName = AppName("app1")
     val createDiskConfig = PersistentDiskRequest(disk.name, None, None, Map.empty)
@@ -246,7 +246,7 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
     val res = kubeServiceInterp
       .createApp(userInfo, project, appName, appReq)
       .attempt
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+      .unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
 
     res.swap.toOption.get.getMessage shouldBe ("Disk is not formatted yet. Only disks previously used by galaxy app can be re-used to create a new galaxy app")
   }
@@ -261,7 +261,7 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
                                   galaxyRestore = Some(GalaxyRestore(PvcId("pv-id"), PvcId("pv-id2"), app.id)))
       .copy(googleProject = project)
       .save()
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+      .unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
 
     val appName = AppName("app1")
     val createDiskConfig = PersistentDiskRequest(disk.name, None, None, Map.empty)
@@ -273,7 +273,7 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
     val res = kubeServiceInterp
       .createApp(userInfo, project, appName, appReq)
       .attempt
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+      .unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
     res.swap.toOption.get.getMessage shouldBe ("workspace name has to be the same as last used app in order to restore data from existing disk")
   }
 
@@ -287,7 +287,7 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
                                   formattedBy = Some(FormattedBy.Galaxy))
       .copy(googleProject = project)
       .save()
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+      .unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
 
     val appName = AppName("app1")
     val createDiskConfig = PersistentDiskRequest(disk.name, None, None, Map.empty)
@@ -296,9 +296,9 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
 
     val publisherQueue = QueueFactory.makePublisherQueue()
     val kubeServiceInterp = makeInterp(publisherQueue)
-    kubeServiceInterp.createApp(userInfo, project, appName, appReq).unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    kubeServiceInterp.createApp(userInfo, project, appName, appReq).unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
 
-    val message = publisherQueue.take.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    val message = publisherQueue.take.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
     message.messageType shouldBe LeoPubsubMessageType.CreateApp
     message.asInstanceOf[CreateAppMessage].createDisk shouldBe None
 
@@ -314,7 +314,7 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
     val disk = makePersistentDisk(None, formattedBy = Some(FormattedBy.Galaxy))
       .copy(googleProject = project)
       .save()
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+      .unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
 
     val appName = AppName("app1")
     val createDiskConfig = PersistentDiskRequest(disk.name, None, None, Map.empty)
@@ -325,7 +325,7 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
     val res = kubeServiceInterp
       .createApp(userInfo, project, appName, appReq)
       .attempt
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+      .unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
 
     res.swap.toOption.get.getMessage shouldBe ("Existing disk found, but no restore info found in DB")
   }
@@ -337,7 +337,7 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
     an[AppRequiresDiskException] should be thrownBy {
       kubeServiceInterp
         .createApp(userInfo, project, appName, appReq)
-        .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+        .unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
     }
   }
 
@@ -351,7 +351,7 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
                                   galaxyRestore = Some(GalaxyRestore(PvcId("pv-id"), PvcId("pv-id2"), app.id)))
       .copy(googleProject = project)
       .save()
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+      .unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
     val appName1 = AppName("app1")
     val appName2 = AppName("app2")
 
@@ -360,7 +360,7 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
 
     kubeServiceInterp
       .createApp(userInfo, project, appName1, appReq)
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+      .unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
     val appResult = dbFutureValue {
       KubernetesServiceDbQueries.getActiveFullAppByName(project, appName1)
     }
@@ -373,7 +373,7 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
     a[DiskAlreadyAttachedException] should be thrownBy {
       kubeServiceInterp
         .createApp(userInfo, project, appName2, appReq)
-        .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+        .unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
     }
   }
 
@@ -382,12 +382,12 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
     val createDiskConfig = PersistentDiskRequest(diskName, None, None, Map.empty)
     val appReq = createAppRequest.copy(diskConfig = Some(createDiskConfig))
 
-    kubeServiceInterp.createApp(userInfo, project, appName, appReq).unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    kubeServiceInterp.createApp(userInfo, project, appName, appReq).unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
 
     an[AppAlreadyExistsException] should be thrownBy {
       kubeServiceInterp
         .createApp(userInfo, project, appName, appReq)
-        .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+        .unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
     }
   }
 
@@ -399,7 +399,7 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
     a[BadRequestException] should be thrownBy {
       kubeServiceInterp
         .createApp(userInfo, project, appName, appReq)
-        .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+        .unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
     }
   }
 
@@ -410,7 +410,7 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
     val createDiskConfig = PersistentDiskRequest(diskName, None, None, Map.empty)
     val appReq = createAppRequest.copy(diskConfig = Some(createDiskConfig))
 
-    kubeServiceInterp.createApp(userInfo, project, appName, appReq).unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    kubeServiceInterp.createApp(userInfo, project, appName, appReq).unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
 
     val appResultPreStatusUpdate = dbFutureValue {
       KubernetesServiceDbQueries.getActiveFullAppByName(project, appName)
@@ -427,7 +427,7 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
     appResultPreDelete.get.app.auditInfo.destroyedDate shouldBe None
 
     val params = DeleteAppRequest(userInfo, project, appName, false)
-    kubeServiceInterp.deleteApp(params).unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    kubeServiceInterp.deleteApp(params).unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
     val clusterPostDelete = dbFutureValue {
       KubernetesServiceDbQueries.listFullApps(Some(project), includeDeleted = true)
     }
@@ -439,9 +439,9 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
     app.status shouldEqual AppStatus.Predeleting
 
     //throw away create message
-    publisherQueue.take.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    publisherQueue.take.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
 
-    val message = publisherQueue.take.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    val message = publisherQueue.take.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
     message.messageType shouldBe LeoPubsubMessageType.DeleteApp
     val deleteAppMessage = message.asInstanceOf[DeleteAppMessage]
     deleteAppMessage.appId shouldBe app.id
@@ -454,7 +454,7 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
     val createDiskConfig = PersistentDiskRequest(diskName, None, None, Map.empty)
     val appReq = createAppRequest.copy(diskConfig = Some(createDiskConfig))
 
-    kubeServiceInterp.createApp(userInfo, project, appName, appReq).unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    kubeServiceInterp.createApp(userInfo, project, appName, appReq).unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
 
     val appResultPreDelete = dbFutureValue {
       KubernetesServiceDbQueries.getActiveFullAppByName(project, appName)
@@ -466,7 +466,7 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
 
     val params = DeleteAppRequest(userInfo, project, appName, false)
     an[AppCannotBeDeletedException] should be thrownBy {
-      kubeServiceInterp.deleteApp(params).unsafeRunSync()(cats.effect.unsafe.implicits.global)
+      kubeServiceInterp.deleteApp(params).unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
     }
   }
 
@@ -477,7 +477,7 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
     val createDiskConfig = PersistentDiskRequest(diskName, None, None, Map.empty)
     val appReq = createAppRequest.copy(diskConfig = Some(createDiskConfig))
 
-    kubeServiceInterp.createApp(userInfo, project, appName, appReq).unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    kubeServiceInterp.createApp(userInfo, project, appName, appReq).unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
 
     val appResultPreStatusUpdate = dbFutureValue {
       KubernetesServiceDbQueries.getActiveFullAppByName(project, appName)
@@ -502,7 +502,7 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
 
     // Call deleteApp
     val params = DeleteAppRequest(userInfo, project, appName, true)
-    kubeServiceInterp.deleteApp(params).unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    kubeServiceInterp.deleteApp(params).unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
 
     // Verify database state
     val clusterPostDelete = dbFutureValue {
@@ -519,10 +519,10 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
     disk shouldBe None
 
     // throw away create message
-    publisherQueue.take.unsafeRunSync()(cats.effect.unsafe.implicits.global) shouldBe a[CreateAppMessage]
+    publisherQueue.take.unsafeRunSync()(cats.effect.unsafe.IORuntime.global) shouldBe a[CreateAppMessage]
 
     // Verify no DeleteAppMessage message generated
-    publisherQueue.tryTake.unsafeRunSync()(cats.effect.unsafe.implicits.global) shouldBe None
+    publisherQueue.tryTake.unsafeRunSync()(cats.effect.unsafe.IORuntime.global) shouldBe None
   }
 
   it should "list apps" in isolatedDbTest {
@@ -537,7 +537,7 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
 
     kubeServiceInterp
       .createApp(userInfo, project, appName1, appReq1)
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+      .unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
 
     val appResult = dbFutureValue {
       KubernetesServiceDbQueries.getActiveFullAppByName(project, appName1)
@@ -546,13 +546,13 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
 
     kubeServiceInterp
       .createApp(userInfo, project, appName2, appReq2)
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+      .unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
     kubeServiceInterp
       .createApp(userInfo, project2, appName3, appReq1)
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+      .unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
 
     val listAllApps =
-      kubeServiceInterp.listApp(userInfo, None, Map()).unsafeRunSync()(cats.effect.unsafe.implicits.global)
+      kubeServiceInterp.listApp(userInfo, None, Map()).unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
     listAllApps.length shouldEqual 3
     listAllApps.map(_.appName) should contain(appName1)
     listAllApps.map(_.appName) should contain(appName2)
@@ -561,20 +561,20 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
       .sortBy(_.get.value)
 
     val listProject1Apps =
-      kubeServiceInterp.listApp(userInfo, Some(project), Map()).unsafeRunSync()(cats.effect.unsafe.implicits.global)
+      kubeServiceInterp.listApp(userInfo, Some(project), Map()).unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
     listProject1Apps.length shouldBe 2
     listProject1Apps.map(_.appName) should contain(appName1)
     listProject1Apps.map(_.appName) should contain(appName2)
 
     val listProject2Apps =
-      kubeServiceInterp.listApp(userInfo, Some(project2), Map()).unsafeRunSync()(cats.effect.unsafe.implicits.global)
+      kubeServiceInterp.listApp(userInfo, Some(project2), Map()).unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
     listProject2Apps.length shouldBe 1
     listProject2Apps.map(_.appName) should contain(appName3)
 
     val listProject3Apps =
       kubeServiceInterp
         .listApp(userInfo, Some(GoogleProject("fakeProject")), Map())
-        .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+        .unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
     listProject3Apps.length shouldBe 0
   }
 
@@ -593,7 +593,7 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
 
     kubeServiceInterp
       .createApp(userInfo, project, appName1, appReq1)
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+      .unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
 
     val app1Result = dbFutureValue {
       KubernetesServiceDbQueries.getActiveFullAppByName(project, appName1)
@@ -603,7 +603,7 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
 
     kubeServiceInterp
       .createApp(userInfo, project, appName2, appReq2)
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+      .unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
 
     val app2Result = dbFutureValue {
       KubernetesServiceDbQueries.getActiveFullAppByName(project, appName2)
@@ -613,20 +613,20 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
 
     kubeServiceInterp
       .createApp(userInfo, project2, appName3, appReq1)
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+      .unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
 
     val listLabelApp =
-      kubeServiceInterp.listApp(userInfo, None, labels).unsafeRunSync()(cats.effect.unsafe.implicits.global)
+      kubeServiceInterp.listApp(userInfo, None, labels).unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
     listLabelApp.length shouldEqual 1
     listLabelApp.map(_.appName) should contain(appName2)
 
     val listPartialLabelApp1 =
-      kubeServiceInterp.listApp(userInfo, None, Map(label1)).unsafeRunSync()(cats.effect.unsafe.implicits.global)
+      kubeServiceInterp.listApp(userInfo, None, Map(label1)).unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
     listPartialLabelApp1.length shouldEqual 1
     listPartialLabelApp1.map(_.appName) should contain(appName2)
 
     val listPartialLabelApp2 =
-      kubeServiceInterp.listApp(userInfo, None, Map(label2)).unsafeRunSync()(cats.effect.unsafe.implicits.global)
+      kubeServiceInterp.listApp(userInfo, None, Map(label2)).unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
     listPartialLabelApp2.length shouldEqual 1
     listPartialLabelApp2.map(_.appName) should contain(appName2)
   }
@@ -650,7 +650,7 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
       listResponse.map(_.appName).toSet shouldBe Set(app1.appName, app2.appName)
     }
 
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   it should "get app" in isolatedDbTest {
@@ -665,7 +665,7 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
 
     kubeServiceInterp
       .createApp(userInfo, project, appName1, appReq1)
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+      .unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
 
     val appResult = dbFutureValue {
       KubernetesServiceDbQueries.getActiveFullAppByName(project, appName1)
@@ -674,24 +674,24 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
 
     kubeServiceInterp
       .createApp(userInfo, project, appName2, appReq2)
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+      .unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
 
     val diskName3 = DiskName("newDiskName2")
     val createDiskConfig3 = PersistentDiskRequest(diskName3, None, None, Map.empty)
     kubeServiceInterp
       .createApp(userInfo, project2, appName3, appReq1.copy(diskConfig = Some(createDiskConfig3)))
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+      .unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
 
     val getApp1 =
-      kubeServiceInterp.getApp(userInfo, project, appName1).unsafeRunSync()(cats.effect.unsafe.implicits.global)
+      kubeServiceInterp.getApp(userInfo, project, appName1).unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
     getApp1.diskName shouldBe Some(diskName)
 
     val getApp2 =
-      kubeServiceInterp.getApp(userInfo, project, appName2).unsafeRunSync()(cats.effect.unsafe.implicits.global)
+      kubeServiceInterp.getApp(userInfo, project, appName2).unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
     getApp2.diskName shouldBe Some(diskName2)
 
     val getApp3 =
-      kubeServiceInterp.getApp(userInfo, project2, appName3).unsafeRunSync()(cats.effect.unsafe.implicits.global)
+      kubeServiceInterp.getApp(userInfo, project2, appName3).unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
     getApp3.diskName shouldBe Some(diskName3)
   }
 
@@ -699,7 +699,7 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
     an[AppNotFoundException] should be thrownBy {
       kubeServiceInterp
         .getApp(userInfo, project, AppName("schrodingersApp"))
-        .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+        .unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
     }
   }
 
@@ -732,7 +732,7 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
       }
     } yield ()
 
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   it should "start an app" in isolatedDbTest {
@@ -764,7 +764,7 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
       }
     } yield ()
 
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   private def withLeoPublisher(

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/DiskServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/DiskServiceInterpSpec.scala
@@ -57,7 +57,7 @@ class DiskServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with Test
     } yield {
       d shouldBe (Left(ForbiddenError(userInfo.userEmail)))
     }
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   it should "successfully create a persistent disk" in isolatedDbTest {
@@ -86,7 +86,7 @@ class DiskServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with Test
 
       message shouldBe expectedMessage
     }
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   it should "get a disk" in isolatedDbTest {
@@ -103,7 +103,7 @@ class DiskServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with Test
       getResponse.samResource shouldBe disk.samResource
       getResponse.labels shouldBe labelResp
     }
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   it should "list disks" in isolatedDbTest {
@@ -117,7 +117,7 @@ class DiskServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with Test
       listResponse.map(_.id).toSet shouldBe Set(disk1.id, disk2.id)
     }
 
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   it should "list disks with a project" in isolatedDbTest {
@@ -132,7 +132,7 @@ class DiskServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with Test
       listResponse.map(_.id).toSet shouldBe Set(disk1.id, disk2.id)
     }
 
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   it should "list disks with parameters" in isolatedDbTest {
@@ -147,7 +147,7 @@ class DiskServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with Test
       listResponse.map(_.id).toSet shouldBe Set(disk1.id)
     }
 
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   it should "list disks belonging to other users" in isolatedDbTest {
@@ -168,7 +168,7 @@ class DiskServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with Test
       listResponse.map(_.id).toSet shouldBe Set(disk1.id, disk2.id)
     }
 
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   it should "delete a disk" in isolatedDbTest {
@@ -191,7 +191,7 @@ class DiskServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with Test
       message shouldBe expectedMessage
     }
 
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   it should "fail to delete a disk if it is attached to a runtime" in isolatedDbTest {
@@ -215,7 +215,7 @@ class DiskServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with Test
       err shouldBe Left(DiskAlreadyAttachedException(project, disk.name, t.traceId))
     }
 
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   List(DiskStatus.Creating, DiskStatus.Restoring, DiskStatus.Failed, DiskStatus.Deleting, DiskStatus.Deleted).foreach {
@@ -233,7 +233,7 @@ class DiskServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with Test
         } yield {
           fail shouldBe Left(DiskCannotBeUpdatedException(disk.projectNameString, disk.status, traceId = t.traceId))
         }
-        res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+        res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
       }
   }
 
@@ -252,6 +252,6 @@ class DiskServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with Test
       message shouldBe expectedMessage
     }
 
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/DiskServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/DiskServiceInterpSpec.scala
@@ -4,7 +4,6 @@ package service
 
 import java.time.Instant
 import java.util.UUID
-
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import cats.effect.IO
 import cats.mtl.Ask
@@ -19,7 +18,6 @@ import org.broadinstitute.dsde.workbench.leonardo.util.QueueFactory
 import org.broadinstitute.dsde.workbench.model
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.broadinstitute.dsde.workbench.model.{UserInfo, WorkbenchEmail, WorkbenchUserId}
-
 import scala.concurrent.ExecutionContext.Implicits.global
 import org.scalatest.flatspec.AnyFlatSpec
 
@@ -59,7 +57,7 @@ class DiskServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with Test
     } yield {
       d shouldBe (Left(ForbiddenError(userInfo.userEmail)))
     }
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "successfully create a persistent disk" in isolatedDbTest {
@@ -79,7 +77,7 @@ class DiskServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with Test
         .attempt
       diskOpt <- persistentDiskQuery.getActiveByName(googleProject, diskName).transaction
       disk = diskOpt.get
-      message <- publisherQueue.dequeue1
+      message <- publisherQueue.take
     } yield {
       d shouldBe Right(())
       disk.googleProject shouldBe (googleProject)
@@ -88,7 +86,7 @@ class DiskServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with Test
 
       message shouldBe expectedMessage
     }
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "get a disk" in isolatedDbTest {
@@ -105,7 +103,7 @@ class DiskServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with Test
       getResponse.samResource shouldBe disk.samResource
       getResponse.labels shouldBe labelResp
     }
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "list disks" in isolatedDbTest {
@@ -119,7 +117,7 @@ class DiskServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with Test
       listResponse.map(_.id).toSet shouldBe Set(disk1.id, disk2.id)
     }
 
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "list disks with a project" in isolatedDbTest {
@@ -134,7 +132,7 @@ class DiskServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with Test
       listResponse.map(_.id).toSet shouldBe Set(disk1.id, disk2.id)
     }
 
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "list disks with parameters" in isolatedDbTest {
@@ -149,7 +147,7 @@ class DiskServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with Test
       listResponse.map(_.id).toSet shouldBe Set(disk1.id)
     }
 
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "list disks belonging to other users" in isolatedDbTest {
@@ -170,7 +168,7 @@ class DiskServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with Test
       listResponse.map(_.id).toSet shouldBe Set(disk1.id, disk2.id)
     }
 
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "delete a disk" in isolatedDbTest {
@@ -186,14 +184,14 @@ class DiskServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with Test
         .getActiveByName(disk.googleProject, disk.name)
         .transaction
       dbDisk = dbDiskOpt.get
-      message <- publisherQueue.dequeue1
+      message <- publisherQueue.take
     } yield {
       dbDisk.status shouldBe DiskStatus.Deleting
       val expectedMessage = DeleteDiskMessage(disk.id, Some(context.traceId))
       message shouldBe expectedMessage
     }
 
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "fail to delete a disk if it is attached to a runtime" in isolatedDbTest {
@@ -217,7 +215,7 @@ class DiskServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with Test
       err shouldBe Left(DiskAlreadyAttachedException(project, disk.name, t.traceId))
     }
 
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   List(DiskStatus.Creating, DiskStatus.Restoring, DiskStatus.Failed, DiskStatus.Deleting, DiskStatus.Deleted).foreach {
@@ -235,7 +233,7 @@ class DiskServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with Test
         } yield {
           fail shouldBe Left(DiskCannotBeUpdatedException(disk.projectNameString, disk.status, traceId = t.traceId))
         }
-        res.unsafeRunSync()
+        res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
       }
   }
 
@@ -248,12 +246,12 @@ class DiskServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with Test
       disk <- makePersistentDisk(None).copy(samResource = diskSamResource).save()
       req = UpdateDiskRequest(Map.empty, DiskSize(600))
       _ <- diskService.updateDisk(userInfo, disk.googleProject, disk.name, req)
-      message <- publisherQueue.dequeue1
+      message <- publisherQueue.take
     } yield {
       val expectedMessage = UpdateDiskMessage(disk.id, DiskSize(600), Some(context.traceId))
       message shouldBe expectedMessage
     }
 
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterpSpec.scala
@@ -9,7 +9,8 @@ import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import cats.effect.IO
 import cats.mtl.Ask
-import fs2.concurrent.InspectableQueue
+import cats.effect.std.Queue
+import scala.concurrent.ExecutionContext.Implicits.global
 import org.broadinstitute.dsde.workbench.google2.mock.{
   FakeGoogleComputeService,
   FakeGooglePublisher,
@@ -42,12 +43,11 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatestplus.mockito.MockitoSugar
 
 import java.nio.file.Paths
-import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 
 class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with TestComponent with MockitoSugar {
   val publisherQueue = QueueFactory.makePublisherQueue()
-  def makeRuntimeService(publisherQueue: InspectableQueue[IO, LeoPubsubMessage]) =
+  def makeRuntimeService(publisherQueue: Queue[IO, LeoPubsubMessage]) =
     new RuntimeServiceInterp(
       RuntimeServiceConfig(Config.proxyConfig.proxyUrlBase,
                            imageConfig,
@@ -99,7 +99,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
     } yield {
       r shouldBe (Left(ForbiddenError(userInfo.userEmail)))
     }
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "calculate autopause threshold properly" in {
@@ -110,11 +110,13 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
   }
 
   it should "throw ClusterAlreadyExistsException when creating a cluster with same name and project as an existing cluster" in isolatedDbTest {
-    runtimeService.createRuntime(userInfo, project, name0, emptyCreateRuntimeReq).unsafeRunSync()
+    runtimeService
+      .createRuntime(userInfo, project, name0, emptyCreateRuntimeReq)
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
     val exc = runtimeService
       .createRuntime(userInfo, project, name0, emptyCreateRuntimeReq)
       .attempt
-      .unsafeRunSync()
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
       .swap
       .toOption
       .get
@@ -131,7 +133,13 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
       )
     )
     val response =
-      runtimeService.createRuntime(userInfo, project, name0, clusterRequest).attempt.unsafeRunSync().swap.toOption.get
+      runtimeService
+        .createRuntime(userInfo, project, name0, clusterRequest)
+        .attempt
+        .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+        .swap
+        .toOption
+        .get
 
     response shouldBe a[BucketObjectException]
   }
@@ -149,7 +157,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
           )
         )
         .attempt
-        .unsafeRunSync()
+        .unsafeRunSync()(cats.effect.unsafe.implicits.global)
         .swap
         .toOption
         .get
@@ -163,7 +171,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
     val runtimeName = RuntimeName("clusterName1")
 
     val res = for {
-      _ <- publisherQueue.tryDequeue1 // just to make sure there's no messages in the queue to start with
+      _ <- publisherQueue.tryTake // just to make sure there's no messages in the queue to start with
       context <- ctx.ask[AppContext]
       r <- runtimeService
         .createRuntime(
@@ -173,10 +181,12 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
           emptyCreateRuntimeReq
         )
         .attempt
-      clusterOpt <- clusterQuery.getActiveClusterByNameMinimal(googleProject, runtimeName).transaction
+      clusterOpt <- clusterQuery
+        .getActiveClusterByNameMinimal(googleProject, runtimeName)(scala.concurrent.ExecutionContext.global)
+        .transaction
       cluster = clusterOpt.get
       runtimeConfig <- RuntimeConfigQueries.getRuntimeConfig(cluster.runtimeConfigId).transaction
-      message <- publisherQueue.dequeue1
+      message <- publisherQueue.take
       gceRuntimeConfig = runtimeConfig.asInstanceOf[RuntimeConfig.GceConfig]
       gceRuntimeConfigRequest = LeoLenses.runtimeConfigPrism.getOption(gceRuntimeConfig).get
     } yield {
@@ -203,7 +213,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
         )
       message shouldBe expectedMessage
     }
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "successfully accept https as user script and user startup script" in isolatedDbTest {
@@ -232,11 +242,11 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
           request
         )
         .attempt
-      _ <- publisherQueue.dequeue1 //dequeue the message so that it doesn't affect other tests
+      _ <- publisherQueue.take //dequeue the message so that it doesn't affect other tests
     } yield {
       r shouldBe Right(())
     }
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "successfully create a cluster with an rstudio image" in isolatedDbTest {
@@ -258,12 +268,12 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
         )
         .attempt
       runtime <- clusterQuery.getActiveClusterByName(googleProject, runtimeName).transaction
-      _ <- publisherQueue.dequeue1 //dequeue the message so that it doesn't affect other tests
+      _ <- publisherQueue.take //dequeue the message so that it doesn't affect other tests
     } yield {
       r shouldBe Right(())
       runtime.get.runtimeImages.map(_.imageType) contains (RuntimeImageType.RStudio)
     }
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "successfully create a dataproc runtime when explicitly told so when numberOfWorkers is 0" in isolatedDbTest {
@@ -288,7 +298,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
     )
 
     val res = for {
-      _ <- publisherQueue.tryDequeue1
+      _ <- publisherQueue.tryTake
       context <- ctx.ask[AppContext]
       _ <- runtimeService
         .createRuntime(
@@ -298,11 +308,15 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
           req
         )
         .attempt
-      clusterOpt <- clusterQuery.getActiveClusterByNameMinimal(googleProject, runtimeName).transaction
+      clusterOpt <- clusterQuery
+        .getActiveClusterByNameMinimal(googleProject, runtimeName)(scala.concurrent.ExecutionContext.global)
+        .transaction
       cluster = clusterOpt.get
-      runtimeConfig <- RuntimeConfigQueries.getRuntimeConfig(cluster.runtimeConfigId).transaction
+      runtimeConfig <- RuntimeConfigQueries
+        .getRuntimeConfig(cluster.runtimeConfigId)(scala.concurrent.ExecutionContext.global)
+        .transaction
       runtimeConfigRequest = LeoLenses.runtimeConfigPrism.getOption(runtimeConfig).get
-      message <- publisherQueue.dequeue1
+      message <- publisherQueue.take
     } yield {
       // Default worker is 0, hence all worker configs are None
       val expectedRuntimeConfig = Config.dataprocConfig.runtimeConfigDefaults.copy(
@@ -331,7 +345,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
         )
       message shouldBe expectedMessage
     }
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "successfully create a dataproc runtime when explicitly told so when numberOfWorkers is more than 0" in isolatedDbTest {
@@ -356,7 +370,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
     )
 
     val res = for {
-      _ <- publisherQueue.tryDequeue1
+      _ <- publisherQueue.tryTake
       context <- ctx.ask[AppContext]
       _ <- runtimeService
         .createRuntime(
@@ -366,11 +380,13 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
           req
         )
         .attempt
-      clusterOpt <- clusterQuery.getActiveClusterByNameMinimal(googleProject, runtimeName).transaction
+      clusterOpt <- clusterQuery
+        .getActiveClusterByNameMinimal(googleProject, runtimeName)(scala.concurrent.ExecutionContext.global)
+        .transaction
       cluster = clusterOpt.get
       runtimeConfig <- RuntimeConfigQueries.getRuntimeConfig(cluster.runtimeConfigId).transaction
       runtimeConfigRequest = LeoLenses.runtimeConfigPrism.getOption(runtimeConfig).get
-      message <- publisherQueue.dequeue1
+      message <- publisherQueue.take
     } yield {
       runtimeConfig shouldBe Config.dataprocConfig.runtimeConfigDefaults.copy(numberOfWorkers = 2)
       val expectedMessage = CreateRuntimeMessage
@@ -392,7 +408,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
         )
       message shouldBe expectedMessage
     }
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "create a runtime with the latest welder from welderRegistry" in isolatedDbTest {
@@ -428,20 +444,22 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
         )
         .attempt
 
-      runtimeOpt1 <- clusterQuery.getActiveClusterByName(googleProject, runtimeName1).transaction
+      runtimeOpt1 <- clusterQuery
+        .getActiveClusterByName(googleProject, runtimeName1)(scala.concurrent.ExecutionContext.global)
+        .transaction
       runtime1 = runtimeOpt1.get
       welder1 = runtime1.runtimeImages.filter(_.imageType == RuntimeImageType.Welder).headOption
-      _ <- publisherQueue.dequeue1
+      _ <- publisherQueue.take
 
       runtimeOpt2 <- clusterQuery.getActiveClusterByName(googleProject, runtimeName2).transaction
       runtime2 = runtimeOpt2.get
       welder2 = runtime2.runtimeImages.filter(_.imageType == RuntimeImageType.Welder).headOption
-      _ <- publisherQueue.dequeue1
+      _ <- publisherQueue.take
 
       runtimeOpt3 <- clusterQuery.getActiveClusterByName(googleProject, runtimeName3).transaction
       runtime3 = runtimeOpt3.get
       welder3 = runtime3.runtimeImages.filter(_.imageType == RuntimeImageType.Welder).headOption
-      _ <- publisherQueue.dequeue1
+      _ <- publisherQueue.take
     } yield {
       r1 shouldBe Right(())
       runtime1.runtimeName shouldBe (runtimeName1)
@@ -458,7 +476,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
       welder3 shouldBe defined
       welder3.get.imageUrl shouldBe Config.imageConfig.welderGcrImage.imageUrl
     }
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "create a runtime with the crypto-detector image" in isolatedDbTest {
@@ -486,13 +504,17 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
         )
         .attempt
 
-      runtimeOpt1 <- clusterQuery.getActiveClusterByName(googleProject, runtimeName1).transaction
+      runtimeOpt1 <- clusterQuery
+        .getActiveClusterByName(googleProject, runtimeName1)(scala.concurrent.ExecutionContext.global)
+        .transaction
       runtime1 = runtimeOpt1.get
-      _ <- publisherQueue.dequeue1
+      _ <- publisherQueue.take
 
-      runtimeOpt2 <- clusterQuery.getActiveClusterByName(googleProject, runtimeName2).transaction
+      runtimeOpt2 <- clusterQuery
+        .getActiveClusterByName(googleProject, runtimeName2)(scala.concurrent.ExecutionContext.global)
+        .transaction
       runtime2 = runtimeOpt2.get
-      _ <- publisherQueue.dequeue1
+      _ <- publisherQueue.take
     } yield {
       // Crypto detector not supported on DockerHub
       r1 shouldBe Right(())
@@ -503,7 +525,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
       runtime2.runtimeName shouldBe runtimeName2
       runtime2.runtimeImages.map(_.imageType) shouldBe Set(Jupyter, Welder, RuntimeImageType.Proxy, CryptoDetector)
     }
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "create a runtime with a disk config" in isolatedDbTest {
@@ -533,13 +555,19 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
           req
         )
         .attempt
-      runtimeOpt <- clusterQuery.getActiveClusterByNameMinimal(project, name0).transaction
+      runtimeOpt <- clusterQuery
+        .getActiveClusterByNameMinimal(project, name0)(scala.concurrent.ExecutionContext.global)
+        .transaction
       runtime = runtimeOpt.get
-      diskOpt <- persistentDiskQuery.getActiveByName(project, diskName).transaction
+      diskOpt <- persistentDiskQuery
+        .getActiveByName(project, diskName)(scala.concurrent.ExecutionContext.global)
+        .transaction
       disk = diskOpt.get
-      runtimeConfig <- RuntimeConfigQueries.getRuntimeConfig(runtime.runtimeConfigId).transaction
+      runtimeConfig <- RuntimeConfigQueries
+        .getRuntimeConfig(runtime.runtimeConfigId)(scala.concurrent.ExecutionContext.global)
+        .transaction
       runtimeConfigRequest = LeoLenses.runtimeConfigPrism.getOption(runtimeConfig).get
-      message <- publisherQueue.dequeue1
+      message <- publisherQueue.take
     } yield {
       r shouldBe Right(())
       runtime.googleProject shouldBe project
@@ -580,7 +608,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
       message shouldBe expectedMessage
     }
 
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "fail to delete a runtime while it's still creating" in isolatedDbTest {
@@ -599,7 +627,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
       r.swap.toOption.get.isInstanceOf[RuntimeCannotBeDeletedException] shouldBe true
     }
 
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "create a runtime with a gpu config" in isolatedDbTest {
@@ -616,7 +644,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
     )
 
     val res = for {
-      _ <- publisherQueue.tryDequeue1
+      _ <- publisherQueue.tryTake
       r <- runtimeService
         .createRuntime(
           userInfo,
@@ -625,10 +653,14 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
           req
         )
         .attempt
-      runtimeOpt <- clusterQuery.getActiveClusterByNameMinimal(project, name0).transaction
+      runtimeOpt <- clusterQuery
+        .getActiveClusterByNameMinimal(project, name0)(scala.concurrent.ExecutionContext.global)
+        .transaction
       runtime = runtimeOpt.get
-      runtimeConfig <- RuntimeConfigQueries.getRuntimeConfig(runtime.runtimeConfigId).transaction
-      message <- publisherQueue.dequeue1
+      runtimeConfig <- RuntimeConfigQueries
+        .getRuntimeConfig(runtime.runtimeConfigId)(scala.concurrent.ExecutionContext.global)
+        .transaction
+      message <- publisherQueue.take
     } yield {
       r shouldBe Right(())
       runtime.googleProject shouldBe project
@@ -641,7 +673,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
         .gpuConfig shouldBe gpuConfig
     }
 
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "get a runtime" in isolatedDbTest {
@@ -654,14 +686,14 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
     } yield {
       getResponse.samResource shouldBe testRuntime.samResource
     }
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "throw ClusterNotFoundException for nonexistent clusters" in isolatedDbTest {
     val exc = runtimeService
       .getRuntime(userInfo, GoogleProject("nonexistent"), RuntimeName("cluster"))
       .attempt
-      .unsafeRunSync()
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
       .swap
       .toOption
       .get
@@ -681,7 +713,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
       listResponse.map(_.samResource).toSet shouldBe Set(samResource1, samResource2)
     }
 
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "list runtimes with a project" in isolatedDbTest {
@@ -697,7 +729,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
       listResponse.map(_.samResource).toSet shouldBe Set(samResource1, samResource2)
     }
 
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "list runtimes with parameters" in isolatedDbTest {
@@ -714,7 +746,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
       listResponse.map(_.samResource).toSet shouldBe Set(samResource1)
     }
 
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   // See https://broadworkbench.atlassian.net/browse/PROD-440
@@ -741,7 +773,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
       listResponse.map(_.samResource).toSet shouldBe Set(samResource1, samResource2)
     }
 
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "list runtimes with labels" in isolatedDbTest {
@@ -755,10 +787,12 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
       autopause = Some(true),
       autopauseThreshold = Some(30 minutes)
     )
-    runtimeService.createRuntime(userInfo, project, clusterName1, req).unsafeRunSync()
+    runtimeService
+      .createRuntime(userInfo, project, clusterName1, req)
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
     val runtime1 = runtimeService
       .getRuntime(userInfo, project, clusterName1)
-      .unsafeRunSync()
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
     val listRuntimeResponse1 = ListRuntimeResponse2(
       runtime1.id,
       runtime1.samResource,
@@ -775,10 +809,10 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
     val clusterName2 = RuntimeName(s"cluster-${UUID.randomUUID.toString}")
     runtimeService
       .createRuntime(userInfo, project, clusterName2, req.copy(labels = Map("a" -> "b", "foo" -> "bar")))
-      .unsafeRunSync()
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
     val runtime2 = runtimeService
       .getRuntime(userInfo, project, clusterName2)
-      .unsafeRunSync()
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
     val listRuntimeResponse2 = ListRuntimeResponse2(
       runtime2.id,
       runtime2.samResource,
@@ -792,29 +826,44 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
       runtime2.patchInProgress
     )
 
-    runtimeService.listRuntimes(userInfo, None, Map("_labels" -> "foo=bar")).unsafeRunSync().toSet shouldBe Set(
+    runtimeService
+      .listRuntimes(userInfo, None, Map("_labels" -> "foo=bar"))
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+      .toSet shouldBe Set(
       listRuntimeResponse1,
       listRuntimeResponse2
     )
-    runtimeService.listRuntimes(userInfo, None, Map("_labels" -> "foo=bar,bam=yes")).unsafeRunSync().toSet shouldBe Set(
+    runtimeService
+      .listRuntimes(userInfo, None, Map("_labels" -> "foo=bar,bam=yes"))
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+      .toSet shouldBe Set(
       listRuntimeResponse1
     )
     runtimeService
       .listRuntimes(userInfo, None, Map("_labels" -> "foo=bar,bam=yes,vcf=no"))
-      .unsafeToFuture()
+      .unsafeToFuture()(cats.effect.unsafe.implicits.global)
       .futureValue
       .toSet shouldBe Set(listRuntimeResponse1)
-    runtimeService.listRuntimes(userInfo, None, Map("_labels" -> "a=b")).unsafeRunSync().toSet shouldBe Set(
+    runtimeService
+      .listRuntimes(userInfo, None, Map("_labels" -> "a=b"))
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+      .toSet shouldBe Set(
       listRuntimeResponse2
     )
-    runtimeService.listRuntimes(userInfo, None, Map("_labels" -> "baz=biz")).unsafeRunSync().toSet shouldBe Set.empty
-    runtimeService.listRuntimes(userInfo, None, Map("_labels" -> "A=B")).unsafeRunSync().toSet shouldBe Set(
+    runtimeService
+      .listRuntimes(userInfo, None, Map("_labels" -> "baz=biz"))
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+      .toSet shouldBe Set.empty
+    runtimeService
+      .listRuntimes(userInfo, None, Map("_labels" -> "A=B"))
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+      .toSet shouldBe Set(
       listRuntimeResponse2
     ) // labels are not case sensitive because MySQL
     runtimeService
       .listRuntimes(userInfo, None, Map("_labels" -> "foo%3Dbar"))
       .attempt
-      .unsafeRunSync()
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
       .swap
       .toOption
       .get
@@ -822,7 +871,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
     runtimeService
       .listRuntimes(userInfo, None, Map("_labels" -> "foo=bar;bam=yes"))
       .attempt
-      .unsafeRunSync()
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
       .swap
       .toOption
       .get
@@ -830,7 +879,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
     runtimeService
       .listRuntimes(userInfo, None, Map("_labels" -> "foo=bar,bam"))
       .attempt
-      .unsafeRunSync()
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
       .swap
       .toOption
       .get
@@ -839,7 +888,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
     runtimeService
       .listRuntimes(userInfo, None, Map("_labels" -> "bogus"))
       .attempt
-      .unsafeRunSync()
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
       .swap
       .toOption
       .get
@@ -848,7 +897,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
     runtimeService
       .listRuntimes(userInfo, None, Map("_labels" -> "a,b"))
       .attempt
-      .unsafeRunSync()
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
       .swap
       .toOption
       .get
@@ -859,7 +908,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
     val userInfo = UserInfo(OAuth2BearerToken(""), WorkbenchUserId("userId"), WorkbenchEmail("user1@example.com"), 0) // this email is white listed
 
     val res = for {
-      publisherQueue <- InspectableQueue.bounded[IO, LeoPubsubMessage](10)
+      publisherQueue <- Queue.bounded[IO, LeoPubsubMessage](10)
       service = makeRuntimeService(publisherQueue)
       samResource <- IO(RuntimeSamResourceId(UUID.randomUUID.toString))
       testRuntime <- IO(makeCluster(1).copy(samResource = samResource).save())
@@ -872,7 +921,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
           dbRuntimeOpt <- clusterQuery
             .getActiveClusterByNameMinimal(testRuntime.googleProject, testRuntime.runtimeName)
             .transaction
-          message <- publisherQueue.tryDequeue1
+          message <- publisherQueue.tryTake
         } yield {
           dbRuntimeOpt.get.status shouldBe RuntimeStatus.Deleting
           message shouldBe (None)
@@ -880,14 +929,14 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
       }
     } yield res
 
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "delete a runtime with disk properly" in isolatedDbTest {
     val userInfo = UserInfo(OAuth2BearerToken(""), WorkbenchUserId("userId"), WorkbenchEmail("user1@example.com"), 0) // this email is white listed
 
     val res = for {
-      publisherQueue <- InspectableQueue.bounded[IO, LeoPubsubMessage](10)
+      publisherQueue <- Queue.bounded[IO, LeoPubsubMessage](10)
       service = makeRuntimeService(publisherQueue)
       pd <- makePersistentDisk().save()
       testRuntime <- IO(
@@ -904,14 +953,14 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
       _ <- service.deleteRuntime(
         DeleteRuntimeRequest(userInfo, testRuntime.googleProject, testRuntime.runtimeName, true)
       )
-      diskStatus <- persistentDiskQuery.getStatus(pd.id).transaction
+      diskStatus <- persistentDiskQuery.getStatus(pd.id)(scala.concurrent.ExecutionContext.global).transaction
       _ = diskStatus shouldBe Some(DiskStatus.Deleting)
       res <- withLeoPublisher(publisherQueue) {
         for {
           dbRuntimeOpt <- clusterQuery
             .getActiveClusterByNameMinimal(testRuntime.googleProject, testRuntime.runtimeName)
             .transaction
-          message <- publisherQueue.tryDequeue1
+          message <- publisherQueue.tryTake
         } yield {
           dbRuntimeOpt.get.status shouldBe RuntimeStatus.Deleting
           message shouldBe (None)
@@ -919,14 +968,14 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
       }
     } yield res
 
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "stop a runtime" in isolatedDbTest {
     val userInfo = UserInfo(OAuth2BearerToken(""), WorkbenchUserId("userId"), WorkbenchEmail("user1@example.com"), 0) // this email is white listed
 
     val res = for {
-      publisherQueue <- InspectableQueue.bounded[IO, LeoPubsubMessage](10)
+      publisherQueue <- Queue.bounded[IO, LeoPubsubMessage](10)
       service = makeRuntimeService(publisherQueue)
       samResource <- IO(RuntimeSamResourceId(UUID.randomUUID.toString))
       testRuntime <- IO(makeCluster(1).copy(samResource = samResource).save())
@@ -937,7 +986,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
           dbRuntimeOpt <- clusterQuery
             .getActiveClusterByNameMinimal(testRuntime.googleProject, testRuntime.runtimeName)
             .transaction
-          message <- publisherQueue.tryDequeue1
+          message <- publisherQueue.tryTake
         } yield {
           dbRuntimeOpt.get.status shouldBe RuntimeStatus.Stopping
           message shouldBe (None)
@@ -945,14 +994,14 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
       }
     } yield res
 
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "not stop a stopping runtime and also not error" in isolatedDbTest {
     val userInfo = UserInfo(OAuth2BearerToken(""), WorkbenchUserId("userId"), WorkbenchEmail("user1@example.com"), 0) // this email is white listed
 
     val res = for {
-      publisherQueue <- InspectableQueue.bounded[IO, LeoPubsubMessage](10)
+      publisherQueue <- Queue.bounded[IO, LeoPubsubMessage](10)
       service = makeRuntimeService(publisherQueue)
       samResource <- IO(RuntimeSamResourceId(UUID.randomUUID.toString))
       testRuntime <- IO(makeCluster(1).copy(samResource = samResource, status = RuntimeStatus.PreStopping).save())
@@ -963,7 +1012,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
           dbRuntimeOpt <- clusterQuery
             .getActiveClusterByNameMinimal(testRuntime.googleProject, testRuntime.runtimeName)
             .transaction
-          message <- publisherQueue.tryDequeue1
+          message <- publisherQueue.tryTake
         } yield {
           dbRuntimeOpt.get.status shouldBe RuntimeStatus.PreStopping
           message shouldBe (None)
@@ -971,14 +1020,14 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
       }
     } yield res
 
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "start a runtime" in isolatedDbTest {
     val userInfo = UserInfo(OAuth2BearerToken(""), WorkbenchUserId("userId"), WorkbenchEmail("user1@example.com"), 0) // this email is white listed
 
     val res = for {
-      publisherQueue <- InspectableQueue.bounded[IO, LeoPubsubMessage](10)
+      publisherQueue <- Queue.bounded[IO, LeoPubsubMessage](10)
       service = makeRuntimeService(publisherQueue)
       samResource <- IO(RuntimeSamResourceId(UUID.randomUUID.toString))
       testRuntime <- IO(makeCluster(1).copy(samResource = samResource, status = RuntimeStatus.Stopped).save())
@@ -989,7 +1038,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
           dbRuntimeOpt <- clusterQuery
             .getActiveClusterByNameMinimal(testRuntime.googleProject, testRuntime.runtimeName)
             .transaction
-          message <- publisherQueue.tryDequeue1
+          message <- publisherQueue.tryTake
         } yield {
           dbRuntimeOpt.get.status shouldBe RuntimeStatus.Starting
           message shouldBe (None)
@@ -997,14 +1046,16 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
       }
     } yield res
 
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "update autopause" in isolatedDbTest {
     val userInfo = UserInfo(OAuth2BearerToken(""), WorkbenchUserId("userId"), WorkbenchEmail("user1@example.com"), 0) // this email is white listed
 
     val res = for {
-      _ <- publisherQueue.tryDequeueChunk1(10)
+      // remove some existing items in the queue just to be safe
+      _ <- publisherQueue.tryTake
+      _ <- publisherQueue.tryTake
       samResource <- IO(RuntimeSamResourceId(UUID.randomUUID.toString))
       testRuntime <- IO(makeCluster(1).copy(samResource = samResource, status = RuntimeStatus.Running).save())
       req = UpdateRuntimeRequest(None, false, Some(true), Some(120.minutes), Map.empty, Set.empty)
@@ -1014,13 +1065,13 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
         .getActiveClusterByNameMinimal(testRuntime.googleProject, testRuntime.runtimeName)
         .transaction
       dbRuntime = dbRuntimeOpt.get
-      messageOpt <- publisherQueue.tryDequeue1
+      messageOpt <- publisherQueue.tryTake
     } yield {
       dbRuntime.autopauseThreshold shouldBe 120
       messageOpt shouldBe None
     }
 
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   val reqMaps: List[LabelMap] = List(
@@ -1050,13 +1101,15 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
         )
         req = UpdateRuntimeRequest(None, false, Some(true), Some(120.minutes), upsertLabels, Set.empty)
         _ <- runtimeService.updateRuntime(userInfo, testRuntime.googleProject, testRuntime.runtimeName, req)
-        dbLabelMap <- labelQuery.getAllForResource(testRuntime.id, LabelResourceType.runtime).transaction
-        _ <- publisherQueue.tryDequeue1
+        dbLabelMap <- labelQuery
+          .getAllForResource(testRuntime.id, LabelResourceType.runtime)(scala.concurrent.ExecutionContext.global)
+          .transaction
+        _ <- publisherQueue.tryTake
 
       } yield {
         finalUpsertMaps.contains(dbLabelMap) shouldBe true
       }
-      res.unsafeRunSync()
+      res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
     }
   }
 
@@ -1087,11 +1140,11 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
         req = UpdateRuntimeRequest(None, false, Some(true), Some(120.minutes), Map.empty, deleteLabelSet)
         _ <- runtimeService.updateRuntime(userInfo, testRuntime.googleProject, testRuntime.runtimeName, req)
         dbLabelMap <- labelQuery.getAllForResource(testRuntime.id, LabelResourceType.runtime).transaction
-        _ <- publisherQueue.tryDequeue1
+        _ <- publisherQueue.tryTake
       } yield {
         finalDeleteMaps.contains(dbLabelMap) shouldBe true
       }
-      res.unsafeRunSync()
+      res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
     }
   }
 
@@ -1109,7 +1162,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
         } yield {
           fail shouldBe Left(RuntimeCannotBeUpdatedException(testRuntime.projectNameString, testRuntime.status))
         }
-        res.unsafeRunSync()
+        res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
       }
   }
 
@@ -1123,18 +1176,18 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
         WrongCloudServiceException(CloudService.GCE, CloudService.Dataproc, ctx.traceId)
       )
     }
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   "RuntimeServiceInterp.processUpdateGceConfigRequest" should "not update a GCE runtime when there are no changes" in {
     val req = UpdateRuntimeConfigRequest.GceConfig(Some(gceRuntimeConfig.machineType), Some(gceRuntimeConfig.diskSize))
     val res = for {
       _ <- runtimeService.processUpdateRuntimeConfigRequest(req, false, testClusterRecord, gceRuntimeConfig)
-      messageOpt <- publisherQueue.tryDequeue1
+      messageOpt <- publisherQueue.tryTake
     } yield {
       messageOpt shouldBe None
     }
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "update patchInProgress flag if stopToUpdateMachineType is true" in isolatedDbTest {
@@ -1154,7 +1207,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
         gceRuntimeConfig
       )
       patchInProgress <- patchQuery.isInprogress(savedRuntime.id).transaction
-      message <- publisherQueue.dequeue1
+      message <- publisherQueue.take
     } yield {
       patchInProgress shouldBe (true)
       message shouldBe UpdateRuntimeMessage(savedRuntime.id,
@@ -1165,7 +1218,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
                                             None,
                                             Some(ctx.traceId))
     }
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "update a GCE machine type in Stopped state" in {
@@ -1176,7 +1229,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
                                                             false,
                                                             testClusterRecord.copy(status = RuntimeStatus.Stopped),
                                                             gceRuntimeConfig)
-      message <- publisherQueue.dequeue1
+      message <- publisherQueue.take
     } yield {
       message shouldBe UpdateRuntimeMessage(testClusterRecord.id,
                                             Some(MachineTypeName("n1-micro-2")),
@@ -1186,7 +1239,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
                                             None,
                                             Some(ctx.traceId))
     }
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "update a GCE machine type in Running state" in {
@@ -1197,7 +1250,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
                                                             true,
                                                             testClusterRecord.copy(status = RuntimeStatus.Running),
                                                             gceRuntimeConfig)
-      message <- publisherQueue.dequeue1
+      message <- publisherQueue.take
     } yield {
       message shouldBe UpdateRuntimeMessage(testClusterRecord.id,
                                             Some(MachineTypeName("n1-micro-2")),
@@ -1207,7 +1260,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
                                             None,
                                             Some(ctx.traceId))
     }
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "fail to update a GCE machine type in Running state with allowStop set to false" in {
@@ -1218,7 +1271,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
                                                             testClusterRecord.copy(status = RuntimeStatus.Running),
                                                             gceRuntimeConfig)
     } yield ()
-    res.attempt.unsafeRunSync() shouldBe Left(
+    res.attempt.unsafeRunSync()(cats.effect.unsafe.implicits.global) shouldBe Left(
       RuntimeMachineTypeCannotBeChangedException(testClusterRecord.projectNameString, RuntimeStatus.Running)
     )
   }
@@ -1228,7 +1281,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
     val res = for {
       ctx <- appContext.ask[AppContext]
       _ <- runtimeService.processUpdateRuntimeConfigRequest(req, false, testClusterRecord, gceRuntimeConfig)
-      message <- publisherQueue.dequeue1
+      message <- publisherQueue.take
     } yield {
       message shouldBe UpdateRuntimeMessage(testCluster.id,
                                             None,
@@ -1238,11 +1291,11 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
                                             None,
                                             Some(ctx.traceId))
     }
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "increase the persistent disk is attached to a GCE runtime" in isolatedDbTest {
-    val disk = makePersistentDisk(None).save().unsafeRunSync()
+    val disk = makePersistentDisk(None).save().unsafeRunSync()(cats.effect.unsafe.implicits.global)
     val req = UpdateRuntimeConfigRequest.GceConfig(None, Some(DiskSize(1024)))
     val res = for {
       ctx <- appContext.ask[AppContext]
@@ -1252,7 +1305,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
         testClusterRecord,
         gceWithPdRuntimeConfig.copy(persistentDiskId = Some(disk.id))
       )
-      message <- publisherQueue.dequeue1
+      message <- publisherQueue.take
     } yield {
       message shouldBe UpdateRuntimeMessage(testCluster.id,
                                             None,
@@ -1262,11 +1315,11 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
                                             None,
                                             Some(ctx.traceId))
     }
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "fail to increase the disk on a GCE runtime if allowStop is false" in {
-    val disk = makePersistentDisk(None).save().unsafeRunSync()
+    val disk = makePersistentDisk(None).save().unsafeRunSync()(cats.effect.unsafe.implicits.global)
     val req = UpdateRuntimeConfigRequest.GceConfig(None, Some(DiskSize(1024)))
     val res = for {
       _ <- runtimeService.processUpdateRuntimeConfigRequest(
@@ -1276,7 +1329,9 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
         gceWithPdRuntimeConfig.copy(persistentDiskId = Some(disk.id))
       )
     } yield ()
-    res.attempt.unsafeRunSync() shouldBe Left(RuntimeDiskSizeCannotBeChangedException(testCluster.projectNameString))
+    res.attempt.unsafeRunSync()(cats.effect.unsafe.implicits.global) shouldBe Left(
+      RuntimeDiskSizeCannotBeChangedException(testCluster.projectNameString)
+    )
   }
 
   it should "fail to decrease the disk on a GCE runtime" in {
@@ -1284,7 +1339,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
     val res = for {
       _ <- runtimeService.processUpdateRuntimeConfigRequest(req, false, testClusterRecord, gceRuntimeConfig)
     } yield ()
-    res.attempt.unsafeRunSync() shouldBe Left(
+    res.attempt.unsafeRunSync()(cats.effect.unsafe.implicits.global) shouldBe Left(
       RuntimeDiskSizeCannotBeDecreasedException(testClusterRecord.projectNameString)
     )
   }
@@ -1312,17 +1367,19 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
       )
       _ <- IO(cluster.saveWithRuntimeConfig(defaultDataprocRuntimeConfig))
       clusterRecord <- clusterQuery
-        .getActiveClusterRecordByName(testCluster.googleProject, testCluster.runtimeName)
+        .getActiveClusterRecordByName(testCluster.googleProject, testCluster.runtimeName)(
+          scala.concurrent.ExecutionContext.global
+        )
         .transaction
       _ <- runtimeService.processUpdateDataprocConfigRequest(req,
                                                              false,
                                                              clusterRecord.get,
                                                              defaultDataprocRuntimeConfig)
-      messageOpt <- publisherQueue.tryDequeue1
+      messageOpt <- publisherQueue.tryTake
     } yield {
       messageOpt shouldBe None
     }
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "disallow updating dataproc cluster number of workers if runtime is not Running" in {
@@ -1345,7 +1402,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
         .getOrElse(throw new Exception("this test failed"))
         .asInstanceOf[LeoException] shouldEqual expectedException
     }
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "update Dataproc workers and preemptibles" in isolatedDbTest {
@@ -1373,7 +1430,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
                                                              false,
                                                              clusterRecord.get,
                                                              defaultDataprocRuntimeConfig)
-      message <- publisherQueue.dequeue1
+      message <- publisherQueue.take
     } yield {
       message shouldBe UpdateRuntimeMessage(clusterRecord.get.id,
                                             None,
@@ -1383,7 +1440,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
                                             Some(1000),
                                             Some(ctx.traceId))
     }
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "update a Dataproc master machine type in Stopped state" in isolatedDbTest {
@@ -1404,13 +1461,15 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
       )
       _ <- IO(cluster.saveWithRuntimeConfig(defaultDataprocRuntimeConfig))
       clusterRecord <- clusterQuery
-        .getActiveClusterRecordByName(testCluster.googleProject, testCluster.runtimeName)
+        .getActiveClusterRecordByName(testCluster.googleProject, testCluster.runtimeName)(
+          scala.concurrent.ExecutionContext.global
+        )
         .transaction
       _ <- runtimeService.processUpdateDataprocConfigRequest(req,
                                                              false,
                                                              clusterRecord.get.copy(status = RuntimeStatus.Stopped),
                                                              defaultDataprocRuntimeConfig)
-      message <- publisherQueue.dequeue1
+      message <- publisherQueue.take
     } yield {
       message shouldBe UpdateRuntimeMessage(clusterRecord.get.id,
                                             Some(MachineTypeName("n1-micro-2")),
@@ -1420,7 +1479,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
                                             None,
                                             Some(ctx.traceId))
     }
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "update a Dataproc machine type in Running state" in isolatedDbTest {
@@ -1441,13 +1500,15 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
       )
       _ <- IO(cluster.saveWithRuntimeConfig(defaultDataprocRuntimeConfig))
       clusterRecord <- clusterQuery
-        .getActiveClusterRecordByName(testCluster.googleProject, testCluster.runtimeName)
+        .getActiveClusterRecordByName(testCluster.googleProject, testCluster.runtimeName)(
+          scala.concurrent.ExecutionContext.global
+        )
         .transaction
       _ <- runtimeService.processUpdateDataprocConfigRequest(req,
                                                              true,
                                                              clusterRecord.get.copy(status = RuntimeStatus.Running),
                                                              defaultDataprocRuntimeConfig)
-      message <- publisherQueue.dequeue1
+      message <- publisherQueue.take
     } yield {
       message shouldBe UpdateRuntimeMessage(clusterRecord.get.id,
                                             Some(MachineTypeName("n1-micro-2")),
@@ -1457,7 +1518,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
                                             None,
                                             Some(ctx.traceId))
     }
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
   it should "fail to update a Dataproc machine type in Running state with allowStop set to false" in {
     val req = UpdateRuntimeConfigRequest.DataprocConfig(Some(MachineTypeName("n1-micro-2")), None, None, None)
@@ -1467,7 +1528,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
                                                              testClusterRecord.copy(status = RuntimeStatus.Running),
                                                              defaultDataprocRuntimeConfig)
     } yield ()
-    res.attempt.unsafeRunSync() shouldBe Left(
+    res.attempt.unsafeRunSync()(cats.effect.unsafe.implicits.global) shouldBe Left(
       RuntimeMachineTypeCannotBeChangedException(testClusterRecord.projectNameString, RuntimeStatus.Running)
     )
   }
@@ -1480,7 +1541,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
                                                              testClusterRecord.copy(status = RuntimeStatus.Running),
                                                              defaultDataprocRuntimeConfig)
     } yield ()
-    res.attempt.unsafeRunSync().isLeft shouldBe true
+    res.attempt.unsafeRunSync()(cats.effect.unsafe.implicits.global).isLeft shouldBe true
   }
 
   it should "increase the disk on a Dataproc runtime" in isolatedDbTest {
@@ -1502,10 +1563,12 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
       )
       _ <- IO(cluster.saveWithRuntimeConfig(defaultDataprocRuntimeConfig))
       clusterRecord <- clusterQuery
-        .getActiveClusterRecordByName(testCluster.googleProject, testCluster.runtimeName)
+        .getActiveClusterRecordByName(testCluster.googleProject, testCluster.runtimeName)(
+          scala.concurrent.ExecutionContext.global
+        )
         .transaction
       _ <- runtimeService.processUpdateDataprocConfigRequest(req, true, clusterRecord.get, defaultDataprocRuntimeConfig)
-      message <- publisherQueue.dequeue1
+      message <- publisherQueue.take
     } yield {
       message shouldBe UpdateRuntimeMessage(clusterRecord.get.id,
                                             None,
@@ -1515,7 +1578,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
                                             None,
                                             Some(ctx.traceId))
     }
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "fail to decrease the disk on a Dataproc runtime" in isolatedDbTest {
@@ -1536,11 +1599,13 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
       )
       _ <- IO(cluster.saveWithRuntimeConfig(defaultDataprocRuntimeConfig))
       clusterRecord <- clusterQuery
-        .getActiveClusterRecordByName(testCluster.googleProject, testCluster.runtimeName)
+        .getActiveClusterRecordByName(testCluster.googleProject, testCluster.runtimeName)(
+          scala.concurrent.ExecutionContext.global
+        )
         .transaction
       _ <- runtimeService.processUpdateDataprocConfigRequest(req, true, clusterRecord.get, defaultDataprocRuntimeConfig)
     } yield ()
-    res.attempt.unsafeRunSync() shouldBe Left(
+    res.attempt.unsafeRunSync()(cats.effect.unsafe.implicits.global) shouldBe Left(
       RuntimeDiskSizeCannotBeDecreasedException(testClusterRecord.projectNameString)
     )
   }
@@ -1549,16 +1614,20 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
     val req = PersistentDiskRequest(diskName, Some(DiskSize(500)), None, Map("foo" -> "bar"))
     val res = for {
       context <- ctx.ask[AppContext]
-      diskResult <- RuntimeServiceInterp.processPersistentDiskRequest(req,
-                                                                      zone,
-                                                                      project,
-                                                                      userInfo,
-                                                                      serviceAccount,
-                                                                      FormattedBy.GCE,
-                                                                      whitelistAuthProvider,
-                                                                      ConfigReader.appConfig.persistentDisk)
+      diskResult <- RuntimeServiceInterp.processPersistentDiskRequest(
+        req,
+        zone,
+        project,
+        userInfo,
+        serviceAccount,
+        FormattedBy.GCE,
+        whitelistAuthProvider,
+        ConfigReader.appConfig.persistentDisk
+      )(implicitly, implicitly, implicitly, scala.concurrent.ExecutionContext.global, implicitly)
       disk = diskResult.disk
-      persistedDisk <- persistentDiskQuery.getById(disk.id).transaction
+      persistedDisk <- persistentDiskQuery
+        .getById(disk.id)(scala.concurrent.ExecutionContext.global)
+        .transaction
     } yield {
       diskResult.creationNeeded shouldBe true
       disk.googleProject shouldBe project
@@ -1581,7 +1650,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
       persistedDisk.get shouldEqual disk
     }
 
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "reject a request if requested PD's zone is different from target zone" in isolatedDbTest {
@@ -1592,14 +1661,16 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
       // save a PD with default zone
       targetZone = ZoneName("europe-west2-c")
       diskResult <- RuntimeServiceInterp
-        .processPersistentDiskRequest(req,
-                                      targetZone,
-                                      project,
-                                      userInfo,
-                                      serviceAccount,
-                                      FormattedBy.GCE,
-                                      whitelistAuthProvider,
-                                      ConfigReader.appConfig.persistentDisk)
+        .processPersistentDiskRequest(
+          req,
+          targetZone,
+          project,
+          userInfo,
+          serviceAccount,
+          FormattedBy.GCE,
+          whitelistAuthProvider,
+          ConfigReader.appConfig.persistentDisk
+        )(implicitly, implicitly, implicitly, scala.concurrent.ExecutionContext.global, implicitly)
         .attempt
     } yield {
       diskResult shouldBe (Left(
@@ -1610,7 +1681,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
       ))
     }
 
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "persist non-default zone disk properly" in isolatedDbTest {
@@ -1619,20 +1690,24 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
 
     val res = for {
       diskResult <- RuntimeServiceInterp
-        .processPersistentDiskRequest(req,
-                                      targetZone,
-                                      project,
-                                      userInfo,
-                                      serviceAccount,
-                                      FormattedBy.GCE,
-                                      whitelistAuthProvider,
-                                      ConfigReader.appConfig.persistentDisk)
-      persistedDisk <- persistentDiskQuery.getById(diskResult.disk.id).transaction
+        .processPersistentDiskRequest(
+          req,
+          targetZone,
+          project,
+          userInfo,
+          serviceAccount,
+          FormattedBy.GCE,
+          whitelistAuthProvider,
+          ConfigReader.appConfig.persistentDisk
+        )(implicitly, implicitly, implicitly, scala.concurrent.ExecutionContext.global, implicitly)
+      persistedDisk <- persistentDiskQuery
+        .getById(diskResult.disk.id)(scala.concurrent.ExecutionContext.global)
+        .transaction
     } yield {
       persistedDisk.get.zone shouldBe (targetZone)
     }
 
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "return existing disk if a disk with the same name already exists" in isolatedDbTest {
@@ -1641,20 +1716,22 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
       disk <- makePersistentDisk(None).save()
       req = PersistentDiskRequest(disk.name, Some(DiskSize(50)), None, Map("foo" -> "bar"))
       returnedDisk <- RuntimeServiceInterp
-        .processPersistentDiskRequest(req,
-                                      zone,
-                                      project,
-                                      userInfo,
-                                      serviceAccount,
-                                      FormattedBy.GCE,
-                                      whitelistAuthProvider,
-                                      ConfigReader.appConfig.persistentDisk)
+        .processPersistentDiskRequest(
+          req,
+          zone,
+          project,
+          userInfo,
+          serviceAccount,
+          FormattedBy.GCE,
+          whitelistAuthProvider,
+          ConfigReader.appConfig.persistentDisk
+        )(implicitly, implicitly, implicitly, scala.concurrent.ExecutionContext.global, implicitly)
         .attempt
     } yield {
       returnedDisk shouldBe Right(PersistentDiskRequestResult(disk, false))
     }
 
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "fail to create a disk when caller has no permission" in isolatedDbTest {
@@ -1663,15 +1740,17 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
 
     val thrown = the[ForbiddenError] thrownBy {
       RuntimeServiceInterp
-        .processPersistentDiskRequest(req,
-                                      zone,
-                                      project,
-                                      userInfo,
-                                      serviceAccount,
-                                      FormattedBy.GCE,
-                                      whitelistAuthProvider,
-                                      ConfigReader.appConfig.persistentDisk)
-        .unsafeRunSync()
+        .processPersistentDiskRequest(
+          req,
+          zone,
+          project,
+          userInfo,
+          serviceAccount,
+          FormattedBy.GCE,
+          whitelistAuthProvider,
+          ConfigReader.appConfig.persistentDisk
+        )(implicitly, implicitly, implicitly, scala.concurrent.ExecutionContext.global, implicitly)
+        .unsafeRunSync()(cats.effect.unsafe.implicits.global)
     }
 
     thrown shouldBe ForbiddenError(userInfo.userEmail)
@@ -1692,20 +1771,22 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
       )
       req = PersistentDiskRequest(savedDisk.name, Some(savedDisk.size), Some(savedDisk.diskType), savedDisk.labels)
       err <- RuntimeServiceInterp
-        .processPersistentDiskRequest(req,
-                                      zone,
-                                      project,
-                                      userInfo,
-                                      serviceAccount,
-                                      FormattedBy.GCE,
-                                      whitelistAuthProvider,
-                                      ConfigReader.appConfig.persistentDisk)
+        .processPersistentDiskRequest(
+          req,
+          zone,
+          project,
+          userInfo,
+          serviceAccount,
+          FormattedBy.GCE,
+          whitelistAuthProvider,
+          ConfigReader.appConfig.persistentDisk
+        )(implicitly, implicitly, implicitly, scala.concurrent.ExecutionContext.global, implicitly)
         .attempt
     } yield {
       err shouldBe Left(DiskAlreadyAttachedException(project, savedDisk.name, t.traceId))
     }
 
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "fail to process a disk reference when the disk is already formatted by another app" in isolatedDbTest {
@@ -1714,26 +1795,30 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
       gceDisk <- makePersistentDisk(Some(DiskName("gceDisk")), Some(FormattedBy.GCE)).save()
       req = PersistentDiskRequest(gceDisk.name, Some(gceDisk.size), Some(gceDisk.diskType), gceDisk.labels)
       formatGceDiskError <- RuntimeServiceInterp
-        .processPersistentDiskRequest(req,
-                                      zone,
-                                      project,
-                                      userInfo,
-                                      serviceAccount,
-                                      FormattedBy.Galaxy,
-                                      whitelistAuthProvider,
-                                      ConfigReader.appConfig.persistentDisk)
+        .processPersistentDiskRequest(
+          req,
+          zone,
+          project,
+          userInfo,
+          serviceAccount,
+          FormattedBy.Galaxy,
+          whitelistAuthProvider,
+          ConfigReader.appConfig.persistentDisk
+        )(implicitly, implicitly, implicitly, scala.concurrent.ExecutionContext.global, implicitly)
         .attempt
       galaxyDisk <- makePersistentDisk(Some(DiskName("galaxyDisk")), Some(FormattedBy.Galaxy)).save()
       req = PersistentDiskRequest(galaxyDisk.name, Some(galaxyDisk.size), Some(galaxyDisk.diskType), galaxyDisk.labels)
       formatGalaxyDiskError <- RuntimeServiceInterp
-        .processPersistentDiskRequest(req,
-                                      zone,
-                                      project,
-                                      userInfo,
-                                      serviceAccount,
-                                      FormattedBy.GCE,
-                                      whitelistAuthProvider,
-                                      ConfigReader.appConfig.persistentDisk)
+        .processPersistentDiskRequest(
+          req,
+          zone,
+          project,
+          userInfo,
+          serviceAccount,
+          FormattedBy.GCE,
+          whitelistAuthProvider,
+          ConfigReader.appConfig.persistentDisk
+        )(implicitly, implicitly, implicitly, scala.concurrent.ExecutionContext.global, implicitly)
         .attempt
     } yield {
       formatGceDiskError shouldBe Left(
@@ -1744,7 +1829,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
       )
     }
 
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "fail to attach a disk when caller has no attach permission" in isolatedDbTest {
@@ -1752,27 +1837,35 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
     val res = for {
       savedDisk <- makePersistentDisk(None).save()
       req = PersistentDiskRequest(savedDisk.name, Some(savedDisk.size), Some(savedDisk.diskType), savedDisk.labels)
-      _ <- RuntimeServiceInterp.processPersistentDiskRequest(req,
-                                                             zone,
-                                                             project,
-                                                             userInfo,
-                                                             serviceAccount,
-                                                             FormattedBy.GCE,
-                                                             whitelistAuthProvider,
-                                                             ConfigReader.appConfig.persistentDisk)
+      _ <- RuntimeServiceInterp.processPersistentDiskRequest(
+        req,
+        zone,
+        project,
+        userInfo,
+        serviceAccount,
+        FormattedBy.GCE,
+        whitelistAuthProvider,
+        ConfigReader.appConfig.persistentDisk
+      )(implicitly, implicitly, implicitly, scala.concurrent.ExecutionContext.global, implicitly)
     } yield ()
 
     val thrown = the[ForbiddenError] thrownBy {
-      res.unsafeRunSync()
+      res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
     }
 
     thrown shouldBe ForbiddenError(userInfo.userEmail)
   }
 
   private def withLeoPublisher(
-    publisherQueue: InspectableQueue[IO, LeoPubsubMessage]
+    publisherQueue: Queue[IO, LeoPubsubMessage]
   )(validations: IO[Assertion]): IO[Assertion] = {
-    val leoPublisher = new LeoPublisher[IO](publisherQueue, new FakeGooglePublisher)
+    val leoPublisher = new LeoPublisher[IO](publisherQueue, new FakeGooglePublisher)(
+      implicitly,
+      implicitly,
+      implicitly,
+      scala.concurrent.ExecutionContext.global,
+      loggerIO
+    )
     withInfiniteStream(leoPublisher.process, validations)
   }
 }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterpSpec.scala
@@ -99,7 +99,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
     } yield {
       r shouldBe (Left(ForbiddenError(userInfo.userEmail)))
     }
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   it should "calculate autopause threshold properly" in {
@@ -112,11 +112,11 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
   it should "throw ClusterAlreadyExistsException when creating a cluster with same name and project as an existing cluster" in isolatedDbTest {
     runtimeService
       .createRuntime(userInfo, project, name0, emptyCreateRuntimeReq)
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+      .unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
     val exc = runtimeService
       .createRuntime(userInfo, project, name0, emptyCreateRuntimeReq)
       .attempt
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+      .unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
       .swap
       .toOption
       .get
@@ -136,7 +136,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
       runtimeService
         .createRuntime(userInfo, project, name0, clusterRequest)
         .attempt
-        .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+        .unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
         .swap
         .toOption
         .get
@@ -157,7 +157,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
           )
         )
         .attempt
-        .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+        .unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
         .swap
         .toOption
         .get
@@ -213,7 +213,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
         )
       message shouldBe expectedMessage
     }
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   it should "successfully accept https as user script and user startup script" in isolatedDbTest {
@@ -246,7 +246,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
     } yield {
       r shouldBe Right(())
     }
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   it should "successfully create a cluster with an rstudio image" in isolatedDbTest {
@@ -273,7 +273,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
       r shouldBe Right(())
       runtime.get.runtimeImages.map(_.imageType) contains (RuntimeImageType.RStudio)
     }
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   it should "successfully create a dataproc runtime when explicitly told so when numberOfWorkers is 0" in isolatedDbTest {
@@ -345,7 +345,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
         )
       message shouldBe expectedMessage
     }
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   it should "successfully create a dataproc runtime when explicitly told so when numberOfWorkers is more than 0" in isolatedDbTest {
@@ -408,7 +408,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
         )
       message shouldBe expectedMessage
     }
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   it should "create a runtime with the latest welder from welderRegistry" in isolatedDbTest {
@@ -476,7 +476,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
       welder3 shouldBe defined
       welder3.get.imageUrl shouldBe Config.imageConfig.welderGcrImage.imageUrl
     }
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   it should "create a runtime with the crypto-detector image" in isolatedDbTest {
@@ -525,7 +525,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
       runtime2.runtimeName shouldBe runtimeName2
       runtime2.runtimeImages.map(_.imageType) shouldBe Set(Jupyter, Welder, RuntimeImageType.Proxy, CryptoDetector)
     }
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   it should "create a runtime with a disk config" in isolatedDbTest {
@@ -608,7 +608,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
       message shouldBe expectedMessage
     }
 
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   it should "fail to delete a runtime while it's still creating" in isolatedDbTest {
@@ -627,7 +627,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
       r.swap.toOption.get.isInstanceOf[RuntimeCannotBeDeletedException] shouldBe true
     }
 
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   it should "create a runtime with a gpu config" in isolatedDbTest {
@@ -673,7 +673,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
         .gpuConfig shouldBe gpuConfig
     }
 
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   it should "get a runtime" in isolatedDbTest {
@@ -686,14 +686,14 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
     } yield {
       getResponse.samResource shouldBe testRuntime.samResource
     }
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   it should "throw ClusterNotFoundException for nonexistent clusters" in isolatedDbTest {
     val exc = runtimeService
       .getRuntime(userInfo, GoogleProject("nonexistent"), RuntimeName("cluster"))
       .attempt
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+      .unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
       .swap
       .toOption
       .get
@@ -713,7 +713,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
       listResponse.map(_.samResource).toSet shouldBe Set(samResource1, samResource2)
     }
 
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   it should "list runtimes with a project" in isolatedDbTest {
@@ -729,7 +729,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
       listResponse.map(_.samResource).toSet shouldBe Set(samResource1, samResource2)
     }
 
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   it should "list runtimes with parameters" in isolatedDbTest {
@@ -746,7 +746,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
       listResponse.map(_.samResource).toSet shouldBe Set(samResource1)
     }
 
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   // See https://broadworkbench.atlassian.net/browse/PROD-440
@@ -773,7 +773,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
       listResponse.map(_.samResource).toSet shouldBe Set(samResource1, samResource2)
     }
 
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   it should "list runtimes with labels" in isolatedDbTest {
@@ -789,10 +789,10 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
     )
     runtimeService
       .createRuntime(userInfo, project, clusterName1, req)
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+      .unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
     val runtime1 = runtimeService
       .getRuntime(userInfo, project, clusterName1)
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+      .unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
     val listRuntimeResponse1 = ListRuntimeResponse2(
       runtime1.id,
       runtime1.samResource,
@@ -809,10 +809,10 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
     val clusterName2 = RuntimeName(s"cluster-${UUID.randomUUID.toString}")
     runtimeService
       .createRuntime(userInfo, project, clusterName2, req.copy(labels = Map("a" -> "b", "foo" -> "bar")))
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+      .unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
     val runtime2 = runtimeService
       .getRuntime(userInfo, project, clusterName2)
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+      .unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
     val listRuntimeResponse2 = ListRuntimeResponse2(
       runtime2.id,
       runtime2.samResource,
@@ -828,42 +828,42 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
 
     runtimeService
       .listRuntimes(userInfo, None, Map("_labels" -> "foo=bar"))
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+      .unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
       .toSet shouldBe Set(
       listRuntimeResponse1,
       listRuntimeResponse2
     )
     runtimeService
       .listRuntimes(userInfo, None, Map("_labels" -> "foo=bar,bam=yes"))
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+      .unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
       .toSet shouldBe Set(
       listRuntimeResponse1
     )
     runtimeService
       .listRuntimes(userInfo, None, Map("_labels" -> "foo=bar,bam=yes,vcf=no"))
-      .unsafeToFuture()(cats.effect.unsafe.implicits.global)
+      .unsafeToFuture()(cats.effect.unsafe.IORuntime.global)
       .futureValue
       .toSet shouldBe Set(listRuntimeResponse1)
     runtimeService
       .listRuntimes(userInfo, None, Map("_labels" -> "a=b"))
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+      .unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
       .toSet shouldBe Set(
       listRuntimeResponse2
     )
     runtimeService
       .listRuntimes(userInfo, None, Map("_labels" -> "baz=biz"))
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+      .unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
       .toSet shouldBe Set.empty
     runtimeService
       .listRuntimes(userInfo, None, Map("_labels" -> "A=B"))
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+      .unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
       .toSet shouldBe Set(
       listRuntimeResponse2
     ) // labels are not case sensitive because MySQL
     runtimeService
       .listRuntimes(userInfo, None, Map("_labels" -> "foo%3Dbar"))
       .attempt
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+      .unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
       .swap
       .toOption
       .get
@@ -871,7 +871,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
     runtimeService
       .listRuntimes(userInfo, None, Map("_labels" -> "foo=bar;bam=yes"))
       .attempt
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+      .unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
       .swap
       .toOption
       .get
@@ -879,7 +879,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
     runtimeService
       .listRuntimes(userInfo, None, Map("_labels" -> "foo=bar,bam"))
       .attempt
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+      .unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
       .swap
       .toOption
       .get
@@ -888,7 +888,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
     runtimeService
       .listRuntimes(userInfo, None, Map("_labels" -> "bogus"))
       .attempt
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+      .unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
       .swap
       .toOption
       .get
@@ -897,7 +897,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
     runtimeService
       .listRuntimes(userInfo, None, Map("_labels" -> "a,b"))
       .attempt
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+      .unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
       .swap
       .toOption
       .get
@@ -929,7 +929,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
       }
     } yield res
 
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   it should "delete a runtime with disk properly" in isolatedDbTest {
@@ -968,7 +968,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
       }
     } yield res
 
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   it should "stop a runtime" in isolatedDbTest {
@@ -994,7 +994,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
       }
     } yield res
 
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   it should "not stop a stopping runtime and also not error" in isolatedDbTest {
@@ -1020,7 +1020,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
       }
     } yield res
 
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   it should "start a runtime" in isolatedDbTest {
@@ -1046,7 +1046,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
       }
     } yield res
 
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   it should "update autopause" in isolatedDbTest {
@@ -1071,7 +1071,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
       messageOpt shouldBe None
     }
 
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   val reqMaps: List[LabelMap] = List(
@@ -1109,7 +1109,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
       } yield {
         finalUpsertMaps.contains(dbLabelMap) shouldBe true
       }
-      res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+      res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
     }
   }
 
@@ -1144,7 +1144,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
       } yield {
         finalDeleteMaps.contains(dbLabelMap) shouldBe true
       }
-      res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+      res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
     }
   }
 
@@ -1162,7 +1162,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
         } yield {
           fail shouldBe Left(RuntimeCannotBeUpdatedException(testRuntime.projectNameString, testRuntime.status))
         }
-        res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+        res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
       }
   }
 
@@ -1176,7 +1176,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
         WrongCloudServiceException(CloudService.GCE, CloudService.Dataproc, ctx.traceId)
       )
     }
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   "RuntimeServiceInterp.processUpdateGceConfigRequest" should "not update a GCE runtime when there are no changes" in {
@@ -1187,7 +1187,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
     } yield {
       messageOpt shouldBe None
     }
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   it should "update patchInProgress flag if stopToUpdateMachineType is true" in isolatedDbTest {
@@ -1218,7 +1218,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
                                             None,
                                             Some(ctx.traceId))
     }
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   it should "update a GCE machine type in Stopped state" in {
@@ -1239,7 +1239,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
                                             None,
                                             Some(ctx.traceId))
     }
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   it should "update a GCE machine type in Running state" in {
@@ -1260,7 +1260,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
                                             None,
                                             Some(ctx.traceId))
     }
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   it should "fail to update a GCE machine type in Running state with allowStop set to false" in {
@@ -1271,7 +1271,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
                                                             testClusterRecord.copy(status = RuntimeStatus.Running),
                                                             gceRuntimeConfig)
     } yield ()
-    res.attempt.unsafeRunSync()(cats.effect.unsafe.implicits.global) shouldBe Left(
+    res.attempt.unsafeRunSync()(cats.effect.unsafe.IORuntime.global) shouldBe Left(
       RuntimeMachineTypeCannotBeChangedException(testClusterRecord.projectNameString, RuntimeStatus.Running)
     )
   }
@@ -1291,11 +1291,11 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
                                             None,
                                             Some(ctx.traceId))
     }
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   it should "increase the persistent disk is attached to a GCE runtime" in isolatedDbTest {
-    val disk = makePersistentDisk(None).save().unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    val disk = makePersistentDisk(None).save().unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
     val req = UpdateRuntimeConfigRequest.GceConfig(None, Some(DiskSize(1024)))
     val res = for {
       ctx <- appContext.ask[AppContext]
@@ -1315,11 +1315,11 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
                                             None,
                                             Some(ctx.traceId))
     }
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   it should "fail to increase the disk on a GCE runtime if allowStop is false" in {
-    val disk = makePersistentDisk(None).save().unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    val disk = makePersistentDisk(None).save().unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
     val req = UpdateRuntimeConfigRequest.GceConfig(None, Some(DiskSize(1024)))
     val res = for {
       _ <- runtimeService.processUpdateRuntimeConfigRequest(
@@ -1329,7 +1329,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
         gceWithPdRuntimeConfig.copy(persistentDiskId = Some(disk.id))
       )
     } yield ()
-    res.attempt.unsafeRunSync()(cats.effect.unsafe.implicits.global) shouldBe Left(
+    res.attempt.unsafeRunSync()(cats.effect.unsafe.IORuntime.global) shouldBe Left(
       RuntimeDiskSizeCannotBeChangedException(testCluster.projectNameString)
     )
   }
@@ -1339,7 +1339,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
     val res = for {
       _ <- runtimeService.processUpdateRuntimeConfigRequest(req, false, testClusterRecord, gceRuntimeConfig)
     } yield ()
-    res.attempt.unsafeRunSync()(cats.effect.unsafe.implicits.global) shouldBe Left(
+    res.attempt.unsafeRunSync()(cats.effect.unsafe.IORuntime.global) shouldBe Left(
       RuntimeDiskSizeCannotBeDecreasedException(testClusterRecord.projectNameString)
     )
   }
@@ -1379,7 +1379,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
     } yield {
       messageOpt shouldBe None
     }
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   it should "disallow updating dataproc cluster number of workers if runtime is not Running" in {
@@ -1402,7 +1402,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
         .getOrElse(throw new Exception("this test failed"))
         .asInstanceOf[LeoException] shouldEqual expectedException
     }
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   it should "update Dataproc workers and preemptibles" in isolatedDbTest {
@@ -1440,7 +1440,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
                                             Some(1000),
                                             Some(ctx.traceId))
     }
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   it should "update a Dataproc master machine type in Stopped state" in isolatedDbTest {
@@ -1479,7 +1479,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
                                             None,
                                             Some(ctx.traceId))
     }
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   it should "update a Dataproc machine type in Running state" in isolatedDbTest {
@@ -1518,7 +1518,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
                                             None,
                                             Some(ctx.traceId))
     }
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
   it should "fail to update a Dataproc machine type in Running state with allowStop set to false" in {
     val req = UpdateRuntimeConfigRequest.DataprocConfig(Some(MachineTypeName("n1-micro-2")), None, None, None)
@@ -1528,7 +1528,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
                                                              testClusterRecord.copy(status = RuntimeStatus.Running),
                                                              defaultDataprocRuntimeConfig)
     } yield ()
-    res.attempt.unsafeRunSync()(cats.effect.unsafe.implicits.global) shouldBe Left(
+    res.attempt.unsafeRunSync()(cats.effect.unsafe.IORuntime.global) shouldBe Left(
       RuntimeMachineTypeCannotBeChangedException(testClusterRecord.projectNameString, RuntimeStatus.Running)
     )
   }
@@ -1541,7 +1541,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
                                                              testClusterRecord.copy(status = RuntimeStatus.Running),
                                                              defaultDataprocRuntimeConfig)
     } yield ()
-    res.attempt.unsafeRunSync()(cats.effect.unsafe.implicits.global).isLeft shouldBe true
+    res.attempt.unsafeRunSync()(cats.effect.unsafe.IORuntime.global).isLeft shouldBe true
   }
 
   it should "increase the disk on a Dataproc runtime" in isolatedDbTest {
@@ -1578,7 +1578,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
                                             None,
                                             Some(ctx.traceId))
     }
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   it should "fail to decrease the disk on a Dataproc runtime" in isolatedDbTest {
@@ -1605,7 +1605,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
         .transaction
       _ <- runtimeService.processUpdateDataprocConfigRequest(req, true, clusterRecord.get, defaultDataprocRuntimeConfig)
     } yield ()
-    res.attempt.unsafeRunSync()(cats.effect.unsafe.implicits.global) shouldBe Left(
+    res.attempt.unsafeRunSync()(cats.effect.unsafe.IORuntime.global) shouldBe Left(
       RuntimeDiskSizeCannotBeDecreasedException(testClusterRecord.projectNameString)
     )
   }
@@ -1650,7 +1650,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
       persistedDisk.get shouldEqual disk
     }
 
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   it should "reject a request if requested PD's zone is different from target zone" in isolatedDbTest {
@@ -1681,7 +1681,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
       ))
     }
 
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   it should "persist non-default zone disk properly" in isolatedDbTest {
@@ -1707,7 +1707,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
       persistedDisk.get.zone shouldBe (targetZone)
     }
 
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   it should "return existing disk if a disk with the same name already exists" in isolatedDbTest {
@@ -1731,7 +1731,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
       returnedDisk shouldBe Right(PersistentDiskRequestResult(disk, false))
     }
 
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   it should "fail to create a disk when caller has no permission" in isolatedDbTest {
@@ -1750,7 +1750,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
           whitelistAuthProvider,
           ConfigReader.appConfig.persistentDisk
         )(implicitly, implicitly, implicitly, scala.concurrent.ExecutionContext.global, implicitly)
-        .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+        .unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
     }
 
     thrown shouldBe ForbiddenError(userInfo.userEmail)
@@ -1786,7 +1786,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
       err shouldBe Left(DiskAlreadyAttachedException(project, savedDisk.name, t.traceId))
     }
 
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   it should "fail to process a disk reference when the disk is already formatted by another app" in isolatedDbTest {
@@ -1829,7 +1829,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
       )
     }
 
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   it should "fail to attach a disk when caller has no attach permission" in isolatedDbTest {
@@ -1850,7 +1850,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
     } yield ()
 
     val thrown = the[ForbiddenError] thrownBy {
-      res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+      res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
     }
 
     thrown shouldBe ForbiddenError(userInfo.userEmail)

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/AutopauseMonitorSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/AutopauseMonitorSpec.scala
@@ -43,7 +43,7 @@ class AutopauseMonitorSpec extends AnyFlatSpec with LeonardoTestSuite with TestC
       event.get shouldBe a[LeoPubsubMessage.StopRuntimeMessage]
     }
 
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   it should "not auto freeze the cluster if jupyter kernel is still running" in isolatedDbTest {
@@ -70,7 +70,7 @@ class AutopauseMonitorSpec extends AnyFlatSpec with LeonardoTestSuite with TestC
       event shouldBe (None)
     }
 
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   it should "auto freeze the cluster if we fail to get jupyter kernel status" in isolatedDbTest {
@@ -97,7 +97,7 @@ class AutopauseMonitorSpec extends AnyFlatSpec with LeonardoTestSuite with TestC
       event.get shouldBe a[LeoPubsubMessage.StopRuntimeMessage]
     }
 
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   it should "auto freeze the cluster if the max kernel busy time is exceeded" in isolatedDbTest {
@@ -128,7 +128,7 @@ class AutopauseMonitorSpec extends AnyFlatSpec with LeonardoTestSuite with TestC
       event.get shouldBe a[LeoPubsubMessage.StopRuntimeMessage]
     }
 
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   private def monitor(

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/BaseCloudServiceRuntimeMonitorSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/BaseCloudServiceRuntimeMonitorSpec.scala
@@ -21,7 +21,6 @@ import org.broadinstitute.dsde.workbench.openTelemetry.OpenTelemetryMetrics
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
-import java.time.Instant
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/BaseCloudServiceRuntimeMonitorSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/BaseCloudServiceRuntimeMonitorSpec.scala
@@ -1,11 +1,13 @@
 package org.broadinstitute.dsde.workbench.leonardo
 package monitor
 
+import java.time.Instant
 import cats.Parallel
-import cats.effect.{ConcurrentEffect, IO, Timer}
+import cats.effect.{Async, IO}
 import cats.mtl.Ask
 import com.google.cloud.compute.v1._
 import fs2.Stream
+import org.typelevel.log4cats.StructuredLogger
 import org.broadinstitute.dsde.workbench.google2.GoogleStorageService
 import org.broadinstitute.dsde.workbench.leonardo.CommonTestData._
 import org.broadinstitute.dsde.workbench.leonardo.config.{Config, RuntimeBucketConfig}
@@ -18,11 +20,9 @@ import org.broadinstitute.dsde.workbench.model.{IP, TraceId}
 import org.broadinstitute.dsde.workbench.openTelemetry.OpenTelemetryMetrics
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-import org.typelevel.log4cats.StructuredLogger
 
 import java.time.Instant
 import scala.concurrent.ExecutionContext
-import scala.concurrent.ExecutionContext.global
 import scala.concurrent.duration._
 
 class BaseCloudServiceRuntimeMonitorSpec extends AnyFlatSpec with Matchers with TestComponent with LeonardoTestSuite {
@@ -32,13 +32,13 @@ class BaseCloudServiceRuntimeMonitorSpec extends AnyFlatSpec with Matchers with 
     val res = for {
       runtime <- IO(makeCluster(0).copy(status = RuntimeStatus.Creating).save())
       s1 = runtimeMonitor.process(runtime.id, RuntimeStatus.Creating)
-      s2 = Stream.sleep(2 seconds) ++ Stream.eval(
+      s2 = Stream.sleep[IO](2 seconds) ++ Stream.eval(
         clusterQuery.updateClusterStatus(runtime.id, RuntimeStatus.Deleting, Instant.now()).transaction
       )
       // run s1 and s2 concurrently. s1 will run indefinitely if s2 doesn't happen. So by validating the combined Stream terminate, we verify s1 is terminated due to unexpected status change for the runtime
       _ <- Stream(s1, s2).parJoin(2).compile.drain.timeout(10 seconds)
     } yield succeed
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "transition cluster to Stopping if Starting times out" in isolatedDbTest {
@@ -54,20 +54,20 @@ class BaseCloudServiceRuntimeMonitorSpec extends AnyFlatSpec with Matchers with 
       } yield status.get shouldBe RuntimeStatus.Stopping
       _ <- withInfiniteStream(runtimeMonitor.process(runtime.id, RuntimeStatus.Starting), assersions)
     } yield ()
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   "handleCheckTools" should "move to Running status if all tools are ready" in isolatedDbTest {
     val runtimeMonitor = baseRuntimeMonitor(true)
 
     val res = for {
-      start <- nowInstant
+      start <- IO.realTimeInstant
       tid <- traceId.ask[TraceId]
       runtime <- IO(makeCluster(0).copy(status = RuntimeStatus.Creating).save())
       runtimeAndRuntimeConfig = RuntimeAndRuntimeConfig(runtime, CommonTestData.defaultDataprocRuntimeConfig)
       monitorContext = MonitorContext(start, runtime.id, tid, RuntimeStatus.Creating)
       res <- runtimeMonitor.handleCheckTools(monitorContext, runtimeAndRuntimeConfig, IP("1.2.3.4"), Set.empty)
-      end <- nowInstant
+      end <- IO.realTimeInstant
       elapsed = end.toEpochMilli - start.toEpochMilli
       status <- clusterQuery.getClusterStatus(runtime.id).transaction
     } yield {
@@ -79,20 +79,20 @@ class BaseCloudServiceRuntimeMonitorSpec extends AnyFlatSpec with Matchers with 
       res shouldBe (((), None))
     }
 
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "move to failed status if tools are not ready" in isolatedDbTest {
     val runtimeMonitor = baseRuntimeMonitor(false)
 
     val res = for {
-      start <- nowInstant
+      start <- IO.realTimeInstant
       tid <- traceId.ask[TraceId]
       runtime <- IO(makeCluster(0).copy(status = RuntimeStatus.Creating).save())
       runtimeAndRuntimeConfig = RuntimeAndRuntimeConfig(runtime, CommonTestData.defaultDataprocRuntimeConfig)
       monitorContext = MonitorContext(start, runtime.id, tid, RuntimeStatus.Creating)
       res <- runtimeMonitor.handleCheckTools(monitorContext, runtimeAndRuntimeConfig, IP("1.2.3.4"), Set.empty)
-      end <- nowInstant
+      end <- IO.realTimeInstant
       elapsed = end.toEpochMilli - start.toEpochMilli
       status <- clusterQuery.getClusterStatus(runtime.id).transaction
     } yield {
@@ -102,16 +102,16 @@ class BaseCloudServiceRuntimeMonitorSpec extends AnyFlatSpec with Matchers with 
       res shouldBe (((), None))
     }
 
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "not move to failed status if tools are not ready and runtime is Deleted" in isolatedDbTest {
     val runtimeMonitor = baseRuntimeMonitor(false)
 
     val res = for {
-      start <- nowInstant
+      start <- IO.realTimeInstant
       tid <- traceId.ask[TraceId]
-      implicit0(ec: ExecutionContext) = global
+      implicit0(ec: ExecutionContext) = scala.concurrent.ExecutionContext.Implicits.global
       runtime <- IO(makeCluster(0).copy(status = RuntimeStatus.Creating).save())
       runtimeAndRuntimeConfig = RuntimeAndRuntimeConfig(runtime, CommonTestData.defaultDataprocRuntimeConfig)
       monitorContext = MonitorContext(start, runtime.id, tid, RuntimeStatus.Creating)
@@ -119,13 +119,13 @@ class BaseCloudServiceRuntimeMonitorSpec extends AnyFlatSpec with Matchers with 
       runCheckTools = Stream.eval(
         runtimeMonitor.handleCheckTools(monitorContext, runtimeAndRuntimeConfig, IP("1.2.3.4"), Set.empty)
       )
-      deleteRuntime = Stream.sleep(2 seconds) ++ Stream.eval(
+      deleteRuntime = Stream.sleep[IO](2 seconds) ++ Stream.eval(
         clusterQuery.completeDeletion(runtime.id, start).transaction
       )
       // run above tasks concurrently and wait for both to terminate
       _ <- Stream(runCheckTools, deleteRuntime).parJoin(2).compile.drain.timeout(15 seconds)
 
-      end <- nowInstant
+      end <- IO.realTimeInstant
       elapsed = end.toEpochMilli - start.toEpochMilli
       status <- clusterQuery.getClusterStatus(runtime.id).transaction
     } yield {
@@ -134,20 +134,16 @@ class BaseCloudServiceRuntimeMonitorSpec extends AnyFlatSpec with Matchers with 
       status shouldBe Some(RuntimeStatus.Deleted)
     }
 
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
-  class MockRuntimeMonitor(isWelderReady: Boolean, timeouts: Map[RuntimeStatus, FiniteDuration])
-      extends BaseCloudServiceRuntimeMonitor[IO] {
-    implicit override def F: ConcurrentEffect[IO] = IO.ioConcurrentEffect(cs)
-
-    implicit override def parallel: Parallel[IO] = IO.ioParallel(cs)
-
-    override def timer: Timer[IO] = testTimer
-
+  class MockRuntimeMonitor(isWelderReady: Boolean, timeouts: Map[RuntimeStatus, FiniteDuration])(
+    implicit override val F: Async[IO],
+    implicit override val parallel: Parallel[IO]
+  ) extends BaseCloudServiceRuntimeMonitor[IO] {
     implicit override def dbRef: DbReference[IO] = testDbRef
 
-    implicit override def ec: ExecutionContext = global
+    implicit override def ec: ExecutionContext = scala.concurrent.ExecutionContext.global
 
     implicit override def runtimeToolToToolDao
       : RuntimeContainerServiceType => ToolDAO[IO, RuntimeContainerServiceType] = x => {

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/BaseCloudServiceRuntimeMonitorSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/BaseCloudServiceRuntimeMonitorSpec.scala
@@ -38,7 +38,7 @@ class BaseCloudServiceRuntimeMonitorSpec extends AnyFlatSpec with Matchers with 
       // run s1 and s2 concurrently. s1 will run indefinitely if s2 doesn't happen. So by validating the combined Stream terminate, we verify s1 is terminated due to unexpected status change for the runtime
       _ <- Stream(s1, s2).parJoin(2).compile.drain.timeout(10 seconds)
     } yield succeed
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   it should "transition cluster to Stopping if Starting times out" in isolatedDbTest {
@@ -54,7 +54,7 @@ class BaseCloudServiceRuntimeMonitorSpec extends AnyFlatSpec with Matchers with 
       } yield status.get shouldBe RuntimeStatus.Stopping
       _ <- withInfiniteStream(runtimeMonitor.process(runtime.id, RuntimeStatus.Starting), assersions)
     } yield ()
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   "handleCheckTools" should "move to Running status if all tools are ready" in isolatedDbTest {
@@ -79,7 +79,7 @@ class BaseCloudServiceRuntimeMonitorSpec extends AnyFlatSpec with Matchers with 
       res shouldBe (((), None))
     }
 
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   it should "move to failed status if tools are not ready" in isolatedDbTest {
@@ -102,7 +102,7 @@ class BaseCloudServiceRuntimeMonitorSpec extends AnyFlatSpec with Matchers with 
       res shouldBe (((), None))
     }
 
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   it should "not move to failed status if tools are not ready and runtime is Deleted" in isolatedDbTest {
@@ -134,7 +134,7 @@ class BaseCloudServiceRuntimeMonitorSpec extends AnyFlatSpec with Matchers with 
       status shouldBe Some(RuntimeStatus.Deleted)
     }
 
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   class MockRuntimeMonitor(isWelderReady: Boolean, timeouts: Map[RuntimeStatus, FiniteDuration])(

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterToolMonitorSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterToolMonitorSpec.scala
@@ -9,7 +9,6 @@ import org.broadinstitute.dsde.workbench.leonardo.dao._
 import org.broadinstitute.dsde.workbench.leonardo.db.TestComponent
 import org.broadinstitute.dsde.workbench.leonardo.{GcsPathUtils, RuntimeContainerServiceType, RuntimeStatus}
 import org.broadinstitute.dsde.workbench.openTelemetry.OpenTelemetryMetrics
-import cats.syntax.all._
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
 import org.scalatest.concurrent.Eventually.eventually
@@ -114,12 +113,12 @@ class ClusterToolMonitorSpec
                                                              ArgumentMatchers.any[Map[String, String]])
         }
 
-        val res = testTimer.sleep(clusterToolConfig.pollPeriod) >> IO(
+        val res = IO.sleep(clusterToolConfig.pollPeriod) >> IO(
           verify(mockNewRelic, never()).incrementCounter(ArgumentMatchers.eq("WelderServiceDown"),
                                                          ArgumentMatchers.anyLong(),
                                                          ArgumentMatchers.any[Map[String, String]])
         )
-        res.unsafeRunSync
+        res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
     }
   }
 

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterToolMonitorSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterToolMonitorSpec.scala
@@ -118,7 +118,7 @@ class ClusterToolMonitorSpec
                                                          ArgumentMatchers.anyLong(),
                                                          ArgumentMatchers.any[Map[String, String]])
         )
-        res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+        res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
     }
   }
 

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/DataprocRuntimeMonitorSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/DataprocRuntimeMonitorSpec.scala
@@ -1,6 +1,7 @@
 package org.broadinstitute.dsde.workbench.leonardo
 package monitor
 
+import java.time.Instant
 import cats.effect.IO
 import cats.mtl.Ask
 import com.google.cloud.compute.v1.{AccessConfig, Instance, NetworkInterface, Operation}
@@ -32,7 +33,6 @@ import org.broadinstitute.dsde.workbench.model.{IP, TraceId}
 import org.scalatest.EitherValues
 import org.scalatest.flatspec.AnyFlatSpec
 
-import java.time.Instant
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.jdk.CollectionConverters._
 
@@ -44,7 +44,10 @@ class DataprocRuntimeMonitorSpec extends AnyFlatSpec with TestComponent with Leo
       status = RuntimeStatus.Creating
     )
     val monitorContext =
-      MonitorContext(Instant.now(), runtime.id, appContext.ask.unsafeRunSync().traceId, RuntimeStatus.Creating)
+      MonitorContext(Instant.now(),
+                     runtime.id,
+                     appContext.ask.unsafeRunSync()(cats.effect.unsafe.implicits.global).traceId,
+                     RuntimeStatus.Creating)
 
     val res = for {
       savedRuntime <- IO(runtime.save())
@@ -55,7 +58,7 @@ class DataprocRuntimeMonitorSpec extends AnyFlatSpec with TestComponent with Leo
       r._2 shouldBe (Some(Check(runtimeAndRuntimeConfig, None)))
     }
 
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "will check again status is either Creating or Unknown" in isolatedDbTest {
@@ -87,7 +90,7 @@ class DataprocRuntimeMonitorSpec extends AnyFlatSpec with TestComponent with Leo
       r2._2 shouldBe (Some(Check(runtimeAndRuntimeConfig, None)))
     }
 
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "will check again status is Running but not all instances are running" in isolatedDbTest {
@@ -113,7 +116,7 @@ class DataprocRuntimeMonitorSpec extends AnyFlatSpec with TestComponent with Leo
       r._2 shouldBe (Some(Check(runtimeAndRuntimeConfig, None)))
     }
 
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "will error if can't find zone for master instance" in isolatedDbTest {
@@ -140,7 +143,7 @@ class DataprocRuntimeMonitorSpec extends AnyFlatSpec with TestComponent with Leo
       error.head.errorMessage shouldBe ("Can't find master instance for this cluster")
     }
 
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "will persist error if cluster is in Error state" in isolatedDbTest {
@@ -167,7 +170,7 @@ class DataprocRuntimeMonitorSpec extends AnyFlatSpec with TestComponent with Leo
       error.head.errorMessage shouldBe ("Error not available")
     }
 
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "will error if cluster is in unexpected state when trying to create" in isolatedDbTest {
@@ -194,7 +197,7 @@ class DataprocRuntimeMonitorSpec extends AnyFlatSpec with TestComponent with Leo
       error.head.errorMessage shouldBe ("unexpected Dataproc cluster status Updating when trying to creating an instance")
     }
 
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "will try to persist user script error if cluster is in Error state but no error shown from dataproc" in isolatedDbTest {
@@ -222,7 +225,7 @@ class DataprocRuntimeMonitorSpec extends AnyFlatSpec with TestComponent with Leo
       error.head.errorMessage shouldBe ("Error not available")
     }
 
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "will persist error if cluster is in Error state when Creating" in isolatedDbTest {
@@ -258,7 +261,7 @@ class DataprocRuntimeMonitorSpec extends AnyFlatSpec with TestComponent with Leo
       error.head.errorMessage shouldBe ("time out")
     }
 
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   "startingRuntime" should "will check again if not all instances are Running when trying to start" in isolatedDbTest {
@@ -283,7 +286,7 @@ class DataprocRuntimeMonitorSpec extends AnyFlatSpec with TestComponent with Leo
       r._2 shouldBe (Some(Check(runtimeAndRuntimeConfig, None)))
     }
 
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "will check again if master instance doesn't have IP when trying to start" in isolatedDbTest {
@@ -308,7 +311,7 @@ class DataprocRuntimeMonitorSpec extends AnyFlatSpec with TestComponent with Leo
       r._2 shouldBe (Some(Check(runtimeAndRuntimeConfig, None)))
     }
 
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "will persist error if cluster is in Error state when Starting" in isolatedDbTest {
@@ -334,7 +337,7 @@ class DataprocRuntimeMonitorSpec extends AnyFlatSpec with TestComponent with Leo
       error.head.errorMessage shouldBe ("Cluster failed to start")
     }
 
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   "stoppingRuntime" should "check again if there's still instance Running" in isolatedDbTest {
@@ -357,7 +360,7 @@ class DataprocRuntimeMonitorSpec extends AnyFlatSpec with TestComponent with Leo
       r._2 shouldBe (Some(Check(runtimeAndRuntimeConfig, None)))
     }
 
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   "stoppingRuntime" should "update DB when all instances are stopped" in isolatedDbTest {
@@ -382,7 +385,7 @@ class DataprocRuntimeMonitorSpec extends AnyFlatSpec with TestComponent with Leo
       updatedStatus shouldBe (Some(RuntimeStatus.Stopped))
     }
 
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "terminate monitoring stopping if cluster doesn't exist" in isolatedDbTest {
@@ -407,7 +410,7 @@ class DataprocRuntimeMonitorSpec extends AnyFlatSpec with TestComponent with Leo
       )
     }
 
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   "updatingRuntime" should "terminate monitoring stopping if cluster doesn't exist" in isolatedDbTest {
@@ -434,7 +437,7 @@ class DataprocRuntimeMonitorSpec extends AnyFlatSpec with TestComponent with Leo
       error.head.errorMessage shouldBe (s"-1/${ctx.traceId.asString} | Can't update an instance that hasn't been initialized yet or doesn't exist")
     }
 
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "check again if cluster is still being updated" in isolatedDbTest {
@@ -457,7 +460,7 @@ class DataprocRuntimeMonitorSpec extends AnyFlatSpec with TestComponent with Leo
       r._2 shouldBe Some(Check(runtimeAndRuntimeConfig, None))
     }
 
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "check again if not all instances are Running" in isolatedDbTest {
@@ -482,7 +485,7 @@ class DataprocRuntimeMonitorSpec extends AnyFlatSpec with TestComponent with Leo
       r._2 shouldBe Some(Check(runtimeAndRuntimeConfig, None))
     }
 
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "check again if instance IP is not available yet" in isolatedDbTest {
@@ -507,7 +510,7 @@ class DataprocRuntimeMonitorSpec extends AnyFlatSpec with TestComponent with Leo
       r._2 shouldBe Some(Check(runtimeAndRuntimeConfig, None))
     }
 
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "complete update" in isolatedDbTest {
@@ -534,7 +537,7 @@ class DataprocRuntimeMonitorSpec extends AnyFlatSpec with TestComponent with Leo
       status.head shouldBe (RuntimeStatus.Running)
     }
 
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   "deleteRuntime" should "check again if cluster still exists" in isolatedDbTest {
@@ -557,7 +560,7 @@ class DataprocRuntimeMonitorSpec extends AnyFlatSpec with TestComponent with Leo
       r._2 shouldBe Some(Check(runtimeAndRuntimeConfig, None))
     }
 
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "delete runtime if runtime no longer exists in google" in isolatedDbTest {
@@ -581,7 +584,7 @@ class DataprocRuntimeMonitorSpec extends AnyFlatSpec with TestComponent with Leo
       status shouldBe Some(RuntimeStatus.Deleted)
     }
 
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   val successToolDao: RuntimeContainerServiceType => ToolDAO[IO, RuntimeContainerServiceType] = _ => MockToolDAO(true)
@@ -627,8 +630,8 @@ class DataprocRuntimeMonitorSpec extends AnyFlatSpec with TestComponent with Leo
       ): IO[Option[Instance]] = {
         val instanceBuilder = Instance
           .newBuilder()
-          .setStatus(status.toString)
-          .setId("100")
+          .setStatus(status.instanceStatus)
+          .setId(100)
         val instance = ip.fold(instanceBuilder.build()) { i =>
           instanceBuilder
             .addNetworkInterfaces(

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/DataprocRuntimeMonitorSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/DataprocRuntimeMonitorSpec.scala
@@ -46,7 +46,7 @@ class DataprocRuntimeMonitorSpec extends AnyFlatSpec with TestComponent with Leo
     val monitorContext =
       MonitorContext(Instant.now(),
                      runtime.id,
-                     appContext.ask.unsafeRunSync()(cats.effect.unsafe.implicits.global).traceId,
+                     appContext.ask.unsafeRunSync()(cats.effect.unsafe.IORuntime.global).traceId,
                      RuntimeStatus.Creating)
 
     val res = for {
@@ -58,7 +58,7 @@ class DataprocRuntimeMonitorSpec extends AnyFlatSpec with TestComponent with Leo
       r._2 shouldBe (Some(Check(runtimeAndRuntimeConfig, None)))
     }
 
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   it should "will check again status is either Creating or Unknown" in isolatedDbTest {
@@ -90,7 +90,7 @@ class DataprocRuntimeMonitorSpec extends AnyFlatSpec with TestComponent with Leo
       r2._2 shouldBe (Some(Check(runtimeAndRuntimeConfig, None)))
     }
 
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   it should "will check again status is Running but not all instances are running" in isolatedDbTest {
@@ -116,7 +116,7 @@ class DataprocRuntimeMonitorSpec extends AnyFlatSpec with TestComponent with Leo
       r._2 shouldBe (Some(Check(runtimeAndRuntimeConfig, None)))
     }
 
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   it should "will error if can't find zone for master instance" in isolatedDbTest {
@@ -143,7 +143,7 @@ class DataprocRuntimeMonitorSpec extends AnyFlatSpec with TestComponent with Leo
       error.head.errorMessage shouldBe ("Can't find master instance for this cluster")
     }
 
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   it should "will persist error if cluster is in Error state" in isolatedDbTest {
@@ -170,7 +170,7 @@ class DataprocRuntimeMonitorSpec extends AnyFlatSpec with TestComponent with Leo
       error.head.errorMessage shouldBe ("Error not available")
     }
 
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   it should "will error if cluster is in unexpected state when trying to create" in isolatedDbTest {
@@ -197,7 +197,7 @@ class DataprocRuntimeMonitorSpec extends AnyFlatSpec with TestComponent with Leo
       error.head.errorMessage shouldBe ("unexpected Dataproc cluster status Updating when trying to creating an instance")
     }
 
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   it should "will try to persist user script error if cluster is in Error state but no error shown from dataproc" in isolatedDbTest {
@@ -225,7 +225,7 @@ class DataprocRuntimeMonitorSpec extends AnyFlatSpec with TestComponent with Leo
       error.head.errorMessage shouldBe ("Error not available")
     }
 
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   it should "will persist error if cluster is in Error state when Creating" in isolatedDbTest {
@@ -261,7 +261,7 @@ class DataprocRuntimeMonitorSpec extends AnyFlatSpec with TestComponent with Leo
       error.head.errorMessage shouldBe ("time out")
     }
 
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   "startingRuntime" should "will check again if not all instances are Running when trying to start" in isolatedDbTest {
@@ -286,7 +286,7 @@ class DataprocRuntimeMonitorSpec extends AnyFlatSpec with TestComponent with Leo
       r._2 shouldBe (Some(Check(runtimeAndRuntimeConfig, None)))
     }
 
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   it should "will check again if master instance doesn't have IP when trying to start" in isolatedDbTest {
@@ -311,7 +311,7 @@ class DataprocRuntimeMonitorSpec extends AnyFlatSpec with TestComponent with Leo
       r._2 shouldBe (Some(Check(runtimeAndRuntimeConfig, None)))
     }
 
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   it should "will persist error if cluster is in Error state when Starting" in isolatedDbTest {
@@ -337,7 +337,7 @@ class DataprocRuntimeMonitorSpec extends AnyFlatSpec with TestComponent with Leo
       error.head.errorMessage shouldBe ("Cluster failed to start")
     }
 
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   "stoppingRuntime" should "check again if there's still instance Running" in isolatedDbTest {
@@ -360,7 +360,7 @@ class DataprocRuntimeMonitorSpec extends AnyFlatSpec with TestComponent with Leo
       r._2 shouldBe (Some(Check(runtimeAndRuntimeConfig, None)))
     }
 
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   "stoppingRuntime" should "update DB when all instances are stopped" in isolatedDbTest {
@@ -385,7 +385,7 @@ class DataprocRuntimeMonitorSpec extends AnyFlatSpec with TestComponent with Leo
       updatedStatus shouldBe (Some(RuntimeStatus.Stopped))
     }
 
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   it should "terminate monitoring stopping if cluster doesn't exist" in isolatedDbTest {
@@ -410,7 +410,7 @@ class DataprocRuntimeMonitorSpec extends AnyFlatSpec with TestComponent with Leo
       )
     }
 
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   "updatingRuntime" should "terminate monitoring stopping if cluster doesn't exist" in isolatedDbTest {
@@ -437,7 +437,7 @@ class DataprocRuntimeMonitorSpec extends AnyFlatSpec with TestComponent with Leo
       error.head.errorMessage shouldBe (s"-1/${ctx.traceId.asString} | Can't update an instance that hasn't been initialized yet or doesn't exist")
     }
 
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   it should "check again if cluster is still being updated" in isolatedDbTest {
@@ -460,7 +460,7 @@ class DataprocRuntimeMonitorSpec extends AnyFlatSpec with TestComponent with Leo
       r._2 shouldBe Some(Check(runtimeAndRuntimeConfig, None))
     }
 
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   it should "check again if not all instances are Running" in isolatedDbTest {
@@ -485,7 +485,7 @@ class DataprocRuntimeMonitorSpec extends AnyFlatSpec with TestComponent with Leo
       r._2 shouldBe Some(Check(runtimeAndRuntimeConfig, None))
     }
 
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   it should "check again if instance IP is not available yet" in isolatedDbTest {
@@ -510,7 +510,7 @@ class DataprocRuntimeMonitorSpec extends AnyFlatSpec with TestComponent with Leo
       r._2 shouldBe Some(Check(runtimeAndRuntimeConfig, None))
     }
 
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   it should "complete update" in isolatedDbTest {
@@ -537,7 +537,7 @@ class DataprocRuntimeMonitorSpec extends AnyFlatSpec with TestComponent with Leo
       status.head shouldBe (RuntimeStatus.Running)
     }
 
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   "deleteRuntime" should "check again if cluster still exists" in isolatedDbTest {
@@ -560,7 +560,7 @@ class DataprocRuntimeMonitorSpec extends AnyFlatSpec with TestComponent with Leo
       r._2 shouldBe Some(Check(runtimeAndRuntimeConfig, None))
     }
 
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   it should "delete runtime if runtime no longer exists in google" in isolatedDbTest {
@@ -584,7 +584,7 @@ class DataprocRuntimeMonitorSpec extends AnyFlatSpec with TestComponent with Leo
       status shouldBe Some(RuntimeStatus.Deleted)
     }
 
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   val successToolDao: RuntimeContainerServiceType => ToolDAO[IO, RuntimeContainerServiceType] = _ => MockToolDAO(true)

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/GceRuntimeMonitorSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/GceRuntimeMonitorSpec.scala
@@ -98,7 +98,7 @@ class GceRuntimeMonitorSpec
       res6.left.value.getMessage shouldBe (s"${ctx} | staging bucket field hasn't been updated properly before monitoring started")
     }
 
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   "validateUserStartupScript" should "validate user startup script properly" in {
@@ -139,20 +139,20 @@ class GceRuntimeMonitorSpec
       res6 shouldBe (UserScriptsValidationResult.CheckAgain(s"${ctx} | Instance is not ready yet"))
     }
 
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   it should "check whether user script has failed correctly" in {
     val monitor = gceRuntimeMonitor()
     monitor
       .checkUserScriptsOutputFile(model.google.GcsPath(GcsBucketName("failure"), GcsObjectName("")))
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global) shouldBe (Some(false))
+      .unsafeRunSync()(cats.effect.unsafe.IORuntime.global) shouldBe (Some(false))
     monitor
       .checkUserScriptsOutputFile(model.google.GcsPath(GcsBucketName("success"), GcsObjectName("")))
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global) shouldBe (Some(true))
+      .unsafeRunSync()(cats.effect.unsafe.IORuntime.global) shouldBe (Some(true))
     monitor
       .checkUserScriptsOutputFile(model.google.GcsPath(GcsBucketName("nonExistent"), GcsObjectName("")))
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global) shouldBe (None)
+      .unsafeRunSync()(cats.effect.unsafe.IORuntime.global) shouldBe (None)
   }
 
   it should "retrieve user script from instance metadata properly" in {
@@ -189,7 +189,7 @@ class GceRuntimeMonitorSpec
       error.head.errorMessage shouldBe s"User script failed. See output in gs://failure/userscript_output.txt"
     }
 
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   // process, Creating
@@ -242,7 +242,7 @@ class GceRuntimeMonitorSpec
       error.head.errorMessage shouldBe s"User startup script failed. See output in gs://staging_bucket/failed_userstartupscript_output.txt"
     }
 
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   // process, Creating
@@ -281,7 +281,7 @@ class GceRuntimeMonitorSpec
       status shouldBe Some(RuntimeStatus.Running)
     }
 
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   // process, Starting
@@ -319,7 +319,7 @@ class GceRuntimeMonitorSpec
       status shouldBe Some(RuntimeStatus.Running)
     }
 
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   it should "transition gce runtime to Stopping if Starting times out" in isolatedDbTest {
@@ -349,7 +349,7 @@ class GceRuntimeMonitorSpec
       } yield status.get shouldBe RuntimeStatus.Stopped
       _ <- withInfiniteStream(monitor.process(runtime.id, RuntimeStatus.Starting), assersions)
     } yield ()
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   it should "terminate if instance is terminated after 5 seconds when trying to Starting one" in isolatedDbTest {
@@ -389,7 +389,7 @@ class GceRuntimeMonitorSpec
       status shouldBe Some(RuntimeStatus.Stopped)
     }
 
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   it should "fail Starting if user startup script failed" in isolatedDbTest {
@@ -441,7 +441,7 @@ class GceRuntimeMonitorSpec
       error.head.errorMessage shouldBe s"User startup script failed. See output in gs://staging_bucket/failed_userstartupscript_output.txt"
     }
 
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   // process
@@ -464,7 +464,7 @@ class GceRuntimeMonitorSpec
       status shouldBe (Some(RuntimeStatus.Stopped))
     }
 
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   // process, Stopping
@@ -487,7 +487,7 @@ class GceRuntimeMonitorSpec
       status shouldBe (Some(RuntimeStatus.Stopping))
     }
 
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   // process, Stopping
@@ -518,7 +518,7 @@ class GceRuntimeMonitorSpec
       status shouldBe (Some(RuntimeStatus.Stopped))
     }
 
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   // process, Stopping
@@ -544,7 +544,7 @@ class GceRuntimeMonitorSpec
       status shouldBe Some(RuntimeStatus.Stopped)
     }
 
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   // process, Deleting
@@ -567,7 +567,7 @@ class GceRuntimeMonitorSpec
       status shouldBe (Some(RuntimeStatus.Deleted))
     }
 
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   // process, Deleting
@@ -606,7 +606,7 @@ class GceRuntimeMonitorSpec
       status shouldBe Some(RuntimeStatus.Deleted)
     }
 
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   //pollCheck, Deleting
@@ -633,7 +633,7 @@ class GceRuntimeMonitorSpec
       r.left.value.getMessage shouldBe "Monitoring Deleted with pollOperation is not supported"
     }
 
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   it should "set runtime to PreDeleting if Stopping is interrupted by Deleting" in isolatedDbTest {
@@ -668,7 +668,7 @@ class GceRuntimeMonitorSpec
       status shouldBe (Some(RuntimeStatus.PreDeleting))
     }
 
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   it should "monitor Deleting successfully" in {
@@ -713,7 +713,7 @@ class GceRuntimeMonitorSpec
       status shouldBe Some(RuntimeStatus.Deleted)
     }
 
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   //pollCheck Deleting
@@ -751,7 +751,7 @@ class GceRuntimeMonitorSpec
       error.head.errorMessage shouldBe s"Deleting dsp-leo-test/clustername2 fail to complete in a timely manner"
     }
 
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   implicit val toolDao: RuntimeContainerServiceType => ToolDAO[IO, RuntimeContainerServiceType] = _ => MockToolDAO(true)

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/GceRuntimeMonitorSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/GceRuntimeMonitorSpec.scala
@@ -2,7 +2,9 @@ package org.broadinstitute.dsde.workbench.leonardo
 package monitor
 
 import cats.effect.IO
+import cats.effect.std.Queue
 import cats.mtl.Ask
+import com.google.cloud.compute.v1.Instance.Status
 import com.google.cloud.compute.v1._
 import org.broadinstitute.dsde.workbench.google2.mock.{FakeGoogleComputeService, MockComputePollOperation}
 import org.broadinstitute.dsde.workbench.google2.{
@@ -27,7 +29,6 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
 import java.time.Instant
-import java.util.concurrent.TimeUnit
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 
@@ -39,7 +40,7 @@ class GceRuntimeMonitorSpec
     with EitherValues {
   val readyInstance = Instance
     .newBuilder()
-    .setStatus("Running")
+    .setStatus(Status.RUNNING)
     .setMetadata(
       Metadata
         .newBuilder()
@@ -97,7 +98,7 @@ class GceRuntimeMonitorSpec
       res6.left.value.getMessage shouldBe (s"${ctx} | staging bucket field hasn't been updated properly before monitoring started")
     }
 
-    res.unsafeRunSync
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   "validateUserStartupScript" should "validate user startup script properly" in {
@@ -138,20 +139,20 @@ class GceRuntimeMonitorSpec
       res6 shouldBe (UserScriptsValidationResult.CheckAgain(s"${ctx} | Instance is not ready yet"))
     }
 
-    res.unsafeRunSync
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "check whether user script has failed correctly" in {
     val monitor = gceRuntimeMonitor()
     monitor
       .checkUserScriptsOutputFile(model.google.GcsPath(GcsBucketName("failure"), GcsObjectName("")))
-      .unsafeRunSync() shouldBe (Some(false))
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global) shouldBe (Some(false))
     monitor
       .checkUserScriptsOutputFile(model.google.GcsPath(GcsBucketName("success"), GcsObjectName("")))
-      .unsafeRunSync() shouldBe (Some(true))
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global) shouldBe (Some(true))
     monitor
       .checkUserScriptsOutputFile(model.google.GcsPath(GcsBucketName("nonExistent"), GcsObjectName("")))
-      .unsafeRunSync() shouldBe (None)
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global) shouldBe (None)
   }
 
   it should "retrieve user script from instance metadata properly" in {
@@ -175,11 +176,11 @@ class GceRuntimeMonitorSpec
     }
 
     val res = for {
-      start <- nowInstant[IO]
+      start <- IO.realTimeInstant
       monitor = gceRuntimeMonitor(googleComputeService = computeService)
       savedRuntime <- IO(runtime.saveWithRuntimeConfig(gceRuntimeConfig))
       _ <- monitor.process(savedRuntime.id, RuntimeStatus.Creating).compile.drain //start monitoring process
-      afterMonitor <- nowInstant
+      afterMonitor <- IO.realTimeInstant
       status <- clusterQuery.getClusterStatus(savedRuntime.id).transaction
       error <- clusterErrorQuery.get(savedRuntime.id).transaction
     } yield {
@@ -188,7 +189,7 @@ class GceRuntimeMonitorSpec
       error.head.errorMessage shouldBe s"User script failed. See output in gs://failure/userscript_output.txt"
     }
 
-    res.unsafeRunSync
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   // process, Creating
@@ -209,7 +210,7 @@ class GceRuntimeMonitorSpec
       ): IO[Option[Instance]] = {
         val runningInstance = Instance
           .newBuilder()
-          .setStatus("Running")
+          .setStatus(Status.RUNNING)
           .setMetadata(
             Metadata
               .newBuilder()
@@ -228,11 +229,11 @@ class GceRuntimeMonitorSpec
     }
 
     val res = for {
-      start <- nowInstant[IO]
+      start <- IO.realTimeInstant
       monitor = gceRuntimeMonitor(googleComputeService = computeService)
       savedRuntime <- IO(runtime.saveWithRuntimeConfig(gceRuntimeConfig))
       _ <- monitor.process(savedRuntime.id, RuntimeStatus.Creating).compile.drain //start monitoring process
-      afterMonitor <- nowInstant
+      afterMonitor <- IO.realTimeInstant
       status <- clusterQuery.getClusterStatus(savedRuntime.id).transaction
       error <- clusterErrorQuery.get(savedRuntime.id).transaction
     } yield {
@@ -241,7 +242,7 @@ class GceRuntimeMonitorSpec
       error.head.errorMessage shouldBe s"User startup script failed. See output in gs://staging_bucket/failed_userstartupscript_output.txt"
     }
 
-    res.unsafeRunSync
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   // process, Creating
@@ -260,8 +261,8 @@ class GceRuntimeMonitorSpec
         val runningInstance = readyInstance
 
         for {
-          now <- testTimer.clock.realTime(TimeUnit.MILLISECONDS)
-          res <- if (now - start < 5000)
+          now <- IO.realTimeInstant
+          res <- if (now.toEpochMilli - start < 5000)
             IO.pure(beforeInstance)
           else IO.pure(Some(runningInstance))
         } yield res
@@ -269,18 +270,18 @@ class GceRuntimeMonitorSpec
     }
 
     val res = for {
-      start <- nowInstant[IO]
+      start <- IO.realTimeInstant
       monitor = gceRuntimeMonitor(googleComputeService = computeService(start.toEpochMilli))
       savedRuntime <- IO(runtime.saveWithRuntimeConfig(gceRuntimeConfig))
       _ <- monitor.process(savedRuntime.id, RuntimeStatus.Creating).compile.drain //start monitoring process
-      afterMonitor <- nowInstant
+      afterMonitor <- IO.realTimeInstant
       status <- clusterQuery.getClusterStatus(savedRuntime.id).transaction
     } yield {
       (afterMonitor.toEpochMilli - start.toEpochMilli > 5000) shouldBe true // For 5 seconds, google is returning terminated no instance found
       status shouldBe Some(RuntimeStatus.Running)
     }
 
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   // process, Starting
@@ -295,11 +296,11 @@ class GceRuntimeMonitorSpec
       override def getInstance(project: GoogleProject, zone: ZoneName, instanceName: InstanceName)(
         implicit ev: Ask[IO, TraceId]
       ): IO[Option[Instance]] = {
-        val beforeInstance = Instance.newBuilder().setStatus("Stopping").build()
+        val beforeInstance = Instance.newBuilder().setStatus(Status.STOPPING).build()
 
         for {
-          now <- testTimer.clock.realTime(TimeUnit.MILLISECONDS)
-          res <- if (now - start < 5000)
+          now <- IO.realTimeInstant
+          res <- if (now.toEpochMilli - start < 5000)
             IO.pure(Some(beforeInstance))
           else IO.pure(Some(readyInstance))
         } yield res
@@ -307,18 +308,18 @@ class GceRuntimeMonitorSpec
     }
 
     val res = for {
-      start <- nowInstant[IO]
+      start <- IO.realTimeInstant
       monitor = gceRuntimeMonitor(googleComputeService = computeService(start.toEpochMilli))
       savedRuntime <- IO(runtime.saveWithRuntimeConfig(gceRuntimeConfig))
       _ <- monitor.process(savedRuntime.id, RuntimeStatus.Starting).compile.drain //start monitoring process
-      afterMonitor <- nowInstant
+      afterMonitor <- IO.realTimeInstant
       status <- clusterQuery.getClusterStatus(savedRuntime.id).transaction
     } yield {
       (afterMonitor.toEpochMilli - start.toEpochMilli > 5000) shouldBe true // For 5 seconds, google is returning terminated no instance found
       status shouldBe Some(RuntimeStatus.Running)
     }
 
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "transition gce runtime to Stopping if Starting times out" in isolatedDbTest {
@@ -326,12 +327,12 @@ class GceRuntimeMonitorSpec
       override def getInstance(project: GoogleProject, zone: ZoneName, instanceName: InstanceName)(
         implicit ev: Ask[IO, TraceId]
       ): IO[Option[Instance]] = {
-        val beforeInstance = Instance.newBuilder().setStatus("Provisioning").build()
-        val afterInstance = Instance.newBuilder().setStatus("Stopped").build()
+        val beforeInstance = Instance.newBuilder().setStatus(Status.PROVISIONING).build()
+        val afterInstance = Instance.newBuilder().setStatus(Status.STOPPED).build()
 
         for {
-          now <- testTimer.clock.realTime(TimeUnit.MILLISECONDS)
-          res <- if (now - start < 5000)
+          now <- IO.realTimeInstant
+          res <- if (now.toEpochMilli - start < 5000)
             IO.pure(Some(beforeInstance))
           else IO.pure(Some(afterInstance))
         } yield res
@@ -339,7 +340,7 @@ class GceRuntimeMonitorSpec
     }
 
     val res = for {
-      start <- nowInstant[IO]
+      start <- IO.realTimeInstant
       monitor = gceRuntimeMonitor(googleComputeService = computeService(start.toEpochMilli),
                                   monitorStatusTimeouts = Some(Map(RuntimeStatus.Starting -> 2.seconds)))
       runtime <- IO(makeCluster(0).copy(status = RuntimeStatus.Starting).saveWithRuntimeConfig(gceRuntimeConfig))
@@ -348,7 +349,7 @@ class GceRuntimeMonitorSpec
       } yield status.get shouldBe RuntimeStatus.Stopped
       _ <- withInfiniteStream(monitor.process(runtime.id, RuntimeStatus.Starting), assersions)
     } yield ()
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "terminate if instance is terminated after 5 seconds when trying to Starting one" in isolatedDbTest {
@@ -362,12 +363,12 @@ class GceRuntimeMonitorSpec
       override def getInstance(project: GoogleProject, zone: ZoneName, instanceName: InstanceName)(
         implicit ev: Ask[IO, TraceId]
       ): IO[Option[Instance]] = {
-        val beforeInstance = Instance.newBuilder().setStatus("STOPPING").build()
-        val terminatedInstance = Instance.newBuilder().setStatus("TERMINATED").build()
+        val beforeInstance = Instance.newBuilder().setStatus(Status.STOPPING).build()
+        val terminatedInstance = Instance.newBuilder().setStatus(Status.TERMINATED).build()
 
         for {
-          now <- testTimer.clock.realTime(TimeUnit.MILLISECONDS)
-          res <- if (now - start < 4000)
+          now <- IO.realTimeInstant
+          res <- if (now.toEpochMilli - start < 4000)
             IO.pure(Some(beforeInstance))
           else IO.pure(Some(terminatedInstance))
         } yield res
@@ -375,11 +376,11 @@ class GceRuntimeMonitorSpec
     }
 
     val res = for {
-      start <- nowInstant[IO]
+      start <- IO.realTimeInstant
       monitor = gceRuntimeMonitor(googleComputeService = computeService(start.toEpochMilli))
       savedRuntime <- IO(runtime.saveWithRuntimeConfig(gceRuntimeConfig))
       _ <- monitor.process(savedRuntime.id, RuntimeStatus.Starting).compile.drain //start monitoring process
-      afterMonitor <- nowInstant
+      afterMonitor <- IO.realTimeInstant
       status <- clusterQuery.getClusterStatus(savedRuntime.id).transaction
     } yield {
       val delay = afterMonitor.toEpochMilli - start.toEpochMilli
@@ -388,7 +389,7 @@ class GceRuntimeMonitorSpec
       status shouldBe Some(RuntimeStatus.Stopped)
     }
 
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "fail Starting if user startup script failed" in isolatedDbTest {
@@ -408,7 +409,7 @@ class GceRuntimeMonitorSpec
       ): IO[Option[Instance]] = {
         val runningInstance = Instance
           .newBuilder()
-          .setStatus("Running")
+          .setStatus(Status.RUNNING)
           .setMetadata(
             Metadata
               .newBuilder()
@@ -427,11 +428,11 @@ class GceRuntimeMonitorSpec
     }
 
     val res = for {
-      start <- nowInstant[IO]
+      start <- IO.realTimeInstant
       monitor = gceRuntimeMonitor(googleComputeService = computeService)
       savedRuntime <- IO(runtime.saveWithRuntimeConfig(gceRuntimeConfig))
       _ <- monitor.process(savedRuntime.id, RuntimeStatus.Starting).compile.drain //start monitoring process
-      afterMonitor <- nowInstant
+      afterMonitor <- IO.realTimeInstant
       status <- clusterQuery.getClusterStatus(savedRuntime.id).transaction
       error <- clusterErrorQuery.get(savedRuntime.id).transaction
     } yield {
@@ -440,7 +441,7 @@ class GceRuntimeMonitorSpec
       error.head.errorMessage shouldBe s"User startup script failed. See output in gs://staging_bucket/failed_userstartupscript_output.txt"
     }
 
-    res.unsafeRunSync
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   // process
@@ -454,16 +455,16 @@ class GceRuntimeMonitorSpec
     val monitor = gceRuntimeMonitor()
     val savedRuntime = runtime.saveWithRuntimeConfig(gceRuntimeConfig)
     val res = for {
-      now <- nowInstant[IO]
+      now <- IO.realTimeInstant
       _ <- monitor.process(savedRuntime.id, RuntimeStatus.Creating).compile.drain //start monitoring process
-      afterMonitor <- nowInstant
+      afterMonitor <- IO.realTimeInstant
       status <- clusterQuery.getClusterStatus(savedRuntime.id).transaction
     } yield {
       (afterMonitor.toEpochMilli - now.toEpochMilli < 6000) shouldBe true // initial delay in tests is 2 seconds and 1 second polling interval, the stream should terminate after initial check
       status shouldBe (Some(RuntimeStatus.Stopped))
     }
 
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   // process, Stopping
@@ -477,16 +478,16 @@ class GceRuntimeMonitorSpec
     val monitor = gceRuntimeMonitor()
     val savedRuntime = runtime.saveWithRuntimeConfig(gceRuntimeConfig)
     val res = for {
-      now <- nowInstant[IO]
+      now <- IO.realTimeInstant
       _ <- monitor.process(savedRuntime.id, RuntimeStatus.Stopping).compile.drain //start monitoring process
-      afterMonitor <- nowInstant
+      afterMonitor <- IO.realTimeInstant
       status <- clusterQuery.getClusterStatus(savedRuntime.id).transaction
     } yield {
       (afterMonitor.toEpochMilli - now.toEpochMilli < 5000) shouldBe true // initial delay in tests is 2 seconds and 1 second polling interval, the stream should terminate after initial check
       status shouldBe (Some(RuntimeStatus.Stopping))
     }
 
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   // process, Stopping
@@ -501,23 +502,23 @@ class GceRuntimeMonitorSpec
       override def getInstance(project: GoogleProject, zone: ZoneName, instanceName: InstanceName)(
         implicit ev: Ask[IO, TraceId]
       ): IO[Option[Instance]] = {
-        val instance = Instance.newBuilder().setStatus("Terminated").build()
+        val instance = Instance.newBuilder().setStatus(Status.TERMINATED).build()
         IO.pure(Some(instance))
       }
     }
     val monitor = gceRuntimeMonitor(googleComputeService = computeService)
     val savedRuntime = runtime.saveWithRuntimeConfig(gceRuntimeConfig)
     val res = for {
-      now <- nowInstant[IO]
+      now <- IO.realTimeInstant
       _ <- monitor.process(savedRuntime.id, RuntimeStatus.Stopping).compile.drain //start monitoring process
-      afterMonitor <- nowInstant
+      afterMonitor <- IO.realTimeInstant
       status <- clusterQuery.getClusterStatus(savedRuntime.id).transaction
     } yield {
       (afterMonitor.toEpochMilli - now.toEpochMilli < 5000) shouldBe true // initial delay in tests is 2 seconds and 1 second polling interval, the stream should terminate after initial check
       status shouldBe (Some(RuntimeStatus.Stopped))
     }
 
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   // process, Stopping
@@ -529,21 +530,21 @@ class GceRuntimeMonitorSpec
     )
 
     val res = for {
-      start <- nowInstant[IO]
+      start <- IO.realTimeInstant
       monitor = gceRuntimeMonitor(
         googleComputeService =
           computeService(start.toEpochMilli, Some(GceInstanceStatus.Running), Some(GceInstanceStatus.Terminated))
       )
       savedRuntime <- IO(runtime.saveWithRuntimeConfig(gceRuntimeConfig))
       _ <- monitor.process(savedRuntime.id, RuntimeStatus.Stopping).compile.drain //start monitoring process
-      afterMonitor <- nowInstant
+      afterMonitor <- IO.realTimeInstant
       status <- clusterQuery.getClusterStatus(savedRuntime.id).transaction
     } yield {
       (afterMonitor.toEpochMilli - start.toEpochMilli > 5000) shouldBe true // initial delay in tests is 2 seconds and 1 second polling interval, the stream should terminate after a few more checks
       status shouldBe Some(RuntimeStatus.Stopped)
     }
 
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   // process, Deleting
@@ -557,16 +558,16 @@ class GceRuntimeMonitorSpec
     val monitor = gceRuntimeMonitor()
     val savedRuntime = runtime.saveWithRuntimeConfig(gceRuntimeConfig)
     val res = for {
-      now <- nowInstant[IO]
+      now <- IO.realTimeInstant
       _ <- monitor.process(savedRuntime.id, RuntimeStatus.Deleting).compile.drain //start monitoring process
-      afterMonitor <- nowInstant
+      afterMonitor <- IO.realTimeInstant
       status <- clusterQuery.getClusterStatus(savedRuntime.id).transaction
     } yield {
       (afterMonitor.toEpochMilli - now.toEpochMilli < 5000) shouldBe true // initial delay in tests is 2 seconds and 1 second polling interval, the stream should terminate after initial check
       status shouldBe (Some(RuntimeStatus.Deleted))
     }
 
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   // process, Deleting
@@ -581,11 +582,11 @@ class GceRuntimeMonitorSpec
       override def getInstance(project: GoogleProject, zone: ZoneName, instanceName: InstanceName)(
         implicit ev: Ask[IO, TraceId]
       ): IO[Option[Instance]] = {
-        val runningInstance = Instance.newBuilder().setStatus("Running").build()
+        val runningInstance = Instance.newBuilder().setStatus(Status.RUNNING).build()
 
         for {
-          now <- testTimer.clock.realTime(TimeUnit.MILLISECONDS)
-          res <- if (now - start < 5000)
+          now <- IO.realTimeInstant
+          res <- if (now.toEpochMilli - start < 5000)
             IO.pure(Some(runningInstance))
           else IO.pure(None)
         } yield res
@@ -593,11 +594,11 @@ class GceRuntimeMonitorSpec
     }
 
     val res = for {
-      start <- nowInstant[IO]
+      start <- IO.realTimeInstant
       monitor = gceRuntimeMonitor(googleComputeService = computeService(start.toEpochMilli))
       savedRuntime <- IO(runtime.saveWithRuntimeConfig(gceRuntimeConfig))
       _ <- monitor.process(savedRuntime.id, RuntimeStatus.Deleting).compile.drain //start monitoring process
-      afterMonitor <- nowInstant
+      afterMonitor <- IO.realTimeInstant
 
       status <- clusterQuery.getClusterStatus(savedRuntime.id).transaction
     } yield {
@@ -605,7 +606,7 @@ class GceRuntimeMonitorSpec
       status shouldBe Some(RuntimeStatus.Deleted)
     }
 
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   //pollCheck, Deleting
@@ -632,11 +633,17 @@ class GceRuntimeMonitorSpec
       r.left.value.getMessage shouldBe "Monitoring Deleted with pollOperation is not supported"
     }
 
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "set runtime to PreDeleting if Stopping is interrupted by Deleting" in isolatedDbTest {
-    val op = Operation.newBuilder().setId("op").setName("opName").setTargetId("target").setStatus("PENDING").build()
+    val op = Operation
+      .newBuilder()
+      .setId(123)
+      .setName("opName")
+      .setTargetId(234)
+      .setStatus(com.google.cloud.compute.v1.Operation.Status.PENDING)
+      .build()
     val res = for {
       runtime <- IO(makeCluster(1).copy(status = RuntimeStatus.Stopping).saveWithRuntimeConfig(gceRuntimeConfig))
       pollOperation = new MockComputePollOperation {
@@ -661,7 +668,7 @@ class GceRuntimeMonitorSpec
       status shouldBe (Some(RuntimeStatus.PreDeleting))
     }
 
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "monitor Deleting successfully" in {
@@ -671,18 +678,18 @@ class GceRuntimeMonitorSpec
       status = RuntimeStatus.Deleting
     )
 
-    val initialOp = com.google.cloud.compute.v1.Operation.newBuilder().setStatus("PENDING").build()
+    val initialOp = com.google.cloud.compute.v1.Operation.newBuilder().setStatus(Operation.Status.PENDING).build()
 
     def computePollOperation(start: Long): ComputePollOperation[IO] = new MockComputePollOperation {
       override def getGlobalOperation(project: GoogleProject, operationName: OperationName)(
         implicit ev: Ask[IO, TraceId]
       ): IO[Operation] = {
-        val pendingOp = com.google.cloud.compute.v1.Operation.newBuilder().setStatus("PENDING").build()
-        val afterOperation = com.google.cloud.compute.v1.Operation.newBuilder().setStatus("DONE").build()
+        val pendingOp = com.google.cloud.compute.v1.Operation.newBuilder().setStatus(Operation.Status.PENDING).build()
+        val afterOperation = com.google.cloud.compute.v1.Operation.newBuilder().setStatus(Operation.Status.DONE).build()
 
         for {
-          now <- testTimer.clock.realTime(TimeUnit.MILLISECONDS)
-          res <- if (now - start < 4000)
+          now <- IO.realTimeInstant
+          res <- if (now.toEpochMilli - start < 4000)
             IO.pure(pendingOp)
           else IO.pure(afterOperation)
         } yield res
@@ -690,7 +697,7 @@ class GceRuntimeMonitorSpec
     }
 
     val res = for {
-      start <- nowInstant[IO]
+      start <- IO.realTimeInstant
       monitor = gceRuntimeMonitor(computePollOperation = computePollOperation(start.toEpochMilli))
       savedRuntime <- IO(runtime.saveWithRuntimeConfig(gceRuntimeConfig))
       _ <- monitor.pollCheck(
@@ -699,14 +706,14 @@ class GceRuntimeMonitorSpec
         initialOp,
         RuntimeStatus.Deleting
       ) //start monitoring process
-      afterMonitor <- nowInstant
+      afterMonitor <- IO.realTimeInstant
       status <- clusterQuery.getClusterStatus(savedRuntime.id).transaction
     } yield {
       (afterMonitor.toEpochMilli - start.toEpochMilli > 4000) shouldBe true // initial delay in tests is 2 seconds and 1 second polling interval, the stream should terminate after a few more checks
       status shouldBe Some(RuntimeStatus.Deleted)
     }
 
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   //pollCheck Deleting
@@ -717,7 +724,7 @@ class GceRuntimeMonitorSpec
       status = RuntimeStatus.Deleting
     )
 
-    val op = com.google.cloud.compute.v1.Operation.newBuilder().setStatus("PENDING").build()
+    val op = com.google.cloud.compute.v1.Operation.newBuilder().setStatus(Operation.Status.PENDING).build()
 
     val pollOperation: ComputePollOperation[IO] = new MockComputePollOperation {
       override def getGlobalOperation(project: GoogleProject, operationName: OperationName)(
@@ -726,7 +733,7 @@ class GceRuntimeMonitorSpec
     }
 
     val res = for {
-      start <- nowInstant[IO]
+      start <- IO.realTimeInstant
       monitor = gceRuntimeMonitor(computePollOperation = pollOperation)
       savedRuntime <- IO(runtime.saveWithRuntimeConfig(gceRuntimeConfig))
       _ <- monitor.pollCheck(
@@ -735,7 +742,7 @@ class GceRuntimeMonitorSpec
         op,
         RuntimeStatus.Deleting
       ) //start monitoring process
-      afterMonitor <- nowInstant
+      afterMonitor <- IO.realTimeInstant
       status <- clusterQuery.getClusterStatus(savedRuntime.id).transaction
       error <- clusterErrorQuery.get(savedRuntime.id).transaction
     } yield {
@@ -744,7 +751,7 @@ class GceRuntimeMonitorSpec
       error.head.errorMessage shouldBe s"Deleting dsp-leo-test/clustername2 fail to complete in a timely manner"
     }
 
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   implicit val toolDao: RuntimeContainerServiceType => ToolDAO[IO, RuntimeContainerServiceType] = _ => MockToolDAO(true)
@@ -752,7 +759,7 @@ class GceRuntimeMonitorSpec
   def gceRuntimeMonitor(
     googleComputeService: GoogleComputeService[IO] = FakeGoogleComputeService,
     computePollOperation: ComputePollOperation[IO] = new MockComputePollOperation,
-    publisherQueue: fs2.concurrent.Queue[IO, LeoPubsubMessage] = QueueFactory.makePublisherQueue(),
+    publisherQueue: Queue[IO, LeoPubsubMessage] = QueueFactory.makePublisherQueue(),
     monitorStatusTimeouts: Option[Map[RuntimeStatus, FiniteDuration]] = None
   ): GceRuntimeMonitor[IO] = {
     val config =
@@ -776,12 +783,12 @@ class GceRuntimeMonitorSpec
     override def getInstance(project: GoogleProject, zone: ZoneName, instanceName: InstanceName)(
       implicit ev: Ask[IO, TraceId]
     ): IO[Option[Instance]] = {
-      val beforeInstance = beforeStatus.map(s => Instance.newBuilder().setStatus(s.toString).build())
-      val afterInstance = afterStatus.map(s => Instance.newBuilder().setStatus(s.toString).build())
+      val beforeInstance = beforeStatus.map(s => Instance.newBuilder().setStatus(s.instanceStatus).build())
+      val afterInstance = afterStatus.map(s => Instance.newBuilder().setStatus(s.instanceStatus).build())
 
       for {
-        now <- testTimer.clock.realTime(TimeUnit.MILLISECONDS)
-        res <- if (now - start < 5000)
+        now <- IO.realTimeInstant
+        res <- if (now.toEpochMilli - start < 5000)
           IO.pure(beforeInstance)
         else IO.pure(afterInstance)
       } yield res

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriberSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriberSpec.scala
@@ -2,18 +2,18 @@ package org.broadinstitute.dsde.workbench.leonardo
 package monitor
 
 import java.time.Instant
-
 import akka.actor.ActorSystem
 import akka.testkit.TestKit
 import cats.data.Kleisli
-import cats.effect.IO
+import cats.effect.{IO, Resource}
 import cats.mtl.Ask
 import cats.syntax.all._
 import com.google.cloud.compute.v1.{Disk, Operation}
 import com.google.cloud.pubsub.v1.AckReplyConsumer
 import com.google.protobuf.Timestamp
 import fs2.Stream
-import fs2.concurrent.InspectableQueue
+import cats.effect.std.Queue
+import com.google.cloud.compute.v1.Operation.Status
 import org.broadinstitute.dsde.workbench.google.GoogleStorageDAO
 import org.broadinstitute.dsde.workbench.google.mock._
 import org.broadinstitute.dsde.workbench.google2.KubernetesModels.PodStatus
@@ -23,7 +23,8 @@ import org.broadinstitute.dsde.workbench.google2.mock.{
   FakeGoogleDataprocService,
   FakeGoogleResourceService,
   MockComputePollOperation,
-  MockGKEService
+  MockGKEService,
+  MockGoogleDiskService
 }
 import org.broadinstitute.dsde.workbench.google2.{
   ComputePollOperation,
@@ -33,7 +34,6 @@ import org.broadinstitute.dsde.workbench.google2.{
   GoogleDiskService,
   KubernetesModels,
   MachineTypeName,
-  MockGoogleDiskService,
   OperationName,
   RegionName,
   ZoneName
@@ -109,7 +109,7 @@ class LeoPubsubMessageSubscriberSpec
   val bucketHelperConfig =
     BucketHelperConfig(imageConfig, welderConfig, proxyConfig, clusterFilesConfig)
   val bucketHelper =
-    new BucketHelper[IO](bucketHelperConfig, FakeGoogleStorageService, serviceAccountProvider, blocker)
+    new BucketHelper[IO](bucketHelperConfig, FakeGoogleStorageService, serviceAccountProvider)
 
   val vpcInterp =
     new VPCInterpreter[IO](Config.vpcInterpreterConfig,
@@ -126,15 +126,13 @@ class LeoPubsubMessageSubscriberSpec
                                                    mockGoogleDirectoryDAO,
                                                    iamDAO,
                                                    resourceService,
-                                                   mockWelderDAO,
-                                                   blocker)
+                                                   mockWelderDAO)
   val gceInterp = new GceInterpreter[IO](Config.gceInterpreterConfig,
                                          bucketHelper,
                                          vpcInterp,
                                          FakeGoogleComputeService,
                                          MockGoogleDiskService,
-                                         mockWelderDAO,
-                                         blocker)
+                                         mockWelderDAO)
 
   val runningCluster = makeCluster(1).copy(
     serviceAccount = serviceAccount,
@@ -150,29 +148,31 @@ class LeoPubsubMessageSubscriberSpec
   )
 
   it should "handle CreateRuntimeMessage and create cluster" in isolatedDbTest {
-    val leoSubscriber = makeLeoSubscriber()
-
-    val res = for {
-      runtime <- IO(
-        makeCluster(1)
-          .copy(asyncRuntimeFields = None, status = RuntimeStatus.Creating, serviceAccount = serviceAccount)
-          .save()
-      )
-      tr <- traceId.ask[TraceId]
-      gceRuntimeConfigRequest = LeoLenses.runtimeConfigPrism.getOption(gceRuntimeConfig).get
-      _ <- leoSubscriber.messageResponder(CreateRuntimeMessage.fromRuntime(runtime, gceRuntimeConfigRequest, Some(tr)))
-      updatedRuntime <- clusterQuery.getClusterById(runtime.id).transaction
-    } yield {
-      updatedRuntime shouldBe defined
-      updatedRuntime.get.asyncRuntimeFields shouldBe defined
-      updatedRuntime.get.asyncRuntimeFields.get.stagingBucket.value should startWith("leostaging")
-      updatedRuntime.get.asyncRuntimeFields.get.hostIp shouldBe None
-      updatedRuntime.get.asyncRuntimeFields.get.operationName.value shouldBe "opName"
-      updatedRuntime.get.asyncRuntimeFields.get.googleId.value shouldBe "target"
-      updatedRuntime.get.runtimeImages.map(_.imageType) should contain(BootSource)
+    val res = makeLeoSubscriber().use { leoSubscriber =>
+      for {
+        runtime <- IO(
+          makeCluster(1)
+            .copy(asyncRuntimeFields = None, status = RuntimeStatus.Creating, serviceAccount = serviceAccount)
+            .save()
+        )
+        tr <- traceId.ask[TraceId]
+        gceRuntimeConfigRequest = LeoLenses.runtimeConfigPrism.getOption(gceRuntimeConfig).get
+        _ <- leoSubscriber.messageResponder(
+          CreateRuntimeMessage.fromRuntime(runtime, gceRuntimeConfigRequest, Some(tr))
+        )
+        updatedRuntime <- clusterQuery.getClusterById(runtime.id).transaction
+      } yield {
+        updatedRuntime shouldBe defined
+        updatedRuntime.get.asyncRuntimeFields shouldBe defined
+        updatedRuntime.get.asyncRuntimeFields.get.stagingBucket.value should startWith("leostaging")
+        updatedRuntime.get.asyncRuntimeFields.get.hostIp shouldBe None
+        updatedRuntime.get.asyncRuntimeFields.get.operationName.value shouldBe "opName"
+        updatedRuntime.get.asyncRuntimeFields.get.googleId.value shouldBe "258165385"
+        updatedRuntime.get.runtimeImages.map(_.imageType) should contain(BootSource)
+      }
     }
 
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   /**
@@ -186,202 +186,213 @@ class LeoPubsubMessageSubscriberSpec
         implicit ev: Ask[IO, AppContext]
       ): IO[Option[CreateGoogleRuntimeResponse]] = IO.pure(None)
     }
-    val leoSubscriber = makeLeoSubscriber(gceRuntimeAlgebra = runtimeAlgebra)
 
     val asyncFields = makeAsyncRuntimeFields(1)
-    val res = for {
-      runtime <- IO(
-        makeCluster(1)
-          .copy(status = RuntimeStatus.Creating,
-                serviceAccount = serviceAccount,
-                asyncRuntimeFields = Some(asyncFields))
-          .save()
-      )
-      tr <- traceId.ask[TraceId]
-      gceRuntimeConfigRequest = LeoLenses.runtimeConfigPrism.getOption(gceRuntimeConfig).get
-      _ <- leoSubscriber.messageResponder(CreateRuntimeMessage.fromRuntime(runtime, gceRuntimeConfigRequest, Some(tr)))
-      updatedRuntime <- clusterQuery.getClusterById(runtime.id).transaction
-    } yield {
-      updatedRuntime shouldBe defined
-      updatedRuntime.get.asyncRuntimeFields shouldBe Some(asyncFields)
-      updatedRuntime.get.runtimeImages shouldBe runtime.runtimeImages
+
+    val res = makeLeoSubscriber(gceRuntimeAlgebra = runtimeAlgebra).use { leoSubscriber =>
+      for {
+        runtime <- IO(
+          makeCluster(1)
+            .copy(status = RuntimeStatus.Creating,
+                  serviceAccount = serviceAccount,
+                  asyncRuntimeFields = Some(asyncFields))
+            .save()
+        )
+        tr <- traceId.ask[TraceId]
+        gceRuntimeConfigRequest = LeoLenses.runtimeConfigPrism.getOption(gceRuntimeConfig).get
+        _ <- leoSubscriber.messageResponder(
+          CreateRuntimeMessage.fromRuntime(runtime, gceRuntimeConfigRequest, Some(tr))
+        )
+        updatedRuntime <- clusterQuery.getClusterById(runtime.id).transaction
+      } yield {
+        updatedRuntime shouldBe defined
+        updatedRuntime.get.asyncRuntimeFields shouldBe Some(asyncFields)
+        updatedRuntime.get.runtimeImages shouldBe runtime.runtimeImages
+      }
     }
 
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "handle DeleteRuntimeMessage and delete cluster" in isolatedDbTest {
-    val res = for {
-      runtime <- IO(makeCluster(1).copy(status = RuntimeStatus.Deleting).saveWithRuntimeConfig(gceRuntimeConfig))
-      tr <- traceId.ask[TraceId]
-      monitor = new MockRuntimeMonitor {
-        override def pollCheck(a: CloudService)(
-          googleProject: GoogleProject,
-          runtimeAndRuntimeConfig: RuntimeAndRuntimeConfig,
-          operation: com.google.cloud.compute.v1.Operation,
-          action: RuntimeStatus
-        )(implicit ev: Ask[IO, TraceId]): IO[Unit] =
-          clusterQuery.completeDeletion(runtime.id, Instant.now()).transaction
-      }
-      queue = InspectableQueue.bounded[IO, Task[IO]](10).unsafeRunSync()
-      leoSubscriber = makeLeoSubscriber(runtimeMonitor = monitor, asyncTaskQueue = queue)
-      asyncTaskProcessor = AsyncTaskProcessor(AsyncTaskProcessor.Config(10, 10), queue)
+    val queue = Queue.bounded[IO, Task[IO]](10).unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    val runtime = makeCluster(1).copy(status = RuntimeStatus.Deleting).saveWithRuntimeConfig(gceRuntimeConfig)
+    val monitor = new MockRuntimeMonitor {
+      override def pollCheck(a: CloudService)(
+        googleProject: GoogleProject,
+        runtimeAndRuntimeConfig: RuntimeAndRuntimeConfig,
+        operation: com.google.cloud.compute.v1.Operation,
+        action: RuntimeStatus
+      )(implicit ev: Ask[IO, TraceId]): IO[Unit] =
+        clusterQuery.completeDeletion(runtime.id, Instant.now()).transaction
+    }
+    val res = makeLeoSubscriber(runtimeMonitor = monitor, asyncTaskQueue = queue).use { leoSubscriber =>
+      for {
+        tr <- traceId.ask[TraceId]
+        asyncTaskProcessor = AsyncTaskProcessor(AsyncTaskProcessor.Config(10, 10), queue)
 
-      _ <- leoSubscriber.messageResponder(DeleteRuntimeMessage(runtime.id, None, Some(tr)))
-      _ <- withInfiniteStream(
-        asyncTaskProcessor.process,
-        clusterQuery
-          .getClusterStatus(runtime.id)
-          .transaction
-          .map(status => status shouldBe (Some(RuntimeStatus.Deleted)))
-      )
-    } yield ()
+        _ <- leoSubscriber.messageResponder(DeleteRuntimeMessage(runtime.id, None, Some(tr)))
+        _ <- withInfiniteStream(
+          asyncTaskProcessor.process,
+          clusterQuery
+            .getClusterStatus(runtime.id)
+            .transaction
+            .map(status => status shouldBe (Some(RuntimeStatus.Deleted)))
+        )
+      } yield ()
+    }
 
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "delete disk when handling DeleteRuntimeMessage when autoDeleteDisks is set" in isolatedDbTest {
-    val queue = InspectableQueue.bounded[IO, Task[IO]](10).unsafeRunSync()
-    val leoSubscriber = makeLeoSubscriber(asyncTaskQueue = queue)
+    val queue = Queue.bounded[IO, Task[IO]](10).unsafeRunSync()(cats.effect.unsafe.implicits.global)
     val asyncTaskProcessor = AsyncTaskProcessor(AsyncTaskProcessor.Config(10, 10), queue)
 
-    val res = for {
-      disk <- makePersistentDisk(None, Some(FormattedBy.GCE)).save()
-      runtimeConfig = RuntimeConfig.GceWithPdConfig(MachineTypeName("n1-standard-4"),
-                                                    bootDiskSize = DiskSize(50),
-                                                    persistentDiskId = Some(disk.id),
-                                                    zone = ZoneName("us-central1-a"),
-                                                    gpuConfig = None)
+    val res = makeLeoSubscriber(asyncTaskQueue = queue).use { leoSubscriber =>
+      for {
+        disk <- makePersistentDisk(None, Some(FormattedBy.GCE)).save()
+        runtimeConfig = RuntimeConfig.GceWithPdConfig(MachineTypeName("n1-standard-4"),
+                                                      bootDiskSize = DiskSize(50),
+                                                      persistentDiskId = Some(disk.id),
+                                                      zone = ZoneName("us-central1-a"),
+                                                      gpuConfig = None)
 
-      runtime <- IO(makeCluster(1).copy(status = RuntimeStatus.Deleting).saveWithRuntimeConfig(runtimeConfig))
-      tr <- traceId.ask[TraceId]
-      _ <- leoSubscriber.messageResponder(
-        DeleteRuntimeMessage(runtime.id, Some(disk.id), Some(tr))
-      )
-      _ <- withInfiniteStream(
-        asyncTaskProcessor.process,
-        persistentDiskQuery.getStatus(disk.id).transaction.map(status => status shouldBe (Some(DiskStatus.Deleted)))
-      )
-    } yield ()
+        runtime <- IO(makeCluster(1).copy(status = RuntimeStatus.Deleting).saveWithRuntimeConfig(runtimeConfig))
+        tr <- traceId.ask[TraceId]
+        _ <- leoSubscriber.messageResponder(
+          DeleteRuntimeMessage(runtime.id, Some(disk.id), Some(tr))
+        )
+        _ <- withInfiniteStream(
+          asyncTaskProcessor.process,
+          persistentDiskQuery
+            .getStatus(disk.id)
+            .transaction
+            .map(status => status shouldBe (Some(DiskStatus.Deleted)))
+        )
+      } yield ()
+    }
 
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "persist delete disk error when if fail to delete disk" in isolatedDbTest {
-    val queue = InspectableQueue.bounded[IO, Task[IO]](10).unsafeRunSync()
+    val queue = Queue.bounded[IO, Task[IO]](10).unsafeRunSync()(cats.effect.unsafe.implicits.global)
     val pollOperation = new MockComputePollOperation {
       override def getZoneOperation(project: GoogleProject, zoneName: ZoneName, operationName: OperationName)(
         implicit ev: Ask[IO, TraceId]
       ): IO[Operation] = IO.pure(
-        Operation.newBuilder().setId("op").setName("opName").setTargetId("target").setStatus("PENDING").build()
+        Operation.newBuilder().setId(123).setName("opName").setTargetId(345).setStatus(Status.PENDING).build()
       )
     }
-    val leoSubscriber = makeLeoSubscriber(asyncTaskQueue = queue, computePollOperation = pollOperation)
     val asyncTaskProcessor = AsyncTaskProcessor(AsyncTaskProcessor.Config(10, 10), queue)
 
-    val res = for {
-      disk <- makePersistentDisk(None, Some(FormattedBy.GCE)).save()
-      runtimeConfig = RuntimeConfig.GceWithPdConfig(MachineTypeName("n1-standard-4"),
-                                                    bootDiskSize = DiskSize(50),
-                                                    persistentDiskId = Some(disk.id),
-                                                    zone = ZoneName("us-cetnral1-a"),
-                                                    gpuConfig = None)
+    val res = makeLeoSubscriber(asyncTaskQueue = queue, computePollOperation = pollOperation).use { leoSubscriber =>
+      for {
+        disk <- makePersistentDisk(None, Some(FormattedBy.GCE)).save()
+        runtimeConfig = RuntimeConfig.GceWithPdConfig(MachineTypeName("n1-standard-4"),
+                                                      bootDiskSize = DiskSize(50),
+                                                      persistentDiskId = Some(disk.id),
+                                                      zone = ZoneName("us-cetnral1-a"),
+                                                      gpuConfig = None)
 
-      runtime <- IO(makeCluster(1).copy(status = RuntimeStatus.Deleting).saveWithRuntimeConfig(runtimeConfig))
-      tr <- traceId.ask[TraceId]
-      _ <- leoSubscriber.messageResponder(DeleteRuntimeMessage(runtime.id, Some(disk.id), Some(tr)))
-      _ <- withInfiniteStream(
-        asyncTaskProcessor.process,
-        clusterErrorQuery.get(runtime.id).transaction.map { error =>
-          val dummyNow = Instant.now()
-          error.head.copy(timestamp = dummyNow) shouldBe RuntimeError(s"Fail to delete ${disk.name} in a timely manner",
-                                                                      None,
-                                                                      dummyNow)
-        }
-      )
-    } yield ()
-
-    res.unsafeRunSync()
+        runtime <- IO(makeCluster(1).copy(status = RuntimeStatus.Deleting).saveWithRuntimeConfig(runtimeConfig))
+        tr <- traceId.ask[TraceId]
+        _ <- leoSubscriber.messageResponder(DeleteRuntimeMessage(runtime.id, Some(disk.id), Some(tr)))
+        _ <- withInfiniteStream(
+          asyncTaskProcessor.process,
+          clusterErrorQuery.get(runtime.id).transaction.map { error =>
+            val dummyNow = Instant.now()
+            error.head.copy(timestamp = dummyNow) shouldBe RuntimeError(
+              s"Fail to delete ${disk.name} in a timely manner",
+              None,
+              dummyNow
+            )
+          }
+        )
+      } yield ()
+    }
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "not handle DeleteRuntimeMessage when cluster is not in Deleting status" in isolatedDbTest {
-    val leoSubscriber = makeLeoSubscriber()
-
-    val res = for {
-      runtime <- IO(makeCluster(1).copy(status = RuntimeStatus.Running).saveWithRuntimeConfig(gceRuntimeConfig))
-      tr <- traceId.ask[TraceId]
-      message = DeleteRuntimeMessage(runtime.id, None, Some(tr))
-      attempt <- leoSubscriber.messageResponder(message).attempt
-    } yield {
-      attempt shouldBe Left(ClusterInvalidState(runtime.id, runtime.projectNameString, runtime, message))
+    val res = makeLeoSubscriber().use { leoSubscriber =>
+      for {
+        runtime <- IO(makeCluster(1).copy(status = RuntimeStatus.Running).saveWithRuntimeConfig(gceRuntimeConfig))
+        tr <- traceId.ask[TraceId]
+        message = DeleteRuntimeMessage(runtime.id, None, Some(tr))
+        attempt <- leoSubscriber.messageResponder(message).attempt
+      } yield {
+        attempt shouldBe Left(ClusterInvalidState(runtime.id, runtime.projectNameString, runtime, message))
+      }
     }
 
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "handle StopRuntimeMessage and stop cluster" in isolatedDbTest {
-    val leoSubscriber = makeLeoSubscriber()
+    val res = makeLeoSubscriber().use { leoSubscriber =>
+      for {
+        runtime <- IO(makeCluster(1).copy(status = RuntimeStatus.Stopping).saveWithRuntimeConfig(gceRuntimeConfig))
+        tr <- traceId.ask[TraceId]
 
-    val res = for {
-      runtime <- IO(makeCluster(1).copy(status = RuntimeStatus.Stopping).saveWithRuntimeConfig(gceRuntimeConfig))
-      tr <- traceId.ask[TraceId]
-
-      _ <- leoSubscriber.messageResponder(StopRuntimeMessage(runtime.id, Some(tr)))
-      updatedRuntime <- clusterQuery.getClusterById(runtime.id).transaction
-    } yield {
-      updatedRuntime shouldBe defined
-      updatedRuntime.get.status shouldBe RuntimeStatus.Stopping
+        _ <- leoSubscriber.messageResponder(StopRuntimeMessage(runtime.id, Some(tr)))
+        updatedRuntime <- clusterQuery.getClusterById(runtime.id).transaction
+      } yield {
+        updatedRuntime shouldBe defined
+        updatedRuntime.get.status shouldBe RuntimeStatus.Stopping
+      }
     }
 
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "not handle StopRuntimeMessage when cluster is not in Stopping status" in isolatedDbTest {
-    val leoSubscriber = makeLeoSubscriber()
-
-    val res = for {
-      runtime <- IO(makeCluster(1).copy(status = RuntimeStatus.Running).saveWithRuntimeConfig(gceRuntimeConfig))
-      tr <- traceId.ask[TraceId]
-      message = StopRuntimeMessage(runtime.id, Some(tr))
-      attempt <- leoSubscriber.messageResponder(message).attempt
-    } yield {
-      attempt shouldBe Left(ClusterInvalidState(runtime.id, runtime.projectNameString, runtime, message))
+    val res = makeLeoSubscriber().use { leoSubscriber =>
+      for {
+        runtime <- IO(makeCluster(1).copy(status = RuntimeStatus.Running).saveWithRuntimeConfig(gceRuntimeConfig))
+        tr <- traceId.ask[TraceId]
+        message = StopRuntimeMessage(runtime.id, Some(tr))
+        attempt <- leoSubscriber.messageResponder(message).attempt
+      } yield {
+        attempt shouldBe Left(ClusterInvalidState(runtime.id, runtime.projectNameString, runtime, message))
+      }
     }
 
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "handle StartRuntimeMessage and start cluster" in isolatedDbTest {
-    val leoSubscriber = makeLeoSubscriber()
+    val res = makeLeoSubscriber().use { leoSubscriber =>
+      for {
+        now <- IO(Instant.now)
+        runtime <- IO(makeCluster(1).copy(status = RuntimeStatus.Starting).saveWithRuntimeConfig(gceRuntimeConfig))
+        tr <- traceId.ask[TraceId]
 
-    val res = for {
-      now <- IO(Instant.now)
-      runtime <- IO(makeCluster(1).copy(status = RuntimeStatus.Starting).saveWithRuntimeConfig(gceRuntimeConfig))
-      tr <- traceId.ask[TraceId]
-
-      _ <- leoSubscriber.messageResponder(StartRuntimeMessage(runtime.id, Some(tr)))
-      updatedRuntime <- clusterQuery.getClusterById(runtime.id).transaction
-    } yield {
-      updatedRuntime shouldBe defined
-      updatedRuntime.get.status shouldBe RuntimeStatus.Starting
+        _ <- leoSubscriber.messageResponder(StartRuntimeMessage(runtime.id, Some(tr)))
+        updatedRuntime <- clusterQuery.getClusterById(runtime.id).transaction
+      } yield {
+        updatedRuntime shouldBe defined
+        updatedRuntime.get.status shouldBe RuntimeStatus.Starting
+      }
     }
 
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "not handle StartRuntimeMessage when cluster is not in Starting status" in isolatedDbTest {
-    val leoSubscriber = makeLeoSubscriber()
-
-    val res = for {
-      runtime <- IO(makeCluster(1).copy(status = RuntimeStatus.Running).saveWithRuntimeConfig(gceRuntimeConfig))
-      tr <- traceId.ask[TraceId]
-      message = StartRuntimeMessage(runtime.id, Some(tr))
-      attempt <- leoSubscriber.messageResponder(message).attempt
-    } yield {
-      attempt shouldBe Left(ClusterInvalidState(runtime.id, runtime.projectNameString, runtime, message))
+    val res = makeLeoSubscriber().use { leoSubscriber =>
+      for {
+        runtime <- IO(makeCluster(1).copy(status = RuntimeStatus.Running).saveWithRuntimeConfig(gceRuntimeConfig))
+        tr <- traceId.ask[TraceId]
+        message = StartRuntimeMessage(runtime.id, Some(tr))
+        attempt <- leoSubscriber.messageResponder(message).attempt
+      } yield {
+        attempt shouldBe Left(ClusterInvalidState(runtime.id, runtime.projectNameString, runtime, message))
+      }
     }
 
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "handle UpdateRuntimeMessage, resize dataproc cluster and setting DB status properly" in isolatedDbTest {
@@ -398,31 +409,32 @@ class LeoPubsubMessageSubscriberSpec
       )(runtimeId: Long, action: RuntimeStatus)(implicit ev: Ask[IO, TraceId]): Stream[IO, Unit] =
         Stream.eval(clusterQuery.setToRunning(runtimeId, IP("0.0.0.0"), Instant.now).transaction.void)
     }
-    val queue = InspectableQueue.bounded[IO, Task[IO]](10).unsafeRunSync()
-    val leoSubscriber = makeLeoSubscriber(runtimeMonitor = monitor, asyncTaskQueue = queue)
+    val queue = Queue.bounded[IO, Task[IO]](10).unsafeRunSync()(cats.effect.unsafe.implicits.global)
     val asyncTaskProcessor = AsyncTaskProcessor(AsyncTaskProcessor.Config(10, 10), queue)
 
-    val res = for {
-      runtime <- IO(
-        makeCluster(1).copy(status = RuntimeStatus.Running).saveWithRuntimeConfig(defaultDataprocRuntimeConfig)
-      )
-      tr <- traceId.ask[TraceId]
-      _ <- leoSubscriber.messageResponder(
-        UpdateRuntimeMessage(runtime.id, None, false, None, Some(100), None, Some(tr))
-      )
-      updatedRuntime <- clusterQuery.getClusterById(runtime.id).transaction
-      updatedRuntimeConfig <- updatedRuntime.traverse(r =>
-        RuntimeConfigQueries.getRuntimeConfig(r.runtimeConfigId).transaction
-      )
-      _ <- withInfiniteStream(
-        asyncTaskProcessor.process,
-        clusterQuery.getClusterStatus(runtime.id).transaction.map(s => s shouldBe Some(RuntimeStatus.Running))
-      )
-    } yield {
-      updatedRuntimeConfig.get.asInstanceOf[RuntimeConfig.DataprocConfig].numberOfWorkers shouldBe 100
+    val res = makeLeoSubscriber(runtimeMonitor = monitor, asyncTaskQueue = queue).use { leoSubscriber =>
+      for {
+        runtime <- IO(
+          makeCluster(1).copy(status = RuntimeStatus.Running).saveWithRuntimeConfig(defaultDataprocRuntimeConfig)
+        )
+        tr <- traceId.ask[TraceId]
+        _ <- leoSubscriber.messageResponder(
+          UpdateRuntimeMessage(runtime.id, None, false, None, Some(100), None, Some(tr))
+        )
+        updatedRuntime <- clusterQuery.getClusterById(runtime.id).transaction
+        updatedRuntimeConfig <- updatedRuntime.traverse(r =>
+          RuntimeConfigQueries.getRuntimeConfig(r.runtimeConfigId).transaction
+        )
+        _ <- withInfiniteStream(
+          asyncTaskProcessor.process,
+          clusterQuery.getClusterStatus(runtime.id).transaction.map(s => s shouldBe Some(RuntimeStatus.Running))
+        )
+      } yield {
+        updatedRuntimeConfig.get.asInstanceOf[RuntimeConfig.DataprocConfig].numberOfWorkers shouldBe 100
+      }
     }
 
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "handle UpdateRuntimeMessage and stop the cluster when there's a machine type change" in isolatedDbTest {
@@ -434,215 +446,218 @@ class LeoPubsubMessageSubscriberSpec
         action: RuntimeStatus
       )(implicit ev: Ask[IO, TraceId]): IO[Unit] = IO.never
     }
-    val leoSubscriber = makeLeoSubscriber(monitor)
 
-    val res = for {
-      runtime <- IO(makeCluster(1).copy(status = RuntimeStatus.Running).saveWithRuntimeConfig(gceRuntimeConfig))
-      tr <- traceId.ask[TraceId]
+    val res = makeLeoSubscriber(monitor).use { leoSubscriber =>
+      for {
+        runtime <- IO(makeCluster(1).copy(status = RuntimeStatus.Running).saveWithRuntimeConfig(gceRuntimeConfig))
+        tr <- traceId.ask[TraceId]
 
-      _ <- leoSubscriber.messageResponder(
-        UpdateRuntimeMessage(runtime.id, Some(MachineTypeName("n1-highmem-64")), true, None, None, None, Some(tr))
-      )
-      updatedRuntime <- clusterQuery.getClusterById(runtime.id).transaction
-      updatedRuntimeConfig <- updatedRuntime.traverse(r =>
-        RuntimeConfigQueries.getRuntimeConfig(r.runtimeConfigId).transaction
-      )
-    } yield {
-      // runtime should be Stopping
-      updatedRuntime shouldBe defined
-      updatedRuntime.get.status shouldBe RuntimeStatus.Stopping
-      // machine type should not be updated yet
-      updatedRuntimeConfig shouldBe defined
-      updatedRuntimeConfig.get.machineType shouldBe MachineTypeName("n1-standard-4")
+        _ <- leoSubscriber.messageResponder(
+          UpdateRuntimeMessage(runtime.id, Some(MachineTypeName("n1-highmem-64")), true, None, None, None, Some(tr))
+        )
+        updatedRuntime <- clusterQuery.getClusterById(runtime.id).transaction
+        updatedRuntimeConfig <- updatedRuntime.traverse(r =>
+          RuntimeConfigQueries.getRuntimeConfig(r.runtimeConfigId).transaction
+        )
+      } yield {
+        // runtime should be Stopping
+        updatedRuntime shouldBe defined
+        updatedRuntime.get.status shouldBe RuntimeStatus.Stopping
+        // machine type should not be updated yet
+        updatedRuntimeConfig shouldBe defined
+        updatedRuntimeConfig.get.machineType shouldBe MachineTypeName("n1-standard-4")
+      }
     }
 
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "handle UpdateRuntimeMessage and go through a stop-start transition for machine type" in isolatedDbTest {
-    val queue = InspectableQueue.bounded[IO, Task[IO]](10).unsafeRunSync()
-    val leoSubscriber = makeLeoSubscriber(asyncTaskQueue = queue)
+    val queue = Queue.bounded[IO, Task[IO]](10).unsafeRunSync()(cats.effect.unsafe.implicits.global)
     val asyncTaskProcessor = AsyncTaskProcessor(AsyncTaskProcessor.Config(10, 10), queue)
 
-    val res = for {
-      runtime <- IO(makeCluster(1).copy(status = RuntimeStatus.Running).saveWithRuntimeConfig(gceRuntimeConfig))
-      tr <- traceId.ask[TraceId]
+    val res = makeLeoSubscriber(asyncTaskQueue = queue).use { leoSubscriber =>
+      for {
+        runtime <- IO(makeCluster(1).copy(status = RuntimeStatus.Running).saveWithRuntimeConfig(gceRuntimeConfig))
+        tr <- traceId.ask[TraceId]
 
-      _ <- leoSubscriber.messageResponder(
-        UpdateRuntimeMessage(runtime.id, Some(MachineTypeName("n1-highmem-64")), true, None, None, None, Some(tr))
-      )
-      _ <- withInfiniteStream(
-        asyncTaskProcessor.process,
-        for {
-          updatedRuntime <- clusterQuery.getClusterById(runtime.id).transaction
-          updatedRuntimeConfig <- updatedRuntime.traverse(r =>
-            RuntimeConfigQueries.getRuntimeConfig(r.runtimeConfigId).transaction
-          )
-          patchInProgress <- patchQuery.isInprogress(runtime.id).transaction
-        } yield {
-          // runtime should be Starting after having gone through a stop -> update -> start
-          updatedRuntime shouldBe defined
-          updatedRuntime.get.status shouldBe RuntimeStatus.Starting
-          // machine type should be updated
-          updatedRuntimeConfig shouldBe defined
-          updatedRuntimeConfig.get.machineType shouldBe MachineTypeName("n1-highmem-64")
-          patchInProgress shouldBe false
-        }
-      )
-    } yield ()
-
-    res.unsafeRunSync()
+        _ <- leoSubscriber.messageResponder(
+          UpdateRuntimeMessage(runtime.id, Some(MachineTypeName("n1-highmem-64")), true, None, None, None, Some(tr))
+        )
+        _ <- withInfiniteStream(
+          asyncTaskProcessor.process,
+          for {
+            updatedRuntime <- clusterQuery.getClusterById(runtime.id).transaction
+            updatedRuntimeConfig <- updatedRuntime.traverse(r =>
+              RuntimeConfigQueries.getRuntimeConfig(r.runtimeConfigId).transaction
+            )
+            patchInProgress <- patchQuery.isInprogress(runtime.id).transaction
+          } yield {
+            // runtime should be Starting after having gone through a stop -> update -> start
+            updatedRuntime shouldBe defined
+            updatedRuntime.get.status shouldBe RuntimeStatus.Starting
+            // machine type should be updated
+            updatedRuntimeConfig shouldBe defined
+            updatedRuntimeConfig.get.machineType shouldBe MachineTypeName("n1-highmem-64")
+            patchInProgress shouldBe false
+          }
+        )
+      } yield ()
+    }
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "handle UpdateRuntimeMessage and restart runtime for persistent disk size update" in isolatedDbTest {
-    val queue = InspectableQueue.bounded[IO, Task[IO]](10).unsafeRunSync()
-    val leoSubscriber = makeLeoSubscriber(asyncTaskQueue = queue)
+    val queue = Queue.bounded[IO, Task[IO]](10).unsafeRunSync()(cats.effect.unsafe.implicits.global)
     val asyncTaskProcessor = AsyncTaskProcessor(AsyncTaskProcessor.Config(10, 10), queue)
 
-    val res = for {
-      disk <- makePersistentDisk(None).copy(size = DiskSize(100)).save()
-      runtime <- IO(
-        makeCluster(1)
-          .copy(status = RuntimeStatus.Running)
-          .saveWithRuntimeConfig(gceWithPdRuntimeConfig.copy(persistentDiskId = Some(disk.id)))
-      )
-      tr <- traceId.ask[TraceId]
+    val res = makeLeoSubscriber(asyncTaskQueue = queue).use { leoSubscriber =>
+      for {
+        disk <- makePersistentDisk(None).copy(size = DiskSize(100)).save()
+        runtime <- IO(
+          makeCluster(1)
+            .copy(status = RuntimeStatus.Running)
+            .saveWithRuntimeConfig(gceWithPdRuntimeConfig.copy(persistentDiskId = Some(disk.id)))
+        )
+        tr <- traceId.ask[TraceId]
 
-      _ <- leoSubscriber.messageResponder(
-        UpdateRuntimeMessage(runtime.id,
-                             None,
-                             true,
-                             Some(DiskUpdate.PdSizeUpdate(disk.id, disk.name, DiskSize(200))),
-                             None,
-                             None,
-                             Some(tr))
-      )
+        _ <- leoSubscriber.messageResponder(
+          UpdateRuntimeMessage(runtime.id,
+                               None,
+                               true,
+                               Some(DiskUpdate.PdSizeUpdate(disk.id, disk.name, DiskSize(200))),
+                               None,
+                               None,
+                               Some(tr))
+        )
 
-      assert = for {
-        updatedRuntime <- clusterQuery.getClusterById(runtime.id).transaction
-        updatedDisk <- persistentDiskQuery.getById(disk.id).transaction
-      } yield {
-        // runtime should be Starting after having gone through a stop -> start
-        updatedRuntime shouldBe defined
-        updatedRuntime.get.status shouldBe RuntimeStatus.Starting
-        // machine type should be updated
-        updatedDisk shouldBe defined
-        updatedDisk.get.size shouldBe DiskSize(200)
-      }
+        assert = for {
+          updatedRuntime <- clusterQuery.getClusterById(runtime.id).transaction
+          updatedDisk <- persistentDiskQuery.getById(disk.id)(scala.concurrent.ExecutionContext.global).transaction
+        } yield {
+          // runtime should be Starting after having gone through a stop -> start
+          updatedRuntime shouldBe defined
+          updatedRuntime.get.status shouldBe RuntimeStatus.Starting
+          // machine type should be updated
+          updatedDisk shouldBe defined
+          updatedDisk.get.size shouldBe DiskSize(200)
+        }
 
-      _ <- withInfiniteStream(
-        asyncTaskProcessor.process,
-        assert
-      )
-    } yield ()
-
-    res.unsafeRunSync()
+        _ <- withInfiniteStream(
+          asyncTaskProcessor.process,
+          assert
+        )
+      } yield ()
+    }
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "update diskSize should trigger a stop-start transition" in isolatedDbTest {
-    val leoSubscriber = makeLeoSubscriber()
+    val res = makeLeoSubscriber().use { leoSubscriber =>
+      for {
+        runtime <- IO(makeCluster(1).copy(status = RuntimeStatus.Stopped).saveWithRuntimeConfig(gceRuntimeConfig))
+        tr <- traceId.ask[TraceId]
 
-    val res = for {
-      runtime <- IO(makeCluster(1).copy(status = RuntimeStatus.Stopped).saveWithRuntimeConfig(gceRuntimeConfig))
-      tr <- traceId.ask[TraceId]
-
-      _ <- leoSubscriber.messageResponder(
-        UpdateRuntimeMessage(runtime.id,
-                             Some(MachineTypeName("n1-highmem-64")),
-                             false,
-                             Some(DiskUpdate.NoPdSizeUpdate(DiskSize(1024))),
-                             None,
-                             None,
-                             Some(tr))
-      )
-      updatedRuntime <- clusterQuery.getClusterById(runtime.id).transaction
-      updatedRuntimeConfig <- updatedRuntime.traverse(r =>
-        RuntimeConfigQueries.getRuntimeConfig(r.runtimeConfigId).transaction
-      )
-    } yield {
-      // runtime should still be Stopped
-      updatedRuntime shouldBe defined
-      updatedRuntime.get.status shouldBe RuntimeStatus.Stopped
-      // machine type and disk size should be updated
-      updatedRuntimeConfig shouldBe defined
-      updatedRuntimeConfig.get.machineType shouldBe MachineTypeName("n1-highmem-64")
-      updatedRuntimeConfig.get.asInstanceOf[RuntimeConfig.GceConfig].diskSize shouldBe DiskSize(1024)
+        _ <- leoSubscriber.messageResponder(
+          UpdateRuntimeMessage(runtime.id,
+                               Some(MachineTypeName("n1-highmem-64")),
+                               false,
+                               Some(DiskUpdate.NoPdSizeUpdate(DiskSize(1024))),
+                               None,
+                               None,
+                               Some(tr))
+        )
+        updatedRuntime <- clusterQuery.getClusterById(runtime.id).transaction
+        updatedRuntimeConfig <- updatedRuntime.traverse(r =>
+          RuntimeConfigQueries.getRuntimeConfig(r.runtimeConfigId).transaction
+        )
+      } yield {
+        // runtime should still be Stopped
+        updatedRuntime shouldBe defined
+        updatedRuntime.get.status shouldBe RuntimeStatus.Stopped
+        // machine type and disk size should be updated
+        updatedRuntimeConfig shouldBe defined
+        updatedRuntimeConfig.get.machineType shouldBe MachineTypeName("n1-highmem-64")
+        updatedRuntimeConfig.get.asInstanceOf[RuntimeConfig.GceConfig].diskSize shouldBe DiskSize(1024)
+      }
     }
 
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "handle CreateDiskMessage and create disk" in isolatedDbTest {
-    val leoSubscriber = makeLeoSubscriber()
-
-    val res = for {
-      disk <- makePersistentDisk(None).copy(status = DiskStatus.Creating).save()
-      tr <- traceId.ask[TraceId]
-      now <- IO(Instant.now)
-      _ <- leoSubscriber.messageResponder(CreateDiskMessage.fromDisk(disk, Some(tr)))
-      updatedDisk <- persistentDiskQuery.getById(disk.id).transaction
-    } yield {
-      updatedDisk shouldBe defined
-      updatedDisk.get.googleId.get.value shouldBe "target"
+    val res = makeLeoSubscriber().use { leoSubscriber =>
+      for {
+        disk <- makePersistentDisk(None).copy(status = DiskStatus.Creating).save()
+        tr <- traceId.ask[TraceId]
+        now <- IO(Instant.now)
+        _ <- leoSubscriber.messageResponder(CreateDiskMessage.fromDisk(disk, Some(tr)))
+        updatedDisk <- persistentDiskQuery.getById(disk.id)(scala.concurrent.ExecutionContext.global).transaction
+      } yield {
+        updatedDisk shouldBe defined
+        updatedDisk.get.googleId.get.value shouldBe "258165385"
+      }
     }
 
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "handle DeleteDiskMessage and delete disk" in isolatedDbTest {
-    val leoSubscriber = makeLeoSubscriber()
+    val res = makeLeoSubscriber().use { leoSubscriber =>
+      for {
+        disk <- makePersistentDisk(None).copy(status = DiskStatus.Deleting).save()
+        tr <- traceId.ask[TraceId]
 
-    val res = for {
-      disk <- makePersistentDisk(None).copy(status = DiskStatus.Deleting).save()
-      tr <- traceId.ask[TraceId]
-
-      _ <- leoSubscriber.messageResponder(DeleteDiskMessage(disk.id, Some(tr)))
-      updatedDisk <- persistentDiskQuery.getById(disk.id).transaction
-    } yield {
-      updatedDisk shouldBe defined
-      updatedDisk.get.status shouldBe DiskStatus.Deleting
+        _ <- leoSubscriber.messageResponder(DeleteDiskMessage(disk.id, Some(tr)))
+        updatedDisk <- persistentDiskQuery.getById(disk.id)(scala.concurrent.ExecutionContext.global).transaction
+      } yield {
+        updatedDisk shouldBe defined
+        updatedDisk.get.status shouldBe DiskStatus.Deleting
+      }
     }
 
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "handle DeleteDiskMessage when disk is not in Deleting status" in isolatedDbTest {
-    val leoSubscriber = makeLeoSubscriber()
-
-    val res = for {
-      disk <- makePersistentDisk(None).copy(status = DiskStatus.Ready).save()
-      tr <- traceId.ask[TraceId]
-      message = DeleteDiskMessage(disk.id, Some(tr))
-      attempt <- leoSubscriber.messageResponder(message).attempt
-    } yield {
-      attempt shouldBe Right(())
+    val res = makeLeoSubscriber().use { leoSubscriber =>
+      for {
+        disk <- makePersistentDisk(None).copy(status = DiskStatus.Ready).save()
+        tr <- traceId.ask[TraceId]
+        message = DeleteDiskMessage(disk.id, Some(tr))
+        attempt <- leoSubscriber.messageResponder(message).attempt
+      } yield {
+        attempt shouldBe Right(())
+      }
     }
 
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "handle UpdateDiskMessage and update disk size" in isolatedDbTest {
-    val leoSubscriber = makeLeoSubscriber()
+    val res = makeLeoSubscriber().use { leoSubscriber =>
+      for {
+        disk <- makePersistentDisk(None).copy(status = DiskStatus.Ready).save()
+        tr <- traceId.ask[TraceId]
 
-    val res = for {
-      disk <- makePersistentDisk(None).copy(status = DiskStatus.Ready).save()
-      tr <- traceId.ask[TraceId]
-
-      _ <- leoSubscriber.messageResponder(UpdateDiskMessage(disk.id, DiskSize(550), Some(tr)))
-      updatedDisk <- persistentDiskQuery.getById(disk.id).transaction
-    } yield {
-      updatedDisk shouldBe defined
-      //TODO: fix tests
+        _ <- leoSubscriber.messageResponder(UpdateDiskMessage(disk.id, DiskSize(550), Some(tr)))
+        updatedDisk <- persistentDiskQuery.getById(disk.id)(scala.concurrent.ExecutionContext.global).transaction
+      } yield {
+        updatedDisk shouldBe defined
+        //TODO: fix tests
 //      updatedDisk.get.size shouldBe DiskSize(550)
+      }
     }
 
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "handle create app message with a create cluster" in isolatedDbTest {
     val savedCluster1 = makeKubeCluster(1).save()
     val savedNodepool1 = makeNodepool(1, savedCluster1.id).save()
-    val disk = makePersistentDisk(Some(DiskName("disk1")), Some(FormattedBy.Galaxy)).save().unsafeRunSync()
+    val disk = makePersistentDisk(Some(DiskName("disk1")), Some(FormattedBy.Galaxy))
+      .save()
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
     val makeApp1 = makeApp(1, savedNodepool1.id)
     val savedApp1 = makeApp1
       .copy(appResources =
@@ -689,38 +704,44 @@ class LeoPubsubMessageSubscriberSpec
       )
     }
 
-    val res = for {
-      tr <- traceId.ask[TraceId]
-      dummyNodepool = savedCluster1.nodepools.filter(_.isDefault).head
-      msg = CreateAppMessage(
-        savedCluster1.googleProject,
-        Some(ClusterNodepoolAction.CreateClusterAndNodepool(savedCluster1.id, dummyNodepool.id, savedNodepool1.id)),
-        savedApp1.id,
-        savedApp1.appName,
-        Some(disk.id),
-        Map.empty,
-        AppType.Galaxy,
-        savedApp1.appResources.namespace.name,
-        Some(tr)
-      )
-      queue <- InspectableQueue.bounded[IO, Task[IO]](10)
+    val queue = Queue.bounded[IO, Task[IO]](10).unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    val subscriber = for {
       lock <- nodepoolLock
-      leoSubscriber = makeLeoSubscriber(asyncTaskQueue = queue,
-                                        gkeInterpreter = makeGKEInterp(lock, List(savedApp1.release)))
-      asyncTaskProcessor = AsyncTaskProcessor(AsyncTaskProcessor.Config(10, 10), queue)
-      _ <- leoSubscriber.handleCreateAppMessage(msg)
-      _ <- withInfiniteStream(asyncTaskProcessor.process, assertions)
-    } yield ()
+      leoSubscriber <- makeLeoSubscriber(asyncTaskQueue = queue,
+                                         gkeAlgebra = makeGKEInterp(lock, List(savedApp1.release)))
+    } yield leoSubscriber
 
-    res.unsafeRunSync()
+    val res = subscriber.use { leoSubscriber =>
+      for {
+        tr <- traceId.ask[TraceId]
+        dummyNodepool = savedCluster1.nodepools.filter(_.isDefault).head
+        msg = CreateAppMessage(
+          savedCluster1.googleProject,
+          Some(ClusterNodepoolAction.CreateClusterAndNodepool(savedCluster1.id, dummyNodepool.id, savedNodepool1.id)),
+          savedApp1.id,
+          savedApp1.appName,
+          Some(disk.id),
+          Map.empty,
+          AppType.Galaxy,
+          savedApp1.appResources.namespace.name,
+          Some(tr)
+        )
+
+        asyncTaskProcessor = AsyncTaskProcessor(AsyncTaskProcessor.Config(10, 10), queue)
+        _ <- leoSubscriber.handleCreateAppMessage(msg)
+        _ <- withInfiniteStream(asyncTaskProcessor.process, assertions)
+      } yield ()
+    }
+
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "be able to create multiple apps in a cluster" in isolatedDbTest {
     val savedCluster1 = makeKubeCluster(1).save()
     val savedNodepool1 = makeNodepool(1, savedCluster1.id).save()
     val savedNodepool2 = makeNodepool(2, savedCluster1.id).save()
-    val disk1 = makePersistentDisk(Some(DiskName("disk1"))).save().unsafeRunSync()
-    val disk2 = makePersistentDisk(Some(DiskName("disk2"))).save().unsafeRunSync()
+    val disk1 = makePersistentDisk(Some(DiskName("disk1"))).save().unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    val disk2 = makePersistentDisk(Some(DiskName("disk2"))).save().unsafeRunSync()(cats.effect.unsafe.implicits.global)
 
     val makeApp1 = makeApp(1, savedNodepool1.id)
     val savedApp1 = makeApp1
@@ -776,230 +797,47 @@ class LeoPubsubMessageSubscriberSpec
       )
     }
 
-    val res = for {
-      tr <- traceId.ask[TraceId]
-      dummyNodepool = savedCluster1.nodepools.filter(_.isDefault).head
-      msg1 = CreateAppMessage(
-        savedCluster1.googleProject,
-        Some(ClusterNodepoolAction.CreateClusterAndNodepool(savedCluster1.id, dummyNodepool.id, savedNodepool1.id)),
-        savedApp1.id,
-        savedApp1.appName,
-        Some(disk1.id),
-        Map.empty,
-        AppType.Galaxy,
-        savedApp1.appResources.namespace.name,
-        Some(tr)
-      )
-      msg2 = CreateAppMessage(
-        savedCluster1.googleProject,
-        Some(ClusterNodepoolAction.CreateNodepool(savedNodepool2.id)),
-        savedApp2.id,
-        savedApp2.appName,
-        Some(disk2.id),
-        Map.empty,
-        AppType.Galaxy,
-        savedApp2.appResources.namespace.name,
-        Some(tr)
-      )
-      queue <- InspectableQueue.bounded[IO, Task[IO]](10)
+    val queue = Queue.bounded[IO, Task[IO]](10).unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    val subscriber = for {
       lock <- nodepoolLock
-      leoSubscriber = makeLeoSubscriber(
-        asyncTaskQueue = queue,
-        gkeInterpreter = makeGKEInterp(lock, List(savedApp1.release, savedApp2.release))
-      )
-      asyncTaskProcessor = AsyncTaskProcessor(AsyncTaskProcessor.Config(10, 10), queue)
-      _ <- leoSubscriber.handleCreateAppMessage(msg1)
-      _ <- leoSubscriber.handleCreateAppMessage(msg2)
-      _ <- withInfiniteStream(asyncTaskProcessor.process, assertions)
-    } yield ()
+      leoSubscriber <- makeLeoSubscriber(asyncTaskQueue = queue,
+                                         gkeAlgebra = makeGKEInterp(lock, List(savedApp1.release, savedApp2.release)))
+    } yield leoSubscriber
 
-    res.unsafeRunSync()
-  }
-
-  //handle an error in createCluster
-  it should "error on create if cluster doesn't exist" in isolatedDbTest {
-    val savedCluster1 = makeKubeCluster(1).save()
-    val savedNodepool1 = makeNodepool(1, savedCluster1.id).save()
-    val savedApp1 = makeApp(1, savedNodepool1.id).save()
-    val mockAckConsumer = mock[AckReplyConsumer]
-
-    val assertions = for {
-      getAppOpt <- KubernetesServiceDbQueries
-        .getActiveFullAppByName(savedCluster1.googleProject, savedApp1.appName)
-        .transaction
-      getApp = getAppOpt.get
-    } yield {
-      getApp.app.errors.size shouldBe 1
-      getApp.app.errors.map(_.action) should contain(ErrorAction.CreateApp)
-      getApp.app.errors.map(_.source) should contain(ErrorSource.Cluster)
-      getApp.app.status shouldBe AppStatus.Error
-      //we shouldn't see an error status here because the cluster we passed doesn't exist
-      getApp.cluster.status shouldBe KubernetesClusterStatus.Unspecified
-    }
-
-    val res = for {
-      tr <- traceId.ask[TraceId]
-      msg = CreateAppMessage(
-        project,
-        Some(
-          ClusterNodepoolAction.CreateClusterAndNodepool(KubernetesClusterLeoId(-1),
-                                                         NodepoolLeoId(-1),
-                                                         NodepoolLeoId(-1))
-        ),
-        savedApp1.id,
-        savedApp1.appName,
-        None,
-        Map.empty,
-        AppType.Galaxy,
-        savedApp1.appResources.namespace.name,
-        Some(tr)
-      )
-      queue <- InspectableQueue.bounded[IO, Task[IO]](10)
-      leoSubscriber = makeLeoSubscriber(asyncTaskQueue = queue)
-      asyncTaskProcessor = AsyncTaskProcessor(AsyncTaskProcessor.Config(10, 10), queue)
-      _ <- leoSubscriber.messageHandler(Event(msg, None, timestamp, mockAckConsumer))
-      _ <- withInfiniteStream(asyncTaskProcessor.process, assertions)
-    } yield ()
-    res.unsafeRunSync()
-    assertions.unsafeRunSync()
-  }
-
-  //handle an error in createNodepool
-  //update error table and status
-  it should "error on create if default nodepool doesn't exist" in isolatedDbTest {
-    val savedCluster1 = makeKubeCluster(1).save()
-    val savedNodepool1 = makeNodepool(1, savedCluster1.id).save()
-    val savedApp1 = makeApp(1, savedNodepool1.id).save()
-    val mockAckConsumer = mock[AckReplyConsumer]
-
-    val assertions = for {
-      getAppOpt <- KubernetesServiceDbQueries
-        .getFullAppByName(savedCluster1.googleProject, savedApp1.id)
-        .transaction
-      getApp = getAppOpt.get
-    } yield {
-      getApp.app.errors.size shouldBe 1
-      getApp.app.errors.map(_.action) should contain(ErrorAction.CreateApp)
-      getApp.app.errors.map(_.source) should contain(ErrorSource.Cluster)
-      getApp.nodepool.status shouldBe NodepoolStatus.Deleted
-    }
-
-    val res = for {
-      tr <- traceId.ask[TraceId]
-      msg = CreateAppMessage(
-        savedCluster1.googleProject,
-        Some(ClusterNodepoolAction.CreateClusterAndNodepool(savedCluster1.id, NodepoolLeoId(-1), NodepoolLeoId(-2))),
-        savedApp1.id,
-        savedApp1.appName,
-        None,
-        Map.empty,
-        AppType.Galaxy,
-        savedApp1.appResources.namespace.name,
-        Some(tr)
-      )
-      queue <- InspectableQueue.bounded[IO, Task[IO]](10)
-      leoSubscriber = makeLeoSubscriber(asyncTaskQueue = queue)
-      asyncTaskProcessor = AsyncTaskProcessor(AsyncTaskProcessor.Config(10, 10), queue)
-      _ <- leoSubscriber.messageHandler(Event(msg, None, timestamp, mockAckConsumer))
-      _ <- withInfiniteStream(asyncTaskProcessor.process, assertions)
-    } yield ()
-
-    res.unsafeRunSync()
-    assertions.unsafeRunSync()
-  }
-
-  it should "error on create if user nodepool doesn't exist" in isolatedDbTest {
-    val savedCluster1 = makeKubeCluster(1).save()
-    val savedNodepool1 = makeNodepool(1, savedCluster1.id).save()
-    val savedApp1 = makeApp(1, savedNodepool1.id).save()
-    val mockAckConsumer = mock[AckReplyConsumer]
-
-    val assertions = for {
-      getAppOpt <- KubernetesServiceDbQueries
-        .getFullAppByName(savedCluster1.googleProject, savedApp1.id)
-        .transaction
-      getApp = getAppOpt.get
-    } yield {
-      getApp.app.errors.size shouldBe 1
-      getApp.app.errors.map(_.action) should contain(ErrorAction.CreateApp)
-      getApp.app.errors.map(_.source) should contain(ErrorSource.Cluster)
-      getApp.nodepool.status shouldBe NodepoolStatus.Deleted
-    }
-
-    val res = for {
-      tr <- traceId.ask[TraceId]
-      dummyNodepool = savedCluster1.nodepools.filter(_.isDefault).head
-      msg = CreateAppMessage(
-        savedCluster1.googleProject,
-        Some(ClusterNodepoolAction.CreateClusterAndNodepool(savedCluster1.id, dummyNodepool.id, NodepoolLeoId(-2))),
-        savedApp1.id,
-        savedApp1.appName,
-        None,
-        Map.empty,
-        AppType.Galaxy,
-        savedApp1.appResources.namespace.name,
-        Some(tr)
-      )
-      queue <- InspectableQueue.bounded[IO, Task[IO]](10)
-      leoSubscriber = makeLeoSubscriber(asyncTaskQueue = queue)
-      asyncTaskProcessor = AsyncTaskProcessor(AsyncTaskProcessor.Config(10, 10), queue)
-      _ <- leoSubscriber.messageHandler(Event(msg, None, timestamp, mockAckConsumer))
-      _ <- withInfiniteStream(asyncTaskProcessor.process, assertions)
-    } yield ()
-
-    res.unsafeRunSync()
-    verify(mockAckConsumer, times(1)).ack()
-  }
-
-  it should "error on create if app doesn't exist" in isolatedDbTest {
-    val savedCluster1 = makeKubeCluster(1).save()
-    val savedNodepool1 = makeNodepool(1, savedCluster1.id).save()
-    val disk1 = makePersistentDisk(None).save().unsafeRunSync()
-    val makeApp1 = makeApp(1, savedNodepool1.id)
-    val savedApp1 = makeApp1
-      .copy(appResources =
-        makeApp1.appResources.copy(
-          disk = Some(disk1),
-          services = List(makeService(1), makeService(2))
+    val res = subscriber.use { leoSubscriber =>
+      for {
+        tr <- traceId.ask[TraceId]
+        dummyNodepool = savedCluster1.nodepools.filter(_.isDefault).head
+        msg1 = CreateAppMessage(
+          savedCluster1.googleProject,
+          Some(ClusterNodepoolAction.CreateClusterAndNodepool(savedCluster1.id, dummyNodepool.id, savedNodepool1.id)),
+          savedApp1.id,
+          savedApp1.appName,
+          Some(disk1.id),
+          Map.empty,
+          AppType.Galaxy,
+          savedApp1.appResources.namespace.name,
+          Some(tr)
         )
-      )
-      .save()
-    val mockAckConsumer = mock[AckReplyConsumer]
-
-    val assertions = for {
-      getAppOpt <- KubernetesServiceDbQueries
-        .getFullAppByName(savedCluster1.googleProject, savedApp1.id)
-        .transaction
-      getApp = getAppOpt.get
-    } yield {
-      getApp.app.errors.size shouldBe 1
-      getApp.app.errors.map(_.action) should contain(ErrorAction.CreateApp)
-      getApp.app.errors.map(_.source) should contain(ErrorSource.App)
-      getApp.nodepool.status shouldBe NodepoolStatus.Running
+        msg2 = CreateAppMessage(
+          savedCluster1.googleProject,
+          Some(ClusterNodepoolAction.CreateNodepool(savedNodepool2.id)),
+          savedApp2.id,
+          savedApp2.appName,
+          Some(disk2.id),
+          Map.empty,
+          AppType.Galaxy,
+          savedApp2.appResources.namespace.name,
+          Some(tr)
+        )
+        asyncTaskProcessor = AsyncTaskProcessor(AsyncTaskProcessor.Config(10, 10), queue)
+        _ <- leoSubscriber.handleCreateAppMessage(msg1)
+        _ <- leoSubscriber.handleCreateAppMessage(msg2)
+        _ <- withInfiniteStream(asyncTaskProcessor.process, assertions)
+      } yield ()
     }
 
-    val res = for {
-      tr <- traceId.ask[TraceId]
-      msg = CreateAppMessage(
-        savedCluster1.googleProject,
-        Some(ClusterNodepoolAction.CreateNodepool(savedNodepool1.id)),
-        savedApp1.id,
-        AppName("fakeapp"),
-        Some(disk1.id),
-        Map.empty,
-        AppType.Galaxy,
-        savedApp1.appResources.namespace.name,
-        Some(tr)
-      )
-      queue <- InspectableQueue.bounded[IO, Task[IO]](10)
-      leoSubscriber = makeLeoSubscriber(asyncTaskQueue = queue, diskInterp = makeDetachingDiskInterp())
-      asyncTaskProcessor = AsyncTaskProcessor(AsyncTaskProcessor.Config(10, 10), queue)
-      _ <- leoSubscriber.messageHandler(Event(msg, None, timestamp, mockAckConsumer))
-      _ <- withInfiniteStream(asyncTaskProcessor.process, assertions, maxRetry = 40)
-    } yield ()
-
-    res.unsafeRunSync()
-    verify(mockAckConsumer, times(1)).ack()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "handle error in createApp if createDisk is specified with no disk" in isolatedDbTest {
@@ -1018,28 +856,28 @@ class LeoPubsubMessageSubscriberSpec
       getApp.app.errors.map(_.action) should contain(ErrorAction.CreateApp)
       getApp.app.errors.map(_.source) should contain(ErrorSource.Disk)
     }
+    val queue = Queue.bounded[IO, Task[IO]](10).unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    val res = makeLeoSubscriber(asyncTaskQueue = queue, diskInterp = makeDetachingDiskInterp()).use { leoSubscriber =>
+      for {
+        tr <- traceId.ask[TraceId]
+        msg = CreateAppMessage(
+          savedCluster1.googleProject,
+          Some(ClusterNodepoolAction.CreateNodepool(savedNodepool1.id)),
+          savedApp1.id,
+          savedApp1.appName,
+          Some(DiskId(-1)),
+          Map.empty,
+          AppType.Galaxy,
+          savedApp1.appResources.namespace.name,
+          Some(tr)
+        )
+        asyncTaskProcessor = AsyncTaskProcessor(AsyncTaskProcessor.Config(10, 10), queue)
+        _ <- leoSubscriber.messageHandler(Event(msg, None, timestamp, mockAckConsumer))
+        _ <- withInfiniteStream(asyncTaskProcessor.process, assertions)
+      } yield ()
+    }
 
-    val res = for {
-      tr <- traceId.ask[TraceId]
-      msg = CreateAppMessage(
-        savedCluster1.googleProject,
-        Some(ClusterNodepoolAction.CreateNodepool(savedNodepool1.id)),
-        savedApp1.id,
-        savedApp1.appName,
-        Some(DiskId(-1)),
-        Map.empty,
-        AppType.Galaxy,
-        savedApp1.appResources.namespace.name,
-        Some(tr)
-      )
-      queue <- InspectableQueue.bounded[IO, Task[IO]](10)
-      leoSubscriber = makeLeoSubscriber(asyncTaskQueue = queue, diskInterp = makeDetachingDiskInterp())
-      asyncTaskProcessor = AsyncTaskProcessor(AsyncTaskProcessor.Config(10, 10), queue)
-      _ <- leoSubscriber.messageHandler(Event(msg, None, timestamp, mockAckConsumer))
-      _ <- withInfiniteStream(asyncTaskProcessor.process, assertions)
-    } yield ()
-
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
     verify(mockAckConsumer, times(1)).ack()
   }
 
@@ -1048,7 +886,7 @@ class LeoPubsubMessageSubscriberSpec
   it should "delete app and not delete disk when specified" in isolatedDbTest {
     val savedCluster1 = makeKubeCluster(1).save()
     val savedNodepool1 = makeNodepool(1, savedCluster1.id).save()
-    val disk = makePersistentDisk(None).save().unsafeRunSync()
+    val disk = makePersistentDisk(None).save().unsafeRunSync()(cats.effect.unsafe.implicits.global)
     val makeApp1 = makeApp(1, savedNodepool1.id)
     val savedApp1 = makeApp1
       .copy(appResources =
@@ -1072,24 +910,28 @@ class LeoPubsubMessageSubscriberSpec
       getDisk.status shouldBe DiskStatus.Ready
     }
 
-    val res = for {
-      tr <- traceId.ask[TraceId]
-      msg = DeleteAppMessage(savedApp1.id, savedApp1.appName, savedCluster1.googleProject, None, Some(tr))
-      queue <- InspectableQueue.bounded[IO, Task[IO]](10)
-      leoSubscriber = makeLeoSubscriber(asyncTaskQueue = queue, diskInterp = makeDetachingDiskInterp())
-      asyncTaskProcessor = AsyncTaskProcessor(AsyncTaskProcessor.Config(10, 10), queue)
-      _ <- leoSubscriber.handleDeleteAppMessage(msg)
-      _ <- withInfiniteStream(asyncTaskProcessor.process, assertions)
-    } yield ()
+    val queue = Queue.bounded[IO, Task[IO]](10).unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    val res = makeLeoSubscriber(asyncTaskQueue = queue, diskInterp = makeDetachingDiskInterp()).use { leoSubscriber =>
+      for {
+        tr <- traceId.ask[TraceId]
+        msg = DeleteAppMessage(savedApp1.id, savedApp1.appName, savedCluster1.googleProject, None, Some(tr))
+        asyncTaskProcessor = AsyncTaskProcessor(AsyncTaskProcessor.Config(10, 10), queue)
+        _ <- leoSubscriber.handleDeleteAppMessage(msg)
+        _ <- withInfiniteStream(asyncTaskProcessor.process, assertions)
+      } yield ()
+    }
 
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "delete app and delete disk when specified" in isolatedDbTest {
     val savedCluster1 = makeKubeCluster(1).save()
     val savedNodepool1 = makeNodepool(1, savedCluster1.id).save()
 
-    val disk = makePersistentDisk(None).copy(status = DiskStatus.Deleting).save().unsafeRunSync()
+    val disk = makePersistentDisk(None)
+      .copy(status = DiskStatus.Deleting)
+      .save()
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
     val makeApp1 = makeApp(1, savedNodepool1.id)
     val savedApp1 = makeApp1
       .copy(appResources =
@@ -1113,17 +955,18 @@ class LeoPubsubMessageSubscriberSpec
       getDisk.status shouldBe DiskStatus.Deleted
     }
 
-    val res = for {
-      tr <- traceId.ask[TraceId]
-      msg = DeleteAppMessage(savedApp1.id, savedApp1.appName, savedCluster1.googleProject, Some(disk.id), Some(tr))
-      queue <- InspectableQueue.bounded[IO, Task[IO]](10)
-      leoSubscriber = makeLeoSubscriber(asyncTaskQueue = queue, diskInterp = makeDetachingDiskInterp())
-      asyncTaskProcessor = AsyncTaskProcessor(AsyncTaskProcessor.Config(10, 10), queue)
-      _ <- leoSubscriber.handleDeleteAppMessage(msg)
-      _ <- withInfiniteStream(asyncTaskProcessor.process, assertions)
-    } yield ()
+    val queue = Queue.bounded[IO, Task[IO]](10).unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    val res = makeLeoSubscriber(asyncTaskQueue = queue, diskInterp = makeDetachingDiskInterp()).use { leoSubscriber =>
+      for {
+        tr <- traceId.ask[TraceId]
+        msg = DeleteAppMessage(savedApp1.id, savedApp1.appName, savedCluster1.googleProject, Some(disk.id), Some(tr))
+        asyncTaskProcessor = AsyncTaskProcessor(AsyncTaskProcessor.Config(10, 10), queue)
+        _ <- leoSubscriber.handleDeleteAppMessage(msg)
+        _ <- withInfiniteStream(asyncTaskProcessor.process, assertions)
+      } yield ()
+    }
 
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "handle an error in delete app" in isolatedDbTest {
@@ -1142,11 +985,8 @@ class LeoPubsubMessageSubscriberSpec
       getApp.app.errors.map(_.source) should contain(ErrorSource.App)
       getApp.nodepool.status shouldBe NodepoolStatus.Unspecified
     }
-
-    val res = for {
-      tr <- traceId.ask[TraceId]
-      msg = DeleteAppMessage(savedApp1.id, savedApp1.appName, savedCluster1.googleProject, None, Some(tr))
-      queue <- InspectableQueue.bounded[IO, Task[IO]](10)
+    val queue = Queue.bounded[IO, Task[IO]](10).unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    val subscriber = for {
       lock <- nodepoolLock
       mockKubernetesService = new MockKubernetesService(PodStatus.Failed, appRelease = List(savedApp1.release)) {
         override def deleteNamespace(
@@ -1164,20 +1004,26 @@ class LeoPubsubMessageSubscriberSpec
                                         iamDAOKubernetes,
                                         makeDetachingDiskInterp(),
                                         MockAppDescriptorDAO,
-                                        blocker,
                                         lock)
-      leoSubscriber = makeLeoSubscriber(asyncTaskQueue = queue, gkeInterpreter = gkeInter)
-      asyncTaskProcessor = AsyncTaskProcessor(AsyncTaskProcessor.Config(10, 10), queue)
-      _ <- leoSubscriber.messageHandler(Event(msg, None, timestamp, mockAckConsumer))
-      _ <- withInfiniteStream(asyncTaskProcessor.process, assertions)
-    } yield ()
+      leoSubscriber <- makeLeoSubscriber(asyncTaskQueue = queue, gkeAlgebra = gkeInter)
+    } yield leoSubscriber
 
-    res.unsafeRunSync()
+    val res = subscriber.use { leoSubscriber =>
+      for {
+        tr <- traceId.ask[TraceId]
+        msg = DeleteAppMessage(savedApp1.id, savedApp1.appName, savedCluster1.googleProject, None, Some(tr))
+        asyncTaskProcessor = AsyncTaskProcessor(AsyncTaskProcessor.Config(10, 10), queue)
+        _ <- leoSubscriber.messageHandler(Event(msg, None, timestamp, mockAckConsumer))
+        _ <- withInfiniteStream(asyncTaskProcessor.process, assertions)
+      } yield ()
+    }
+
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
     verify(mockAckConsumer, times(1)).ack()
   }
 
   it should "be able to create app with a pre-created nodepool" in isolatedDbTest {
-    val disk = makePersistentDisk(None).save().unsafeRunSync()
+    val disk = makePersistentDisk(None).save().unsafeRunSync()(cats.effect.unsafe.implicits.global)
     val savedCluster1 = makeKubeCluster(1).copy(status = KubernetesClusterStatus.Running).save()
     val savedNodepool1 = makeNodepool(1, savedCluster1.id).copy(status = NodepoolStatus.Running).save()
     val makeApp1 = makeApp(1, savedNodepool1.id)
@@ -1213,37 +1059,43 @@ class LeoPubsubMessageSubscriberSpec
       getApp.nodepool.status shouldBe NodepoolStatus.Running
       getDisk.status shouldBe DiskStatus.Ready
     }
-    val res = for {
-      tr <- traceId.ask[TraceId]
-      msg = CreateAppMessage(
-        savedCluster1.googleProject,
-        None,
-        savedApp1.id,
-        savedApp1.appName,
-        Some(disk.id),
-        Map.empty,
-        AppType.Galaxy,
-        savedApp1.appResources.namespace.name,
-        Some(tr)
-      )
-      queue <- InspectableQueue.bounded[IO, Task[IO]](10)
-      lock <- nodepoolLock
-      leoSubscriber = makeLeoSubscriber(asyncTaskQueue = queue,
-                                        gkeInterpreter = makeGKEInterp(lock, List(savedApp1.release)))
-      asyncTaskProcessor = AsyncTaskProcessor(AsyncTaskProcessor.Config(10, 10), queue)
-      _ <- leoSubscriber.handleCreateAppMessage(msg)
-      _ <- withInfiniteStream(asyncTaskProcessor.process, assertions)
-    } yield ()
 
-    res.unsafeRunSync()
-    assertions.unsafeRunSync()
+    val queue = Queue.bounded[IO, Task[IO]](10).unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    val subscriber = for {
+      lock <- nodepoolLock
+      leoSubscriber <- makeLeoSubscriber(asyncTaskQueue = queue,
+                                         gkeAlgebra = makeGKEInterp(lock, List(savedApp1.release)))
+    } yield leoSubscriber
+
+    val res = subscriber.use { leoSubscriber =>
+      for {
+        tr <- traceId.ask[TraceId]
+        msg = CreateAppMessage(
+          savedCluster1.googleProject,
+          None,
+          savedApp1.id,
+          savedApp1.appName,
+          Some(disk.id),
+          Map.empty,
+          AppType.Galaxy,
+          savedApp1.appResources.namespace.name,
+          Some(tr)
+        )
+        asyncTaskProcessor = AsyncTaskProcessor(AsyncTaskProcessor.Config(10, 10), queue)
+        _ <- leoSubscriber.handleCreateAppMessage(msg)
+        _ <- withInfiniteStream(asyncTaskProcessor.process, assertions)
+      } yield ()
+    }
+
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    assertions.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "clean-up google resources on error" in isolatedDbTest {
     val savedCluster1 = makeKubeCluster(1).save()
     val savedNodepool1 = makeNodepool(1, savedCluster1.id).save()
 
-    val disk = makePersistentDisk(None).save().unsafeRunSync()
+    val disk = makePersistentDisk(None).save().unsafeRunSync()(cats.effect.unsafe.implicits.global)
     val makeApp1 = makeApp(1, savedNodepool1.id)
     val savedApp1 = makeApp1
       .copy(appResources =
@@ -1291,21 +1143,8 @@ class LeoPubsubMessageSubscriberSpec
       deleteCalled shouldBe true
     }
 
-    val res = for {
-      tr <- traceId.ask[TraceId]
-      dummyNodepool = savedCluster1.nodepools.filter(_.isDefault).head
-      msg = CreateAppMessage(
-        savedCluster1.googleProject,
-        Some(ClusterNodepoolAction.CreateClusterAndNodepool(savedCluster1.id, dummyNodepool.id, savedNodepool1.id)),
-        savedApp1.id,
-        savedApp1.appName,
-        Some(disk.id),
-        Map.empty,
-        AppType.Galaxy,
-        savedApp1.appResources.namespace.name,
-        Some(tr)
-      )
-      queue <- InspectableQueue.bounded[IO, Task[IO]](10)
+    val queue = Queue.bounded[IO, Task[IO]](10).unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    val subscriber = for {
       lock <- nodepoolLock
       mockKubernetesService = new MockKubernetesService(PodStatus.Succeeded, List(savedApp1.release)) {
         override def deleteNamespace(
@@ -1326,24 +1165,41 @@ class LeoPubsubMessageSubscriberSpec
                                          iamDAOKubernetes,
                                          makeDetachingDiskInterp(),
                                          MockAppDescriptorDAO,
-                                         blocker,
                                          lock)
-      leoSubscriber = makeLeoSubscriber(asyncTaskQueue = queue,
-                                        diskInterp = makeDetachingDiskInterp(),
-                                        gkeInterpreter = gkeInterp)
-      asyncTaskProcessor = AsyncTaskProcessor(AsyncTaskProcessor.Config(10, 10), queue)
-      _ <- leoSubscriber.handleCreateAppMessage(msg)
-      _ <- withInfiniteStream(asyncTaskProcessor.process, assertions, maxRetry = 50)
-    } yield ()
+      leoSubscriber <- makeLeoSubscriber(asyncTaskQueue = queue,
+                                         diskInterp = makeDetachingDiskInterp(),
+                                         gkeAlgebra = gkeInterp)
+    } yield leoSubscriber
 
-    res.unsafeRunSync()
+    val res = subscriber.use { leoSubscriber =>
+      for {
+        tr <- traceId.ask[TraceId]
+        dummyNodepool = savedCluster1.nodepools.filter(_.isDefault).head
+        msg = CreateAppMessage(
+          savedCluster1.googleProject,
+          Some(ClusterNodepoolAction.CreateClusterAndNodepool(savedCluster1.id, dummyNodepool.id, savedNodepool1.id)),
+          savedApp1.id,
+          savedApp1.appName,
+          Some(disk.id),
+          Map.empty,
+          AppType.Galaxy,
+          savedApp1.appResources.namespace.name,
+          Some(tr)
+        )
+        asyncTaskProcessor = AsyncTaskProcessor(AsyncTaskProcessor.Config(10, 10), queue)
+        _ <- leoSubscriber.handleCreateAppMessage(msg)
+        _ <- withInfiniteStream(asyncTaskProcessor.process, assertions, maxRetry = 50)
+      } yield ()
+    }
+
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
-  it should "not delete a disk that already existing on error" in isolatedDbTest {
+  it should "not delete a disk that already existing when app errors out" in isolatedDbTest {
     val savedCluster1 = makeKubeCluster(1).save()
     val savedNodepool1 = makeNodepool(1, savedCluster1.id).save()
 
-    val disk = makePersistentDisk(None).save().unsafeRunSync()
+    val disk = makePersistentDisk(None).save().unsafeRunSync()(cats.effect.unsafe.implicits.global)
     val makeApp1 = makeApp(1, savedNodepool1.id)
     val savedApp1 = makeApp1
       .copy(appResources =
@@ -1353,41 +1209,6 @@ class LeoPubsubMessageSubscriberSpec
         )
       )
       .save()
-
-    val mockKubernetesService = new MockKubernetesService(PodStatus.Succeeded) {
-      override def createServiceAccount(
-        clusterId: GKEModels.KubernetesClusterId,
-        serviceAccount: KubernetesModels.KubernetesServiceAccount,
-        namespaceName: KubernetesModels.KubernetesNamespace
-      )(implicit ev: Ask[IO, TraceId]): IO[Unit] =
-        IO.raiseError(new Exception("this is an intentional test exception"))
-    }
-
-    val helmClient = new MockHelm {
-      override def installChart(release: Release,
-                                chartName: ChartName,
-                                chartVersion: ChartVersion,
-                                values: Values,
-                                createNamespace: Boolean): Kleisli[IO, AuthContext, Unit] =
-        if (chartName == Config.gkeInterpConfig.terraAppSetupChartConfig.chartName)
-          Kleisli.liftF(IO.raiseError(new Exception("this is an intentional test exception")))
-        else Kleisli.liftF(IO.unit)
-    }
-
-    val makeGKEInterp = for {
-      lock <- nodepoolLock
-    } yield new GKEInterpreter[IO](Config.gkeInterpConfig,
-                                   vpcInterp,
-                                   MockGKEService,
-                                   mockKubernetesService,
-                                   helmClient,
-                                   MockAppDAO,
-                                   credentials,
-                                   iamDAOKubernetes,
-                                   makeDetachingDiskInterp(),
-                                   MockAppDescriptorDAO,
-                                   blocker,
-                                   lock)
 
     val assertions = for {
       clusterOpt <- kubernetesClusterQuery.getMinimalClusterById(savedCluster1.id).transaction
@@ -1399,45 +1220,51 @@ class LeoPubsubMessageSubscriberSpec
       getDiskOpt <- persistentDiskQuery.getById(savedApp1.appResources.disk.get.id).transaction
       getDisk = getDiskOpt.get
     } yield {
-      getCluster.status shouldBe KubernetesClusterStatus.Running
       //The non-default nodepool should still be there, as it is not deleted on app deletion
       getCluster.nodepools.size shouldBe 2
-      getCluster.nodepools.filter(_.isDefault).head.status shouldBe NodepoolStatus.Running
       getApp.app.errors.size shouldBe 1
       getApp.app.status shouldBe AppStatus.Error
-      getApp.nodepool.status shouldBe NodepoolStatus.Running
       getDisk.status shouldBe disk.status
     }
 
-    val res = for {
-      tr <- traceId.ask[TraceId]
-      dummyNodepool = savedCluster1.nodepools.filter(_.isDefault).head
-      msg = CreateAppMessage(
-        savedCluster1.googleProject,
-        Some(ClusterNodepoolAction.CreateClusterAndNodepool(savedCluster1.id, dummyNodepool.id, savedNodepool1.id)),
-        savedApp1.id,
-        savedApp1.appName,
-        None,
-        Map.empty,
-        AppType.Galaxy,
-        savedApp1.appResources.namespace.name,
-        Some(tr)
-      )
-      queue <- InspectableQueue.bounded[IO, Task[IO]](10)
-      leoSubscriber = makeLeoSubscriber(asyncTaskQueue = queue, diskInterp = makeDetachingDiskInterp())
-      asyncTaskProcessor = AsyncTaskProcessor(AsyncTaskProcessor.Config(10, 10), queue)
-      _ <- leoSubscriber.handleCreateAppMessage(msg)
-      _ <- withInfiniteStream(asyncTaskProcessor.process, assertions, maxRetry = 50)
-    } yield ()
+    val queue = Queue.bounded[IO, Task[IO]](10).unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    val gkeAlg = new org.broadinstitute.dsde.workbench.leonardo.MockGKEService {
+      override def createAndPollApp(params: CreateAppParams)(implicit ev: Ask[IO, AppContext]): IO[Unit] =
+        IO.raiseError(new RuntimeException("app creation failed"))
+    }
+    val res =
+      makeLeoSubscriber(asyncTaskQueue = queue, diskInterp = makeDetachingDiskInterp(), gkeAlgebra = gkeAlg).use {
+        leoSubscriber =>
+          for {
+            tr <- traceId.ask[TraceId]
+            dummyNodepool = savedCluster1.nodepools.filter(_.isDefault).head
+            msg = CreateAppMessage(
+              savedCluster1.googleProject,
+              Some(
+                ClusterNodepoolAction.CreateClusterAndNodepool(savedCluster1.id, dummyNodepool.id, savedNodepool1.id)
+              ),
+              savedApp1.id,
+              savedApp1.appName,
+              None,
+              Map.empty,
+              AppType.Galaxy,
+              savedApp1.appResources.namespace.name,
+              Some(tr)
+            )
+            asyncTaskProcessor = AsyncTaskProcessor(AsyncTaskProcessor.Config(10, 10), queue)
+            _ <- leoSubscriber.handleCreateAppMessage(msg)
+            _ <- withInfiniteStream(asyncTaskProcessor.process, assertions, maxRetry = 50)
+          } yield ()
+      }
 
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "delete a cluster and put that app in error status on cluster error" in isolatedDbTest {
     val savedCluster1 = makeKubeCluster(1).save()
     val savedNodepool1 = makeNodepool(1, savedCluster1.id).save()
 
-    val disk = makePersistentDisk(None).save().unsafeRunSync()
+    val disk = makePersistentDisk(None).save().unsafeRunSync()(cats.effect.unsafe.implicits.global)
     val makeApp1 = makeApp(1, savedNodepool1.id)
     val savedApp1 = makeApp1
       .copy(appResources =
@@ -1469,21 +1296,8 @@ class LeoPubsubMessageSubscriberSpec
       getApp.app.errors.size shouldBe 1
     }
 
-    val res = for {
-      tr <- traceId.ask[TraceId]
-      dummyNodepool = savedCluster1.nodepools.filter(_.isDefault).head
-      msg = CreateAppMessage(
-        savedCluster1.googleProject,
-        Some(ClusterNodepoolAction.CreateClusterAndNodepool(savedCluster1.id, dummyNodepool.id, savedNodepool1.id)),
-        savedApp1.id,
-        savedApp1.appName,
-        None,
-        Map.empty,
-        AppType.Galaxy,
-        savedApp1.appResources.namespace.name,
-        Some(tr)
-      )
-      queue <- InspectableQueue.bounded[IO, Task[IO]](10)
+    val queue = Queue.bounded[IO, Task[IO]](10).unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    val subscriber = for {
       lock <- nodepoolLock
       gkeInterp = new GKEInterpreter[IO](Config.gkeInterpConfig,
                                          vpcInterp,
@@ -1495,14 +1309,33 @@ class LeoPubsubMessageSubscriberSpec
                                          iamDAO,
                                          makeDetachingDiskInterp(),
                                          MockAppDescriptorDAO,
-                                         blocker,
                                          lock)
-      leoSubscriber = makeLeoSubscriber(asyncTaskQueue = queue, gkeInterpreter = gkeInterp)
-      _ <- leoSubscriber.messageHandler(Event(msg, None, timestamp, mockAckConsumer))
-    } yield ()
+      leoSubscriber <- makeLeoSubscriber(asyncTaskQueue = queue,
+                                         diskInterp = makeDetachingDiskInterp(),
+                                         gkeAlgebra = gkeInterp)
+    } yield leoSubscriber
 
-    res.unsafeRunSync()
-    assertions.unsafeRunSync()
+    val res = subscriber.use { leoSubscriber =>
+      for {
+        tr <- traceId.ask[TraceId]
+        dummyNodepool = savedCluster1.nodepools.filter(_.isDefault).head
+        msg = CreateAppMessage(
+          savedCluster1.googleProject,
+          Some(ClusterNodepoolAction.CreateClusterAndNodepool(savedCluster1.id, dummyNodepool.id, savedNodepool1.id)),
+          savedApp1.id,
+          savedApp1.appName,
+          None,
+          Map.empty,
+          AppType.Galaxy,
+          savedApp1.appResources.namespace.name,
+          Some(tr)
+        )
+        _ <- leoSubscriber.messageHandler(Event(msg, None, timestamp, mockAckConsumer))
+      } yield ()
+    }
+
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    assertions.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "handle StopAppMessage" in isolatedDbTest {
@@ -1510,28 +1343,15 @@ class LeoPubsubMessageSubscriberSpec
     val savedNodepool1 = makeNodepool(1, savedCluster1.id).copy(status = NodepoolStatus.Running).save()
     val savedApp1 = makeApp(1, savedNodepool1.id).copy(status = AppStatus.Stopping).save()
 
-    val assertions = for {
-      getAppOpt <- KubernetesServiceDbQueries.getFullAppByName(savedCluster1.googleProject, savedApp1.id).transaction
-      getApp = getAppOpt.get
-    } yield {
-      getApp.app.errors.size shouldBe 0
-      getApp.app.status shouldBe AppStatus.Stopped
-      getApp.nodepool.status shouldBe NodepoolStatus.Running
-      getApp.nodepool.autoscalingEnabled shouldBe true
-      getApp.nodepool.numNodes shouldBe NumNodes(2)
+    val queue = Queue.bounded[IO, Task[IO]](10).unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    val res = makeLeoSubscriber(asyncTaskQueue = queue).use { leoSubscriber =>
+      for {
+        tr <- traceId.ask[TraceId]
+        msg = StopAppMessage(savedApp1.id, savedApp1.appName, savedCluster1.googleProject, Some(tr))
+        _ <- leoSubscriber.handleStopAppMessage(msg)
+      } yield ()
     }
-
-    val res = for {
-      tr <- traceId.ask[TraceId]
-      msg = StopAppMessage(savedApp1.id, savedApp1.appName, savedCluster1.googleProject, Some(tr))
-      queue <- InspectableQueue.bounded[IO, Task[IO]](10)
-      leoSubscriber = makeLeoSubscriber(asyncTaskQueue = queue)
-      asyncTaskProcessor = AsyncTaskProcessor(AsyncTaskProcessor.Config(10, 10), queue)
-      _ <- leoSubscriber.handleStopAppMessage(msg)
-      _ <- withInfiniteStream(asyncTaskProcessor.process, assertions)
-    } yield ()
-
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "handle StartAppMessage" in isolatedDbTest {
@@ -1539,28 +1359,16 @@ class LeoPubsubMessageSubscriberSpec
     val savedNodepool1 = makeNodepool(1, savedCluster1.id).copy(status = NodepoolStatus.Running).save()
     val savedApp1 = makeApp(1, savedNodepool1.id).copy(status = AppStatus.Starting).save()
 
-    val assertions = for {
-      getAppOpt <- KubernetesServiceDbQueries.getFullAppByName(savedCluster1.googleProject, savedApp1.id).transaction
-      getApp = getAppOpt.get
-    } yield {
-      getApp.app.errors.size shouldBe 0
-      getApp.app.status shouldBe AppStatus.Running
-      getApp.nodepool.status shouldBe NodepoolStatus.Running
-      getApp.nodepool.autoscalingEnabled shouldBe true
-      getApp.nodepool.numNodes shouldBe NumNodes(2)
+    val queue = Queue.bounded[IO, Task[IO]](10).unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    val res = makeLeoSubscriber(asyncTaskQueue = queue).use { leoSubscriber =>
+      for {
+        tr <- traceId.ask[TraceId]
+        msg = StartAppMessage(savedApp1.id, savedApp1.appName, savedCluster1.googleProject, Some(tr))
+        _ <- leoSubscriber.handleStartAppMessage(msg)
+      } yield ()
     }
 
-    val res = for {
-      tr <- traceId.ask[TraceId]
-      msg = StartAppMessage(savedApp1.id, savedApp1.appName, savedCluster1.googleProject, Some(tr))
-      queue <- InspectableQueue.bounded[IO, Task[IO]](10)
-      leoSubscriber = makeLeoSubscriber(asyncTaskQueue = queue)
-      asyncTaskProcessor = AsyncTaskProcessor(AsyncTaskProcessor.Config(10, 10), queue)
-      _ <- leoSubscriber.handleStartAppMessage(msg)
-      _ <- withInfiniteStream(asyncTaskProcessor.process, assertions)
-    } yield ()
-
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "handle start app timeouts" in isolatedDbTest {
@@ -1581,39 +1389,44 @@ class LeoPubsubMessageSubscriberSpec
       getApp.nodepool.autoscalingEnabled shouldBe true
       getApp.nodepool.numNodes shouldBe NumNodes(2)
     }
-
-    val res = for {
-      tr <- traceId.ask[TraceId]
-      msg = StartAppMessage(savedApp1.id, savedApp1.appName, savedCluster1.googleProject, Some(tr))
-      queue <- InspectableQueue.bounded[IO, Task[IO]](10)
+    val queue = Queue.bounded[IO, Task[IO]](10).unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    val subscriber = for {
       lock <- nodepoolLock
-      // create a GKEInterpreter instance with a 'down' GalaxyDAO to simulate a timeout
-      gkeInter = new GKEInterpreter[IO](Config.gkeInterpConfig,
-                                        vpcInterp,
-                                        MockGKEService,
-                                        new MockKubernetesService(),
-                                        MockHelm,
-                                        new MockAppDAO(false),
-                                        credentials,
-                                        iamDAOKubernetes,
-                                        makeDetachingDiskInterp(),
-                                        MockAppDescriptorDAO,
-                                        blocker,
-                                        lock)
-      leoSubscriber = makeLeoSubscriber(asyncTaskQueue = queue, gkeInterpreter = gkeInter)
-      asyncTaskProcessor = AsyncTaskProcessor(AsyncTaskProcessor.Config(10, 10), queue)
-      _ <- leoSubscriber.handleStartAppMessage(msg)
-      _ <- withInfiniteStream(asyncTaskProcessor.process, assertions)
-    } yield ()
+      gkeInterp = new GKEInterpreter[IO](Config.gkeInterpConfig,
+                                         vpcInterp,
+                                         MockGKEService,
+                                         new MockKubernetesService(),
+                                         MockHelm,
+                                         new MockAppDAO(false),
+                                         credentials,
+                                         iamDAOKubernetes,
+                                         makeDetachingDiskInterp(),
+                                         MockAppDescriptorDAO,
+                                         lock)
+      leoSubscriber <- makeLeoSubscriber(asyncTaskQueue = queue,
+                                         diskInterp = makeDetachingDiskInterp(),
+                                         gkeAlgebra = gkeInterp)
+    } yield leoSubscriber
 
-    res.unsafeRunSync()
+    val res = subscriber.use { leoSubscriber =>
+      for {
+        tr <- traceId.ask[TraceId]
+        msg = StartAppMessage(savedApp1.id, savedApp1.appName, savedCluster1.googleProject, Some(tr))
+        // create a GKEInterpreter instance with a 'down' GalaxyDAO to simulate a timeout
+        asyncTaskProcessor = AsyncTaskProcessor(AsyncTaskProcessor.Config(10, 10), queue)
+        _ <- leoSubscriber.handleStartAppMessage(msg)
+        _ <- withInfiniteStream(asyncTaskProcessor.process, assertions)
+      } yield ()
+    }
+
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "be idempotent for create app" in isolatedDbTest {
     val savedCluster1 = makeKubeCluster(1).save()
     val savedNodepool1 = makeNodepool(1, savedCluster1.id).save()
 
-    val disk = makePersistentDisk(None).save().unsafeRunSync()
+    val disk = makePersistentDisk(None).save().unsafeRunSync()(cats.effect.unsafe.implicits.global)
     val makeApp1 = makeApp(1, savedNodepool1.id)
     val savedApp1 = makeApp1
       .copy(appResources =
@@ -1656,32 +1469,37 @@ class LeoPubsubMessageSubscriberSpec
       getDisk.status shouldBe DiskStatus.Ready
     }
 
-    val res = for {
-      tr <- traceId.ask[TraceId]
-      dummyNodepool = savedCluster1.nodepools.filter(_.isDefault).head
-      msg = CreateAppMessage(
-        savedCluster1.googleProject,
-        Some(ClusterNodepoolAction.CreateClusterAndNodepool(savedCluster1.id, dummyNodepool.id, savedNodepool1.id)),
-        savedApp1.id,
-        savedApp1.appName,
-        Some(disk.id),
-        Map.empty,
-        savedApp1.appType,
-        savedApp1.appResources.namespace.name,
-        Some(tr)
-      )
-      queue <- InspectableQueue.bounded[IO, Task[IO]](10)
+    val queue = Queue.bounded[IO, Task[IO]](10).unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    val subscriber = for {
       lock <- nodepoolLock
-      leoSubscriber = makeLeoSubscriber(asyncTaskQueue = queue,
-                                        gkeInterpreter = makeGKEInterp(lock, List(savedApp1.release)))
-      asyncTaskProcessor = AsyncTaskProcessor(AsyncTaskProcessor.Config(10, 10), queue)
-      // send message twice
-      _ <- leoSubscriber.handleCreateAppMessage(msg)
-      _ <- leoSubscriber.handleCreateAppMessage(msg)
-      _ <- withInfiniteStream(asyncTaskProcessor.process, assertions)
-    } yield ()
+      leoSubscriber <- makeLeoSubscriber(asyncTaskQueue = queue,
+                                         gkeAlgebra = makeGKEInterp(lock, List(savedApp1.release)))
+    } yield leoSubscriber
 
-    res.unsafeRunSync()
+    val res = subscriber.use { leoSubscriber =>
+      for {
+        tr <- traceId.ask[TraceId]
+        dummyNodepool = savedCluster1.nodepools.filter(_.isDefault).head
+        msg = CreateAppMessage(
+          savedCluster1.googleProject,
+          Some(ClusterNodepoolAction.CreateClusterAndNodepool(savedCluster1.id, dummyNodepool.id, savedNodepool1.id)),
+          savedApp1.id,
+          savedApp1.appName,
+          Some(disk.id),
+          Map.empty,
+          savedApp1.appType,
+          savedApp1.appResources.namespace.name,
+          Some(tr)
+        )
+        asyncTaskProcessor = AsyncTaskProcessor(AsyncTaskProcessor.Config(10, 10), queue)
+        // send message twice
+        _ <- leoSubscriber.handleCreateAppMessage(msg)
+        _ <- leoSubscriber.handleCreateAppMessage(msg)
+        _ <- withInfiniteStream(asyncTaskProcessor.process, assertions)
+      } yield ()
+    }
+
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "be idempotent for delete app" in isolatedDbTest {
@@ -1697,60 +1515,59 @@ class LeoPubsubMessageSubscriberSpec
       getApp.app.status shouldBe AppStatus.Deleted
       getApp.nodepool.status shouldBe savedNodepool1.status
     }
+    val queue = Queue.bounded[IO, Task[IO]](10).unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    val res = makeLeoSubscriber(asyncTaskQueue = queue, diskInterp = makeDetachingDiskInterp()).use { leoSubscriber =>
+      for {
+        tr <- traceId.ask[TraceId]
+        msg = DeleteAppMessage(savedApp1.id, savedApp1.appName, savedCluster1.googleProject, None, Some(tr))
+        asyncTaskProcessor = AsyncTaskProcessor(AsyncTaskProcessor.Config(10, 10), queue)
+        // send message twice
+        _ <- leoSubscriber.handleDeleteAppMessage(msg)
+        _ <- leoSubscriber.handleDeleteAppMessage(msg)
+        _ <- withInfiniteStream(asyncTaskProcessor.process, assertions)
+      } yield ()
+    }
 
-    val res = for {
-      tr <- traceId.ask[TraceId]
-      msg = DeleteAppMessage(savedApp1.id, savedApp1.appName, savedCluster1.googleProject, None, Some(tr))
-      queue <- InspectableQueue.bounded[IO, Task[IO]](10)
-      leoSubscriber = makeLeoSubscriber(asyncTaskQueue = queue, diskInterp = makeDetachingDiskInterp())
-      asyncTaskProcessor = AsyncTaskProcessor(AsyncTaskProcessor.Config(10, 10), queue)
-      // send message twice
-      _ <- leoSubscriber.handleDeleteAppMessage(msg)
-      _ <- leoSubscriber.handleDeleteAppMessage(msg)
-      _ <- withInfiniteStream(asyncTaskProcessor.process, assertions)
-    } yield ()
-
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "be idempotent for create disk" in isolatedDbTest {
-    val leoSubscriber = makeLeoSubscriber()
+    val res = makeLeoSubscriber().use { leoSubscriber =>
+      for {
+        disk <- makePersistentDisk(None).copy(status = DiskStatus.Creating).save()
+        tr <- traceId.ask[TraceId]
 
-    val res = for {
-      disk <- makePersistentDisk(None).copy(status = DiskStatus.Creating).save()
-      tr <- traceId.ask[TraceId]
-      now <- IO(Instant.now)
-
-      message = CreateDiskMessage.fromDisk(disk, Some(tr))
-      // send 2 messages
-      _ <- leoSubscriber.messageResponder(message)
-      _ <- leoSubscriber.messageResponder(message)
-      updatedDisk <- persistentDiskQuery.getById(disk.id).transaction
-    } yield {
-      updatedDisk shouldBe defined
-      updatedDisk.get.googleId.get.value shouldBe "target"
+        message = CreateDiskMessage.fromDisk(disk, Some(tr))
+        // send 2 messages
+        _ <- leoSubscriber.messageResponder(message)
+        _ <- leoSubscriber.messageResponder(message)
+        updatedDisk <- persistentDiskQuery.getById(disk.id)(scala.concurrent.ExecutionContext.global).transaction
+      } yield {
+        updatedDisk shouldBe defined
+        updatedDisk.get.googleId.get.value shouldBe "258165385"
+      }
     }
 
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
   it should "be idempotent for delete disk" in isolatedDbTest {
-    val leoSubscriber = makeLeoSubscriber()
+    val res = makeLeoSubscriber().use { leoSubscriber =>
+      for {
+        disk <- makePersistentDisk(None).copy(status = DiskStatus.Deleting).save()
+        tr <- traceId.ask[TraceId]
 
-    val res = for {
-      disk <- makePersistentDisk(None).copy(status = DiskStatus.Deleting).save()
-      tr <- traceId.ask[TraceId]
-
-      message = DeleteDiskMessage(disk.id, Some(tr))
-      // send 2 messages
-      _ <- leoSubscriber.messageResponder(message)
-      _ <- leoSubscriber.messageResponder(message)
-      updatedDisk <- persistentDiskQuery.getById(disk.id).transaction
-    } yield {
-      updatedDisk shouldBe defined
-      updatedDisk.get.status shouldBe DiskStatus.Deleting
+        message = DeleteDiskMessage(disk.id, Some(tr))
+        // send 2 messages
+        _ <- leoSubscriber.messageResponder(message)
+        _ <- leoSubscriber.messageResponder(message)
+        updatedDisk <- persistentDiskQuery.getById(disk.id)(scala.concurrent.ExecutionContext.global).transaction
+      } yield {
+        updatedDisk shouldBe defined
+        updatedDisk.get.status shouldBe DiskStatus.Deleting
+      }
     }
 
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   def makeGKEInterp(lock: KeyLock[IO, GKEModels.KubernetesClusterId],
@@ -1765,18 +1582,18 @@ class LeoPubsubMessageSubscriberSpec
                            iamDAOKubernetes,
                            makeDetachingDiskInterp(),
                            MockAppDescriptorDAO,
-                           blocker,
                            lock)
 
   def makeLeoSubscriber(
     runtimeMonitor: RuntimeMonitor[IO, CloudService] = MockRuntimeMonitor,
-    asyncTaskQueue: InspectableQueue[IO, Task[IO]] = InspectableQueue.bounded[IO, Task[IO]](10).unsafeRunSync(),
+    asyncTaskQueue: Queue[IO, Task[IO]] =
+      Queue.bounded[IO, Task[IO]](10).unsafeRunSync()(cats.effect.unsafe.implicits.global),
     computePollOperation: ComputePollOperation[IO] = new MockComputePollOperation,
-    gkeInterpreter: GKEInterpreter[IO] = makeGKEInterp(nodepoolLock.unsafeRunSync(), appRelease = List.empty),
+    gkeAlgebra: GKEAlgebra[IO] = new org.broadinstitute.dsde.workbench.leonardo.MockGKEService,
     diskInterp: GoogleDiskService[IO] = MockGoogleDiskService,
     dataprocRuntimeAlgebra: RuntimeAlgebra[IO] = dataprocInterp,
     gceRuntimeAlgebra: RuntimeAlgebra[IO] = gceInterp
-  ): LeoPubsubMessageSubscriber[IO] = {
+  ): Resource[IO, LeoPubsubMessageSubscriber[IO]] = nodepoolLock.map { lock =>
     val googleSubscriber = new FakeGoogleSubcriber[LeoPubsubMessage]
 
     implicit val runtimeInstances = new RuntimeInstances[IO](dataprocRuntimeAlgebra, gceRuntimeAlgebra)
@@ -1786,13 +1603,14 @@ class LeoPubsubMessageSubscriberSpec
     new LeoPubsubMessageSubscriber[IO](
       LeoPubsubMessageSubscriberConfig(1,
                                        30 seconds,
-                                       Config.leoPubsubMessageSubscriberConfig.persistentDiskMonitorConfig),
+                                       Config.leoPubsubMessageSubscriberConfig.persistentDiskMonitorConfig,
+                                       Config.leoPubsubMessageSubscriberConfig.galaxyDiskConfig),
       googleSubscriber,
       asyncTaskQueue,
       diskInterp,
       computePollOperation,
       MockAuthProvider,
-      gkeInterpreter,
+      gkeAlgebra,
       org.broadinstitute.dsde.workbench.errorReporting.FakeErrorReporting
     )
   }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/MonitorAtBootSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/MonitorAtBootSpec.scala
@@ -58,7 +58,7 @@ class MonitorAtBootSpec extends AnyFlatSpec with TestComponent with LeonardoTest
     } yield {
       (msg eqv Some(LeoPubsubMessage.StopRuntimeMessage(runtime.id, None))) shouldBe (true)
     }
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   it should "recover RuntimeStatus.Deleting properly" in isolatedDbTest {
@@ -71,7 +71,7 @@ class MonitorAtBootSpec extends AnyFlatSpec with TestComponent with LeonardoTest
     } yield {
       (msg eqv Some(LeoPubsubMessage.DeleteRuntimeMessage(runtime.id, None, None))) shouldBe (true)
     }
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   it should "recover RuntimeStatus.Starting properly" in isolatedDbTest {
@@ -84,7 +84,7 @@ class MonitorAtBootSpec extends AnyFlatSpec with TestComponent with LeonardoTest
     } yield {
       (msg eqv Some(LeoPubsubMessage.StartRuntimeMessage(runtime.id, None))) shouldBe (true)
     }
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   it should "recover RuntimeStatus.Creating properly" in isolatedDbTest {
@@ -104,7 +104,7 @@ class MonitorAtBootSpec extends AnyFlatSpec with TestComponent with LeonardoTest
         )
       )) shouldBe (true)
     }
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   it should "recover AppStatus.Provisioning properly with cluster and nodepool creation" in isolatedDbTest {
@@ -134,7 +134,7 @@ class MonitorAtBootSpec extends AnyFlatSpec with TestComponent with LeonardoTest
       )
       (msg eqv Some(expected)) shouldBe true
     }
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   it should "recover AppStatus.Provisioning properly with nodepool creation" in isolatedDbTest {
@@ -163,7 +163,7 @@ class MonitorAtBootSpec extends AnyFlatSpec with TestComponent with LeonardoTest
       )
       (msg eqv Some(expected)) shouldBe true
     }
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   it should "recover AppStatus.Provisioning properly" in isolatedDbTest {
@@ -192,7 +192,7 @@ class MonitorAtBootSpec extends AnyFlatSpec with TestComponent with LeonardoTest
       )
       (msg eqv Some(expected)) shouldBe true
     }
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   it should "recover AppStatus.Deleting properly" in isolatedDbTest {
@@ -217,7 +217,7 @@ class MonitorAtBootSpec extends AnyFlatSpec with TestComponent with LeonardoTest
       )
       (msg eqv Some(expected)) shouldBe true
     }
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   it should "ignore non-monitored apps" in isolatedDbTest {
@@ -235,12 +235,12 @@ class MonitorAtBootSpec extends AnyFlatSpec with TestComponent with LeonardoTest
     } yield {
       msg shouldBe None
     }
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   def createMonitorAtBoot(
     queue: Queue[IO, LeoPubsubMessage] =
-      Queue.bounded[IO, LeoPubsubMessage](10).unsafeRunSync()(cats.effect.unsafe.implicits.global)
+      Queue.bounded[IO, LeoPubsubMessage](10).unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   ): MonitorAtBoot[IO] =
     new MonitorAtBoot[IO](queue, org.broadinstitute.dsde.workbench.errorReporting.FakeErrorReporting)
 }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/NonLeoMessageSubscriberSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/NonLeoMessageSubscriberSpec.scala
@@ -125,7 +125,7 @@ class NonLeoMessageSubscriberSpec extends AnyFlatSpec with LeonardoTestSuite wit
       clusterOpt.get.status shouldBe KubernetesClusterStatus.Deleting
     }
 
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   it should "handle DeleteNodepoolMessage" in isolatedDbTest {
@@ -142,7 +142,7 @@ class NonLeoMessageSubscriberSpec extends AnyFlatSpec with LeonardoTestSuite wit
       attempt shouldBe Right(())
     }
 
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   def makeSubscribler(
@@ -151,7 +151,7 @@ class NonLeoMessageSubscriberSpec extends AnyFlatSpec with LeonardoTestSuite wit
     computeService: GoogleComputeService[IO] = FakeGoogleComputeService,
     publisher: GooglePublisher[IO] = new FakeGooglePublisher,
     asyncTaskQueue: Queue[IO, Task[IO]] =
-      Queue.bounded[IO, Task[IO]](10).unsafeRunSync()(cats.effect.unsafe.implicits.global)
+      Queue.bounded[IO, Task[IO]](10).unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   ): NonLeoMessageSubscriber[IO] = {
     val googleSubscriber = new FakeGoogleSubcriber[NonLeoMessage]
     new NonLeoMessageSubscriber(gkeInterp, computeService, samDao, googleSubscriber, publisher, asyncTaskQueue)

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/DataprocInterpreterSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/DataprocInterpreterSpec.scala
@@ -170,10 +170,11 @@ class DataprocInterpreterSpec
 
   private class ErroredMockGoogleIamDAO(statusCode: Int = 400) extends MockGoogleIamDAO {
     var invocationCount = 0
-    override def addIamRoles(iamProject: GoogleProject,
-                             email: WorkbenchEmail,
+    override def addIamRoles(googleProject: GoogleProject,
+                             userEmail: WorkbenchEmail,
                              memberType: MemberType,
-                             rolesToAdd: Set[String]): Future[Boolean] = {
+                             rolesToAdd: Set[String],
+                             retryIfGroupDoesNotExist: Boolean): Future[Boolean] = {
       invocationCount += 1
       val jsonFactory = new MockJsonFactory
       val testException =

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/DataprocInterpreterSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/DataprocInterpreterSpec.scala
@@ -98,7 +98,7 @@ class DataprocInterpreterSpec
                                                None)
             )
         )
-        .unsafeToFuture()(cats.effect.unsafe.implicits.global)
+        .unsafeToFuture()(cats.effect.unsafe.IORuntime.global)
         .futureValue
 
     // verify the returned cluster
@@ -139,7 +139,7 @@ class DataprocInterpreterSpec
                                                None)
             )
         )
-        .unsafeToFuture()(cats.effect.unsafe.implicits.global)
+        .unsafeToFuture()(cats.effect.unsafe.IORuntime.global)
         .failed
         .futureValue
     exception shouldBe a[GoogleJsonResponseException]
@@ -162,7 +162,7 @@ class DataprocInterpreterSpec
       .getClusterResourceContraints(testClusterClusterProjectAndName,
                                     runtimeConfig.machineType,
                                     RegionName("us-central1"))
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+      .unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
 
     // 7680m (in mock compute dao) - 6g (dataproc allocated) - 768m (welder allocated) = 768m
     resourceConstraints.memoryLimit shouldBe MemorySize.fromMb(768)

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreterSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreterSpec.scala
@@ -42,7 +42,7 @@ class GKEInterpreterSpec extends AnyFlatSpecLike with TestComponent with Leonard
                            FakeGoogleComputeService,
                            new MockComputePollOperation)
 
-  val gkeInterpResource = nodepoolLock.map(lock =>
+  val gkeInterp =
     new GKEInterpreter[IO](
       Config.gkeInterpConfig,
       vpcInterp,
@@ -54,9 +54,8 @@ class GKEInterpreterSpec extends AnyFlatSpecLike with TestComponent with Leonard
       googleIamDao,
       MockGoogleDiskService,
       MockAppDescriptorDAO,
-      lock
+      nodepoolLock
     )
-  )
 
   "GKEInterpreter" should "create a nodepool with autoscaling" in isolatedDbTest {
     val savedCluster1 = makeKubeCluster(1).save()
@@ -66,15 +65,10 @@ class GKEInterpreterSpec extends AnyFlatSpecLike with TestComponent with Leonard
       .copy(autoscalingEnabled = true,
             autoscalingConfig = Some(AutoscalingConfig(AutoscalingMin(minNodes), AutoscalingMax(maxNodes))))
       .save()
-    val res = gkeInterpResource.use { gkeInterp =>
-      val googleNodepool = gkeInterp.buildGoogleNodepool(savedNodepool1)
-      IO {
-        googleNodepool.getAutoscaling.getEnabled shouldBe true
-        googleNodepool.getAutoscaling.getMinNodeCount shouldBe minNodes
-        googleNodepool.getAutoscaling.getMaxNodeCount shouldBe maxNodes
-      }
-    }
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    val googleNodepool = gkeInterp.buildGoogleNodepool(savedNodepool1)
+    googleNodepool.getAutoscaling.getEnabled shouldBe true
+    googleNodepool.getAutoscaling.getMinNodeCount shouldBe minNodes
+    googleNodepool.getAutoscaling.getMaxNodeCount shouldBe maxNodes
   }
 
   it should "get a helm auth context" in {
@@ -88,12 +82,10 @@ class GKEInterpreterSpec extends AnyFlatSpecLike with TestComponent with Leonard
       )
       .build
 
-    val authContext = gkeInterpResource
-      .use { gkeInterp =>
-        gkeInterp
-          .getHelmAuthContext(googleCluster, makeKubeCluster(1), NamespaceName("ns"))
-      }
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    val authContext =
+      gkeInterp
+        .getHelmAuthContext(googleCluster, makeKubeCluster(1), NamespaceName("ns"))
+        .unsafeRunSync()(cats.effect.unsafe.implicits.global)
 
     authContext.namespace.asString shouldBe "ns"
     authContext.kubeApiServer.asString shouldBe "https://1.2.3.4"
@@ -105,102 +97,82 @@ class GKEInterpreterSpec extends AnyFlatSpecLike with TestComponent with Leonard
   it should "build Galaxy override values string" in {
     val savedCluster1 = makeKubeCluster(1)
     val savedDisk1 = makePersistentDisk(Some(DiskName("disk1")), Some(FormattedBy.Galaxy))
-    val res = gkeInterpResource.use { gkeInterp =>
-      IO {
-        val r = gkeInterp.buildGalaxyChartOverrideValuesString(
-          AppName("app1"),
-          Release("app1-galaxy-rls"),
-          savedCluster1,
-          NodepoolName("pool1"),
-          userEmail,
-          Map("WORKSPACE_NAME" -> "test-workspace",
-              "WORKSPACE_BUCKET" -> "gs://test-bucket",
-              "WORKSPACE_NAMESPACE" -> "dsp-leo-test1"),
-          ServiceAccountName("app1-galaxy-ksa"),
-          NamespaceName("ns"),
-          savedDisk1,
-          DiskName("disk1-gxy-postres-disk"),
-          None
-        )
+    val res = gkeInterp.buildGalaxyChartOverrideValuesString(
+      AppName("app1"),
+      Release("app1-galaxy-rls"),
+      savedCluster1,
+      NodepoolName("pool1"),
+      userEmail,
+      Map("WORKSPACE_NAME" -> "test-workspace",
+          "WORKSPACE_BUCKET" -> "gs://test-bucket",
+          "WORKSPACE_NAMESPACE" -> "dsp-leo-test1"),
+      ServiceAccountName("app1-galaxy-ksa"),
+      NamespaceName("ns"),
+      savedDisk1,
+      DiskName("disk1-gxy-postres-disk"),
+      None
+    )
 
-        r.mkString(",") shouldBe """nfs.storageClass.name=nfs-app1-galaxy-rls,cvmfs.repositories.cvmfs-gxy-data-app1-galaxy-rls=data.galaxyproject.org,cvmfs.cache.alienCache.storageClass=nfs-app1-galaxy-rls,galaxy.persistence.storageClass=nfs-app1-galaxy-rls,galaxy.cvmfs.galaxyPersistentVolumeClaims.data.storageClassName=cvmfs-gxy-data-app1-galaxy-rls,galaxy.nodeSelector.cloud\.google\.com/gke-nodepool=pool1,nfs.nodeSelector.cloud\.google\.com/gke-nodepool=pool1,galaxy.configs.job_conf\.yml.runners.k8s.k8s_node_selector=cloud.google.com/gke-nodepool: pool1,galaxy.postgresql.master.nodeSelector.cloud\.google\.com/gke-nodepool=pool1,galaxy.ingress.path=/proxy/google/v1/apps/dsp-leo-test1/app1/galaxy,galaxy.ingress.annotations.nginx\.ingress\.kubernetes\.io/proxy-redirect-from=https://1455694897.jupyter.firecloud.org,galaxy.ingress.annotations.nginx\.ingress\.kubernetes\.io/proxy-redirect-to=https://leo,galaxy.ingress.hosts[0].host=1455694897.jupyter.firecloud.org,galaxy.ingress.hosts[0].paths[0].path=/proxy/google/v1/apps/dsp-leo-test1/app1/galaxy,galaxy.ingress.tls[0].hosts[0]=1455694897.jupyter.firecloud.org,galaxy.ingress.tls[0].secretName=tls-secret,galaxy.configs.galaxy\.yml.galaxy.single_user=user1@example.com,galaxy.configs.galaxy\.yml.galaxy.admin_users=user1@example.com,galaxy.terra.launch.workspace=test-workspace,galaxy.terra.launch.namespace=dsp-leo-test1,galaxy.configs.file_sources_conf\.yml[0].api_url=https://firecloud-orchestration.dsde-dev.broadinstitute.org/api/,galaxy.configs.file_sources_conf\.yml[0].drs_url=https://us-central1-broad-dsde-dev.cloudfunctions.net/martha_v3,galaxy.configs.file_sources_conf\.yml[0].doc=test-workspace,galaxy.configs.file_sources_conf\.yml[0].id=test-workspace,galaxy.configs.file_sources_conf\.yml[0].workspace=test-workspace,galaxy.configs.file_sources_conf\.yml[0].namespace=dsp-leo-test1,galaxy.configs.file_sources_conf\.yml[0].type=anvil,galaxy.configs.file_sources_conf\.yml[0].on_anvil=True,galaxy.configs.file_sources_conf\.yml[0].writable=True,galaxy.serviceAccount.create=false,galaxy.serviceAccount.name=app1-galaxy-ksa,rbac.serviceAccount=app1-galaxy-ksa,persistence.nfs.name=ns-nfs-disk,persistence.nfs.persistentVolume.extraSpec.gcePersistentDisk.pdName=disk1,persistence.nfs.size=250Gi,persistence.postgres.name=ns-postgres-disk,galaxy.postgresql.galaxyDatabasePassword=replace-me,persistence.postgres.persistentVolume.extraSpec.gcePersistentDisk.pdName=disk1-gxy-postres-disk,persistence.postgres.size=10Gi,nfs.persistence.existingClaim=ns-nfs-disk-pvc,nfs.persistence.size=250Gi,galaxy.postgresql.persistence.existingClaim=ns-postgres-disk-pvc,galaxy.persistence.size=200Gi,configs.WORKSPACE_NAME=test-workspace,extraEnv[0].name=WORKSPACE_NAME,extraEnv[0].valueFrom.configMapKeyRef.name=app1-galaxy-rls-galaxykubeman-configs,extraEnv[0].valueFrom.configMapKeyRef.key=WORKSPACE_NAME,configs.WORKSPACE_BUCKET=gs://test-bucket,extraEnv[1].name=WORKSPACE_BUCKET,extraEnv[1].valueFrom.configMapKeyRef.name=app1-galaxy-rls-galaxykubeman-configs,extraEnv[1].valueFrom.configMapKeyRef.key=WORKSPACE_BUCKET,configs.WORKSPACE_NAMESPACE=dsp-leo-test1,extraEnv[2].name=WORKSPACE_NAMESPACE,extraEnv[2].valueFrom.configMapKeyRef.name=app1-galaxy-rls-galaxykubeman-configs,extraEnv[2].valueFrom.configMapKeyRef.key=WORKSPACE_NAMESPACE"""
-      }
-    }
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.mkString(",") shouldBe """nfs.storageClass.name=nfs-app1-galaxy-rls,cvmfs.repositories.cvmfs-gxy-data-app1-galaxy-rls=data.galaxyproject.org,cvmfs.cache.alienCache.storageClass=nfs-app1-galaxy-rls,galaxy.persistence.storageClass=nfs-app1-galaxy-rls,galaxy.cvmfs.galaxyPersistentVolumeClaims.data.storageClassName=cvmfs-gxy-data-app1-galaxy-rls,galaxy.nodeSelector.cloud\.google\.com/gke-nodepool=pool1,nfs.nodeSelector.cloud\.google\.com/gke-nodepool=pool1,galaxy.configs.job_conf\.yml.runners.k8s.k8s_node_selector=cloud.google.com/gke-nodepool: pool1,galaxy.postgresql.master.nodeSelector.cloud\.google\.com/gke-nodepool=pool1,galaxy.ingress.path=/proxy/google/v1/apps/dsp-leo-test1/app1/galaxy,galaxy.ingress.annotations.nginx\.ingress\.kubernetes\.io/proxy-redirect-from=https://1455694897.jupyter.firecloud.org,galaxy.ingress.annotations.nginx\.ingress\.kubernetes\.io/proxy-redirect-to=https://leo,galaxy.ingress.hosts[0].host=1455694897.jupyter.firecloud.org,galaxy.ingress.hosts[0].paths[0].path=/proxy/google/v1/apps/dsp-leo-test1/app1/galaxy,galaxy.ingress.tls[0].hosts[0]=1455694897.jupyter.firecloud.org,galaxy.ingress.tls[0].secretName=tls-secret,galaxy.configs.galaxy\.yml.galaxy.single_user=user1@example.com,galaxy.configs.galaxy\.yml.galaxy.admin_users=user1@example.com,galaxy.terra.launch.workspace=test-workspace,galaxy.terra.launch.namespace=dsp-leo-test1,galaxy.configs.file_sources_conf\.yml[0].api_url=https://firecloud-orchestration.dsde-dev.broadinstitute.org/api/,galaxy.configs.file_sources_conf\.yml[0].drs_url=https://us-central1-broad-dsde-dev.cloudfunctions.net/martha_v3,galaxy.configs.file_sources_conf\.yml[0].doc=test-workspace,galaxy.configs.file_sources_conf\.yml[0].id=test-workspace,galaxy.configs.file_sources_conf\.yml[0].workspace=test-workspace,galaxy.configs.file_sources_conf\.yml[0].namespace=dsp-leo-test1,galaxy.configs.file_sources_conf\.yml[0].type=anvil,galaxy.configs.file_sources_conf\.yml[0].on_anvil=True,galaxy.configs.file_sources_conf\.yml[0].writable=True,galaxy.serviceAccount.create=false,galaxy.serviceAccount.name=app1-galaxy-ksa,rbac.serviceAccount=app1-galaxy-ksa,persistence.nfs.name=ns-nfs-disk,persistence.nfs.persistentVolume.extraSpec.gcePersistentDisk.pdName=disk1,persistence.nfs.size=250Gi,persistence.postgres.name=ns-postgres-disk,galaxy.postgresql.galaxyDatabasePassword=replace-me,persistence.postgres.persistentVolume.extraSpec.gcePersistentDisk.pdName=disk1-gxy-postres-disk,persistence.postgres.size=10Gi,nfs.persistence.existingClaim=ns-nfs-disk-pvc,nfs.persistence.size=250Gi,galaxy.postgresql.persistence.existingClaim=ns-postgres-disk-pvc,galaxy.persistence.size=200Gi,configs.WORKSPACE_NAME=test-workspace,extraEnv[0].name=WORKSPACE_NAME,extraEnv[0].valueFrom.configMapKeyRef.name=app1-galaxy-rls-galaxykubeman-configs,extraEnv[0].valueFrom.configMapKeyRef.key=WORKSPACE_NAME,configs.WORKSPACE_BUCKET=gs://test-bucket,extraEnv[1].name=WORKSPACE_BUCKET,extraEnv[1].valueFrom.configMapKeyRef.name=app1-galaxy-rls-galaxykubeman-configs,extraEnv[1].valueFrom.configMapKeyRef.key=WORKSPACE_BUCKET,configs.WORKSPACE_NAMESPACE=dsp-leo-test1,extraEnv[2].name=WORKSPACE_NAMESPACE,extraEnv[2].valueFrom.configMapKeyRef.name=app1-galaxy-rls-galaxykubeman-configs,extraEnv[2].valueFrom.configMapKeyRef.key=WORKSPACE_NAMESPACE"""
   }
 
   it should "build Galaxy override values string with restore info" in {
     val savedCluster1 = makeKubeCluster(1)
     val savedDisk1 = makePersistentDisk(Some(DiskName("disk1")), Some(FormattedBy.Galaxy))
-    val result = gkeInterpResource
-      .use { gkeInterp =>
-        IO(
-          gkeInterp.buildGalaxyChartOverrideValuesString(
-            AppName("app1"),
-            Release("app1-galaxy-rls"),
-            savedCluster1,
-            NodepoolName("pool1"),
-            userEmail,
-            Map("WORKSPACE_NAME" -> "test-workspace",
-                "WORKSPACE_BUCKET" -> "gs://test-bucket",
-                "WORKSPACE_NAMESPACE" -> "dsp-leo-test1"),
-            ServiceAccountName("app1-galaxy-ksa"),
-            NamespaceName("ns"),
-            savedDisk1,
-            DiskName("disk1-gxy-postres"),
-            Some(
-              GalaxyRestore(PvcId("galaxy-pvc-id"), PvcId("cvmfs-pvc-id"), AppId(123))
-            )
-          )
+    val result =
+      gkeInterp.buildGalaxyChartOverrideValuesString(
+        AppName("app1"),
+        Release("app1-galaxy-rls"),
+        savedCluster1,
+        NodepoolName("pool1"),
+        userEmail,
+        Map("WORKSPACE_NAME" -> "test-workspace",
+            "WORKSPACE_BUCKET" -> "gs://test-bucket",
+            "WORKSPACE_NAMESPACE" -> "dsp-leo-test1"),
+        ServiceAccountName("app1-galaxy-ksa"),
+        NamespaceName("ns"),
+        savedDisk1,
+        DiskName("disk1-gxy-postres"),
+        Some(
+          GalaxyRestore(PvcId("galaxy-pvc-id"), PvcId("cvmfs-pvc-id"), AppId(123))
         )
-      }
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+      )
     result.mkString(",") shouldBe """nfs.storageClass.name=nfs-app1-galaxy-rls,cvmfs.repositories.cvmfs-gxy-data-app1-galaxy-rls=data.galaxyproject.org,cvmfs.cache.alienCache.storageClass=nfs-app1-galaxy-rls,galaxy.persistence.storageClass=nfs-app1-galaxy-rls,galaxy.cvmfs.galaxyPersistentVolumeClaims.data.storageClassName=cvmfs-gxy-data-app1-galaxy-rls,galaxy.nodeSelector.cloud\.google\.com/gke-nodepool=pool1,nfs.nodeSelector.cloud\.google\.com/gke-nodepool=pool1,galaxy.configs.job_conf\.yml.runners.k8s.k8s_node_selector=cloud.google.com/gke-nodepool: pool1,galaxy.postgresql.master.nodeSelector.cloud\.google\.com/gke-nodepool=pool1,galaxy.ingress.path=/proxy/google/v1/apps/dsp-leo-test1/app1/galaxy,galaxy.ingress.annotations.nginx\.ingress\.kubernetes\.io/proxy-redirect-from=https://1455694897.jupyter.firecloud.org,galaxy.ingress.annotations.nginx\.ingress\.kubernetes\.io/proxy-redirect-to=https://leo,galaxy.ingress.hosts[0].host=1455694897.jupyter.firecloud.org,galaxy.ingress.hosts[0].paths[0].path=/proxy/google/v1/apps/dsp-leo-test1/app1/galaxy,galaxy.ingress.tls[0].hosts[0]=1455694897.jupyter.firecloud.org,galaxy.ingress.tls[0].secretName=tls-secret,galaxy.configs.galaxy\.yml.galaxy.single_user=user1@example.com,galaxy.configs.galaxy\.yml.galaxy.admin_users=user1@example.com,galaxy.terra.launch.workspace=test-workspace,galaxy.terra.launch.namespace=dsp-leo-test1,galaxy.configs.file_sources_conf\.yml[0].api_url=https://firecloud-orchestration.dsde-dev.broadinstitute.org/api/,galaxy.configs.file_sources_conf\.yml[0].drs_url=https://us-central1-broad-dsde-dev.cloudfunctions.net/martha_v3,galaxy.configs.file_sources_conf\.yml[0].doc=test-workspace,galaxy.configs.file_sources_conf\.yml[0].id=test-workspace,galaxy.configs.file_sources_conf\.yml[0].workspace=test-workspace,galaxy.configs.file_sources_conf\.yml[0].namespace=dsp-leo-test1,galaxy.configs.file_sources_conf\.yml[0].type=anvil,galaxy.configs.file_sources_conf\.yml[0].on_anvil=True,galaxy.configs.file_sources_conf\.yml[0].writable=True,galaxy.serviceAccount.create=false,galaxy.serviceAccount.name=app1-galaxy-ksa,rbac.serviceAccount=app1-galaxy-ksa,persistence.nfs.name=ns-nfs-disk,persistence.nfs.persistentVolume.extraSpec.gcePersistentDisk.pdName=disk1,persistence.nfs.size=250Gi,persistence.postgres.name=ns-postgres-disk,galaxy.postgresql.galaxyDatabasePassword=replace-me,persistence.postgres.persistentVolume.extraSpec.gcePersistentDisk.pdName=disk1-gxy-postres,persistence.postgres.size=10Gi,nfs.persistence.existingClaim=ns-nfs-disk-pvc,nfs.persistence.size=250Gi,galaxy.postgresql.persistence.existingClaim=ns-postgres-disk-pvc,galaxy.persistence.size=200Gi,configs.WORKSPACE_NAME=test-workspace,extraEnv[0].name=WORKSPACE_NAME,extraEnv[0].valueFrom.configMapKeyRef.name=app1-galaxy-rls-galaxykubeman-configs,extraEnv[0].valueFrom.configMapKeyRef.key=WORKSPACE_NAME,configs.WORKSPACE_BUCKET=gs://test-bucket,extraEnv[1].name=WORKSPACE_BUCKET,extraEnv[1].valueFrom.configMapKeyRef.name=app1-galaxy-rls-galaxykubeman-configs,extraEnv[1].valueFrom.configMapKeyRef.key=WORKSPACE_BUCKET,configs.WORKSPACE_NAMESPACE=dsp-leo-test1,extraEnv[2].name=WORKSPACE_NAMESPACE,extraEnv[2].valueFrom.configMapKeyRef.name=app1-galaxy-rls-galaxykubeman-configs,extraEnv[2].valueFrom.configMapKeyRef.key=WORKSPACE_NAMESPACE,restore.persistence.nfs.galaxy.pvcID=galaxy-pvc-id,restore.persistence.nfs.cvmfsCache.pvcID=cvmfs-pvc-id,galaxy.persistence.existingClaim=app1-galaxy-rls-galaxy-pvc,cvmfs.cache.alienCache.existingClaim=app1-galaxy-rls-cvmfs-alien-cache-pvc""".stripMargin
   }
 
   it should "check if a pod is done" in {
-    val res = gkeInterpResource.use { gkeInterp =>
-      IO {
-        gkeInterp.isPodDone(KubernetesPodStatus(PodName("pod1"), PodStatus.Succeeded)) shouldBe true
-        gkeInterp.isPodDone(KubernetesPodStatus(PodName("pod2"), PodStatus.Pending)) shouldBe false
-        gkeInterp.isPodDone(KubernetesPodStatus(PodName("pod3"), PodStatus.Failed)) shouldBe true
-        gkeInterp.isPodDone(KubernetesPodStatus(PodName("pod4"), PodStatus.Unknown)) shouldBe false
-        gkeInterp.isPodDone(KubernetesPodStatus(PodName("pod5"), PodStatus.Running)) shouldBe false
-      }
-    }
-
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    gkeInterp.isPodDone(KubernetesPodStatus(PodName("pod1"), PodStatus.Succeeded)) shouldBe true
+    gkeInterp.isPodDone(KubernetesPodStatus(PodName("pod2"), PodStatus.Pending)) shouldBe false
+    gkeInterp.isPodDone(KubernetesPodStatus(PodName("pod3"), PodStatus.Failed)) shouldBe true
+    gkeInterp.isPodDone(KubernetesPodStatus(PodName("pod4"), PodStatus.Unknown)) shouldBe false
+    gkeInterp.isPodDone(KubernetesPodStatus(PodName("pod5"), PodStatus.Running)) shouldBe false
   }
 
   it should "deleteAndPollCluster properly" in isolatedDbTest {
-    val res = gkeInterpResource.use { gkeInterp =>
-      for {
-        savedCluster <- IO(makeKubeCluster(1).save())
-        m = DeleteClusterParams(
-          savedCluster.id,
-          savedCluster.googleProject
-        )
-        _ <- gkeInterp.deleteAndPollCluster(m)
-        clusterOpt <- kubernetesClusterQuery.getMinimalClusterById(savedCluster.id).transaction
-      } yield {
-        clusterOpt.get.status shouldBe KubernetesClusterStatus.Deleted
-      }
+    val res = for {
+      savedCluster <- IO(makeKubeCluster(1).save())
+      m = DeleteClusterParams(
+        savedCluster.id,
+        savedCluster.googleProject
+      )
+      _ <- gkeInterp.deleteAndPollCluster(m)
+      clusterOpt <- kubernetesClusterQuery.getMinimalClusterById(savedCluster.id).transaction
+    } yield {
+      clusterOpt.get.status shouldBe KubernetesClusterStatus.Deleted
     }
 
     res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "deleteAndPollNodepool properly" in isolatedDbTest {
-    val res = gkeInterpResource.use { gkeInterp =>
-      for {
-        savedCluster <- IO(makeKubeCluster(1).save())
-        savedNodepool <- IO(makeNodepool(1, savedCluster.id).save())
-        m = DeleteNodepoolParams(savedNodepool.id, savedCluster.googleProject)
-        _ <- gkeInterp.deleteAndPollNodepool(m)
-        nodepoolOpt <- nodepoolQuery.getMinimalById(savedNodepool.id).transaction
-      } yield {
-        nodepoolOpt.get.status shouldBe NodepoolStatus.Deleted
-      }
+    val res = for {
+      savedCluster <- IO(makeKubeCluster(1).save())
+      savedNodepool <- IO(makeNodepool(1, savedCluster.id).save())
+      m = DeleteNodepoolParams(savedNodepool.id, savedCluster.googleProject)
+      _ <- gkeInterp.deleteAndPollNodepool(m)
+      nodepoolOpt <- nodepoolQuery.getMinimalById(savedNodepool.id).transaction
+    } yield {
+      nodepoolOpt.get.status shouldBe NodepoolStatus.Deleted
     }
 
     res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
@@ -213,7 +185,7 @@ class GKEInterpreterSpec extends AnyFlatSpecLike with TestComponent with Leonard
       ): IO[Option[Operation]] = IO.pure(None)
     }
 
-    val gkeInterpDelete = nodepoolLock.map(nl =>
+    val gkeInterpDelete =
       new GKEInterpreter[IO](
         Config.gkeInterpConfig,
         vpcInterp,
@@ -225,20 +197,17 @@ class GKEInterpreterSpec extends AnyFlatSpecLike with TestComponent with Leonard
         googleIamDao,
         MockGoogleDiskService,
         MockAppDescriptorDAO,
-        nl
+        nodepoolLock
       )
-    )
 
-    val res = gkeInterpDelete.use { gkeInterp =>
-      for {
-        savedCluster <- IO(makeKubeCluster(1).save())
-        savedNodepool <- IO(makeNodepool(1, savedCluster.id).save())
-        m = DeleteNodepoolParams(savedNodepool.id, savedCluster.googleProject)
-        _ <- gkeInterp.deleteAndPollNodepool(m)
-        nodepoolOpt <- nodepoolQuery.getMinimalById(savedNodepool.id).transaction
-      } yield {
-        nodepoolOpt.get.status shouldBe NodepoolStatus.Deleted
-      }
+    val res = for {
+      savedCluster <- IO(makeKubeCluster(1).save())
+      savedNodepool <- IO(makeNodepool(1, savedCluster.id).save())
+      m = DeleteNodepoolParams(savedNodepool.id, savedCluster.googleProject)
+      _ <- gkeInterpDelete.deleteAndPollNodepool(m)
+      nodepoolOpt <- nodepoolQuery.getMinimalById(savedNodepool.id).transaction
+    } yield {
+      nodepoolOpt.get.status shouldBe NodepoolStatus.Deleted
     }
 
     res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
@@ -249,18 +218,16 @@ class GKEInterpreterSpec extends AnyFlatSpecLike with TestComponent with Leonard
     val savedNodepool1 = makeNodepool(1, savedCluster1.id).copy(status = NodepoolStatus.Running).save()
     val savedApp1 = makeApp(1, savedNodepool1.id).copy(status = AppStatus.Stopping).save()
 
-    val res = gkeInterpResource.use { gkeInterp =>
-      for {
-        _ <- gkeInterp.stopAndPollApp(StopAppParams(savedApp1.id, savedApp1.appName, savedCluster1.googleProject))
-        getAppOpt <- KubernetesServiceDbQueries.getFullAppByName(savedCluster1.googleProject, savedApp1.id).transaction
-        getApp = getAppOpt.get
-      } yield {
-        getApp.app.errors.size shouldBe 0
-        getApp.app.status shouldBe AppStatus.Stopped
-        getApp.nodepool.status shouldBe NodepoolStatus.Running
-        getApp.nodepool.autoscalingEnabled shouldBe true
-        getApp.nodepool.numNodes shouldBe NumNodes(2)
-      }
+    val res = for {
+      _ <- gkeInterp.stopAndPollApp(StopAppParams(savedApp1.id, savedApp1.appName, savedCluster1.googleProject))
+      getAppOpt <- KubernetesServiceDbQueries.getFullAppByName(savedCluster1.googleProject, savedApp1.id).transaction
+      getApp = getAppOpt.get
+    } yield {
+      getApp.app.errors.size shouldBe 0
+      getApp.app.status shouldBe AppStatus.Stopped
+      getApp.nodepool.status shouldBe NodepoolStatus.Running
+      getApp.nodepool.autoscalingEnabled shouldBe true
+      getApp.nodepool.numNodes shouldBe NumNodes(2)
     }
 
     res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
@@ -271,110 +238,100 @@ class GKEInterpreterSpec extends AnyFlatSpecLike with TestComponent with Leonard
     val savedNodepool1 = makeNodepool(1, savedCluster1.id).copy(status = NodepoolStatus.Running).save()
     val savedApp1 = makeApp(1, savedNodepool1.id).copy(status = AppStatus.Stopping).save()
 
-    val res = gkeInterpResource.use { gkeInterp =>
-      for {
-        _ <- gkeInterp.startAndPollApp(StartAppParams(savedApp1.id, savedApp1.appName, savedCluster1.googleProject))
-        getAppOpt <- KubernetesServiceDbQueries.getFullAppByName(savedCluster1.googleProject, savedApp1.id).transaction
-        getApp = getAppOpt.get
-      } yield {
-        getApp.app.errors.size shouldBe 0
-        getApp.app.status shouldBe AppStatus.Running
-        getApp.nodepool.status shouldBe NodepoolStatus.Running
-        getApp.nodepool.autoscalingEnabled shouldBe true
-        getApp.nodepool.numNodes shouldBe NumNodes(2)
-      }
+    val res = for {
+      _ <- gkeInterp.startAndPollApp(StartAppParams(savedApp1.id, savedApp1.appName, savedCluster1.googleProject))
+      getAppOpt <- KubernetesServiceDbQueries.getFullAppByName(savedCluster1.googleProject, savedApp1.id).transaction
+      getApp = getAppOpt.get
+    } yield {
+      getApp.app.errors.size shouldBe 0
+      getApp.app.status shouldBe AppStatus.Running
+      getApp.nodepool.status shouldBe NodepoolStatus.Running
+      getApp.nodepool.autoscalingEnabled shouldBe true
+      getApp.nodepool.numNodes shouldBe NumNodes(2)
     }
 
     res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "error during createCluster if cluster doesn't exist in database" in isolatedDbTest {
-    val res = gkeInterpResource.use { gkeInterp =>
-      for {
-        ctx <- appContext.ask[AppContext]
-        r <- gkeInterp
-          .createCluster(
-            CreateClusterParams(KubernetesClusterLeoId(-1),
-                                GoogleProject("fake"),
-                                List(NodepoolLeoId(-1), NodepoolLeoId(-1)))
-          )
-          .attempt
-      } yield {
-        r shouldBe (Left(
-          KubernetesClusterNotFoundException(
-            s"Failed kubernetes cluster creation. Cluster with id -1 not found in database | trace id: ${ctx.traceId}"
-          )
-        ))
-      }
+    val res = for {
+      ctx <- appContext.ask[AppContext]
+      r <- gkeInterp
+        .createCluster(
+          CreateClusterParams(KubernetesClusterLeoId(-1),
+                              GoogleProject("fake"),
+                              List(NodepoolLeoId(-1), NodepoolLeoId(-1)))
+        )
+        .attempt
+    } yield {
+      r shouldBe (Left(
+        KubernetesClusterNotFoundException(
+          s"Failed kubernetes cluster creation. Cluster with id -1 not found in database | trace id: ${ctx.traceId}"
+        )
+      ))
     }
     res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "error on pollCluster if default nodepool doesn't exist" in isolatedDbTest {
     val savedCluster1 = makeKubeCluster(1, false).saveWithOutDefaultNodepool()
-    val res = gkeInterpResource.use { gkeInterp =>
-      for {
-        createResult <- gkeInterp
-          .createCluster(
-            CreateClusterParams(savedCluster1.id, savedCluster1.googleProject, List())
-          )
-        r <- gkeInterp
-          .pollCluster(
-            PollClusterParams(savedCluster1.id, savedCluster1.googleProject, createResult.get)
-          )
-          .attempt
-      } yield {
-        r shouldBe (Left(
-          DefaultNodepoolNotFoundException(savedCluster1.id)
-        ))
-      }
+    val res = for {
+      createResult <- gkeInterp
+        .createCluster(
+          CreateClusterParams(savedCluster1.id, savedCluster1.googleProject, List())
+        )
+      r <- gkeInterp
+        .pollCluster(
+          PollClusterParams(savedCluster1.id, savedCluster1.googleProject, createResult.get)
+        )
+        .attempt
+    } yield {
+      r shouldBe (Left(
+        DefaultNodepoolNotFoundException(savedCluster1.id)
+      ))
     }
     res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "error on createCluster if user nodepool doesn't exist" in isolatedDbTest {
     val savedCluster1 = makeKubeCluster(1, false).save()
-    val res = gkeInterpResource.use { gkeInterp =>
-      for {
-        ctx <- appContext.ask[AppContext]
+    val res = for {
+      ctx <- appContext.ask[AppContext]
 
-        r <- gkeInterp
-          .createCluster(
-            CreateClusterParams(savedCluster1.id, savedCluster1.googleProject, List(NodepoolLeoId(-2)))
-          )
-          .attempt
-      } yield {
-        r shouldBe (Left(
-          org.broadinstitute.dsde.workbench.leonardo.util.ClusterCreationException(
-            ctx.traceId,
-            s"CreateCluster was called with nodepools that are not present in the database for cluster ${savedCluster1.getGkeClusterId.toString}"
-          )
-        ))
-      }
+      r <- gkeInterp
+        .createCluster(
+          CreateClusterParams(savedCluster1.id, savedCluster1.googleProject, List(NodepoolLeoId(-2)))
+        )
+        .attempt
+    } yield {
+      r shouldBe (Left(
+        org.broadinstitute.dsde.workbench.leonardo.util.ClusterCreationException(
+          ctx.traceId,
+          s"CreateCluster was called with nodepools that are not present in the database for cluster ${savedCluster1.getGkeClusterId.toString}"
+        )
+      ))
     }
     res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "error on createAndPollApp if app doesn't exist" in isolatedDbTest {
     val savedCluster1 = makeKubeCluster(1, false).save()
-    val res = gkeInterpResource.use { gkeInterp =>
-      for {
-        ctx <- appContext.ask[AppContext]
+    val res = for {
+      ctx <- appContext.ask[AppContext]
 
-        r <- gkeInterp
-          .createAndPollApp(
-            CreateAppParams(AppId(-1), savedCluster1.googleProject, AppName("non-existent"))
-          )
-          .attempt
-      } yield {
-        r shouldBe (Left(
-          AppNotFoundException(
-            savedCluster1.googleProject,
-            AppName("non-existent"),
-            ctx.traceId
-          )
-        ))
-      }
+      r <- gkeInterp
+        .createAndPollApp(
+          CreateAppParams(AppId(-1), savedCluster1.googleProject, AppName("non-existent"))
+        )
+        .attempt
+    } yield {
+      r shouldBe (Left(
+        AppNotFoundException(
+          savedCluster1.googleProject,
+          AppName("non-existent"),
+          ctx.traceId
+        )
+      ))
     }
     res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreterSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreterSpec.scala
@@ -85,7 +85,7 @@ class GKEInterpreterSpec extends AnyFlatSpecLike with TestComponent with Leonard
     val authContext =
       gkeInterp
         .getHelmAuthContext(googleCluster, makeKubeCluster(1), NamespaceName("ns"))
-        .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+        .unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
 
     authContext.namespace.asString shouldBe "ns"
     authContext.kubeApiServer.asString shouldBe "https://1.2.3.4"
@@ -161,7 +161,7 @@ class GKEInterpreterSpec extends AnyFlatSpecLike with TestComponent with Leonard
       clusterOpt.get.status shouldBe KubernetesClusterStatus.Deleted
     }
 
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   it should "deleteAndPollNodepool properly" in isolatedDbTest {
@@ -175,7 +175,7 @@ class GKEInterpreterSpec extends AnyFlatSpecLike with TestComponent with Leonard
       nodepoolOpt.get.status shouldBe NodepoolStatus.Deleted
     }
 
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   it should "mark a nodepool as Deleted in DB when it doesn't exist in Google" in isolatedDbTest {
@@ -210,7 +210,7 @@ class GKEInterpreterSpec extends AnyFlatSpecLike with TestComponent with Leonard
       nodepoolOpt.get.status shouldBe NodepoolStatus.Deleted
     }
 
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   it should "stopAndPollApp properly" in isolatedDbTest {
@@ -230,7 +230,7 @@ class GKEInterpreterSpec extends AnyFlatSpecLike with TestComponent with Leonard
       getApp.nodepool.numNodes shouldBe NumNodes(2)
     }
 
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   it should "startAndPollApp properly" in isolatedDbTest {
@@ -250,7 +250,7 @@ class GKEInterpreterSpec extends AnyFlatSpecLike with TestComponent with Leonard
       getApp.nodepool.numNodes shouldBe NumNodes(2)
     }
 
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   it should "error during createCluster if cluster doesn't exist in database" in isolatedDbTest {
@@ -270,7 +270,7 @@ class GKEInterpreterSpec extends AnyFlatSpecLike with TestComponent with Leonard
         )
       ))
     }
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   it should "error on pollCluster if default nodepool doesn't exist" in isolatedDbTest {
@@ -290,7 +290,7 @@ class GKEInterpreterSpec extends AnyFlatSpecLike with TestComponent with Leonard
         DefaultNodepoolNotFoundException(savedCluster1.id)
       ))
     }
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   it should "error on createCluster if user nodepool doesn't exist" in isolatedDbTest {
@@ -311,7 +311,7 @@ class GKEInterpreterSpec extends AnyFlatSpecLike with TestComponent with Leonard
         )
       ))
     }
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   it should "error on createAndPollApp if app doesn't exist" in isolatedDbTest {
@@ -333,6 +333,6 @@ class GKEInterpreterSpec extends AnyFlatSpecLike with TestComponent with Leonard
         )
       ))
     }
-    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreterSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreterSpec.scala
@@ -9,17 +9,24 @@ import org.broadinstitute.dsde.workbench.google2.GKEModels.NodepoolName
 import org.broadinstitute.dsde.workbench.google2.KubernetesModels.{KubernetesPodStatus, PodStatus}
 import org.broadinstitute.dsde.workbench.google2.KubernetesSerializableName._
 import org.broadinstitute.dsde.workbench.google2.mock._
+import org.broadinstitute.dsde.workbench.google2.{DiskName, GKEModels, KubernetesClusterNotFoundException}
 import org.broadinstitute.dsde.workbench.leonardo.CommonTestData._
-import org.broadinstitute.dsde.workbench.leonardo.KubernetesTestData.{makeKubeCluster, makeNodepool}
+import org.broadinstitute.dsde.workbench.leonardo.KubernetesTestData.{makeApp, makeKubeCluster, makeNodepool}
 import org.broadinstitute.dsde.workbench.leonardo.config.Config
 import org.broadinstitute.dsde.workbench.leonardo.dao.{MockAppDAO, MockAppDescriptorDAO}
-import org.broadinstitute.dsde.workbench.leonardo.db.{kubernetesClusterQuery, nodepoolQuery, TestComponent}
+import org.broadinstitute.dsde.workbench.leonardo.db.{
+  kubernetesClusterQuery,
+  nodepoolQuery,
+  KubernetesServiceDbQueries,
+  TestComponent
+}
 import org.broadinstitute.dsde.workbench.leonardo.http.dbioToIO
+import org.broadinstitute.dsde.workbench.leonardo.http.service.AppNotFoundException
+import org.broadinstitute.dsde.workbench.model.TraceId
+import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.broadinstitute.dsp.Release
 import org.broadinstitute.dsp.mocks._
 import org.scalatest.flatspec.AnyFlatSpecLike
-import org.broadinstitute.dsde.workbench.google2.{DiskName, GKEModels, MockGoogleDiskService}
-import org.broadinstitute.dsde.workbench.model.TraceId
 
 import java.nio.file.Files
 import java.util.Base64
@@ -35,7 +42,7 @@ class GKEInterpreterSpec extends AnyFlatSpecLike with TestComponent with Leonard
                            FakeGoogleComputeService,
                            new MockComputePollOperation)
 
-  val gkeInterp =
+  val gkeInterpResource = nodepoolLock.map(lock =>
     new GKEInterpreter[IO](
       Config.gkeInterpConfig,
       vpcInterp,
@@ -47,9 +54,9 @@ class GKEInterpreterSpec extends AnyFlatSpecLike with TestComponent with Leonard
       googleIamDao,
       MockGoogleDiskService,
       MockAppDescriptorDAO,
-      blocker,
-      nodepoolLock.unsafeRunSync()
+      lock
     )
+  )
 
   "GKEInterpreter" should "create a nodepool with autoscaling" in isolatedDbTest {
     val savedCluster1 = makeKubeCluster(1).save()
@@ -59,11 +66,15 @@ class GKEInterpreterSpec extends AnyFlatSpecLike with TestComponent with Leonard
       .copy(autoscalingEnabled = true,
             autoscalingConfig = Some(AutoscalingConfig(AutoscalingMin(minNodes), AutoscalingMax(maxNodes))))
       .save()
-
-    val googleNodepool = gkeInterp.buildGoogleNodepool(savedNodepool1)
-    googleNodepool.getAutoscaling.getEnabled shouldBe true
-    googleNodepool.getAutoscaling.getMinNodeCount shouldBe minNodes
-    googleNodepool.getAutoscaling.getMaxNodeCount shouldBe maxNodes
+    val res = gkeInterpResource.use { gkeInterp =>
+      val googleNodepool = gkeInterp.buildGoogleNodepool(savedNodepool1)
+      IO {
+        googleNodepool.getAutoscaling.getEnabled shouldBe true
+        googleNodepool.getAutoscaling.getMinNodeCount shouldBe minNodes
+        googleNodepool.getAutoscaling.getMaxNodeCount shouldBe maxNodes
+      }
+    }
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "get a helm auth context" in {
@@ -77,8 +88,12 @@ class GKEInterpreterSpec extends AnyFlatSpecLike with TestComponent with Leonard
       )
       .build
 
-    val authContext =
-      gkeInterp.getHelmAuthContext(googleCluster, makeKubeCluster(1), NamespaceName("ns")).unsafeRunSync()
+    val authContext = gkeInterpResource
+      .use { gkeInterp =>
+        gkeInterp
+          .getHelmAuthContext(googleCluster, makeKubeCluster(1), NamespaceName("ns"))
+      }
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
 
     authContext.namespace.asString shouldBe "ns"
     authContext.kubeApiServer.asString shouldBe "https://1.2.3.4"
@@ -90,84 +105,105 @@ class GKEInterpreterSpec extends AnyFlatSpecLike with TestComponent with Leonard
   it should "build Galaxy override values string" in {
     val savedCluster1 = makeKubeCluster(1)
     val savedDisk1 = makePersistentDisk(Some(DiskName("disk1")), Some(FormattedBy.Galaxy))
-    val result = gkeInterp.buildGalaxyChartOverrideValuesString(
-      AppName("app1"),
-      Release("app1-galaxy-rls"),
-      savedCluster1,
-      NodepoolName("pool1"),
-      userEmail,
-      Map("WORKSPACE_NAME" -> "test-workspace",
-          "WORKSPACE_BUCKET" -> "gs://test-bucket",
-          "WORKSPACE_NAMESPACE" -> "dsp-leo-test1"),
-      ServiceAccountName("app1-galaxy-ksa"),
-      NamespaceName("ns"),
-      savedDisk1,
-      DiskName("disk1-gxy-postres-disk"),
-      None
-    )
+    val res = gkeInterpResource.use { gkeInterp =>
+      IO {
+        val r = gkeInterp.buildGalaxyChartOverrideValuesString(
+          AppName("app1"),
+          Release("app1-galaxy-rls"),
+          savedCluster1,
+          NodepoolName("pool1"),
+          userEmail,
+          Map("WORKSPACE_NAME" -> "test-workspace",
+              "WORKSPACE_BUCKET" -> "gs://test-bucket",
+              "WORKSPACE_NAMESPACE" -> "dsp-leo-test1"),
+          ServiceAccountName("app1-galaxy-ksa"),
+          NamespaceName("ns"),
+          savedDisk1,
+          DiskName("disk1-gxy-postres-disk"),
+          None
+        )
 
-    result.mkString(",") shouldBe """nfs.storageClass.name=nfs-app1-galaxy-rls,cvmfs.repositories.cvmfs-gxy-data-app1-galaxy-rls=data.galaxyproject.org,cvmfs.cache.alienCache.storageClass=nfs-app1-galaxy-rls,galaxy.persistence.storageClass=nfs-app1-galaxy-rls,galaxy.cvmfs.galaxyPersistentVolumeClaims.data.storageClassName=cvmfs-gxy-data-app1-galaxy-rls,galaxy.nodeSelector.cloud\.google\.com/gke-nodepool=pool1,nfs.nodeSelector.cloud\.google\.com/gke-nodepool=pool1,galaxy.configs.job_conf\.yml.runners.k8s.k8s_node_selector=cloud.google.com/gke-nodepool: pool1,galaxy.postgresql.master.nodeSelector.cloud\.google\.com/gke-nodepool=pool1,galaxy.ingress.path=/proxy/google/v1/apps/dsp-leo-test1/app1/galaxy,galaxy.ingress.annotations.nginx\.ingress\.kubernetes\.io/proxy-redirect-from=https://1455694897.jupyter.firecloud.org,galaxy.ingress.annotations.nginx\.ingress\.kubernetes\.io/proxy-redirect-to=https://leo,galaxy.ingress.hosts[0].host=1455694897.jupyter.firecloud.org,galaxy.ingress.hosts[0].paths[0].path=/proxy/google/v1/apps/dsp-leo-test1/app1/galaxy,galaxy.ingress.tls[0].hosts[0]=1455694897.jupyter.firecloud.org,galaxy.ingress.tls[0].secretName=tls-secret,galaxy.configs.galaxy\.yml.galaxy.single_user=user1@example.com,galaxy.configs.galaxy\.yml.galaxy.admin_users=user1@example.com,galaxy.terra.launch.workspace=test-workspace,galaxy.terra.launch.namespace=dsp-leo-test1,galaxy.configs.file_sources_conf\.yml[0].api_url=https://firecloud-orchestration.dsde-dev.broadinstitute.org/api/,galaxy.configs.file_sources_conf\.yml[0].drs_url=https://us-central1-broad-dsde-dev.cloudfunctions.net/martha_v3,galaxy.configs.file_sources_conf\.yml[0].doc=test-workspace,galaxy.configs.file_sources_conf\.yml[0].id=test-workspace,galaxy.configs.file_sources_conf\.yml[0].workspace=test-workspace,galaxy.configs.file_sources_conf\.yml[0].namespace=dsp-leo-test1,galaxy.configs.file_sources_conf\.yml[0].type=anvil,galaxy.configs.file_sources_conf\.yml[0].on_anvil=True,galaxy.configs.file_sources_conf\.yml[0].writable=True,galaxy.serviceAccount.create=false,galaxy.serviceAccount.name=app1-galaxy-ksa,rbac.serviceAccount=app1-galaxy-ksa,persistence.nfs.name=ns-nfs-disk,persistence.nfs.persistentVolume.extraSpec.gcePersistentDisk.pdName=disk1,persistence.nfs.size=250Gi,persistence.postgres.name=ns-postgres-disk,galaxy.postgresql.galaxyDatabasePassword=replace-me,persistence.postgres.persistentVolume.extraSpec.gcePersistentDisk.pdName=disk1-gxy-postres-disk,persistence.postgres.size=10Gi,nfs.persistence.existingClaim=ns-nfs-disk-pvc,nfs.persistence.size=250Gi,galaxy.postgresql.persistence.existingClaim=ns-postgres-disk-pvc,galaxy.persistence.size=200Gi,configs.WORKSPACE_NAME=test-workspace,extraEnv[0].name=WORKSPACE_NAME,extraEnv[0].valueFrom.configMapKeyRef.name=app1-galaxy-rls-galaxykubeman-configs,extraEnv[0].valueFrom.configMapKeyRef.key=WORKSPACE_NAME,configs.WORKSPACE_BUCKET=gs://test-bucket,extraEnv[1].name=WORKSPACE_BUCKET,extraEnv[1].valueFrom.configMapKeyRef.name=app1-galaxy-rls-galaxykubeman-configs,extraEnv[1].valueFrom.configMapKeyRef.key=WORKSPACE_BUCKET,configs.WORKSPACE_NAMESPACE=dsp-leo-test1,extraEnv[2].name=WORKSPACE_NAMESPACE,extraEnv[2].valueFrom.configMapKeyRef.name=app1-galaxy-rls-galaxykubeman-configs,extraEnv[2].valueFrom.configMapKeyRef.key=WORKSPACE_NAMESPACE"""
+        r.mkString(",") shouldBe """nfs.storageClass.name=nfs-app1-galaxy-rls,cvmfs.repositories.cvmfs-gxy-data-app1-galaxy-rls=data.galaxyproject.org,cvmfs.cache.alienCache.storageClass=nfs-app1-galaxy-rls,galaxy.persistence.storageClass=nfs-app1-galaxy-rls,galaxy.cvmfs.galaxyPersistentVolumeClaims.data.storageClassName=cvmfs-gxy-data-app1-galaxy-rls,galaxy.nodeSelector.cloud\.google\.com/gke-nodepool=pool1,nfs.nodeSelector.cloud\.google\.com/gke-nodepool=pool1,galaxy.configs.job_conf\.yml.runners.k8s.k8s_node_selector=cloud.google.com/gke-nodepool: pool1,galaxy.postgresql.master.nodeSelector.cloud\.google\.com/gke-nodepool=pool1,galaxy.ingress.path=/proxy/google/v1/apps/dsp-leo-test1/app1/galaxy,galaxy.ingress.annotations.nginx\.ingress\.kubernetes\.io/proxy-redirect-from=https://1455694897.jupyter.firecloud.org,galaxy.ingress.annotations.nginx\.ingress\.kubernetes\.io/proxy-redirect-to=https://leo,galaxy.ingress.hosts[0].host=1455694897.jupyter.firecloud.org,galaxy.ingress.hosts[0].paths[0].path=/proxy/google/v1/apps/dsp-leo-test1/app1/galaxy,galaxy.ingress.tls[0].hosts[0]=1455694897.jupyter.firecloud.org,galaxy.ingress.tls[0].secretName=tls-secret,galaxy.configs.galaxy\.yml.galaxy.single_user=user1@example.com,galaxy.configs.galaxy\.yml.galaxy.admin_users=user1@example.com,galaxy.terra.launch.workspace=test-workspace,galaxy.terra.launch.namespace=dsp-leo-test1,galaxy.configs.file_sources_conf\.yml[0].api_url=https://firecloud-orchestration.dsde-dev.broadinstitute.org/api/,galaxy.configs.file_sources_conf\.yml[0].drs_url=https://us-central1-broad-dsde-dev.cloudfunctions.net/martha_v3,galaxy.configs.file_sources_conf\.yml[0].doc=test-workspace,galaxy.configs.file_sources_conf\.yml[0].id=test-workspace,galaxy.configs.file_sources_conf\.yml[0].workspace=test-workspace,galaxy.configs.file_sources_conf\.yml[0].namespace=dsp-leo-test1,galaxy.configs.file_sources_conf\.yml[0].type=anvil,galaxy.configs.file_sources_conf\.yml[0].on_anvil=True,galaxy.configs.file_sources_conf\.yml[0].writable=True,galaxy.serviceAccount.create=false,galaxy.serviceAccount.name=app1-galaxy-ksa,rbac.serviceAccount=app1-galaxy-ksa,persistence.nfs.name=ns-nfs-disk,persistence.nfs.persistentVolume.extraSpec.gcePersistentDisk.pdName=disk1,persistence.nfs.size=250Gi,persistence.postgres.name=ns-postgres-disk,galaxy.postgresql.galaxyDatabasePassword=replace-me,persistence.postgres.persistentVolume.extraSpec.gcePersistentDisk.pdName=disk1-gxy-postres-disk,persistence.postgres.size=10Gi,nfs.persistence.existingClaim=ns-nfs-disk-pvc,nfs.persistence.size=250Gi,galaxy.postgresql.persistence.existingClaim=ns-postgres-disk-pvc,galaxy.persistence.size=200Gi,configs.WORKSPACE_NAME=test-workspace,extraEnv[0].name=WORKSPACE_NAME,extraEnv[0].valueFrom.configMapKeyRef.name=app1-galaxy-rls-galaxykubeman-configs,extraEnv[0].valueFrom.configMapKeyRef.key=WORKSPACE_NAME,configs.WORKSPACE_BUCKET=gs://test-bucket,extraEnv[1].name=WORKSPACE_BUCKET,extraEnv[1].valueFrom.configMapKeyRef.name=app1-galaxy-rls-galaxykubeman-configs,extraEnv[1].valueFrom.configMapKeyRef.key=WORKSPACE_BUCKET,configs.WORKSPACE_NAMESPACE=dsp-leo-test1,extraEnv[2].name=WORKSPACE_NAMESPACE,extraEnv[2].valueFrom.configMapKeyRef.name=app1-galaxy-rls-galaxykubeman-configs,extraEnv[2].valueFrom.configMapKeyRef.key=WORKSPACE_NAMESPACE"""
+      }
+    }
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "build Galaxy override values string with restore info" in {
     val savedCluster1 = makeKubeCluster(1)
     val savedDisk1 = makePersistentDisk(Some(DiskName("disk1")), Some(FormattedBy.Galaxy))
-    val result = gkeInterp.buildGalaxyChartOverrideValuesString(
-      AppName("app1"),
-      Release("app1-galaxy-rls"),
-      savedCluster1,
-      NodepoolName("pool1"),
-      userEmail,
-      Map("WORKSPACE_NAME" -> "test-workspace",
-          "WORKSPACE_BUCKET" -> "gs://test-bucket",
-          "WORKSPACE_NAMESPACE" -> "dsp-leo-test1"),
-      ServiceAccountName("app1-galaxy-ksa"),
-      NamespaceName("ns"),
-      savedDisk1,
-      DiskName("disk1-gxy-postres"),
-      Some(
-        GalaxyRestore(PvcId("galaxy-pvc-id"), PvcId("cvmfs-pvc-id"), AppId(123))
-      )
-    )
+    val result = gkeInterpResource
+      .use { gkeInterp =>
+        IO(
+          gkeInterp.buildGalaxyChartOverrideValuesString(
+            AppName("app1"),
+            Release("app1-galaxy-rls"),
+            savedCluster1,
+            NodepoolName("pool1"),
+            userEmail,
+            Map("WORKSPACE_NAME" -> "test-workspace",
+                "WORKSPACE_BUCKET" -> "gs://test-bucket",
+                "WORKSPACE_NAMESPACE" -> "dsp-leo-test1"),
+            ServiceAccountName("app1-galaxy-ksa"),
+            NamespaceName("ns"),
+            savedDisk1,
+            DiskName("disk1-gxy-postres"),
+            Some(
+              GalaxyRestore(PvcId("galaxy-pvc-id"), PvcId("cvmfs-pvc-id"), AppId(123))
+            )
+          )
+        )
+      }
+      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
     result.mkString(",") shouldBe """nfs.storageClass.name=nfs-app1-galaxy-rls,cvmfs.repositories.cvmfs-gxy-data-app1-galaxy-rls=data.galaxyproject.org,cvmfs.cache.alienCache.storageClass=nfs-app1-galaxy-rls,galaxy.persistence.storageClass=nfs-app1-galaxy-rls,galaxy.cvmfs.galaxyPersistentVolumeClaims.data.storageClassName=cvmfs-gxy-data-app1-galaxy-rls,galaxy.nodeSelector.cloud\.google\.com/gke-nodepool=pool1,nfs.nodeSelector.cloud\.google\.com/gke-nodepool=pool1,galaxy.configs.job_conf\.yml.runners.k8s.k8s_node_selector=cloud.google.com/gke-nodepool: pool1,galaxy.postgresql.master.nodeSelector.cloud\.google\.com/gke-nodepool=pool1,galaxy.ingress.path=/proxy/google/v1/apps/dsp-leo-test1/app1/galaxy,galaxy.ingress.annotations.nginx\.ingress\.kubernetes\.io/proxy-redirect-from=https://1455694897.jupyter.firecloud.org,galaxy.ingress.annotations.nginx\.ingress\.kubernetes\.io/proxy-redirect-to=https://leo,galaxy.ingress.hosts[0].host=1455694897.jupyter.firecloud.org,galaxy.ingress.hosts[0].paths[0].path=/proxy/google/v1/apps/dsp-leo-test1/app1/galaxy,galaxy.ingress.tls[0].hosts[0]=1455694897.jupyter.firecloud.org,galaxy.ingress.tls[0].secretName=tls-secret,galaxy.configs.galaxy\.yml.galaxy.single_user=user1@example.com,galaxy.configs.galaxy\.yml.galaxy.admin_users=user1@example.com,galaxy.terra.launch.workspace=test-workspace,galaxy.terra.launch.namespace=dsp-leo-test1,galaxy.configs.file_sources_conf\.yml[0].api_url=https://firecloud-orchestration.dsde-dev.broadinstitute.org/api/,galaxy.configs.file_sources_conf\.yml[0].drs_url=https://us-central1-broad-dsde-dev.cloudfunctions.net/martha_v3,galaxy.configs.file_sources_conf\.yml[0].doc=test-workspace,galaxy.configs.file_sources_conf\.yml[0].id=test-workspace,galaxy.configs.file_sources_conf\.yml[0].workspace=test-workspace,galaxy.configs.file_sources_conf\.yml[0].namespace=dsp-leo-test1,galaxy.configs.file_sources_conf\.yml[0].type=anvil,galaxy.configs.file_sources_conf\.yml[0].on_anvil=True,galaxy.configs.file_sources_conf\.yml[0].writable=True,galaxy.serviceAccount.create=false,galaxy.serviceAccount.name=app1-galaxy-ksa,rbac.serviceAccount=app1-galaxy-ksa,persistence.nfs.name=ns-nfs-disk,persistence.nfs.persistentVolume.extraSpec.gcePersistentDisk.pdName=disk1,persistence.nfs.size=250Gi,persistence.postgres.name=ns-postgres-disk,galaxy.postgresql.galaxyDatabasePassword=replace-me,persistence.postgres.persistentVolume.extraSpec.gcePersistentDisk.pdName=disk1-gxy-postres,persistence.postgres.size=10Gi,nfs.persistence.existingClaim=ns-nfs-disk-pvc,nfs.persistence.size=250Gi,galaxy.postgresql.persistence.existingClaim=ns-postgres-disk-pvc,galaxy.persistence.size=200Gi,configs.WORKSPACE_NAME=test-workspace,extraEnv[0].name=WORKSPACE_NAME,extraEnv[0].valueFrom.configMapKeyRef.name=app1-galaxy-rls-galaxykubeman-configs,extraEnv[0].valueFrom.configMapKeyRef.key=WORKSPACE_NAME,configs.WORKSPACE_BUCKET=gs://test-bucket,extraEnv[1].name=WORKSPACE_BUCKET,extraEnv[1].valueFrom.configMapKeyRef.name=app1-galaxy-rls-galaxykubeman-configs,extraEnv[1].valueFrom.configMapKeyRef.key=WORKSPACE_BUCKET,configs.WORKSPACE_NAMESPACE=dsp-leo-test1,extraEnv[2].name=WORKSPACE_NAMESPACE,extraEnv[2].valueFrom.configMapKeyRef.name=app1-galaxy-rls-galaxykubeman-configs,extraEnv[2].valueFrom.configMapKeyRef.key=WORKSPACE_NAMESPACE,restore.persistence.nfs.galaxy.pvcID=galaxy-pvc-id,restore.persistence.nfs.cvmfsCache.pvcID=cvmfs-pvc-id,galaxy.persistence.existingClaim=app1-galaxy-rls-galaxy-pvc,cvmfs.cache.alienCache.existingClaim=app1-galaxy-rls-cvmfs-alien-cache-pvc""".stripMargin
   }
 
   it should "check if a pod is done" in {
-    gkeInterp.isPodDone(KubernetesPodStatus(PodName("pod1"), PodStatus.Succeeded)) shouldBe true
-    gkeInterp.isPodDone(KubernetesPodStatus(PodName("pod2"), PodStatus.Pending)) shouldBe false
-    gkeInterp.isPodDone(KubernetesPodStatus(PodName("pod3"), PodStatus.Failed)) shouldBe true
-    gkeInterp.isPodDone(KubernetesPodStatus(PodName("pod4"), PodStatus.Unknown)) shouldBe false
-    gkeInterp.isPodDone(KubernetesPodStatus(PodName("pod5"), PodStatus.Running)) shouldBe false
+    val res = gkeInterpResource.use { gkeInterp =>
+      IO {
+        gkeInterp.isPodDone(KubernetesPodStatus(PodName("pod1"), PodStatus.Succeeded)) shouldBe true
+        gkeInterp.isPodDone(KubernetesPodStatus(PodName("pod2"), PodStatus.Pending)) shouldBe false
+        gkeInterp.isPodDone(KubernetesPodStatus(PodName("pod3"), PodStatus.Failed)) shouldBe true
+        gkeInterp.isPodDone(KubernetesPodStatus(PodName("pod4"), PodStatus.Unknown)) shouldBe false
+        gkeInterp.isPodDone(KubernetesPodStatus(PodName("pod5"), PodStatus.Running)) shouldBe false
+      }
+    }
+
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "deleteAndPollCluster properly" in isolatedDbTest {
-    val res = for {
-      savedCluster <- IO(makeKubeCluster(1).save())
-      m = DeleteClusterParams(
-        savedCluster.id,
-        savedCluster.googleProject
-      )
-      _ <- gkeInterp.deleteAndPollCluster(m)
-      clusterOpt <- kubernetesClusterQuery.getMinimalClusterById(savedCluster.id).transaction
-    } yield {
-      clusterOpt.get.status shouldBe KubernetesClusterStatus.Deleted
+    val res = gkeInterpResource.use { gkeInterp =>
+      for {
+        savedCluster <- IO(makeKubeCluster(1).save())
+        m = DeleteClusterParams(
+          savedCluster.id,
+          savedCluster.googleProject
+        )
+        _ <- gkeInterp.deleteAndPollCluster(m)
+        clusterOpt <- kubernetesClusterQuery.getMinimalClusterById(savedCluster.id).transaction
+      } yield {
+        clusterOpt.get.status shouldBe KubernetesClusterStatus.Deleted
+      }
     }
 
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "deleteAndPollNodepool properly" in isolatedDbTest {
-    val res = for {
-      savedCluster <- IO(makeKubeCluster(1).save())
-      savedNodepool <- IO(makeNodepool(1, savedCluster.id).save())
-      m = DeleteNodepoolParams(savedNodepool.id, savedCluster.googleProject)
-      _ <- gkeInterp.deleteAndPollNodepool(m)
-      nodepoolOpt <- nodepoolQuery.getMinimalById(savedNodepool.id).transaction
-    } yield {
-      nodepoolOpt.get.status shouldBe NodepoolStatus.Deleted
+    val res = gkeInterpResource.use { gkeInterp =>
+      for {
+        savedCluster <- IO(makeKubeCluster(1).save())
+        savedNodepool <- IO(makeNodepool(1, savedCluster.id).save())
+        m = DeleteNodepoolParams(savedNodepool.id, savedCluster.googleProject)
+        _ <- gkeInterp.deleteAndPollNodepool(m)
+        nodepoolOpt <- nodepoolQuery.getMinimalById(savedNodepool.id).transaction
+      } yield {
+        nodepoolOpt.get.status shouldBe NodepoolStatus.Deleted
+      }
     }
 
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   it should "mark a nodepool as Deleted in DB when it doesn't exist in Google" in isolatedDbTest {
@@ -177,7 +213,7 @@ class GKEInterpreterSpec extends AnyFlatSpecLike with TestComponent with Leonard
       ): IO[Option[Operation]] = IO.pure(None)
     }
 
-    val gkeInterpDelete =
+    val gkeInterpDelete = nodepoolLock.map(nl =>
       new GKEInterpreter[IO](
         Config.gkeInterpConfig,
         vpcInterp,
@@ -189,20 +225,157 @@ class GKEInterpreterSpec extends AnyFlatSpecLike with TestComponent with Leonard
         googleIamDao,
         MockGoogleDiskService,
         MockAppDescriptorDAO,
-        blocker,
-        nodepoolLock.unsafeRunSync()
+        nl
       )
+    )
 
-    val res = for {
-      savedCluster <- IO(makeKubeCluster(1).save())
-      savedNodepool <- IO(makeNodepool(1, savedCluster.id).save())
-      m = DeleteNodepoolParams(savedNodepool.id, savedCluster.googleProject)
-      _ <- gkeInterpDelete.deleteAndPollNodepool(m)
-      nodepoolOpt <- nodepoolQuery.getMinimalById(savedNodepool.id).transaction
-    } yield {
-      nodepoolOpt.get.status shouldBe NodepoolStatus.Deleted
+    val res = gkeInterpDelete.use { gkeInterp =>
+      for {
+        savedCluster <- IO(makeKubeCluster(1).save())
+        savedNodepool <- IO(makeNodepool(1, savedCluster.id).save())
+        m = DeleteNodepoolParams(savedNodepool.id, savedCluster.googleProject)
+        _ <- gkeInterp.deleteAndPollNodepool(m)
+        nodepoolOpt <- nodepoolQuery.getMinimalById(savedNodepool.id).transaction
+      } yield {
+        nodepoolOpt.get.status shouldBe NodepoolStatus.Deleted
+      }
     }
 
-    res.unsafeRunSync()
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+  }
+
+  it should "stopAndPollApp properly" in isolatedDbTest {
+    val savedCluster1 = makeKubeCluster(1).copy(status = KubernetesClusterStatus.Running).save()
+    val savedNodepool1 = makeNodepool(1, savedCluster1.id).copy(status = NodepoolStatus.Running).save()
+    val savedApp1 = makeApp(1, savedNodepool1.id).copy(status = AppStatus.Stopping).save()
+
+    val res = gkeInterpResource.use { gkeInterp =>
+      for {
+        _ <- gkeInterp.stopAndPollApp(StopAppParams(savedApp1.id, savedApp1.appName, savedCluster1.googleProject))
+        getAppOpt <- KubernetesServiceDbQueries.getFullAppByName(savedCluster1.googleProject, savedApp1.id).transaction
+        getApp = getAppOpt.get
+      } yield {
+        getApp.app.errors.size shouldBe 0
+        getApp.app.status shouldBe AppStatus.Stopped
+        getApp.nodepool.status shouldBe NodepoolStatus.Running
+        getApp.nodepool.autoscalingEnabled shouldBe true
+        getApp.nodepool.numNodes shouldBe NumNodes(2)
+      }
+    }
+
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+  }
+
+  it should "startAndPollApp properly" in isolatedDbTest {
+    val savedCluster1 = makeKubeCluster(1).copy(status = KubernetesClusterStatus.Running).save()
+    val savedNodepool1 = makeNodepool(1, savedCluster1.id).copy(status = NodepoolStatus.Running).save()
+    val savedApp1 = makeApp(1, savedNodepool1.id).copy(status = AppStatus.Stopping).save()
+
+    val res = gkeInterpResource.use { gkeInterp =>
+      for {
+        _ <- gkeInterp.startAndPollApp(StartAppParams(savedApp1.id, savedApp1.appName, savedCluster1.googleProject))
+        getAppOpt <- KubernetesServiceDbQueries.getFullAppByName(savedCluster1.googleProject, savedApp1.id).transaction
+        getApp = getAppOpt.get
+      } yield {
+        getApp.app.errors.size shouldBe 0
+        getApp.app.status shouldBe AppStatus.Running
+        getApp.nodepool.status shouldBe NodepoolStatus.Running
+        getApp.nodepool.autoscalingEnabled shouldBe true
+        getApp.nodepool.numNodes shouldBe NumNodes(2)
+      }
+    }
+
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+  }
+
+  it should "error during createCluster if cluster doesn't exist in database" in isolatedDbTest {
+    val res = gkeInterpResource.use { gkeInterp =>
+      for {
+        ctx <- appContext.ask[AppContext]
+        r <- gkeInterp
+          .createCluster(
+            CreateClusterParams(KubernetesClusterLeoId(-1),
+                                GoogleProject("fake"),
+                                List(NodepoolLeoId(-1), NodepoolLeoId(-1)))
+          )
+          .attempt
+      } yield {
+        r shouldBe (Left(
+          KubernetesClusterNotFoundException(
+            s"Failed kubernetes cluster creation. Cluster with id -1 not found in database | trace id: ${ctx.traceId}"
+          )
+        ))
+      }
+    }
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+  }
+
+  it should "error on pollCluster if default nodepool doesn't exist" in isolatedDbTest {
+    val savedCluster1 = makeKubeCluster(1, false).saveWithOutDefaultNodepool()
+    val res = gkeInterpResource.use { gkeInterp =>
+      for {
+        createResult <- gkeInterp
+          .createCluster(
+            CreateClusterParams(savedCluster1.id, savedCluster1.googleProject, List())
+          )
+        r <- gkeInterp
+          .pollCluster(
+            PollClusterParams(savedCluster1.id, savedCluster1.googleProject, createResult.get)
+          )
+          .attempt
+      } yield {
+        r shouldBe (Left(
+          DefaultNodepoolNotFoundException(savedCluster1.id)
+        ))
+      }
+    }
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+  }
+
+  it should "error on createCluster if user nodepool doesn't exist" in isolatedDbTest {
+    val savedCluster1 = makeKubeCluster(1, false).save()
+    val res = gkeInterpResource.use { gkeInterp =>
+      for {
+        ctx <- appContext.ask[AppContext]
+
+        r <- gkeInterp
+          .createCluster(
+            CreateClusterParams(savedCluster1.id, savedCluster1.googleProject, List(NodepoolLeoId(-2)))
+          )
+          .attempt
+      } yield {
+        r shouldBe (Left(
+          org.broadinstitute.dsde.workbench.leonardo.util.ClusterCreationException(
+            ctx.traceId,
+            s"CreateCluster was called with nodepools that are not present in the database for cluster ${savedCluster1.getGkeClusterId.toString}"
+          )
+        ))
+      }
+    }
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+  }
+
+  it should "error on createAndPollApp if app doesn't exist" in isolatedDbTest {
+    val savedCluster1 = makeKubeCluster(1, false).save()
+    val res = gkeInterpResource.use { gkeInterp =>
+      for {
+        ctx <- appContext.ask[AppContext]
+
+        r <- gkeInterp
+          .createAndPollApp(
+            CreateAppParams(AppId(-1), savedCluster1.googleProject, AppName("non-existent"))
+          )
+          .attempt
+      } yield {
+        r shouldBe (Left(
+          AppNotFoundException(
+            savedCluster1.googleProject,
+            AppName("non-existent"),
+            ctx.traceId
+          )
+        ))
+      }
+    }
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/QueueFactory.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/QueueFactory.scala
@@ -1,20 +1,17 @@
 package org.broadinstitute.dsde.workbench.leonardo.util
 
 import cats.effect.IO
-import fs2.concurrent.InspectableQueue
+import cats.effect.std.Queue
+import cats.effect.unsafe.implicits.global
 import org.broadinstitute.dsde.workbench.google2.Event
 import org.broadinstitute.dsde.workbench.leonardo.monitor.LeoPubsubMessage
 
-import scala.concurrent.ExecutionContext.Implicits.global
-
 object QueueFactory {
-  implicit val cs = IO.contextShift(global)
-  implicit val t = IO.timer(global)
   val queueSize = 1000
 
   def makePublisherQueue() =
-    InspectableQueue.bounded[IO, LeoPubsubMessage](queueSize).unsafeRunSync()
+    Queue.bounded[IO, LeoPubsubMessage](queueSize).unsafeRunSync()
 
   def makeSubscriberQueue() =
-    InspectableQueue.bounded[IO, Event[LeoPubsubMessage]](queueSize).unsafeRunSync()
+    Queue.bounded[IO, Event[LeoPubsubMessage]](queueSize).unsafeRunSync()
 }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/RuntimeTemplateValuesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/RuntimeTemplateValuesSpec.scala
@@ -90,7 +90,7 @@ class RuntimeTemplateValuesSpec extends LeonardoTestSuite with AnyFlatSpecLike {
       result.welderServerName shouldBe "welder-server"
     }
 
-    test.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    test.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
 }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/RuntimeTemplateValuesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/RuntimeTemplateValuesSpec.scala
@@ -1,6 +1,7 @@
 package org.broadinstitute.dsde.workbench.leonardo
 package util
 
+import cats.effect.IO
 import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GcsObjectName, GcsPath}
 import org.scalatest.flatspec.AnyFlatSpecLike
 
@@ -23,7 +24,7 @@ class RuntimeTemplateValuesSpec extends LeonardoTestSuite with AnyFlatSpecLike {
     )
 
     val test = for {
-      now <- nowInstant
+      now <- IO.realTimeInstant
       result = RuntimeTemplateValues(config, Some(now))
     } yield {
       // note: alphabetized
@@ -89,7 +90,7 @@ class RuntimeTemplateValuesSpec extends LeonardoTestSuite with AnyFlatSpecLike {
       result.welderServerName shouldBe "welder-server"
     }
 
-    test.unsafeRunSync()
+    test.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
 }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/VPCInterpreterSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/VPCInterpreterSpec.scala
@@ -2,7 +2,7 @@ package org.broadinstitute.dsde.workbench.leonardo
 package util
 
 import cats.effect.IO
-import cats.syntax.all._
+import cats.effect.unsafe.implicits.global
 import cats.mtl.Ask
 import com.google.cloud.compute.v1.{Firewall, Network, Operation}
 import org.broadinstitute.dsde.workbench.google2.mock.{
@@ -15,9 +15,9 @@ import org.broadinstitute.dsde.workbench.leonardo.CommonTestData._
 import org.broadinstitute.dsde.workbench.leonardo.config.Config
 import org.broadinstitute.dsde.workbench.model.TraceId
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
+import org.scalatest.flatspec.AnyFlatSpecLike
 
 import scala.jdk.CollectionConverters._
-import org.scalatest.flatspec.AnyFlatSpecLike
 
 class VPCInterpreterSpec extends AnyFlatSpecLike with LeonardoTestSuite {
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -16,7 +16,7 @@ object Dependencies {
   val opencensusV = "0.28.3"
 
 
-  private val workbenchLibsHash = "ae90d1a7-SNAP"
+  private val workbenchLibsHash = "99bd567c-SNAP"
   val serviceTestV = s"0.20-$workbenchLibsHash"
   val workbenchModelV = s"0.14-$workbenchLibsHash"
   val workbenchGoogleV = s"0.21-$workbenchLibsHash"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -16,7 +16,7 @@ object Dependencies {
   val opencensusV = "0.28.3"
 
 
-  private val workbenchLibsHash = "99bd567c-SNAP"
+  private val workbenchLibsHash = "a0eeb83d-SNAP"
   val serviceTestV = s"0.20-$workbenchLibsHash"
   val workbenchModelV = s"0.14-$workbenchLibsHash"
   val workbenchGoogleV = s"0.21-$workbenchLibsHash"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,13 +10,13 @@ object Dependencies {
   val scalaLoggingV = "3.9.4"
   val scalaTestV = "3.2.10"
   val slickV = "3.3.3"
-  val http4sVersion = "1.0.0-M24"
+  val http4sVersion = "1.0.0-M25"
   val guavaV = "31.1.1-jre"
   val monocleV = "2.1.0"
   val opencensusV = "0.28.3"
 
 
-  private val workbenchLibsHash = "6140478"
+  private val workbenchLibsHash = "2f39598c-SNAP"
   val serviceTestV = s"0.19-$workbenchLibsHash"
   val workbenchModelV = s"0.14-$workbenchLibsHash"
   val workbenchGoogleV = s"0.21-$workbenchLibsHash"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,21 +10,21 @@ object Dependencies {
   val scalaLoggingV = "3.9.4"
   val scalaTestV = "3.2.10"
   val slickV = "3.3.3"
-  val http4sVersion = "0.21.26"
-  val guavaV = "31.0.1-jre"
+  val http4sVersion = "1.0.0-M24"
+  val guavaV = "31.1.1-jre"
   val monocleV = "2.1.0"
   val opencensusV = "0.28.3"
 
 
-  private val workbenchLibsHash = "bf66e61"
+  private val workbenchLibsHash = "4e7b8c6e-SNAP"
   val serviceTestV = s"0.19-$workbenchLibsHash"
   val workbenchModelV = s"0.14-$workbenchLibsHash"
   val workbenchGoogleV = s"0.21-$workbenchLibsHash"
-  val workbenchGoogle2V = s"0.21-$workbenchLibsHash"
-  val workbenchOpenTelemetryV = s"0.1-$workbenchLibsHash"
-  val workbenchErrorReportingV = s"0.1-$workbenchLibsHash"
+  val workbenchGoogle2V = s"0.22-$workbenchLibsHash"
+  val workbenchOpenTelemetryV = s"0.2-$workbenchLibsHash"
+  val workbenchErrorReportingV = s"0.2-$workbenchLibsHash"
 
-  val helmScalaSdkV = "0.0.3"
+  val helmScalaSdkV = "0.0.4"
 
   val excludeAkkaHttp = ExclusionRule(organization = "com.typesafe.akka", name = s"akka-http_${scalaV}")
   val excludeAkkaStream = ExclusionRule(organization = "com.typesafe.akka", name = s"akka-stream_${scalaV}")
@@ -127,9 +127,7 @@ object Dependencies {
   val sealerate: ModuleID =       "ca.mrvisser"         %% "sealerate"            % "0.0.6"
   val googleCloudNio: ModuleID =  "com.google.cloud"    % "google-cloud-nio"      % "0.123.2" % Test // brought in for FakeStorageInterpreter
 
-  val http4sCirce =       "org.http4s"        %% "http4s-circe"         % http4sVersion
   val circeYaml =         "io.circe"          %% "circe-yaml"           % "0.14.1"
-  val http4sBlazeClient = "org.http4s"        %% "http4s-blaze-client"  % http4sVersion
   val http4sBlazeServer = "org.http4s"        %% "http4s-blaze-server"  % http4sVersion
   val http4sDsl =         "org.http4s"        %% "http4s-dsl"           % http4sVersion
   val guava: ModuleID =   "com.google.guava"  % "guava"                 % guavaV
@@ -153,9 +151,7 @@ object Dependencies {
     "com.github.pureconfig" %% "pureconfig" % "0.17.0" % Provided,
     sealerate,
     enumeratum,
-    http4sCirce,
     circeYaml,
-    http4sBlazeClient,
     http4sDsl,
     scalaTestScalaCheck
   )

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -16,7 +16,7 @@ object Dependencies {
   val opencensusV = "0.28.3"
 
 
-  private val workbenchLibsHash = "a0eeb83d-SNAP"
+  private val workbenchLibsHash = "8803c71d-SNAP"
   val serviceTestV = s"0.20-$workbenchLibsHash"
   val workbenchModelV = s"0.14-$workbenchLibsHash"
   val workbenchGoogleV = s"0.21-$workbenchLibsHash"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -16,8 +16,8 @@ object Dependencies {
   val opencensusV = "0.28.3"
 
 
-  private val workbenchLibsHash = "598cf7a8-SNAP"
-  val serviceTestV = s"0.19-$workbenchLibsHash"
+  private val workbenchLibsHash = "125c127e-SNAP"
+  val serviceTestV = s"0.20-$workbenchLibsHash"
   val workbenchModelV = s"0.14-$workbenchLibsHash"
   val workbenchGoogleV = s"0.21-$workbenchLibsHash"
   val workbenchGoogle2V = s"0.22-$workbenchLibsHash"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -127,6 +127,7 @@ object Dependencies {
   val sealerate: ModuleID =       "ca.mrvisser"         %% "sealerate"            % "0.0.6"
   val googleCloudNio: ModuleID =  "com.google.cloud"    % "google-cloud-nio"      % "0.123.2" % Test // brought in for FakeStorageInterpreter
 
+  val scalaCache = "com.github.cb372" %% "scalacache-caffeine" % "1.0.0-M4"
   val circeYaml =         "io.circe"          %% "circe-yaml"           % "0.14.1"
   val http4sBlazeServer = "org.http4s"        %% "http4s-blaze-server"  % http4sVersion
   val http4sDsl =         "org.http4s"        %% "http4s-dsl"           % http4sVersion
@@ -186,7 +187,8 @@ object Dependencies {
     "io.opencensus" % "opencensus-exporter-trace-stackdriver" % opencensusV,
     http4sBlazeServer % Test,
     scalaTestSelenium,
-    scalaTestMockito
+    scalaTestMockito,
+    scalaCache
   )
 
   val workbenchServiceTest: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-service-test" % serviceTestV % "test" classifier "tests" excludeAll (excludeGuava, excludeStatsD)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -125,7 +125,7 @@ object Dependencies {
   val mysql: ModuleID =           "mysql"               % "mysql-connector-java"  % "8.0.22"
   val liquibase: ModuleID =       "org.liquibase"       % "liquibase-core"        % "4.5.0"
   val sealerate: ModuleID =       "ca.mrvisser"         %% "sealerate"            % "0.0.6"
-  val googleCloudNio: ModuleID =  "com.google.cloud"    % "google-cloud-nio"      % "0.123.2" % Test // brought in for FakeStorageInterpreter
+  val googleCloudNio: ModuleID =  "com.google.cloud"    % "google-cloud-nio"      % "0.123.10" % Test // brought in for FakeStorageInterpreter
 
   val scalaCache = "com.github.cb372" %% "scalacache-caffeine" % "1.0.0-M4"
   val circeYaml =         "io.circe"          %% "circe-yaml"           % "0.14.1"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,7 +11,7 @@ object Dependencies {
   val scalaTestV = "3.2.10"
   val slickV = "3.3.3"
   val http4sVersion = "1.0.0-M27"
-  val guavaV = "31.1.1-jre"
+  val guavaV = "31.0.1-jre"
   val monocleV = "2.1.0"
   val opencensusV = "0.28.3"
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -154,7 +154,8 @@ object Dependencies {
     enumeratum,
     circeYaml,
     http4sDsl,
-    scalaTestScalaCheck
+    scalaTestScalaCheck,
+    scalaCache
   )
 
   val httpDependencies = Seq(
@@ -187,8 +188,7 @@ object Dependencies {
     "io.opencensus" % "opencensus-exporter-trace-stackdriver" % opencensusV,
     http4sBlazeServer % Test,
     scalaTestSelenium,
-    scalaTestMockito,
-    scalaCache
+    scalaTestMockito
   )
 
   val workbenchServiceTest: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-service-test" % serviceTestV % "test" classifier "tests" excludeAll (excludeGuava, excludeStatsD)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,13 +10,13 @@ object Dependencies {
   val scalaLoggingV = "3.9.4"
   val scalaTestV = "3.2.10"
   val slickV = "3.3.3"
-  val http4sVersion = "1.0.0-M27"
+  val http4sVersion = "0.23.4"
   val guavaV = "31.0.1-jre"
   val monocleV = "2.1.0"
   val opencensusV = "0.28.3"
 
 
-  private val workbenchLibsHash = "125c127e-SNAP"
+  private val workbenchLibsHash = "bf368048-SNAP"
   val serviceTestV = s"0.20-$workbenchLibsHash"
   val workbenchModelV = s"0.14-$workbenchLibsHash"
   val workbenchGoogleV = s"0.21-$workbenchLibsHash"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -16,7 +16,7 @@ object Dependencies {
   val opencensusV = "0.28.3"
 
 
-  private val workbenchLibsHash = "49a5bae6-SNAP"
+  private val workbenchLibsHash = "ae90d1a7-SNAP"
   val serviceTestV = s"0.20-$workbenchLibsHash"
   val workbenchModelV = s"0.14-$workbenchLibsHash"
   val workbenchGoogleV = s"0.21-$workbenchLibsHash"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,13 +10,13 @@ object Dependencies {
   val scalaLoggingV = "3.9.4"
   val scalaTestV = "3.2.10"
   val slickV = "3.3.3"
-  val http4sVersion = "1.0.0-M25"
+  val http4sVersion = "1.0.0-M27"
   val guavaV = "31.1.1-jre"
   val monocleV = "2.1.0"
   val opencensusV = "0.28.3"
 
 
-  private val workbenchLibsHash = "2f39598c-SNAP"
+  private val workbenchLibsHash = "598cf7a8-SNAP"
   val serviceTestV = s"0.19-$workbenchLibsHash"
   val workbenchModelV = s"0.14-$workbenchLibsHash"
   val workbenchGoogleV = s"0.21-$workbenchLibsHash"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -16,7 +16,7 @@ object Dependencies {
   val opencensusV = "0.28.3"
 
 
-  private val workbenchLibsHash = "bf368048-SNAP"
+  private val workbenchLibsHash = "49a5bae6-SNAP"
   val serviceTestV = s"0.20-$workbenchLibsHash"
   val workbenchModelV = s"0.14-$workbenchLibsHash"
   val workbenchGoogleV = s"0.21-$workbenchLibsHash"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,13 +10,13 @@ object Dependencies {
   val scalaLoggingV = "3.9.4"
   val scalaTestV = "3.2.10"
   val slickV = "3.3.3"
-  val http4sVersion = "0.23.4"
+  val http4sVersion = "0.23.5"
   val guavaV = "31.0.1-jre"
   val monocleV = "2.1.0"
   val opencensusV = "0.28.3"
 
 
-  private val workbenchLibsHash = "8803c71d-SNAP"
+  private val workbenchLibsHash = "6bb15228-SNAP"
   val serviceTestV = s"0.20-$workbenchLibsHash"
   val workbenchModelV = s"0.14-$workbenchLibsHash"
   val workbenchGoogleV = s"0.21-$workbenchLibsHash"
@@ -125,7 +125,6 @@ object Dependencies {
   val sealerate: ModuleID =       "ca.mrvisser"         %% "sealerate"            % "0.0.6"
   val googleCloudNio: ModuleID =  "com.google.cloud"    % "google-cloud-nio"      % "0.123.10" % Test // brought in for FakeStorageInterpreter
 
-  val scalaCache = "com.github.cb372" %% "scalacache-caffeine" % "1.0.0-M4"
   val circeYaml =         "io.circe"          %% "circe-yaml"           % "0.14.1"
   val http4sBlazeServer = "org.http4s"        %% "http4s-blaze-server"  % http4sVersion
   val http4sDsl =         "org.http4s"        %% "http4s-dsl"           % http4sVersion
@@ -152,8 +151,7 @@ object Dependencies {
     enumeratum,
     circeYaml,
     http4sDsl,
-    scalaTestScalaCheck,
-    scalaCache
+    scalaTestScalaCheck
   )
 
   val httpDependencies = Seq(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -16,7 +16,7 @@ object Dependencies {
   val opencensusV = "0.28.3"
 
 
-  private val workbenchLibsHash = "6bb15228-SNAP"
+  private val workbenchLibsHash = "4cb37a0"
   val serviceTestV = s"0.20-$workbenchLibsHash"
   val workbenchModelV = s"0.14-$workbenchLibsHash"
   val workbenchGoogleV = s"0.21-$workbenchLibsHash"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -31,7 +31,6 @@ object Dependencies {
   val excludeAkkaHttpSprayJson = ExclusionRule(organization = "com.typesafe.akka", name = s"akka-http-spray-json_${scalaV}")
   val excludeGuavaJDK5 = ExclusionRule(organization = "com.google.guava", name = "guava-jdk5")
   val excludeGuava = ExclusionRule(organization = "com.google.guava", name = "guava")
-  val excludeWorkbenchModel = ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = s"workbench-model_${scalaV}")
   val excludeWorkbenchMetrics = ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = s"workbench-metrics_${scalaV}")
   val excludeIoGrpc = ExclusionRule(organization = "io.grpc", name = "grpc-core")
   val excludeFindbugsJsr = ExclusionRule(organization = "com.google.code.findbugs", name = "jsr305")
@@ -93,7 +92,6 @@ object Dependencies {
     excludeStatsD,
     excludeKms)
   val workbenchGoogle2: ModuleID =      "org.broadinstitute.dsde.workbench" %% "workbench-google2"  % workbenchGoogle2V excludeAll (
-    excludeWorkbenchModel,
     excludeWorkbenchMetrics,
     excludeIoGrpc,
     excludeFindbugsJsr,
@@ -110,7 +108,7 @@ object Dependencies {
     excludeSundrCodegen,
     excludeGuava)
 
-  val workbenchGoogleTest: ModuleID =   "org.broadinstitute.dsde.workbench" %% "workbench-google"   % workbenchGoogleV  % "test" classifier "tests" excludeAll (excludeWorkbenchModel, excludeGuava, excludeStatsD)
+  val workbenchGoogleTest: ModuleID =   "org.broadinstitute.dsde.workbench" %% "workbench-google"   % workbenchGoogleV  % "test" classifier "tests" excludeAll (excludeGuava, excludeStatsD)
   val workbenchGoogle2Test: ModuleID =  "org.broadinstitute.dsde.workbench" %% "workbench-google2"  % workbenchGoogle2V % "test" classifier "tests" excludeAll (excludeGuava) //for generators
   val workbenchOpenTelemetry: ModuleID =     "org.broadinstitute.dsde.workbench" %% "workbench-opentelemetry" % workbenchOpenTelemetryV excludeAll (excludeGuava)
   val workbenchOpenTelemetryTest: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-opentelemetry" % workbenchOpenTelemetryV % Test classifier "tests" excludeAll (excludeGuava)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -16,7 +16,7 @@ object Dependencies {
   val opencensusV = "0.28.3"
 
 
-  private val workbenchLibsHash = "4e7b8c6e-SNAP"
+  private val workbenchLibsHash = "6140478"
   val serviceTestV = s"0.19-$workbenchLibsHash"
   val workbenchModelV = s"0.14-$workbenchLibsHash"
   val workbenchGoogleV = s"0.21-$workbenchLibsHash"


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-2881
https://broadworkbench.atlassian.net/browse/IA-2878


Depends on https://github.com/broadinstitute/workbench-libs/pull/698

* Made `LeoPubsubMessageSubscriber` depends on `GKEAlgebra[F]` instead of `GKEInterpreter[F]` (this will prevent we rely on implementation details of `GKEInterpreter[F]` in `LeoPubsubMessageSubscriberSpec`). Moved some unit tests in `LeoPubsubMessageSubscriberSpec` that essentially testing `GKEInterpreter`'s behavior to `GKEInterpreterSpec`. This should make these tests a lot more focused on what they're trying to validate.

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
