### PR TITLE
IA-2977 Refactoring some database fields to accommodate Azure VM 

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
@@ -424,7 +424,7 @@ trait LeonardoTestUtils
 
       caught.message should include("\"statusCode\":422")
       caught.message should include(
-        s"""Proxy host ${googleProject.value}/${runtimeName.asString} is stopped. Start your runtime before proceeding."""
+        s"""Proxy host Gcp/${googleProject.value}/${runtimeName.asString} is stopped. Start your runtime before proceeding."""
       )
     }
   }

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/JsonCodec.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/JsonCodec.scala
@@ -251,8 +251,8 @@ object JsonCodec {
   implicit val gceInstanceStatusDecoder: Decoder[GceInstanceStatus] =
     Decoder.decodeString.emap(s => GceInstanceStatus.withNameInsensitiveOption(s).toRight(s"invalid gce status ${s}"))
   implicit val operationNameDecoder: Decoder[OperationName] = Decoder.decodeString.map(OperationName)
-  implicit val managedResourceGroupDecoder: Decoder[ManagedResourceGroup] =
-    Decoder.decodeString.map(ManagedResourceGroup)
+  implicit val managedResourceGroupDecoder: Decoder[AzureCloudContext] =
+    Decoder.decodeString.emap(s => AzureCloudContext.fromString(s))
   implicit val cloudProviderDecoder: Decoder[CloudProvider] =
     Decoder.decodeString.emap(s => CloudProvider.stringToCloudProvider.get(s).toRight(s"invalid cloud provider ${s}"))
   implicit val googleIdDecoder: Decoder[ProxyHostName] = Decoder.decodeString.map(ProxyHostName)
@@ -293,7 +293,7 @@ object JsonCodec {
         case CloudProvider.Gcp =>
           x.downField("cloudResource").as[GoogleProject].map(p => CloudContext.Gcp(p))
         case CloudProvider.Azure =>
-          x.downField("cloudResource").as[ManagedResourceGroup].map(p => CloudContext.Azure(p))
+          x.downField("cloudResource").as[AzureCloudContext].map(p => CloudContext.Azure(p))
       }
     } yield context
   }
@@ -385,7 +385,7 @@ object JsonCodec {
               case CloudProvider.Gcp =>
                 x.downField("cloudContext").as[GoogleProject].map(p => CloudContext.Gcp(p))
               case CloudProvider.Azure =>
-                x.downField("cloudContext").as[ManagedResourceGroup].map(mrg => CloudContext.Azure(mrg))
+                x.downField("cloudContext").as[AzureCloudContext].map(mrg => CloudContext.Azure(mrg))
             }
           case None =>
             x.downField("googleProject")

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/azureModels.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/azureModels.scala
@@ -1,0 +1,3 @@
+package org.broadinstitute.dsde.workbench.leonardo
+
+final case class ManagedResourceGroup(value: String) extends AnyVal

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/azureModels.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/azureModels.scala
@@ -1,3 +1,25 @@
 package org.broadinstitute.dsde.workbench.leonardo
 
