### PR TITLE
IA-2963 add welderRegistry in encoder

### DIFF
--- a/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/RuntimeRoutesTestJsonCodec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/RuntimeRoutesTestJsonCodec.scala
@@ -72,7 +72,7 @@ object RuntimeRoutesTestJsonCodec {
     }
   }
 
-  implicit val createRuntime2RequestEncoder: Encoder[CreateRuntime2Request] = Encoder.forProduct11(
+  implicit val createRuntime2RequestEncoder: Encoder[CreateRuntime2Request] = Encoder.forProduct12(
     "labels",
     "userScriptUri",
     "startUserScriptUri",
@@ -82,6 +82,7 @@ object RuntimeRoutesTestJsonCodec {
     "autopauseThreshold",
     "defaultClientId",
     "toolDockerImage",
+    "welderRegistry",
     "scopes",
     "customEnvironmentVariables"
   )(x =>
@@ -95,6 +96,7 @@ object RuntimeRoutesTestJsonCodec {
       x.autopauseThreshold.map(_.toMinutes),
       x.defaultClientId,
       x.toolDockerImage,
+      x.welderRegistry,
       x.scopes,
       x.customEnvironmentVariables
     )


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-2963

Tested in fiab that with this change, `AoUSpec` will be using dockerhub for welder as intended.

```
Oct 07 18:16:06 automation-test-amwe7rz2z GCEMetadataScripts[370]: [595B blob data]
Oct 07 18:16:06 automation-test-amwe7rz2z GCEMetadataScripts[370]: 2021/10/07 18:16:06 GCEMetadataScripts: startup-script-url: ERROR: for welder  manifest for broadinstitute/welder-server:a10dd87 not found: manifest unknown: manifest unknown
```

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
