### PR TITLE
IA-3035 take 2: remove the leonardo-private tag sooner

### DIFF
--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/DataprocRuntimeMonitor.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/DataprocRuntimeMonitor.scala
@@ -5,7 +5,7 @@ import cats.Parallel
 import cats.effect.Async
 import cats.mtl.Ask
 import cats.syntax.all._
-import com.google.cloud.compute.v1.{Instance, Tags}
+import com.google.cloud.compute.v1.Instance
 import com.google.cloud.dataproc.v1.Cluster
 import org.broadinstitute.dsde.workbench.google2
 import org.broadinstitute.dsde.workbench.google2.{
@@ -137,32 +137,14 @@ class DataprocRuntimeMonitor[F[_]: Parallel](
                   // Note we don't need to check startup script results here because Dataproc
                   // won't transition the cluster to Running if a startup script failed.
 
-                  val masterInstance = dataprocAndComputeInstances.find(_._1.dataprocRole == DataprocRole.Master)
+                  val masterInstance = instances.find(_.dataprocRole == DataprocRole.Master)
 
                   masterInstance match {
-                    case Some((dataprocInstance, computeInstance)) =>
+                    case Some(dataprocInstance) =>
                       dataprocInstance.ip match {
                         case Some(ip) =>
-                          for {
-                            // If the cluster is configured with worker private access, then
-                            // remove the workerPrivateAccessNetworkTag from the master node
-                            // once it is running.
-                            _ <- if (dataprocConfig.workerPrivateAccess) {
-                              googleComputeService.setInstanceTags(
-                                dataprocInstance.key.project,
-                                dataprocInstance.key.zone,
-                                dataprocInstance.key.name,
-                                Tags
-                                  .newBuilder()
-                                  .addItems(config.vpcConfig.networkTag.value)
-                                  .setFingerprint(computeInstance.getTags.getFingerprint)
-                                  .build()
-                              )
-                            } else F.unit
-                            // It takes a bit for jupyter to startup, hence wait 5 seconds before we check jupyter
-                            _ <- F.sleep(8 seconds)
-                            result <- handleCheckTools(monitorContext, runtimeAndRuntimeConfig, ip, instances)
-                          } yield result
+                          // It takes a bit for jupyter to startup, hence wait 5 seconds before we check jupyter
+                          F.sleep(8 seconds) >> handleCheckTools(monitorContext, runtimeAndRuntimeConfig, ip, instances)
                         case None =>
                           checkAgain(monitorContext,
                                      runtimeAndRuntimeConfig,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/DataprocInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/DataprocInterpreter.scala
@@ -9,20 +9,26 @@ import cats.mtl.Ask
 import cats.syntax.all._
 import com.google.api.gax.rpc.ApiException
 import com.google.api.services.admin.directory.model.Group
+import com.google.cloud.compute.v1.Tags
 import com.google.cloud.dataproc.v1._
 import com.typesafe.scalalogging.LazyLogging
+import org.broadinstitute.dsde.workbench.DoneCheckable
 import org.broadinstitute.dsde.workbench.google.GoogleIamDAO.MemberType
 import org.broadinstitute.dsde.workbench.google.GoogleUtilities.RetryPredicates._
 import org.broadinstitute.dsde.workbench.google._
 import org.broadinstitute.dsde.workbench.google2.DataprocRole.Master
 import org.broadinstitute.dsde.workbench.google2.{
+  streamUntilDoneOrTimeout,
   CreateClusterConfig,
   DataprocClusterName,
+  DataprocRole,
+  DataprocRoleZonePreemptibility,
   DiskName,
   GoogleComputeService,
   GoogleDataprocService,
   GoogleDiskService,
   GoogleResourceService,
+  InstanceName,
   MachineTypeName,
   RegionName,
   ZoneName
@@ -289,6 +295,42 @@ class DataprocInterpreter[F[_]: Parallel](
             None
           )
         )
+
+        // If the cluster is configured with worker private access, then remove the private access
+        // network tag from the master node as soon as possible.
+        //
+        // We intentionally do this here instead of DataprocRuntimeMonitor to more quickly remove
+        // the tag because the init script may depend on public Internet access.
+        _ <- if (machineConfig.workerPrivateAccess) {
+          val op = for {
+            dataprocInstances <- googleDataprocService
+              .getClusterInstances(
+                params.runtimeProjectAndName.googleProject,
+                machineConfig.region,
+                DataprocClusterName(params.runtimeProjectAndName.runtimeName.asString)
+              )
+            masterComputeInstance <- dataprocInstances.find(_._1.role == DataprocRole.Master).flatTraverse {
+              case (DataprocRoleZonePreemptibility(_, z, _), is) =>
+                is.headOption.flatTraverse { i =>
+                  googleComputeService.getInstance(params.runtimeProjectAndName.googleProject, z, i)
+                }
+            }
+            op <- masterComputeInstance.traverse { m =>
+              googleComputeService.setInstanceTags(
+                params.runtimeProjectAndName.googleProject,
+                ZoneName(m.getZone),
+                InstanceName(m.getName),
+                Tags
+                  .newBuilder()
+                  .addItems(config.vpcConfig.networkTag.value)
+                  .setFingerprint(m.getTags.getFingerprint)
+                  .build()
+              )
+            }
+          } yield op
+
+          streamUntilDoneOrTimeout(op, 60, 1 second, "Could not retrieve Dataproc master instance after 1 minute")
+        } else F.unit
       } yield asyncRuntimeFields.map(s =>
         CreateGoogleRuntimeResponse(s, initBucketName, BootSource.VmImage(dataprocImage))
       )
@@ -756,4 +798,6 @@ class DataprocInterpreter[F[_]: Parallel](
       )
       .build()
   }
+
+  implicit private def optionDoneCheckable[A]: DoneCheckable[Option[A]] = (a: Option[A]) => a.isDefined
 }


### PR DESCRIPTION
cc @Qi77Qi I haven't tested this yet but here is what I'm thinking: we remove the `leonardo-private` tag from the master as soon as possible in `DataprocInterpreter` instead of waiting for the status in Dataproc to be `Running`. Hopefully that's quick enough so the init script can run..

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
