### PR TITLE
Revert "IA-3040 Don't create firewall if certain project labels exist"

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/package.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/package.scala
@@ -4,7 +4,6 @@ import cats.Applicative
 import cats.effect.Sync
 import cats.mtl.Ask
 import cats.syntax.all._
-import org.broadinstitute.dsde.workbench.google2.RegionName
 import org.broadinstitute.dsde.workbench.model.TraceId
 import org.typelevel.ci._
 
@@ -40,33 +39,4 @@ package object leonardo {
           s"Invalid name ${nameString}. Only lowercase alphanumeric characters, numbers and dashes are allowed in leo names"
         )
     }
-
-  val allSupportedRegions = List(
-    RegionName("us-central1"),
-    RegionName("northamerica-northeast1"),
-    RegionName("southamerica-east1"),
-    RegionName("us-east1"),
-    RegionName("us-east4"),
-    RegionName("us-west1"),
-    RegionName("us-west2"),
-    RegionName("us-west3"),
-    RegionName("us-west4"),
-    RegionName("europe-central2"),
-    RegionName("europe-north1"),
-    RegionName("europe-west1"),
-    RegionName("europe-west2"),
-    RegionName("europe-west3"),
-    RegionName("europe-west4"),
-    RegionName("europe-west6"),
-    RegionName("asia-east1"),
-    RegionName("asia-east2"),
-    RegionName("asia-northeast1"),
-    RegionName("asia-northeast2"),
-    RegionName("asia-northeast3"),
-    RegionName("asia-south1"),
-    RegionName("asia-southeast1"),
-    RegionName("asia-southeast2"),
-    RegionName("australia-southeast1"),
-    RegionName("northamerica-northeast2")
-  )
 }

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -150,8 +150,6 @@ dateAccessedUpdater {
 vpc {
   highSecurityProjectNetworkLabel = "vpc-network-name"
   highSecurityProjectSubnetworkLabel = "vpc-subnetwork-name"
-  firewallAllowHttpsLabelKey = "leonardo-allow-https-firewall-name"
-  firewallAllowInternalLabelKey = "leonardo-allow-internal-firewall-name"
   networkName = "leonardo-network"
   networkTag = "leonardo"
   privateAccessNetworkTag = "leonardo-private"
@@ -194,8 +192,6 @@ vpc {
     # Allows Leonardo proxy traffic on port 443
     {
       name-prefix = "leonardo-allow-https"
-      # See https://github.com/DataBiosphere/terra-resource-buffer/blob/master/src/main/java/bio/terra/buffer/service/resource/flight/CreateFirewallRuleStep.java#L37
-      rbs-name = "leonardo-ssl"
       sourceRanges = {
         us-central1 = ["0.0.0.0/0"]
         northamerica-northeast1 = ["0.0.0.0/0"]
@@ -236,8 +232,6 @@ vpc {
     # Values are copied from https://github.com/DataBiosphere/terra-resource-buffer/blob/master/src/main/java/bio/terra/buffer/service/resource/flight/CreateSubnetsStep.java#L53
     {
       name-prefix = "leonardo-allow-internal"
-      # See https://github.com/DataBiosphere/terra-resource-buffer/blob/master/src/main/java/bio/terra/buffer/service/resource/flight/CreateFirewallRuleStep.java#L34
-      rbs-name = "leonardo-allow-internal"
       sourceRanges = {
         asia-east1 = ["10.140.0.0/20"]
         asia-east2 = ["10.170.0.0/20"]

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
@@ -373,10 +373,6 @@ object Config {
     MemorySize(config.getBytes(path))
   implicit private val networkNameValueReader: ValueReader[NetworkName] = stringValueReader.map(NetworkName)
   implicit private val subnetworkNameValueReader: ValueReader[SubnetworkName] = stringValueReader.map(SubnetworkName)
-  implicit private val firewallAllowHttpsLabelKeyReader: ValueReader[FirewallAllowHttpsLabelKey] =
-    stringValueReader.map(FirewallAllowHttpsLabelKey)
-  implicit private val firewallAllowInternalLabelKeyReader: ValueReader[FirewallAllowInternalLabelKey] =
-    stringValueReader.map(FirewallAllowInternalLabelKey)
   implicit private val ipRangeValueReader: ValueReader[IpRange] = stringValueReader.map(IpRange)
   // TODO(wnojopra): Make these more FP-friendly
   implicit private val subnetworkRegionIpRangeMapReader: ValueReader[Map[RegionName, IpRange]] =
@@ -386,8 +382,6 @@ object Config {
     VPCConfig(
       config.as[NetworkLabel]("highSecurityProjectNetworkLabel"),
       config.as[SubnetworkLabel]("highSecurityProjectSubnetworkLabel"),
-      config.as[FirewallAllowHttpsLabelKey]("firewallAllowHttpsLabelKey"),
-      config.as[FirewallAllowInternalLabelKey]("firewallAllowInternalLabelKey"),
       config.as[NetworkName]("networkName"),
       config.as[NetworkTag]("networkTag"),
       config.as[NetworkTag]("privateAccessNetworkTag"),
@@ -407,7 +401,6 @@ object Config {
   implicit private val firewallRuleConfigReader: ValueReader[FirewallRuleConfig] = ValueReader.relative { config =>
     FirewallRuleConfig(
       config.as[String]("name-prefix"),
-      config.as[Option[String]]("rbs-name"),
       config.as[Map[RegionName, List[IpRange]]]("sourceRanges"),
       config.as[List[Allowed]]("allowed")
     )

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/VPCConfig.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/VPCConfig.scala
@@ -1,13 +1,12 @@
 package org.broadinstitute.dsde.workbench.leonardo
 package config
 import org.broadinstitute.dsde.workbench.google2.{FirewallRuleName, NetworkName, RegionName, SubnetworkName}
+import org.broadinstitute.dsde.workbench.leonardo.{IpRange, NetworkTag}
 
 import scala.concurrent.duration.FiniteDuration
 
 final case class VPCConfig(highSecurityProjectNetworkLabel: NetworkLabel,
                            highSecurityProjectSubnetworkLabel: SubnetworkLabel,
-                           firewallAllowHttpsLabelKey: FirewallAllowHttpsLabelKey,
-                           firewallAllowInternalLabelKey: FirewallAllowInternalLabelKey,
                            networkName: NetworkName,
                            networkTag: NetworkTag,
                            privateAccessNetworkTag: NetworkTag,
@@ -20,7 +19,6 @@ final case class VPCConfig(highSecurityProjectNetworkLabel: NetworkLabel,
                            maxAttempts: Int)
 
 final case class FirewallRuleConfig(namePrefix: String,
-                                    rbsName: Option[String],
                                     sourceRanges: Map[RegionName, List[IpRange]],
                                     allowed: List[Allowed])
 
@@ -28,5 +26,3 @@ final case class Allowed(protocol: String, port: Option[String])
 
 final case class NetworkLabel(value: String) extends AnyVal
 final case class SubnetworkLabel(value: String) extends AnyVal
-final case class FirewallAllowHttpsLabelKey(value: String) extends AnyVal
-final case class FirewallAllowInternalLabelKey(value: String) extends AnyVal

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/DataprocInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/DataprocInterpreter.scala
@@ -120,8 +120,11 @@ class DataprocInterpreter[F[_]: Parallel](
 
       createOp = for {
         // Set up VPC network and firewall
-        (network, subnetwork) <- vpcAlg.setUpProjectNetworkAndFirewalls(
+        (network, subnetwork) <- vpcAlg.setUpProjectNetwork(
           SetUpProjectNetworkParams(params.runtimeProjectAndName.googleProject, machineConfig.region)
+        )
+        _ <- vpcAlg.setUpProjectFirewalls(
+          SetUpProjectFirewallsParams(params.runtimeProjectAndName.googleProject, network, machineConfig.region)
         )
 
         // Add member to the Google Group that has the IAM role to pull the Dataproc image

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
@@ -98,8 +98,11 @@ class GKEInterpreter[F[_]](
       else F.unit
 
       // Set up VPC and firewall
-      (network, subnetwork) <- vpcAlg.setUpProjectNetworkAndFirewalls(
+      (network, subnetwork) <- vpcAlg.setUpProjectNetwork(
         SetUpProjectNetworkParams(params.googleProject, dbCluster.region)
+      )
+      _ <- vpcAlg.setUpProjectFirewalls(
+        SetUpProjectFirewallsParams(params.googleProject, network, dbCluster.region)
       )
 
       kubeNetwork = KubernetesNetwork(dbCluster.googleProject, network)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GceInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GceInterpreter.scala
@@ -76,8 +76,11 @@ class GceInterpreter[F[_]](
       regionParam = RegionName(zoneParam.value.substring(0, zoneParam.value.length - 2))
 
       // Set up VPC and firewall
-      (_, subnetwork) <- vpcAlg.setUpProjectNetworkAndFirewalls(
+      (network, subnetwork) <- vpcAlg.setUpProjectNetwork(
         SetUpProjectNetworkParams(params.runtimeProjectAndName.googleProject, regionParam)
+      )
+      _ <- vpcAlg.setUpProjectFirewalls(
+        SetUpProjectFirewallsParams(params.runtimeProjectAndName.googleProject, network, regionParam)
       )
 
       // Get resource (e.g. memory) constraints for the instance

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/VPCAlgebra.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/VPCAlgebra.scala
@@ -8,15 +8,14 @@ import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 
 trait VPCAlgebra[F[_]] {
 
-  def setUpProjectNetworkAndFirewalls(params: SetUpProjectNetworkParams)(
+  def setUpProjectNetwork(params: SetUpProjectNetworkParams)(
     implicit ev: Ask[F, TraceId]
   ): F[(NetworkName, SubnetworkName)]
+
+  def setUpProjectFirewalls(params: SetUpProjectFirewallsParams)(implicit ev: Ask[F, TraceId]): F[Unit]
 
 }
 
 final case class VPCInterpreterConfig(vpcConfig: VPCConfig)
 final case class SetUpProjectNetworkParams(project: GoogleProject, region: RegionName)
-final case class SetUpProjectFirewallsParams(project: GoogleProject,
-                                             networkName: NetworkName,
-                                             region: RegionName,
-                                             projectLabels: Map[String, String])
+final case class SetUpProjectFirewallsParams(project: GoogleProject, networkName: NetworkName, region: RegionName)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/VPCInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/VPCInterpreter.scala
@@ -59,7 +59,7 @@ final class VPCInterpreter[F[_]: StructuredLogger: Parallel](
     RetryPredicates.whenStatusCode(409)
   )
 
-  override def setUpProjectNetworkAndFirewalls(
+  override def setUpProjectNetwork(
     params: SetUpProjectNetworkParams
   )(implicit ev: Ask[F, TraceId]): F[(NetworkName, SubnetworkName)] =
     for {
@@ -109,19 +109,15 @@ final class VPCInterpreter[F[_]: StructuredLogger: Parallel](
         case _ =>
           F.raiseError[(NetworkName, SubnetworkName)](InvalidVPCSetupException(params.project))
       }
-      _ <- setUpProjectFirewalls(
-        SetUpProjectFirewallsParams(params.project, network, params.region, projectLabels.getOrElse(Map.empty))
-      )
     } yield (network, subnetwork)
 
-  private[util] def setUpProjectFirewalls(
+  override def setUpProjectFirewalls(
     params: SetUpProjectFirewallsParams
   )(implicit ev: Ask[F, TraceId]): F[Unit] =
     for {
       ctx <- ev.ask
-      finalFirewallRulesToAdd = firewallRulesToAdd(params.projectLabels)
       // create firewalls in the Leonardo network
-      _ <- finalFirewallRulesToAdd.parTraverse_ { fw =>
+      _ <- config.vpcConfig.firewallsToAdd.parTraverse_ { fw =>
         for {
           firewallRegionalIprange <- F.fromOption(
             fw.sourceRanges.get(params.region),
@@ -149,13 +145,6 @@ final class VPCInterpreter[F[_]: StructuredLogger: Parallel](
       } else F.unit
     } yield ()
 
-  private[util] def firewallRulesToAdd(projectLabels: Map[String, String]): List[FirewallRuleConfig] = {
-    val rbsAllowHttpsFirewallRuleName = projectLabels.get(config.vpcConfig.firewallAllowHttpsLabelKey.value)
-    val rbsAllowInternalFirewallruleName =
-      projectLabels.get(config.vpcConfig.firewallAllowInternalLabelKey.value)
-    val firewallRulesCreatedByRbs = List(rbsAllowHttpsFirewallRuleName, rbsAllowInternalFirewallruleName).flatten
-    config.vpcConfig.firewallsToAdd.filterNot(rule => rule.rbsName.exists(n => firewallRulesCreatedByRbs.contains(n)))
-  }
   private def createIfAbsent[A](project: GoogleProject,
                                 get: F[Option[A]],
                                 create: F[Operation],

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/VPCInterpreterSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/VPCInterpreterSpec.scala
@@ -12,7 +12,7 @@ import org.broadinstitute.dsde.workbench.google2.mock.{
 }
 import org.broadinstitute.dsde.workbench.google2.{FirewallRuleName, NetworkName, RegionName, SubnetworkName}
 import org.broadinstitute.dsde.workbench.leonardo.CommonTestData._
-import org.broadinstitute.dsde.workbench.leonardo.config.{Allowed, Config, FirewallRuleConfig}
+import org.broadinstitute.dsde.workbench.leonardo.config.Config
 import org.broadinstitute.dsde.workbench.model.TraceId
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.scalatest.flatspec.AnyFlatSpecLike
@@ -31,7 +31,7 @@ class VPCInterpreterSpec extends AnyFlatSpecLike with LeonardoTestSuite {
                                   new MockComputePollOperation)
 
     test
-      .setUpProjectNetworkAndFirewalls(SetUpProjectNetworkParams(project, RegionName("us-central1")))
+      .setUpProjectNetwork(SetUpProjectNetworkParams(project, RegionName("us-central1")))
       .unsafeRunSync() shouldBe (NetworkName("my_network"), SubnetworkName("my_subnet"))
   }
 
@@ -44,7 +44,7 @@ class VPCInterpreterSpec extends AnyFlatSpecLike with LeonardoTestSuite {
                                   new MockComputePollOperation)
 
     test
-      .setUpProjectNetworkAndFirewalls(SetUpProjectNetworkParams(project, RegionName("us-central1")))
+      .setUpProjectNetwork(SetUpProjectNetworkParams(project, RegionName("us-central1")))
       .attempt
       .unsafeRunSync() shouldBe Left(
       InvalidVPCSetupException(project)
@@ -58,7 +58,7 @@ class VPCInterpreterSpec extends AnyFlatSpecLike with LeonardoTestSuite {
                                    new MockComputePollOperation)
 
     test2
-      .setUpProjectNetworkAndFirewalls(SetUpProjectNetworkParams(project, RegionName("us-central1")))
+      .setUpProjectNetwork(SetUpProjectNetworkParams(project, RegionName("us-central1")))
       .attempt
       .unsafeRunSync() shouldBe Left(
       InvalidVPCSetupException(project)
@@ -72,7 +72,7 @@ class VPCInterpreterSpec extends AnyFlatSpecLike with LeonardoTestSuite {
                                   new MockComputePollOperation)
 
     test
-      .setUpProjectNetworkAndFirewalls(SetUpProjectNetworkParams(project, RegionName("us-central1")))
+      .setUpProjectNetwork(SetUpProjectNetworkParams(project, RegionName("us-central1")))
       .unsafeRunSync() shouldBe (vpcConfig.networkName, vpcConfig.subnetworkName)
   }
 
@@ -84,9 +84,7 @@ class VPCInterpreterSpec extends AnyFlatSpecLike with LeonardoTestSuite {
                                   new MockComputePollOperation)
 
     test
-      .setUpProjectFirewalls(
-        SetUpProjectFirewallsParams(project, vpcConfig.networkName, RegionName("us-central1"), Map.empty)
-      )
+      .setUpProjectFirewalls(SetUpProjectFirewallsParams(project, vpcConfig.networkName, RegionName("us-central1")))
       .unsafeRunSync()
     computeService.firewallMap.size shouldBe 3
     vpcConfig.firewallsToAdd.foreach { fwConfig =>
@@ -111,49 +109,9 @@ class VPCInterpreterSpec extends AnyFlatSpecLike with LeonardoTestSuite {
                                   computeService,
                                   new MockComputePollOperation)
     test
-      .setUpProjectFirewalls(
-        SetUpProjectFirewallsParams(project, vpcConfig.networkName, RegionName("us-central1"), Map.empty)
-      )
+      .setUpProjectFirewalls(SetUpProjectFirewallsParams(project, vpcConfig.networkName, RegionName("us-central1")))
       .unsafeRunSync()
     vpcConfig.firewallsToRemove.foreach(fw => computeService.firewallMap should not contain key(fw))
-  }
-
-  it should "create only firewallrules if necessary" in {
-    val computeService = new MockGoogleComputeServiceWithFirewalls()
-    val expectedSshFirewallRules = FirewallRuleConfig(
-      "leonardo-allow-broad-ssh",
-      None,
-      allSupportedRegions
-        .map(r =>
-          r -> List(
-            IpRange("69.173.127.0/25"),
-            IpRange("69.173.124.0/23"),
-            IpRange("69.173.126.0/24"),
-            IpRange("69.173.127.230/31"),
-            IpRange("69.173.64.0/19"),
-            IpRange("69.173.127.224/30"),
-            IpRange("69.173.127.192/27"),
-            IpRange("69.173.120.0/22"),
-            IpRange("69.173.127.228/32"),
-            IpRange("69.173.127.232/29"),
-            IpRange("69.173.127.128/26"),
-            IpRange("69.173.96.0/20"),
-            IpRange("69.173.127.240/28"),
-            IpRange("69.173.112.0/21")
-          )
-        )
-        .toMap,
-      List(Allowed("tcp", Some("22")))
-    )
-    val test = new VPCInterpreter(Config.vpcInterpreterConfig,
-                                  stubResourceService(Map.empty),
-                                  computeService,
-                                  new MockComputePollOperation)
-
-    test.firewallRulesToAdd(
-      Map("leonardo-allow-internal-firewall-name" -> "leonardo-allow-internal",
-          "leonardo-allow-https-firewall-name" -> "leonardo-ssl")
-    ) shouldBe List(expectedSshFirewallRules)
   }
 
   private def stubResourceService(labels: Map[String, String]): FakeGoogleResourceService =


### PR DESCRIPTION
Reverts DataBiosphere/leonardo#2383

this was weird... I thought all tests passed when I merged the PR (I was on my phone, so that might've been a problem that the app was behaving weirdly)