### PR TITLE
IA-2994 use built-in stopCluster

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeDataprocSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeDataprocSpec.scala
@@ -298,7 +298,7 @@ class RuntimeDataprocSpec
       status <- IO.fromOption(DataprocClusterStatus.withNameInsensitiveOption(cluster.getStatus.getState.name))(
         fail(s"Unknown Dataproc status ${cluster.getStatus.getState.name}")
       )
-      _ <- IO(status shouldBe DataprocClusterStatus.Running)
+      _ <- IO(List(DataprocClusterStatus.Running, DataprocClusterStatus.Stopped).contains(status) shouldBe true)
 
       // check cluster instances in Dataproc
       instances = GoogleDataprocInterpreter.getAllInstanceNames(cluster)

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeDataprocSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeDataprocSpec.scala
@@ -244,7 +244,7 @@ class RuntimeDataprocSpec
                             2,
                             0,
                             RegionName("us-central1"),
-                            RuntimeStatus.Stopped)
+                            DataprocClusterStatus.Stopped)
 
         // start the cluster
         _ <- IO(startAndMonitorRuntime(runtime.googleProject, runtime.clusterName))
@@ -296,7 +296,7 @@ class RuntimeDataprocSpec
     expectedNumWorkers: Int,
     expectedPreemptibles: Int,
     expectedRegion: RegionName,
