### PR TITLE
IA-3052 increase boot disk size

### DIFF
--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -108,7 +108,7 @@ gce {
   runtimeDefaults {
     machineType = "n1-standard-4"
     diskSize = 30 # This is default size for just user disk
-    bootDiskSize = 80
+    bootDiskSize = 85
     zone = "us-central1-a"
   }
   gceReservedMemory = 1g

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterpSpec.scala
@@ -581,7 +581,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
       runtimeConfig shouldBe RuntimeConfig.GceWithPdConfig(
         MachineTypeName("n1-standard-4"),
         Some(disk.id),
-        bootDiskSize = DiskSize(80),
+        bootDiskSize = DiskSize(85),
         zone = ZoneName("us-central1-a"),
         None
       ) //TODO: this is a problem in terms of inconsistency

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterpSpec.scala
@@ -603,7 +603,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
           scopes = Config.gceConfig.defaultScopes,
           runtimeConfig = RuntimeConfigInCreateRuntimeMessage.GceWithPdConfig(runtimeConfig.machineType,
                                                                               disk.id,
-                                                                              bootDiskSize = DiskSize(80),
+                                                                              bootDiskSize = DiskSize(85),
                                                                               zone = ZoneName("us-central1-a"),
                                                                               None)
         )


### PR DESCRIPTION
There's still a few test failures even after removing terra-jupyter-base from custom image. Hence increase boot disk size a bit...

UI PR:
https://github.com/DataBiosphere/terra-ui/pull/2693

This shouldn't impact AoU since bootDisk for GCE is not controllable by clients

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
