### PR TITLE
Persistence config values to allow Leo to delete disk attached to Cromwell App [BW-873]

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ ENV TERRA_APP_VERSION 0.3.0
 ENV GALAXY_VERSION 1.1.0
 ENV NGINX_VERSION 3.23.0
 # If you update this here, make sure to also update reference.conf:
-ENV CROMWELL_CHART_VERSION 0.1.3
+ENV CROMWELL_CHART_VERSION 0.1.4
 
 RUN mkdir /leonardo
 COPY ./leonardo*.jar /leonardo

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -414,7 +414,7 @@ gke {
   cromwellApp {
     # If you update the chart name or version here, make sure to also update it in the dockerfile:
     chartName = "/leonardo/cromwell"
-    chartVersion = "0.1.3"
+    chartVersion = "0.1.4"
     services = [
       {
         name = "cromwell-service"

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreterSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreterSpec.scala
@@ -142,7 +142,7 @@ class GKEInterpreterSpec extends AnyFlatSpecLike with TestComponent with Leonard
 
   it should "build Cromwell override values string" in {
     val savedCluster1 = makeKubeCluster(1)
-    val savedDisk1 = makePersistentDisk(Some(DiskName("disk1")), Some(FormattedBy.Galaxy))
+    val savedDisk1 = makePersistentDisk(Some(DiskName("disk1")), Some(FormattedBy.Custom))
     val res = gkeInterp.buildCromwellAppChartOverrideValuesString(
       AppName("app1"),
       savedCluster1,
@@ -151,7 +151,7 @@ class GKEInterpreterSpec extends AnyFlatSpecLike with TestComponent with Leonard
       savedDisk1
     )
 
-    res.mkString(",") shouldBe """nodeSelector.cloud\.google\.com/gke-nodepool=pool1,ingress.enabled=true,ingress.annotations.nginx\.ingress\.kubernetes\.io/proxy-redirect-from=https://1455694897.jupyter.firecloud.org,ingress.annotations.nginx\.ingress\.kubernetes\.io/proxy-redirect-to=https://leo,ingress.annotations.nginx\.ingress\.kubernetes\.io/rewrite-target=/$2,ingress.annotations.nginx\.ingress\.kubernetes\.io/auth-tls-secret=ns/ca-secret,ingress.path=/proxy/google/v1/apps/dsp-leo-test1/app1/cromwell-service,ingress.hosts[0].host=1455694897.jupyter.firecloud.org,ingress.hosts[0].paths[0]=/proxy/google/v1/apps/dsp-leo-test1/app1/cromwell-service(/|$)(.*),ingress.tls[0].secretName=tls-secret,ingress.tls[0].hosts[0]=1455694897.jupyter.firecloud.org"""
+    res.mkString(",") shouldBe """nodeSelector.cloud\.google\.com/gke-nodepool=pool1,persistence.size=250G,persistence.gcePersistentDisk=disk1,ingress.enabled=true,ingress.annotations.nginx\.ingress\.kubernetes\.io/proxy-redirect-from=https://1455694897.jupyter.firecloud.org,ingress.annotations.nginx\.ingress\.kubernetes\.io/proxy-redirect-to=https://leo,ingress.annotations.nginx\.ingress\.kubernetes\.io/rewrite-target=/$2,ingress.annotations.nginx\.ingress\.kubernetes\.io/auth-tls-secret=ns/ca-secret,ingress.path=/proxy/google/v1/apps/dsp-leo-test1/app1/cromwell-service,ingress.hosts[0].host=1455694897.jupyter.firecloud.org,ingress.hosts[0].paths[0]=/proxy/google/v1/apps/dsp-leo-test1/app1/cromwell-service(/|$)(.*),ingress.tls[0].secretName=tls-secret,ingress.tls[0].hosts[0]=1455694897.jupyter.firecloud.org"""
   }
 
   it should "check if a pod is done" in {

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreterSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreterSpec.scala
@@ -142,7 +142,7 @@ class GKEInterpreterSpec extends AnyFlatSpecLike with TestComponent with Leonard
 
   it should "build Cromwell override values string" in {
     val savedCluster1 = makeKubeCluster(1)
-    val savedDisk1 = makePersistentDisk(Some(DiskName("disk1")), Some(FormattedBy.Custom))
+    val savedDisk1 = makePersistentDisk(Some(DiskName("disk1")))
     val res = gkeInterp.buildCromwellAppChartOverrideValuesString(
       AppName("app1"),
       savedCluster1,

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreterSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreterSpec.scala
@@ -142,11 +142,13 @@ class GKEInterpreterSpec extends AnyFlatSpecLike with TestComponent with Leonard
 
   it should "build Cromwell override values string" in {
     val savedCluster1 = makeKubeCluster(1)
+    val savedDisk1 = makePersistentDisk(Some(DiskName("disk1")), Some(FormattedBy.Galaxy))
     val res = gkeInterp.buildCromwellAppChartOverrideValuesString(
       AppName("app1"),
       savedCluster1,
       NodepoolName("pool1"),
-      NamespaceName("ns")
+      NamespaceName("ns"),
+      savedDisk1
     )
 
     res.mkString(",") shouldBe """nodeSelector.cloud\.google\.com/gke-nodepool=pool1,ingress.enabled=true,ingress.annotations.nginx\.ingress\.kubernetes\.io/proxy-redirect-from=https://1455694897.jupyter.firecloud.org,ingress.annotations.nginx\.ingress\.kubernetes\.io/proxy-redirect-to=https://leo,ingress.annotations.nginx\.ingress\.kubernetes\.io/rewrite-target=/$2,ingress.annotations.nginx\.ingress\.kubernetes\.io/auth-tls-secret=ns/ca-secret,ingress.path=/proxy/google/v1/apps/dsp-leo-test1/app1/cromwell-service,ingress.hosts[0].host=1455694897.jupyter.firecloud.org,ingress.hosts[0].paths[0]=/proxy/google/v1/apps/dsp-leo-test1/app1/cromwell-service(/|$)(.*),ingress.tls[0].secretName=tls-secret,ingress.tls[0].hosts[0]=1455694897.jupyter.firecloud.org"""


### PR DESCRIPTION
Tested this in a FIAB by creating a Cromwell App, upgrading the Cromwell helm yaml and deleting the app from UI. Snapshots that show the `data disk failed to detach within the time limit` error did not appear and cluster was deleted properly. Automation test will be added as part of [BW-864](https://broadworkbench.atlassian.net/browse/BW-864).

![Screen Shot 2021-10-26 at 4 49 03 PM](https://user-images.githubusercontent.com/16748522/138961207-d282472a-41d0-4879-9aad-ada3b2663435.png)
_____
![Screen Shot 2021-10-26 at 4 49 16 PM](https://user-images.githubusercontent.com/16748522/138961255-1c829937-838c-4d34-b487-44395a401790.png)
______
![Screen Shot 2021-10-26 at 4 52 21 PM](https://user-images.githubusercontent.com/16748522/138961302-9201d8ec-2a5a-42a9-901d-6a543d3043d4.png)

Related Cromwhelm PR: https://github.com/broadinstitute/cromwhelm/pull/10

Closes https://broadworkbench.atlassian.net/browse/BW-873

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
