### PR TITLE
PROD-621 fix bug for error reporting

### DIFF
--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/Boot.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/Boot.scala
@@ -395,6 +395,9 @@ object Boot extends IOApp {
       credential <- credentialResource(pathToCredentialJson)
       scopedCredential = credential.createScoped(Seq(ComputeScopes.COMPUTE).asJava)
       kubernetesScopedCredential = credential.createScoped(Seq(ContainerScopes.CLOUD_PLATFORM).asJava)
+      cloudPlatformScopedCredential = credential.createScoped(
+        "https://www.googleapis.com/auth/cloud-platform"
+      ) // See https://developers.google.com/identity/protocols/oauth2/scopes
       credentialJson <- Resource.eval(
         readFileToString(applicationConfig.leoServiceAccountJsonFile)
       )
@@ -440,7 +443,7 @@ object Boot extends IOApp {
       _ <- OpenTelemetryMetrics.registerTracing[F](Paths.get(pathToCredentialJson))
       googleDiskService <- GoogleDiskService.resource(pathToCredentialJson, semaphore)
       computePollOperation <- ComputePollOperation.resourceFromCredential(scopedCredential, semaphore)
-      errorReporting <- ErrorReporting.fromCredential(scopedCredential,
+      errorReporting <- ErrorReporting.fromCredential(cloudPlatformScopedCredential,
                                                       applicationConfig.applicationName,
                                                       ProjectName.of(applicationConfig.leoGoogleProject.value))
       googleOauth2DAO <- GoogleOAuth2Service.resource(semaphore)


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/PROD-621

I notice that the scope for error reporting isn't right...`scopedCredential` is only scoped to compute, which explains why the permission error...This means error reporting probably never worked (we do only invoke error reporting for exceptions that's really unexpected, which explains why we haven't seen this in prod more)

```
message: "Failed to start leonardo"
stack_trace: "com.google.api.gax.rpc.PermissionDeniedException: io.grpc.StatusRuntimeException: PERMISSION_DENIED: Request had insufficient authentication scopes.
	at com.google.api.gax.rpc.ApiExceptionFactory.createException(ApiExceptionFactory.java:55)
	at com.google.api.gax.grpc.GrpcApiExceptionFactory.create(GrpcApiExceptionFactory.java:72)
	at com.google.api.gax.grpc.GrpcApiExceptionFactory.create(GrpcApiExceptionFactory.java:60)
	at com.google.api.gax.grpc.GrpcExceptionCallable$ExceptionTransformingFuture.onFailure(GrpcExceptionCallable.java:97)
	at com.google.api.core.ApiFutures$1.onFailure(ApiFutures.java:68)
	at com.google.common.util.concurrent.Futures$CallbackListener.run(Futures.java:1133)
	at com.google.common.util.concurrent.DirectExecutor.execute(DirectExecutor.java:31)
	at com.google.common.util.concurrent.AbstractFuture.executeListener(AbstractFuture.java:1277)
	at com.google.common.util.concurrent.AbstractFuture.complete(AbstractFuture.java:1038)
	at com.google.common.util.concurrent.AbstractFuture.setException(AbstractFuture.java:808)
	at io.grpc.stub.ClientCalls$GrpcFuture.setException(ClientCalls.java:563)
	at io.grpc.stub.ClientCalls$UnaryStreamToFuture.onClose(ClientCalls.java:533)
	at io.grpc.internal.DelayedClientCall$DelayedListener$3.run(DelayedClientCall.java:463)
	at io.grpc.internal.DelayedClientCall$DelayedListener.delayOrExecute(DelayedClientCall.java:427)
	at io.grpc.internal.DelayedClientCall$DelayedListener.onClose(DelayedClientCall.java:460)
	at io.grpc.internal.ClientCallImpl.closeObserver(ClientCallImpl.java:557)
	at io.grpc.internal.ClientCallImpl.access$300(ClientCallImpl.java:69)
	at io.grpc.internal.ClientCallImpl$ClientStreamListenerImpl$1StreamClosed.runInternal(ClientCallImpl.java:738)
	at io.grpc.internal.ClientCallImpl$ClientStreamListenerImpl$1StreamClosed.runInContext(ClientCallImpl.java:717)
	at io.grpc.internal.ContextRunnable.run(ContextRunnable.java:37)
	at io.grpc.internal.SerializingExecutor.run(SerializingExecutor.java:133)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
	at java.base/java.lang.Thread.run(Unknown Source)
	at delay @ org.broadinstitute.dsde.workbench.errorReporting.ErrorReportingInterpreter.$anonfun$reportError$10(ErrorReportingInterpreter.scala:40)
	at map @ org.broadinstitute.dsde.workbench.errorReporting.ErrorReportingInterpreter.$anonfun$reportError$10(ErrorReportingInterpreter.scala:40)
	at delay @ org.broadinstitute.dsde.workbench.errorReporting.ErrorReportingInterpreter.$anonfun$reportError$7(ErrorReportingInterpreter.scala:34)
	at map @ org.broadinstitute.dsde.workbench.errorReporting.ErrorReportingInterpreter.$anonfun$reportError$7(ErrorReportingInterpreter.scala:34)
	at flatMap @ org.broadinstitute.dsde.workbench.errorReporting.ErrorReportingInterpreter.$anonfun$reportError$7(ErrorReportingInterpreter.scala:34)
	at delay @ org.broadinstitute.dsde.workbench.errorReporting.ErrorReportingInterpreter.reportError(ErrorReportingInterpreter.scala:29)
	at make @ fs2.io.file.FilesCompanionPlatform$AsyncFiles.openFileChannel(FilesPlatform.scala:303)
	at make @ fs2.io.file.FilesCompanionPlatform$AsyncFiles.openFileChannel(FilesPlatform.scala:303)
	at use @ fs2.Compiler$Target.compile(Compiler.scala:157)
	at delay @ org.typelevel.log4cats.slf4j.internal.Slf4jLoggerInternal$.org$typelevel$log4cats$slf4j$internal$Slf4jLoggerInternal$$contextLog(Slf4jLoggerInternal.scala:43)
	Suppressed: com.google.api.gax.rpc.AsyncTaskException: Asynchronous task failed
		at com.google.api.gax.rpc.ApiExceptions.callAndTranslateApiException(ApiExceptions.java:57)
		at com.google.api.gax.rpc.UnaryCallable.call(UnaryCallable.java:112)
		at com.google.cloud.errorreporting.v1beta1.ReportErrorsServiceClient.reportErrorEvent(ReportErrorsServiceClient.java:220)
		at com.google.cloud.errorreporting.v1beta1.ReportErrorsServiceClient.reportErrorEvent(ReportErrorsServiceClient.java:170)
		at org.broadinstitute.dsde.workbench.errorReporting.ErrorReportingInterpreter.$anonfun$reportError$11(ErrorReportingInterpreter.scala:40)
		at cats.effect.IOFiber.runLoop(IOFiber.scala:319)
		at cats.effect.IOFiber.asyncContinueSuccessfulR(IOFiber.scala:1175)
		at cats.effect.IOFiber.run(IOFiber.scala:129)
		at cats.effect.unsafe.WorkerThread.run(WorkerThread.scala:435)
Caused by: io.grpc.StatusRuntimeException: PERMISSION_DENIED: Request had insufficient authentication scopes.
	at io.grpc.Status.asRuntimeException(Status.java:535)
	at io.grpc.stub.ClientCalls$UnaryStreamToFuture.onClose(ClientCalls.java:533)
	at io.grpc.internal.DelayedClientCall$DelayedListener$3.run(DelayedClientCall.java:463)
	at io.grpc.internal.DelayedClientCall$DelayedListener.delayOrExecute(DelayedClientCall.java:427)
	at io.grpc.internal.DelayedClientCall$DelayedListener.onClose(DelayedClientCall.java:460)
	at io.grpc.internal.ClientCallImpl.closeObserver(ClientCallImpl.java:557)
	at io.grpc.internal.ClientCallImpl.access$300(ClientCallImpl.java:69)
	at io.grpc.internal.ClientCallImpl$ClientStreamListenerImpl$1StreamClosed.runInternal(ClientCallImpl.java:738)
	at io.grpc.internal.ClientCallImpl$ClientStreamListenerImpl$1StreamClosed.runInContext(ClientCallImpl.java:717)
	at io.grpc.internal.ContextRunnable.run(ContextRunnable.java:37)
	at io.grpc.internal.SerializingExecutor.run(SerializingExecutor.java:133)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
	at java.base/java.lang.Thread.run(Unknown Source)
```

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
