### PR TITLE
IA-2904 add request Uri to the error message

### DIFF
--- a/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestSuite.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestSuite.scala
@@ -21,7 +21,7 @@ trait LeonardoTestSuite extends Matchers {
   implicit val testTimer: Timer[IO] = IO.timer(global)
   implicit val cs: ContextShift[IO] = IO.contextShift(global)
   implicit val loggerIO: StructuredLogger[IO] = Slf4jLogger.getLogger[IO]
-  implicit val appContext = AppContext.lift[IO](None).unsafeRunSync()
+  implicit val appContext = AppContext.lift[IO](None, "").unsafeRunSync()
 
   val blocker = Blocker.liftExecutionContext(global)
   val semaphore = Semaphore[IO](10).unsafeRunSync()

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/Boot.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/Boot.scala
@@ -183,7 +183,7 @@ object Boot extends IOApp {
       val httpServer = for {
         start <- Timer[IO].clock.realTime(TimeUnit.MILLISECONDS)
         implicit0(ctx: Ask[IO, AppContext]) = Ask.const[IO, AppContext](
-          AppContext(TraceId(s"Boot_${start}"), Instant.ofEpochMilli(start))
+          AppContext(TraceId(s"Boot_${start}"), Instant.ofEpochMilli(start), "")
         )
 
         _ <- if (leoExecutionModeConfig == LeoExecutionModeConfig.BackLeoOnly) {

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/package.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/package.scala
@@ -37,12 +37,12 @@ package object api {
       }
   }
 
-  def extractAppContext(span: Option[Span]): Directive1[Ask[IO, AppContext]] =
+  def extractAppContext(span: Option[Span], requestUri: String = ""): Directive1[Ask[IO, AppContext]] =
     optionalHeaderValueByName(traceIdHeaderString).map {
       case uuidOpt =>
         val traceId = uuidOpt.getOrElse(UUID.randomUUID().toString)
         val now = Instant.now()
-        val appContext = AppContext(TraceId(traceId), now, span)
+        val appContext = AppContext(TraceId(traceId), now, requestUri, span)
         Ask.const[IO, AppContext](appContext)
     }
 }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/ProxyService.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/ProxyService.scala
@@ -193,15 +193,11 @@ class ProxyService(
       res <- resourceId match {
         case Some(samResource) => IO.pure(samResource)
         case None =>
-          IO(
-            logger.error(
-              s"${ctx.traceId} | Unable to look up sam resource for ${key.toString}"
-            )
-          ) >> IO.raiseError(
+          IO.raiseError(
             RuntimeNotFoundException(
               key.googleProject,
               key.name,
-              s"${ctx.traceId} | Unable to look up sam resource for runtime ${key.googleProject.value} / ${key.name.asString}"
+              s"${ctx.traceId} | Unable to look up sam resource for runtime ${key.googleProject.value} / ${key.name.asString}. Request: ${ctx.requestUri}"
             )
           )
       }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/NonLeoMessageSubscriber.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/NonLeoMessageSubscriber.scala
@@ -62,7 +62,7 @@ class NonLeoMessageSubscriber[F[_]: Timer](gkeAlg: GKEAlgebra[F],
     val traceId = event.traceId.getOrElse(TraceId("None"))
     for {
       now <- nowInstant[F]
-      implicit0(ev: Ask[F, AppContext]) <- F.pure(Ask.const[F, AppContext](AppContext(traceId, now, None)))
+      implicit0(ev: Ask[F, AppContext]) <- F.pure(Ask.const[F, AppContext](AppContext(traceId, now, "", None)))
       _ <- metrics.incrementCounter(s"NonLeoPubSub/${event.msg.messageType}")
       res <- messageResponder(event.msg).attempt
       _ <- res match {


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-2904

Starting 7/19, we're seeing lots of the following error in leo log. It's hard to tell what's the original request resulted in this error. Hence adding requestUri to error message so that it's easier to debug in the future
```
message: "request failed due to: Runtime :/jupyter not found. Details: TraceId(268bc0ebc3fec8975584a293d0e5da4b/14341969644338633615) | Unable to look up sam resource for runtime : / jupyter"
stack_trace: "org.broadinstitute.dsde.workbench.leonardo.model.RuntimeNotFoundException: Runtime :/jupyter not found. Details: TraceId(268bc0ebc3fec8975584a293d0e5da4b/14341969644338633615) | Unable to look up sam resource for runtime : / jupyter
	at org.broadinstitute.dsde.workbench.leonardo.http.service.ProxyService.$anonfun$getCachedRuntimeSamResource$5(ProxyService.scala:201)
	at cats.syntax.FlatMapOps$.$anonfun$$greater$greater$1(flatMap.scala:33)
	at >>$extension @ org.broadinstitute.dsde.workbench.leonardo.db.DbReference$.$anonfun$init$8(DbReference.scala:61)
	at delay$extension @ fs2.io.file.FileHandle$.fromPath(FileHandle.scala:107)
	at flatMap @ org.broadinstitute.dsde.workbench.leonardo.http.service.ProxyService.$anonfun$getCachedRuntimeSamResource$1(ProxyService.scala:191)
	at flatMap @ org.broadinstitute.dsde.workbench.leonardo.http.service.ProxyService.getCachedRuntimeSamResource(ProxyService.scala:190)
	at flatMap @ org.broadinstitute.dsde.workbench.leonardo.http.service.ProxyService.$anonfun$proxyRequest$1(ProxyService.scala:242)
	at flatMap @ org.broadinstitute.dsde.workbench.leonardo.http.service.ProxyService.proxyRequest(ProxyService.scala:241)
	at make @ org.broadinstitute.dsde.workbench.util2.ExecutionContexts$.cachedThreadPool(ExecutionContexts.scala:31)
```

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
