### PR TITLE
IA-3040 Don't create firewall if certain project labels exist

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/package.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/package.scala
@@ -4,6 +4,7 @@ import cats.Applicative
 import cats.effect.Sync
 import cats.mtl.Ask
 import cats.syntax.all._
+import org.broadinstitute.dsde.workbench.google2.RegionName
 import org.broadinstitute.dsde.workbench.model.TraceId
 import org.typelevel.ci._
 
@@ -39,4 +40,33 @@ package object leonardo {
           s"Invalid name ${nameString}. Only lowercase alphanumeric characters, numbers and dashes are allowed in leo names"
         )
     }
+
+  val allSupportedRegions = List(
+    RegionName("us-central1"),
+    RegionName("northamerica-northeast1"),
+    RegionName("southamerica-east1"),
+    RegionName("us-east1"),
+    RegionName("us-east4"),
+    RegionName("us-west1"),
+    RegionName("us-west2"),
+    RegionName("us-west3"),
+    RegionName("us-west4"),
+    RegionName("europe-central2"),
+    RegionName("europe-north1"),
+    RegionName("europe-west1"),
+    RegionName("europe-west2"),
+    RegionName("europe-west3"),
+    RegionName("europe-west4"),
+    RegionName("europe-west6"),
+    RegionName("asia-east1"),
+    RegionName("asia-east2"),
+    RegionName("asia-northeast1"),
+    RegionName("asia-northeast2"),
+    RegionName("asia-northeast3"),
+    RegionName("asia-south1"),
+    RegionName("asia-southeast1"),
+    RegionName("asia-southeast2"),
+    RegionName("australia-southeast1"),
+    RegionName("northamerica-northeast2")
+  )
 }

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -150,6 +150,8 @@ dateAccessedUpdater {
 vpc {
   highSecurityProjectNetworkLabel = "vpc-network-name"
   highSecurityProjectSubnetworkLabel = "vpc-subnetwork-name"
+  firewallAllowHttpsLabelKey = "leonardo-allow-https-firewall-name"
+  firewallAllowInternalLabelKey = "leonardo-allow-internal-firewall-name"
   networkName = "leonardo-network"
   networkTag = "leonardo"
   privateAccessNetworkTag = "leonardo-private"
@@ -192,6 +194,8 @@ vpc {
     # Allows Leonardo proxy traffic on port 443
     {
       name-prefix = "leonardo-allow-https"
+      # See https://github.com/DataBiosphere/terra-resource-buffer/blob/master/src/main/java/bio/terra/buffer/service/resource/flight/CreateFirewallRuleStep.java#L37
+      rbs-name = "leonardo-ssl"
       sourceRanges = {
         us-central1 = ["0.0.0.0/0"]
         northamerica-northeast1 = ["0.0.0.0/0"]
@@ -232,6 +236,8 @@ vpc {
     # Values are copied from https://github.com/DataBiosphere/terra-resource-buffer/blob/master/src/main/java/bio/terra/buffer/service/resource/flight/CreateSubnetsStep.java#L53
     {
       name-prefix = "leonardo-allow-internal"
+      # See https://github.com/DataBiosphere/terra-resource-buffer/blob/master/src/main/java/bio/terra/buffer/service/resource/flight/CreateFirewallRuleStep.java#L34
+      rbs-name = "leonardo-allow-internal"
       sourceRanges = {
         asia-east1 = ["10.140.0.0/20"]
         asia-east2 = ["10.170.0.0/20"]

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
@@ -373,6 +373,10 @@ object Config {
     MemorySize(config.getBytes(path))
   implicit private val networkNameValueReader: ValueReader[NetworkName] = stringValueReader.map(NetworkName)
   implicit private val subnetworkNameValueReader: ValueReader[SubnetworkName] = stringValueReader.map(SubnetworkName)
+  implicit private val firewallAllowHttpsLabelKeyReader: ValueReader[FirewallAllowHttpsLabelKey] =
+    stringValueReader.map(FirewallAllowHttpsLabelKey)
+  implicit private val firewallAllowInternalLabelKeyReader: ValueReader[FirewallAllowInternalLabelKey] =
+    stringValueReader.map(FirewallAllowInternalLabelKey)
   implicit private val ipRangeValueReader: ValueReader[IpRange] = stringValueReader.map(IpRange)
   // TODO(wnojopra): Make these more FP-friendly
   implicit private val subnetworkRegionIpRangeMapReader: ValueReader[Map[RegionName, IpRange]] =
@@ -382,6 +386,8 @@ object Config {
     VPCConfig(
       config.as[NetworkLabel]("highSecurityProjectNetworkLabel"),
       config.as[SubnetworkLabel]("highSecurityProjectSubnetworkLabel"),
+      config.as[FirewallAllowHttpsLabelKey]("firewallAllowHttpsLabelKey"),
+      config.as[FirewallAllowInternalLabelKey]("firewallAllowInternalLabelKey"),
       config.as[NetworkName]("networkName"),
       config.as[NetworkTag]("networkTag"),
       config.as[NetworkTag]("privateAccessNetworkTag"),
@@ -401,6 +407,7 @@ object Config {
   implicit private val firewallRuleConfigReader: ValueReader[FirewallRuleConfig] = ValueReader.relative { config =>
     FirewallRuleConfig(
       config.as[String]("name-prefix"),
+      config.as[Option[String]]("rbs-name"),
       config.as[Map[RegionName, List[IpRange]]]("sourceRanges"),
       config.as[List[Allowed]]("allowed")
     )

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/VPCConfig.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/VPCConfig.scala
@@ -1,12 +1,13 @@
 package org.broadinstitute.dsde.workbench.leonardo
 package config
 import org.broadinstitute.dsde.workbench.google2.{FirewallRuleName, NetworkName, RegionName, SubnetworkName}
-import org.broadinstitute.dsde.workbench.leonardo.{IpRange, NetworkTag}
 
 import scala.concurrent.duration.FiniteDuration
 
 final case class VPCConfig(highSecurityProjectNetworkLabel: NetworkLabel,
                            highSecurityProjectSubnetworkLabel: SubnetworkLabel,
+                           firewallAllowHttpsLabelKey: FirewallAllowHttpsLabelKey,
+                           firewallAllowInternalLabelKey: FirewallAllowInternalLabelKey,
                            networkName: NetworkName,
                            networkTag: NetworkTag,
                            privateAccessNetworkTag: NetworkTag,
@@ -19,6 +20,7 @@ final case class VPCConfig(highSecurityProjectNetworkLabel: NetworkLabel,
                            maxAttempts: Int)
 
 final case class FirewallRuleConfig(namePrefix: String,
+                                    rbsName: Option[String],
                                     sourceRanges: Map[RegionName, List[IpRange]],
                                     allowed: List[Allowed])
 
@@ -26,3 +28,5 @@ final case class Allowed(protocol: String, port: Option[String])
 
 final case class NetworkLabel(value: String) extends AnyVal
 final case class SubnetworkLabel(value: String) extends AnyVal
+final case class FirewallAllowHttpsLabelKey(value: String) extends AnyVal
+final case class FirewallAllowInternalLabelKey(value: String) extends AnyVal

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/DataprocInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/DataprocInterpreter.scala
@@ -120,11 +120,8 @@ class DataprocInterpreter[F[_]: Parallel](
 
       createOp = for {
         // Set up VPC network and firewall
-        (network, subnetwork) <- vpcAlg.setUpProjectNetwork(
+        (network, subnetwork) <- vpcAlg.setUpProjectNetworkAndFirewalls(
           SetUpProjectNetworkParams(params.runtimeProjectAndName.googleProject, machineConfig.region)
-        )
-        _ <- vpcAlg.setUpProjectFirewalls(
-          SetUpProjectFirewallsParams(params.runtimeProjectAndName.googleProject, network, machineConfig.region)
         )
 
         // Add member to the Google Group that has the IAM role to pull the Dataproc image

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
@@ -98,11 +98,8 @@ class GKEInterpreter[F[_]](
       else F.unit
 
       // Set up VPC and firewall
-      (network, subnetwork) <- vpcAlg.setUpProjectNetwork(
+      (network, subnetwork) <- vpcAlg.setUpProjectNetworkAndFirewalls(
         SetUpProjectNetworkParams(params.googleProject, dbCluster.region)
-      )
-      _ <- vpcAlg.setUpProjectFirewalls(
-        SetUpProjectFirewallsParams(params.googleProject, network, dbCluster.region)
       )
 
       kubeNetwork = KubernetesNetwork(dbCluster.googleProject, network)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GceInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GceInterpreter.scala
@@ -76,11 +76,8 @@ class GceInterpreter[F[_]](
       regionParam = RegionName(zoneParam.value.substring(0, zoneParam.value.length - 2))
 
       // Set up VPC and firewall
-      (network, subnetwork) <- vpcAlg.setUpProjectNetwork(
+      (_, subnetwork) <- vpcAlg.setUpProjectNetworkAndFirewalls(
         SetUpProjectNetworkParams(params.runtimeProjectAndName.googleProject, regionParam)
-      )
-      _ <- vpcAlg.setUpProjectFirewalls(
-        SetUpProjectFirewallsParams(params.runtimeProjectAndName.googleProject, network, regionParam)
       )
 
       // Get resource (e.g. memory) constraints for the instance

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/VPCAlgebra.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/VPCAlgebra.scala
@@ -8,14 +8,15 @@ import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 
 trait VPCAlgebra[F[_]] {
 
-  def setUpProjectNetwork(params: SetUpProjectNetworkParams)(
+  def setUpProjectNetworkAndFirewalls(params: SetUpProjectNetworkParams)(
     implicit ev: Ask[F, TraceId]
   ): F[(NetworkName, SubnetworkName)]
-
-  def setUpProjectFirewalls(params: SetUpProjectFirewallsParams)(implicit ev: Ask[F, TraceId]): F[Unit]
 
 }
 
 final case class VPCInterpreterConfig(vpcConfig: VPCConfig)
 final case class SetUpProjectNetworkParams(project: GoogleProject, region: RegionName)
-final case class SetUpProjectFirewallsParams(project: GoogleProject, networkName: NetworkName, region: RegionName)
+final case class SetUpProjectFirewallsParams(project: GoogleProject,
+                                             networkName: NetworkName,
+                                             region: RegionName,
+                                             projectLabels: Map[String, String])

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/VPCInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/VPCInterpreter.scala
@@ -150,10 +150,10 @@ final class VPCInterpreter[F[_]: StructuredLogger: Parallel](
     } yield ()
 
   private[util] def firewallRulesToAdd(projectLabels: Map[String, String]): List[FirewallRuleConfig] = {
-    val rbsAllowHttpsFirewallruleName = projectLabels.get(config.vpcConfig.firewallAllowHttpsLabelKey.value)
+    val rbsAllowHttpsFirewallRuleName = projectLabels.get(config.vpcConfig.firewallAllowHttpsLabelKey.value)
     val rbsAllowInternalFirewallruleName =
       projectLabels.get(config.vpcConfig.firewallAllowInternalLabelKey.value)
-    val firewallRulesCreatedByRbs = List(rbsAllowHttpsFirewallruleName, rbsAllowInternalFirewallruleName).flatten
+    val firewallRulesCreatedByRbs = List(rbsAllowHttpsFirewallRuleName, rbsAllowInternalFirewallruleName).flatten
     config.vpcConfig.firewallsToAdd.filterNot(rule => rule.rbsName.exists(n => firewallRulesCreatedByRbs.contains(n)))
   }
   private def createIfAbsent[A](project: GoogleProject,

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/VPCInterpreterSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/VPCInterpreterSpec.scala
@@ -31,7 +31,7 @@ class VPCInterpreterSpec extends AnyFlatSpecLike with LeonardoTestSuite {
                                   new MockComputePollOperation)
 
     test
-      .setUpProjectNetwork(SetUpProjectNetworkParams(project, RegionName("us-central1")))
+      .setUpProjectNetworkAndFirewalls(SetUpProjectNetworkParams(project, RegionName("us-central1")))
       .unsafeRunSync() shouldBe (NetworkName("my_network"), SubnetworkName("my_subnet"))
   }
 
@@ -44,7 +44,7 @@ class VPCInterpreterSpec extends AnyFlatSpecLike with LeonardoTestSuite {
                                   new MockComputePollOperation)
 
     test
-      .setUpProjectNetwork(SetUpProjectNetworkParams(project, RegionName("us-central1")))
+      .setUpProjectNetworkAndFirewalls(SetUpProjectNetworkParams(project, RegionName("us-central1")))
       .attempt
       .unsafeRunSync() shouldBe Left(
       InvalidVPCSetupException(project)
@@ -58,7 +58,7 @@ class VPCInterpreterSpec extends AnyFlatSpecLike with LeonardoTestSuite {
                                    new MockComputePollOperation)
 
     test2
-      .setUpProjectNetwork(SetUpProjectNetworkParams(project, RegionName("us-central1")))
+      .setUpProjectNetworkAndFirewalls(SetUpProjectNetworkParams(project, RegionName("us-central1")))
       .attempt
       .unsafeRunSync() shouldBe Left(
       InvalidVPCSetupException(project)
@@ -72,7 +72,7 @@ class VPCInterpreterSpec extends AnyFlatSpecLike with LeonardoTestSuite {
                                   new MockComputePollOperation)
 
     test
-      .setUpProjectNetwork(SetUpProjectNetworkParams(project, RegionName("us-central1")))
+      .setUpProjectNetworkAndFirewalls(SetUpProjectNetworkParams(project, RegionName("us-central1")))
       .unsafeRunSync() shouldBe (vpcConfig.networkName, vpcConfig.subnetworkName)
   }
 
@@ -84,7 +84,9 @@ class VPCInterpreterSpec extends AnyFlatSpecLike with LeonardoTestSuite {
                                   new MockComputePollOperation)
 
     test
-      .setUpProjectFirewalls(SetUpProjectFirewallsParams(project, vpcConfig.networkName, RegionName("us-central1")))
+      .setUpProjectFirewalls(
+        SetUpProjectFirewallsParams(project, vpcConfig.networkName, RegionName("us-central1"), Map.empty)
+      )
       .unsafeRunSync()
     computeService.firewallMap.size shouldBe 3
     vpcConfig.firewallsToAdd.foreach { fwConfig =>
@@ -109,7 +111,9 @@ class VPCInterpreterSpec extends AnyFlatSpecLike with LeonardoTestSuite {
                                   computeService,
                                   new MockComputePollOperation)
     test
-      .setUpProjectFirewalls(SetUpProjectFirewallsParams(project, vpcConfig.networkName, RegionName("us-central1")))
+      .setUpProjectFirewalls(
+        SetUpProjectFirewallsParams(project, vpcConfig.networkName, RegionName("us-central1"), Map.empty)
+      )
       .unsafeRunSync()
     vpcConfig.firewallsToRemove.foreach(fw => computeService.firewallMap should not contain key(fw))
   }


### PR DESCRIPTION
[\<your comments for this PR go here\>](https://broadworkbench.atlassian.net/browse/IA-3040

No need to insert firewall rules if leonardo-allow-https-firewall-name, leonardo-allow-internal-firewall-name exist in project.

Tested in fiab. No new firewall rules are created with new RBS
<img width="1704" alt="Screen Shot 2021-11-15 at 1 39 34 PM" src="https://user-images.githubusercontent.com/32771737/141836916-e9579570-2d7d-49de-b138-46094df10e20.png">



---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