-final case class ManagedResourceGroup(value: String) extends AnyVal
+import cats.implicits._
+
+final case class TenantId(value: String) extends AnyVal
+final case class SubscriptionId(value: String) extends AnyVal
+final case class ManagedResourceGroupName(value: String) extends AnyVal
+
+final case class AzureCloudContext(tenantId: TenantId,
+                                   subscriptionId: SubscriptionId,
+                                   managedResourceGroupName: ManagedResourceGroupName) {
+  val asString = s"${tenantId.value}/${subscriptionId.value}/${managedResourceGroupName.value}"
+}
+
+object AzureCloudContext {
+  def fromString(s: String): Either[String, AzureCloudContext] = {
+    val res = for {
+      splitted <- Either.catchNonFatal(s.split("/"))
+      tenantId <- Either.catchNonFatal(splitted(0)).map(TenantId)
+      subscriptionId <- Either.catchNonFatal(splitted(1)).map(SubscriptionId)
+      mrgName <- Either.catchNonFatal(splitted(2)).map(ManagedResourceGroupName)
+    } yield AzureCloudContext(tenantId, subscriptionId, mrgName)
+    res.leftMap(t => s"Fail to decode $s as Azure Cloud Context due to ${t.getMessage}")
+  }
+}

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/diskModels.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/diskModels.scala
@@ -7,10 +7,9 @@ import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 
 final case class PersistentDisk(id: DiskId,
-                                googleProject: GoogleProject,
+                                cloudContext: CloudContext,
                                 zone: ZoneName,
                                 name: DiskName,
-                                googleId: Option[GoogleId],
                                 serviceAccount: WorkbenchEmail,
                                 samResource: PersistentDiskSamResourceId,
                                 status: DiskStatus,
@@ -21,20 +20,21 @@ final case class PersistentDisk(id: DiskId,
                                 formattedBy: Option[FormattedBy],
                                 galaxyRestore: Option[GalaxyRestore],
                                 labels: LabelMap) {
-  def projectNameString: String = s"${googleProject.value}/${name.value}"
+  def projectNameString: String = s"${cloudContext.asStringWithProvider}/${name.value}"
 }
 
 final case class DiskId(value: Long) extends AnyVal
 
 /** Default persistent disk labels */
 case class DefaultDiskLabels(diskName: DiskName,
-                             googleProject: GoogleProject,
+                             cloudContext: CloudContext,
                              creator: WorkbenchEmail,
                              serviceAccount: WorkbenchEmail) {
   def toMap: LabelMap =
     Map(
       "diskName" -> diskName.value,
-      "googleProject" -> googleProject.value,
+      "googleProject" -> cloudContext.asString, //TODO: remove googleProject in the future.
+      "cloudContext" -> cloudContext.asString,
       "creator" -> creator.value,
       "serviceAccount" -> serviceAccount.value
     ).filterNot(_._2 == null)

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/diskRoutesModels.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/diskRoutesModels.scala
@@ -2,9 +2,8 @@ package org.broadinstitute.dsde.workbench.leonardo
 package http
 
 import org.broadinstitute.dsde.workbench.google2.{DiskName, ZoneName}
-import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
-import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.broadinstitute.dsde.workbench.leonardo.SamResourceId.PersistentDiskSamResourceId
+import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
 
 final case class CreateDiskRequest(labels: LabelMap,
                                    size: Option[DiskSize],
@@ -29,7 +28,7 @@ object DiskConfig {
 }
 
 final case class ListPersistentDiskResponse(id: DiskId,
-                                            googleProject: GoogleProject,
+                                            cloudContext: CloudContext,
                                             zone: ZoneName,
                                             name: DiskName,
                                             status: DiskStatus,
@@ -40,10 +39,9 @@ final case class ListPersistentDiskResponse(id: DiskId,
                                             labels: LabelMap)
 
 final case class GetPersistentDiskResponse(id: DiskId,
-                                           googleProject: GoogleProject,
+                                           cloudContext: CloudContext,
                                            zone: ZoneName,
                                            name: DiskName,
-                                           googleId: Option[GoogleId],
                                            serviceAccount: WorkbenchEmail,
                                            samResource: PersistentDiskSamResourceId,
                                            status: DiskStatus,

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/runtimeRoutesModels.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/runtimeRoutesModels.scala
@@ -1,30 +1,12 @@
-package org.broadinstitute.dsde.workbench.leonardo.http
+package org.broadinstitute.dsde.workbench.leonardo
+package http
 
 import org.broadinstitute.dsde.workbench.google2.{MachineTypeName, RegionName, ZoneName}
 import org.broadinstitute.dsde.workbench.leonardo.SamResourceId._
-import org.broadinstitute.dsde.workbench.leonardo.{
-  AsyncRuntimeFields,
-  AuditInfo,
-  CloudService,
-  ContainerImage,
-  ContainerRegistry,
-  DiskSize,
-  GpuConfig,
-  LabelMap,
-  Runtime,
-  RuntimeConfig,
-  RuntimeError,
-  RuntimeImage,
-  RuntimeName,
-  RuntimeStatus,
-  UserJupyterExtensionConfig,
-  UserScriptPath
-}
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
-import org.broadinstitute.dsde.workbench.model.google.GoogleProject
+
 import java.net.URL
 import java.time.Instant
-
 import scala.concurrent.duration.FiniteDuration
 
 sealed trait RuntimeConfigRequest extends Product with Serializable {
@@ -108,7 +90,7 @@ final case class UpdateRuntimeRequest(updatedRuntimeConfig: Option[UpdateRuntime
 final case class GetRuntimeResponse(id: Long,
                                     samResource: RuntimeSamResourceId,
                                     clusterName: RuntimeName,
-                                    googleProject: GoogleProject,
+                                    cloudContext: CloudContext,
                                     serviceAccountInfo: WorkbenchEmail,
                                     asyncRuntimeFields: Option[AsyncRuntimeFields],
                                     auditInfo: AuditInfo,
@@ -135,7 +117,7 @@ object GetRuntimeResponse {
     runtime.id,
     runtime.samResource,
     runtime.runtimeName,
-    runtime.googleProject,
+    runtime.cloudContext,
     runtime.serviceAccount,
     runtime.asyncRuntimeFields,
     runtime.auditInfo,

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/models.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/models.scala
@@ -1,0 +1,41 @@
+package org.broadinstitute.dsde.workbench.leonardo
+
+import ca.mrvisser.sealerate
+import org.broadinstitute.dsde.workbench.model.google.GoogleProject
+
+final case class WorkspaceId(value: String) extends AnyVal
+
+final case class CloudContextDb(value: String) extends AnyVal
+
+sealed abstract class CloudContext extends Product with Serializable {
+  def asString: String
+  def asStringWithProvider: String
+  def cloudProvider: CloudProvider
+  def asCloudContextDb: CloudContextDb = CloudContextDb(asString)
+}
+object CloudContext {
+  final case class Gcp(value: GoogleProject) extends CloudContext {
+    override val asString = value.value
+    override val asStringWithProvider = s"Gcp/${value.value}"
+    override def cloudProvider: CloudProvider = CloudProvider.Gcp
+  }
+  final case class Azure(value: ManagedResourceGroup) extends CloudContext {
+    override val asString = value.value
+    override val asStringWithProvider = s"Azure/${value.value}"
+    override def cloudProvider: CloudProvider = CloudProvider.Azure
+  }
+}
+
+sealed abstract class CloudProvider extends Product with Serializable {
+  def asString: String
+}
+object CloudProvider {
+  final case object Gcp extends CloudProvider {
+    override val asString = "GCP"
+  }
+  final case object Azure extends CloudProvider {
+    override val asString = "AZURE"
+  }
+
+  val stringToCloudProvider = sealerate.values[CloudProvider].map(p => (p.asString, p)).toMap
+}

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/models.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/models.scala
@@ -19,9 +19,9 @@ object CloudContext {
     override val asStringWithProvider = s"Gcp/${value.value}"
     override def cloudProvider: CloudProvider = CloudProvider.Gcp
   }
-  final case class Azure(value: ManagedResourceGroup) extends CloudContext {
-    override val asString = value.value
-    override val asStringWithProvider = s"Azure/${value.value}"
+  final case class Azure(value: AzureCloudContext) extends CloudContext {
+    override val asString = value.asString
+    override val asStringWithProvider = s"Azure/${value.asString}"
     override def cloudProvider: CloudProvider = CloudProvider.Azure
   }
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/runtimeModels.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/runtimeModels.scala
@@ -63,9 +63,14 @@ object Runtime {
       .headOption
       .getOrElse(JupyterService)
 
-    new URL(
-      urlBase + cloudContext.asString + "/" + runtimeName.asString + "/" + tool.proxySegment
-    )
+    cloudContext match {
+      case _: CloudContext.Gcp =>
+        new URL(
+          urlBase + cloudContext.asString + "/" + runtimeName.asString + "/" + tool.proxySegment
+        )
+      case _: CloudContext.Azure =>
+        throw new NotImplementedError("Proxying Azure runtime is not supported yet")
+    }
   }
 }
 

--- a/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/DiskRoutesTestJsonCodec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/DiskRoutesTestJsonCodec.scala
@@ -28,10 +28,13 @@ object DiskRoutesTestJsonCodec {
   implicit val getDiskResponseDecoder: Decoder[GetPersistentDiskResponse] = Decoder.instance { x =>
     for {
       id <- x.downField("id").as[DiskId]
-      googleProject <- x.downField("googleProject").as[GoogleProject]
+      _ <- x
+        .downField("googleProject")
+        .as[GoogleProject] //this is only here for backwards-compatibility test. Once the API move away from googleProject, we can remove this as well
+      cloudContext <- x.downField("cloudContext").as[CloudContext]
       zone <- x.downField("zone").as[ZoneName]
       name <- x.downField("name").as[DiskName]
-      googleId <- x.downField("googleId").as[Option[GoogleId]]
+      googleId <- x.downField("googleId").as[Option[ProxyHostName]]
       serviceAccount <- x.downField("serviceAccount").as[WorkbenchEmail]
       status <- x.downField("status").as[DiskStatus]
       auditInfo <- x.downField("auditInfo").as[AuditInfo]
@@ -39,29 +42,27 @@ object DiskRoutesTestJsonCodec {
       diskType <- x.downField("diskType").as[DiskType]
       blockSize <- x.downField("blockSize").as[BlockSize]
       labels <- x.downField("labels").as[LabelMap]
-    } yield GetPersistentDiskResponse(
-      id,
-      googleProject,
-      zone,
-      name,
-      googleId,
-      serviceAccount,
-      // TODO samResource probably shouldn't be in the GetPersistentDiskResponse
-      // if it's not in the encoder
-      PersistentDiskSamResourceId("test"),
-      status,
-      auditInfo,
-      size,
-      diskType,
-      blockSize,
-      labels
-    )
+    } yield GetPersistentDiskResponse(id,
+                                      cloudContext,
+                                      zone,
+                                      name,
+                                      serviceAccount,
+                                      PersistentDiskSamResourceId("test"),
+                                      status,
+                                      auditInfo,
+                                      size,
+                                      diskType,
+                                      blockSize,
+                                      labels)
   }
 
   implicit val listDiskResponseDecoder: Decoder[ListPersistentDiskResponse] = Decoder.instance { x =>
     for {
       id <- x.downField("id").as[DiskId]
-      googleProject <- x.downField("googleProject").as[GoogleProject]
+      _ <- x
+        .downField("googleProject")
+        .as[GoogleProject] //this is only here for backwards-compatibility test. Once the API move away from googleProject, we can remove this as well
+      cloudContext <- x.downField("cloudContext").as[CloudContext]
       zone <- x.downField("zone").as[ZoneName]
       name <- x.downField("name").as[DiskName]
       status <- x.downField("status").as[DiskStatus]
@@ -72,7 +73,7 @@ object DiskRoutesTestJsonCodec {
       labels <- x.downField("labels").as[LabelMap]
     } yield ListPersistentDiskResponse(
       id,
-      googleProject,
+      cloudContext,
       zone,
       name,
       status,

--- a/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/DiskRoutesTestJsonCodecSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/DiskRoutesTestJsonCodecSpec.scala
@@ -1,14 +1,14 @@
 package org.broadinstitute.dsde.workbench.leonardo
 package http
 
-import org.scalatest.flatspec.AnyFlatSpecLike
-import org.scalatest.matchers.should.Matchers
-import DiskRoutesTestJsonCodec._
 import io.circe.parser._
 import org.broadinstitute.dsde.workbench.google2._
 import org.broadinstitute.dsde.workbench.leonardo.SamResourceId.PersistentDiskSamResourceId
+import org.broadinstitute.dsde.workbench.leonardo.http.DiskRoutesTestJsonCodec._
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
+import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.matchers.should.Matchers
 
 import java.time.Instant
 
@@ -19,6 +19,7 @@ class DiskRoutesTestJsonCodecSpec extends LeonardoTestSuite with Matchers with A
         |{
         |    "id": 107,
         |    "googleProject": "gpalloc-dev-master-tzprbkr",
+        |    "cloudContext": {"cloudResource": "gpalloc-dev-master-tzprbkr", "cloudProvider": "GCP"},
         |    "zone": "us-central1-a",
         |    "name": "rzxybksgvy",
         |    "googleId": "3579418231488887016",
@@ -47,10 +48,9 @@ class DiskRoutesTestJsonCodecSpec extends LeonardoTestSuite with Matchers with A
     val res = decode[GetPersistentDiskResponse](inputString)
     val expected = GetPersistentDiskResponse(
       DiskId(107),
-      GoogleProject("gpalloc-dev-master-tzprbkr"),
+      CloudContext.Gcp(GoogleProject("gpalloc-dev-master-tzprbkr")),
       ZoneName("us-central1-a"),
       DiskName("rzxybksgvy"),
-      Some(GoogleId("3579418231488887016")),
       WorkbenchEmail("b305pet-114763077412354570085@gpalloc-dev-master-tzprbkr.iam.gserviceaccount.com"),
       PersistentDiskSamResourceId("test"),
       DiskStatus.Ready,

--- a/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/RuntimeRoutesTestJsonCodec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/RuntimeRoutesTestJsonCodec.scala
@@ -6,6 +6,7 @@ import org.broadinstitute.dsde.workbench.leonardo.JsonCodec._
 import org.broadinstitute.dsde.workbench.leonardo.{
   AsyncRuntimeFields,
   AuditInfo,
+  CloudContext,
   LabelMap,
   RuntimeConfig,
   RuntimeError,
@@ -17,9 +18,9 @@ import org.broadinstitute.dsde.workbench.leonardo.{
 }
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
+
 import java.net.URL
 import java.time.Instant
-
 import org.broadinstitute.dsde.workbench.leonardo.SamResourceId.RuntimeSamResourceId
 
 object RuntimeRoutesTestJsonCodec {
@@ -150,7 +151,10 @@ object RuntimeRoutesTestJsonCodec {
     for {
       id <- x.downField("id").as[Long]
       clusterName <- x.downField("runtimeName").as[RuntimeName]
-      googleProject <- x.downField("googleProject").as[GoogleProject]
+      _ <- x
+        .downField("googleProject")
+        .as[GoogleProject] //this is only here for backwards-compatibility test. Once the API move away from googleProject, we can remove this as well
+      cloudContext <- x.downField("cloudContext").as[CloudContext]
       serviceAccount <- x.downField("serviceAccount").as[WorkbenchEmail]
       asyncRuntimeFields <- x.downField("asyncRuntimeFields").as[Option[AsyncRuntimeFields]]
       auditInfo <- x.downField("auditInfo").as[AuditInfo]
@@ -171,7 +175,7 @@ object RuntimeRoutesTestJsonCodec {
       id,
       RuntimeSamResourceId(""),
       clusterName,
-      googleProject,
+      cloudContext,
       serviceAccount,
       asyncRuntimeFields,
       auditInfo,

--- a/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changelog.xml
+++ b/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changelog.xml
@@ -79,4 +79,5 @@
     <include file="changesets/20210517_add_gpu_config.xml" relativeToChangelogFile="true" />
     <include file="changesets/20210723_add_component_gateway_enabled_flag.xml" relativeToChangelogFile="true" />
     <include file="changesets/20211103_add_worker_private_access.xml" relativeToChangelogFile="true" />
+    <include file="changesets/20211115_support_proxy_to_azure_vm.xml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changelog.xml
+++ b/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changelog.xml
@@ -80,4 +80,5 @@
     <include file="changesets/20210723_add_component_gateway_enabled_flag.xml" relativeToChangelogFile="true" />
     <include file="changesets/20211103_add_worker_private_access.xml" relativeToChangelogFile="true" />
     <include file="changesets/20211115_support_proxy_to_azure_vm.xml" relativeToChangelogFile="true" />
+    <include file="changesets/20211129_support_proxy_to_azure_pd.xml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/20211015_support_proxy_to_azure_vm.xml
+++ b/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/20211015_support_proxy_to_azure_vm.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog logicalFilePath="leonardo" xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+
+<changeSet logicalFilePath="leonardo" author="qi" id="support_proxy_to_azure_vm">
+    <addColumn tableName="CLUSTER">
+        <column name="workspaceId" type="varchar(254)">
+            <constraints nullable="true"/>
+        </column>
+    </addColumn>
+
+    <addColumn tableName="CLUSTER">
+        <column name="cloudProvider" type="ENUM('GCP', 'AZURE')" defaultValue="GCP">
+            <constraints nullable="false"/>
+        </column>
+    </addColumn>
+
+    <addColumn tableName="PERSISTENT_DISK">
+        <column name="cloudProvider" type="ENUM('GCP', 'AZURE')" defaultValue="GCP">
+            <constraints nullable="false"/>
+        </column>
+    </addColumn>
+
+    <dropUniqueConstraint tableName="CLUSTER" constraintName="IDX_CLUSTER_GOOGLEID_UNIQUE"/>
+    <dropUniqueConstraint tableName="CLUSTER" constraintName="IDX_CLUSTER_UNIQUE"/>
+
+    <renameColumn newColumnName="proxyHostName"
+                  columnDataType="varchar(255)"
+                  oldColumnName="googleId"
+                  tableName="CLUSTER"/>
+
+    <renameColumn newColumnName="runtimeName"
+                  columnDataType="varchar(255)"
+                  oldColumnName="clusterName"
+                  tableName="CLUSTER"/>
+
+    <renameColumn newColumnName="cloudContext"
+                  columnDataType="varchar(254)"
+                  oldColumnName="googleProject"
+                  tableName="CLUSTER"/>
+
+    <renameColumn newColumnName="cloudContext"
+                  columnDataType="varchar(254)"
+                  oldColumnName="googleProject"
+                  tableName="PERSISTENT_DISK"/>
+
+    <addUniqueConstraint
+            columnNames="cloudContext,runtimeName,destroyedDate"
+            constraintName="IDX_CLUSTER_UNIQUE_V2"
+            tableName="CLUSTER"
+    />
+
+    <createTable tableName="RUNTIME_CONTROLLED_RESOURCE">
+        <column name="runtimeId" type="BIGINT">
+            <constraints nullable="false"/>
+        </column>
+        <column name="workspaceId" type="VARCHAR(254)">
+            <constraints nullable="false"/>
+        </column>
+        <column name="resourceId" type="VARCHAR(254)">
+            <constraints nullable="false"/>
+        </column>
+        <column name="resourceType" type="VARCHAR(254)">
+            <constraints nullable="false"/>
+        </column>
+    </createTable>
+
+    <createIndex indexName="FK_RUNTIME_CONTROLLED_RESOURCE" tableName="RUNTIME_CONTROLLED_RESOURCE">
+        <column name="runtimeId"/>
+    </createIndex>
+    <addForeignKeyConstraint baseColumnNames="runtimeId" baseTableName="RUNTIME_CONTROLLED_RESOURCE" constraintName="FK_RUNTIME_CONTROLLED_RESOURCE" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="id" referencedTableName="CLUSTER"/>
+    <addUniqueConstraint columnNames="runtimeId, workspaceId, resourceId, resourceType" constraintName="IDX_RUNTIME_CONTROLLED_RESOURCE_UNIQUE" tableName="RUNTIME_CONTROLLED_RESOURCE"/>
+</changeSet>
+
+</databaseChangeLog>

--- a/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/20211115_support_proxy_to_azure_vm.xml
+++ b/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/20211115_support_proxy_to_azure_vm.xml
@@ -14,12 +14,6 @@
         </column>
     </addColumn>
 
-    <addColumn tableName="PERSISTENT_DISK">
-        <column name="cloudProvider" type="ENUM('GCP', 'AZURE')" defaultValue="GCP">
-            <constraints nullable="false"/>
-        </column>
-    </addColumn>
-
     <dropUniqueConstraint tableName="CLUSTER" constraintName="IDX_CLUSTER_GOOGLEID_UNIQUE"/>
     <dropUniqueConstraint tableName="CLUSTER" constraintName="IDX_CLUSTER_UNIQUE"/>
 
@@ -38,37 +32,11 @@
                   oldColumnName="googleProject"
                   tableName="CLUSTER"/>
 
-    <renameColumn newColumnName="cloudContext"
-                  columnDataType="varchar(254)"
-                  oldColumnName="googleProject"
-                  tableName="PERSISTENT_DISK"/>
-
     <addUniqueConstraint
-            columnNames="cloudContext,runtimeName,destroyedDate"
+            columnNames="cloudProvider,cloudContext,runtimeName,destroyedDate"
             constraintName="IDX_CLUSTER_UNIQUE_V2"
             tableName="CLUSTER"
     />
-
-    <createTable tableName="RUNTIME_CONTROLLED_RESOURCE">
-        <column name="runtimeId" type="BIGINT">
-            <constraints nullable="false"/>
-        </column>
-        <column name="workspaceId" type="VARCHAR(254)">
-            <constraints nullable="false"/>
-        </column>
-        <column name="resourceId" type="VARCHAR(254)">
-            <constraints nullable="false"/>
-        </column>
-        <column name="resourceType" type="VARCHAR(254)">
-            <constraints nullable="false"/>
-        </column>
-    </createTable>
-
-    <createIndex indexName="FK_RUNTIME_CONTROLLED_RESOURCE" tableName="RUNTIME_CONTROLLED_RESOURCE">
-        <column name="runtimeId"/>
-    </createIndex>
-    <addForeignKeyConstraint baseColumnNames="runtimeId" baseTableName="RUNTIME_CONTROLLED_RESOURCE" constraintName="FK_RUNTIME_CONTROLLED_RESOURCE" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="id" referencedTableName="CLUSTER"/>
-    <addUniqueConstraint columnNames="runtimeId, workspaceId, resourceId, resourceType" constraintName="IDX_RUNTIME_CONTROLLED_RESOURCE_UNIQUE" tableName="RUNTIME_CONTROLLED_RESOURCE"/>
 </changeSet>
 
 </databaseChangeLog>

--- a/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/20211129_support_proxy_to_azure_pd.xml
+++ b/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/20211129_support_proxy_to_azure_pd.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog logicalFilePath="leonardo" xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+
+<changeSet logicalFilePath="leonardo" author="qi" id="support_proxy_to_azure_pd">
+    <addColumn tableName="PERSISTENT_DISK">
+        <column name="cloudProvider" type="ENUM('GCP', 'AZURE')" defaultValue="GCP">
+            <constraints nullable="false"/>
+        </column>
+    </addColumn>
+
+    <renameColumn newColumnName="cloudContext"
+                  columnDataType="varchar(254)"
+                  oldColumnName="googleProject"
+                  tableName="PERSISTENT_DISK"/>
+
+    <createTable tableName="RUNTIME_CONTROLLED_RESOURCE">
+        <column name="runtimeId" type="BIGINT">
+            <constraints nullable="false"/>
+        </column>
+        <column name="workspaceId" type="VARCHAR(254)">
+            <constraints nullable="false"/>
+        </column>
+        <column name="resourceId" type="VARCHAR(254)">
+            <constraints nullable="false"/>
+        </column>
+        <column name="resourceType" type="VARCHAR(254)">
+            <constraints nullable="false"/>
+        </column>
+    </createTable>
+
+    <createIndex indexName="FK_RUNTIME_CONTROLLED_RESOURCE" tableName="RUNTIME_CONTROLLED_RESOURCE">
+        <column name="runtimeId"/>
+    </createIndex>
+    <addForeignKeyConstraint baseColumnNames="runtimeId" baseTableName="RUNTIME_CONTROLLED_RESOURCE" constraintName="FK_RUNTIME_CONTROLLED_RESOURCE" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="id" referencedTableName="CLUSTER"/>
+    <addUniqueConstraint columnNames="runtimeId, workspaceId, resourceId, resourceType" constraintName="IDX_RUNTIME_CONTROLLED_RESOURCE_UNIQUE" tableName="RUNTIME_CONTROLLED_RESOURCE"/>
+</changeSet>
+
+</databaseChangeLog>

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/LeoLenses.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/LeoLenses.scala
@@ -45,10 +45,10 @@ object LeoLenses {
         case _: CloudContext.Azure => none[GoogleProject]
       }
     }(googleProjectOpt => cloudContext => googleProjectOpt.fold(cloudContext)(p => CloudContext.Gcp(p)))
-  val cloudContextToManagedResourceGroup: Lens[CloudContext, Option[ManagedResourceGroup]] =
-    Lens[CloudContext, Option[ManagedResourceGroup]] { x =>
+  val cloudContextToManagedResourceGroup: Lens[CloudContext, Option[AzureCloudContext]] =
+    Lens[CloudContext, Option[AzureCloudContext]] { x =>
       x match {
-        case _: CloudContext.Gcp   => none[ManagedResourceGroup]
+        case _: CloudContext.Gcp   => none[AzureCloudContext]
         case p: CloudContext.Azure => p.value.some
       }
     }(mrg => cloudContext => mrg.fold(cloudContext)(p => CloudContext.Azure(p)))

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpWelderDAO.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpWelderDAO.scala
@@ -5,7 +5,6 @@ import cats.effect.Async
 import cats.syntax.all._
 import org.broadinstitute.dsde.workbench.leonardo.dao.HostStatus.HostReady
 import org.broadinstitute.dsde.workbench.leonardo.dns.RuntimeDnsCache
-import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.broadinstitute.dsde.workbench.openTelemetry.OpenTelemetryMetrics
 import org.http4s.client.Client
 import org.http4s.{Method, Request, Uri}
@@ -18,23 +17,23 @@ class HttpWelderDAO[F[_]: Async: Logger](
   implicit metrics: OpenTelemetryMetrics[F]
 ) extends WelderDAO[F] {
 
-  def flushCache(googleProject: GoogleProject, runtimeName: RuntimeName): F[Unit] =
+  def flushCache(cloudContext: CloudContext, runtimeName: RuntimeName): F[Unit] =
     for {
-      host <- Proxy.getRuntimeTargetHost(runtimeDnsCache, googleProject, runtimeName)
+      host <- Proxy.getRuntimeTargetHost(runtimeDnsCache, cloudContext, runtimeName)
       res <- host match {
         case HostReady(targetHost) =>
           client.successful(
             Request[F](
               method = Method.POST,
               uri = Uri.unsafeFromString(
-                s"https://${targetHost.address}/proxy/${googleProject.value}/${runtimeName.asString}/welder/cache/flush"
+                s"https://${targetHost.address}/proxy/${cloudContext.asString}/${runtimeName.asString}/welder/cache/flush"
               )
             )
           )
         case x =>
           Logger[F]
             .error(
-              s"fail to get target host name for welder for ${googleProject.value}/${runtimeName.asString} when trying to flush cache. Host status ${x}"
+              s"fail to get target host name for welder for ${cloudContext.asStringWithProvider}/${runtimeName.asString} when trying to flush cache. Host status ${x}"
             )
             .as(false)
       }
@@ -44,9 +43,9 @@ class HttpWelderDAO[F[_]: Async: Logger](
         metrics.incrementCounter("welder/flushcache", tags = Map("result" -> "failure"))
     } yield ()
 
-  def isProxyAvailable(googleProject: GoogleProject, runtimeName: RuntimeName): F[Boolean] =
+  def isProxyAvailable(cloudContext: CloudContext, runtimeName: RuntimeName): F[Boolean] =
     for {
-      host <- Proxy.getRuntimeTargetHost(runtimeDnsCache, googleProject, runtimeName)
+      host <- Proxy.getRuntimeTargetHost(runtimeDnsCache, cloudContext, runtimeName)
       res <- host match {
         case HostReady(targetHost) =>
           client
@@ -54,7 +53,7 @@ class HttpWelderDAO[F[_]: Async: Logger](
               Request[F](
                 method = Method.GET,
                 uri = Uri.unsafeFromString(
-                  s"https://${targetHost.address}/proxy/${googleProject.value}/${runtimeName.asString}/welder/status"
+                  s"https://${targetHost.address}/proxy/${cloudContext.asString}/${runtimeName.asString}/welder/status"
                 )
               )
             )
@@ -62,7 +61,7 @@ class HttpWelderDAO[F[_]: Async: Logger](
         case x =>
           Logger[F]
             .error(
-              s"fail to get target host name for welder for ${googleProject.value}/${runtimeName.asString}. Host status ${x}"
+              s"fail to get target host name for welder for ${cloudContext.asString}/${runtimeName.asString}. Host status ${x}"
             )
             .as(false)
       }
@@ -74,6 +73,6 @@ class HttpWelderDAO[F[_]: Async: Logger](
 }
 
 trait WelderDAO[F[_]] {
-  def flushCache(googleProject: GoogleProject, runtimeName: RuntimeName): F[Unit]
-  def isProxyAvailable(googleProject: GoogleProject, runtimeName: RuntimeName): F[Boolean]
+  def flushCache(cloudContext: CloudContext, runtimeName: RuntimeName): F[Unit]
+  def isProxyAvailable(cloudContext: CloudContext, runtimeName: RuntimeName): F[Boolean]
 }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/ProxyDAO.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/ProxyDAO.scala
@@ -19,9 +19,9 @@ object HostStatus {
 
 object Proxy {
   def getRuntimeTargetHost[F[_]: Async](runtimeDnsCache: RuntimeDnsCache[F],
-                                        googleProject: GoogleProject,
+                                        cloudContext: CloudContext,
                                         runtimeName: RuntimeName): F[HostStatus] =
-    runtimeDnsCache.getHostStatus(RuntimeDnsCacheKey(googleProject, runtimeName)).timeout(5 seconds)
+    runtimeDnsCache.getHostStatus(RuntimeDnsCacheKey(cloudContext, runtimeName)).timeout(5 seconds)
 
   def getAppTargetHost[F[_]: Async](kubernetesDnsCache: KubernetesDnsCache[F],
                                     googleProject: GoogleProject,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/ToolDAO.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/ToolDAO.scala
@@ -5,11 +5,10 @@ import org.broadinstitute.dsde.workbench.leonardo.RuntimeContainerServiceType.{
   RStudioService,
   WelderService
 }
-import org.broadinstitute.dsde.workbench.leonardo.{RuntimeContainerServiceType, RuntimeName}
-import org.broadinstitute.dsde.workbench.model.google.GoogleProject
+import org.broadinstitute.dsde.workbench.leonardo.{CloudContext, RuntimeContainerServiceType, RuntimeName}
 
 trait ToolDAO[F[_], A] {
-  def isProxyAvailable(googleProject: GoogleProject, runtimeName: RuntimeName): F[Boolean]
+  def isProxyAvailable(cloudContext: CloudContext, runtimeName: RuntimeName): F[Boolean]
 }
 
 object ToolDAO {
@@ -21,13 +20,13 @@ object ToolDAO {
     clusterTool =>
       clusterTool match {
         case JupyterService =>
-          (googleProject: GoogleProject, runtimeName: RuntimeName) =>
-            jupyterDAO.isProxyAvailable(googleProject, runtimeName)
+          (cloudContext: CloudContext, runtimeName: RuntimeName) =>
+            jupyterDAO.isProxyAvailable(cloudContext, runtimeName)
         case WelderService =>
-          (googleProject: GoogleProject, runtimeName: RuntimeName) =>
-            welderDAO.isProxyAvailable(googleProject, runtimeName)
+          (cloudContext: CloudContext, runtimeName: RuntimeName) =>
+            welderDAO.isProxyAvailable(cloudContext, runtimeName)
         case RStudioService =>
-          (googleProject: GoogleProject, runtimeName: RuntimeName) =>
-            rstudioDAO.isProxyAvailable(googleProject, runtimeName)
+          (cloudContext: CloudContext, runtimeName: RuntimeName) =>
+            rstudioDAO.isProxyAvailable(cloudContext, runtimeName)
       }
 }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponent.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponent.scala
@@ -1,11 +1,16 @@
 package org.broadinstitute.dsde.workbench.leonardo
 package db
 
-import java.time.Instant
-
 import cats.data.Chain
 import cats.syntax.all._
-import org.broadinstitute.dsde.workbench.model.{IP, WorkbenchEmail}
+import org.broadinstitute.dsde.workbench.google2.OperationName
+import org.broadinstitute.dsde.workbench.leonardo.SamResourceId.RuntimeSamResourceId
+import org.broadinstitute.dsde.workbench.leonardo.config.Config
+import org.broadinstitute.dsde.workbench.leonardo.db.LeoProfile.api._
+import org.broadinstitute.dsde.workbench.leonardo.db.LeoProfile.dummyDate
+import org.broadinstitute.dsde.workbench.leonardo.db.LeoProfile.mappedColumnImplicits._
+import org.broadinstitute.dsde.workbench.leonardo.db.RuntimeConfigQueries.runtimeConfigs
+import org.broadinstitute.dsde.workbench.leonardo.monitor.RuntimeToMonitor
 import org.broadinstitute.dsde.workbench.model.google.{
   parseGcsPath,
   GcsBucketName,
@@ -14,22 +19,16 @@ import org.broadinstitute.dsde.workbench.model.google.{
   GoogleProject,
   ServiceAccountKeyId
 }
-import LeoProfile.api._
-import LeoProfile.mappedColumnImplicits._
-import LeoProfile.dummyDate
-import org.broadinstitute.dsde.workbench.google2.OperationName
-import org.broadinstitute.dsde.workbench.leonardo.SamResourceId.RuntimeSamResourceId
-import org.broadinstitute.dsde.workbench.leonardo.config.Config
-import org.broadinstitute.dsde.workbench.leonardo.db.RuntimeConfigQueries.runtimeConfigs
-import org.broadinstitute.dsde.workbench.leonardo.monitor.RuntimeToMonitor
+import org.broadinstitute.dsde.workbench.model.{IP, WorkbenchEmail}
 
+import java.time.Instant
 import scala.concurrent.ExecutionContext
 
 final case class ClusterRecord(id: Long,
                                internalId: String,
                                runtimeName: RuntimeName,
-                               googleId: Option[GoogleId],
-                               googleProject: GoogleProject,
+                               googleId: Option[ProxyHostName],
+                               cloudContext: CloudContext,
                                operationName: Option[String],
                                status: RuntimeStatus,
                                hostIp: Option[String],
@@ -46,15 +45,18 @@ final case class ClusterRecord(id: Long,
                                customClusterEnvironmentVariables: Map[String, String],
                                runtimeConfigId: RuntimeConfigId,
                                deletedFrom: Option[String]) {
-  def projectNameString: String = s"${googleProject.value}/${runtimeName.asString}"
+  def projectNameString: String = s"${cloudContext.asStringWithProvider}/${runtimeName.asString}"
 }
 
 class ClusterTable(tag: Tag) extends Table[ClusterRecord](tag, "CLUSTER") {
   def id = column[Long]("id", O.PrimaryKey, O.AutoInc)
   def internalId = column[String]("internalId", O.Length(254))
-  def clusterName = column[RuntimeName]("clusterName", O.Length(254))
-  def googleId = column[Option[GoogleId]]("googleId")
-  def googleProject = column[GoogleProject]("googleProject", O.Length(254))
+  def runtimeName = column[RuntimeName]("runtimeName", O.Length(254))
+  def proxyHostName = column[Option[ProxyHostName]]("proxyHostName")
+  // For Google resources, cloudContext is google project;
+  // For Azure resources, cloudContext is managed resource group
+  def cloudContextDb = column[CloudContextDb]("cloudContext", O.Length(254))
+  def cloudProvider = column[CloudProvider]("cloudProvider", O.Length(50))
   def serviceAccount = column[WorkbenchEmail]("serviceAccount", O.Length(254))
   def operationName = column[Option[String]]("operationName", O.Length(254))
   def status = column[RuntimeStatus]("status", O.Length(254))
@@ -75,8 +77,6 @@ class ClusterTable(tag: Tag) extends Table[ClusterRecord](tag, "CLUSTER") {
   def customClusterEnvironmentVariables = column[Option[Map[String, String]]]("customClusterEnvironmentVariables")
   def deletedFrom = column[Option[String]]("deletedFrom")
 
-  def uniqueKey = index("IDX_CLUSTER_UNIQUE", (googleProject, clusterName, destroyedDate), unique = true)
-
   // Can't use the shorthand
   //   def * = (...) <> (ClusterRecord.tupled, ClusterRecord.unapply)
   // because CLUSTER has more than 22 columns.
@@ -85,9 +85,9 @@ class ClusterTable(tag: Tag) extends Table[ClusterRecord](tag, "CLUSTER") {
     (
       id,
       internalId,
-      clusterName,
-      googleId,
-      googleProject,
+      runtimeName,
+      proxyHostName,
+      (cloudProvider, cloudContextDb),
       operationName,
       status,
       hostIp,
@@ -108,8 +108,8 @@ class ClusterTable(tag: Tag) extends Table[ClusterRecord](tag, "CLUSTER") {
       case (id,
             internalId,
             clusterName,
-            googleId,
-            googleProject,
+            proxyHostname,
+            (cloudProvider, cloudContextDb),
             operationName,
             status,
             hostIp,
@@ -130,8 +130,13 @@ class ClusterTable(tag: Tag) extends Table[ClusterRecord](tag, "CLUSTER") {
           id,
           internalId,
           clusterName,
-          googleId,
-          googleProject,
+          proxyHostname,
+          cloudProvider match {
+            case CloudProvider.Gcp =>
+              CloudContext.Gcp(GoogleProject(cloudContextDb.value)): CloudContext
+            case CloudProvider.Azure =>
+              CloudContext.Azure(ManagedResourceGroup(cloudContextDb.value)): CloudContext
+          },
           operationName,
           status,
           hostIp,
@@ -167,7 +172,12 @@ class ClusterTable(tag: Tag) extends Table[ClusterRecord](tag, "CLUSTER") {
           c.internalId,
           c.runtimeName,
           c.googleId,
-          c.googleProject,
+          c.cloudContext match {
+            case CloudContext.Gcp(value) =>
+              (CloudProvider.Gcp, CloudContextDb(value.value))
+            case CloudContext.Azure(value) =>
+              (CloudProvider.Azure, CloudContextDb(value.value))
+          },
           c.operationName,
           c.status,
           c.hostIp,
@@ -221,25 +231,25 @@ object clusterQuery extends TableQuery(new ClusterTable(_)) {
     } yield (cluster, image)
   }
 
-  def fullClusterQueryByUniqueKey(googleProject: GoogleProject,
+  def fullClusterQueryByUniqueKey(cloudContext: CloudContext,
                                   clusterName: RuntimeName,
                                   destroyedDateOpt: Option[Instant]) = {
     val destroyedDate = destroyedDateOpt.getOrElse(dummyDate)
     val baseQuery = clusterQuery
-      .filter(_.googleProject === googleProject)
-      .filter(_.clusterName === clusterName)
+      .filter(_.cloudContextDb === cloudContext.asCloudContextDb)
+      .filter(_.runtimeName === clusterName)
       .filter(_.destroyedDate === destroyedDate)
 
     fullClusterQuery(baseQuery)
   }
 
-  def getRuntimeQueryByUniqueKey(googleProject: GoogleProject,
+  def getRuntimeQueryByUniqueKey(cloudContext: CloudContext,
                                  clusterName: RuntimeName,
                                  destroyedDateOpt: Option[Instant]) = {
     val destroyedDate = destroyedDateOpt.getOrElse(dummyDate)
     val baseQuery = clusterQuery
-      .filter(_.googleProject === googleProject)
-      .filter(_.clusterName === clusterName)
+      .filter(_.cloudContextDb === cloudContext.asCloudContextDb)
+      .filter(_.runtimeName === clusterName)
       .filter(_.destroyedDate === destroyedDate)
 
     for {
@@ -255,13 +265,13 @@ object clusterQuery extends TableQuery(new ClusterTable(_)) {
     } yield (cluster, error, label, extension, image, scopes, patch)
   }
 
-  def clusterRecordQueryByUniqueKey(googleProject: GoogleProject,
+  def clusterRecordQueryByUniqueKey(cloudContext: CloudContext,
                                     clusterName: RuntimeName,
                                     destroyedDateOpt: Option[Instant]) = {
     val destroyedDate = destroyedDateOpt.getOrElse(dummyDate)
     clusterQuery
-      .filter(_.googleProject === googleProject)
-      .filter(_.clusterName === clusterName)
+      .filter(_.cloudContextDb === cloudContext.asCloudContextDb)
+      .filter(_.runtimeName === clusterName)
       .filter(_.destroyedDate === destroyedDate)
   }
 
@@ -362,32 +372,32 @@ object clusterQuery extends TableQuery(new ClusterTable(_)) {
       .length
       .result
 
-  def countActiveByProject(googleProject: GoogleProject) =
+  def countActiveByProject(cloudContext: CloudContext) =
     clusterQuery
-      .filter(_.googleProject === googleProject)
+      .filter(_.cloudContextDb === cloudContext.asCloudContextDb)
       .filter(_.status inSetBind RuntimeStatus.activeStatuses)
       .length
       .result
 
   // find* and get* methods do query the INSTANCE table
 
-  def getActiveClusterByName(project: GoogleProject,
+  def getActiveClusterByName(cloudContext: CloudContext,
                              name: RuntimeName)(implicit ec: ExecutionContext): DBIO[Option[Runtime]] =
-    fullClusterQueryByUniqueKey(project, name, Some(dummyDate)).result map { recs =>
+    fullClusterQueryByUniqueKey(cloudContext, name, Some(dummyDate)).result map { recs =>
       unmarshalFullCluster(recs).headOption
     }
 
-  def getDeletingClusterByName(project: GoogleProject,
+  def getDeletingClusterByName(cloudContext: CloudContext,
                                name: RuntimeName)(implicit ec: ExecutionContext): DBIO[Option[Runtime]] =
-    fullClusterQueryByUniqueKey(project, name, Some(dummyDate)).filter {
+    fullClusterQueryByUniqueKey(cloudContext, name, Some(dummyDate)).filter {
       _._1.status === (RuntimeStatus.Deleting: RuntimeStatus)
     }.result map { recs => unmarshalFullCluster(recs).headOption }
 
-  def getActiveClusterByNameMinimal(project: GoogleProject,
+  def getActiveClusterByNameMinimal(cloudContext: CloudContext,
                                     name: RuntimeName)(implicit ec: ExecutionContext): DBIO[Option[Runtime]] = {
     val res = clusterQuery
-      .filter(_.googleProject === project)
-      .filter(_.clusterName === name)
+      .filter(_.cloudContextDb === cloudContext.asCloudContextDb)
+      .filter(_.runtimeName === name)
       .filter(_.destroyedDate === dummyDate)
       .result
 
@@ -398,11 +408,11 @@ object clusterQuery extends TableQuery(new ClusterTable(_)) {
     }
   }
 
-  def getActiveClusterRecordByName(project: GoogleProject,
+  def getActiveClusterRecordByName(cloudContext: CloudContext,
                                    name: RuntimeName)(implicit ec: ExecutionContext): DBIO[Option[ClusterRecord]] =
     clusterQuery
-      .filter(_.googleProject === project)
-      .filter(_.clusterName === name)
+      .filter(_.cloudContextDb === cloudContext.asCloudContextDb)
+      .filter(_.runtimeName === name)
       .filter(_.destroyedDate === dummyDate)
       .result
       .map(recs => recs.headOption)
@@ -410,55 +420,56 @@ object clusterQuery extends TableQuery(new ClusterTable(_)) {
   def getClusterById(id: Long)(implicit ec: ExecutionContext): DBIO[Option[Runtime]] =
     fullClusterQueryById(id).result map { recs => unmarshalFullCluster(recs).headOption }
 
-  def getActiveClusterInternalIdByName(project: GoogleProject, name: RuntimeName)(
+  def getActiveClusterInternalIdByName(cloudContext: CloudContext, name: RuntimeName)(
     implicit ec: ExecutionContext
   ): DBIO[Option[RuntimeSamResourceId]] =
     clusterQuery
-      .filter(_.googleProject === project)
-      .filter(_.clusterName === name)
+      .filter(_.cloudContextDb === cloudContext.asCloudContextDb)
+      .filter(_.runtimeName === name)
       .filter(_.destroyedDate === dummyDate)
       .result
       .map(recs => recs.headOption.map(clusterRec => RuntimeSamResourceId(clusterRec.internalId)))
 
   private[leonardo] def getIdByUniqueKey(cluster: Runtime)(implicit ec: ExecutionContext): DBIO[Option[Long]] =
-    getIdByUniqueKey(cluster.googleProject, cluster.runtimeName, cluster.auditInfo.destroyedDate)
+    getIdByUniqueKey(cluster.cloudContext, cluster.runtimeName, cluster.auditInfo.destroyedDate)
 
   private[leonardo] def getIdByUniqueKey(
-    googleProject: GoogleProject,
+    cloudContext: CloudContext,
     clusterName: RuntimeName,
     destroyedDateOpt: Option[Instant]
   )(implicit ec: ExecutionContext): DBIO[Option[Long]] =
-    getClusterByUniqueKey(googleProject, clusterName, destroyedDateOpt).map(_.map(_.id))
+    getClusterByUniqueKey(cloudContext, clusterName, destroyedDateOpt).map(_.map(_.id))
 
   // Convenience method for tests, in several of which we define a cluster and later on need
   // to retrieve its updated status, etc. but don't know its id to look up
   private[leonardo] def getClusterByUniqueKey(
     getClusterId: GetClusterKey
   )(implicit ec: ExecutionContext): DBIO[Option[Runtime]] =
-    getClusterByUniqueKey(getClusterId.googleProject, getClusterId.clusterName, getClusterId.destroyedDate)
+    getClusterByUniqueKey(getClusterId.cloudContext, getClusterId.clusterName, getClusterId.destroyedDate)
 
   private[leonardo] def getClusterByUniqueKey(
-    googleProject: GoogleProject,
+    cloudContext: CloudContext,
     clusterName: RuntimeName,
     destroyedDateOpt: Option[Instant]
   )(implicit ec: ExecutionContext): DBIO[Option[Runtime]] =
-    fullClusterQueryByUniqueKey(googleProject, clusterName, destroyedDateOpt).result map { recs =>
+    fullClusterQueryByUniqueKey(cloudContext, clusterName, destroyedDateOpt).result map { recs =>
       unmarshalFullCluster(recs).headOption
     }
 
-  def getInitBucket(project: GoogleProject, name: RuntimeName)(implicit ec: ExecutionContext): DBIO[Option[GcsPath]] =
+  def getInitBucket(cloudContext: CloudContext,
+                    name: RuntimeName)(implicit ec: ExecutionContext): DBIO[Option[GcsPath]] =
     clusterQuery
-      .filter(_.googleProject === project)
-      .filter(_.clusterName === name)
+      .filter(_.cloudContextDb === cloudContext.asCloudContextDb)
+      .filter(_.runtimeName === name)
       .map(_.initBucket)
       .result
       .map(recs => recs.headOption.flatten.flatMap(head => parseGcsPath(head).toOption))
 
-  def getStagingBucket(project: GoogleProject,
+  def getStagingBucket(cloudContext: CloudContext,
                        name: RuntimeName)(implicit ec: ExecutionContext): DBIO[Option[GcsPath]] =
     clusterQuery
-      .filter(_.googleProject === project)
-      .filter(_.clusterName === name)
+      .filter(_.cloudContextDb === cloudContext.asCloudContextDb)
+      .filter(_.runtimeName === name)
       .map(_.stagingBucket)
       .result
       // staging bucket is saved as a bucket name rather than a path
@@ -501,13 +512,13 @@ object clusterQuery extends TableQuery(new ClusterTable(_)) {
       _ <- RuntimeConfigQueries.updatePersistentDiskId(rid, None, destroyedDate): DBIO[Int]
     } yield ()
 
-  def markDeleted(googleProject: GoogleProject,
+  def markDeleted(cloudContext: CloudContext,
                   runtimeName: RuntimeName,
                   destroyedDate: Instant,
                   deletedFrom: Option[String])(
     implicit ec: ExecutionContext
   ): DBIO[Unit] =
-    clusterRecordQueryByUniqueKey(googleProject, runtimeName, Some(dummyDate))
+    clusterRecordQueryByUniqueKey(cloudContext, runtimeName, Some(dummyDate))
       .map(c => (c.destroyedDate, c.status, c.hostIp, c.dateAccessed, c.deletedFrom))
       .update((destroyedDate, RuntimeStatus.Deleted, None, destroyedDate, deletedFrom))
       .map(_ => ())
@@ -540,11 +551,11 @@ object clusterQuery extends TableQuery(new ClusterTable(_)) {
 
   def updateAsyncClusterCreationFields(updateAsyncClusterCreationFields: UpdateAsyncClusterCreationFields): DBIO[Int] =
     findByIdQuery(updateAsyncClusterCreationFields.clusterId)
-      .map(c => (c.initBucket, c.googleId, c.operationName, c.stagingBucket, c.dateAccessed))
+      .map(c => (c.initBucket, c.proxyHostName, c.operationName, c.stagingBucket, c.dateAccessed))
       .update(
         (
           updateAsyncClusterCreationFields.initBucket.map(_.toUri),
-          updateAsyncClusterCreationFields.asyncRuntimeFields.map(_.googleId),
+          updateAsyncClusterCreationFields.asyncRuntimeFields.map(_.proxyHostName),
           updateAsyncClusterCreationFields.asyncRuntimeFields.map(_.operationName.value),
           updateAsyncClusterCreationFields.asyncRuntimeFields.map(_.stagingBucket.value),
           updateAsyncClusterCreationFields.dateAccessed
@@ -553,7 +564,7 @@ object clusterQuery extends TableQuery(new ClusterTable(_)) {
 
   def clearAsyncClusterCreationFields(cluster: Runtime, dateAccessed: Instant): DBIO[Int] =
     findByIdQuery(cluster.id)
-      .map(c => (c.initBucket, c.googleId, c.operationName, c.stagingBucket, c.dateAccessed))
+      .map(c => (c.initBucket, c.proxyHostName, c.operationName, c.stagingBucket, c.dateAccessed))
       .update((None, None, None, None, dateAccessed))
 
   def updateClusterStatus(id: Long, newStatus: RuntimeStatus, dateAccessed: Instant): DBIO[Int] =
@@ -569,10 +580,10 @@ object clusterQuery extends TableQuery(new ClusterTable(_)) {
       .map(_.dateAccessed)
       .update(dateAccessed)
 
-  def updateDateAccessedByProjectAndName(googleProject: GoogleProject, clusterName: RuntimeName, dateAccessed: Instant)(
+  def updateDateAccessedByProjectAndName(cloudContext: CloudContext, clusterName: RuntimeName, dateAccessed: Instant)(
     implicit ec: ExecutionContext
   ): DBIO[Int] =
-    clusterQuery.getActiveClusterByNameMinimal(googleProject, clusterName) flatMap {
+    clusterQuery.getActiveClusterByNameMinimal(cloudContext, clusterName) flatMap {
       case Some(c) => clusterQuery.updateDateAccessed(c.id, dateAccessed)
       case None    => DBIO.successful(0)
     }
@@ -585,10 +596,10 @@ object clusterQuery extends TableQuery(new ClusterTable(_)) {
       .map(c => (c.kernelFoundBusyDate, c.dateAccessed))
       .update((Some(kernelFoundBusyDate), dateAccessed))
 
-  def clearKernelFoundBusyDateByProjectAndName(googleProject: GoogleProject,
+  def clearKernelFoundBusyDateByProjectAndName(cloudContext: CloudContext,
                                                clusterName: RuntimeName,
                                                dateAccessed: Instant)(implicit ec: ExecutionContext): DBIO[Int] =
-    clusterQuery.getActiveClusterByNameMinimal(googleProject, clusterName) flatMap {
+    clusterQuery.getActiveClusterByNameMinimal(cloudContext, clusterName) flatMap {
       case Some(c) => clusterQuery.clearKernelFoundBusyDate(c.id, dateAccessed)
       case None    => DBIO.successful(0)
     }
@@ -620,8 +631,8 @@ object clusterQuery extends TableQuery(new ClusterTable(_)) {
       id = 0, // DB AutoInc
       runtime.samResource.resourceId,
       runtime.runtimeName,
-      runtime.asyncRuntimeFields.map(_.googleId),
-      runtime.googleProject,
+      runtime.asyncRuntimeFields.map(_.proxyHostName),
+      runtime.cloudContext,
       runtime.asyncRuntimeFields.map(_.operationName.value),
       runtime.status,
       runtime.asyncRuntimeFields.flatMap(_.hostIp.map(_.asString)),
@@ -674,7 +685,7 @@ object clusterQuery extends TableQuery(new ClusterTable(_)) {
         val containers = Chain.fromSeq(
           RuntimeContainerServiceType.imageTypeToRuntimeContainerServiceType.get(clusterImageRec.imageType).toSeq
         )
-        Map(RunningRuntime(clusterRec.googleProject, clusterRec.runtimeName, List.empty) -> containers)
+        Map(RunningRuntime(clusterRec.cloudContext, clusterRec.runtimeName, List.empty) -> containers)
     }
 
     clusterContainerMap.toSeq.map {
@@ -751,7 +762,7 @@ object clusterQuery extends TableQuery(new ClusterTable(_)) {
                                scopes: List[ScopeRecord],
                                patch: List[PatchRecord]): Runtime = {
     val name = clusterRecord.runtimeName
-    val project = clusterRecord.googleProject
+    val cloudContext = clusterRecord.cloudContext
     val dataprocInfo = (clusterRecord.googleId, clusterRecord.operationName, clusterRecord.stagingBucket).mapN {
       (googleId, operationName, stagingBucket) =>
         AsyncRuntimeFields(googleId,
@@ -769,33 +780,33 @@ object clusterQuery extends TableQuery(new ClusterTable(_)) {
       clusterRecord.id,
       RuntimeSamResourceId(clusterRecord.internalId),
       name,
-      project,
-      clusterRecord.serviceAccountInfo,
-      dataprocInfo,
-      clusterRecord.auditInfo,
-      clusterRecord.kernelFoundBusyDate,
-      Runtime.getProxyUrl(Config.proxyConfig.proxyUrlBase, project, name, clusterImages, labels),
-      clusterRecord.status,
-      labels,
-      clusterRecord.userScriptUri,
-      clusterRecord.startUserScriptUri,
-      errors map clusterErrorQuery.unmarshallClusterErrorRecord,
-      instanceRecords map instanceQuery.unmarshalInstance toSet,
-      extensionQuery.unmarshallExtensions(userJupyterExtensionConfig),
-      clusterRecord.autopauseThreshold,
-      clusterRecord.defaultClientId,
-      false,
-      clusterImages,
-      scopeQuery.unmarshallScopes(scopes),
-      clusterRecord.welderEnabled,
-      clusterRecord.customClusterEnvironmentVariables,
-      clusterRecord.runtimeConfigId.value,
-      patchInProgress
+      serviceAccount = clusterRecord.serviceAccountInfo,
+      asyncRuntimeFields = dataprocInfo,
+      auditInfo = clusterRecord.auditInfo,
+      kernelFoundBusyDate = clusterRecord.kernelFoundBusyDate,
+      proxyUrl = Runtime.getProxyUrl(Config.proxyConfig.proxyUrlBase, cloudContext, name, clusterImages, labels),
+      status = clusterRecord.status,
+      labels = labels,
+      userScriptUri = clusterRecord.userScriptUri,
+      startUserScriptUri = clusterRecord.startUserScriptUri,
+      errors = errors map clusterErrorQuery.unmarshallClusterErrorRecord,
+      dataprocInstances = instanceRecords map instanceQuery.unmarshalInstance toSet,
+      userJupyterExtensionConfig = extensionQuery.unmarshallExtensions(userJupyterExtensionConfig),
+      autopauseThreshold = clusterRecord.autopauseThreshold,
+      defaultClientId = clusterRecord.defaultClientId,
+      allowStop = false,
+      runtimeImages = clusterImages,
+      scopes = scopeQuery.unmarshallScopes(scopes),
+      welderEnabled = clusterRecord.welderEnabled,
+      customEnvironmentVariables = clusterRecord.customClusterEnvironmentVariables,
+      runtimeConfigId = clusterRecord.runtimeConfigId.value,
+      patchInProgress = patchInProgress,
+      cloudContext = clusterRecord.cloudContext
     )
   }
 }
 
-final case class GetClusterKey(googleProject: GoogleProject, clusterName: RuntimeName, destroyedDate: Option[Instant])
+final case class GetClusterKey(cloudContext: CloudContext, clusterName: RuntimeName, destroyedDate: Option[Instant])
 
 final case class UpdateAsyncClusterCreationFields(initBucket: Option[GcsPath],
                                                   clusterId: Long,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/LeoProfile.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/LeoProfile.scala
@@ -70,6 +70,18 @@ private[leonardo] object LeoProfile extends MySQLProfile {
               .getOrElse(throw ColumnDecodingException(s"unexpected runtime status ${s} from database"))
         )
 
+    implicit val cloudContextDbMappedColumnType: BaseColumnType[CloudContextDb] =
+      MappedColumnType
+        .base[CloudContextDb, String](_.value, CloudContextDb.apply)
+    implicit val cloudProviderMappedColumnType: BaseColumnType[CloudProvider] =
+      MappedColumnType
+        .base[CloudProvider, String](
+          _.asString,
+          s =>
+            CloudProvider.stringToCloudProvider
+              .get(s)
+              .getOrElse(throw ColumnDecodingException(s"unexpected CloudProvider ${s} from database"))
+        )
     implicit val googleProjectMappedColumnType: BaseColumnType[GoogleProject] =
       MappedColumnType
         .base[GoogleProject, String](_.value, GoogleProject.apply)
@@ -118,8 +130,8 @@ private[leonardo] object LeoProfile extends MySQLProfile {
     )
     implicit val runtimeConfigIdMappedColumnType: BaseColumnType[RuntimeConfigId] =
       MappedColumnType.base[RuntimeConfigId, Long](_.id, RuntimeConfigId.apply)
-    implicit val googleIdMappedColumnType: BaseColumnType[GoogleId] =
-      MappedColumnType.base[GoogleId, String](_.value, GoogleId.apply)
+    implicit val googleIdMappedColumnType: BaseColumnType[ProxyHostName] =
+      MappedColumnType.base[ProxyHostName, String](_.value, ProxyHostName.apply)
     implicit val diskIdMappedColumnType: BaseColumnType[DiskId] =
       MappedColumnType.base[DiskId, Long](_.value, DiskId.apply)
     implicit val diskSizeMappedColumnType: BaseColumnType[DiskSize] =

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/PersistentDiskComponent.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/PersistentDiskComponent.scala
@@ -1,8 +1,6 @@
 package org.broadinstitute.dsde.workbench.leonardo
 package db
 
-import java.time.Instant
-
 import cats.syntax.all._
 import org.broadinstitute.dsde.workbench.google2.{DiskName, ZoneName}
 import org.broadinstitute.dsde.workbench.leonardo.SamResourceId.PersistentDiskSamResourceId
@@ -12,13 +10,13 @@ import org.broadinstitute.dsde.workbench.leonardo.db.LeoProfile.{dummyDate, unma
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 
+import java.time.Instant
 import scala.concurrent.ExecutionContext
 
 final case class PersistentDiskRecord(id: DiskId,
-                                      googleProject: GoogleProject,
+                                      cloudContext: CloudContext,
                                       zone: ZoneName,
                                       name: DiskName,
-                                      googleId: Option[GoogleId],
                                       serviceAccount: WorkbenchEmail,
                                       samResource: PersistentDiskSamResourceId,
                                       status: DiskStatus,
@@ -34,10 +32,10 @@ final case class PersistentDiskRecord(id: DiskId,
 
 class PersistentDiskTable(tag: Tag) extends Table[PersistentDiskRecord](tag, "PERSISTENT_DISK") {
   def id = column[DiskId]("id", O.PrimaryKey, O.AutoInc)
-  def googleProject = column[GoogleProject]("googleProject", O.Length(255))
+  def cloudContext = column[CloudContextDb]("cloudContext", O.Length(255))
+  def cloudProvider = column[CloudProvider]("cloudProvider", O.Length(50))
   def zone = column[ZoneName]("zone", O.Length(255))
   def name = column[DiskName]("name", O.Length(255))
-  def googleId = column[Option[GoogleId]]("googleId", O.Length(255))
   def serviceAccount = column[WorkbenchEmail]("serviceAccount", O.Length(255))
   def samResourceId = column[PersistentDiskSamResourceId]("samResourceId", O.Length(255))
   def status = column[DiskStatus]("status", O.Length(255))
@@ -55,10 +53,9 @@ class PersistentDiskTable(tag: Tag) extends Table[PersistentDiskRecord](tag, "PE
 
   override def * =
     (id,
-     googleProject,
+     (cloudProvider, cloudContext),
      zone,
      name,
-     googleId,
      serviceAccount,
      samResourceId,
      status,
@@ -72,10 +69,9 @@ class PersistentDiskTable(tag: Tag) extends Table[PersistentDiskRecord](tag, "PE
      formattedBy,
      (galaxyPvcId, cvmfsPvcId, lastUsedBy)) <> ({
       case (id,
-            googleProject,
+            (cloudProvider, cloudContextDb),
             zone,
             name,
-            googleId,
             serviceAccount,
             samResourceId,
             status,
@@ -90,10 +86,14 @@ class PersistentDiskTable(tag: Tag) extends Table[PersistentDiskRecord](tag, "PE
             (galaxyPvcId, cvmfsPvcId, lastUsedBy)) =>
         PersistentDiskRecord(
           id,
-          googleProject,
+          cloudProvider match {
+            case CloudProvider.Gcp =>
+              CloudContext.Gcp(GoogleProject(cloudContextDb.value)): CloudContext
+            case CloudProvider.Azure =>
+              CloudContext.Azure(ManagedResourceGroup(cloudContextDb.value)): CloudContext
+          },
           zone,
           name,
-          googleId,
           serviceAccount,
           samResourceId,
           status,
@@ -110,10 +110,14 @@ class PersistentDiskTable(tag: Tag) extends Table[PersistentDiskRecord](tag, "PE
     }, { record: PersistentDiskRecord =>
       Some(
         record.id,
-        record.googleProject,
+        record.cloudContext match {
+          case CloudContext.Gcp(value) =>
+            (CloudProvider.Gcp, CloudContextDb(value.value))
+          case CloudContext.Azure(value) =>
+            (CloudProvider.Azure, CloudContextDb(value.value))
+        },
         record.zone,
         record.name,
-        record.googleId,
         record.serviceAccount,
         record.samResource,
         record.status,
@@ -137,15 +141,17 @@ object persistentDiskQuery {
 
   private[db] def findByIdQuery(id: DiskId) = tableQuery.filter(_.id === id)
 
-  private[db] def findActiveByNameQuery(googleProject: GoogleProject, name: DiskName) =
+  private[db] def findActiveByNameQuery(cloudContext: CloudContext, name: DiskName) =
     tableQuery
-      .filter(_.googleProject === googleProject)
+      .filter(_.cloudContext === cloudContext.asCloudContextDb)
       .filter(_.name === name)
       .filter(_.destroyedDate === dummyDate)
 
-  private[db] def findByNameQuery(googleProject: GoogleProject, name: DiskName) =
+  private[db] def findByNameQuery(cloudContext: CloudContext, name: DiskName) =
     tableQuery
-      .filter(_.googleProject === googleProject)
+      .filter(
+        _.cloudContext === cloudContext.asCloudContextDb
+      )
       .filter(_.name === name)
 
   private[db] def joinLabelQuery(baseQuery: Query[PersistentDiskTable, PersistentDiskRecord, Seq]) =
@@ -189,9 +195,9 @@ object persistentDiskQuery {
   def getPersistentDiskRecord(id: DiskId): DBIO[Option[PersistentDiskRecord]] =
     findByIdQuery(id).result.headOption
 
-  def getActiveByName(googleProject: GoogleProject,
+  def getActiveByName(cloudContext: CloudContext,
                       name: DiskName)(implicit ec: ExecutionContext): DBIO[Option[PersistentDisk]] =
-    joinLabelQuery(findActiveByNameQuery(googleProject, name)).result.map(aggregateLabels).map(_.headOption)
+    joinLabelQuery(findActiveByNameQuery(cloudContext, name)).result.map(aggregateLabels).map(_.headOption)
 
   def updateStatus(id: DiskId, newStatus: DiskStatus, dateAccessed: Instant) =
     findByIdQuery(id).map(d => (d.status, d.dateAccessed)).update((newStatus, dateAccessed))
@@ -212,9 +218,6 @@ object persistentDiskQuery {
     findByIdQuery(id)
       .map(d => (d.status, d.destroyedDate, d.dateAccessed))
       .update((DiskStatus.Deleted, destroyedDate, destroyedDate))
-
-  def updateGoogleId(id: DiskId, googleId: GoogleId, dateAccessed: Instant) =
-    findByIdQuery(id).map(d => (d.googleId, d.dateAccessed)).update((Some(googleId), dateAccessed))
 
   def updateSize(id: DiskId, newSize: DiskSize, dateAccessed: Instant) =
     findByIdQuery(id).map(d => (d.size, d.dateAccessed)).update((newSize, dateAccessed))
@@ -241,10 +244,9 @@ object persistentDiskQuery {
   private[db] def marshalPersistentDisk(disk: PersistentDisk): PersistentDiskRecord =
     PersistentDiskRecord(
       disk.id,
-      disk.googleProject,
+      disk.cloudContext,
       disk.zone,
       disk.name,
-      disk.googleId,
       disk.serviceAccount,
       disk.samResource,
       disk.status,
@@ -278,10 +280,9 @@ object persistentDiskQuery {
   private[db] def unmarshalPersistentDisk(rec: PersistentDiskRecord, labels: LabelMap): PersistentDisk =
     PersistentDisk(
       rec.id,
-      rec.googleProject,
+      rec.cloudContext,
       rec.zone,
       rec.name,
-      rec.googleId,
       rec.serviceAccount,
       rec.samResource,
       rec.status,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dns/RuntimeDnsCache.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dns/RuntimeDnsCache.scala
@@ -1,4 +1,5 @@
-package org.broadinstitute.dsde.workbench.leonardo.dns
+package org.broadinstitute.dsde.workbench.leonardo
+package dns
 
 import akka.http.scaladsl.model.Uri.Host
 import cats.effect.{Async, Ref}
@@ -7,16 +8,14 @@ import org.broadinstitute.dsde.workbench.leonardo.config.ProxyConfig
 import org.broadinstitute.dsde.workbench.leonardo.dao.HostStatus
 import org.broadinstitute.dsde.workbench.leonardo.dao.HostStatus._
 import org.broadinstitute.dsde.workbench.leonardo.db.{clusterQuery, DbReference}
-import org.broadinstitute.dsde.workbench.leonardo.{GoogleId, Runtime, RuntimeName}
 import org.broadinstitute.dsde.workbench.model.IP
-import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.broadinstitute.dsde.workbench.openTelemetry.OpenTelemetryMetrics
 import org.typelevel.log4cats.Logger
 import scalacache.Cache
 
 import scala.concurrent.ExecutionContext
 
-final case class RuntimeDnsCacheKey(googleProject: GoogleProject, runtimeName: RuntimeName)
+final case class RuntimeDnsCacheKey(cloudContext: CloudContext, runtimeName: RuntimeName)
 
 /**
  * This class provides an in-memory cache of (GoogleProject, RuntimeName) -> HostStatus.
@@ -37,9 +36,9 @@ class RuntimeDnsCache[F[_]: Logger: OpenTelemetryMetrics](
   private def getHostStatusHelper(key: RuntimeDnsCacheKey): F[HostStatus] =
     for {
       _ <- Logger[F]
-        .debug(s"DNS Cache miss for ${key.googleProject} / ${key.runtimeName}...loading from DB...")
+        .debug(s"DNS Cache miss for ${key.cloudContext} / ${key.runtimeName}...loading from DB...")
       runtimeOpt <- dbRef.inTransaction {
-        clusterQuery.getActiveClusterByNameMinimal(key.googleProject, key.runtimeName)
+        clusterQuery.getActiveClusterByNameMinimal(key.cloudContext, key.runtimeName)
       }
       hostStatus <- runtimeOpt match {
         case Some(runtime) =>
@@ -49,13 +48,13 @@ class RuntimeDnsCache[F[_]: Logger: OpenTelemetryMetrics](
       }
     } yield hostStatus
 
-  private def host(googleId: GoogleId): Host =
+  private def host(googleId: ProxyHostName): Host =
     Host(googleId.value + proxyConfig.proxyDomain)
 
   private def hostStatusByProjectAndCluster(r: Runtime): F[HostStatus] = {
     val hostAndIpOpt = for {
       a <- r.asyncRuntimeFields
-      h = host(a.googleId)
+      h = host(a.proxyHostName)
       ip <- a.hostIp
     } yield (h, ip)
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/package.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/package.scala
@@ -1,4 +1,5 @@
-package org.broadinstitute.dsde.workbench.leonardo.http
+package org.broadinstitute.dsde.workbench.leonardo
+package http
 
 import akka.http.scaladsl.marshalling.Marshaller
 import akka.http.scaladsl.server.Directive1
@@ -9,7 +10,6 @@ import cats.mtl.Ask
 import io.opencensus.trace.Span
 import org.broadinstitute.dsde.workbench.google2.KubernetesSerializableName.ServiceName
 import org.broadinstitute.dsde.workbench.leonardo.dao.TerminalName
-import org.broadinstitute.dsde.workbench.leonardo.{traceIdHeaderString, AppContext, AppName, RuntimeName}
 import org.broadinstitute.dsde.workbench.model.TraceId
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 
@@ -23,6 +23,7 @@ package object api {
 
   val googleProjectSegment = Segment.map(GoogleProject)
   val runtimeNameSegment = Segment.map(RuntimeName)
+  val workspaceIdSegment = Segment.map(WorkspaceId)
   val appNameSegment = Segment.map(AppName)
   val serviceNameSegment = Segment.map(ServiceName)
   val terminalNameSegment = Segment.map(TerminalName)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/DiskService.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/DiskService.scala
@@ -3,7 +3,7 @@ package service
 
 import cats.mtl.Ask
 import org.broadinstitute.dsde.workbench.google2.DiskName
-import org.broadinstitute.dsde.workbench.leonardo.AppContext
+import org.broadinstitute.dsde.workbench.leonardo.{AppContext, CloudContext}
 import org.broadinstitute.dsde.workbench.leonardo.http.api.UpdateDiskRequest
 import org.broadinstitute.dsde.workbench.model.UserInfo
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
@@ -13,11 +13,11 @@ trait DiskService[F[_]] {
     implicit as: Ask[F, AppContext]
   ): F[Unit]
 
-  def getDisk(userInfo: UserInfo, googleProject: GoogleProject, diskName: DiskName)(
+  def getDisk(userInfo: UserInfo, cloudContext: CloudContext, diskName: DiskName)(
     implicit as: Ask[F, AppContext]
   ): F[GetPersistentDiskResponse]
 
-  def listDisks(userInfo: UserInfo, googleProject: Option[GoogleProject], params: Map[String, String])(
+  def listDisks(userInfo: UserInfo, cloudContext: Option[CloudContext], params: Map[String, String])(
     implicit as: Ask[F, AppContext]
   ): F[Vector[ListPersistentDiskResponse]]
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/ProxyService.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/ProxyService.scala
@@ -44,7 +44,10 @@ sealed trait SamResourceCacheKey extends Product with Serializable {
   def googleProject: GoogleProject
 }
 object SamResourceCacheKey {
-  final case class RuntimeCacheKey(googleProject: GoogleProject, name: RuntimeName) extends SamResourceCacheKey
+  final case class RuntimeCacheKey(cloudContext: CloudContext, name: RuntimeName) extends SamResourceCacheKey {
+    override val googleProject
+      : GoogleProject = GoogleProject(cloudContext.asString) //TODO: remove this once AppCacheKey is also moved to use cloudContext
+  }
   final case class AppCacheKey(googleProject: GoogleProject, name: AppName) extends SamResourceCacheKey
 }
 
@@ -152,7 +155,7 @@ class ProxyService(
         case None =>
           IO.raiseError(
             RuntimeNotFoundException(
-              key.googleProject,
+              key.cloudContext,
               key.name,
               s"${ctx.traceId} | Unable to look up sam resource for runtime ${key.googleProject.value} / ${key.name.asString}. Request: ${ctx.requestUri}"
             )
@@ -187,28 +190,28 @@ class ProxyService(
   def invalidateAccessToken(token: String): IO[Unit] =
     googleTokenCache.remove(token)
 
-  def proxyRequest(userInfo: UserInfo, googleProject: GoogleProject, runtimeName: RuntimeName, request: HttpRequest)(
+  def proxyRequest(userInfo: UserInfo, cloudContext: CloudContext, runtimeName: RuntimeName, request: HttpRequest)(
     implicit ev: Ask[IO, AppContext]
   ): IO[HttpResponse] =
     for {
       ctx <- ev.ask[AppContext]
-      samResource <- getCachedRuntimeSamResource(RuntimeCacheKey(googleProject, runtimeName))
+      samResource <- getCachedRuntimeSamResource(RuntimeCacheKey(cloudContext, runtimeName))
       // Note both these Sam actions are cached so it should be okay to call hasPermission twice
       hasViewPermission <- authProvider.hasPermission(samResource, RuntimeAction.GetRuntimeStatus, userInfo)
       _ <- if (!hasViewPermission) {
-        IO.raiseError(RuntimeNotFoundException(googleProject, runtimeName, ctx.traceId.asString))
+        IO.raiseError(RuntimeNotFoundException(cloudContext, runtimeName, ctx.traceId.asString))
       } else IO.unit
       hasConnectPermission <- authProvider.hasPermission(samResource, RuntimeAction.ConnectToRuntime, userInfo)
       _ <- if (!hasConnectPermission) {
         IO.raiseError(ForbiddenError(userInfo.userEmail))
       } else IO.unit
-      hostStatus <- getRuntimeTargetHost(googleProject, runtimeName)
+      hostStatus <- getRuntimeTargetHost(cloudContext, runtimeName)
       _ <- hostStatus match {
         case HostReady(_) =>
-          dateAccessUpdaterQueue.offer(UpdateDateAccessMessage(runtimeName, googleProject, ctx.now))
+          dateAccessUpdaterQueue.offer(UpdateDateAccessMessage(runtimeName, cloudContext, ctx.now))
         case _ => IO.unit
       }
-      hostContext = HostContext(hostStatus, s"${googleProject.value}/${runtimeName.asString}")
+      hostContext = HostContext(hostStatus, s"${cloudContext.asStringWithProvider}/${runtimeName.asString}")
       r <- proxyInternal(hostContext, request)
     } yield r
 
@@ -223,7 +226,7 @@ class ProxyService(
         IO.unit
       else
         jupyterDAO.createTerminal(googleProject, runtimeName)
-      r <- proxyRequest(userInfo, googleProject, runtimeName, request)
+      r <- proxyRequest(userInfo, CloudContext.Gcp(googleProject), runtimeName, request)
     } yield r
 
   def proxyAppRequest(userInfo: UserInfo,
@@ -250,8 +253,8 @@ class ProxyService(
       r <- proxyInternal(hostContext, request)
     } yield r
 
-  private[service] def getRuntimeTargetHost(googleProject: GoogleProject, runtimeName: RuntimeName): IO[HostStatus] =
-    Proxy.getRuntimeTargetHost[IO](runtimeDnsCache, googleProject, runtimeName)
+  private[service] def getRuntimeTargetHost(cloudContext: CloudContext, runtimeName: RuntimeName): IO[HostStatus] =
+    Proxy.getRuntimeTargetHost[IO](runtimeDnsCache, cloudContext, runtimeName)
 
   private[service] def getAppTargetHost(googleProject: GoogleProject, appName: AppName): IO[HostStatus] =
     Proxy.getAppTargetHost[IO](kubernetesDnsCache, googleProject, appName)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeService.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeService.scala
@@ -22,15 +22,15 @@ import scala.concurrent.ExecutionContext
 
 trait RuntimeService[F[_]] {
   def createRuntime(userInfo: UserInfo,
-                    googleProject: GoogleProject,
+                    cloudContext: CloudContext,
                     runtimeName: RuntimeName,
                     req: CreateRuntime2Request)(implicit as: Ask[F, AppContext]): F[Unit]
 
-  def getRuntime(userInfo: UserInfo, googleProject: GoogleProject, runtimeName: RuntimeName)(
+  def getRuntime(userInfo: UserInfo, cloudContext: CloudContext, runtimeName: RuntimeName)(
     implicit as: Ask[F, AppContext]
   ): F[GetRuntimeResponse]
 
-  def listRuntimes(userInfo: UserInfo, googleProject: Option[GoogleProject], params: Map[String, String])(
+  def listRuntimes(userInfo: UserInfo, cloudContext: Option[CloudContext], params: Map[String, String])(
     implicit as: Ask[F, AppContext]
   ): F[Vector[ListRuntimeResponse2]]
 
@@ -38,7 +38,7 @@ trait RuntimeService[F[_]] {
     implicit as: Ask[F, AppContext]
   ): F[Unit]
 
-  def stopRuntime(userInfo: UserInfo, googleProject: GoogleProject, runtimeName: RuntimeName)(
+  def stopRuntime(userInfo: UserInfo, cloudContext: CloudContext, runtimeName: RuntimeName)(
     implicit as: Ask[F, AppContext]
   ): F[Unit]
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeoException.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeoException.scala
@@ -45,13 +45,15 @@ final case class LeoInternalServerError(msg: String, traceId: Option[TraceId])
       traceId = traceId
     )
 
-case class RuntimeNotFoundException(googleProject: GoogleProject,
+case class RuntimeNotFoundException(cloudContext: CloudContext,
                                     runtimeName: RuntimeName,
                                     msg: String,
                                     traceId: Option[TraceId] = None)
-    extends LeoException(s"Runtime ${googleProject.value}/${runtimeName.asString} not found. Details: ${msg}",
-                         StatusCodes.NotFound,
-                         traceId = traceId)
+    extends LeoException(
+      s"Runtime ${cloudContext.asStringWithProvider}/${runtimeName.asString} not found. Details: ${msg}",
+      StatusCodes.NotFound,
+      traceId = traceId
+    )
 
 case class RuntimeNotFoundByIdException(id: Long, msg: String)
     extends LeoException(s"Runtime with id ${id} not found. Details: ${msg}", StatusCodes.NotFound, traceId = None)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/AutopauseMonitor.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/AutopauseMonitor.scala
@@ -40,7 +40,7 @@ class AutopauseMonitor[F[_]](
       clusters <- clusterQuery.getClustersReadyToAutoFreeze.transaction
       now <- F.realTimeInstant
       pauseableClusters <- clusters.toList.filterA { cluster =>
-        jupyterDAO.isAllKernelsIdle(cluster.googleProject, cluster.runtimeName).attempt.flatMap {
+        jupyterDAO.isAllKernelsIdle(cluster.cloudContext, cluster.runtimeName).attempt.flatMap {
           case Left(t) =>
             logger.error(s"Fail to get kernel status for ${cluster.projectNameString} due to $t").as(true)
           case Right(isIdle) =>
@@ -61,13 +61,13 @@ class AutopauseMonitor[F[_]](
                 metrics.incrementCounter("autoPause/maxKernelActiveTimeExceeded") >>
                   logger
                     .info(
-                      s"Auto pausing ${cluster.googleProject}/${cluster.runtimeName} due to exceeded max kernel active time"
+                      s"Auto pausing ${cluster.cloudContext}/${cluster.runtimeName} due to exceeded max kernel active time"
                     )
                     .as(true),
                 metrics.incrementCounter("autoPause/activeKernelClusters") >>
                   logger
                     .info(
-                      s"Not going to auto pause cluster ${cluster.googleProject}/${cluster.runtimeName} due to active kernels"
+                      s"Not going to auto pause cluster ${cluster.cloudContext}/${cluster.runtimeName} due to active kernels"
                     )
                     .as(false)
               )

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterToolMonitor.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterToolMonitor.scala
@@ -66,7 +66,7 @@ class ClusterToolMonitor(
       val toolName = status.tool.toString
       IO(
         logger.warn(
-          s"The tool ${toolName} is down on runtime ${status.runtime.googleProject.value}/${status.runtime.runtimeName.asString}"
+          s"The tool ${toolName} is down on runtime ${status.runtime.cloudContext.asStringWithProvider}/${status.runtime.runtimeName.asString}"
         )
       ) >> metrics.incrementCounter(toolName + "Down", 1)
     } else IO.unit
@@ -79,7 +79,7 @@ class ClusterToolMonitor(
   def checkClusterStatus(runtime: RunningRuntime): IO[List[ToolStatus]] =
     runtime.containers.traverse { tool =>
       tool
-        .isProxyAvailable(runtime.googleProject, runtime.runtimeName)
+        .isProxyAvailable(runtime.cloudContext, runtime.runtimeName)
         .map(status => ToolStatus(status, tool, runtime))
     }
 }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/leoPubsubMessageSubscriberModels.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/leoPubsubMessageSubscriberModels.scala
@@ -188,7 +188,7 @@ object LeoPubsubMessage {
                     traceId: Option[TraceId]): CreateRuntimeMessage =
       CreateRuntimeMessage(
         runtime.id,
-        RuntimeProjectAndName(runtime.googleProject, runtime.runtimeName),
+        RuntimeProjectAndName(runtime.cloudContext, runtime.runtimeName),
         runtime.serviceAccount,
         runtime.asyncRuntimeFields,
         runtime.auditInfo,
@@ -221,7 +221,9 @@ object LeoPubsubMessage {
     def fromDisk(disk: PersistentDisk, traceId: Option[TraceId]): CreateDiskMessage =
       CreateDiskMessage(
         disk.id,
-        disk.googleProject,
+        GoogleProject(
+          disk.cloudContext.asString
+        ), //TODO: we might think about use cloudContext in CreateDiskMessage to support Azure
         disk.name,
         disk.zone,
         disk.size,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/BaseRuntimeInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/BaseRuntimeInterpreter.scala
@@ -50,7 +50,7 @@ abstract private[util] class BaseRuntimeInterpreter[F[_]](
       // Flush the welder cache to disk
       _ <- if (params.runtimeAndRuntimeConfig.runtime.welderEnabled) {
         welderDao
-          .flushCache(params.runtimeAndRuntimeConfig.runtime.googleProject,
+          .flushCache(params.runtimeAndRuntimeConfig.runtime.cloudContext,
                       params.runtimeAndRuntimeConfig.runtime.runtimeName)
           .handleErrorWith(e =>
             logger.error(ctx.loggingCtx, e)(
@@ -144,8 +144,8 @@ abstract private[util] class BaseRuntimeInterpreter[F[_]](
         clusterQuery.updateWelder(runtime.id, RuntimeImage(Welder, newWelderImageUrl, None, now), now)
       }
 
-      newRuntime = runtime.copy(welderEnabled = true,
-                                runtimeImages = runtime.runtimeImages.filterNot(_.imageType == Welder) + welderImage)
+      newRuntime = runtime.copy(runtimeImages = runtime.runtimeImages.filterNot(_.imageType == Welder) + welderImage,
+                                welderEnabled = true)
     } yield newRuntime
 
   override def updateMachineType(params: UpdateMachineTypeParams)(implicit ev: Ask[F, AppContext]): F[Unit] =

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/DataprocInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/DataprocInterpreter.scala
@@ -67,7 +67,7 @@ final case class ClusterResourceConstraintsException(clusterProjectAndName: Runt
                                                      machineType: MachineTypeName,
                                                      region: RegionName)
     extends LeoException(
-      s"Unable to calculate memory constraints for cluster ${clusterProjectAndName.googleProject}/${clusterProjectAndName.runtimeName} with master machine type ${machineType} in region ${region}",
+      s"Unable to calculate memory constraints for cluster ${clusterProjectAndName.cloudContext}/${clusterProjectAndName.runtimeName} with master machine type ${machineType} in region ${region}",
       traceId = None
     )
 
@@ -116,34 +116,35 @@ class DataprocInterpreter[F[_]: Parallel](
             new RuntimeException("DataprocInterpreter shouldn't get a GCE request")
           )
       }
+      googleProject <- F.fromOption(
+        LeoLenses.cloudContextToGoogleProject.get(params.runtimeProjectAndName.cloudContext),
+        new RuntimeException("this should never happen. Dataproc runtime's cloud context should be a google project")
+      )
       initBucketName = generateUniqueBucketName("leoinit-" + params.runtimeProjectAndName.runtimeName.asString)
       stagingBucketName = generateUniqueBucketName("leostaging-" + params.runtimeProjectAndName.runtimeName.asString)
 
       createOp = for {
         // Set up VPC network and firewall
-        (network, subnetwork) <- vpcAlg.setUpProjectNetworkAndFirewalls(
-          SetUpProjectNetworkParams(params.runtimeProjectAndName.googleProject, machineConfig.region)
+        (_, subnetwork) <- vpcAlg.setUpProjectNetworkAndFirewalls(
+          SetUpProjectNetworkParams(googleProject, machineConfig.region)
         )
 
         // Add member to the Google Group that has the IAM role to pull the Dataproc image
-        _ <- updateDataprocImageGroupMembership(params.runtimeProjectAndName.googleProject, createCluster = true)
+        _ <- updateDataprocImageGroupMembership(googleProject, createCluster = true)
 
         // Set up IAM roles for the pet service account necessary to create a cluster.
-        _ <- createClusterIamRoles(params.runtimeProjectAndName.googleProject, params.serviceAccountInfo)
+        _ <- createClusterIamRoles(googleProject, params.serviceAccountInfo)
 
         // Create the bucket in the cluster's google project and populate with initialization files.
         // ACLs are granted so the cluster service account can access the files at initialization time.
         _ <- bucketHelper
-          .createInitBucket(params.runtimeProjectAndName.googleProject, initBucketName, params.serviceAccountInfo)
+          .createInitBucket(googleProject, initBucketName, params.serviceAccountInfo)
           .compile
           .drain
 
         // Create the cluster staging bucket. ACLs are granted so the user/pet can access it.
         _ <- bucketHelper
-          .createStagingBucket(params.auditInfo.creator,
-                               params.runtimeProjectAndName.googleProject,
-                               stagingBucketName,
-                               params.serviceAccountInfo)
+          .createStagingBucket(params.auditInfo.creator, googleProject, stagingBucketName, params.serviceAccountInfo)
           .compile
           .drain
 
@@ -256,9 +257,7 @@ class DataprocInterpreter[F[_]: Parallel](
             .getOrElse((None, None))
         } else (None, None)
 
-        softwareConfig = getSoftwareConfig(params.runtimeProjectAndName.googleProject,
-                                           params.runtimeProjectAndName.runtimeName,
-                                           machineConfig)
+        softwareConfig = getSoftwareConfig(googleProject, params.runtimeProjectAndName.runtimeName, machineConfig)
 
         // Enables Dataproc Component Gateway. Used for enabling cluster web UIs.
         // See https://cloud.google.com/dataproc/docs/concepts/accessing/dataproc-gateways
@@ -279,7 +278,7 @@ class DataprocInterpreter[F[_]: Parallel](
         )
 
         op <- googleDataprocService.createCluster(
-          params.runtimeProjectAndName.googleProject,
+          googleProject,
           machineConfig.region,
           DataprocClusterName(params.runtimeProjectAndName.runtimeName.asString),
           Some(createClusterConfig)
@@ -287,7 +286,7 @@ class DataprocInterpreter[F[_]: Parallel](
 
         asyncRuntimeFields = op.map(o =>
           AsyncRuntimeFields(
-            GoogleId(o.metadata.getClusterUuid),
+            ProxyHostName(o.metadata.getClusterUuid),
             o.name,
             stagingBucketName,
             None
@@ -338,7 +337,7 @@ class DataprocInterpreter[F[_]: Parallel](
 
       res <- createOp.handleErrorWith { throwable =>
         cleanUpGoogleResourcesOnError(
-          params.runtimeProjectAndName.googleProject,
+          googleProject,
           params.runtimeProjectAndName.runtimeName,
           initBucketName,
           params.serviceAccountInfo,
@@ -364,9 +363,12 @@ class DataprocInterpreter[F[_]: Parallel](
             googleComputeService
               .addInstanceMetadata(instance.key.project, instance.key.zone, instance.key.name, metadata)
         }
-
+        googleProject <- F.fromOption(
+          LeoLenses.cloudContextToGoogleProject.get(params.runtimeAndRuntimeConfig.runtime.cloudContext),
+          new RuntimeException("this should never happen. Dataproc runtime's cloud context should be a google project")
+        )
         _ <- googleDataprocService.deleteCluster(
-          params.runtimeAndRuntimeConfig.runtime.googleProject,
+          googleProject,
           region,
           DataprocClusterName(params.runtimeAndRuntimeConfig.runtime.runtimeName.asString)
         )
@@ -375,8 +377,12 @@ class DataprocInterpreter[F[_]: Parallel](
 
   override def finalizeDelete(params: FinalizeDeleteParams)(implicit ev: Ask[F, AppContext]): F[Unit] =
     for {
-      _ <- removeClusterIamRoles(params.runtime.googleProject, params.runtime.serviceAccount)
-      _ <- updateDataprocImageGroupMembership(params.runtime.googleProject, createCluster = false)
+      googleProject <- F.fromOption(
+        LeoLenses.cloudContextToGoogleProject.get(params.runtime.cloudContext),
+        new RuntimeException("this should never happen. Dataproc runtime's cloud context should be a google project")
+      )
+      _ <- removeClusterIamRoles(googleProject, params.runtime.serviceAccount)
+      _ <- updateDataprocImageGroupMembership(googleProject, createCluster = false)
     } yield ()
 
   override protected def stopGoogleRuntime(params: StopGoogleRuntime)(
@@ -388,8 +394,12 @@ class DataprocInterpreter[F[_]: Parallel](
         new RuntimeException("DataprocInterpreter shouldn't get a GCE request")
       )
       metadata <- getShutdownScript(params.runtimeAndRuntimeConfig)
+      googleProject <- F.fromOption(
+        LeoLenses.cloudContextToGoogleProject.get(params.runtimeAndRuntimeConfig.runtime.cloudContext),
+        new RuntimeException("this should never happen. Dataproc runtime's cloud context should be a google project")
+      )
       _ <- googleDataprocService.stopCluster(
-        params.runtimeAndRuntimeConfig.runtime.googleProject,
+        googleProject,
         region,
         DataprocClusterName(params.runtimeAndRuntimeConfig.runtime.runtimeName.asString),
         Some(metadata),
@@ -405,8 +415,12 @@ class DataprocInterpreter[F[_]: Parallel](
         LeoLenses.dataprocPrism.getOption(params.runtimeAndRuntimeConfig.runtimeConfig),
         new RuntimeException("DataprocInterpreter shouldn't get a GCE request")
       )
+      googleProject <- F.fromOption(
+        LeoLenses.cloudContextToGoogleProject.get(params.runtimeAndRuntimeConfig.runtime.cloudContext),
+        new RuntimeException("this should never happen. Dataproc runtime's cloud context should be a google project")
+      )
       resourceConstraints <- getClusterResourceContraints(
-        RuntimeProjectAndName(params.runtimeAndRuntimeConfig.runtime.googleProject,
+        RuntimeProjectAndName(params.runtimeAndRuntimeConfig.runtime.cloudContext,
                               params.runtimeAndRuntimeConfig.runtime.runtimeName),
         params.runtimeAndRuntimeConfig.runtimeConfig.machineType,
         dataprocConfig.region
@@ -418,7 +432,7 @@ class DataprocInterpreter[F[_]: Parallel](
                                    false)
 
       _ <- googleDataprocService.startCluster(
-        params.runtimeAndRuntimeConfig.runtime.googleProject,
+        googleProject,
         dataprocConfig.region,
         DataprocClusterName(params.runtimeAndRuntimeConfig.runtime.runtimeName.asString),
         dataprocConfig.numberOfPreemptibleWorkers,
@@ -428,21 +442,22 @@ class DataprocInterpreter[F[_]: Parallel](
 
   override def resizeCluster(params: ResizeClusterParams)(implicit ev: Ask[F, AppContext]): F[Unit] =
     (for {
-      ctx <- ev.ask
       region <- F.fromOption(
         LeoLenses.dataprocRegion.getOption(params.runtimeAndRuntimeConfig.runtimeConfig),
         new RuntimeException("DataprocInterpreter shouldn't get a GCE request")
       )
+      googleProject <- F.fromOption(
+        LeoLenses.cloudContextToGoogleProject.get(params.runtimeAndRuntimeConfig.runtime.cloudContext),
+        new RuntimeException("this should never happen. Dataproc runtime's cloud context should be a google project")
+      )
       // IAM roles should already exist for a non-deleted cluster; this method is a no-op if the roles already exist.
-      _ <- createClusterIamRoles(params.runtimeAndRuntimeConfig.runtime.googleProject,
-                                 params.runtimeAndRuntimeConfig.runtime.serviceAccount)
+      _ <- createClusterIamRoles(googleProject, params.runtimeAndRuntimeConfig.runtime.serviceAccount)
 
-      _ <- updateDataprocImageGroupMembership(params.runtimeAndRuntimeConfig.runtime.googleProject,
-                                              createCluster = true)
+      _ <- updateDataprocImageGroupMembership(googleProject, createCluster = true)
 
       // Resize the cluster in Google
       _ <- googleDataprocService.resizeCluster(
-        params.runtimeAndRuntimeConfig.runtime.googleProject,
+        googleProject,
         region,
         DataprocClusterName(params.runtimeAndRuntimeConfig.runtime.runtimeName.asString),
         params.numWorkers,
@@ -454,11 +469,15 @@ class DataprocInterpreter[F[_]: Parallel](
         // resize the cluster we need to revoke it manually here
         for {
           ctx <- ev.ask
-          _ <- removeClusterIamRoles(params.runtimeAndRuntimeConfig.runtime.googleProject,
-                                     params.runtimeAndRuntimeConfig.runtime.serviceAccount)
+          googleProject <- F.fromOption(
+            LeoLenses.cloudContextToGoogleProject.get(params.runtimeAndRuntimeConfig.runtime.cloudContext),
+            new RuntimeException(
+              "this should never happen. Dataproc runtime's cloud context should be a google project"
+            )
+          )
+          _ <- removeClusterIamRoles(googleProject, params.runtimeAndRuntimeConfig.runtime.serviceAccount)
           // Remove member from the Google Group that has the IAM role to pull the Dataproc image
-          _ <- updateDataprocImageGroupMembership(params.runtimeAndRuntimeConfig.runtime.googleProject,
-                                                  createCluster = false)
+          _ <- updateDataprocImageGroupMembership(googleProject, createCluster = false)
           _ <- logger.error(ctx.loggingCtx, e)(
             s"Could not successfully update cluster ${params.runtimeAndRuntimeConfig.runtime.projectNameString}"
           )
@@ -565,7 +584,7 @@ class DataprocInterpreter[F[_]: Parallel](
                                          createCluster: Boolean)(implicit ev: Ask[F, AppContext]): F[Unit] =
     parseImageProject(config.dataprocConfig.customDataprocImage).traverse_ { imageProject =>
       for {
-        count <- inTransaction(clusterQuery.countActiveByProject(googleProject))
+        count <- inTransaction(clusterQuery.countActiveByProject(CloudContext.Gcp(googleProject)))
         // Note: Don't remove the account if there are existing active clusters in the same project,
         // because it could potentially break other clusters. We only check this for the 'remove' case.
         _ <- if (count > 0 && !createCluster) {
@@ -658,16 +677,18 @@ class DataprocInterpreter[F[_]: Parallel](
   ): F[RuntimeResourceConstraints] =
     for {
       ctx <- ev.ask
+      googleProject <- F.fromOption(
+        LeoLenses.cloudContextToGoogleProject.get(runtimeProjectAndName.cloudContext),
+        new RuntimeException("this should never happen. Dataproc runtime's cloud context should be a google project")
+      )
       // Find an arbitrary zone in the configured region in which to query the machine type
-      zones <- googleComputeService.getZones(runtimeProjectAndName.googleProject, region)
+      zones <- googleComputeService.getZones(googleProject, region)
       zoneUri <- F.fromOption(zones.headOption.map(z => ZoneName(z.getName)),
                               ClusterResourceConstraintsException(runtimeProjectAndName, machineType, region))
       _ <- logger.debug(ctx.loggingCtx)(s"Using zone ${zoneUri} to resolve machine type")
 
       // Resolve the master machine type in Google to get the total memory.
-      resolvedMachineTypeOpt <- googleComputeService.getMachineType(runtimeProjectAndName.googleProject,
-                                                                    zoneUri,
-                                                                    machineType)
+      resolvedMachineTypeOpt <- googleComputeService.getMachineType(googleProject, zoneUri, machineType)
       resolvedMachineType <- F.fromOption(
         resolvedMachineTypeOpt,
         ClusterResourceConstraintsException(runtimeProjectAndName, machineType, region)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
@@ -918,8 +918,12 @@ class GKEInterpreter[F[_]](
       _ <- logger.info(ctx.loggingCtx)(
         s"Installing helm chart ${config.galaxyAppConfig.chart} for app ${appName.value} in cluster ${dbCluster.getGkeClusterId.toString}"
       )
+      googleProject <- F.fromOption(
+        LeoLenses.cloudContextToGoogleProject.get(nfsDisk.cloudContext),
+        new RuntimeException("this should never happen. Galaxy disk's cloud context should be a google project")
+      )
       postgresDiskNameOpt <- for {
-        disk <- getGalaxyPostgresDisk(nfsDisk.name, namespaceName, nfsDisk.googleProject, nfsDisk.zone)
+        disk <- getGalaxyPostgresDisk(nfsDisk.name, namespaceName, googleProject, nfsDisk.zone)
       } yield disk.map(x => DiskName(x.getName))
 
       postgresDiskName <- F.fromOption(

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GceInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GceInterpreter.scala
@@ -71,19 +71,20 @@ class GceInterpreter[F[_]](
             )
           )
       }
-
+      googleProject <- F.fromOption(
+        LeoLenses.cloudContextToGoogleProject.get(params.runtimeProjectAndName.cloudContext),
+        new RuntimeException("this should never happen. GCE runtime's cloud context should be a google project")
+      )
       // We get region by removing the last two characters of zone
       regionParam = RegionName(zoneParam.value.substring(0, zoneParam.value.length - 2))
 
       // Set up VPC and firewall
       (_, subnetwork) <- vpcAlg.setUpProjectNetworkAndFirewalls(
-        SetUpProjectNetworkParams(params.runtimeProjectAndName.googleProject, regionParam)
+        SetUpProjectNetworkParams(googleProject, regionParam)
       )
 
       // Get resource (e.g. memory) constraints for the instance
-      resourceConstraints <- getResourceConstraints(params.runtimeProjectAndName.googleProject,
-                                                    zoneParam,
-                                                    params.runtimeConfig.machineType)
+      resourceConstraints <- getResourceConstraints(googleProject, zoneParam, params.runtimeConfig.machineType)
 
       // Create the bucket in the cluster's google project and populate with initialization files.
       // ACLs are granted so the cluster service account can access the files at initialization time.
@@ -91,15 +92,12 @@ class GceInterpreter[F[_]](
       stagingBucketName = generateUniqueBucketName("leostaging-" + params.runtimeProjectAndName.runtimeName.asString)
 
       _ <- bucketHelper
-        .createInitBucket(params.runtimeProjectAndName.googleProject, initBucketName, params.serviceAccountInfo)
+        .createInitBucket(googleProject, initBucketName, params.serviceAccountInfo)
         .compile
         .drain
 
       _ <- bucketHelper
-        .createStagingBucket(params.auditInfo.creator,
-                             params.runtimeProjectAndName.googleProject,
-                             stagingBucketName,
-                             params.serviceAccountInfo)
+        .createStagingBucket(params.auditInfo.creator, googleProject, stagingBucketName, params.serviceAccountInfo)
         .compile
         .drain
 
@@ -170,8 +168,7 @@ class GceInterpreter[F[_]](
                   .setDiskSizeGb(persistentDisk.size.gb)
                   .putAllLabels(Map("leonardo" -> "true").asJava)
                   .setDiskType(
-                    persistentDisk.diskType.googleString(params.runtimeProjectAndName.googleProject,
-                                                         persistentDisk.zone)
+                    persistentDisk.diskType.googleString(googleProject, persistentDisk.zone)
                   )
                   .build()
               )
@@ -229,7 +226,9 @@ class GceInterpreter[F[_]](
         .setDescription("Leonardo Managed VM")
         .setTags(Tags.newBuilder().addItems(config.vpcConfig.networkTag.value).build())
         .setMachineType(buildMachineTypeUri(zoneParam, params.runtimeConfig.machineType))
-        .addNetworkInterfaces(buildNetworkInterfaces(params.runtimeProjectAndName, subnetwork, zoneParam))
+        .addNetworkInterfaces(
+          buildNetworkInterfaces(params.runtimeProjectAndName, subnetwork, zoneParam, googleProject)
+        )
         .addAllDisks(
           List(bootDisk, userDisk).asJava
         )
@@ -282,7 +281,7 @@ class GceInterpreter[F[_]](
       instance = gpuConfig match {
         case Some(gc) =>
           val acceleratorType =
-            s"projects/${params.runtimeProjectAndName.googleProject.value}/zones/${zoneParam.value}/acceleratorTypes/${gc.gpuType.asString}"
+            s"projects/${googleProject.value}/zones/${zoneParam.value}/acceleratorTypes/${gc.gpuType.asString}"
           instanceBuilder
             .addGuestAccelerators(
               AcceleratorConfig
@@ -303,11 +302,11 @@ class GceInterpreter[F[_]](
 
       }
 
-      operation <- googleComputeService.createInstance(params.runtimeProjectAndName.googleProject, zoneParam, instance)
+      operation <- googleComputeService.createInstance(googleProject, zoneParam, instance)
 
       res = operation.map(o =>
         CreateGoogleRuntimeResponse(
-          AsyncRuntimeFields(GoogleId(o.getTargetId.toString), OperationName(o.getName), stagingBucketName, None),
+          AsyncRuntimeFields(ProxyHostName(o.getTargetId.toString), OperationName(o.getName), stagingBucketName, None),
           initBucketName,
           BootSource.VmImage(config.gceConfig.sourceImage)
         )
@@ -324,14 +323,18 @@ class GceInterpreter[F[_]](
           "GceInterpreter shouldn't get a stop dataproc runtime request. Something is very wrong"
         )
       )
+      googleProject <- F.fromOption(
+        LeoLenses.cloudContextToGoogleProject.get(params.runtimeAndRuntimeConfig.runtime.cloudContext),
+        new RuntimeException("this should never happen. GCE runtime's cloud context should be a google project")
+      )
       metadata <- getShutdownScript(params.runtimeAndRuntimeConfig)
       _ <- googleComputeService.addInstanceMetadata(
-        params.runtimeAndRuntimeConfig.runtime.googleProject,
+        googleProject,
         zoneParam,
         InstanceName(params.runtimeAndRuntimeConfig.runtime.runtimeName.asString),
         metadata
       )
-      r <- googleComputeService.stopInstance(params.runtimeAndRuntimeConfig.runtime.googleProject,
+      r <- googleComputeService.stopInstance(googleProject,
                                              zoneParam,
                                              InstanceName(params.runtimeAndRuntimeConfig.runtime.runtimeName.asString))
     } yield Some(r)
@@ -341,13 +344,17 @@ class GceInterpreter[F[_]](
   ): F[Unit] =
     for {
       ctx <- ev.ask
+      googleProject <- F.fromOption(
+        LeoLenses.cloudContextToGoogleProject.get(params.runtimeAndRuntimeConfig.runtime.cloudContext),
+        new RuntimeException("this should never happen. GCE runtime's cloud context should be a google project")
+      )
       zoneParam <- F.fromOption(
         LeoLenses.gceZone.getOption(params.runtimeAndRuntimeConfig.runtimeConfig),
         new RuntimeException(
           "GceInterpreter shouldn't get a dataproc runtime creation request. Something is very wrong"
         )
       )
-      resourceConstraints <- getResourceConstraints(params.runtimeAndRuntimeConfig.runtime.googleProject,
+      resourceConstraints <- getResourceConstraints(googleProject,
                                                     zoneParam,
                                                     params.runtimeAndRuntimeConfig.runtimeConfig.machineType)
       metadata <- getStartupScript(params.runtimeAndRuntimeConfig,
@@ -357,13 +364,13 @@ class GceInterpreter[F[_]](
                                    true)
       // remove the startup-script-url metadata entry if present which is only used at creation time
       _ <- googleComputeService.modifyInstanceMetadata(
-        params.runtimeAndRuntimeConfig.runtime.googleProject,
+        googleProject,
         zoneParam,
         InstanceName(params.runtimeAndRuntimeConfig.runtime.runtimeName.asString),
         metadataToAdd = metadata,
         metadataToRemove = Set("startup-script-url")
       )
-      _ <- googleComputeService.startInstance(params.runtimeAndRuntimeConfig.runtime.googleProject,
+      _ <- googleComputeService.startInstance(googleProject,
                                               zoneParam,
                                               InstanceName(params.runtimeAndRuntimeConfig.runtime.runtimeName.asString))
     } yield ()
@@ -378,8 +385,12 @@ class GceInterpreter[F[_]](
           "GceInterpreter shouldn't get a dataproc runtime creation request. Something is very wrong"
         )
       )
+      googleProject <- F.fromOption(
+        LeoLenses.cloudContextToGoogleProject.get(params.runtimeAndRuntimeConfig.runtime.cloudContext),
+        new RuntimeException("this should never happen. GCE runtime's cloud context should be a google project")
+      )
       _ <- googleComputeService.setMachineType(
-        params.runtimeAndRuntimeConfig.runtime.googleProject,
+        googleProject,
         zoneParam,
         InstanceName(params.runtimeAndRuntimeConfig.runtime.runtimeName.asString),
         params.machineType
@@ -398,9 +409,13 @@ class GceInterpreter[F[_]](
           )
         )
         metadata <- getShutdownScript(params.runtimeAndRuntimeConfig)
+        googleProject <- F.fromOption(
+          LeoLenses.cloudContextToGoogleProject.get(params.runtimeAndRuntimeConfig.runtime.cloudContext),
+          new RuntimeException("this should never happen. GCE runtime's cloud context should be a google project")
+        )
         _ <- googleComputeService
           .addInstanceMetadata(
-            params.runtimeAndRuntimeConfig.runtime.googleProject,
+            googleProject,
             zoneParam,
             InstanceName(params.runtimeAndRuntimeConfig.runtime.runtimeName.asString),
             metadata
@@ -412,7 +427,7 @@ class GceInterpreter[F[_]](
             case e => F.raiseError[Unit](e)
           }
         op <- googleComputeService
-          .deleteInstance(params.runtimeAndRuntimeConfig.runtime.googleProject,
+          .deleteInstance(googleProject,
                           zoneParam,
                           InstanceName(params.runtimeAndRuntimeConfig.runtime.runtimeName.asString))
       } yield op
@@ -466,14 +481,13 @@ class GceInterpreter[F[_]](
 
   private def buildNetworkInterfaces(runtimeProjectAndName: RuntimeProjectAndName,
                                      subnetwork: SubnetworkName,
-                                     zone: ZoneName): NetworkInterface =
+                                     zone: ZoneName,
+                                     googleProject: GoogleProject): NetworkInterface =
     // We get region by removing the last two characters of zone
     NetworkInterface
       .newBuilder()
       .setSubnetwork(
-        buildSubnetworkUri(runtimeProjectAndName.googleProject,
-                           RegionName(zone.value.substring(0, zone.value.length - 2)),
-                           subnetwork)
+        buildSubnetworkUri(googleProject, RegionName(zone.value.substring(0, zone.value.length - 2)), subnetwork)
       )
       .addAccessConfigs(AccessConfig.newBuilder().setName("Leonardo VM external IP").build)
       .build

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/RuntimeTemplateValues.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/RuntimeTemplateValues.scala
@@ -150,7 +150,7 @@ object RuntimeTemplateValuesConfig {
                   useGceStartupScript: Boolean): RuntimeTemplateValuesConfig = {
     val runtime = runtimeAndRuntimeConfig.runtime
     RuntimeTemplateValuesConfig(
-      RuntimeProjectAndName(runtime.googleProject, runtime.runtimeName),
+      RuntimeProjectAndName(runtime.cloudContext, runtime.runtimeName),
       runtimeAndRuntimeConfig.runtimeConfig match {
         case gce: RuntimeConfig.GceConfig       => gce.gpuConfig.isDefined
         case gce: RuntimeConfig.GceWithPdConfig => gce.gpuConfig.isDefined
@@ -191,7 +191,7 @@ object RuntimeTemplateValues {
         .flatMap(_.homeDirectory.map(_.toString))
         .getOrElse("/home/jupyter")
     RuntimeTemplateValues(
-      config.runtimeProjectAndName.googleProject.value,
+      config.runtimeProjectAndName.cloudContext.asString,
       config.gpuEnabled.toString,
       config.runtimeProjectAndName.runtimeName.asString,
       config.initBucketName.map(_.value).getOrElse(""),

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/CommonTestData.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/CommonTestData.scala
@@ -66,7 +66,9 @@ object CommonTestData {
   val name3 = RuntimeName("clustername3")
   val runtimeSamResource = RuntimeSamResourceId("067e2867-5d4a-47f3-a53c-fd711529b287")
   val project = GoogleProject("dsp-leo-test")
+  val cloudContext = CloudContext.Gcp(project)
   val project2 = GoogleProject("dsp-leo-test-2")
+  val cloudContext2 = CloudContext.Gcp(project2)
   val userEmail = WorkbenchEmail("user1@example.com")
   val userEmail2 = WorkbenchEmail("user2@example.com")
   val userInfo = UserInfo(OAuth2BearerToken("accessToken"), WorkbenchUserId("user1"), userEmail, 0)
@@ -105,7 +107,7 @@ object CommonTestData {
   )
   val zone = ZoneName("us-central1-a")
   val diskName = DiskName("disk-name")
-  val googleId = GoogleId("google-id")
+  val googleId = ProxyHostName("google-id")
   val diskSamResource = PersistentDiskSamResourceId("disk-resource-id")
   val diskSize = DiskSize(250)
   val diskType = leonardo.DiskType.Standard
@@ -181,7 +183,7 @@ object CommonTestData {
 
   def makeAsyncRuntimeFields(index: Int): AsyncRuntimeFields =
     AsyncRuntimeFields(
-      GoogleId(UUID.randomUUID().toString),
+      ProxyHostName(UUID.randomUUID().toString),
       OperationName("operationName" + index.toString),
       GcsBucketName("stagingbucketname" + index.toString),
       Some(IP("numbers.and.dots"))
@@ -255,14 +257,14 @@ object CommonTestData {
     val clusterName = RuntimeName("clustername" + index.toString)
     Runtime(
       id = -1,
-      runtimeName = clusterName,
       samResource = runtimeSamResource,
-      googleProject = project,
+      runtimeName = clusterName,
+      cloudContext = cloudContext,
       serviceAccount = serviceAccount,
       asyncRuntimeFields = Some(makeAsyncRuntimeFields(index)),
       auditInfo = auditInfo,
       kernelFoundBusyDate = None,
-      proxyUrl = Runtime.getProxyUrl(proxyUrlBase, project, clusterName, Set(jupyterImage), Map.empty),
+      proxyUrl = Runtime.getProxyUrl(proxyUrlBase, cloudContext, clusterName, Set(jupyterImage), Map.empty),
       status = RuntimeStatus.Unknown,
       labels = Map(),
       userScriptUri = None,
@@ -284,16 +286,16 @@ object CommonTestData {
 
   val testCluster = Runtime(
     id = -1,
-    runtimeName = name1,
     samResource = runtimeSamResource,
-    googleProject = project,
+    runtimeName = name1,
+    cloudContext = cloudContext,
     serviceAccount = serviceAccount,
     asyncRuntimeFields = Some(
-      AsyncRuntimeFields(GoogleId(UUID.randomUUID().toString), OperationName("op"), stagingBucketName, None)
+      AsyncRuntimeFields(ProxyHostName(UUID.randomUUID().toString), OperationName("op"), stagingBucketName, None)
     ),
     auditInfo = AuditInfo(userEmail, Instant.now(), None, Instant.now()),
     kernelFoundBusyDate = None,
-    proxyUrl = Runtime.getProxyUrl(proxyUrlBase, project, name1, Set(jupyterImage), Map.empty),
+    proxyUrl = Runtime.getProxyUrl(proxyUrlBase, cloudContext, name1, Set(jupyterImage), Map.empty),
     status = RuntimeStatus.Unknown,
     labels = Map(),
     userScriptUri = Some(UserScriptPath.Gcs(GcsPath(GcsBucketName("bucket-name"), GcsObjectName("userScript")))),
@@ -317,8 +319,8 @@ object CommonTestData {
     id = -1,
     runtimeName = name1,
     internalId = runtimeSamResource.resourceId,
-    googleProject = project,
-    googleId = testCluster.asyncRuntimeFields.map(_.googleId),
+    cloudContext = cloudContext,
+    googleId = testCluster.asyncRuntimeFields.map(_.proxyHostName),
     operationName = testCluster.asyncRuntimeFields.map(_.operationName.value),
     status = testCluster.status,
     auditInfo = testCluster.auditInfo,
@@ -363,13 +365,12 @@ object CommonTestData {
                          formattedBy: Option[FormattedBy] = None,
                          galaxyRestore: Option[GalaxyRestore] = None,
                          zoneName: Option[ZoneName] = None,
-                         googleProject: Option[GoogleProject] = None): PersistentDisk =
+                         cloudContextOpt: Option[CloudContext] = None): PersistentDisk =
     PersistentDisk(
       DiskId(-1),
-      googleProject.getOrElse(project),
+      cloudContextOpt.getOrElse(cloudContext),
       zoneName.getOrElse(zone),
       diskName.getOrElse(DiskName("disk")),
-      Some(googleId),
       serviceAccount,
       diskSamResource,
       DiskStatus.Ready,

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/TestUtils.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/TestUtils.scala
@@ -204,11 +204,11 @@ object TestUtils extends Matchers {
   }
 
   def stripFieldsForListCluster: Runtime => Runtime = { cluster =>
-    cluster.copy(dataprocInstances = Set.empty,
+    cluster.copy(errors = List.empty,
+                 dataprocInstances = Set.empty,
+                 userJupyterExtensionConfig = None,
                  runtimeImages = Set.empty,
-                 errors = List.empty,
-                 scopes = Set.empty,
-                 userJupyterExtensionConfig = None)
+                 scopes = Set.empty)
   }
 
   def sslContext(implicit as: ActorSystem): SSLContext =

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpJupyterDAOSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpJupyterDAOSpec.scala
@@ -69,7 +69,7 @@ class HttpJupyterDAOSpec extends AnyFlatSpec with Matchers with LeonardoTestSuit
       new RuntimeDnsCache(proxyConfig, testDbRef, hostToIpMapping, runtimeDnsCaffeineCache)
 
     val jupyterDAO = new HttpJupyterDAO(clusterDnsCache, FakeHttpClient.client)
-    val res = jupyterDAO.isAllKernelsIdle(GoogleProject("project1"), RuntimeName("rt"))
+    val res = jupyterDAO.isAllKernelsIdle(CloudContext.Gcp(GoogleProject("project1")), RuntimeName("rt"))
     res.map(r => r shouldBe true).unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/MockJupyterDAO.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/MockJupyterDAO.scala
@@ -1,14 +1,14 @@
 package org.broadinstitute.dsde.workbench.leonardo.dao
 
 import cats.effect.IO
-import org.broadinstitute.dsde.workbench.leonardo.RuntimeName
+import org.broadinstitute.dsde.workbench.leonardo.{CloudContext, RuntimeName}
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 
 class MockJupyterDAO(isUp: Boolean = true) extends JupyterDAO[IO] {
-  override def isProxyAvailable(googleProject: GoogleProject, clusterName: RuntimeName): IO[Boolean] =
+  override def isProxyAvailable(cloudContext: CloudContext, clusterName: RuntimeName): IO[Boolean] =
     IO.pure(isUp)
 
-  override def isAllKernelsIdle(googleProject: GoogleProject, clusterName: RuntimeName): IO[Boolean] =
+  override def isAllKernelsIdle(cloudContext: CloudContext, clusterName: RuntimeName): IO[Boolean] =
     IO.pure(isUp)
 
   override def createTerminal(googleProject: GoogleProject, runtimeName: RuntimeName): IO[Unit] = IO.unit

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/MockRStudioDAO.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/MockRStudioDAO.scala
@@ -1,11 +1,10 @@
 package org.broadinstitute.dsde.workbench.leonardo.dao
 
 import cats.effect.IO
-import org.broadinstitute.dsde.workbench.leonardo.RuntimeName
-import org.broadinstitute.dsde.workbench.model.google.GoogleProject
+import org.broadinstitute.dsde.workbench.leonardo.{CloudContext, RuntimeName}
 
 class MockRStudioDAO(isUp: Boolean = true) extends RStudioDAO[IO] {
-  override def isProxyAvailable(googleProject: GoogleProject, clusterName: RuntimeName): IO[Boolean] =
+  override def isProxyAvailable(cloudContext: CloudContext, clusterName: RuntimeName): IO[Boolean] =
     IO.pure(isUp)
 }
 

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/MockToolDAO.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/MockToolDAO.scala
@@ -1,11 +1,10 @@
 package org.broadinstitute.dsde.workbench.leonardo.dao
 
 import cats.effect.IO
-import org.broadinstitute.dsde.workbench.leonardo.{RuntimeContainerServiceType, RuntimeName}
-import org.broadinstitute.dsde.workbench.model.google.GoogleProject
+import org.broadinstitute.dsde.workbench.leonardo.{CloudContext, RuntimeContainerServiceType, RuntimeName}
 
 class MockToolDAO(isProxyAvailable: Boolean) extends ToolDAO[IO, RuntimeContainerServiceType] {
-  override def isProxyAvailable(googleProject: GoogleProject, runtimeName: RuntimeName): IO[Boolean] =
+  override def isProxyAvailable(cloudContext: CloudContext, runtimeName: RuntimeName): IO[Boolean] =
     IO.pure(isProxyAvailable)
 }
 

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/MockWelderDAO.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/MockWelderDAO.scala
@@ -1,13 +1,12 @@
 package org.broadinstitute.dsde.workbench.leonardo.dao
 
 import cats.effect.IO
-import org.broadinstitute.dsde.workbench.leonardo.RuntimeName
-import org.broadinstitute.dsde.workbench.model.google.GoogleProject
+import org.broadinstitute.dsde.workbench.leonardo.{CloudContext, RuntimeName}
 
 class MockWelderDAO(isUp: Boolean = true) extends WelderDAO[IO] {
-  override def isProxyAvailable(googleProject: GoogleProject, clusterName: RuntimeName): IO[Boolean] = IO.pure(isUp)
+  override def isProxyAvailable(cloudContext: CloudContext, clusterName: RuntimeName): IO[Boolean] = IO.pure(isUp)
 
-  override def flushCache(googleProject: GoogleProject, clusterName: RuntimeName): IO[Unit] = IO.unit
+  override def flushCache(cloudContext: CloudContext, clusterName: RuntimeName): IO[Unit] = IO.unit
 }
 
 object MockWelderDAO extends MockWelderDAO(isUp = true)

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/ExtensionComponentSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/ExtensionComponentSpec.scala
@@ -12,7 +12,7 @@ import org.scalatest.flatspec.AnyFlatSpecLike
 class ExtensionComponentSpec extends AnyFlatSpecLike with TestComponent with GcsPathUtils {
   "ExtensionComponent" should "save, get,and delete" in isolatedDbTest {
     val savedCluster1 = makeCluster(1)
-      .copy(userJupyterExtensionConfig = Some(userExtConfig), userScriptUri = Some(userScriptUri))
+      .copy(userScriptUri = Some(userScriptUri), userJupyterExtensionConfig = Some(userExtConfig))
       .save()
 
     val savedCluster2 = makeCluster(2).save()

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/PersistentDiskComponentSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/PersistentDiskComponentSpec.scala
@@ -19,7 +19,7 @@ class PersistentDiskComponentSpec extends AnyFlatSpecLike with TestComponent {
   "PersistentDiskComponent" should "save and get records" in isolatedDbTest {
     val disk1 = makePersistentDisk(Some(DiskName("d1")))
     val disk2 =
-      makePersistentDisk(Some(DiskName("d2"))).copy(size = DiskSize(1000), blockSize = BlockSize(16384), diskType = SSD)
+      makePersistentDisk(Some(DiskName("d2"))).copy(size = DiskSize(1000), diskType = SSD, blockSize = BlockSize(16384))
 
     val res = for {
       savedDisk1 <- disk1.save()
@@ -43,8 +43,8 @@ class PersistentDiskComponentSpec extends AnyFlatSpecLike with TestComponent {
     val res = for {
       disk <- makePersistentDisk(Some(DiskName("d1"))).save()
       _ <- deletedDisk.save()
-      d1 <- persistentDiskQuery.getActiveByName(disk.googleProject, disk.name).transaction
-      d2 <- persistentDiskQuery.getActiveByName(deletedDisk.googleProject, deletedDisk.name).transaction
+      d1 <- persistentDiskQuery.getActiveByName(disk.cloudContext, disk.name).transaction
+      d2 <- persistentDiskQuery.getActiveByName(deletedDisk.cloudContext, deletedDisk.name).transaction
     } yield {
       d1.get shouldEqual disk
       d2 shouldEqual None

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/TestComponent.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/TestComponent.scala
@@ -6,7 +6,7 @@ import org.broadinstitute.dsde.workbench.leonardo.config.{Config, LiquibaseConfi
 import org.broadinstitute.dsde.workbench.leonardo.db.LeoProfile.dummyDate
 import org.broadinstitute.dsde.workbench.leonardo.{
   App,
-  AppContext,
+  CloudContext,
   CommonTestData,
   DefaultNodepool,
   GcsPathUtils,
@@ -19,7 +19,7 @@ import org.broadinstitute.dsde.workbench.leonardo.{
   RuntimeConfig,
   RuntimeName
 }
-import org.broadinstitute.dsde.workbench.model.google.{GoogleProject, ServiceAccountKeyId}
+import org.broadinstitute.dsde.workbench.model.google.ServiceAccountKeyId
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.time.{Seconds, Span}
 import org.scalatest.{BeforeAndAfterAll, TestSuite}
@@ -93,12 +93,12 @@ trait TestComponent extends LeonardoTestSuite with ScalaFutures with GcsPathUtil
     }
 
   protected def getClusterId(getClusterIdRequest: GetClusterKey): Long =
-    getClusterId(getClusterIdRequest.googleProject, getClusterIdRequest.clusterName, getClusterIdRequest.destroyedDate)
+    getClusterId(getClusterIdRequest.cloudContext, getClusterIdRequest.clusterName, getClusterIdRequest.destroyedDate)
 
-  protected def getClusterId(googleProject: GoogleProject,
+  protected def getClusterId(cloudContext: CloudContext,
                              clusterName: RuntimeName,
                              destroyedDateOpt: Option[Instant]): Long =
-    dbFutureValue(clusterQuery.getIdByUniqueKey(googleProject, clusterName, destroyedDateOpt)).get
+    dbFutureValue(clusterQuery.getIdByUniqueKey(cloudContext, clusterName, destroyedDateOpt)).get
 
   implicit class ClusterExtensions(cluster: Runtime) {
     def save(serviceAccountKeyId: Option[ServiceAccountKeyId] = Some(defaultServiceAccountKeyId)): Runtime =

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dns/RuntimeDnsCacheSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dns/RuntimeDnsCacheSpec.scala
@@ -29,25 +29,25 @@ class RuntimeDnsCacheSpec
 
   val clusterBeingCreated: Runtime =
     makeCluster(2)
-      .copy(status = RuntimeStatus.Creating, asyncRuntimeFields = Some(makeAsyncRuntimeFields(2).copy(hostIp = None)))
+      .copy(asyncRuntimeFields = Some(makeAsyncRuntimeFields(2).copy(hostIp = None)), status = RuntimeStatus.Creating)
   val runningCluster: Runtime = makeCluster(1).copy(status = RuntimeStatus.Running)
   val stoppedCluster: Runtime =
     makeCluster(3)
-      .copy(status = RuntimeStatus.Stopped, asyncRuntimeFields = Some(makeAsyncRuntimeFields(2).copy(hostIp = None)))
+      .copy(asyncRuntimeFields = Some(makeAsyncRuntimeFields(2).copy(hostIp = None)), status = RuntimeStatus.Stopped)
 
   val cacheKeyForClusterBeingCreated =
-    RuntimeDnsCacheKey(clusterBeingCreated.googleProject, clusterBeingCreated.runtimeName)
-  val cacheKeyForRunningCluster = RuntimeDnsCacheKey(runningCluster.googleProject, runningCluster.runtimeName)
-  val cacheKeyForStoppedCluster = RuntimeDnsCacheKey(stoppedCluster.googleProject, stoppedCluster.runtimeName)
+    RuntimeDnsCacheKey(clusterBeingCreated.cloudContext, clusterBeingCreated.runtimeName)
+  val cacheKeyForRunningCluster = RuntimeDnsCacheKey(runningCluster.cloudContext, runningCluster.runtimeName)
+  val cacheKeyForStoppedCluster = RuntimeDnsCacheKey(stoppedCluster.cloudContext, stoppedCluster.runtimeName)
 
   val runningClusterHost = Host(
-    s"${runningCluster.asyncRuntimeFields.map(_.googleId).get.value.toString}.jupyter.firecloud.org"
+    s"${runningCluster.asyncRuntimeFields.map(_.proxyHostName).get.value.toString}.jupyter.firecloud.org"
   )
   val clusterBeingCreatedHost = Host(
-    s"${clusterBeingCreated.asyncRuntimeFields.map(_.googleId).get.value.toString}.jupyter.firecloud.org"
+    s"${clusterBeingCreated.asyncRuntimeFields.map(_.proxyHostName).get.value.toString}.jupyter.firecloud.org"
   )
   val stoppedClusterHost = Host(
-    s"${stoppedCluster.asyncRuntimeFields.map(_.googleId).get.value.toString}.jupyter.firecloud.org"
+    s"${stoppedCluster.asyncRuntimeFields.map(_.proxyHostName).get.value.toString}.jupyter.firecloud.org"
   )
   val underlyingRuntimeDnsCache =
     Caffeine.newBuilder().maximumSize(10000L).recordStats().build[String, scalacache.Entry[HostStatus]]()

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/HttpRoutesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/HttpRoutesSpec.scala
@@ -145,7 +145,7 @@ class HttpRoutesSpec
       responseClusters should have size 1
 
       val cluster = responseClusters.head
-      cluster.googleProject shouldEqual GoogleProject(googleProject)
+      cluster.cloudContext shouldEqual CloudContext.Gcp(GoogleProject(googleProject))
       cluster.clusterName shouldEqual RuntimeName(s"${clusterName}-6")
       cluster.labels shouldEqual Map(
         "clusterName" -> s"${clusterName}-6",
@@ -167,7 +167,7 @@ class HttpRoutesSpec
       responseClusters should have size 1
 
       val cluster = responseClusters.head
-      cluster.googleProject.value shouldEqual googleProject
+      cluster.cloudContext.asString shouldEqual googleProject
       cluster.clusterName shouldEqual RuntimeName(s"${clusterName}-4")
       cluster.labels shouldEqual Map(
         "clusterName" -> s"${clusterName}-4",
@@ -621,7 +621,7 @@ object HttpRoutesSpec {
     for {
       id <- x.downField("id").as[Long]
       clusterName <- x.downField("runtimeName").as[RuntimeName]
-      googleProject <- x.downField("googleProject").as[GoogleProject]
+      cloudContext <- x.downField("cloudContext").as[CloudContext]
       auditInfo <- x.downField("auditInfo").as[AuditInfo]
       machineConfig <- x.downField("runtimeConfig").as[RuntimeConfig]
       clusterUrl <- x.downField("proxyUrl").as[URL]
@@ -632,7 +632,7 @@ object HttpRoutesSpec {
       id,
       RuntimeSamResourceId("fakeId"),
       clusterName,
-      googleProject,
+      cloudContext,
       auditInfo,
       machineConfig,
       clusterUrl,

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/RuntimeRoutesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/RuntimeRoutesSpec.scala
@@ -329,7 +329,7 @@ class RuntimeRoutesSpec extends AnyFlatSpec with Matchers with LeonardoTestSuite
       -1,
       runtimeSamResource,
       name1,
-      project,
+      cloudContext,
       auditInfo.copy(createdDate = date, dateAccessed = date),
       gceRuntimeConfigWithGpu,
       new URL("https://leo.org/proxy"),
@@ -344,6 +344,10 @@ class RuntimeRoutesSpec extends AnyFlatSpec with Matchers with LeonardoTestSuite
         |  "id" : -1,
         |  "runtimeName" : "clustername1",
         |  "googleProject" : "dsp-leo-test",
+        |  "cloudContext" : {
+        |    "cloudProvider" : "GCP",
+        |    "cloudResource" : "dsp-leo-test"
+        |  },
         |  "auditInfo" : {
         |    "creator" : "user1@example.com",
         |    "createdDate" : "2020-11-20T17:23:24.650Z",
@@ -377,9 +381,9 @@ class RuntimeRoutesSpec extends AnyFlatSpec with Matchers with LeonardoTestSuite
       -1,
       runtimeSamResource,
       name1,
-      project,
+      cloudContext,
       serviceAccountEmail,
-      Some(makeAsyncRuntimeFields(1).copy(googleId = GoogleId(uuid.toString))),
+      Some(makeAsyncRuntimeFields(1).copy(proxyHostName = ProxyHostName(uuid.toString))),
       auditInfo.copy(createdDate = date, dateAccessed = date),
       Some(date),
       defaultGceRuntimeConfig,
@@ -406,6 +410,10 @@ class RuntimeRoutesSpec extends AnyFlatSpec with Matchers with LeonardoTestSuite
         |  "id" : -1,
         |  "runtimeName" : "clustername1",
         |  "googleProject" : "dsp-leo-test",
+        |  "cloudContext" : {
+        |    "cloudProvider" : "GCP",
+        |    "cloudResource" : "dsp-leo-test"
+        |  },
         |  "serviceAccount" : "pet-1234567890@test-project.iam.gserviceaccount.com",
         |  "asyncRuntimeFields" : {
         |    "googleId" : "65bc3f6d-a413-4cbe-88f8-b15ed9694543",

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/AppServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/AppServiceInterpSpec.scala
@@ -288,7 +288,7 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
 
   it should "not able to create an app with an existing non-used disk" in isolatedDbTest {
     val disk = makePersistentDisk(None)
-      .copy(googleProject = project)
+      .copy(cloudContext = cloudContext)
       .save()
       .unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
 
@@ -314,7 +314,7 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
     val disk = makePersistentDisk(None,
                                   formattedBy = Some(FormattedBy.Galaxy),
                                   galaxyRestore = Some(GalaxyRestore(PvcId("pv-id"), PvcId("pv-id2"), app.id)))
-      .copy(googleProject = project)
+      .copy(cloudContext = cloudContext)
       .save()
       .unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
 
@@ -340,7 +340,7 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
     val disk = makePersistentDisk(None,
                                   galaxyRestore = Some(GalaxyRestore(PvcId("pv-id"), PvcId("pv-id2"), app.id)),
                                   formattedBy = Some(FormattedBy.Galaxy))
-      .copy(googleProject = project)
+      .copy(cloudContext = cloudContext)
       .save()
       .unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
 
@@ -367,7 +367,7 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
 
   it should "error creating an app with an existing disk if no restore info found" in isolatedDbTest {
     val disk = makePersistentDisk(None, formattedBy = Some(FormattedBy.Galaxy))
-      .copy(googleProject = project)
+      .copy(cloudContext = cloudContext)
       .save()
       .unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
 
@@ -404,7 +404,7 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
     val disk = makePersistentDisk(None,
                                   formattedBy = Some(FormattedBy.Galaxy),
                                   galaxyRestore = Some(GalaxyRestore(PvcId("pv-id"), PvcId("pv-id2"), app.id)))
-      .copy(googleProject = project)
+      .copy(cloudContext = cloudContext)
       .save()
       .unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
     val appName1 = AppName("app1")

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/MockDiskServiceInterp.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/MockDiskServiceInterp.scala
@@ -16,16 +16,15 @@ object MockDiskServiceInterp extends DiskService[IO] {
     implicit as: Ask[IO, AppContext]
   ): IO[Unit] = IO.unit
 
-  def getDisk(userInfo: UserInfo, googleProject: GoogleProject, diskName: DiskName)(
+  def getDisk(userInfo: UserInfo, cloudContext: CloudContext, diskName: DiskName)(
     implicit as: Ask[IO, AppContext]
   ): IO[GetPersistentDiskResponse] =
     IO.pure(
       GetPersistentDiskResponse(
         DiskId(-1),
-        CommonTestData.project,
+        CommonTestData.cloudContext,
         CommonTestData.zone,
         CommonTestData.diskName,
-        Some(CommonTestData.googleId),
         CommonTestData.serviceAccount,
         CommonTestData.diskSamResource,
         DiskStatus.Ready,
@@ -37,14 +36,14 @@ object MockDiskServiceInterp extends DiskService[IO] {
       )
     )
 
-  def listDisks(userInfo: UserInfo, googleProject: Option[GoogleProject], params: Map[String, String])(
+  def listDisks(userInfo: UserInfo, cloudContext: Option[CloudContext], params: Map[String, String])(
     implicit as: Ask[IO, AppContext]
   ): IO[Vector[ListPersistentDiskResponse]] =
     IO.pure(
       Vector(
         ListPersistentDiskResponse(
           DiskId(-1),
-          CommonTestData.project,
+          CommonTestData.cloudContext,
           CommonTestData.zone,
           CommonTestData.diskName,
           DiskStatus.Ready,

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/MockProxyService.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/MockProxyService.scala
@@ -51,7 +51,7 @@ class MockProxyService(
                          googleTokenCache,
                          samResourceCache) {
 
-  override def getRuntimeTargetHost(googleProject: GoogleProject, clusterName: RuntimeName): IO[HostStatus] =
+  override def getRuntimeTargetHost(cloudContext: CloudContext, clusterName: RuntimeName): IO[HostStatus] =
     IO.pure(HostReady(Host("localhost")))
 
   override def getAppTargetHost(googleProject: GoogleProject, appName: AppName): IO[HostStatus] =

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/MockRuntimeServiceInterp.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/MockRuntimeServiceInterp.scala
@@ -11,20 +11,20 @@ import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 class BaseMockRuntimeServiceInterp extends RuntimeService[IO] {
   override def createRuntime(
     userInfo: UserInfo,
-    googleProject: GoogleProject,
+    cloudContext: CloudContext,
     runtimeName: RuntimeName,
     req: CreateRuntime2Request
   )(implicit as: Ask[IO, AppContext]): IO[Unit] =
     IO.unit
 
-  override def getRuntime(userInfo: UserInfo, googleProject: GoogleProject, runtimeName: RuntimeName)(
+  override def getRuntime(userInfo: UserInfo, cloudContext: CloudContext, runtimeName: RuntimeName)(
     implicit as: Ask[IO, AppContext]
   ): IO[GetRuntimeResponse] =
     IO.pure(
       GetRuntimeResponse.fromRuntime(CommonTestData.testCluster, CommonTestData.defaultDataprocRuntimeConfig, None)
     )
 
-  override def listRuntimes(userInfo: UserInfo, googleProject: Option[GoogleProject], params: Map[String, String])(
+  override def listRuntimes(userInfo: UserInfo, cloudContext: Option[CloudContext], params: Map[String, String])(
     implicit as: Ask[IO, AppContext]
   ): IO[Vector[ListRuntimeResponse2]] =
     IO.pure(
@@ -33,7 +33,7 @@ class BaseMockRuntimeServiceInterp extends RuntimeService[IO] {
           CommonTestData.testCluster.id,
           CommonTestData.testCluster.samResource,
           CommonTestData.testCluster.runtimeName,
-          CommonTestData.testCluster.googleProject,
+          CommonTestData.testCluster.cloudContext,
           CommonTestData.testCluster.auditInfo,
           CommonTestData.defaultGceRuntimeConfig,
           CommonTestData.testCluster.proxyUrl,
@@ -49,7 +49,7 @@ class BaseMockRuntimeServiceInterp extends RuntimeService[IO] {
   ): IO[Unit] =
     IO.unit
 
-  override def stopRuntime(userInfo: UserInfo, googleProject: GoogleProject, runtimeName: RuntimeName)(
+  override def stopRuntime(userInfo: UserInfo, cloudContext: CloudContext, runtimeName: RuntimeName)(
     implicit as: Ask[IO, AppContext]
   ): IO[Unit] =
     IO.unit

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterpSpec.scala
@@ -1717,7 +1717,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
 
   it should "return existing disk if a disk with the same name already exists" in isolatedDbTest {
     val res = for {
-      t <- ctx.ask[AppContext]
+      t <- appContext.ask[AppContext]
       disk <- makePersistentDisk(None).save()
       req = PersistentDiskRequest(disk.name, Some(DiskSize(50)), None, Map("foo" -> "bar"))
       returnedDisk <- RuntimeServiceInterp
@@ -1763,7 +1763,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
 
   it should "fail to process a disk reference when the disk is already attached" in isolatedDbTest {
     val res = for {
-      t <- ctx.ask[AppContext]
+      t <- appContext.ask[AppContext]
       savedDisk <- makePersistentDisk(None).save()
       _ <- IO(
         makeCluster(1).saveWithRuntimeConfig(
@@ -1796,7 +1796,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
 
   it should "fail to process a disk reference when the disk is already formatted by another app" in isolatedDbTest {
     val res = for {
-      t <- ctx.ask[AppContext]
+      t <- appContext.ask[AppContext]
       gceDisk <- makePersistentDisk(Some(DiskName("gceDisk")), Some(FormattedBy.GCE)).save()
       req = PersistentDiskRequest(gceDisk.name, Some(gceDisk.size), Some(gceDisk.diskType), gceDisk.labels)
       formatGceDiskError <- RuntimeServiceInterp

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeonardoModelSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeonardoModelSpec.scala
@@ -211,38 +211,38 @@ class LeonardoModelSpec extends LeonardoTestSuite with AnyFlatSpecLike {
 
     // No images or labels -> default to Jupyter
     Runtime
-      .getProxyUrl(proxyUrlBase, project, name0, Set.empty, Map.empty)
+      .getProxyUrl(proxyUrlBase, cloudContext, name0, Set.empty, Map.empty)
       .toString shouldBe expectedBase + "jupyter"
 
     // images only
     Runtime
-      .getProxyUrl(proxyUrlBase, project, name0, Set(jupyterImage), Map.empty)
+      .getProxyUrl(proxyUrlBase, cloudContext, name0, Set(jupyterImage), Map.empty)
       .toString shouldBe expectedBase + "jupyter"
     Runtime
-      .getProxyUrl(proxyUrlBase, project, name0, Set(welderImage, customDataprocImage, jupyterImage), Map.empty)
+      .getProxyUrl(proxyUrlBase, cloudContext, name0, Set(welderImage, customDataprocImage, jupyterImage), Map.empty)
       .toString shouldBe expectedBase + "jupyter"
     Runtime
-      .getProxyUrl(proxyUrlBase, project, name0, Set(rstudioImage), Map.empty)
+      .getProxyUrl(proxyUrlBase, cloudContext, name0, Set(rstudioImage), Map.empty)
       .toString shouldBe expectedBase + "rstudio"
     Runtime
-      .getProxyUrl(proxyUrlBase, project, name0, Set(welderImage, customDataprocImage, rstudioImage), Map.empty)
+      .getProxyUrl(proxyUrlBase, cloudContext, name0, Set(welderImage, customDataprocImage, rstudioImage), Map.empty)
       .toString shouldBe expectedBase + "rstudio"
 
     // labels only
     Runtime
-      .getProxyUrl(proxyUrlBase, project, name0, Set.empty, Map("tool" -> "Jupyter", "foo" -> "bar"))
+      .getProxyUrl(proxyUrlBase, cloudContext, name0, Set.empty, Map("tool" -> "Jupyter", "foo" -> "bar"))
       .toString shouldBe expectedBase + "jupyter"
     Runtime
-      .getProxyUrl(proxyUrlBase, project, name0, Set.empty, Map("tool" -> "RStudio", "foo" -> "bar"))
+      .getProxyUrl(proxyUrlBase, cloudContext, name0, Set.empty, Map("tool" -> "RStudio", "foo" -> "bar"))
       .toString shouldBe expectedBase + "rstudio"
     Runtime
-      .getProxyUrl(proxyUrlBase, project, name0, Set.empty, Map("foo" -> "bar"))
+      .getProxyUrl(proxyUrlBase, cloudContext, name0, Set.empty, Map("foo" -> "bar"))
       .toString shouldBe expectedBase + "jupyter"
 
     // images and labels -> images take precedence
     Runtime
       .getProxyUrl(proxyUrlBase,
-                   project,
+                   cloudContext,
                    name0,
                    Set(welderImage, customDataprocImage, rstudioImage),
                    Map("tool" -> "Jupyter", "foo" -> "bar"))

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterToolMonitorSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterToolMonitorSpec.scala
@@ -36,16 +36,16 @@ class ClusterToolMonitorSpec
   }
 
   val welderEnabledCluster = makeCluster(1).copy(status = RuntimeStatus.Running,
-                                                 welderEnabled = true,
-                                                 runtimeImages = Set(jupyterImage, welderImage))
+                                                 runtimeImages = Set(jupyterImage, welderImage),
+                                                 welderEnabled = true)
   val welderDisabledCluster =
-    makeCluster(2).copy(status = RuntimeStatus.Running, welderEnabled = false, runtimeImages = Set(jupyterImage))
+    makeCluster(2).copy(status = RuntimeStatus.Running, runtimeImages = Set(jupyterImage), welderEnabled = false)
   val notRunningCluster = makeCluster(3).copy(status = RuntimeStatus.Deleted,
-                                              welderEnabled = true,
-                                              runtimeImages = Set(jupyterImage, welderImage))
+                                              runtimeImages = Set(jupyterImage, welderImage),
+                                              welderEnabled = true)
   val rstudioCluster = makeCluster(4).copy(status = RuntimeStatus.Running,
-                                           welderEnabled = true,
-                                           runtimeImages = Set(rstudioImage, welderImage))
+                                           runtimeImages = Set(rstudioImage, welderImage),
+                                           welderEnabled = true)
 
   it should "report all services are up normally" in isolatedDbTest {
     welderEnabledCluster.save()

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/DataprocRuntimeMonitorSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/DataprocRuntimeMonitorSpec.scala
@@ -38,11 +38,9 @@ import scala.jdk.CollectionConverters._
 
 class DataprocRuntimeMonitorSpec extends AnyFlatSpec with TestComponent with LeonardoTestSuite with EitherValues {
   "creatingRuntime" should "check again if cluster doesn't exist yet" in isolatedDbTest {
-    val runtime = makeCluster(1).copy(
-      serviceAccount = clusterServiceAccountFromProject(project).get,
-      asyncRuntimeFields = Some(makeAsyncRuntimeFields(1)),
-      status = RuntimeStatus.Creating
-    )
+    val runtime = makeCluster(1).copy(serviceAccount = clusterServiceAccountFromProject(project).get,
+                                      asyncRuntimeFields = Some(makeAsyncRuntimeFields(1)),
+                                      status = RuntimeStatus.Creating)
     val monitorContext =
       MonitorContext(Instant.now(),
                      runtime.id,
@@ -62,11 +60,9 @@ class DataprocRuntimeMonitorSpec extends AnyFlatSpec with TestComponent with Leo
   }
 
   it should "will check again status is either Creating or Unknown" in isolatedDbTest {
-    val runtime = makeCluster(1).copy(
-      serviceAccount = clusterServiceAccountFromProject(project).get,
-      asyncRuntimeFields = Some(makeAsyncRuntimeFields(1)),
-      status = RuntimeStatus.Starting
-    )
+    val runtime = makeCluster(1).copy(serviceAccount = clusterServiceAccountFromProject(project).get,
+                                      asyncRuntimeFields = Some(makeAsyncRuntimeFields(1)),
+                                      status = RuntimeStatus.Starting)
 
     val cluster1 = getCluster(State.CREATING)
     val cluster2 = getCluster(State.UNKNOWN)
@@ -94,11 +90,9 @@ class DataprocRuntimeMonitorSpec extends AnyFlatSpec with TestComponent with Leo
   }
 
   it should "will check again status is Running but not all instances are running" in isolatedDbTest {
-    val runtime = makeCluster(1).copy(
-      serviceAccount = clusterServiceAccountFromProject(project).get,
-      asyncRuntimeFields = Some(makeAsyncRuntimeFields(1)),
-      status = RuntimeStatus.Starting
-    )
+    val runtime = makeCluster(1).copy(serviceAccount = clusterServiceAccountFromProject(project).get,
+                                      asyncRuntimeFields = Some(makeAsyncRuntimeFields(1)),
+                                      status = RuntimeStatus.Starting)
 
     val cluster = getCluster(State.RUNNING, Some(ZoneName("zone-a")))
 
@@ -120,11 +114,9 @@ class DataprocRuntimeMonitorSpec extends AnyFlatSpec with TestComponent with Leo
   }
 
   it should "will error if can't find zone for master instance" in isolatedDbTest {
-    val runtime = makeCluster(1).copy(
-      serviceAccount = clusterServiceAccountFromProject(project).get,
-      asyncRuntimeFields = Some(makeAsyncRuntimeFields(1)),
-      status = RuntimeStatus.Starting
-    )
+    val runtime = makeCluster(1).copy(serviceAccount = clusterServiceAccountFromProject(project).get,
+                                      asyncRuntimeFields = Some(makeAsyncRuntimeFields(1)),
+                                      status = RuntimeStatus.Starting)
 
     val cluster = getCluster(State.RUNNING, None)
 
@@ -147,11 +139,9 @@ class DataprocRuntimeMonitorSpec extends AnyFlatSpec with TestComponent with Leo
   }
 
   it should "will persist error if cluster is in Error state" in isolatedDbTest {
-    val runtime = makeCluster(1).copy(
-      serviceAccount = clusterServiceAccountFromProject(project).get,
-      asyncRuntimeFields = Some(makeAsyncRuntimeFields(1)),
-      status = RuntimeStatus.Starting
-    )
+    val runtime = makeCluster(1).copy(serviceAccount = clusterServiceAccountFromProject(project).get,
+                                      asyncRuntimeFields = Some(makeAsyncRuntimeFields(1)),
+                                      status = RuntimeStatus.Starting)
 
     val cluster = getCluster(State.ERROR)
 
@@ -174,11 +164,9 @@ class DataprocRuntimeMonitorSpec extends AnyFlatSpec with TestComponent with Leo
   }
 
   it should "will error if cluster is in unexpected state when trying to create" in isolatedDbTest {
-    val runtime = makeCluster(1).copy(
-      serviceAccount = clusterServiceAccountFromProject(project).get,
-      asyncRuntimeFields = Some(makeAsyncRuntimeFields(1)),
-      status = RuntimeStatus.Starting
-    )
+    val runtime = makeCluster(1).copy(serviceAccount = clusterServiceAccountFromProject(project).get,
+                                      asyncRuntimeFields = Some(makeAsyncRuntimeFields(1)),
+                                      status = RuntimeStatus.Starting)
 
     val cluster = getCluster(State.UPDATING)
 
@@ -201,11 +189,9 @@ class DataprocRuntimeMonitorSpec extends AnyFlatSpec with TestComponent with Leo
   }
 
   it should "will try to persist user script error if cluster is in Error state but no error shown from dataproc" in isolatedDbTest {
-    val runtime = makeCluster(1).copy(
-      serviceAccount = clusterServiceAccountFromProject(project).get,
-      asyncRuntimeFields = Some(makeAsyncRuntimeFields(1)),
-      status = RuntimeStatus.Starting
-    )
+    val runtime = makeCluster(1).copy(serviceAccount = clusterServiceAccountFromProject(project).get,
+                                      asyncRuntimeFields = Some(makeAsyncRuntimeFields(1)),
+                                      status = RuntimeStatus.Starting)
 
     val cluster = getCluster(State.ERROR)
 
@@ -229,11 +215,9 @@ class DataprocRuntimeMonitorSpec extends AnyFlatSpec with TestComponent with Leo
   }
 
   it should "will persist error if cluster is in Error state when Creating" in isolatedDbTest {
-    val runtime = makeCluster(1).copy(
-      serviceAccount = clusterServiceAccountFromProject(project).get,
-      asyncRuntimeFields = Some(makeAsyncRuntimeFields(1)),
-      status = RuntimeStatus.Starting
-    )
+    val runtime = makeCluster(1).copy(serviceAccount = clusterServiceAccountFromProject(project).get,
+                                      asyncRuntimeFields = Some(makeAsyncRuntimeFields(1)),
+                                      status = RuntimeStatus.Starting)
 
     val cluster = getCluster(State.ERROR)
 
@@ -265,11 +249,9 @@ class DataprocRuntimeMonitorSpec extends AnyFlatSpec with TestComponent with Leo
   }
 
   "startingRuntime" should "will check again if not all instances are Running when trying to start" in isolatedDbTest {
-    val runtime = makeCluster(1).copy(
-      serviceAccount = clusterServiceAccountFromProject(project).get,
-      asyncRuntimeFields = Some(makeAsyncRuntimeFields(1)),
-      status = RuntimeStatus.Starting
-    )
+    val runtime = makeCluster(1).copy(serviceAccount = clusterServiceAccountFromProject(project).get,
+                                      asyncRuntimeFields = Some(makeAsyncRuntimeFields(1)),
+                                      status = RuntimeStatus.Starting)
 
     val cluster = getCluster(State.RUNNING, Some(ZoneName("zone-a")))
 
@@ -290,11 +272,9 @@ class DataprocRuntimeMonitorSpec extends AnyFlatSpec with TestComponent with Leo
   }
 
   it should "will check again if master instance doesn't have IP when trying to start" in isolatedDbTest {
-    val runtime = makeCluster(1).copy(
-      serviceAccount = clusterServiceAccountFromProject(project).get,
-      asyncRuntimeFields = Some(makeAsyncRuntimeFields(1)),
-      status = RuntimeStatus.Starting
-    )
+    val runtime = makeCluster(1).copy(serviceAccount = clusterServiceAccountFromProject(project).get,
+                                      asyncRuntimeFields = Some(makeAsyncRuntimeFields(1)),
+                                      status = RuntimeStatus.Starting)
 
     val cluster = getCluster(State.RUNNING, Some(ZoneName("zone-a")))
 
@@ -315,11 +295,9 @@ class DataprocRuntimeMonitorSpec extends AnyFlatSpec with TestComponent with Leo
   }
 
   it should "will persist error if cluster is in Error state when Starting" in isolatedDbTest {
-    val runtime = makeCluster(1).copy(
-      serviceAccount = clusterServiceAccountFromProject(project).get,
-      asyncRuntimeFields = Some(makeAsyncRuntimeFields(1)),
-      status = RuntimeStatus.Starting
-    )
+    val runtime = makeCluster(1).copy(serviceAccount = clusterServiceAccountFromProject(project).get,
+                                      asyncRuntimeFields = Some(makeAsyncRuntimeFields(1)),
+                                      status = RuntimeStatus.Starting)
 
     val cluster = getCluster(State.ERROR)
 
@@ -341,11 +319,9 @@ class DataprocRuntimeMonitorSpec extends AnyFlatSpec with TestComponent with Leo
   }
 
   "stoppingRuntime" should "check again if there's still instance Running" in isolatedDbTest {
-    val runtime = makeCluster(1).copy(
-      serviceAccount = clusterServiceAccountFromProject(project).get,
-      asyncRuntimeFields = Some(makeAsyncRuntimeFields(1)),
-      status = RuntimeStatus.Stopping
-    )
+    val runtime = makeCluster(1).copy(serviceAccount = clusterServiceAccountFromProject(project).get,
+                                      asyncRuntimeFields = Some(makeAsyncRuntimeFields(1)),
+                                      status = RuntimeStatus.Stopping)
 
     val cluster = getCluster(State.RUNNING, Some(ZoneName("zone-a")))
 
@@ -364,11 +340,9 @@ class DataprocRuntimeMonitorSpec extends AnyFlatSpec with TestComponent with Leo
   }
 
   "stoppingRuntime" should "update DB when all instances are stopped" in isolatedDbTest {
-    val runtime = makeCluster(1).copy(
-      serviceAccount = clusterServiceAccountFromProject(project).get,
-      asyncRuntimeFields = Some(makeAsyncRuntimeFields(1)),
-      status = RuntimeStatus.Stopping
-    )
+    val runtime = makeCluster(1).copy(serviceAccount = clusterServiceAccountFromProject(project).get,
+                                      asyncRuntimeFields = Some(makeAsyncRuntimeFields(1)),
+                                      status = RuntimeStatus.Stopping)
 
     val cluster = getCluster(State.STOPPED, Some(ZoneName("zone-a")))
 
@@ -389,11 +363,9 @@ class DataprocRuntimeMonitorSpec extends AnyFlatSpec with TestComponent with Leo
   }
 
   it should "terminate monitoring stopping if cluster doesn't exist" in isolatedDbTest {
-    val runtime = makeCluster(1).copy(
-      serviceAccount = clusterServiceAccountFromProject(project).get,
-      asyncRuntimeFields = Some(makeAsyncRuntimeFields(1)),
-      status = RuntimeStatus.Stopping
-    )
+    val runtime = makeCluster(1).copy(serviceAccount = clusterServiceAccountFromProject(project).get,
+                                      asyncRuntimeFields = Some(makeAsyncRuntimeFields(1)),
+                                      status = RuntimeStatus.Stopping)
 
     val res = for {
       ctx <- appContext.ask[AppContext]
@@ -414,11 +386,9 @@ class DataprocRuntimeMonitorSpec extends AnyFlatSpec with TestComponent with Leo
   }
 
   "updatingRuntime" should "terminate monitoring stopping if cluster doesn't exist" in isolatedDbTest {
-    val runtime = makeCluster(1).copy(
-      serviceAccount = clusterServiceAccountFromProject(project).get,
-      asyncRuntimeFields = Some(makeAsyncRuntimeFields(1)),
-      status = RuntimeStatus.Stopping
-    )
+    val runtime = makeCluster(1).copy(serviceAccount = clusterServiceAccountFromProject(project).get,
+                                      asyncRuntimeFields = Some(makeAsyncRuntimeFields(1)),
+                                      status = RuntimeStatus.Stopping)
 
     val res = for {
       ctx <- appContext.ask[AppContext]
@@ -441,11 +411,9 @@ class DataprocRuntimeMonitorSpec extends AnyFlatSpec with TestComponent with Leo
   }
 
   it should "check again if cluster is still being updated" in isolatedDbTest {
-    val runtime = makeCluster(1).copy(
-      serviceAccount = clusterServiceAccountFromProject(project).get,
-      asyncRuntimeFields = Some(makeAsyncRuntimeFields(1)),
-      status = RuntimeStatus.Updating
-    )
+    val runtime = makeCluster(1).copy(serviceAccount = clusterServiceAccountFromProject(project).get,
+                                      asyncRuntimeFields = Some(makeAsyncRuntimeFields(1)),
+                                      status = RuntimeStatus.Updating)
 
     val cluster = getCluster(State.UPDATING, Some(ZoneName("zone-a")))
 
@@ -464,11 +432,9 @@ class DataprocRuntimeMonitorSpec extends AnyFlatSpec with TestComponent with Leo
   }
 
   it should "check again if not all instances are Running" in isolatedDbTest {
-    val runtime = makeCluster(1).copy(
-      serviceAccount = clusterServiceAccountFromProject(project).get,
-      asyncRuntimeFields = Some(makeAsyncRuntimeFields(1)),
-      status = RuntimeStatus.Stopping
-    )
+    val runtime = makeCluster(1).copy(serviceAccount = clusterServiceAccountFromProject(project).get,
+                                      asyncRuntimeFields = Some(makeAsyncRuntimeFields(1)),
+                                      status = RuntimeStatus.Stopping)
 
     val cluster = getCluster(State.RUNNING, Some(ZoneName("zone-a")))
 
@@ -489,11 +455,9 @@ class DataprocRuntimeMonitorSpec extends AnyFlatSpec with TestComponent with Leo
   }
 
   it should "check again if instance IP is not available yet" in isolatedDbTest {
-    val runtime = makeCluster(1).copy(
-      serviceAccount = clusterServiceAccountFromProject(project).get,
-      asyncRuntimeFields = Some(makeAsyncRuntimeFields(1)),
-      status = RuntimeStatus.Updating
-    )
+    val runtime = makeCluster(1).copy(serviceAccount = clusterServiceAccountFromProject(project).get,
+                                      asyncRuntimeFields = Some(makeAsyncRuntimeFields(1)),
+                                      status = RuntimeStatus.Updating)
 
     val cluster = getCluster(State.RUNNING, Some(ZoneName("zone-a")))
 
@@ -514,11 +478,9 @@ class DataprocRuntimeMonitorSpec extends AnyFlatSpec with TestComponent with Leo
   }
 
   it should "complete update" in isolatedDbTest {
-    val runtime = makeCluster(1).copy(
-      serviceAccount = clusterServiceAccountFromProject(project).get,
-      asyncRuntimeFields = Some(makeAsyncRuntimeFields(1)),
-      status = RuntimeStatus.Updating
-    )
+    val runtime = makeCluster(1).copy(serviceAccount = clusterServiceAccountFromProject(project).get,
+                                      asyncRuntimeFields = Some(makeAsyncRuntimeFields(1)),
+                                      status = RuntimeStatus.Updating)
 
     val cluster = getCluster(State.RUNNING, Some(ZoneName("zone-a")))
 
@@ -541,11 +503,9 @@ class DataprocRuntimeMonitorSpec extends AnyFlatSpec with TestComponent with Leo
   }
 
   "deleteRuntime" should "check again if cluster still exists" in isolatedDbTest {
-    val runtime = makeCluster(1).copy(
-      serviceAccount = clusterServiceAccountFromProject(project).get,
-      asyncRuntimeFields = Some(makeAsyncRuntimeFields(1)),
-      status = RuntimeStatus.Deleting
-    )
+    val runtime = makeCluster(1).copy(serviceAccount = clusterServiceAccountFromProject(project).get,
+                                      asyncRuntimeFields = Some(makeAsyncRuntimeFields(1)),
+                                      status = RuntimeStatus.Deleting)
     val cluster = getCluster(State.RUNNING, Some(ZoneName("zone-a")))
     val res = for {
       ctx <- appContext.ask[AppContext]
@@ -564,11 +524,9 @@ class DataprocRuntimeMonitorSpec extends AnyFlatSpec with TestComponent with Leo
   }
 
   it should "delete runtime if runtime no longer exists in google" in isolatedDbTest {
-    val runtime = makeCluster(1).copy(
-      serviceAccount = clusterServiceAccountFromProject(project).get,
-      asyncRuntimeFields = Some(makeAsyncRuntimeFields(1)),
-      status = RuntimeStatus.Deleting
-    )
+    val runtime = makeCluster(1).copy(serviceAccount = clusterServiceAccountFromProject(project).get,
+                                      asyncRuntimeFields = Some(makeAsyncRuntimeFields(1)),
+                                      status = RuntimeStatus.Deleting)
     val res = for {
       ctx <- appContext.ask[AppContext]
       monitorContext = MonitorContext(Instant.now(), runtime.id, ctx.traceId, RuntimeStatus.Deleting)

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/GceRuntimeMonitorSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/GceRuntimeMonitorSpec.scala
@@ -166,9 +166,9 @@ class GceRuntimeMonitorSpec
     val runtime = makeCluster(1).copy(
       serviceAccount = clusterServiceAccountFromProject(project).get,
       asyncRuntimeFields = Some(makeAsyncRuntimeFields(1).copy(stagingBucket = GcsBucketName("failure"))),
+      status = RuntimeStatus.Creating,
       userScriptUri =
-        Some(UserScriptPath.Gcs(GcsPath(GcsBucketName("failure"), GcsObjectName("userscript_output.txt")))),
-      status = RuntimeStatus.Creating
+        Some(UserScriptPath.Gcs(GcsPath(GcsBucketName("failure"), GcsObjectName("userscript_output.txt"))))
     )
 
     val computeService: GoogleComputeService[IO] = new FakeGoogleComputeService {
@@ -199,11 +199,11 @@ class GceRuntimeMonitorSpec
     val runtime = makeCluster(1).copy(
       serviceAccount = clusterServiceAccountFromProject(project).get,
       asyncRuntimeFields = Some(makeAsyncRuntimeFields(1).copy(stagingBucket = GcsBucketName("staging_bucket"))),
+      status = RuntimeStatus.Creating,
       startUserScriptUri = Some(
         UserScriptPath
           .Gcs(GcsPath(GcsBucketName("staging_bucket"), GcsObjectName("failed_userstartupscript_output.txt")))
-      ),
-      status = RuntimeStatus.Creating
+      )
     )
 
     val computeService: GoogleComputeService[IO] = new FakeGoogleComputeService {
@@ -249,11 +249,9 @@ class GceRuntimeMonitorSpec
 
   // process, Creating
   it should "will check again if instance still exists when trying to Creating one" in isolatedDbTest {
-    val runtime = makeCluster(1).copy(
-      serviceAccount = clusterServiceAccountFromProject(project).get,
-      asyncRuntimeFields = Some(makeAsyncRuntimeFields(1)),
-      status = RuntimeStatus.Creating
-    )
+    val runtime = makeCluster(1).copy(serviceAccount = clusterServiceAccountFromProject(project).get,
+                                      asyncRuntimeFields = Some(makeAsyncRuntimeFields(1)),
+                                      status = RuntimeStatus.Creating)
 
     def computeService(start: Long): GoogleComputeService[IO] = new FakeGoogleComputeService {
       override def getInstance(project: GoogleProject, zone: ZoneName, instanceName: InstanceName)(
@@ -288,11 +286,9 @@ class GceRuntimeMonitorSpec
 
   // process, Starting
   it should "will check again if instance still exists when trying to Starting one" in isolatedDbTest {
-    val runtime = makeCluster(1).copy(
-      serviceAccount = clusterServiceAccountFromProject(project).get,
-      asyncRuntimeFields = Some(makeAsyncRuntimeFields(1)),
-      status = RuntimeStatus.Starting
-    )
+    val runtime = makeCluster(1).copy(serviceAccount = clusterServiceAccountFromProject(project).get,
+                                      asyncRuntimeFields = Some(makeAsyncRuntimeFields(1)),
+                                      status = RuntimeStatus.Starting)
 
     def computeService(start: Long): GoogleComputeService[IO] = new FakeGoogleComputeService {
       override def getInstance(project: GoogleProject, zone: ZoneName, instanceName: InstanceName)(
@@ -355,11 +351,9 @@ class GceRuntimeMonitorSpec
   }
 
   it should "terminate if instance is terminated after 5 seconds when trying to Starting one" in isolatedDbTest {
-    val runtime = makeCluster(1).copy(
-      serviceAccount = clusterServiceAccountFromProject(project).get,
-      asyncRuntimeFields = Some(makeAsyncRuntimeFields(1)),
-      status = RuntimeStatus.Starting
-    )
+    val runtime = makeCluster(1).copy(serviceAccount = clusterServiceAccountFromProject(project).get,
+                                      asyncRuntimeFields = Some(makeAsyncRuntimeFields(1)),
+                                      status = RuntimeStatus.Starting)
 
     def computeService(start: Long): GoogleComputeService[IO] = new FakeGoogleComputeService {
       override def getInstance(project: GoogleProject, zone: ZoneName, instanceName: InstanceName)(
@@ -398,11 +392,11 @@ class GceRuntimeMonitorSpec
     val runtime = makeCluster(1).copy(
       serviceAccount = clusterServiceAccountFromProject(project).get,
       asyncRuntimeFields = Some(makeAsyncRuntimeFields(1).copy(stagingBucket = GcsBucketName("staging_bucket"))),
+      status = RuntimeStatus.Starting,
       startUserScriptUri = Some(
         UserScriptPath
           .Gcs(GcsPath(GcsBucketName("staging_bucket"), GcsObjectName("failed_userstartupscript_output.txt")))
-      ),
-      status = RuntimeStatus.Starting
+      )
     )
 
     val computeService: GoogleComputeService[IO] = new FakeGoogleComputeService {
@@ -448,11 +442,9 @@ class GceRuntimeMonitorSpec
 
   // process
   it should "exit monitor if status is not monitored" in isolatedDbTest {
-    val runtime = makeCluster(1).copy(
-      serviceAccount = clusterServiceAccountFromProject(project).get,
-      asyncRuntimeFields = Some(makeAsyncRuntimeFields(1)),
-      status = RuntimeStatus.Stopped
-    )
+    val runtime = makeCluster(1).copy(serviceAccount = clusterServiceAccountFromProject(project).get,
+                                      asyncRuntimeFields = Some(makeAsyncRuntimeFields(1)),
+                                      status = RuntimeStatus.Stopped)
 
     val monitor = gceRuntimeMonitor()
     val savedRuntime = runtime.saveWithRuntimeConfig(gceRuntimeConfig)
@@ -471,11 +463,9 @@ class GceRuntimeMonitorSpec
 
   // process, Stopping
   it should "error when trying to Stop an instance that doesn't exist in GCP" in isolatedDbTest {
-    val runtime = makeCluster(1).copy(
-      serviceAccount = clusterServiceAccountFromProject(project).get,
-      asyncRuntimeFields = Some(makeAsyncRuntimeFields(1)),
-      status = RuntimeStatus.Stopping
-    )
+    val runtime = makeCluster(1).copy(serviceAccount = clusterServiceAccountFromProject(project).get,
+                                      asyncRuntimeFields = Some(makeAsyncRuntimeFields(1)),
+                                      status = RuntimeStatus.Stopping)
 
     val monitor = gceRuntimeMonitor()
     val savedRuntime = runtime.saveWithRuntimeConfig(gceRuntimeConfig)
@@ -494,11 +484,9 @@ class GceRuntimeMonitorSpec
 
   // process, Stopping
   it should "update runtime status appropriately when successfully stopped an instance" in isolatedDbTest {
-    val runtime = makeCluster(1).copy(
-      serviceAccount = clusterServiceAccountFromProject(project).get,
-      asyncRuntimeFields = Some(makeAsyncRuntimeFields(1)),
-      status = RuntimeStatus.Stopping
-    )
+    val runtime = makeCluster(1).copy(serviceAccount = clusterServiceAccountFromProject(project).get,
+                                      asyncRuntimeFields = Some(makeAsyncRuntimeFields(1)),
+                                      status = RuntimeStatus.Stopping)
 
     val computeService = new FakeGoogleComputeService {
       override def getInstance(project: GoogleProject, zone: ZoneName, instanceName: InstanceName)(
@@ -525,11 +513,9 @@ class GceRuntimeMonitorSpec
 
   // process, Stopping
   it should "will check again if instance is not terminated yet when trying to stop one" in isolatedDbTest {
-    val runtime = makeCluster(1).copy(
-      serviceAccount = clusterServiceAccountFromProject(project).get,
-      asyncRuntimeFields = Some(makeAsyncRuntimeFields(1)),
-      status = RuntimeStatus.Stopping
-    )
+    val runtime = makeCluster(1).copy(serviceAccount = clusterServiceAccountFromProject(project).get,
+                                      asyncRuntimeFields = Some(makeAsyncRuntimeFields(1)),
+                                      status = RuntimeStatus.Stopping)
 
     val res = for {
       start <- IO.realTimeInstant
@@ -551,11 +537,9 @@ class GceRuntimeMonitorSpec
 
   // process, Deleting
   it should "delete runtime successfully when instance doesn't exist in GCP" in isolatedDbTest {
-    val runtime = makeCluster(1).copy(
-      serviceAccount = clusterServiceAccountFromProject(project).get,
-      asyncRuntimeFields = Some(makeAsyncRuntimeFields(1)),
-      status = RuntimeStatus.Deleting
-    )
+    val runtime = makeCluster(1).copy(serviceAccount = clusterServiceAccountFromProject(project).get,
+                                      asyncRuntimeFields = Some(makeAsyncRuntimeFields(1)),
+                                      status = RuntimeStatus.Deleting)
 
     val monitor = gceRuntimeMonitor()
     val savedRuntime = runtime.saveWithRuntimeConfig(gceRuntimeConfig)
@@ -574,11 +558,9 @@ class GceRuntimeMonitorSpec
 
   // process, Deleting
   it should "will check again if instance still exists when trying to delete one" in isolatedDbTest {
-    val runtime = makeCluster(1).copy(
-      serviceAccount = clusterServiceAccountFromProject(project).get,
-      asyncRuntimeFields = Some(makeAsyncRuntimeFields(1)),
-      status = RuntimeStatus.Deleting
-    )
+    val runtime = makeCluster(1).copy(serviceAccount = clusterServiceAccountFromProject(project).get,
+                                      asyncRuntimeFields = Some(makeAsyncRuntimeFields(1)),
+                                      status = RuntimeStatus.Deleting)
 
     def computeService(start: Long): GoogleComputeService[IO] = new FakeGoogleComputeService {
       override def getInstance(project: GoogleProject, zone: ZoneName, instanceName: InstanceName)(
@@ -613,11 +595,9 @@ class GceRuntimeMonitorSpec
 
   //pollCheck, Deleting
   "pollCheck" should "raise error if we get invalid monitoring status" in {
-    val runtime = makeCluster(1).copy(
-      serviceAccount = clusterServiceAccountFromProject(project).get,
-      asyncRuntimeFields = Some(makeAsyncRuntimeFields(1)),
-      status = RuntimeStatus.Deleted
-    )
+    val runtime = makeCluster(1).copy(serviceAccount = clusterServiceAccountFromProject(project).get,
+                                      asyncRuntimeFields = Some(makeAsyncRuntimeFields(1)),
+                                      status = RuntimeStatus.Deleted)
 
     val op = com.google.cloud.compute.v1.Operation.newBuilder().build()
     val monitor = gceRuntimeMonitor()
@@ -625,7 +605,7 @@ class GceRuntimeMonitorSpec
       _ <- IO(runtime.saveWithRuntimeConfig(gceRuntimeConfig))
       r <- monitor
         .pollCheck(
-          runtime.googleProject,
+          GoogleProject(runtime.cloudContext.asString),
           RuntimeAndRuntimeConfig(runtime, CommonTestData.defaultDataprocRuntimeConfig),
           op,
           RuntimeStatus.Deleted
@@ -661,7 +641,7 @@ class GceRuntimeMonitorSpec
       }
       monitor = gceRuntimeMonitor(computePollOperation = pollOperation)
 
-      _ <- monitor.pollCheck(runtime.googleProject,
+      _ <- monitor.pollCheck(GoogleProject(runtime.cloudContext.asString),
                              RuntimeAndRuntimeConfig(runtime, gceRuntimeConfig),
                              op,
                              RuntimeStatus.Stopping)
@@ -674,11 +654,9 @@ class GceRuntimeMonitorSpec
   }
 
   it should "monitor Deleting successfully" in {
-    val runtime = makeCluster(2).copy(
-      serviceAccount = clusterServiceAccountFromProject(project).get,
-      asyncRuntimeFields = Some(makeAsyncRuntimeFields(2)),
-      status = RuntimeStatus.Deleting
-    )
+    val runtime = makeCluster(2).copy(serviceAccount = clusterServiceAccountFromProject(project).get,
+                                      asyncRuntimeFields = Some(makeAsyncRuntimeFields(2)),
+                                      status = RuntimeStatus.Deleting)
 
     val initialOp = com.google.cloud.compute.v1.Operation.newBuilder().setStatus(Operation.Status.PENDING).build()
 
@@ -703,7 +681,7 @@ class GceRuntimeMonitorSpec
       monitor = gceRuntimeMonitor(computePollOperation = computePollOperation(start.toEpochMilli))
       savedRuntime <- IO(runtime.saveWithRuntimeConfig(gceRuntimeConfig))
       _ <- monitor.pollCheck(
-        savedRuntime.googleProject,
+        GoogleProject(savedRuntime.cloudContext.asString),
         RuntimeAndRuntimeConfig(savedRuntime, CommonTestData.defaultDataprocRuntimeConfig),
         initialOp,
         RuntimeStatus.Deleting
@@ -720,11 +698,9 @@ class GceRuntimeMonitorSpec
 
   //pollCheck Deleting
   it should "fail if reaches pollCheckMaxAttempts" in isolatedDbTest {
-    val runtime = makeCluster(2).copy(
-      serviceAccount = clusterServiceAccountFromProject(project).get,
-      asyncRuntimeFields = Some(makeAsyncRuntimeFields(2)),
-      status = RuntimeStatus.Deleting
-    )
+    val runtime = makeCluster(2).copy(serviceAccount = clusterServiceAccountFromProject(project).get,
+                                      asyncRuntimeFields = Some(makeAsyncRuntimeFields(2)),
+                                      status = RuntimeStatus.Deleting)
 
     val op = com.google.cloud.compute.v1.Operation.newBuilder().setStatus(Operation.Status.PENDING).build()
 
@@ -739,7 +715,7 @@ class GceRuntimeMonitorSpec
       monitor = gceRuntimeMonitor(computePollOperation = pollOperation)
       savedRuntime <- IO(runtime.saveWithRuntimeConfig(gceRuntimeConfig))
       _ <- monitor.pollCheck(
-        runtime.googleProject,
+        GoogleProject(runtime.cloudContext.asString),
         RuntimeAndRuntimeConfig(savedRuntime, CommonTestData.defaultDataprocRuntimeConfig),
         op,
         RuntimeStatus.Deleting
@@ -750,7 +726,7 @@ class GceRuntimeMonitorSpec
     } yield {
       (afterMonitor.toEpochMilli - start.toEpochMilli > 6000) shouldBe true // max 5 retries, and each poll interval is 1 second
       status shouldBe Some(RuntimeStatus.Error)
-      error.head.errorMessage shouldBe s"Deleting dsp-leo-test/clustername2 fail to complete in a timely manner"
+      error.head.errorMessage shouldBe s"Deleting Gcp/dsp-leo-test/clustername2 fail to complete in a timely manner"
     }
 
     res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubCodecSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubCodecSpec.scala
@@ -2,7 +2,6 @@ package org.broadinstitute.dsde.workbench.leonardo.monitor
 
 import java.time.Instant
 import java.util.UUID
-
 import _root_.io.circe.parser.decode
 import _root_.io.circe.syntax._
 import io.circe.Printer
@@ -15,6 +14,7 @@ import org.broadinstitute.dsde.workbench.leonardo.{
   AppId,
   AppName,
   AuditInfo,
+  CloudContext,
   DiskId,
   DiskSize,
   KubernetesClusterLeoId,
@@ -32,7 +32,7 @@ class LeoPubsubCodecSpec extends AnyFlatSpec with Matchers {
     val now = Instant.now()
     val originalMessage = CreateRuntimeMessage(
       1,
-      RuntimeProjectAndName(GoogleProject("project1"), RuntimeName("runtimeName1")),
+      RuntimeProjectAndName(CloudContext.Gcp(GoogleProject("project1")), RuntimeName("runtimeName1")),
       WorkbenchEmail("email1"),
       None,
       AuditInfo(WorkbenchEmail("email1"), now, None, now),
@@ -61,7 +61,7 @@ class LeoPubsubCodecSpec extends AnyFlatSpec with Matchers {
     val now = Instant.now()
     val originalMessage = CreateRuntimeMessage(
       1,
-      RuntimeProjectAndName(GoogleProject("project1"), RuntimeName("runtimeName1")),
+      RuntimeProjectAndName(CloudContext.Gcp(GoogleProject("project1")), RuntimeName("runtimeName1")),
       WorkbenchEmail("email1"),
       None,
       AuditInfo(WorkbenchEmail("email1"), now, None, now),

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriberSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriberSpec.scala
@@ -142,11 +142,9 @@ class LeoPubsubMessageSubscriberSpec
     dataprocInstances = Set(masterInstance, workerInstance1, workerInstance2)
   )
 
-  val stoppedCluster = makeCluster(2).copy(
-    serviceAccount = serviceAccount,
-    asyncRuntimeFields = Some(makeAsyncRuntimeFields(1).copy(hostIp = None)),
-    status = RuntimeStatus.Stopped
-  )
+  val stoppedCluster = makeCluster(2).copy(serviceAccount = serviceAccount,
+                                           asyncRuntimeFields = Some(makeAsyncRuntimeFields(1).copy(hostIp = None)),
+                                           status = RuntimeStatus.Stopped)
 
   it should "handle CreateRuntimeMessage and create cluster" in isolatedDbTest {
     val leoSubscriber = makeLeoSubscriber()
@@ -154,7 +152,7 @@ class LeoPubsubMessageSubscriberSpec
       for {
         runtime <- IO(
           makeCluster(1)
-            .copy(asyncRuntimeFields = None, status = RuntimeStatus.Creating, serviceAccount = serviceAccount)
+            .copy(serviceAccount = serviceAccount, asyncRuntimeFields = None, status = RuntimeStatus.Creating)
             .save()
         )
         tr <- traceId.ask[TraceId]
@@ -169,7 +167,7 @@ class LeoPubsubMessageSubscriberSpec
         updatedRuntime.get.asyncRuntimeFields.get.stagingBucket.value should startWith("leostaging")
         updatedRuntime.get.asyncRuntimeFields.get.hostIp shouldBe None
         updatedRuntime.get.asyncRuntimeFields.get.operationName.value shouldBe "opName"
-        updatedRuntime.get.asyncRuntimeFields.get.googleId.value shouldBe "258165385"
+        updatedRuntime.get.asyncRuntimeFields.get.proxyHostName.value shouldBe "258165385"
         updatedRuntime.get.runtimeImages.map(_.imageType) should contain(BootSource)
       }
 
@@ -195,9 +193,9 @@ class LeoPubsubMessageSubscriberSpec
       for {
         runtime <- IO(
           makeCluster(1)
-            .copy(status = RuntimeStatus.Creating,
-                  serviceAccount = serviceAccount,
-                  asyncRuntimeFields = Some(asyncFields))
+            .copy(serviceAccount = serviceAccount,
+                  asyncRuntimeFields = Some(asyncFields),
+                  status = RuntimeStatus.Creating)
             .save()
         )
         tr <- traceId.ask[TraceId]
@@ -598,7 +596,6 @@ class LeoPubsubMessageSubscriberSpec
         updatedDisk <- persistentDiskQuery.getById(disk.id)(scala.concurrent.ExecutionContext.global).transaction
       } yield {
         updatedDisk shouldBe defined
-        updatedDisk.get.googleId.get.value shouldBe "258165385"
       }
 
     res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
@@ -1576,7 +1573,6 @@ class LeoPubsubMessageSubscriberSpec
         updatedDisk <- persistentDiskQuery.getById(disk.id)(scala.concurrent.ExecutionContext.global).transaction
       } yield {
         updatedDisk shouldBe defined
-        updatedDisk.get.googleId.get.value shouldBe "258165385"
       }
 
     res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/NonLeoMessageSubscriberSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/NonLeoMessageSubscriberSpec.scala
@@ -257,7 +257,7 @@ class NonLeoMessageSubscriberSpec extends AnyFlatSpec with LeonardoTestSuite wit
           NonLeoMessage
             .CryptoMining("CRYPTOMINING_DETECTED",
                           GoogleResource(GoogleLabels(123L, ZoneName("us-central1-a"))),
-                          runtime.googleProject)
+                          GoogleProject(runtime.cloudContext.asString))
         )
         statusAfterUpdate <- clusterQuery.getClusterStatus(runtime.id).transaction
         deletedFrom <- clusterQuery.getDeletedFrom(runtime.id).transaction
@@ -279,7 +279,7 @@ class NonLeoMessageSubscriberSpec extends AnyFlatSpec with LeonardoTestSuite wit
         subscriber = makeSubscribler()
         _ <- subscriber.messageResponder(
           NonLeoMessage.CryptoMiningScc(
-            CryptoMiningSccResource(runtime.googleProject,
+            CryptoMiningSccResource(GoogleProject(runtime.cloudContext.asString),
                                     CloudService.GCE,
                                     runtime.runtimeName,
                                     CommonTestData.defaultGceRuntimeConfig.zone),

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/DataprocInterpreterSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/DataprocInterpreterSpec.scala
@@ -51,8 +51,8 @@ class DataprocInterpreterSpec
   val mockGoogleStorageDAO = new MockGoogleStorageDAO
 
   val testCluster = makeCluster(1)
-    .copy(status = Creating, asyncRuntimeFields = None)
-  val testClusterClusterProjectAndName = RuntimeProjectAndName(testCluster.googleProject, testCluster.runtimeName)
+    .copy(asyncRuntimeFields = None, status = Creating)
+  val testClusterClusterProjectAndName = RuntimeProjectAndName(testCluster.cloudContext, testCluster.runtimeName)
 
   val bucketHelperConfig =
     BucketHelperConfig(imageConfig, welderConfig, proxyConfig, clusterFilesConfig)
@@ -107,7 +107,7 @@ class DataprocInterpreterSpec
     // verify the returned cluster
     val dpInfo = clusterCreationRes.get.asyncRuntimeFields
     dpInfo.operationName.value shouldBe "opName"
-    dpInfo.googleId.value shouldBe "clusterUuid"
+    dpInfo.proxyHostName.value shouldBe "clusterUuid"
     dpInfo.hostIp shouldBe None
     dpInfo.stagingBucket.value should startWith("leostaging")
 

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/RuntimeTemplateValuesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/RuntimeTemplateValuesSpec.scala
@@ -35,7 +35,7 @@ class RuntimeTemplateValuesSpec extends LeonardoTestSuite with AnyFlatSpecLike {
       result.cryptoDetectorServerName shouldBe "cryptomining-detector"
       result.disableDelocalization shouldBe "false"
       result.googleClientId shouldBe "clientId"
-      result.googleProject shouldBe CommonTestData.testCluster.googleProject.value
+      result.googleProject shouldBe CommonTestData.testCluster.cloudContext.asString
       result.gpuEnabled shouldBe "true"
       result.jupyterCombinedExtensions shouldBe ""
       result.jupyterDockerCompose shouldBe GcsPath(CommonTestData.initBucketName,


### PR DESCRIPTION
Part of https://broadworkbench.atlassian.net/browse/IA-2977

- Mostly look at `20211015_support_proxy_to_azure_vm.xml` to see what's being refactored. The majority of the diff is due to renaming `googleProject` to `cloudContext`, which is term used workspace manager. It's also documented in [here](https://docs.google.com/document/d/1qkte2Y1SB6RR34mFhVNkpqb377Ta5y44yeJh6GUS43g/edit#heading=h.lsjdzdaj8yo7). Not all intended refactoring is done yet to keep the size of the PR.
- Added `proxy/az/v1/runtimes` route, but this is not anywhere close to working yet. This will be actively worked on tgt with more refactoring in a follow up PR


Verified the migration works against dev DB

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
