### PR TITLE
[no ticket] Log additional info when we fail to process pubsub message 

### DIFF
--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
@@ -114,17 +114,17 @@ class LeoPubsubMessageSubscriber[F[_]](
                   case _ => F.unit
                 }
                 _ <- if (ee.isRetryable)
-                  logger.error(e)("Fail to process retryable pubsub message") >> F
+                  logger.error(ctx.loggingCtx, e)("Fail to process retryable pubsub message") >> F
                     .delay(event.consumer.nack())
                 else
-                  logger.error(e)("Fail to process non-retryable pubsub message") >> ack(event)
+                  logger.error(ctx.loggingCtx, e)("Fail to process non-retryable pubsub message") >> ack(event)
               } yield ()
             case ee: WorkbenchException if ee.getMessage.contains("Call to Google API failed") =>
               logger
-                .error(e)("Fail to process retryable pubsub message due to Google API call failure") >> F
+                .error(ctx.loggingCtx, e)("Fail to process retryable pubsub message due to Google API call failure") >> F
                 .delay(event.consumer.nack())
             case _ =>
-              logger.error(e)("Fail to process pubsub message due to unexpected error") >> ack(event)
+              logger.error(ctx.loggingCtx, e)("Fail to process pubsub message due to unexpected error") >> ack(event)
           }
         case Right(_) => ack(event)
       }


### PR DESCRIPTION
Log additional info when we fail to process pubsub message. Mostly I'd like `traceId` getting logged in these error cases

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
