### PR TITLE
[No ticket] disable Rmd file syncing

### DIFF
--- a/http/src/main/resources/init-resources/gce-init.sh
+++ b/http/src/main/resources/init-resources/gce-init.sh
@@ -105,11 +105,12 @@ export MEM_LIMIT=$(memLimit)
 export WELDER_MEM_LIMIT=$(welderMemLimit)
 export PROXY_SERVER_HOST_NAME=$(proxyServerHostName)
 export WELDER_ENABLED=$(welderEnabled)
-if [ ! -z "$RSTUDIO_DOCKER_IMAGE" ] ; then
-  export IS_RSTUDIO_RUNTIME="true"
-else
-  export IS_RSTUDIO_RUNTIME="false"
-fi
+export IS_RSTUDIO_RUNTIME="false" # TODO: update to commented out code once we release Rmd file syncing
+#if [ ! -z "$RSTUDIO_DOCKER_IMAGE" ] ; then
+#  export IS_RSTUDIO_RUNTIME="true"
+#else
+#  export IS_RSTUDIO_RUNTIME="false"
+#fi
 
 START_USER_SCRIPT_URI=$(startUserScriptUri)
 # Include a timestamp suffix to differentiate different startup logs across restarts.

--- a/http/src/main/resources/init-resources/init-actions.sh
+++ b/http/src/main/resources/init-resources/init-actions.sh
@@ -180,11 +180,12 @@ if [[ "${ROLE}" == 'Master' ]]; then
     export DOCKER_COMPOSE_FILES_DIRECTORY='/etc'
     PROXY_SITE_CONF=$(proxySiteConf)
     export HOST_PROXY_SITE_CONF_FILE_PATH=${DOCKER_COMPOSE_FILES_DIRECTORY}/`basename ${PROXY_SITE_CONF}`
-    if [ ! -z "$RSTUDIO_DOCKER_IMAGE" ] ; then
-      export IS_RSTUDIO_RUNTIME="true"
-    else
-      export IS_RSTUDIO_RUNTIME="false"
-    fi
+    export IS_RSTUDIO_RUNTIME="false" # TODO: update to commented out code once we release Rmd file syncing
+#    if [ ! -z "$RSTUDIO_DOCKER_IMAGE" ] ; then
+#      export IS_RSTUDIO_RUNTIME="true"
+#    else
+#      export IS_RSTUDIO_RUNTIME="false"
+#    fi
 
     SERVER_CRT=$(proxyServerCrt)
     SERVER_KEY=$(proxyServerKey)

--- a/http/src/main/resources/init-resources/startup.sh
+++ b/http/src/main/resources/init-resources/startup.sh
@@ -68,11 +68,12 @@ export WELDER_MEM_LIMIT=$(welderMemLimit)
 export MEM_LIMIT=$(memLimit)
 export USE_GCE_STARTUP_SCRIPT=$(useGceStartupScript)
 GPU_ENABLED=$(gpuEnabled)
-if [ ! -z "$RSTUDIO_DOCKER_IMAGE" ] ; then
-  export IS_RSTUDIO_RUNTIME="true"
-else
-  export IS_RSTUDIO_RUNTIME="false"
-fi
+export IS_RSTUDIO_RUNTIME="false" # TODO: update to commented out code once we release Rmd file syncing
+#if [ ! -z "$RSTUDIO_DOCKER_IMAGE" ] ; then
+#  export IS_RSTUDIO_RUNTIME="true"
+#else
+#  export IS_RSTUDIO_RUNTIME="false"
+#fi
 
 # Overwrite old cert on restart
 SERVER_CRT=$(proxyServerCrt)


### PR DESCRIPTION
tested in my fiab
validated that for gce runtimes (both jupyter and rstudio) we set env var `IS_RSTUDIO_RUNTIME` to false and tested jupyter in dataproc as well

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