-    expectedStatus: RuntimeStatus = RuntimeStatus.Running
+    expectedStatus: DataprocClusterStatus = DataprocClusterStatus.Running
   )(implicit httpClient: Client[IO]): IO[Unit] =
     for {
       // check cluster status in Dataproc

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dataprocModels.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dataprocModels.scala
@@ -94,6 +94,8 @@ object DataprocClusterStatus extends Enum[DataprocClusterStatus] {
 
   case object Creating extends DataprocClusterStatus // The cluster is being created and set up. It is not ready for use.
 
+  case object Starting extends DataprocClusterStatus
+
   case object Deleting extends DataprocClusterStatus // The cluster is being deleted. It cannot be used.
 
   case object Error extends DataprocClusterStatus // The cluster encountered an error. It is not ready for use.
@@ -104,5 +106,7 @@ object DataprocClusterStatus extends Enum[DataprocClusterStatus] {
 
   case object Updating extends DataprocClusterStatus // The cluster is being updated. It continues to accept and process jobs.
 
-  case object Stopped extends DataprocClusterStatus // The cluster is being updated. It continues to accept and process jobs.
+  case object Stopping extends DataprocClusterStatus
+
+  case object Stopped extends DataprocClusterStatus
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dataprocModels.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dataprocModels.scala
@@ -103,4 +103,6 @@ object DataprocClusterStatus extends Enum[DataprocClusterStatus] {
   case object Unknown extends DataprocClusterStatus // The cluster state is unknown.
 
   case object Updating extends DataprocClusterStatus // The cluster is being updated. It continues to accept and process jobs.
+
+  case object Stopped extends DataprocClusterStatus // The cluster is being updated. It continues to accept and process jobs.
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/runtimeModels.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/runtimeModels.scala
@@ -134,6 +134,8 @@ object RuntimeStatus extends Enum[RuntimeStatus] {
       case DataprocClusterStatus.Unknown  => Unknown
       case DataprocClusterStatus.Updating => Updating
       case DataprocClusterStatus.Stopped  => Stopped
+      case DataprocClusterStatus.Starting => Starting
+      case DataprocClusterStatus.Stopping => Stopping
     }
 
   def fromGceInstanceStatus(gceInstanceStatus: GceInstanceStatus): RuntimeStatus =

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/runtimeModels.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/runtimeModels.scala
@@ -133,6 +133,7 @@ object RuntimeStatus extends Enum[RuntimeStatus] {
       case DataprocClusterStatus.Running  => Running
       case DataprocClusterStatus.Unknown  => Unknown
       case DataprocClusterStatus.Updating => Updating
+      case DataprocClusterStatus.Stopped  => Stopped
     }
 
   def fromGceInstanceStatus(gceInstanceStatus: GceInstanceStatus): RuntimeStatus =

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/BaseCloudServiceRuntimeMonitor.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/BaseCloudServiceRuntimeMonitor.scala
@@ -236,7 +236,7 @@ abstract class BaseCloudServiceRuntimeMonitor[F[_]] {
             r <- if (runtimeAndRuntimeConfig.runtime.status == RuntimeStatus.Starting) {
               for {
                 _ <- runtimeAlg.stopRuntime(
-                  StopRuntimeParams(runtimeAndRuntimeConfig, now)
+                  StopRuntimeParams(runtimeAndRuntimeConfig, now, true)
                 )
                 // Stopping the runtime
                 _ <- clusterQuery

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/DataprocRuntimeMonitor.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/DataprocRuntimeMonitor.scala
@@ -247,7 +247,7 @@ class DataprocRuntimeMonitor[F[_]: Parallel](
           .withNameInsensitiveOption(c.getStatus.getState.name())
           .getOrElse(DataprocClusterStatus.Unknown) //TODO: this needs to be verified
         r <- clusterStatus match {
-          case DataprocClusterStatus.Stopped =>
+          case DataprocClusterStatus.Stopped | DataprocClusterStatus.Starting =>
             checkAgain(monitorContext,
                        runtimeAndRuntimeConfig,
                        Some(fetchInstances),

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/DataprocRuntimeMonitor.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/DataprocRuntimeMonitor.scala
@@ -237,6 +237,11 @@ class DataprocRuntimeMonitor[F[_]: Parallel](
           .withNameInsensitiveOption(c.getStatus.getState.name())
           .getOrElse(DataprocClusterStatus.Unknown) //TODO: this needs to be verified
         r <- clusterStatus match {
+          case DataprocClusterStatus.Stopped =>
+            checkAgain(monitorContext,
+                       runtimeAndRuntimeConfig,
+                       Some(fetchInstances),
+                       Some(s"Dataproc cluster is still STOPPED"))
           case DataprocClusterStatus.Running if (instances.exists(_.status != GceInstanceStatus.Running)) =>
             checkAgain(monitorContext,
                        runtimeAndRuntimeConfig,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
@@ -276,7 +276,7 @@ class LeoPubsubMessageSubscriber[F[_]](
       else F.unit
       runtimeConfig <- RuntimeConfigQueries.getRuntimeConfig(runtime.runtimeConfigId).transaction
       op <- runtimeConfig.cloudService.interpreter.stopRuntime(
-        StopRuntimeParams(RuntimeAndRuntimeConfig(runtime, runtimeConfig), ctx.now)
+        StopRuntimeParams(RuntimeAndRuntimeConfig(runtime, runtimeConfig), ctx.now, true)
       )
       poll = op match {
         case Some(o) =>
@@ -406,7 +406,7 @@ class LeoPubsubMessageSubscriber[F[_]](
           _ <- dbRef.inTransaction(clusterQuery.updateClusterStatus(msg.runtimeId, RuntimeStatus.Stopping, ctx.now))
           operation <- runtimeConfig.cloudService.interpreter
             .stopRuntime(
-              StopRuntimeParams(RuntimeAndRuntimeConfig(runtime, runtimeConfig), ctx.now)
+              StopRuntimeParams(RuntimeAndRuntimeConfig(runtime, runtimeConfig), ctx.now, false)
             )(
               ctxStopping
             )

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/BaseRuntimeInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/BaseRuntimeInterpreter.scala
@@ -63,7 +63,7 @@ abstract private[util] class BaseRuntimeInterpreter[F[_]](
 
       // Stop the cluster in Google
       r <- stopGoogleRuntime(
-        StopGoogleRuntime(params.runtimeAndRuntimeConfig)
+        StopGoogleRuntime(params.runtimeAndRuntimeConfig, params.isDataprocFullStop)
       )
     } yield r
 
@@ -242,6 +242,6 @@ final case class StartGoogleRuntime(runtimeAndRuntimeConfig: RuntimeAndRuntimeCo
                                     initBucket: GcsBucketName,
                                     welderAction: Option[WelderAction])
 
-final case class StopGoogleRuntime(runtimeAndRuntimeConfig: RuntimeAndRuntimeConfig)
+final case class StopGoogleRuntime(runtimeAndRuntimeConfig: RuntimeAndRuntimeConfig, isDataprocFullStop: Boolean)
 
 final case class SetGoogleMachineType(runtimeAndRuntimeConfig: RuntimeAndRuntimeConfig, machineType: MachineTypeName)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/DataprocInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/DataprocInterpreter.scala
@@ -348,7 +348,6 @@ class DataprocInterpreter[F[_]: Parallel](
     implicit ev: Ask[F, AppContext]
   ): F[Unit] =
     for {
-      ctx <- ev.ask
       dataprocConfig <- F.fromOption(
         LeoLenses.dataprocPrism.getOption(params.runtimeAndRuntimeConfig.runtimeConfig),
         new RuntimeException("DataprocInterpreter shouldn't get a GCE request")

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/DataprocInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/DataprocInterpreter.scala
@@ -340,7 +340,8 @@ class DataprocInterpreter[F[_]: Parallel](
         params.runtimeAndRuntimeConfig.runtime.googleProject,
         region,
         DataprocClusterName(params.runtimeAndRuntimeConfig.runtime.runtimeName.asString),
-        Some(metadata)
+        Some(metadata),
+        params.isDataprocFullStop
       )
     } yield None
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/DataprocInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/DataprocInterpreter.scala
@@ -331,7 +331,6 @@ class DataprocInterpreter[F[_]: Parallel](
     implicit ev: Ask[F, AppContext]
   ): F[Option[com.google.cloud.compute.v1.Operation]] =
     for {
-      ctx <- ev.ask
       region <- F.fromOption(
         LeoLenses.dataprocRegion.getOption(params.runtimeAndRuntimeConfig.runtimeConfig),
         new RuntimeException("DataprocInterpreter shouldn't get a GCE request")

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/RuntimeAlgebra.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/RuntimeAlgebra.scala
@@ -80,7 +80,9 @@ final case class CreateGoogleRuntimeResponse(asyncRuntimeFields: AsyncRuntimeFie
                                              bootSource: BootSource)
 final case class DeleteRuntimeParams(runtimeAndRuntimeConfig: RuntimeAndRuntimeConfig)
 final case class FinalizeDeleteParams(runtime: Runtime)
-final case class StopRuntimeParams(runtimeAndRuntimeConfig: RuntimeAndRuntimeConfig, now: Instant)
+final case class StopRuntimeParams(runtimeAndRuntimeConfig: RuntimeAndRuntimeConfig,
+                                   now: Instant,
+                                   isDataprocFullStop: Boolean)
 final case class StartRuntimeParams(runtimeAndRuntimeConfig: RuntimeAndRuntimeConfig, initBucket: GcsBucketName)
 final case class UpdateMachineTypeParams(runtimeAndRuntimeConfig: RuntimeAndRuntimeConfig,
                                          machineType: MachineTypeName,

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/BaseCloudServiceRuntimeMonitorSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/BaseCloudServiceRuntimeMonitorSpec.scala
@@ -46,7 +46,7 @@ class BaseCloudServiceRuntimeMonitorSpec extends AnyFlatSpec with Matchers with 
       runtimeMonitor = new MockRuntimeMonitor(true, Map(RuntimeStatus.Starting -> 2.seconds)) {
         override def handleCheck(monitorContext: MonitorContext, runtimeAndRuntimeConfig: RuntimeAndRuntimeConfig)(
           implicit ev: Ask[IO, AppContext]
-        ): IO[(Unit, Option[MonitorState])] = checkAgain(monitorContext, runtimeAndRuntimeConfig, Set.empty, None, None)
+        ): IO[(Unit, Option[MonitorState])] = checkAgain(monitorContext, runtimeAndRuntimeConfig, None, None, None)
       }
       assersions = for {
         status <- clusterQuery.getClusterStatus(runtime.id).transaction

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -16,7 +16,7 @@ object Dependencies {
   val opencensusV = "0.28.3"
 
 
-  private val workbenchLibsHash = "0ec3f4bd-SNAP"
+  private val workbenchLibsHash = "0c87ddaa-SNAP"
   val serviceTestV = s"0.20-$workbenchLibsHash"
   val workbenchModelV = s"0.15-$workbenchLibsHash"
   val workbenchGoogleV = s"0.21-$workbenchLibsHash"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -16,7 +16,7 @@ object Dependencies {
   val opencensusV = "0.28.3"
 
 
-  private val workbenchLibsHash = "4ffeef09-SNAP"
+  private val workbenchLibsHash = "c86c53b3-SNAP"
   val serviceTestV = s"0.20-$workbenchLibsHash"
   val workbenchModelV = s"0.15-$workbenchLibsHash"
   val workbenchGoogleV = s"0.21-$workbenchLibsHash"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -16,7 +16,7 @@ object Dependencies {
   val opencensusV = "0.28.3"
 
 
-  private val workbenchLibsHash = "c86c53b3-SNAP"
+  private val workbenchLibsHash = "5a0e200b-SNAP"
   val serviceTestV = s"0.20-$workbenchLibsHash"
   val workbenchModelV = s"0.15-$workbenchLibsHash"
   val workbenchGoogleV = s"0.21-$workbenchLibsHash"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -16,7 +16,7 @@ object Dependencies {
   val opencensusV = "0.28.3"
 
 
-  private val workbenchLibsHash = "48295a9c-SNAP"
+  private val workbenchLibsHash = "4ffeef09-SNAP"
   val serviceTestV = s"0.20-$workbenchLibsHash"
   val workbenchModelV = s"0.15-$workbenchLibsHash"
   val workbenchGoogleV = s"0.21-$workbenchLibsHash"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -16,7 +16,7 @@ object Dependencies {
   val opencensusV = "0.28.3"
 
 
-  private val workbenchLibsHash = "5a0e200b-SNAP"
+  private val workbenchLibsHash = "0ec3f4bd-SNAP"
   val serviceTestV = s"0.20-$workbenchLibsHash"
   val workbenchModelV = s"0.15-$workbenchLibsHash"
   val workbenchGoogleV = s"0.21-$workbenchLibsHash"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -16,7 +16,7 @@ object Dependencies {
   val opencensusV = "0.28.3"
 
 
-  private val workbenchLibsHash = "0c87ddaa-SNAP"
+  private val workbenchLibsHash = "959c1b8"
   val serviceTestV = s"0.20-$workbenchLibsHash"
   val workbenchModelV = s"0.15-$workbenchLibsHash"
   val workbenchGoogleV = s"0.21-$workbenchLibsHash"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -16,9 +16,9 @@ object Dependencies {
   val opencensusV = "0.28.3"
 
 
-  private val workbenchLibsHash = "4cb37a0"
+  private val workbenchLibsHash = "48295a9c-SNAP"
   val serviceTestV = s"0.20-$workbenchLibsHash"
-  val workbenchModelV = s"0.14-$workbenchLibsHash"
+  val workbenchModelV = s"0.15-$workbenchLibsHash"
   val workbenchGoogleV = s"0.21-$workbenchLibsHash"
   val workbenchGoogle2V = s"0.22-$workbenchLibsHash"
   val workbenchOpenTelemetryV = s"0.2-$workbenchLibsHash"


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-2994

Related PR https://github.com/broadinstitute/workbench-libs/pull/783

Dataproc started supporting "stop" a cluster a while ago. This means we can use sdk's stopCluster API directly to stop a cluster, which should save on dataproc premium when users intend to stop a cluster, because today, when user stops a cluster, we manually stops all instances of the cluster, but the cluster itself is still in `RUNNING` status.

However, during a patch update, it is still useful to not have a full cluster stop, hence I introduced a `isDataprocFullStop` flag to indicate whether we intend to also stop the cluster in addition to shutting down all VM instances.

Also made some optimizations in `DataprocMonitor` so that we're not querying instance's status all the time when not needed (for instance, when we create a cluster, if the cluster is still in `Creating`, we don't need to poll individual VMs at that point, but we poll all instances to get VM status regardless of cluster status today)

Separately upgrade http4s to 0.23.6, which has a retry bug fix.

Created https://broadworkbench.atlassian.net/browse/IA-2999 to reflect the cost reduction in UI

Manual tests:
* Create a dataproc cluster via local terra UI. Create/stop/start works as expected
* Add pre-emptibles, and start/stop cluster works as expected

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
