### PR TITLE
BW-890 Add appType to getApp and listApps

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/appRoutesModels.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/appRoutesModels.scala
@@ -39,7 +39,9 @@ final case class GetAppResponse(kubernetesRuntimeConfig: KubernetesRuntimeConfig
                                 proxyUrls: Map[ServiceName, URL],
                                 diskName: Option[DiskName],
                                 customEnvironmentVariables: Map[String, String],
-                                auditInfo: AuditInfo)
+                                auditInfo: AuditInfo,
+                                appType: AppType
+                               )
 
 final case class ListAppResponse(googleProject: GoogleProject,
                                  kubernetesRuntimeConfig: KubernetesRuntimeConfig,
@@ -47,6 +49,7 @@ final case class ListAppResponse(googleProject: GoogleProject,
                                  status: AppStatus, //TODO: do we need some sort of aggregate status?
                                  proxyUrls: Map[ServiceName, URL],
                                  appName: AppName,
+                                 appType: AppType,
                                  diskName: Option[DiskName],
                                  auditInfo: AuditInfo,
                                  labels: LabelMap)
@@ -68,6 +71,7 @@ object ListAppResponse {
           a.status,
           a.getProxyUrls(c.googleProject, proxyUrlBase),
           a.appName,
+          a.appType,
           a.appResources.disk.map(_.name),
           a.auditInfo,
           a.labels.filter(l => labelsToReturn.contains(l._1))
@@ -90,6 +94,7 @@ object GetAppResponse {
       appResult.app.getProxyUrls(appResult.cluster.googleProject, proxyUrlBase),
       appResult.app.appResources.disk.map(_.name),
       appResult.app.customEnvironmentVariables,
-      appResult.app.auditInfo
+      appResult.app.auditInfo,
+      appResult.app.appType
     )
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/appRoutesModels.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/appRoutesModels.scala
@@ -40,8 +40,7 @@ final case class GetAppResponse(kubernetesRuntimeConfig: KubernetesRuntimeConfig
                                 diskName: Option[DiskName],
                                 customEnvironmentVariables: Map[String, String],
                                 auditInfo: AuditInfo,
-                                appType: AppType
-                               )
+                                appType: AppType)
 
 final case class ListAppResponse(googleProject: GoogleProject,
                                  kubernetesRuntimeConfig: KubernetesRuntimeConfig,

--- a/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/AppRoutesTestJsonCodec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/AppRoutesTestJsonCodec.scala
@@ -36,21 +36,23 @@ object AppRoutesTestJsonCodec {
     Decoder.decodeMap[ServiceName, URL](KeyDecoder.decodeKeyString.map(ServiceName), urlDecoder)
 
   implicit val getAppResponseDecoder: Decoder[GetAppResponse] =
-    Decoder.forProduct7("kubernetesRuntimeConfig",
+    Decoder.forProduct8("kubernetesRuntimeConfig",
                         "errors",
                         "status",
                         "proxyUrls",
                         "diskName",
                         "customEnvironmentVariables",
-                        "auditInfo")(GetAppResponse.apply)
+                        "auditInfo",
+                        "appType")(GetAppResponse.apply)
 
   implicit val listAppResponseDecoder: Decoder[ListAppResponse] =
-    Decoder.forProduct9("googleProject",
+    Decoder.forProduct10("googleProject",
                         "kubernetesRuntimeConfig",
                         "errors",
                         "status",
                         "proxyUrls",
                         "appName",
+                        "appType",
                         "diskName",
                         "auditInfo",
                         "labels")(ListAppResponse.apply)

--- a/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/AppRoutesTestJsonCodec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/AppRoutesTestJsonCodec.scala
@@ -47,13 +47,13 @@ object AppRoutesTestJsonCodec {
 
   implicit val listAppResponseDecoder: Decoder[ListAppResponse] =
     Decoder.forProduct10("googleProject",
-                        "kubernetesRuntimeConfig",
-                        "errors",
-                        "status",
-                        "proxyUrls",
-                        "appName",
-                        "appType",
-                        "diskName",
-                        "auditInfo",
-                        "labels")(ListAppResponse.apply)
+                         "kubernetesRuntimeConfig",
+                         "errors",
+                         "status",
+                         "proxyUrls",
+                         "appName",
+                         "appType",
+                         "diskName",
+                         "auditInfo",
+                         "labels")(ListAppResponse.apply)
 }

--- a/http/src/main/resources/swagger/api-docs.yaml
+++ b/http/src/main/resources/swagger/api-docs.yaml
@@ -1990,6 +1990,12 @@ components:
             email: email authorization
             profile: profile authorization
   schemas:
+    AppType:
+      type: string
+      enum:
+        - CROMWELL
+        - CUSTOM
+        - GALAXY
     AppStatus:
       type: string
       enum:
@@ -2862,8 +2868,7 @@ components:
         diskConfig:
           $ref: '#/components/schemas/PersistentDiskRequest'
         appType:
-          type: string
-          description: currently "GALAXY", "CROMWELL" and "CUSTOM" are supported
+          $ref: '#/components/schemas/AppType'
         kubernetesRuntimeConfig:
           $ref: '#/components/schemas/KubernetesRuntimeConfig'
         labels:
@@ -2910,8 +2915,7 @@ components:
         auditInfo:
           $ref: "#/components/schemas/AuditInfo"
         appType:
-          type: string
-          description: the type of app
+          $ref: '#/components/schemas/AppType'
 
     ListAppResponse:
       description: the configuration of an app
@@ -2943,8 +2947,7 @@ components:
           type: string
           description: the name of the app
         appType:
-          type: string
-          description: the type of app
+          $ref: '#/components/schemas/AppType'
         auditInfo:
           $ref: "#/components/schemas/AuditInfo"
         labels:

--- a/http/src/main/resources/swagger/api-docs.yaml
+++ b/http/src/main/resources/swagger/api-docs.yaml
@@ -2909,6 +2909,9 @@ components:
           description: Optional environment variables to be set on the app
         auditInfo:
           $ref: "#/components/schemas/AuditInfo"
+        appType:
+          type: string
+          description: the type of app
 
     ListAppResponse:
       description: the configuration of an app
@@ -2939,6 +2942,9 @@ components:
         appName:
           type: string
           description: the name of the app
+        appType:
+          type: string
+          description: the type of app
         auditInfo:
           $ref: "#/components/schemas/AuditInfo"
         labels:

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/AppRoutes.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/AppRoutes.scala
@@ -229,22 +229,24 @@ object AppRoutes {
 
   implicit val nameKeyEncoder: KeyEncoder[ServiceName] = KeyEncoder.encodeKeyString.contramap(_.value)
   implicit val listAppResponseEncoder: Encoder[ListAppResponse] =
-    Encoder.forProduct9("googleProject",
+    Encoder.forProduct10("googleProject",
                         "kubernetesRuntimeConfig",
                         "errors",
                         "status",
                         "proxyUrls",
                         "appName",
+                        "appType",
                         "diskName",
                         "auditInfo",
                         "labels")(x => ListAppResponse.unapply(x).get)
 
   implicit val getAppResponseEncoder: Encoder[GetAppResponse] =
-    Encoder.forProduct7("kubernetesRuntimeConfig",
+    Encoder.forProduct8("kubernetesRuntimeConfig",
                         "errors",
                         "status",
                         "proxyUrls",
                         "diskName",
                         "customEnvironmentVariables",
-                        "auditInfo")(x => GetAppResponse.unapply(x).get)
+                        "auditInfo",
+                        "appType")(x => GetAppResponse.unapply(x).get)
 }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/AppRoutes.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/AppRoutes.scala
@@ -230,15 +230,15 @@ object AppRoutes {
   implicit val nameKeyEncoder: KeyEncoder[ServiceName] = KeyEncoder.encodeKeyString.contramap(_.value)
   implicit val listAppResponseEncoder: Encoder[ListAppResponse] =
     Encoder.forProduct10("googleProject",
-                        "kubernetesRuntimeConfig",
-                        "errors",
-                        "status",
-                        "proxyUrls",
-                        "appName",
-                        "appType",
-                        "diskName",
-                        "auditInfo",
-                        "labels")(x => ListAppResponse.unapply(x).get)
+                         "kubernetesRuntimeConfig",
+                         "errors",
+                         "status",
+                         "proxyUrls",
+                         "appName",
+                         "appType",
+                         "diskName",
+                         "auditInfo",
+                         "labels")(x => ListAppResponse.unapply(x).get)
 
   implicit val getAppResponseEncoder: Encoder[GetAppResponse] =
     Encoder.forProduct8("kubernetesRuntimeConfig",


### PR DESCRIPTION
Adds app Type information so that it can be displayed in the UI (previously the code in terra-ui was hardcoded to always display "Galaxy").

See https://github.com/DataBiosphere/terra-ui/pull/2675

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
