### PR TITLE
[no ticket] fix potential NPE

### DIFF
--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/AppErrorComponent.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/AppErrorComponent.scala
@@ -37,7 +37,7 @@ object appErrorQuery extends TableQuery(new AppErrorTable(_)) {
     appErrorQuery += AppErrorRecord(
       KubernetesErrorId(0),
       appId,
-      Some(error.errorMessage).map(_.take(1024)).getOrElse("null"),
+      Option(error.errorMessage).map(_.take(1024)).getOrElse("null"),
       error.timestamp,
       error.action,
       error.source,


### PR DESCRIPTION
See https://console.cloud.google.com/logs/query;cursorTimestamp=2021-09-17T20:15:44.511409054Z;query=labels.%22k8s-pod%2Fapp_kubernetes_io%2Fname%22%3D%22leonardo%22%0Aresource.labels.container_name%3D%22leonardo-backend-app%22%20OR%20resource.labels.container_name%3D%22leonardo-frontend-app%22%0Atimestamp%3D%222021-09-17T20:15:44.511409054Z%22%0AinsertId%3D%22qql92c7npbchlr5i%22;summaryFields=:false:32:beginning?project=broad-dsde-alpha


In case the link doesn't work, here's the stacktrace
```
Caused by: java.lang.NullPointerException: null
	at scala.collection.StringOps$.take$extension(StringOps.scala:1213)
	at org.broadinstitute.dsde.workbench.leonardo.db.appErrorQuery$.$anonfun$save$1(AppErrorComponent.scala:40)
	at scala.Option.map(Option.scala:242)
	at org.broadinstitute.dsde.workbench.leonardo.db.appErrorQuery$.save(AppErrorComponent.scala:40)
	at org.broadinstitute.dsde.workbench.leonardo.monitor.LeoPubsubMessageSubscriber.$anonfun$handleKubernetesError$4(LeoPubsubMessageSubscriber.scala:1150)
	at org.broadinstitute.dsde.workbench.leonardo.monitor.LeoPubsubMessageSubscriber.$anonfun$handleKubernetesError$4$adapted(LeoPubsubMessageSubscriber.scala:1150)
	at cats.instances.OptionInstances$$anon$1.traverse(option.scala:129)
	at cats.instances.OptionInstances$$anon$1.traverse(option.scala:15)
	at cats.Traverse$Ops.traverse(Traverse.scala:181)
	at cats.Traverse$Ops.traverse$(Traverse.scala:180)
	at cats.Traverse$ToTraverseOps$$anon$3.traverse(Traverse.scala:206)
	at org.broadinstitute.dsde.workbench.leonardo.monitor.LeoPubsubMessageSubscriber.$anonfun$handleKubernetesError$3(LeoPubsubMessageSubscriber.scala:1150)
	at ifM$extension @ org.typelevel.log4cats.slf4j.internal.Slf4jLoggerInternal$Slf4jLogger.info(Slf4jLoggerInternal.scala:90)
	at flatMap @ org.broadinstitute.dsde.workbench.leonardo.monitor.LeoPubsubMessageSubscriber.$anonfun$handleKubernetesError$1(LeoPubsubMessageSubscriber.scala:1149)
	at flatMap @ org.broadinstitute.dsde.workbench.leonardo.monitor.LeoPubsubMessageSubscriber.handleKubernetesError(LeoPubsubMessageSubscriber.scala:1145)
	at flatTraverse @ org.broadinstitute.dsde.workbench.leonardo.monitor.LeoPubsubMessageSubscriber.$anonfun$deleteApp$4(LeoPubsubMessageSubscriber.scala:923)
	at >>$extension @ org.broadinstitute.dsde.workbench.leonardo.db.DbReference$.$anonfun$init$8(DbReference.scala:61)
	at map @ fs2.internal.CompileScope.$anonfun$close$9(CompileScope.scala:246)
	at flatMap @ fs2.internal.CompileScope.$anonfun$close$6(CompileScope.scala:245)
	at map @ fs2.internal.CompileScope.fs2$internal$CompileScope$$traverseError(CompileScope.scala:222)
```
---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
