### PR TITLE
[SUP-585] [PROD-620] Increase boot disk size

### DIFF
--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -108,7 +108,7 @@ gce {
   runtimeDefaults {
     machineType = "n1-standard-4"
     diskSize = 30 # This is default size for just user disk
-    bootDiskSize = 85
+    bootDiskSize = 100
     zone = "us-central1-a"
   }
   gceReservedMemory = 1g

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterpSpec.scala
@@ -581,7 +581,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
       runtimeConfig shouldBe RuntimeConfig.GceWithPdConfig(
         MachineTypeName("n1-standard-4"),
         Some(disk.id),
-        bootDiskSize = DiskSize(85),
+        bootDiskSize = DiskSize(100),
         zone = ZoneName("us-central1-a"),
         None
       ) //TODO: this is a problem in terms of inconsistency
@@ -603,7 +603,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
           scopes = Config.gceConfig.defaultScopes,
           runtimeConfig = RuntimeConfigInCreateRuntimeMessage.GceWithPdConfig(runtimeConfig.machineType,
                                                                               disk.id,
-                                                                              bootDiskSize = DiskSize(85),
+                                                                              bootDiskSize = DiskSize(100),
                                                                               zone = ZoneName("us-central1-a"),
                                                                               None)
         )


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/SUP-583
https://broadworkbench.atlassian.net/browse/PROD-620

Here's the error when we try to enable GPU
```
2021/11/22 16:34:50 GCEMetadataScripts: startup-script-url: log: exiting because of error: write /tmp/cos-gpu-installer.saturn-37eeca86-c3e2-483a-aa93-57b149b4d9cf.root.log.ERROR.20211122-163450.1094: no space left on device
```

This tells us that the VM ran out of disk space when the error happened. First thing I tried it increasing disk size in UI, this increases user disk size, which didn't help; Hence increasing boot disk size, which proved to work in fiab.

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
