### PR TITLE
[IA-2437] Updating Leo Automation tests to use PPW

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoApiClient.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoApiClient.scala
@@ -216,7 +216,7 @@ object LeonardoApiClient {
   ): IO[GetRuntimeResponseCopy] = {
     val ioa = getRuntime(googleProject, runtimeName)
     for {
-      res <- timer.sleep(80 seconds) >> streamFUntilDone(ioa, 60, 10 seconds).compile.lastOrError
+      res <- timer.sleep(80 seconds) >> streamFUntilDone(ioa, 120, 10 seconds).compile.lastOrError
       _ <- res.status match {
         case ClusterStatus.Error =>
           if (shouldError)

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoSuite.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoSuite.scala
@@ -11,7 +11,7 @@ import org.broadinstitute.dsde.workbench.leonardo.notebooks._
 import org.broadinstitute.dsde.workbench.leonardo.rstudio.RStudioSpec
 import org.broadinstitute.dsde.workbench.leonardo.runtimes._
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
-import org.broadinstitute.dsde.workbench.service.{BillingProject, Orchestration}
+import org.broadinstitute.dsde.workbench.service.{BillingProject, Orchestration, Rawls}
 import org.http4s.AuthScheme
 import org.http4s.Credentials.Token
 import org.http4s.headers.Authorization
@@ -112,13 +112,16 @@ trait GPAllocUtils extends BillingFixtures with LeonardoTestUtils {
                                                       ronEmail,
                                                       BillingProject.BillingProjectRole.User)(hermioneAuthToken)
       )
+      workspaceName = UUID.randomUUID().toString
       _ <- IO(
-        Orchestration.workspaces.create(claimedBillingProject.projectName, UUID.randomUUID().toString)(ronAuthToken)
+        Orchestration.workspaces.create(claimedBillingProject.projectName, workspaceName)(ronAuthToken)
       )
 
-      workspaceDetails <- IO(Orchestration.workspaces.)
+      workspaceDetails = Rawls.workspaces.getWorkspaceDetails(claimedBillingProject.projectName, workspaceName)(ronAuthToken)
+      googleProjectId <- IO(workspaceDetails.parseJson.asJsObject.getFields("googleProjectId"))
+      // _ <- loggerIO.info(s"Workspace details: ${googleProjectId}")
       _ <- loggerIO.info(s"Billing project claimed: ${claimedBillingProject.projectName}")
-    } yield GoogleProject(workspaceDetails.googleProject)
+    } yield GoogleProject(googleProjectId)
 
   /**
    * Unclaiming billing project claim by Hermione

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoSuite.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoSuite.scala
@@ -4,7 +4,6 @@ import cats.effect.IO
 import cats.syntax.all._
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.rawls.model.WorkspaceName
-//import org.broadinstitute.dsde.rawls.model.Workspace
 import org.broadinstitute.dsde.workbench.fixture.{BillingFixtures}
 import org.broadinstitute.dsde.workbench.leonardo.GPAllocFixtureSpec.{shouldUnclaimProjectsKey, _}
 import org.broadinstitute.dsde.workbench.leonardo.apps.{AppCreationSpec, CustomAppCreationSpec}
@@ -42,7 +41,6 @@ trait GPAllocFixtureSpec extends FixtureAnyFreeSpecLike with Retries with LazyLo
 
     sys.props.get(googleProjectKey) match {
       case None => throw new RuntimeException("leonardo.googleProject system property is not set")
-      // case Some(msg) if msg.startsWith(gpallocErrorPrefix) => throw new RuntimeException(msg)
       case Some(googleProjectId) =>
         if (isRetryable(test))
           withRetry(runTestAndCheckOutcome(GoogleProject(googleProjectId)))
@@ -84,7 +82,6 @@ trait GPAllocUtils extends BillingFixtures with LeonardoTestUtils {
       _ <- IO(
         Orchestration.workspaces.create(claimedBillingProject.projectName, workspaceName)(ronAuthToken)
       )
-      // Testing with: sbt "testOnly *RuntimeAutopauseSpec"
       workspaceDetails <- IO(
         Rawls.workspaces.getWorkspaceDetails(claimedBillingProject.projectName, workspaceName)(ronAuthToken)
       )

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoSuite.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoSuite.scala
@@ -97,7 +97,7 @@ trait GPAllocUtils extends BillingFixtures with LeonardoTestUtils {
     for {
       _ <- IO(
         Orchestration.workspaces.delete(workspaceName.namespace, workspaceName.name)(ronAuthToken)
-      )
+      ).attempt
       _ <- IO(
         Orchestration.billing
           .removeUserFromBillingProject(workspaceName.namespace, ronEmail, BillingProject.BillingProjectRole.User)(

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoSuite.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoSuite.scala
@@ -35,13 +35,9 @@ trait GPAllocFixtureSpec extends FixtureAnyFreeSpecLike with Retries with LazyLo
       outcome
     }
 
-    sys.props.get(workspaceNamespaceKey) match {
-      case Some(msg) if msg.startsWith(gpallocErrorPrefix) => throw new RuntimeException(msg)
-      case x => logger.info(s"Workspace namespace is : ${x}")
-    }
-
     sys.props.get(googleProjectKey) match {
       case None => throw new RuntimeException("leonardo.googleProject system property is not set")
+      case Some(msg) if msg.startsWith(gpallocErrorPrefix) => throw new RuntimeException(msg)
       case Some(googleProjectId) =>
         if (isRetryable(test))
           withRetry(runTestAndCheckOutcome(GoogleProject(googleProjectId)))
@@ -138,7 +134,7 @@ trait GPAllocBeforeAndAfterAll extends GPAllocUtils with BeforeAndAfterAll {
       _ <- loggerIO.info(s"Running GPAllocBeforeAndAfterAll beforeAll")
       claimAttempt <- claimGPAllocProjectAndCreateWorkspace().attempt
       _ <- claimAttempt match {
-        case Left(e) => IO(sys.props.put(workspaceNamespaceKey, gpallocErrorPrefix + e.getMessage))
+        case Left(e) => IO(sys.props.put(googleProjectKey, gpallocErrorPrefix + e.getMessage))
         case Right(googleProjectAndWorkspaceName) =>
           IO(
             sys.props.addAll(

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoSuite.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoSuite.scala
@@ -24,7 +24,7 @@ import spray.json.DefaultJsonProtocol.StringJsonFormat
 
 import java.util.UUID
 
-trait GPAllocFixtureSpec extends FixtureAnyFreeSpecLike with Retries with LazyLogging{
+trait GPAllocFixtureSpec extends FixtureAnyFreeSpecLike with Retries with LazyLogging {
   override type FixtureParam = GoogleProject
   override def withFixture(test: OneArgTest): Outcome = {
     def runTestAndCheckOutcome(project: GoogleProject) = {
@@ -36,7 +36,7 @@ trait GPAllocFixtureSpec extends FixtureAnyFreeSpecLike with Retries with LazyLo
     }
 
     sys.props.get(googleProjectKey) match {
-      case None => throw new RuntimeException("leonardo.googleProject system property is not set")
+      case None                                            => throw new RuntimeException("leonardo.googleProject system property is not set")
       case Some(msg) if msg.startsWith(gpallocErrorPrefix) => throw new RuntimeException(msg)
       case Some(googleProjectId) =>
         if (isRetryable(test))
@@ -83,7 +83,7 @@ trait GPAllocUtils extends BillingFixtures with LeonardoTestUtils {
         Rawls.workspaces.getWorkspaceDetails(claimedBillingProject.projectName, workspaceName)(ronAuthToken)
       )
       json <- IO.fromEither(parse(workspaceDetails))
-      googleProjectOpt = json.hcursor.downField("workspace").get[String]("googleProjectId").toOption
+      googleProjectOpt = json.hcursor.downField("workspace").get[String]("googleProject").toOption
       googleProjectId <- IO.fromOption(googleProjectOpt)(
         new Exception(s"Could not get googleProject from workspace $workspaceName")
       )

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoSuite.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoSuite.scala
@@ -2,7 +2,6 @@ package org.broadinstitute.dsde.workbench.leonardo
 
 import cats.effect.IO
 import cats.syntax.all._
-import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.rawls.model.WorkspaceName
 import org.broadinstitute.dsde.workbench.fixture.{BillingFixtures}
 import org.broadinstitute.dsde.workbench.leonardo.GPAllocFixtureSpec.{shouldUnclaimProjectsKey, _}
@@ -23,7 +22,7 @@ import spray.json.DefaultJsonProtocol.StringJsonFormat
 
 import java.util.UUID
 
-trait GPAllocFixtureSpec extends FixtureAnyFreeSpecLike with Retries with LazyLogging {
+trait GPAllocFixtureSpec extends FixtureAnyFreeSpecLike with Retries {
   override type FixtureParam = GoogleProject
   override def withFixture(test: OneArgTest): Outcome = {
     def runTestAndCheckOutcome(project: GoogleProject) = {
@@ -36,7 +35,6 @@ trait GPAllocFixtureSpec extends FixtureAnyFreeSpecLike with Retries with LazyLo
 
     sys.props.get(workspaceNamespaceKey) match {
       case Some(msg) if msg.startsWith(gpallocErrorPrefix) => throw new RuntimeException(msg)
-      case x                                               => logger.info(s"Workspace namespace is: ${x}")
     }
 
     sys.props.get(googleProjectKey) match {
@@ -92,7 +90,6 @@ trait GPAllocUtils extends BillingFixtures with LeonardoTestUtils {
           .head
           .convertTo[String]
       )
-      _ <- loggerIO.info(s"Workspace details: ${workspaceDetails}")
     } yield GoogleProjectAndWorkspaceName(GoogleProject(googleProjectId),
                                           WorkspaceName(claimedBillingProject.projectName, workspaceName))
 

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoSuite.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoSuite.scala
@@ -2,6 +2,7 @@ package org.broadinstitute.dsde.workbench.leonardo
 
 import cats.effect.IO
 import cats.syntax.all._
+import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.rawls.model.WorkspaceName
 //import org.broadinstitute.dsde.rawls.model.Workspace
 import org.broadinstitute.dsde.workbench.fixture.{BillingFixtures}
@@ -23,7 +24,7 @@ import spray.json.DefaultJsonProtocol.StringJsonFormat
 
 import java.util.UUID
 
-trait GPAllocFixtureSpec extends FixtureAnyFreeSpecLike with Retries {
+trait GPAllocFixtureSpec extends FixtureAnyFreeSpecLike with Retries with LazyLogging{
   override type FixtureParam = GoogleProject
   override def withFixture(test: OneArgTest): Outcome = {
     def runTestAndCheckOutcome(project: GoogleProject) = {
@@ -36,7 +37,7 @@ trait GPAllocFixtureSpec extends FixtureAnyFreeSpecLike with Retries {
 
     sys.props.get(workspaceNamespaceKey) match {
       case Some(msg) if msg.startsWith(gpallocErrorPrefix) => throw new RuntimeException(msg)
-      case x => loggerIO.info(s"Workspace namespace is: ${x}").unsafeRunSync()
+      case x => logger.info(s"Workspace namespace is: ${x}")
     }
 
     sys.props.get(googleProjectKey) match {

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoSuite.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoSuite.scala
@@ -87,7 +87,7 @@ trait GPAllocUtils extends BillingFixtures with LeonardoTestUtils {
         Rawls.workspaces.getWorkspaceDetails(claimedBillingProject.projectName, workspaceName)(ronAuthToken)
       )
       json <- IO.fromEither(parse(workspaceDetails))
-      googleProjectOpt = json.hcursor.downField("workspace").get[String]("googleProject").toOption
+      googleProjectOpt = json.hcursor.downField("workspace").get[String]("googleProjectId").toOption
       googleProjectId <- IO.fromOption(googleProjectOpt)(
         new Exception(s"Could not get googleProject from workspace $workspaceName")
       )

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoSuite.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoSuite.scala
@@ -51,55 +51,6 @@ object GPAllocFixtureSpec {
   val initalRuntimeName = RuntimeName("initial-runtime")
 }
 
-//trait WorkspaceUtils extends BillingFixtures with WorkspaceFixtures with LeonardoTestUtils {
-//  this: TestSuite =>
-//
-//  /**
-//   * Claim new billing project by Hermione
-//   */
-//  protected def createWorkspace(): IO[Workspace] =
-//    for {
-//      claimedBillingProject <- IO(claimGPAllocProject(hermioneCreds))
-//      _ <- IO(
-//        Orchestration.billing.addUserToBillingProject(claimedBillingProject.projectName,
-//          ronEmail,
-//          BillingProject.BillingProjectRole.User)(hermioneAuthToken)
-//      )
-//      _ <- loggerIO.info(s"Billing project claimed: ${claimedBillingProject.projectName}")
-//    } yield GoogleProject(claimedBillingProject.projectName)
-//
-//  /**
-//   * Unclaiming billing project claim by Hermione
-//   */
-//  protected def deleteWorkspace(workspace: Workspace): IO[Unit] =
-//    for {
-//      _ <- IO(
-//        Orchestration.billing
-//          .removeUserFromBillingProject(project.value, ronEmail, BillingProject.BillingProjectRole.User)(
-//            hermioneAuthToken
-//          )
-//      )
-//      releaseProject <- IO(releaseGPAllocProject(project.value, hermioneCreds)).attempt
-//      _ <- releaseProject match {
-//        case Left(e) => loggerIO.warn(e)(s"Failed to release billing project: ${project.value}")
-//        case _       => loggerIO.info(s"Billing project released: ${project.value}")
-//      }
-//    } yield ()
-//
-//  def withNewWorkspace[T](testCode: GoogleProject => IO[T]): T = {
-//    val test = for {
-//      _ <- loggerIO.info("Creating a new single-test workspace")
-//      workspace <- createWorkspace()
-//      _ <- loggerIO.info(s"Single workspace ${workspace.name} created")
-//      t <- testCode(workspace.googleProjectId)
-//      _ <- loggerIO.info(s"Deleting single-test workspace: ${workspace.name}")
-//      _ <- deleteWorkspace(workspace)
-//    } yield t
-//
-//    test.unsafeRunSync()
-//  }
-//}
-
 trait GPAllocUtils extends BillingFixtures with LeonardoTestUtils {
   this: TestSuite =>
 
@@ -118,7 +69,7 @@ trait GPAllocUtils extends BillingFixtures with LeonardoTestUtils {
       _ <- IO(
         Orchestration.workspaces.create(claimedBillingProject.projectName, workspaceName)(ronAuthToken)
       )
-
+      // Testing with: sbt "testOnly *RuntimeAutopauseSpec"
       workspaceDetails <- IO(Rawls.workspaces.getWorkspaceDetails(claimedBillingProject.projectName, workspaceName)(ronAuthToken))
       googleProjectId <- IO(workspaceDetails.parseJson.asJsObject.getFields("workspace").flatMap { workspace =>
         workspace.asJsObject.getFields("googleProjectId")}.head.convertTo[String])

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoSuite.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoSuite.scala
@@ -36,11 +36,12 @@ trait GPAllocFixtureSpec extends FixtureAnyFreeSpecLike with Retries {
 
     sys.props.get(workspaceNamespaceKey) match {
       case Some(msg) if msg.startsWith(gpallocErrorPrefix) => throw new RuntimeException(msg)
+      case x => loggerIO.info(s"Workspace namespace is: ${x}").unsafeRunSync()
     }
 
     sys.props.get(googleProjectKey) match {
       case None                                            => throw new RuntimeException("leonardo.googleProject system property is not set")
-      case Some(msg) if msg.startsWith(gpallocErrorPrefix) => throw new RuntimeException(msg)
+      // case Some(msg) if msg.startsWith(gpallocErrorPrefix) => throw new RuntimeException(msg)
       case Some(googleProjectId) =>
         if (isRetryable(test))
           withRetry(runTestAndCheckOutcome(GoogleProject(googleProjectId)))

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/RuntimeFixtureSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/RuntimeFixtureSpec.scala
@@ -122,8 +122,6 @@ abstract class RuntimeFixtureSpec
     sys.props.get(workspaceNamespaceKey) match {
       case Some(msg) if msg.startsWith(gpallocErrorPrefix) =>
         clusterCreationFailureMsg = msg
-      case x => logger.info(s"Workspace namespace is: ${x}")
-
     }
 
     sys.props.get(googleProjectKey) match {

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/RuntimeFixtureSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/RuntimeFixtureSpec.scala
@@ -120,13 +120,13 @@ abstract class RuntimeFixtureSpec
     logger.info("beforeAll")
 
     sys.props.get(googleProjectKey) match {
+      case Some(msg) if msg.startsWith(gpallocErrorPrefix) =>
+        clusterCreationFailureMsg = msg
       case Some(googleProjectId) =>
         Either.catchNonFatal(createRonRuntime(GoogleProject(googleProjectId))).handleError { e =>
           clusterCreationFailureMsg = e.getMessage
           ronCluster = null
         }
-      case Some(msg) if msg.startsWith(gpallocErrorPrefix) =>
-        clusterCreationFailureMsg = msg
       case None =>
         clusterCreationFailureMsg = "leonardo.googleProject system property is not set"
     }

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/RuntimeFixtureSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/RuntimeFixtureSpec.scala
@@ -119,11 +119,14 @@ abstract class RuntimeFixtureSpec
     super.beforeAll()
     logger.info("beforeAll")
 
-    sys.props.get(googleProjectKey) match {
+    sys.props.get(workspaceNamespaceKey) match {
       case Some(msg) if msg.startsWith(gpallocErrorPrefix) =>
         clusterCreationFailureMsg = msg
-      case Some(billingProject) =>
-        Either.catchNonFatal(createRonRuntime(GoogleProject(billingProject))).handleError { e =>
+    }
+
+    sys.props.get(googleProjectKey) match {
+      case Some(googleProjectId) =>
+        Either.catchNonFatal(createRonRuntime(GoogleProject(googleProjectId))).handleError { e =>
           clusterCreationFailureMsg = e.getMessage
           ronCluster = null
         }

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/RuntimeFixtureSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/RuntimeFixtureSpec.scala
@@ -122,6 +122,7 @@ abstract class RuntimeFixtureSpec
     sys.props.get(workspaceNamespaceKey) match {
       case Some(msg) if msg.startsWith(gpallocErrorPrefix) =>
         clusterCreationFailureMsg = msg
+      case x => logger.info(s"Worksapce name space is ${x}")
     }
 
     sys.props.get(googleProjectKey) match {

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/RuntimeFixtureSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/RuntimeFixtureSpec.scala
@@ -122,6 +122,8 @@ abstract class RuntimeFixtureSpec
     sys.props.get(workspaceNamespaceKey) match {
       case Some(msg) if msg.startsWith(gpallocErrorPrefix) =>
         clusterCreationFailureMsg = msg
+      case x => logger.info(s"Workspace namespace is: ${x}")
+
     }
 
     sys.props.get(googleProjectKey) match {

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/RuntimeFixtureSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/RuntimeFixtureSpec.scala
@@ -119,7 +119,7 @@ abstract class RuntimeFixtureSpec
     super.beforeAll()
     logger.info("beforeAll")
 
-    sys.props.get(gpallocProjectKey) match {
+    sys.props.get(googleProjectKey) match {
       case Some(msg) if msg.startsWith(gpallocErrorPrefix) =>
         clusterCreationFailureMsg = msg
       case Some(billingProject) =>
@@ -128,7 +128,7 @@ abstract class RuntimeFixtureSpec
           ronCluster = null
         }
       case None =>
-        clusterCreationFailureMsg = "leonardo.billingProject system property is not set"
+        clusterCreationFailureMsg = "leonardo.googleProject system property is not set"
     }
 
   }
@@ -136,9 +136,9 @@ abstract class RuntimeFixtureSpec
   override def afterAll(): Unit = {
     logger.info("afterAll")
 
-    sys.props.get(gpallocProjectKey) match {
+    sys.props.get(googleProjectKey) match {
       case Some(billingProject) => deleteRonRuntime(GoogleProject(billingProject))
-      case None                 => throw new RuntimeException("leonardo.billingProject system property is not set")
+      case None                 => throw new RuntimeException("leonardo.googleProject system property is not set")
     }
 
     super.afterAll()

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/RuntimeFixtureSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/RuntimeFixtureSpec.scala
@@ -119,18 +119,14 @@ abstract class RuntimeFixtureSpec
     super.beforeAll()
     logger.info("beforeAll")
 
-    sys.props.get(workspaceNamespaceKey) match {
-      case Some(msg) if msg.startsWith(gpallocErrorPrefix) =>
-        clusterCreationFailureMsg = msg
-      case x => logger.info(s"Worksapce name space is ${x}")
-    }
-
     sys.props.get(googleProjectKey) match {
       case Some(googleProjectId) =>
         Either.catchNonFatal(createRonRuntime(GoogleProject(googleProjectId))).handleError { e =>
           clusterCreationFailureMsg = e.getMessage
           ronCluster = null
         }
+      case Some(msg) if msg.startsWith(gpallocErrorPrefix) =>
+        clusterCreationFailureMsg = msg
       case None =>
         clusterCreationFailureMsg = "leonardo.googleProject system property is not set"
     }

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/AppCreationSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/AppCreationSpec.scala
@@ -108,7 +108,8 @@ class AppCreationSpec
                                                                                                         auth,
                                                                                                         loggerIO,
                                                                                                         testTimer)
-              _ <- IO(Sam.user.deleteResource("kubernetes-app", restoreAppName.value)(ronCreds.makeAuthToken()))
+              _ <- LeonardoApiClient.deleteAppWithWait(googleProject, restoreAppName)
+              //_ <- IO(Sam.user.deleteResource("kubernetes-app", restoreAppName.value)(ronCreds.makeAuthToken()))
             } yield ()
           }
         } yield ()

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/AppCreationSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/AppCreationSpec.scala
@@ -100,6 +100,7 @@ class AppCreationSpec extends GPAllocFixtureSpec with LeonardoTestUtils with  GP
                 s"AppCreationSpec: app ${googleProject.value}/${appName.value} delete result: $monitorDeleteResult"
               )
               _ <- LeonardoApiClient.createAppWithWait(googleProject, restoreAppName, createAppRequest)(client, auth, loggerIO, testTimer)
+              _ <- IO(Sam.user.deleteResource("kubernetes-app", restoreAppName.value)(ronCreds.makeAuthToken()))
             } yield ()
           }
         } yield ()
@@ -209,6 +210,7 @@ class AppCreationSpec extends GPAllocFixtureSpec with LeonardoTestUtils with  GP
             loggerIO.warn(
               s"AppCreationSpec: app ${googleProject.value}/${appName.value} did not finish deleting after 20 minutes. Result: $monitorDeleteResult"
             )
+            IO(Sam.user.deleteResource("kubernetes-app", appName.value)(ronCreds.makeAuthToken()))
           } else {
             // verify disk is also deleted
             for {

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/AppCreationSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/AppCreationSpec.scala
@@ -93,7 +93,7 @@ class AppCreationSpec extends GPAllocFixtureSpec with LeonardoTestUtils with GPA
             loggerIO.warn(
               s"AppCreationSpec: app ${googleProject.value}/${appName.value} did not finish deleting after 20 minutes. Result: $monitorDeleteResult"
             )
-            IO(Sam.user.deleteResource("kubernetes-app", appName.value)(ronCreds.makeAuthToken()))
+            //IO(Sam.user.deleteResource("kubernetes-app", appName.value)(ronCreds.makeAuthToken()))
           } else {
             // Verify creating another app with the same disk doesn't error out
             for {
@@ -214,7 +214,7 @@ class AppCreationSpec extends GPAllocFixtureSpec with LeonardoTestUtils with GPA
             loggerIO.warn(
               s"AppCreationSpec: app ${googleProject.value}/${appName.value} did not finish deleting after 30 minutes. Result: $monitorDeleteResult"
             )
-            IO(Sam.user.deleteResource("kubernetes-app", appName.value)(ronCreds.makeAuthToken()))
+            //IO(Sam.user.deleteResource("kubernetes-app", appName.value)(ronCreds.makeAuthToken()))
           } else {
             // verify disk is also deleted
             for {

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/AppCreationSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/AppCreationSpec.scala
@@ -15,7 +15,7 @@ import org.scalatest.ParallelTestExecution
 
 import scala.concurrent.duration._
 
-class AppCreationSpec extends GPAllocFixtureSpec with LeonardoTestUtils with GPAllocUtils with ParallelTestExecution {
+class AppCreationSpec extends GPAllocFixtureSpec with LeonardoTestUtils with  GPAllocUtils with ParallelTestExecution with GPAllocBeforeAndAfterAll {
   implicit val auth: Authorization =
     Authorization(Credentials.Token(AuthScheme.Bearer, ronCreds.makeAuthToken().value))
 

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/AppCreationSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/AppCreationSpec.scala
@@ -3,7 +3,7 @@ package apps
 
 import cats.effect.IO
 import org.broadinstitute.dsde.workbench.DoneCheckable
-import org.broadinstitute.dsde.workbench.google2.{Generators, streamFUntilDone, streamUntilDoneOrTimeout}
+import org.broadinstitute.dsde.workbench.google2.{streamFUntilDone, streamUntilDoneOrTimeout, Generators}
 import org.broadinstitute.dsde.workbench.leonardo.LeonardoApiClient._
 import org.broadinstitute.dsde.workbench.leonardo.http.{ListAppResponse, PersistentDiskRequest}
 import org.broadinstitute.dsde.workbench.service.util.Tags
@@ -15,7 +15,12 @@ import org.scalatest.ParallelTestExecution
 
 import scala.concurrent.duration._
 
-class AppCreationSpec extends GPAllocFixtureSpec with LeonardoTestUtils with  GPAllocUtils with ParallelTestExecution with GPAllocBeforeAndAfterAll {
+class AppCreationSpec
+    extends GPAllocFixtureSpec
+    with LeonardoTestUtils
+    with GPAllocUtils
+    with ParallelTestExecution
+    with GPAllocBeforeAndAfterAll {
   implicit val auth: Authorization =
     Authorization(Credentials.Token(AuthScheme.Bearer, ronCreds.makeAuthToken().value))
 
@@ -99,7 +104,10 @@ class AppCreationSpec extends GPAllocFixtureSpec with LeonardoTestUtils with  GP
               _ <- loggerIO.info(
                 s"AppCreationSpec: app ${googleProject.value}/${appName.value} delete result: $monitorDeleteResult"
               )
-              _ <- LeonardoApiClient.createAppWithWait(googleProject, restoreAppName, createAppRequest)(client, auth, loggerIO, testTimer)
+              _ <- LeonardoApiClient.createAppWithWait(googleProject, restoreAppName, createAppRequest)(client,
+                                                                                                        auth,
+                                                                                                        loggerIO,
+                                                                                                        testTimer)
               _ <- IO(Sam.user.deleteResource("kubernetes-app", restoreAppName.value)(ronCreds.makeAuthToken()))
             } yield ()
           }

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/AppCreationSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/AppCreationSpec.scala
@@ -208,7 +208,7 @@ class AppCreationSpec extends GPAllocFixtureSpec with LeonardoTestUtils with GPA
           // See https://broadworkbench.atlassian.net/browse/IA-2471
           listApps = LeonardoApiClient.listApps(googleProject, true)
           implicit0(doneCheckable: DoneCheckable[List[ListAppResponse]]) = appDeleted(appName)
-          monitorDeleteResult <- streamFUntilDone(listApps, 180, 10 seconds).compile.lastOrError
+          monitorDeleteResult <- streamFUntilDone(listApps, 200, 10 seconds).compile.lastOrError
           // TODO remove first case in below if statement when Galaxy deletion is reliable
           _ <- if (!doneCheckable.isDone(monitorDeleteResult)) {
             loggerIO.warn(

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/AppCreationSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/AppCreationSpec.scala
@@ -105,7 +105,6 @@ class AppCreationSpec extends GPAllocFixtureSpec with LeonardoTestUtils with GPA
                                                                                                         loggerIO,
                                                                                                         testTimer)
               _ <- LeonardoApiClient.deleteAppWithWait(googleProject, restoreAppName)
-              //_ <- IO(Sam.user.deleteResource("kubernetes-app", restoreAppName.value)(ronCreds.makeAuthToken()))
             } yield ()
           }
         } yield ()

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/AppCreationSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/AppCreationSpec.scala
@@ -3,7 +3,7 @@ package apps
 
 import cats.effect.IO
 import org.broadinstitute.dsde.workbench.DoneCheckable
-import org.broadinstitute.dsde.workbench.google2.{Generators, streamFUntilDone, streamUntilDoneOrTimeout}
+import org.broadinstitute.dsde.workbench.google2.{streamFUntilDone, streamUntilDoneOrTimeout, Generators}
 import org.broadinstitute.dsde.workbench.leonardo.LeonardoApiClient._
 import org.broadinstitute.dsde.workbench.leonardo.http.{ListAppResponse, PersistentDiskRequest}
 import org.broadinstitute.dsde.workbench.service.util.Tags
@@ -16,11 +16,7 @@ import org.scalatest.{DoNotDiscover, ParallelTestExecution}
 import scala.concurrent.duration._
 
 @DoNotDiscover
-class AppCreationSpec
-    extends GPAllocFixtureSpec
-    with LeonardoTestUtils
-    with GPAllocUtils
-    with ParallelTestExecution {
+class AppCreationSpec extends GPAllocFixtureSpec with LeonardoTestUtils with GPAllocUtils with ParallelTestExecution {
   implicit val auth: Authorization =
     Authorization(Credentials.Token(AuthScheme.Bearer, ronCreds.makeAuthToken().value))
 

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeAutopauseSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeAutopauseSpec.scala
@@ -1,7 +1,14 @@
 package org.broadinstitute.dsde.workbench.leonardo.runtimes
 
 import org.broadinstitute.dsde.workbench.auth.AuthToken
-import org.broadinstitute.dsde.workbench.leonardo.{ClusterStatus, GPAllocBeforeAndAfterAll, GPAllocFixtureSpec, Leonardo, LeonardoApiClient, LeonardoTestUtils}
+import org.broadinstitute.dsde.workbench.leonardo.{
+  ClusterStatus,
+  GPAllocBeforeAndAfterAll,
+  GPAllocFixtureSpec,
+  Leonardo,
+  LeonardoApiClient,
+  LeonardoTestUtils
+}
 import org.http4s.AuthScheme
 import org.http4s.headers.Authorization
 import org.scalatest.time.{Minutes, Seconds, Span}
@@ -10,7 +17,7 @@ import org.scalatest.{DoNotDiscover, ParallelTestExecution}
 import scala.concurrent.duration._
 
 @DoNotDiscover
-class RuntimeAutopauseSpec extends GPAllocFixtureSpec with ParallelTestExecution with LeonardoTestUtils{
+class RuntimeAutopauseSpec extends GPAllocFixtureSpec with ParallelTestExecution with LeonardoTestUtils {
 
   implicit val ronToken: AuthToken = ronAuthToken
   implicit val auth: Authorization = Authorization(

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeAutopauseSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeAutopauseSpec.scala
@@ -5,12 +5,12 @@ import org.broadinstitute.dsde.workbench.leonardo.{ClusterStatus, GPAllocBeforeA
 import org.http4s.AuthScheme
 import org.http4s.headers.Authorization
 import org.scalatest.time.{Minutes, Seconds, Span}
-import org.scalatest.ParallelTestExecution
+import org.scalatest.{DoNotDiscover, ParallelTestExecution}
 
 import scala.concurrent.duration._
 
-// @DoNotDiscover
-class RuntimeAutopauseSpec extends GPAllocFixtureSpec with ParallelTestExecution with LeonardoTestUtils with GPAllocBeforeAndAfterAll {
+@DoNotDiscover
+class RuntimeAutopauseSpec extends GPAllocFixtureSpec with ParallelTestExecution with LeonardoTestUtils{
 
   implicit val ronToken: AuthToken = ronAuthToken
   implicit val auth: Authorization = Authorization(

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeAutopauseSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeAutopauseSpec.scala
@@ -1,22 +1,16 @@
 package org.broadinstitute.dsde.workbench.leonardo.runtimes
 
 import org.broadinstitute.dsde.workbench.auth.AuthToken
-import org.broadinstitute.dsde.workbench.leonardo.{
-  ClusterStatus,
-  GPAllocFixtureSpec,
-  Leonardo,
-  LeonardoApiClient,
-  LeonardoTestUtils
-}
+import org.broadinstitute.dsde.workbench.leonardo.{ClusterStatus, GPAllocBeforeAndAfterAll, GPAllocFixtureSpec, Leonardo, LeonardoApiClient, LeonardoTestUtils}
 import org.http4s.AuthScheme
 import org.http4s.headers.Authorization
 import org.scalatest.time.{Minutes, Seconds, Span}
-import org.scalatest.{DoNotDiscover, ParallelTestExecution}
+import org.scalatest.ParallelTestExecution
 
 import scala.concurrent.duration._
 
 // @DoNotDiscover
-class RuntimeAutopauseSpec extends GPAllocFixtureSpec with ParallelTestExecution with LeonardoTestUtils {
+class RuntimeAutopauseSpec extends GPAllocFixtureSpec with ParallelTestExecution with LeonardoTestUtils with GPAllocBeforeAndAfterAll {
 
   implicit val ronToken: AuthToken = ronAuthToken
   implicit val auth: Authorization = Authorization(

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeAutopauseSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeAutopauseSpec.scala
@@ -15,7 +15,7 @@ import org.scalatest.{DoNotDiscover, ParallelTestExecution}
 
 import scala.concurrent.duration._
 
-@DoNotDiscover
+// @DoNotDiscover
 class RuntimeAutopauseSpec extends GPAllocFixtureSpec with ParallelTestExecution with LeonardoTestUtils {
 
   implicit val ronToken: AuthToken = ronAuthToken

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeAutopauseSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeAutopauseSpec.scala
@@ -3,7 +3,6 @@ package org.broadinstitute.dsde.workbench.leonardo.runtimes
 import org.broadinstitute.dsde.workbench.auth.AuthToken
 import org.broadinstitute.dsde.workbench.leonardo.{
   ClusterStatus,
-  GPAllocBeforeAndAfterAll,
   GPAllocFixtureSpec,
   Leonardo,
   LeonardoApiClient,


### PR DESCRIPTION
This PR was created in joint effort with CI to get Leonardo using PPW when claiming projects and creating workspace/unclaiming  project and deleting workspace.

We increased the timeout on some polling when we were running into some timeout issues with runtimes/apps. We also implemented some Sam resource clean up when deleteApp fails to ensure we can properly clean up the workspace after the tests finish
---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
