### PR TITLE
[QA-1597] Update GKE version

### DIFF
--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -345,7 +345,7 @@ gke {
                           "69.173.112.0/21"
     ]
     # See https://cloud.google.com/kubernetes-engine/docs/release-notes
-    version = "1.20"
+    version = "1.19"
     nodepoolLockCacheExpiryTime = 1 hour
     nodepoolLockCacheMaxSize = 200
   }

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -345,7 +345,7 @@ gke {
                           "69.173.112.0/21"
     ]
     # See https://cloud.google.com/kubernetes-engine/docs/release-notes
-    version = "1.18"
+    version = "1.20"
     nodepoolLockCacheExpiryTime = 1 hour
     nodepoolLockCacheMaxSize = 200
   }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/config/ConfigSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/config/ConfigSpec.scala
@@ -68,7 +68,7 @@ final class ConfigSpec extends AnyFlatSpec with Matchers {
         "69.173.127.240/28",
         "69.173.112.0/21"
       ).map(CidrIP),
-      KubernetesClusterVersion("1.20"),
+      KubernetesClusterVersion("1.19"),
       1 hour,
       200
     )

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/config/ConfigSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/config/ConfigSpec.scala
@@ -68,7 +68,7 @@ final class ConfigSpec extends AnyFlatSpec with Matchers {
         "69.173.127.240/28",
         "69.173.112.0/21"
       ).map(CidrIP),
-      KubernetesClusterVersion("1.18"),
+      KubernetesClusterVersion("1.20"),
       1 hour,
       200
     )


### PR DESCRIPTION
Looks like `1.18` was discontinued. :( I think this was causing automation tests to fail.

See https://cloud.google.com/kubernetes-engine/docs/release-notes

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
