### PR TITLE
PROD-621 rip out explicit error reporting

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookAouSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookAouSpec.scala
@@ -2,7 +2,7 @@ package org.broadinstitute.dsde.workbench.leonardo.notebooks
 
 import cats.effect.unsafe.implicits.global
 import org.broadinstitute.dsde.workbench.auth.AuthToken
-import org.broadinstitute.dsde.workbench.leonardo.{ContainerRegistry, LeonardoConfig, RuntimeFixtureSpec}
+import org.broadinstitute.dsde.workbench.leonardo.{LeonardoConfig, RuntimeFixtureSpec}
 import org.scalatest.DoNotDiscover
 
 /**

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/package.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/package.scala
@@ -20,7 +20,6 @@ import shapeless._
 import slick.dbio.DBIO
 
 import java.nio.file.Path
-import java.sql.SQLDataException
 import java.time.Instant
 import java.util.UUID
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/package.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/package.scala
@@ -10,15 +10,9 @@ import io.opencensus.scala.http.ServiceData
 import io.opencensus.trace.{AttributeValue, Span}
 import fs2._
 import fs2.io.file.Files
-import org.broadinstitute.dsde.workbench.errorReporting.ReportWorthy
 import org.broadinstitute.dsde.workbench.leonardo.db.DBIOOps
 import org.broadinstitute.dsde.workbench.leonardo.http.api.BuildTimeVersion
-import org.broadinstitute.dsde.workbench.leonardo.monitor.{
-  InvalidMonitorRequest,
-  MonitorAtBootException,
-  RuntimeConfigInCreateRuntimeMessage,
-  RuntimeMonitor
-}
+import org.broadinstitute.dsde.workbench.leonardo.monitor.{RuntimeConfigInCreateRuntimeMessage, RuntimeMonitor}
 import org.broadinstitute.dsde.workbench.leonardo.util.CloudServiceOps
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.broadinstitute.dsde.workbench.model.{ErrorReportSource, TraceId}
@@ -106,15 +100,6 @@ package object http {
     from: RuntimeConfigInCreateRuntimeMessage.DataprocConfig
   ): RuntimeConfig.DataprocConfig =
     genericDataprocRuntimeConfig.from(genericDataprocRuntimeConfigInCreateRuntimeMessage.to(from))
-
-  implicit val throwableReportWorthy: ReportWorthy[Throwable] = e =>
-    e match {
-      case _: SQLDataException             => true
-      case _: InvalidMonitorRequest        => true
-      case _: MonitorAtBootException       => true
-      case _: model.LeoInternalServerError => true
-      case _                               => false
-    }
 }
 
 final case class CloudServiceMonitorOps[F[_], A](a: A)(

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriberSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriberSpec.scala
@@ -1640,8 +1640,7 @@ class LeoPubsubMessageSubscriberSpec
       diskInterp,
       computePollOperation,
       MockAuthProvider,
-      gkeAlgebra,
-      org.broadinstitute.dsde.workbench.errorReporting.FakeErrorReporting
+      gkeAlgebra
     )
   }
 

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/MonitorAtBootSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/MonitorAtBootSpec.scala
@@ -250,7 +250,5 @@ class MonitorAtBootSpec extends AnyFlatSpec with TestComponent with LeonardoTest
     queue: Queue[IO, LeoPubsubMessage] =
       Queue.bounded[IO, LeoPubsubMessage](10).unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   ): MonitorAtBoot[IO] =
-    new MonitorAtBoot[IO](queue,
-                          FakeGoogleComputeService,
-                          org.broadinstitute.dsde.workbench.errorReporting.FakeErrorReporting)
+    new MonitorAtBoot[IO](queue, FakeGoogleComputeService)
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -22,7 +22,6 @@ object Dependencies {
   val workbenchGoogleV = s"0.21-$workbenchLibsHash"
   val workbenchGoogle2V = s"0.23-$workbenchLibsHash"
   val workbenchOpenTelemetryV = s"0.2-$workbenchLibsHash"
-  val workbenchErrorReportingV = s"0.2-$workbenchLibsHash"
 
   val helmScalaSdkV = "0.0.4"
 
@@ -110,8 +109,6 @@ object Dependencies {
   val workbenchGoogle2Test: ModuleID =  "org.broadinstitute.dsde.workbench" %% "workbench-google2"  % workbenchGoogle2V % "test" classifier "tests" excludeAll (excludeGuava) //for generators
   val workbenchOpenTelemetry: ModuleID =     "org.broadinstitute.dsde.workbench" %% "workbench-opentelemetry" % workbenchOpenTelemetryV excludeAll (excludeGuava)
   val workbenchOpenTelemetryTest: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-opentelemetry" % workbenchOpenTelemetryV % Test classifier "tests" excludeAll (excludeGuava)
-  val workbenchErrorReporting: ModuleID =      "org.broadinstitute.dsde.workbench" %% "workbench-error-reporting"  % workbenchErrorReportingV
-  val workbenchErrorReportingTest: ModuleID =      "org.broadinstitute.dsde.workbench" %% "workbench-error-reporting"  % workbenchErrorReportingV % Test classifier "tests"
 
   val helmScalaSdk: ModuleID = "org.broadinstitute.dsp" %% "helm-scala-sdk" % helmScalaSdkV
   val helmScalaSdkTest: ModuleID = "org.broadinstitute.dsp" %% "helm-scala-sdk" % helmScalaSdkV % Test classifier "tests"
@@ -170,8 +167,6 @@ object Dependencies {
     hikariCP,
     workbenchGoogle,
     workbenchGoogleTest,
-    workbenchErrorReporting,
-    workbenchErrorReportingTest,
     "com.rms.miu" %% "slick-cats" % "0.10.4",
     googleCloudNio,
     mysql,

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.5
+sbt.version=1.5.6


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/PROD-621

Here's the exception crashed leo in prod. Not sure why this is happening given the leo SA does have `Error Reporting Writer` role. What we can do to prevent this from happening is either catching error when error reporting fails, or removing the explicit error reporting. And I'm leaning towards the latter. This explicit error reporting code was added before we migrated leonardo to gke. After the migration, we get error reporting for free, so there isn't much need for explicit reporting anymore. We kept it at the time cuz we think it can still be helpful to have some reporting explicitly, but I don't think it adds much value. Another motivation is the google error reporting sdk isn't very actively maintained, its grpc core dependency is couple versions behind some other google libraries, which makes upgrading these google libraries harder.

```
message: "Failed to start leonardo"
stack_trace: "com.google.api.gax.rpc.PermissionDeniedException: io.grpc.StatusRuntimeException: PERMISSION_DENIED: Request had insufficient authentication scopes.
	at com.google.api.gax.rpc.ApiExceptionFactory.createException(ApiExceptionFactory.java:55)
	at com.google.api.gax.grpc.GrpcApiExceptionFactory.create(GrpcApiExceptionFactory.java:72)
	at com.google.api.gax.grpc.GrpcApiExceptionFactory.create(GrpcApiExceptionFactory.java:60)
	at com.google.api.gax.grpc.GrpcExceptionCallable$ExceptionTransformingFuture.onFailure(GrpcExceptionCallable.java:97)
	at com.google.api.core.ApiFutures$1.onFailure(ApiFutures.java:68)
	at com.google.common.util.concurrent.Futures$CallbackListener.run(Futures.java:1133)
	at com.google.common.util.concurrent.DirectExecutor.execute(DirectExecutor.java:31)
	at com.google.common.util.concurrent.AbstractFuture.executeListener(AbstractFuture.java:1277)
	at com.google.common.util.concurrent.AbstractFuture.complete(AbstractFuture.java:1038)
	at com.google.common.util.concurrent.AbstractFuture.setException(AbstractFuture.java:808)
	at io.grpc.stub.ClientCalls$GrpcFuture.setException(ClientCalls.java:563)
	at io.grpc.stub.ClientCalls$UnaryStreamToFuture.onClose(ClientCalls.java:533)
	at io.grpc.internal.DelayedClientCall$DelayedListener$3.run(DelayedClientCall.java:463)
	at io.grpc.internal.DelayedClientCall$DelayedListener.delayOrExecute(DelayedClientCall.java:427)
	at io.grpc.internal.DelayedClientCall$DelayedListener.onClose(DelayedClientCall.java:460)
	at io.grpc.internal.ClientCallImpl.closeObserver(ClientCallImpl.java:557)
	at io.grpc.internal.ClientCallImpl.access$300(ClientCallImpl.java:69)
	at io.grpc.internal.ClientCallImpl$ClientStreamListenerImpl$1StreamClosed.runInternal(ClientCallImpl.java:738)
	at io.grpc.internal.ClientCallImpl$ClientStreamListenerImpl$1StreamClosed.runInContext(ClientCallImpl.java:717)
	at io.grpc.internal.ContextRunnable.run(ContextRunnable.java:37)
	at io.grpc.internal.SerializingExecutor.run(SerializingExecutor.java:133)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
	at java.base/java.lang.Thread.run(Unknown Source)
	at delay @ org.broadinstitute.dsde.workbench.errorReporting.ErrorReportingInterpreter.$anonfun$reportError$10(ErrorReportingInterpreter.scala:40)
	at map @ org.broadinstitute.dsde.workbench.errorReporting.ErrorReportingInterpreter.$anonfun$reportError$10(ErrorReportingInterpreter.scala:40)
	at delay @ org.broadinstitute.dsde.workbench.errorReporting.ErrorReportingInterpreter.$anonfun$reportError$7(ErrorReportingInterpreter.scala:34)
	at map @ org.broadinstitute.dsde.workbench.errorReporting.ErrorReportingInterpreter.$anonfun$reportError$7(ErrorReportingInterpreter.scala:34)
	at flatMap @ org.broadinstitute.dsde.workbench.errorReporting.ErrorReportingInterpreter.$anonfun$reportError$7(ErrorReportingInterpreter.scala:34)
	at delay @ org.broadinstitute.dsde.workbench.errorReporting.ErrorReportingInterpreter.reportError(ErrorReportingInterpreter.scala:29)
	at make @ fs2.io.file.FilesCompanionPlatform$AsyncFiles.openFileChannel(FilesPlatform.scala:303)
	at make @ fs2.io.file.FilesCompanionPlatform$AsyncFiles.openFileChannel(FilesPlatform.scala:303)
	at use @ fs2.Compiler$Target.compile(Compiler.scala:157)
	at delay @ org.typelevel.log4cats.slf4j.internal.Slf4jLoggerInternal$.org$typelevel$log4cats$slf4j$internal$Slf4jLoggerInternal$$contextLog(Slf4jLoggerInternal.scala:43)
	Suppressed: com.google.api.gax.rpc.AsyncTaskException: Asynchronous task failed
		at com.google.api.gax.rpc.ApiExceptions.callAndTranslateApiException(ApiExceptions.java:57)
		at com.google.api.gax.rpc.UnaryCallable.call(UnaryCallable.java:112)
		at com.google.cloud.errorreporting.v1beta1.ReportErrorsServiceClient.reportErrorEvent(ReportErrorsServiceClient.java:220)
		at com.google.cloud.errorreporting.v1beta1.ReportErrorsServiceClient.reportErrorEvent(ReportErrorsServiceClient.java:170)
		at org.broadinstitute.dsde.workbench.errorReporting.ErrorReportingInterpreter.$anonfun$reportError$11(ErrorReportingInterpreter.scala:40)
		at cats.effect.IOFiber.runLoop(IOFiber.scala:319)
		at cats.effect.IOFiber.asyncContinueSuccessfulR(IOFiber.scala:1175)
		at cats.effect.IOFiber.run(IOFiber.scala:129)
		at cats.effect.unsafe.WorkerThread.run(WorkerThread.scala:435)
Caused by: io.grpc.StatusRuntimeException: PERMISSION_DENIED: Request had insufficient authentication scopes.
	at io.grpc.Status.asRuntimeException(Status.java:535)
	at io.grpc.stub.ClientCalls$UnaryStreamToFuture.onClose(ClientCalls.java:533)
	at io.grpc.internal.DelayedClientCall$DelayedListener$3.run(DelayedClientCall.java:463)
	at io.grpc.internal.DelayedClientCall$DelayedListener.delayOrExecute(DelayedClientCall.java:427)
	at io.grpc.internal.DelayedClientCall$DelayedListener.onClose(DelayedClientCall.java:460)
	at io.grpc.internal.ClientCallImpl.closeObserver(ClientCallImpl.java:557)
	at io.grpc.internal.ClientCallImpl.access$300(ClientCallImpl.java:69)
	at io.grpc.internal.ClientCallImpl$ClientStreamListenerImpl$1StreamClosed.runInternal(ClientCallImpl.java:738)
	at io.grpc.internal.ClientCallImpl$ClientStreamListenerImpl$1StreamClosed.runInContext(ClientCallImpl.java:717)
	at io.grpc.internal.ContextRunnable.run(ContextRunnable.java:37)
	at io.grpc.internal.SerializingExecutor.run(SerializingExecutor.java:133)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
	at java.base/java.lang.Thread.run(Unknown Source)
```

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
