### PR TITLE
[IA-2653] Welder background process to sync Rmd files

### DIFF
--- a/http/src/main/resources/init-resources/gce-init.sh
+++ b/http/src/main/resources/init-resources/gce-init.sh
@@ -105,6 +105,11 @@ export MEM_LIMIT=$(memLimit)
 export WELDER_MEM_LIMIT=$(welderMemLimit)
 export PROXY_SERVER_HOST_NAME=$(proxyServerHostName)
 export WELDER_ENABLED=$(welderEnabled)
+if [ ! -z "$RSTUDIO_DOCKER_IMAGE" ] ; then
+  export IS_RSTUDIO_RUNTIME="true"
+else
+  export IS_RSTUDIO_RUNTIME="false"
+fi
 
 START_USER_SCRIPT_URI=$(startUserScriptUri)
 # Include a timestamp suffix to differentiate different startup logs across restarts.
@@ -315,6 +320,7 @@ HOST_PROXY_SITE_CONF_FILE_PATH=${DOCKER_COMPOSE_FILES_DIRECTORY}/`basename ${PRO
 DOCKER_COMPOSE_FILES_DIRECTORY=${DOCKER_COMPOSE_FILES_DIRECTORY}
 RSTUDIO_SERVER_NAME=${RSTUDIO_SERVER_NAME}
 RSTUDIO_DOCKER_IMAGE=${RSTUDIO_DOCKER_IMAGE}
+IS_RSTUDIO_RUNTIME=${IS_RSTUDIO_RUNTIME}
 END
 
 # Create a network that allows containers to talk to each other via exposed ports
@@ -500,7 +506,8 @@ if [ ! -z "$RSTUDIO_DOCKER_IMAGE" ] ; then
   retry 3 docker exec ${RSTUDIO_SERVER_NAME} /bin/bash -c 'echo "GOOGLE_PROJECT=$GOOGLE_PROJECT
 CLUSTER_NAME=$CLUSTER_NAME
 RUNTIME_NAME=$RUNTIME_NAME
-OWNER_EMAIL=$OWNER_EMAIL" >> /usr/local/lib/R/etc/Renviron.site'
+OWNER_EMAIL=$OWNER_EMAIL
+IS_RSTUDIO_RUNTIME=$IS_RSTUDIO_RUNTIME" >> /usr/local/lib/R/etc/Renviron.site'
 
   # Add custom_env_vars.env to Renviron.site
   CUSTOM_ENV_VARS_FILE=/var/custom_env_vars.env

--- a/http/src/main/resources/init-resources/init-actions.sh
+++ b/http/src/main/resources/init-resources/init-actions.sh
@@ -180,6 +180,11 @@ if [[ "${ROLE}" == 'Master' ]]; then
     export DOCKER_COMPOSE_FILES_DIRECTORY='/etc'
     PROXY_SITE_CONF=$(proxySiteConf)
     export HOST_PROXY_SITE_CONF_FILE_PATH=${DOCKER_COMPOSE_FILES_DIRECTORY}/`basename ${PROXY_SITE_CONF}`
+    if [ ! -z "$RSTUDIO_DOCKER_IMAGE" ] ; then
+      export IS_RSTUDIO_RUNTIME="true"
+    else
+      export IS_RSTUDIO_RUNTIME="false"
+    fi
 
     SERVER_CRT=$(proxyServerCrt)
     SERVER_KEY=$(proxyServerKey)
@@ -513,7 +518,8 @@ END
       retry 3 docker exec ${RSTUDIO_SERVER_NAME} /bin/bash -c 'echo "GOOGLE_PROJECT=$GOOGLE_PROJECT
 CLUSTER_NAME=$CLUSTER_NAME
 RUNTIME_NAME=$RUNTIME_NAME
-OWNER_EMAIL=$OWNER_EMAIL" >> /usr/local/lib/R/etc/Renviron.site'
+OWNER_EMAIL=$OWNER_EMAIL
+IS_RSTUDIO_RUNTIME=$IS_RSTUDIO_RUNTIME" >> /usr/local/lib/R/etc/Renviron.site'
 
       # Add custom_env_vars.env to Renviron.site
       CUSTOM_ENV_VARS_FILE=/var/custom_env_vars.env

--- a/http/src/main/resources/init-resources/startup.sh
+++ b/http/src/main/resources/init-resources/startup.sh
@@ -68,6 +68,11 @@ export WELDER_MEM_LIMIT=$(welderMemLimit)
 export MEM_LIMIT=$(memLimit)
 export USE_GCE_STARTUP_SCRIPT=$(useGceStartupScript)
 GPU_ENABLED=$(gpuEnabled)
+if [ ! -z "$RSTUDIO_DOCKER_IMAGE" ] ; then
+  export IS_RSTUDIO_RUNTIME="true"
+else
+  export IS_RSTUDIO_RUNTIME="false"
+fi
 
 # Overwrite old cert on restart
 SERVER_CRT=$(proxyServerCrt)

--- a/http/src/main/resources/init-resources/welder-docker-compose-gce.yaml
+++ b/http/src/main/resources/init-resources/welder-docker-compose-gce.yaml
@@ -20,6 +20,7 @@ services:
       CLUSTER_NAME: "${RUNTIME_NAME}"
       RUNTIME_NAME: "${RUNTIME_NAME}"
       OWNER_EMAIL: "${OWNER_EMAIL}"
+      IS_RSTUDIO_RUNTIME: "${IS_RSTUDIO_RUNTIME}"
     volumes:
       # shared with jupyter
       - ${WORK_DIRECTORY}:/work

--- a/http/src/main/resources/init-resources/welder-docker-compose.yaml
+++ b/http/src/main/resources/init-resources/welder-docker-compose.yaml
@@ -17,6 +17,7 @@ services:
       CLUSTER_NAME: "${RUNTIME_NAME}"
       RUNTIME_NAME: "${RUNTIME_NAME}"
       OWNER_EMAIL: "${OWNER_EMAIL}"
+      IS_RSTUDIO_RUNTIME: "${IS_RSTUDIO_RUNTIME}"
     volumes:
       # shared with jupyter
       - ${WORK_DIRECTORY}:/work

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterp.scala
@@ -549,22 +549,17 @@ class RuntimeServiceInterp[F[_]: Parallel](config: RuntimeServiceConfig,
       // - If present, we will use the client-supplied image.
       // - Otherwise we will pull the latest from the specified welderRegistry.
       // - If welderRegistry is undefined, we take the default GCR image from config.
-      // - If the tool is RStudio do not include a welder image
-      welderImage = toolImage.imageType match {
-        case RuntimeImageType.RStudio => None
-        case _ =>
-          Some(
-            RuntimeImage(
-              Welder,
-              welderRegistry match {
-                case Some(ContainerRegistry.DockerHub) => config.imageConfig.welderDockerHubImage.imageUrl
-                case _                                 => config.imageConfig.welderGcrImage.imageUrl
-              },
-              None,
-              now
-            )
-          )
-      }
+      welderImage = Some(
+        RuntimeImage(
+          Welder,
+          welderRegistry match {
+            case Some(ContainerRegistry.DockerHub) => config.imageConfig.welderDockerHubImage.imageUrl
+            case _                                 => config.imageConfig.welderGcrImage.imageUrl
+          },
+          None,
+          now
+        )
+      )
 
       // Get the proxy image
       proxyImage = RuntimeImage(Proxy, config.imageConfig.proxyImage.imageUrl, None, now)
@@ -858,8 +853,6 @@ object RuntimeServiceInterp {
         else req.scopes //default to create gce runtime if runtimeConfig is not specified
     }
 
-    val welderEnabled = clusterImages.map(_.imageType).contains(Welder)
-
     Runtime(
       0,
       samResource = clusterInternalId,
@@ -881,7 +874,7 @@ object RuntimeServiceInterp {
       defaultClientId = req.defaultClientId,
       runtimeImages = clusterImages,
       scopes = clusterScopes,
-      welderEnabled = welderEnabled,
+      welderEnabled = true,
       customEnvironmentVariables = req.customEnvironmentVariables,
       allowStop = false, //TODO: double check this should be false when cluster is created
       runtimeConfigId = RuntimeConfigId(-1),


### PR DESCRIPTION
This PR does a couple of things:
- It re-enables welder in all runtimes, not just jupyter runtimes since we also want to sync .Rmd files
- It adds the `IS_RSTUDIO_RUNTIME` environment variable to the welder docker compose for both GCE and Dataproc and populates that value depending on if the runtime is RStudio or not

I tested by creating runtimes through swagger and validating that the environment variable is set correctly by ssh-ing into the VM and docker exec-ing into the welder container and validating the value of `echo $IS_RSTUDIO_RUNTIME`


---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
