### PR TITLE
Add northamerica-northeast2 to list of supported regions

### DIFF
--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -14,7 +14,9 @@ application {
 
 # Google Cloud dataproc configuration
 dataproc {
-  # add more regions as necessary
+  # Add more regions as necessary.
+  # This list should match the list of regions in
+  # https://github.com/DataBiosphere/terra-ui/blob/dev/src/components/region-common.js
   supportedRegions = [
     "northamerica-northeast1",
     "southamerica-east1",
@@ -40,7 +42,8 @@ dataproc {
     "asia-south1",
     "asia-southeast1",
     "asia-southeast2",
-    "australia-southeast1"
+    "australia-southeast1",
+    "northamerica-northeast2"
   ]
   defaultScopes = [
     "https://www.googleapis.com/auth/userinfo.email",
@@ -160,6 +163,7 @@ vpc {
     asia-southeast1 = "10.23.0.0/20"
     asia-southeast2 = "10.24.0.0/20"
     australia-southeast1 = "10.25.0.0/20"
+    northamerica-northeast2 = "10.26.0.0/20"
   }
   firewallsToAdd = [
     # Allows Leonardo proxy traffic on port 443
@@ -191,6 +195,7 @@ vpc {
         asia-southeast1 = ["0.0.0.0/0"]
         asia-southeast2 = ["0.0.0.0/0"]
         australia-southeast1 = ["0.0.0.0/0"]
+        northamerica-northeast2 = ["0.0.0.0/0"]
       }
       allowed = [
         {
@@ -229,6 +234,7 @@ vpc {
         asia-southeast1 = ["10.23.0.0/20"]
         asia-southeast2 = ["10.24.0.0/20"]
         australia-southeast1 = ["10.25.0.0/20"]
+        northamerica-northeast2 = ["10.26.0.0/20"]
       }
       allowed = [
         {
@@ -274,6 +280,7 @@ vpc {
         asia-southeast1 = ${gke.cluster.authorizedNetworks}
         asia-southeast2 = ${gke.cluster.authorizedNetworks}
         australia-southeast1 = ${gke.cluster.authorizedNetworks}
+        northamerica-northeast2 = ${gke.cluster.authorizedNetworks}
       }
       allowed = [
         {


### PR DESCRIPTION
Recently the Toronto datacenter was announced by Google as the new northamerica-northeast2 region. 

Currently, I believe this and the terra-ui to be the only places we currently need to keep updated. But we should document if there are others. 

Please note that I did not test this change.