### PR TITLE
Change name of cromwell helm chart to allow the name to be used as part of the templatized names (BW-859, BW-865)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ RUN helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx && \
     helm repo add galaxy https://raw.githubusercontent.com/cloudve/helm-charts/anvil/ && \
     helm repo add terra-app-setup-charts https://storage.googleapis.com/terra-app-setup-chart && \
     helm repo add terra https://terra-app-charts.storage.googleapis.com && \
-    helm repo add cromwell-local https://broadinstitute.github.io/cromwhelm/charts/ && \
+    helm repo add cromwell-helm https://broadinstitute.github.io/cromwhelm/charts/ && \
     helm repo update
 
 # .Files helm helper can't access files outside a chart. Hence in order to populate cert file properly, we're
@@ -59,7 +59,7 @@ RUN cd /leonardo && \
     helm pull galaxy/galaxykubeman --version $GALAXY_VERSION --untar && \
     helm pull terra/terra-app --version $TERRA_APP_VERSION --untar  && \
     helm pull ingress-nginx/ingress-nginx --version $NGINX_VERSION --untar && \
-    helm pull cromwell-local/CromwellHsqldbLocalMinikube --version $CROMWELL_CHART_VERSION --untar && \
+    helm pull cromwell-helm/cromwell --version $CROMWELL_CHART_VERSION --untar && \
     cd /
 
 # Add Leonardo as a service (it will start when the container starts)

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ ENV TERRA_APP_VERSION 0.3.0
 ENV GALAXY_VERSION 1.1.0
 ENV NGINX_VERSION 3.23.0
 # If you update this here, make sure to also update reference.conf:
-ENV CROMWELL_CHART_VERSION 0.1.2
+ENV CROMWELL_CHART_VERSION 0.1.3
 
 RUN mkdir /leonardo
 COPY ./leonardo*.jar /leonardo

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -413,7 +413,7 @@ gke {
   }
   cromwellApp {
     # If you update the chart name or version here, make sure to also update it in the dockerfile:
-    chartName = "/leonardo/CromwellHsqldbLocalMinikube"
+    chartName = "/leonardo/cromwell"
     chartVersion = "0.1.2"
     services = [
       {

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -414,7 +414,7 @@ gke {
   cromwellApp {
     # If you update the chart name or version here, make sure to also update it in the dockerfile:
     chartName = "/leonardo/cromwell"
-    chartVersion = "0.1.2"
+    chartVersion = "0.1.3"
     services = [
       {
         name = "cromwell-service"


### PR DESCRIPTION
This renames the Cromwell helm chart. The related cromwhelm MR is https://github.com/broadinstitute/cromwhelm/pull/9.

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
