### PR TITLE
IA-3040 Don't create firewall if certain project labels exist

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/ConfigImplicits.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/ConfigImplicits.scala
@@ -2,7 +2,7 @@ package org.broadinstitute.dsde.workbench.leonardo
 
 import pureconfig.ConfigReader
 import cats.syntax.all._
-import org.broadinstitute.dsde.workbench.google2.ZoneName
+import org.broadinstitute.dsde.workbench.google2.{NetworkName, RegionName, SubnetworkName, ZoneName}
 import org.broadinstitute.dsp.{ChartName, ChartVersion}
 import pureconfig.error.ExceptionThrown
 
@@ -23,4 +23,22 @@ object ConfigImplicits {
     ConfigReader.intConfigReader.map(s => DiskSize(s))
   implicit val blockSizeConfigReader: ConfigReader[BlockSize] =
     ConfigReader.intConfigReader.map(s => BlockSize(s))
+  implicit val ipRangeReader: ConfigReader[IpRange] =
+    ConfigReader.stringConfigReader.map(s => IpRange(s))
+  implicit val regionNameReader: ConfigReader[RegionName] =
+    ConfigReader.stringConfigReader.map(s => RegionName(s))
+  implicit val networkLabeleReader: ConfigReader[NetworkLabel] =
+    ConfigReader.stringConfigReader.map(s => NetworkLabel(s))
+  implicit val subnetworkLabelReader: ConfigReader[SubnetworkLabel] =
+    ConfigReader.stringConfigReader.map(s => SubnetworkLabel(s))
+  implicit val firewallAllowHttpsLabelKeyReader: ConfigReader[FirewallAllowHttpsLabelKey] =
+    ConfigReader.stringConfigReader.map(s => FirewallAllowHttpsLabelKey(s))
+  implicit val firewallAllowInternalLabelKeyReader: ConfigReader[FirewallAllowInternalLabelKey] =
+    ConfigReader.stringConfigReader.map(s => FirewallAllowInternalLabelKey(s))
+  implicit val networkNameReader: ConfigReader[NetworkName] =
+    ConfigReader.stringConfigReader.map(s => NetworkName(s))
+  implicit val subnetworkNameReader: ConfigReader[SubnetworkName] =
+    ConfigReader.stringConfigReader.map(s => SubnetworkName(s))
+  implicit val networkTagReader: ConfigReader[NetworkTag] =
+    ConfigReader.stringConfigReader.map(s => NetworkTag(s))
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/ConfigImplicits.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/ConfigImplicits.scala
@@ -1,10 +1,11 @@
 package org.broadinstitute.dsde.workbench.leonardo
 
-import pureconfig.ConfigReader
 import cats.syntax.all._
-import org.broadinstitute.dsde.workbench.google2.{NetworkName, RegionName, SubnetworkName, ZoneName}
+import org.broadinstitute.dsde.workbench.google2.{FirewallRuleName, NetworkName, RegionName, SubnetworkName, ZoneName}
 import org.broadinstitute.dsp.{ChartName, ChartVersion}
+import pureconfig.ConfigReader
 import pureconfig.error.ExceptionThrown
+import pureconfig.configurable._
 
 import java.nio.file.{Path, Paths}
 
@@ -41,4 +42,10 @@ object ConfigImplicits {
     ConfigReader.stringConfigReader.map(s => SubnetworkName(s))
   implicit val networkTagReader: ConfigReader[NetworkTag] =
     ConfigReader.stringConfigReader.map(s => NetworkTag(s))
+  implicit val firewallRuleNameReader: ConfigReader[FirewallRuleName] =
+    ConfigReader.stringConfigReader.map(s => FirewallRuleName(s))
+  implicit val sourceRangeMapReader: ConfigReader[Map[RegionName, IpRange]] =
+    genericMapReader[RegionName, IpRange](s => RegionName(s).asRight)
+  implicit val sourceRangeMap2Reader: ConfigReader[Map[RegionName, List[IpRange]]] =
+    genericMapReader[RegionName, List[IpRange]](s => RegionName(s).asRight)
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/configModels.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/configModels.scala
@@ -20,6 +20,7 @@ final case class VPCConfig(highSecurityProjectNetworkLabel: NetworkLabel,
                            maxAttempts: Int)
 
 final case class FirewallRuleConfig(namePrefix: String,
+                                    rbsName: Option[String],
                                     sourceRanges: Map[RegionName, List[IpRange]],
                                     allowed: List[Allowed])
 

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/configModels.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/configModels.scala
@@ -1,12 +1,13 @@
 package org.broadinstitute.dsde.workbench.leonardo
-package config
+
 import org.broadinstitute.dsde.workbench.google2.{FirewallRuleName, NetworkName, RegionName, SubnetworkName}
-import org.broadinstitute.dsde.workbench.leonardo.{IpRange, NetworkTag}
 
 import scala.concurrent.duration.FiniteDuration
 
 final case class VPCConfig(highSecurityProjectNetworkLabel: NetworkLabel,
                            highSecurityProjectSubnetworkLabel: SubnetworkLabel,
+                           firewallAllowHttpsLabelKey: FirewallAllowHttpsLabelKey,
+                           firewallAllowInternalLabelKey: FirewallAllowInternalLabelKey,
                            networkName: NetworkName,
                            networkTag: NetworkTag,
                            privateAccessNetworkTag: NetworkTag,
@@ -26,3 +27,5 @@ final case class Allowed(protocol: String, port: Option[String])
 
 final case class NetworkLabel(value: String) extends AnyVal
 final case class SubnetworkLabel(value: String) extends AnyVal
+final case class FirewallAllowHttpsLabelKey(value: String) extends AnyVal
+final case class FirewallAllowInternalLabelKey(value: String) extends AnyVal

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -194,7 +194,7 @@ vpc {
     # Allows Leonardo proxy traffic on port 443
     {
       name-prefix = "leonardo-allow-https"
-      sourceRanges = {
+      source-ranges = {
         us-central1 = ["0.0.0.0/0"]
         northamerica-northeast1 = ["0.0.0.0/0"]
         southamerica-east1 = ["0.0.0.0/0"]
@@ -234,7 +234,7 @@ vpc {
     # Values are copied from https://github.com/DataBiosphere/terra-resource-buffer/blob/master/src/main/java/bio/terra/buffer/service/resource/flight/CreateSubnetsStep.java#L53
     {
       name-prefix = "leonardo-allow-internal"
-      sourceRanges = {
+      source-ranges = {
         asia-east1 = ["10.140.0.0/20"]
         asia-east2 = ["10.170.0.0/20"]
         asia-northeast1 = ["10.146.0.0/20"]
@@ -280,7 +280,7 @@ vpc {
     # IP list obtained from https://docs.google.com/document/d/1adV0LC2f_GIpl3A1AeoQuNiwcP59NToIt6VYT3xRCkU/edit
     {
       name-prefix = "leonardo-allow-broad-ssh"
-      sourceRanges = {
+      source-ranges = {
         us-central1 = ${gke.cluster.authorizedNetworks}
         northamerica-northeast1 = ${gke.cluster.authorizedNetworks}
         southamerica-east1 = ${gke.cluster.authorizedNetworks}

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -148,19 +148,21 @@ dateAccessedUpdater {
 }
 
 vpc {
-  highSecurityProjectNetworkLabel = "vpc-network-name"
-  highSecurityProjectSubnetworkLabel = "vpc-subnetwork-name"
-  networkName = "leonardo-network"
-  networkTag = "leonardo"
-  privateAccessNetworkTag = "leonardo-private"
+  high-security-project-network-label = "vpc-network-name"
+  high-security-project-subnetwork-label = "vpc-subnetwork-name"
+  firewall-allow-https-label-key = "leonardo-allow-https-firewall-name"
+  firewall-allow-internal-label-key = "leonardo-allow-internal-firewall-name"
+  network-name = "leonardo-network"
+  network-tag = "leonardo"
+  private-access-network-tag = "leonardo-private"
   # Using manual subnet creation mode because we currently only care about 1 region (us-central1)
   # and this allows us to have more control over address space. If/when we support multiple regions
   # consider auto-mode subnet creation.
   # See: https://cloud.google.com/vpc/docs/vpc#auto-mode-considerations
-  autoCreateSubnetworks = false
+  auto-create-subnetworks = false
   # Note the below 2 fields are not used if autoCreateSubnetworks is true
-  subnetworkName = "leonardo-subnetwork"
-  subnetworkRegionIpRangeMap = {
+  subnetwork-name = "leonardo-subnetwork"
+  subnetwork-region-ip-range-map = {
     us-central1 = "10.1.0.0/20"
     northamerica-northeast1 = "10.2.0.0/20"
     southamerica-east1 = "10.3.0.0/20"
@@ -188,7 +190,7 @@ vpc {
     australia-southeast1 = "10.25.0.0/20"
     northamerica-northeast2 = "10.26.0.0/20"
   }
-  firewallsToAdd = [
+  firewalls-to-add = [
     # Allows Leonardo proxy traffic on port 443
     {
       name-prefix = "leonardo-allow-https"
@@ -315,9 +317,9 @@ vpc {
     }
   ]
   # Remove RDP and SSH rules in the default network. Also remove legacy leonardo-notebooks-rule if it exists.
-  firewallsToRemove = ["default-allow-rdp", "default-allow-icmp", "allow-icmp"]
-  pollPeriod = 5 seconds
-  maxAttempts = 24 # 2 minutes
+  firewalls-to-remove = ["default-allow-rdp", "default-allow-icmp", "allow-icmp"]
+  poll-period = 5 seconds
+  max-attempts = 24 # 2 minutes
 }
 
 groups {

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -194,6 +194,7 @@ vpc {
     # Allows Leonardo proxy traffic on port 443
     {
       name-prefix = "leonardo-allow-https"
+      rbs-name = "leonardo-ssl"
       source-ranges = {
         us-central1 = ["0.0.0.0/0"]
         northamerica-northeast1 = ["0.0.0.0/0"]
@@ -234,6 +235,7 @@ vpc {
     # Values are copied from https://github.com/DataBiosphere/terra-resource-buffer/blob/master/src/main/java/bio/terra/buffer/service/resource/flight/CreateSubnetsStep.java#L53
     {
       name-prefix = "leonardo-allow-internal"
+      rbs-name = "leonardo-allow-internal"
       source-ranges = {
         asia-east1 = ["10.140.0.0/20"]
         asia-east2 = ["10.170.0.0/20"]

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
@@ -8,7 +8,6 @@ import net.ceedubs.ficus.readers.ValueReader
 import org.broadinstitute.dsde.workbench.google2.KubernetesSerializableName._
 import org.broadinstitute.dsde.workbench.google2.{
   DeviceName,
-  FirewallRuleName,
   KubernetesName,
   Location,
   MachineTypeName,
@@ -363,10 +362,6 @@ object Config {
   implicit private val memorySizeReader: ValueReader[MemorySize] = (config: TypeSafeConfig, path: String) =>
     MemorySize(config.getBytes(path))
 
-  implicit private val firewallRuleNameValueReader: ValueReader[FirewallRuleName] =
-    stringValueReader.map(FirewallRuleName)
-  implicit private val networkLabelValueReader: ValueReader[NetworkLabel] = stringValueReader.map(NetworkLabel)
-  implicit private val subnetworkLabelValueReader: ValueReader[SubnetworkLabel] = stringValueReader.map(SubnetworkLabel)
   implicit private val diskSizeValueReader: ValueReader[DiskSize] = intValueReader.map(DiskSize)
   implicit private val diskTypeValueReader: ValueReader[DiskType] = stringValueReader.map(s =>
     DiskType.stringToObject.getOrElse(s, throw new RuntimeException(s"Unable to parse diskType from $s"))

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/ConfigReader.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/ConfigReader.scala
@@ -2,8 +2,8 @@ package org.broadinstitute.dsde.workbench.leonardo
 package http
 
 import pureconfig.ConfigSource
-import _root_.pureconfig.generic.auto._
 import org.broadinstitute.dsde.workbench.leonardo.ConfigImplicits._
+import _root_.pureconfig.generic.auto._
 import org.broadinstitute.dsde.workbench.leonardo.util.TerraAppSetupChartConfig
 import org.broadinstitute.dsde.workbench.leonardo.config.PersistentDiskConfig
 
@@ -18,5 +18,6 @@ object ConfigReader {
 // More docs see https://pureconfig.github.io/docs/index.html
 final case class AppConfig(
   terraAppSetupChart: TerraAppSetupChartConfig,
-  persistentDisk: PersistentDiskConfig
+  persistentDisk: PersistentDiskConfig,
+  vpc: VPCConfig
 )

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/AppRoutes.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/AppRoutes.scala
@@ -10,7 +10,7 @@ import cats.effect.IO
 import cats.mtl.Ask
 import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
 import io.circe.{Decoder, Encoder, KeyEncoder}
-import io.opencensus.scala.akka.http.TracingDirective.traceRequestForService
+
 import org.broadinstitute.dsde.workbench.google2.KubernetesSerializableName.ServiceName
 import org.broadinstitute.dsde.workbench.leonardo.JsonCodec._
 import org.broadinstitute.dsde.workbench.leonardo.http.api.AppRoutes._
@@ -23,7 +23,7 @@ import org.http4s.Uri
 class AppRoutes(kubernetesService: AppService[IO], userInfoDirectives: UserInfoDirectives)(
   implicit metrics: OpenTelemetryMetrics[IO]
 ) {
-  val routes: server.Route = traceRequestForService(serviceData) { span =>
+  val routes: server.Route = CustomTracingDirectives.traceRequestForService(serviceData) { span =>
     extractAppContext(Some(span)) { implicit ctx =>
       userInfoDirectives.requireUserInfo { userInfo =>
         CookieSupport.setTokenCookie(userInfo, CookieSupport.tokenCookieName) {

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/DiskRoutes.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/DiskRoutes.scala
@@ -13,7 +13,7 @@ import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
 import io.circe.{Decoder, Encoder}
 import org.broadinstitute.dsde.workbench.google2.{DiskName, ZoneName}
 import org.broadinstitute.dsde.workbench.leonardo.JsonCodec._
-import io.opencensus.scala.akka.http.TracingDirective.traceRequestForService
+
 import org.broadinstitute.dsde.workbench.leonardo.http.api.DiskRoutes._
 import org.broadinstitute.dsde.workbench.leonardo.http.service.DiskService
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
@@ -23,7 +23,7 @@ import org.broadinstitute.dsde.workbench.openTelemetry.OpenTelemetryMetrics
 class DiskRoutes(diskService: DiskService[IO], userInfoDirectives: UserInfoDirectives)(
   implicit metrics: OpenTelemetryMetrics[IO]
 ) {
-  val routes: server.Route = traceRequestForService(serviceData) { span =>
+  val routes: server.Route = CustomTracingDirectives.traceRequestForService(serviceData) { span =>
     extractAppContext(Some(span)) { implicit ctx =>
       userInfoDirectives.requireUserInfo { userInfo =>
         CookieSupport.setTokenCookie(userInfo, CookieSupport.tokenCookieName) {

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/ProxyRoutes.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/ProxyRoutes.scala
@@ -15,7 +15,7 @@ import cats.effect.IO
 import cats.mtl.Ask
 import cats.syntax.all._
 import com.typesafe.scalalogging.LazyLogging
-import io.opencensus.scala.akka.http.TracingDirective.traceRequestForService
+
 import org.broadinstitute.dsde.workbench.google2.KubernetesSerializableName.ServiceName
 import org.broadinstitute.dsde.workbench.leonardo.config.RefererConfig
 import org.broadinstitute.dsde.workbench.leonardo.dao.TerminalName
@@ -31,7 +31,7 @@ class ProxyRoutes(proxyService: ProxyService, corsSupport: CorsSupport, refererC
   metrics: OpenTelemetryMetrics[IO]
 ) extends LazyLogging {
   val route: Route =
-    traceRequestForService(serviceData) { span =>
+    CustomTracingDirectives.traceRequestForService(serviceData) { span =>
       extractRequest { request =>
         extractAppContext(Some(span), request.uri.toString()) { implicit ctx =>
           // Note that the "notebooks" path prefix is deprecated

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/RuntimeRoutes.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/RuntimeRoutes.scala
@@ -12,7 +12,6 @@ import cats.syntax.all._
 import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
 import io.circe.syntax._
 import io.circe.{Decoder, DecodingFailure, Encoder, Json}
-import io.opencensus.scala.akka.http.TracingDirective.traceRequestForService
 import org.broadinstitute.dsde.workbench.google2.{MachineTypeName, RegionName, ZoneName}
 import org.broadinstitute.dsde.workbench.leonardo.JsonCodec._
 import org.broadinstitute.dsde.workbench.leonardo.SamResourceId.RuntimeSamResourceId
@@ -28,7 +27,7 @@ import scala.concurrent.duration._
 class RuntimeRoutes(runtimeService: RuntimeService[IO], userInfoDirectives: UserInfoDirectives)(
   implicit metrics: OpenTelemetryMetrics[IO]
 ) {
-  val routes: server.Route = traceRequestForService(serviceData) { span =>
+  val routes: server.Route = CustomTracingDirectives.traceRequestForService(serviceData) { span =>
     extractAppContext(Some(span)) { implicit ctx =>
       userInfoDirectives.requireUserInfo { userInfo =>
         CookieSupport.setTokenCookie(userInfo, CookieSupport.tokenCookieName) {

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/TracingDirectives.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/TracingDirectives.scala
@@ -1,0 +1,61 @@
+package org.broadinstitute.dsde.workbench.leonardo.http.api
+
+import akka.http.scaladsl.model.headers.RawHeader
+import akka.http.scaladsl.model.{HttpHeader, HttpRequest}
+import io.opencensus.scala.Tracing
+import io.opencensus.scala.akka.http.TracingDirective
+import io.opencensus.scala.http.propagation.{B3FormatPropagation, Propagation}
+import io.opencensus.trace.samplers.Samplers
+import io.opencensus.trace.{EndSpanOptions, Span, SpanBuilder, SpanContext, Status}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+// This whole file is just workaround for the fact
+object CustomTracingDirectives extends TracingDirective {
+  private val tracingInternal = new Tracing {
+    private val tracer = io.opencensus.trace.Tracing.getTracer
+
+    override def startSpan(name: String): Span = buildSpan(tracer.spanBuilder(name))
+
+    override def startSpanWithParent(name: String, parent: Span): Span =
+      buildSpan(tracer.spanBuilderWithExplicitParent(name, parent))
+
+    override def startSpanWithRemoteParent(name: String, parentContext: SpanContext): Span =
+      buildSpan(tracer.spanBuilderWithRemoteParent(name, parentContext))
+
+    override def setStatus(span: Span, status: Status): Unit = span.setStatus(status)
+
+    override def endSpan(span: Span): Unit = span.end()
+
+    override def endSpan(span: Span, status: Status): Unit =
+      span.end(EndSpanOptions.builder().setStatus(status).build())
+
+    override def trace[T](name: String, failureStatus: Throwable => Status)(f: Span => Future[T])(
+      implicit ec: ExecutionContext
+    ): Future[T] = Tracing.trace(name, failureStatus)(f)
+
+    override def traceWithParent[T](name: String, parentSpan: Span, failureStatus: Throwable => Status)(
+      f: Span => Future[T]
+    )(implicit ec: ExecutionContext): Future[T] = Tracing.traceWithParent(name, parentSpan, failureStatus)(f)
+  }
+
+  private def buildSpan(builder: SpanBuilder): Span =
+    builder
+      .setSampler(Samplers.probabilitySampler(0.2))
+      .startSpan()
+
+  override protected def tracing: Tracing = tracingInternal
+
+  override protected def propagation: Propagation[HttpHeader, HttpRequest] = CustomAkkaB3FormatPropagation
+}
+
+object CustomAkkaB3FormatPropagation extends B3FormatPropagation[HttpHeader, HttpRequest] {
+
+  override def headerValue(req: HttpRequest, key: String): Option[String] =
+    req.headers
+      .find(_.lowercaseName() == key.toLowerCase)
+      .map(_.value())
+
+  override def createHeader(key: String, value: String): HttpHeader =
+    RawHeader(key, value)
+}

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/package.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/package.scala
@@ -36,7 +36,7 @@ package object http {
   implicit def dbioToIO[A](dbio: DBIO[A]): DBIOOps[A] = new DBIOOps(dbio)
   implicit def cloudServiceOps(cloudService: CloudService): CloudServiceOps = new CloudServiceOps(cloudService)
 
-  val serviceData = ServiceData(Some("leonardo"), BuildTimeVersion.version)
+  val serviceData = ServiceData(Some("qi-leonardo"), BuildTimeVersion.version)
   def readFileToString[F[_]: Sync: Files](path: Path): F[String] =
     Files[F]
       .readAll(fs2.io.file.Path.fromNioPath(path))

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/RuntimeMonitor.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/RuntimeMonitor.scala
@@ -6,7 +6,7 @@ import cats.mtl.Ask
 import cats.syntax.all._
 import com.google.cloud.compute.v1.Instance
 import fs2.Stream
-import org.broadinstitute.dsde.workbench.leonardo.config.{Config, ImageConfig, RuntimeBucketConfig, VPCConfig}
+import org.broadinstitute.dsde.workbench.leonardo.config.{Config, ImageConfig, RuntimeBucketConfig}
 import org.broadinstitute.dsde.workbench.leonardo.http.userScriptStartupOutputUriMetadataKey
 import org.broadinstitute.dsde.workbench.model.TraceId
 import org.broadinstitute.dsde.workbench.model.google.{GcsPath, GoogleProject}

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/DataprocInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/DataprocInterpreter.scala
@@ -114,11 +114,8 @@ class DataprocInterpreter[F[_]: Parallel](
 
       createOp = for {
         // Set up VPC network and firewall
-        (network, subnetwork) <- vpcAlg.setUpProjectNetwork(
+        (network, subnetwork) <- vpcAlg.setUpProjectNetworkAndFirewalls(
           SetUpProjectNetworkParams(params.runtimeProjectAndName.googleProject, machineConfig.region)
-        )
-        _ <- vpcAlg.setUpProjectFirewalls(
-          SetUpProjectFirewallsParams(params.runtimeProjectAndName.googleProject, network, machineConfig.region)
         )
 
         // Add member to the Google Group that has the IAM role to pull the Dataproc image

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
@@ -210,7 +210,7 @@ class GKEInterpreter[F[_]](
       // and users can no longer create apps in the cluster's project
       // helm install nginx
       loadBalancerIp <- installNginx(dbCluster, googleCluster)
-      ipRange <- F.fromOption(Config.vpcConfig.subnetworkRegionIpRangeMap.get(dbCluster.region),
+      ipRange <- F.fromOption(config.vpcConfig.subnetworkRegionIpRangeMap.get(dbCluster.region),
                               new RegionNotSupportedException(dbCluster.region, ctx.traceId))
 
       _ <- kubernetesClusterQuery
@@ -1500,6 +1500,7 @@ final case class DeleteNodepoolResult(nodepoolId: NodepoolLeoId,
                                       getAppResult: GetAppResult)
 
 final case class GKEInterpreterConfig(terraAppSetupChartConfig: TerraAppSetupChartConfig,
+                                      vpcConfig: VPCConfig,
                                       ingressConfig: KubernetesIngressConfig,
                                       galaxyAppConfig: GalaxyAppConfig,
                                       cromwellAppConfig: CromwellAppConfig,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
@@ -98,11 +98,8 @@ class GKEInterpreter[F[_]](
       else F.unit
 
       // Set up VPC and firewall
-      (network, subnetwork) <- vpcAlg.setUpProjectNetwork(
+      (network, subnetwork) <- vpcAlg.setUpProjectNetworkAndFirewalls(
         SetUpProjectNetworkParams(params.googleProject, dbCluster.region)
-      )
-      _ <- vpcAlg.setUpProjectFirewalls(
-        SetUpProjectFirewallsParams(params.googleProject, network, dbCluster.region)
       )
 
       kubeNetwork = KubernetesNetwork(dbCluster.googleProject, network)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GceInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GceInterpreter.scala
@@ -76,11 +76,8 @@ class GceInterpreter[F[_]](
       regionParam = RegionName(zoneParam.value.substring(0, zoneParam.value.length - 2))
 
       // Set up VPC and firewall
-      (network, subnetwork) <- vpcAlg.setUpProjectNetwork(
+      (network, subnetwork) <- vpcAlg.setUpProjectNetworkAndFirewalls(
         SetUpProjectNetworkParams(params.runtimeProjectAndName.googleProject, regionParam)
-      )
-      _ <- vpcAlg.setUpProjectFirewalls(
-        SetUpProjectFirewallsParams(params.runtimeProjectAndName.googleProject, network, regionParam)
       )
 
       // Get resource (e.g. memory) constraints for the instance

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/VPCAlgebra.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/VPCAlgebra.scala
@@ -8,14 +8,15 @@ import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 
 trait VPCAlgebra[F[_]] {
 
-  def setUpProjectNetwork(params: SetUpProjectNetworkParams)(
+  def setUpProjectNetworkAndFirewalls(params: SetUpProjectNetworkParams)(
     implicit ev: Ask[F, TraceId]
   ): F[(NetworkName, SubnetworkName)]
-
-  def setUpProjectFirewalls(params: SetUpProjectFirewallsParams)(implicit ev: Ask[F, TraceId]): F[Unit]
 
 }
 
 final case class VPCInterpreterConfig(vpcConfig: VPCConfig)
 final case class SetUpProjectNetworkParams(project: GoogleProject, region: RegionName)
-final case class SetUpProjectFirewallsParams(project: GoogleProject, networkName: NetworkName, region: RegionName)
+final case class SetUpProjectFirewallsParams(project: GoogleProject,
+                                             networkName: NetworkName,
+                                             region: RegionName,
+                                             projectLabels: Map[String, String])

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/VPCAlgebra.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/VPCAlgebra.scala
@@ -1,8 +1,8 @@
-package org.broadinstitute.dsde.workbench.leonardo.util
+package org.broadinstitute.dsde.workbench.leonardo
+package util
 
 import cats.mtl.Ask
 import org.broadinstitute.dsde.workbench.google2.{NetworkName, RegionName, SubnetworkName}
-import org.broadinstitute.dsde.workbench.leonardo.config.VPCConfig
 import org.broadinstitute.dsde.workbench.model.TraceId
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/VPCInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/VPCInterpreter.scala
@@ -58,7 +58,7 @@ final class VPCInterpreter[F[_]: StructuredLogger: Parallel](
     RetryPredicates.whenStatusCode(409)
   )
 
-  override def setUpProjectNetwork(
+  override def setUpProjectNetworkAndFirewalls(
     params: SetUpProjectNetworkParams
   )(implicit ev: Ask[F, TraceId]): F[(NetworkName, SubnetworkName)] =
     for {
@@ -108,15 +108,19 @@ final class VPCInterpreter[F[_]: StructuredLogger: Parallel](
         case _ =>
           F.raiseError[(NetworkName, SubnetworkName)](InvalidVPCSetupException(params.project))
       }
+      _ <- setUpProjectFirewalls(
+        SetUpProjectFirewallsParams(params.project, network, params.region, projectLabels.getOrElse(Map.empty))
+      )
     } yield (network, subnetwork)
 
-  override def setUpProjectFirewalls(
+  private[util] def setUpProjectFirewalls(
     params: SetUpProjectFirewallsParams
   )(implicit ev: Ask[F, TraceId]): F[Unit] =
     for {
       ctx <- ev.ask
+      finalFirewallRulesToAdd = firewallRulesToAdd(params.projectLabels)
       // create firewalls in the Leonardo network
-      _ <- config.vpcConfig.firewallsToAdd.parTraverse_ { fw =>
+      _ <- finalFirewallRulesToAdd.parTraverse_ { fw =>
         for {
           firewallRegionalIprange <- F.fromOption(
             fw.sourceRanges.get(params.region),
@@ -143,6 +147,14 @@ final class VPCInterpreter[F[_]: StructuredLogger: Parallel](
           .parTraverse_(fw => googleComputeService.deleteFirewallRule(params.project, fw))
       } else F.unit
     } yield ()
+
+  private[util] def firewallRulesToAdd(projectLabels: Map[String, String]): List[FirewallRuleConfig] = {
+    val rbsAllowHttpsFirewallruleName = projectLabels.get(config.vpcConfig.firewallAllowHttpsLabelKey.value)
+    val rbsAllowInternalFirewallruleName =
+      projectLabels.get(config.vpcConfig.firewallAllowInternalLabelKey.value)
+    val firewallRulesCreatedByRbs = List(rbsAllowHttpsFirewallruleName, rbsAllowInternalFirewallruleName).flatten
+    config.vpcConfig.firewallsToAdd.filterNot(rule => rule.rbsName.exists(n => firewallRulesCreatedByRbs.contains(n)))
+  }
 
   private def createIfAbsent[A](project: GoogleProject,
                                 get: F[Option[A]],

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/VPCInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/VPCInterpreter.scala
@@ -1,4 +1,5 @@
-package org.broadinstitute.dsde.workbench.leonardo.util
+package org.broadinstitute.dsde.workbench.leonardo
+package util
 
 import _root_.org.typelevel.log4cats.StructuredLogger
 import cats.Parallel
@@ -17,8 +18,6 @@ import org.broadinstitute.dsde.workbench.google2.{
   RegionName,
   SubnetworkName
 }
-import org.broadinstitute.dsde.workbench.leonardo.IpRange
-import org.broadinstitute.dsde.workbench.leonardo.config.FirewallRuleConfig
 import org.broadinstitute.dsde.workbench.leonardo.dao.google._
 import org.broadinstitute.dsde.workbench.leonardo.model.LeoException
 import org.broadinstitute.dsde.workbench.model.TraceId

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/CommonTestData.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/CommonTestData.scala
@@ -40,6 +40,7 @@ import org.broadinstitute.dsde.workbench.leonardo.dao.MockSamDAO
 import org.broadinstitute.dsde.workbench.leonardo.db.ClusterRecord
 import org.broadinstitute.dsde.workbench.leonardo.http.{
   userScriptStartupOutputUriMetadataKey,
+  ConfigReader,
   CreateRuntime2Request,
   RuntimeConfigRequest
 }
@@ -118,7 +119,7 @@ object CommonTestData {
   // Let's not use this pattern and directly use `Config.???` going forward :)
   // By using Config.xxx, we'll be actually testing our Config.scala code as well
   val dataprocConfig = Config.dataprocConfig
-  val vpcConfig = Config.vpcConfig
+  val vpcConfig = ConfigReader.appConfig.vpc
   val imageConfig = Config.imageConfig
   val welderConfig = Config.welderConfig
   val clusterFilesConfig = Config.securityFilesConfig

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/ConfigReaderSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/ConfigReaderSpec.scala
@@ -3,6 +3,7 @@ package http
 
 import org.broadinstitute.dsde.workbench.google2.{FirewallRuleName, NetworkName, RegionName, SubnetworkName, ZoneName}
 import org.broadinstitute.dsde.workbench.leonardo.config.PersistentDiskConfig
+import org.broadinstitute.dsde.workbench.leonardo.http.ConfigReaderSpec._
 import org.broadinstitute.dsde.workbench.leonardo.util.TerraAppSetupChartConfig
 import org.broadinstitute.dsp.{ChartName, ChartVersion}
 import org.scalatest.flatspec.AnyFlatSpec
@@ -11,34 +12,7 @@ import org.scalatest.matchers.should.Matchers
 import scala.concurrent.duration._
 
 class ConfigReaderSpec extends AnyFlatSpec with Matchers {
-  val allSupportedRegions = List(
-    RegionName("us-central1"),
-    RegionName("northamerica-northeast1"),
-    RegionName("southamerica-east1"),
-    RegionName("us-east1"),
-    RegionName("us-east4"),
-    RegionName("us-west1"),
-    RegionName("us-west2"),
-    RegionName("us-west3"),
-    RegionName("us-west4"),
-    RegionName("europe-central2"),
-    RegionName("europe-north1"),
-    RegionName("europe-west1"),
-    RegionName("europe-west2"),
-    RegionName("europe-west3"),
-    RegionName("europe-west4"),
-    RegionName("europe-west6"),
-    RegionName("asia-east1"),
-    RegionName("asia-east2"),
-    RegionName("asia-northeast1"),
-    RegionName("asia-northeast2"),
-    RegionName("asia-northeast3"),
-    RegionName("asia-south1"),
-    RegionName("asia-southeast1"),
-    RegionName("asia-southeast2"),
-    RegionName("australia-southeast1"),
-    RegionName("northamerica-northeast2")
-  )
+
   it should "read config file correctly" in {
     val config = ConfigReader.appConfig
     val expectedVPCConfig = VPCConfig(
@@ -82,11 +56,13 @@ class ConfigReaderSpec extends AnyFlatSpec with Matchers {
       List(
         FirewallRuleConfig(
           "leonardo-allow-https",
+          Some("leonardo-allow-internal"),
           allSupportedRegions.map(r => r -> List(IpRange("0.0.0.0/0"))).toMap,
           List(Allowed("tcp", Some("443")))
         ),
         FirewallRuleConfig(
           "leonardo-allow-internal",
+          Some("leonardo-ssl"),
           Map(
             RegionName("asia-east1") -> List(IpRange("10.140.0.0/20")),
             RegionName("asia-east2") -> List(IpRange("10.170.0.0/20")),
@@ -117,30 +93,7 @@ class ConfigReaderSpec extends AnyFlatSpec with Matchers {
           ),
           List(Allowed("tcp", Some("0-65535")), Allowed("udp", Some("0-65535")), Allowed("icmp", None))
         ),
-        FirewallRuleConfig(
-          "leonardo-allow-broad-ssh",
-          allSupportedRegions
-            .map(r =>
-              r -> List(
-                IpRange("69.173.127.0/25"),
-                IpRange("69.173.124.0/23"),
-                IpRange("69.173.126.0/24"),
-                IpRange("69.173.127.230/31"),
-                IpRange("69.173.64.0/19"),
-                IpRange("69.173.127.224/30"),
-                IpRange("69.173.127.192/27"),
-                IpRange("69.173.120.0/22"),
-                IpRange("69.173.127.228/32"),
-                IpRange("69.173.127.232/29"),
-                IpRange("69.173.127.128/26"),
-                IpRange("69.173.96.0/20"),
-                IpRange("69.173.127.240/28"),
-                IpRange("69.173.112.0/21")
-              )
-            )
-            .toMap,
-          List(Allowed("tcp", Some("22")))
-        )
+        expectedSshFirewallRules
       ),
       List(FirewallRuleName("default-allow-rdp"),
            FirewallRuleName("default-allow-icmp"),
@@ -162,4 +115,61 @@ class ConfigReaderSpec extends AnyFlatSpec with Matchers {
 
     config shouldBe expectedConfig
   }
+}
+
+object ConfigReaderSpec {
+  val allSupportedRegions = List(
+    RegionName("us-central1"),
+    RegionName("northamerica-northeast1"),
+    RegionName("southamerica-east1"),
+    RegionName("us-east1"),
+    RegionName("us-east4"),
+    RegionName("us-west1"),
+    RegionName("us-west2"),
+    RegionName("us-west3"),
+    RegionName("us-west4"),
+    RegionName("europe-central2"),
+    RegionName("europe-north1"),
+    RegionName("europe-west1"),
+    RegionName("europe-west2"),
+    RegionName("europe-west3"),
+    RegionName("europe-west4"),
+    RegionName("europe-west6"),
+    RegionName("asia-east1"),
+    RegionName("asia-east2"),
+    RegionName("asia-northeast1"),
+    RegionName("asia-northeast2"),
+    RegionName("asia-northeast3"),
+    RegionName("asia-south1"),
+    RegionName("asia-southeast1"),
+    RegionName("asia-southeast2"),
+    RegionName("australia-southeast1"),
+    RegionName("northamerica-northeast2")
+  )
+
+  val expectedSshFirewallRules = FirewallRuleConfig(
+    "leonardo-allow-broad-ssh",
+    None,
+    allSupportedRegions
+      .map(r =>
+        r -> List(
+          IpRange("69.173.127.0/25"),
+          IpRange("69.173.124.0/23"),
+          IpRange("69.173.126.0/24"),
+          IpRange("69.173.127.230/31"),
+          IpRange("69.173.64.0/19"),
+          IpRange("69.173.127.224/30"),
+          IpRange("69.173.127.192/27"),
+          IpRange("69.173.120.0/22"),
+          IpRange("69.173.127.228/32"),
+          IpRange("69.173.127.232/29"),
+          IpRange("69.173.127.128/26"),
+          IpRange("69.173.96.0/20"),
+          IpRange("69.173.127.240/28"),
+          IpRange("69.173.112.0/21")
+        )
+      )
+      .toMap,
+    List(Allowed("tcp", Some("22")))
+  )
 }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/ConfigReaderSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/ConfigReaderSpec.scala
@@ -1,16 +1,153 @@
-package org.broadinstitute.dsde.workbench.leonardo.http
+package org.broadinstitute.dsde.workbench.leonardo
+package http
 
-import org.broadinstitute.dsde.workbench.google2.ZoneName
+import org.broadinstitute.dsde.workbench.google2.{FirewallRuleName, NetworkName, RegionName, SubnetworkName, ZoneName}
 import org.broadinstitute.dsde.workbench.leonardo.config.PersistentDiskConfig
-import org.broadinstitute.dsde.workbench.leonardo.{BlockSize, DiskSize, DiskType}
 import org.broadinstitute.dsde.workbench.leonardo.util.TerraAppSetupChartConfig
 import org.broadinstitute.dsp.{ChartName, ChartVersion}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
+import scala.concurrent.duration._
+
 class ConfigReaderSpec extends AnyFlatSpec with Matchers {
+  val allSupportedRegions = List(
+    RegionName("us-central1"),
+    RegionName("northamerica-northeast1"),
+    RegionName("southamerica-east1"),
+    RegionName("us-east1"),
+    RegionName("us-east4"),
+    RegionName("us-west1"),
+    RegionName("us-west2"),
+    RegionName("us-west3"),
+    RegionName("us-west4"),
+    RegionName("europe-central2"),
+    RegionName("europe-north1"),
+    RegionName("europe-west1"),
+    RegionName("europe-west2"),
+    RegionName("europe-west3"),
+    RegionName("europe-west4"),
+    RegionName("europe-west6"),
+    RegionName("asia-east1"),
+    RegionName("asia-east2"),
+    RegionName("asia-northeast1"),
+    RegionName("asia-northeast2"),
+    RegionName("asia-northeast3"),
+    RegionName("asia-south1"),
+    RegionName("asia-southeast1"),
+    RegionName("asia-southeast2"),
+    RegionName("australia-southeast1"),
+    RegionName("northamerica-northeast2")
+  )
   it should "read config file correctly" in {
     val config = ConfigReader.appConfig
+    val expectedVPCConfig = VPCConfig(
+      NetworkLabel("vpc-network-name"),
+      SubnetworkLabel("vpc-subnetwork-name"),
+      FirewallAllowHttpsLabelKey("leonardo-allow-https-firewall-name"),
+      FirewallAllowInternalLabelKey("leonardo-allow-internal-firewall-name"),
+      NetworkName("leonardo-network"),
+      NetworkTag("leonardo"),
+      NetworkTag("leonardo-private"),
+      false,
+      SubnetworkName("leonardo-subnetwork"),
+      Map(
+        RegionName("us-central1") -> IpRange("10.1.0.0/20"),
+        RegionName("northamerica-northeast1") -> IpRange("10.2.0.0/20"),
+        RegionName("southamerica-east1") -> IpRange("10.3.0.0/20"),
+        RegionName("us-east1") -> IpRange("10.4.0.0/20"),
+        RegionName("us-east4") -> IpRange("10.5.0.0/20"),
+        RegionName("us-west1") -> IpRange("10.6.0.0/20"),
+        RegionName("us-west2") -> IpRange("10.7.0.0/20"),
+        RegionName("us-west3") -> IpRange("10.8.0.0/20"),
+        RegionName("us-west4") -> IpRange("10.9.0.0/20"),
+        RegionName("europe-central2") -> IpRange("10.10.0.0/20"),
+        RegionName("europe-north1") -> IpRange("10.11.0.0/20"),
+        RegionName("europe-west1") -> IpRange("10.12.0.0/20"),
+        RegionName("europe-west2") -> IpRange("10.13.0.0/20"),
+        RegionName("europe-west3") -> IpRange("10.14.0.0/20"),
+        RegionName("europe-west4") -> IpRange("10.15.0.0/20"),
+        RegionName("europe-west6") -> IpRange("10.16.0.0/20"),
+        RegionName("asia-east1") -> IpRange("10.17.0.0/20"),
+        RegionName("asia-east2") -> IpRange("10.18.0.0/20"),
+        RegionName("asia-northeast1") -> IpRange("10.19.0.0/20"),
+        RegionName("asia-northeast2") -> IpRange("10.20.0.0/20"),
+        RegionName("asia-northeast3") -> IpRange("10.21.0.0/20"),
+        RegionName("asia-south1") -> IpRange("10.22.0.0/20"),
+        RegionName("asia-southeast1") -> IpRange("10.23.0.0/20"),
+        RegionName("asia-southeast2") -> IpRange("10.24.0.0/20"),
+        RegionName("australia-southeast1") -> IpRange("10.25.0.0/20"),
+        RegionName("northamerica-northeast2") -> IpRange("10.26.0.0/20")
+      ),
+      List(
+        FirewallRuleConfig(
+          "leonardo-allow-https",
+          allSupportedRegions.map(r => r -> List(IpRange("0.0.0.0/0"))).toMap,
+          List(Allowed("tcp", Some("443")))
+        ),
+        FirewallRuleConfig(
+          "leonardo-allow-internal",
+          Map(
+            RegionName("asia-east1") -> List(IpRange("10.140.0.0/20")),
+            RegionName("asia-east2") -> List(IpRange("10.170.0.0/20")),
+            RegionName("asia-northeast1") -> List(IpRange("10.146.0.0/20")),
+            RegionName("asia-northeast2") -> List(IpRange("10.174.0.0/20")),
+            RegionName("asia-northeast3") -> List(IpRange("10.178.0.0/20")),
+            RegionName("asia-south1") -> List(IpRange("10.160.0.0/20")),
+            RegionName("asia-southeast1") -> List(IpRange("10.148.0.0/20")),
+            RegionName("asia-southeast2") -> List(IpRange("10.184.0.0/20")),
+            RegionName("australia-southeast1") -> List(IpRange("10.152.0.0/20")),
+            RegionName("europe-central2") -> List(IpRange("10.186.0.0/20")),
+            RegionName("europe-north1") -> List(IpRange("10.166.0.0/20")),
+            RegionName("europe-west1") -> List(IpRange("10.132.0.0/20")),
+            RegionName("europe-west2") -> List(IpRange("10.154.0.0/20")),
+            RegionName("europe-west3") -> List(IpRange("10.156.0.0/20")),
+            RegionName("europe-west4") -> List(IpRange("10.164.0.0/20")),
+            RegionName("europe-west6") -> List(IpRange("10.172.0.0/20")),
+            RegionName("northamerica-northeast1") -> List(IpRange("10.162.0.0/20")),
+            RegionName("northamerica-northeast2") -> List(IpRange("10.188.0.0/20")),
+            RegionName("southamerica-east1") -> List(IpRange("10.158.0.0/20")),
+            RegionName("us-central1") -> List(IpRange("10.128.0.0/20")),
+            RegionName("us-east1") -> List(IpRange("10.142.0.0/20")),
+            RegionName("us-east4") -> List(IpRange("10.150.0.0/20")),
+            RegionName("us-west1") -> List(IpRange("10.138.0.0/20")),
+            RegionName("us-west2") -> List(IpRange("10.168.0.0/20")),
+            RegionName("us-west3") -> List(IpRange("10.180.0.0/20")),
+            RegionName("us-west4") -> List(IpRange("10.182.0.0/20"))
+          ),
+          List(Allowed("tcp", Some("0-65535")), Allowed("udp", Some("0-65535")), Allowed("icmp", None))
+        ),
+        FirewallRuleConfig(
+          "leonardo-allow-broad-ssh",
+          allSupportedRegions
+            .map(r =>
+              r -> List(
+                IpRange("69.173.127.0/25"),
+                IpRange("69.173.124.0/23"),
+                IpRange("69.173.126.0/24"),
+                IpRange("69.173.127.230/31"),
+                IpRange("69.173.64.0/19"),
+                IpRange("69.173.127.224/30"),
+                IpRange("69.173.127.192/27"),
+                IpRange("69.173.120.0/22"),
+                IpRange("69.173.127.228/32"),
+                IpRange("69.173.127.232/29"),
+                IpRange("69.173.127.128/26"),
+                IpRange("69.173.96.0/20"),
+                IpRange("69.173.127.240/28"),
+                IpRange("69.173.112.0/21")
+              )
+            )
+            .toMap,
+          List(Allowed("tcp", Some("22")))
+        )
+      ),
+      List(FirewallRuleName("default-allow-rdp"),
+           FirewallRuleName("default-allow-icmp"),
+           FirewallRuleName("allow-icmp")),
+      5 seconds,
+      24
+    )
     val expectedConfig = AppConfig(
       TerraAppSetupChartConfig(ChartName("/leonardo/terra-app-setup"), ChartVersion("0.0.2")),
       PersistentDiskConfig(
@@ -19,7 +156,8 @@ class ConfigReaderSpec extends AnyFlatSpec with Matchers {
         BlockSize(4096),
         ZoneName("us-central1-a"),
         DiskSize(250)
-      )
+      ),
+      expectedVPCConfig
     )
 
     config shouldBe expectedConfig

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriberSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriberSpec.scala
@@ -680,7 +680,7 @@ class LeoPubsubMessageSubscriberSpec
       getDiskOpt <- persistentDiskQuery.getById(savedApp1.appResources.disk.get.id).transaction
       getDisk = getDiskOpt.get
       galaxyRestore <- persistentDiskQuery.getGalaxyDiskRestore(savedApp1.appResources.disk.get.id).transaction
-      ipRange = Config.vpcConfig.subnetworkRegionIpRangeMap
+      ipRange = ConfigReader.appConfig.vpc.subnetworkRegionIpRangeMap
         .getOrElse(RegionName("us-central1"), throw new Exception(s"Unsupported Region us-central1"))
     } yield {
       getCluster.status shouldBe KubernetesClusterStatus.Running
@@ -696,8 +696,8 @@ class LeoPubsubMessageSubscriberSpec
       getApp.cluster.asyncFields shouldBe Some(
         KubernetesClusterAsyncFields(IP("1.2.3.4"),
                                      IP("0.0.0.0"),
-                                     NetworkFields(Config.vpcConfig.networkName,
-                                                   Config.vpcConfig.subnetworkName,
+                                     NetworkFields(ConfigReader.appConfig.vpc.networkName,
+                                                   ConfigReader.appConfig.vpc.subnetworkName,
                                                    ipRange))
       )
       getDisk.status shouldBe DiskStatus.Ready
@@ -769,7 +769,7 @@ class LeoPubsubMessageSubscriberSpec
         .transaction
       getApp1 = getAppOpt1.get
       getApp2 = getAppOpt2.get
-      ipRange = Config.vpcConfig.subnetworkRegionIpRangeMap
+      ipRange = ConfigReader.appConfig.vpc.subnetworkRegionIpRangeMap
         .getOrElse(RegionName("us-central1"), throw new Exception(s"Unsupported Region us-central1"))
     } yield {
       getApp1.cluster.status shouldBe KubernetesClusterStatus.Running
@@ -784,8 +784,8 @@ class LeoPubsubMessageSubscriberSpec
       getApp1.cluster.asyncFields shouldBe Some(
         KubernetesClusterAsyncFields(IP("1.2.3.4"),
                                      IP("0.0.0.0"),
-                                     NetworkFields(Config.vpcConfig.networkName,
-                                                   Config.vpcConfig.subnetworkName,
+                                     NetworkFields(ConfigReader.appConfig.vpc.networkName,
+                                                   ConfigReader.appConfig.vpc.subnetworkName,
                                                    ipRange))
       )
       getApp2.app.errors shouldBe List()
@@ -1417,7 +1417,7 @@ class LeoPubsubMessageSubscriberSpec
       getApp = getAppOpt.get
       getDiskOpt <- persistentDiskQuery.getById(savedApp1.appResources.disk.get.id).transaction
       getDisk = getDiskOpt.get
-      ipRange = Config.vpcConfig.subnetworkRegionIpRangeMap
+      ipRange = ConfigReader.appConfig.vpc.subnetworkRegionIpRangeMap
         .getOrElse(RegionName("us-central1"), throw new Exception(s"Unsupported Region us-central1"))
     } yield {
       getCluster.status shouldBe KubernetesClusterStatus.Running
@@ -1433,8 +1433,8 @@ class LeoPubsubMessageSubscriberSpec
       getApp.cluster.asyncFields shouldBe Some(
         KubernetesClusterAsyncFields(IP("1.2.3.4"),
                                      IP("0.0.0.0"),
-                                     NetworkFields(Config.vpcConfig.networkName,
-                                                   Config.vpcConfig.subnetworkName,
+                                     NetworkFields(ConfigReader.appConfig.vpc.networkName,
+                                                   ConfigReader.appConfig.vpc.subnetworkName,
                                                    ipRange))
       )
       getDisk.status shouldBe DiskStatus.Ready

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -27,6 +27,7 @@ object Dependencies {
   val helmScalaSdkV = "0.0.4"
 
   val excludeAkkaHttp = ExclusionRule(organization = "com.typesafe.akka", name = s"akka-http_${scalaV}")
+  val excludePureConfig = ExclusionRule(organization = "com.github.pureconfig", name = s"pureconfig_${scalaV}")
   val excludeAkkaStream = ExclusionRule(organization = "com.typesafe.akka", name = s"akka-stream_${scalaV}")
   val excludeAkkaHttpSprayJson = ExclusionRule(organization = "com.typesafe.akka", name = s"akka-http-spray-json_${scalaV}")
   val excludeGuavaJDK5 = ExclusionRule(organization = "com.google.guava", name = "guava-jdk5")
@@ -178,10 +179,7 @@ object Dependencies {
     googleCloudNio,
     mysql,
     liquibase,
-    "com.github.sebruck" %% "opencensus-scala-akka-http" % "0.7.2",
-
-    // Dependent on the trace exporters you want to use add one or more of the following
-    "io.opencensus" % "opencensus-exporter-trace-stackdriver" % opencensusV,
+    "com.github.sebruck" %% "opencensus-scala-akka-http" % "0.7.2" excludeAll(excludePureConfig),
     http4sBlazeServer % Test,
     scalaTestSelenium,
     scalaTestMockito

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -144,9 +144,9 @@ object Dependencies {
     "net.logstash.logback" % "logstash-logback-encoder" % "6.6", // for structured logging in logback
     "com.github.julien-truffaut" %%  "monocle-core"  % monocleV,
     "com.github.julien-truffaut" %%  "monocle-macro" % monocleV,
-    // using provided because `http` depends on `core`, and `http`'s `opencensus-exporter-trace-stackdriver`
-    // brings in an older version of `pureconfig`
-    "com.github.pureconfig" %% "pureconfig" % "0.17.0" % Provided,
+//    // using provided because `http` depends on `core`, and `http`'s `opencensus-exporter-trace-stackdriver`
+//    // brings in an older version of `pureconfig`
+    "com.github.pureconfig" %% "pureconfig" % "0.17.0",
     sealerate,
     enumeratum,
     circeYaml,


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-3040

No need to insert firewall rules if `leonardo-allow-https-firewall-name`, `leonardo-allow-internal-firewall-name` exist in project.

TODO: test in fiab

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
