### PR TITLE
[IA-2886] Runtime creation timeout not being honored

### DIFF
--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -71,9 +71,10 @@ dataproc {
   monitor {
     initialDelay = 30 seconds
     # Defines polling for runtime status transitions. Used commonly for all statuses.
+    # Includes user script execution, if present.
     # Does not include tool checking (see below).
     pollStatus {
-      max-attempts = 80 # 15 seconds * 80 is 20 min
+      max-attempts = 120 # 15 seconds * 120 is 30 min
       interval = 15 seconds
     }
     # Defines a timeout per status transition. If a status is not listed there is no timeout.
@@ -115,9 +116,10 @@ gce {
   monitor {
     initialDelay = 20 seconds
     # Defines polling for runtime status transitions. Used commonly for all statuses.
+    # Includes user script execution, if present.
     # Does not include tool checking (see below).
     pollStatus {
-      max-attempts = 80 # 15 seconds * 80 is 20 min
+      max-attempts = 120 # 15 seconds * 120 is 30 min
       interval = 15 seconds
     }
     # Defines a timeout per status transition. If a status is not listed there is no timeout.

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -70,17 +70,27 @@ dataproc {
 
   monitor {
     initialDelay = 30 seconds
-    pollingInterval = 15 seconds
-    pollCheckMaxAttempts = 120 # 15 seconds * 120 is 30 min
-    checkToolsInterval = 8 seconds
-    checkToolsMaxAttempts = 75 # 8 seconds * 75 = 10 min
-    # Defines timeouts for cluster status transitions. If a status is not listed there is no timeout.
+    # Defines polling for runtime status transitions. Used commonly for all statuses.
+    # Does not include tool checking (see below).
+    pollStatus {
+      max-attempts = 80 # 15 seconds * 80 is 20 min
+      interval = 15 seconds
+    }
+    # Defines a timeout per status transition. If a status is not listed there is no timeout.
     # In the case of a Starting cluster, a timeout will transition it back to Stopped. Otherwise,
     # a timeout will transition it to Error status.
     statusTimeouts {
       creating = 30 minutes
       starting = 20 minutes
       deleting = 30 minutes
+    }
+    # Defines polling for tool checking. This is only done for Creating and Starting status transitions.
+    # Tool checking is not included in the statusTimeouts above, therefore it defines its own
+    # interruptAfter.
+    checkTools {
+      max-attempts = 75 # 8 seconds * 75 = 10 min
+      interval = 8 seconds
+      interruptAfter = 10 minutes
     }
   }
 }
@@ -104,17 +114,27 @@ gce {
 
   monitor {
     initialDelay = 20 seconds
-    pollingInterval = 15 seconds
-    pollCheckMaxAttempts = 120 # 15 seconds * 120 is 30 min
-    checkToolsInterval = 8 seconds
-    checkToolsMaxAttempts = 75 # 8 seconds * 75 = 10 min
-    # Defines timeouts for cluster status transitions. If a status is not listed there is no timeout.
+    # Defines polling for runtime status transitions. Used commonly for all statuses.
+    # Does not include tool checking (see below).
+    pollStatus {
+      max-attempts = 80 # 15 seconds * 80 is 20 min
+      interval = 15 seconds
+    }
+    # Defines a timeout per status transition. If a status is not listed there is no timeout.
     # In the case of a Starting cluster, a timeout will transition it back to Stopped. Otherwise,
     # a timeout will transition it to Error status.
     statusTimeouts {
       creating = 30 minutes
       starting = 20 minutes
       deleting = 30 minutes
+    }
+    # Defines polling for tool checking. This is only done for Creating and Starting status transitions.
+    # Tool checking is not included in the statusTimeouts above, therefore it defines its own
+    # interruptAfter.
+    checkTools {
+      max-attempts = 75 # 8 seconds * 75 = 10 min
+      interval = 8 seconds
+      interruptAfter = 10 minutes
     }
   }
 }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
@@ -1,8 +1,6 @@
 package org.broadinstitute.dsde.workbench.leonardo
 package config
 
-import java.nio.file.{Path, Paths}
-
 import com.google.pubsub.v1.{ProjectSubscriptionName, ProjectTopicName, TopicName}
 import com.typesafe.config.{ConfigFactory, Config => TypeSafeConfig}
 import net.ceedubs.ficus.Ficus._
@@ -38,6 +36,7 @@ import org.broadinstitute.dsde.workbench.leonardo.monitor.{
   PersistentDiskMonitorConfig,
   PollMonitorConfig
 }
+
 import org.broadinstitute.dsde.workbench.leonardo.util.RuntimeInterpreterConfig.{
   DataprocInterpreterConfig,
   GceInterpreterConfig
@@ -49,6 +48,7 @@ import org.broadinstitute.dsde.workbench.util.toScalaDuration
 import org.broadinstitute.dsp.{ChartName, ChartVersion, Release}
 import org.http4s.Uri
 
+import java.nio.file.{Path, Paths}
 import scala.concurrent.duration._
 import scala.jdk.CollectionConverters._
 
@@ -484,12 +484,10 @@ object Config {
 
     GceMonitorConfig(
       config.as[FiniteDuration]("initialDelay"),
-      config.as[FiniteDuration]("pollingInterval"),
-      config.as[Int]("pollCheckMaxAttempts"),
-      config.as[FiniteDuration]("checkToolsInterval"),
-      config.as[Int]("checkToolsMaxAttempts"),
-      clusterBucketConfig,
+      config.as[PollMonitorConfig]("pollStatus"),
       timeoutMap,
+      config.as[InterruptablePollMonitorConfig]("checkTools"),
+      clusterBucketConfig,
       imageConfig
     )
   }
@@ -506,15 +504,14 @@ object Config {
 
       DataprocMonitorConfig(
         config.as[FiniteDuration]("initialDelay"),
-        config.as[FiniteDuration]("pollingInterval"),
-        config.as[Int]("pollCheckMaxAttempts"),
-        config.as[FiniteDuration]("checkToolsInterval"),
-        config.as[Int]("checkToolsMaxAttempts"),
-        clusterBucketConfig,
+        config.as[PollMonitorConfig]("pollStatus"),
         timeoutMap,
+        config.as[InterruptablePollMonitorConfig]("checkTools"),
+        clusterBucketConfig,
         imageConfig
       )
   }
+
   val gceMonitorConfig = config.as[GceMonitorConfig]("gce.monitor")
   val dataprocMonitorConfig = config.as[DataprocMonitorConfig]("dataproc.monitor")
   val uiConfig = config.as[ClusterUIConfig]("ui")

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpDockerDAO.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpDockerDAO.scala
@@ -210,7 +210,7 @@ object HttpDockerDAO {
     val res = for {
       splitted <- Either.catchNonFatal(s.split("="))
       first <- Either.catchNonFatal(splitted(0))
-      second <- Either.catchNonFatal(splitted(1))
+      second <- Either.catchNonFatal(if (splitted.length > 1) splitted(1) else "")
     } yield Env(first, second)
     res.leftMap(_.getMessage)
   }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/BaseCloudServiceRuntimeMonitor.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/BaseCloudServiceRuntimeMonitor.scala
@@ -2,12 +2,12 @@ package org.broadinstitute.dsde.workbench.leonardo.monitor
 
 import cats.Parallel
 import cats.effect.concurrent.Ref
-import cats.effect.{Async, Sync, Timer}
+import cats.effect.{ConcurrentEffect, Sync, Timer}
 import cats.mtl.Ask
 import cats.syntax.all._
 import com.google.cloud.storage.BucketInfo
 import fs2.Stream
-import org.typelevel.log4cats.StructuredLogger
+import monocle.macros.syntax.lens._
 import org.broadinstitute.dsde.workbench.DoneCheckable
 import org.broadinstitute.dsde.workbench.google2.{streamFUntilDone, GcsBlobName, GoogleStorageService}
 import org.broadinstitute.dsde.workbench.leonardo._
@@ -20,17 +20,17 @@ import org.broadinstitute.dsde.workbench.leonardo.monitor.RuntimeMonitor.{
   recordStatusTransitionMetrics,
   CheckResult
 }
-import monocle.macros.syntax.lens._
 import org.broadinstitute.dsde.workbench.leonardo.util.{DeleteRuntimeParams, RuntimeAlgebra, StopRuntimeParams}
 import org.broadinstitute.dsde.workbench.model.google.{GcsPath, GoogleProject}
 import org.broadinstitute.dsde.workbench.model.{IP, TraceId}
 import org.broadinstitute.dsde.workbench.openTelemetry.OpenTelemetryMetrics
+import org.typelevel.log4cats.StructuredLogger
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 
 abstract class BaseCloudServiceRuntimeMonitor[F[_]] {
-  implicit def F: Async[F]
+  implicit def F: ConcurrentEffect[F]
   implicit def parallel: Parallel[F]
   implicit def timer: Timer[F]
   implicit def dbRef: DbReference[F]
@@ -58,7 +58,7 @@ abstract class BaseCloudServiceRuntimeMonitor[F[_]] {
         for {
           _ <- s.newTransition.traverse(newStatus => monitorContextRef.modify(x => (x.copy(action = newStatus), ())))
           monitorContext <- monitorContextRef.get
-          _ <- Timer[F].sleep(monitorConfig.pollingInterval)
+          _ <- Timer[F].sleep(monitorConfig.pollStatus.interval)
           res <- handler(
             monitorContext,
             s
@@ -263,7 +263,7 @@ abstract class BaseCloudServiceRuntimeMonitor[F[_]] {
           logger
             .info(monitorContext.loggingContext)(
               s"Runtime ${runtimeAndRuntimeConfig.runtime.projectNameString} is still in ${runtimeAndRuntimeConfig.runtime.status}, not in ${runtimeAndRuntimeConfig.runtime.status.terminalStatus
-                .getOrElse("final")} state yet and has taken ${timeElapsed.toSeconds} seconds so far. Checking again in ${monitorConfig.pollingInterval}. ${message
+                .getOrElse("final")} state yet and has taken ${timeElapsed.toSeconds} seconds so far. Checking again in ${monitorConfig.pollStatus.interval}. ${message
                 .getOrElse("")}"
             )
             .as(((), Some(Check(runtimeAndRuntimeConfig, None))))
@@ -468,14 +468,17 @@ abstract class BaseCloudServiceRuntimeMonitor[F[_]] {
           )
       }
       // wait for 10 minutes for tools to start up before time out.
-      availableTools <- streamFUntilDone(checkTools,
-                                         monitorConfig.checkToolsMaxAttempts,
-                                         monitorConfig.checkToolsInterval).compile.lastOrError
+      availableTools <- streamFUntilDone(
+        checkTools,
+        monitorConfig.checkTools.maxAttempts,
+        monitorConfig.checkTools.interval
+      ).interruptAfter(monitorConfig.checkTools.interruptAfter).compile.lastOrError
       r <- availableTools match {
         case a if a.forall(_._2) =>
           readyRuntime(runtimeAndRuntimeConfig, ip, monitorContext, dataprocInstances)
         case a =>
           val toolsStillNotAvailable = a.collect { case x if x._2 == false => x._1 }
+          // TODO fix error message
           failedRuntime(
             monitorContext,
             runtimeAndRuntimeConfig,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/BaseCloudServiceRuntimeMonitor.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/BaseCloudServiceRuntimeMonitor.scala
@@ -482,9 +482,7 @@ abstract class BaseCloudServiceRuntimeMonitor[F[_]] {
             monitorContext,
             runtimeAndRuntimeConfig,
             RuntimeErrorDetails(
-              s"Tools [${toolsStillNotAvailable.map(_.entryName).mkString(", ")}] failed to start up " +
-                s"on runtime ${runtimeAndRuntimeConfig.runtime.projectNameString} within the time limit: " +
-                s"${monitorConfig.checkTools.interruptAfter.toMinutes} minutes.",
+              s"${toolsStillNotAvailable.map(_.entryName).mkString(", ")} failed to start after ${monitorConfig.checkTools.interruptAfter.toMinutes} minutes.",
               None,
               Some("tool_start_up")
             ),

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/BaseCloudServiceRuntimeMonitor.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/BaseCloudServiceRuntimeMonitor.scala
@@ -254,7 +254,7 @@ abstract class BaseCloudServiceRuntimeMonitor[F[_]] {
                 monitorContext,
                 runtimeAndRuntimeConfig,
                 RuntimeErrorDetails(
-                  s"Failed to transition ${runtimeAndRuntimeConfig.runtime.projectNameString} from status ${runtimeAndRuntimeConfig.runtime.status} within the time limit: ${timeLimit.toSeconds} seconds"
+                  s"Failed to transition ${runtimeAndRuntimeConfig.runtime.projectNameString} from status ${runtimeAndRuntimeConfig.runtime.status} within the time limit: ${timeLimit.toMinutes} minutes"
                 ),
                 dataprocInstances
               )
@@ -478,11 +478,16 @@ abstract class BaseCloudServiceRuntimeMonitor[F[_]] {
           readyRuntime(runtimeAndRuntimeConfig, ip, monitorContext, dataprocInstances)
         case a =>
           val toolsStillNotAvailable = a.collect { case x if x._2 == false => x._1 }
-          // TODO fix error message
           failedRuntime(
             monitorContext,
             runtimeAndRuntimeConfig,
-            RuntimeErrorDetails(s"${toolsStillNotAvailable} didn't start up properly", None, Some("tool_start_up")),
+            RuntimeErrorDetails(
+              s"Tools [${toolsStillNotAvailable.map(_.entryName).mkString(", ")}] failed to start up " +
+                s"on runtime ${runtimeAndRuntimeConfig.runtime.projectNameString} within the time limit: " +
+                s"${monitorConfig.checkTools.interruptAfter.toMinutes} minutes.",
+              None,
+              Some("tool_start_up")
+            ),
             dataprocInstances
           )
       }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/DataprocRuntimeMonitor.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/DataprocRuntimeMonitor.scala
@@ -2,12 +2,11 @@ package org.broadinstitute.dsde.workbench.leonardo
 package monitor
 
 import cats.Parallel
-import cats.effect.{Async, Timer}
-import cats.syntax.all._
+import cats.effect.{ConcurrentEffect, Timer}
 import cats.mtl.Ask
+import cats.syntax.all._
 import com.google.cloud.compute.v1.Instance
 import com.google.cloud.dataproc.v1.Cluster
-import org.typelevel.log4cats.StructuredLogger
 import org.broadinstitute.dsde.workbench.google2
 import org.broadinstitute.dsde.workbench.google2.{
   DataprocClusterName,
@@ -29,11 +28,12 @@ import org.broadinstitute.dsde.workbench.leonardo.util._
 import org.broadinstitute.dsde.workbench.model.TraceId
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.broadinstitute.dsde.workbench.openTelemetry.OpenTelemetryMetrics
+import org.typelevel.log4cats.StructuredLogger
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 
-class DataprocRuntimeMonitor[F[_]: Parallel](
+class DataprocRuntimeMonitor[F[_]](
   config: DataprocMonitorConfig,
   googleComputeService: GoogleComputeService[F],
   authProvider: LeoAuthProvider[F],
@@ -42,7 +42,7 @@ class DataprocRuntimeMonitor[F[_]: Parallel](
   googleDataprocService: GoogleDataprocService[F]
 )(implicit override val dbRef: DbReference[F],
   override val runtimeToolToToolDao: RuntimeContainerServiceType => ToolDAO[F, RuntimeContainerServiceType],
-  override val F: Async[F],
+  override val F: ConcurrentEffect[F],
   override val parallel: Parallel[F],
   override val timer: Timer[F],
   override val logger: StructuredLogger[F],

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/RuntimeMonitor.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/RuntimeMonitor.scala
@@ -141,31 +141,27 @@ object MonitorState {
 
 sealed trait MonitorConfig {
   def initialDelay: FiniteDuration
-  def pollingInterval: FiniteDuration
-  def imageConfig: ImageConfig
-  def checkToolsInterval: FiniteDuration
-  def checkToolsMaxAttempts: Int
+  def pollStatus: PollMonitorConfig
   def monitorStatusTimeouts: Map[RuntimeStatus, FiniteDuration]
+  def checkTools: InterruptablePollMonitorConfig
+  def runtimeBucketConfig: RuntimeBucketConfig
+  def imageConfig: ImageConfig
 }
 
 object MonitorConfig {
   final case class GceMonitorConfig(initialDelay: FiniteDuration,
-                                    pollingInterval: FiniteDuration,
-                                    pollCheckMaxAttempts: Int,
-                                    checkToolsInterval: FiniteDuration,
-                                    checkToolsMaxAttempts: Int,
-                                    runtimeBucketConfig: RuntimeBucketConfig,
+                                    pollStatus: PollMonitorConfig,
                                     monitorStatusTimeouts: Map[RuntimeStatus, FiniteDuration],
+                                    checkTools: InterruptablePollMonitorConfig,
+                                    runtimeBucketConfig: RuntimeBucketConfig,
                                     imageConfig: ImageConfig)
       extends MonitorConfig
 
   final case class DataprocMonitorConfig(initialDelay: FiniteDuration,
-                                         pollingInterval: FiniteDuration,
-                                         pollCheckMaxAttempts: Int,
-                                         checkToolsInterval: FiniteDuration,
-                                         checkToolsMaxAttempts: Int,
-                                         runtimeBucketConfig: RuntimeBucketConfig,
+                                         pollStatus: PollMonitorConfig,
                                          monitorStatusTimeouts: Map[RuntimeStatus, FiniteDuration],
+                                         checkTools: InterruptablePollMonitorConfig,
+                                         runtimeBucketConfig: RuntimeBucketConfig,
                                          imageConfig: ImageConfig)
       extends MonitorConfig
 }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/config/ConfigSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/config/ConfigSpec.scala
@@ -6,6 +6,7 @@ import org.broadinstitute.dsde.workbench.google2.{Location, MachineTypeName, Reg
 import org.broadinstitute.dsde.workbench.leonardo.KubernetesTestData.{galaxyChartName, galaxyChartVersion}
 import org.broadinstitute.dsde.workbench.leonardo.monitor.MonitorConfig.GceMonitorConfig
 import org.broadinstitute.dsde.workbench.leonardo.monitor.{
+  InterruptablePollMonitorConfig,
   LeoPubsubMessageSubscriberConfig,
   PersistentDiskMonitorConfig,
   PollMonitorConfig
@@ -33,16 +34,14 @@ final class ConfigSpec extends AnyFlatSpec with Matchers {
   it should "read gce.monitor properly" in {
     val expected = GceMonitorConfig(
       20 seconds,
-      15 seconds,
-      120,
-      8 seconds,
-      75,
-      Config.clusterBucketConfig,
+      PollMonitorConfig(80, 15 seconds),
       Map(
         RuntimeStatus.Creating -> 30.minutes,
         RuntimeStatus.Starting -> 20.minutes,
         RuntimeStatus.Deleting -> 30.minutes
       ),
+      InterruptablePollMonitorConfig(75, 8 seconds, 10 minutes),
+      Config.clusterBucketConfig,
       Config.imageConfig
     )
 

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/config/ConfigSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/config/ConfigSpec.scala
@@ -34,7 +34,7 @@ final class ConfigSpec extends AnyFlatSpec with Matchers {
   it should "read gce.monitor properly" in {
     val expected = GceMonitorConfig(
       20 seconds,
-      PollMonitorConfig(80, 15 seconds),
+      PollMonitorConfig(120, 15 seconds),
       Map(
         RuntimeStatus.Creating -> 30.minutes,
         RuntimeStatus.Starting -> 20.minutes,

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/BaseCloudServiceRuntimeMonitorSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/BaseCloudServiceRuntimeMonitorSpec.scala
@@ -96,8 +96,8 @@ class BaseCloudServiceRuntimeMonitorSpec extends AnyFlatSpec with Matchers with 
       elapsed = end.toEpochMilli - start.toEpochMilli
       status <- clusterQuery.getClusterStatus(runtime.id).transaction
     } yield {
-      // handleCheckTools should have timed out after 10 seconds and moved the runtime to Error status
-      elapsed should be >= 10000L
+      // handleCheckTools should have been interrupted after 10 seconds and moved the runtime to Error status
+      elapsed shouldBe 10000L +- 2000L
       status shouldBe Some(RuntimeStatus.Error)
       res shouldBe (((), None))
     }
@@ -169,7 +169,7 @@ class BaseCloudServiceRuntimeMonitorSpec extends AnyFlatSpec with Matchers with 
       2 seconds,
       PollMonitorConfig(5, 1 second),
       timeouts,
-      InterruptablePollMonitorConfig(5, 1 second, 5 seconds),
+      InterruptablePollMonitorConfig(60, 1 second, 10 seconds),
       RuntimeBucketConfig(3 seconds),
       Config.imageConfig
     )

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/DataprocRuntimeMonitorSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/DataprocRuntimeMonitorSpec.scala
@@ -1,8 +1,6 @@
 package org.broadinstitute.dsde.workbench.leonardo
 package monitor
 
-import java.time.Instant
-
 import cats.effect.IO
 import cats.mtl.Ask
 import com.google.cloud.compute.v1.{AccessConfig, Instance, NetworkInterface, Operation}
@@ -34,6 +32,7 @@ import org.broadinstitute.dsde.workbench.model.{IP, TraceId}
 import org.scalatest.EitherValues
 import org.scalatest.flatspec.AnyFlatSpec
 
+import java.time.Instant
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.jdk.CollectionConverters._
 

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/GceRuntimeMonitorSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/GceRuntimeMonitorSpec.scala
@@ -1,9 +1,6 @@
 package org.broadinstitute.dsde.workbench.leonardo
 package monitor
 
-import java.time.Instant
-import java.util.concurrent.TimeUnit
-
 import cats.effect.IO
 import cats.mtl.Ask
 import com.google.cloud.compute.v1._
@@ -29,6 +26,8 @@ import org.scalatest.EitherValues
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
+import java.time.Instant
+import java.util.concurrent.TimeUnit
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 
@@ -757,7 +756,7 @@ class GceRuntimeMonitorSpec
     monitorStatusTimeouts: Option[Map[RuntimeStatus, FiniteDuration]] = None
   ): GceRuntimeMonitor[IO] = {
     val config =
-      Config.gceMonitorConfig.copy(initialDelay = 2 seconds, pollingInterval = 1 seconds, pollCheckMaxAttempts = 5)
+      Config.gceMonitorConfig.copy(initialDelay = 2 seconds, pollStatus = PollMonitorConfig(5, 1 second))
     val configWithCustomTimeouts =
       monitorStatusTimeouts.fold(config)(timeouts => config.copy(monitorStatusTimeouts = timeouts))
     new GceRuntimeMonitor[IO](


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-2886

Fixed runtime monitoring timeout handling. We now have an `interruptAfter` field for tool monitoring so it does not retry beyond the intended timeout. Comments inline.

Tested in a fiab by forcing Jupyter to not start up, it seems to work as intended.

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
