### PR TITLE
IA-3083 Add service context attempt2

### DIFF
--- a/http/src/main/resources/logback.xml
+++ b/http/src/main/resources/logback.xml
@@ -5,6 +5,7 @@
             <fieldNames>
                 <level>severity</level>
             </fieldNames>
+            <includeMdcKeyName>serviceContext</includeMdcKeyName>
         </encoder>
     </appender>
 

--- a/http/src/main/resources/logback.xml
+++ b/http/src/main/resources/logback.xml
@@ -1,11 +1,33 @@
 <configuration>
 
     <appender name="console" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
-            <fieldNames>
-                <level>severity</level>
-            </fieldNames>
-            <includeMdcKeyName>serviceContext</includeMdcKeyName>
+        <encoder class="net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder">
+            <providers>
+                <omitEmptyFields>true</omitEmptyFields>
+
+                <fieldNames>
+                    <level>severity</level>
+                </fieldNames>
+
+                <timestamp/>
+                <version/>
+                <loggerName/>
+                <logLevel/>
+                <mdc>
+                    <excludeMdcKeyName>serviceContext</excludeMdcKeyName>
+                </mdc>
+                <threadName/>
+                <stackTrace/>
+
+                <pattern>
+                    <pattern>
+                        {
+                            "serviceContext": "#tryJson{%mdc{serviceContext}}",
+                            "message": "#tryJson{%message}"
+                        }
+                    </pattern>
+                </pattern>
+            </providers>
         </encoder>
     </appender>
 
@@ -25,22 +47,14 @@
         </encoder>
     </appender>
 
-    <appender name="SYSLOG" class="ch.qos.logback.classic.net.SyslogAppender">
-        <syslogHost>127.0.0.1</syslogHost>
-        <facility>AUDIT</facility>
-        <suffixPattern>[%level] [%d{HH:mm:ss.SSS}] [%thread] %logger{36} - %msg%n</suffixPattern>
-    </appender>
-
     <logger name="org.broadinstitute.dsde" level="info" additivity="false">
         <appender-ref ref="file"/>
         <appender-ref ref="console"/>
-        <appender-ref ref="SYSLOG"/>
     </logger>
 
     <logger name="akka" level="info" additivity="false">
         <appender-ref ref="file"/>
         <appender-ref ref="console"/>
-        <appender-ref ref="SYSLOG"/>
     </logger>
 
     <!-- see https://github.com/slick/slick/blob/master/common-test-resources/logback.xml for more Slick logging -->
@@ -58,7 +72,6 @@
     <root level="info">
         <appender-ref ref="file"/>
         <appender-ref ref="console"/>
-        <appender-ref ref="SYSLOG"/>
     </root>
 
 </configuration>

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/Boot.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/Boot.scala
@@ -43,7 +43,7 @@ import org.broadinstitute.dsde.workbench.leonardo.dao._
 import org.broadinstitute.dsde.workbench.leonardo.dao.google.GoogleOAuth2Service
 import org.broadinstitute.dsde.workbench.leonardo.db.DbReference
 import org.broadinstitute.dsde.workbench.leonardo.dns.{KubernetesDnsCache, ProxyResolver, RuntimeDnsCache}
-import org.broadinstitute.dsde.workbench.leonardo.http.api.{HttpRoutes, StandardUserInfoDirectives}
+import org.broadinstitute.dsde.workbench.leonardo.http.api.{BuildTimeVersion, HttpRoutes, StandardUserInfoDirectives}
 import org.broadinstitute.dsde.workbench.leonardo.http.service.{DiskServiceInterp, LeoAppServiceInterp, _}
 import org.broadinstitute.dsde.workbench.leonardo.model.ServiceAccountProvider
 import org.broadinstitute.dsde.workbench.leonardo.monitor.LeoPubsubCodec.leoPubsubMessageDecoder
@@ -79,7 +79,10 @@ object Boot extends IOApp {
     import org.broadinstitute.dsde.workbench.leonardo.http.serviceDataEncoder
     implicit val logger =
       StructuredLogger.withContext[IO](Slf4jLogger.getLogger[IO])(
-        Map("serviceContext" -> org.broadinstitute.dsde.workbench.leonardo.http.serviceData.asJson.toString)
+        Map(
+          "serviceContext" -> org.broadinstitute.dsde.workbench.leonardo.http.serviceData.asJson.toString,
+          "version" -> BuildTimeVersion.version.getOrElse("unknown")
+        )
       )
 
     createDependencies[IO](applicationConfig.leoServiceAccountJsonFile.toString).use { appDependencies =>

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/Boot.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/Boot.scala
@@ -15,6 +15,7 @@ import com.google.api.services.container.ContainerScopes
 import com.google.auth.oauth2.GoogleCredentials
 import com.google.devtools.clouderrorreporting.v1beta1.ProjectName
 import fs2.Stream
+import io.circe.syntax._
 import io.kubernetes.client.openapi.ApiClient
 import org.broadinstitute.dsde.workbench.errorReporting.ErrorReporting
 import org.broadinstitute.dsde.workbench.google.GoogleCredentialModes.Json
@@ -75,7 +76,11 @@ object Boot extends IOApp {
     implicit val system = ActorSystem(applicationConfig.applicationName)
     import system.dispatcher
 
-    implicit val logger = Slf4jLogger.getLogger[IO]
+    import org.broadinstitute.dsde.workbench.leonardo.http.serviceDataEncoder
+    implicit val logger =
+      StructuredLogger.withContext[IO](Slf4jLogger.getLogger[IO])(
+        Map("serviceContext" -> org.broadinstitute.dsde.workbench.leonardo.http.serviceData.asJson.toString)
+      )
 
     createDependencies[IO](applicationConfig.leoServiceAccountJsonFile.toString).use { appDependencies =>
       val googleDependencies = appDependencies.googleDependencies

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/HttpRoutes.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/HttpRoutes.scala
@@ -7,8 +7,8 @@ import akka.event.{Logging, LoggingAdapter}
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.RouteResult.Complete
-import akka.http.scaladsl.server.directives.{DebuggingDirectives, LogEntry, LoggingMagnet}
 import akka.http.scaladsl.server._
+import akka.http.scaladsl.server.directives.{DebuggingDirectives, LogEntry, LoggingMagnet}
 import akka.stream.scaladsl.Sink
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global
@@ -22,7 +22,6 @@ import org.broadinstitute.dsde.workbench.leonardo.model.LeoException
 import org.broadinstitute.dsde.workbench.model.ErrorReport
 import org.broadinstitute.dsde.workbench.openTelemetry.OpenTelemetryMetrics
 import org.typelevel.log4cats.StructuredLogger
-import io.circe.syntax._
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -71,16 +70,12 @@ class HttpRoutes(
   }
 
   implicit val myExceptionHandler = {
-    val loggingCtx = Map(
-      "serviceContext" -> org.broadinstitute.dsde.workbench.leonardo.http.serviceData.asJson.noSpaces
-    )
-
     ExceptionHandler {
       case leoException: LeoException =>
-        logger.error(loggingCtx, leoException)(s"request failed due to: ${leoException.getMessage}").unsafeToFuture()
+        logger.error(leoException)(s"request failed due to: ${leoException.getMessage}").unsafeToFuture()
         complete(leoException.statusCode, leoException.toErrorReport)
       case e: Throwable =>
-        logger.error(loggingCtx, e)(s"Unexpected error occurred processing route: ${e.getMessage}").unsafeToFuture()
+        logger.error(e)(s"Unexpected error occurred processing route: ${e.getMessage}").unsafeToFuture()
         complete(
           StatusCodes.InternalServerError -> ErrorReport(e.getMessage,
                                                          Some(StatusCodes.InternalServerError),

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/package.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/package.scala
@@ -5,7 +5,6 @@ import cats.Applicative
 import cats.effect.{Resource, Sync}
 import cats.mtl.Ask
 import cats.syntax.all._
-import io.circe.syntax._
 import io.circe.Encoder
 import io.opencensus.scala.http.ServiceData
 import io.opencensus.trace.{AttributeValue, Span}
@@ -134,10 +133,7 @@ final case class CloudServiceMonitorOps[F[_], A](a: A)(
 
 final case class AppContext(traceId: TraceId, now: Instant, requestUri: String = "", span: Option[Span] = None) {
   override def toString: String = s"${traceId.asString}"
-
-  import org.broadinstitute.dsde.workbench.leonardo.http.serviceDataEncoder
-  val loggingCtx = Map("traceId" -> traceId.asString,
-                       "serviceContext" -> org.broadinstitute.dsde.workbench.leonardo.http.serviceData.asJson.noSpaces)
+  val loggingCtx = Map("traceId" -> traceId.asString)
 }
 
 object AppContext {

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterpSpec.scala
@@ -2,15 +2,10 @@ package org.broadinstitute.dsde.workbench.leonardo
 package http
 package service
 
-import java.net.URL
-import java.time.Instant
-import java.util.UUID
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import cats.effect.IO
-import cats.mtl.Ask
 import cats.effect.std.Queue
-import scala.concurrent.ExecutionContext.Implicits.global
 import org.broadinstitute.dsde.workbench.google2.mock.{
   FakeGoogleComputeService,
   FakeGooglePublisher,
@@ -18,10 +13,10 @@ import org.broadinstitute.dsde.workbench.google2.mock.{
   MockComputePollOperation
 }
 import org.broadinstitute.dsde.workbench.google2.{DataprocRole, DiskName, InstanceName, MachineTypeName, ZoneName}
-import org.broadinstitute.dsde.workbench.leonardo.CommonTestData.{gceRuntimeConfig, testCluster, userInfo, _}
+import org.broadinstitute.dsde.workbench.leonardo.CommonTestData._
 import org.broadinstitute.dsde.workbench.leonardo.RuntimeImageType.{CryptoDetector, Jupyter, Welder}
 import org.broadinstitute.dsde.workbench.leonardo.SamResourceId._
-import org.broadinstitute.dsde.workbench.leonardo.TestUtils.leonardoExceptionEq
+import org.broadinstitute.dsde.workbench.leonardo.TestUtils.{appContext, leonardoExceptionEq}
 import org.broadinstitute.dsde.workbench.leonardo.config.Config
 import org.broadinstitute.dsde.workbench.leonardo.dao.MockDockerDAO
 import org.broadinstitute.dsde.workbench.leonardo.db._
@@ -35,15 +30,16 @@ import org.broadinstitute.dsde.workbench.leonardo.monitor.{
   RuntimeConfigInCreateRuntimeMessage
 }
 import org.broadinstitute.dsde.workbench.leonardo.util.QueueFactory
-import org.broadinstitute.dsde.workbench.model
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.broadinstitute.dsde.workbench.model.{IP, UserInfo, WorkbenchEmail, WorkbenchUserId}
 import org.scalatest.Assertion
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatestplus.mockito.MockitoSugar
-import org.broadinstitute.dsde.workbench.leonardo.TestUtils.appContext
 
+import java.net.URL
 import java.nio.file.Paths
+import java.util.UUID
+import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 
 class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with TestComponent with MockitoSugar {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -41,8 +41,6 @@ object Dependencies {
   val excludeJacksonCore = ExclusionRule(organization = "com.fasterxml.jackson.core", name = "jackson-core")
   val excludeJacksonAnnotation = ExclusionRule(organization = "com.fasterxml.jackson.core", name = "jackson-annotations")
   val excludeSlf4j = ExclusionRule(organization = "org.slf4j", name = "slf4j-api")
-  val excludeLogbackCore = ExclusionRule(organization = "ch.qos.logback", name = "logback-core")
-  val excludeLogbackClassic = ExclusionRule(organization = "ch.qos.logback", name = "logback-classic")
   val excludeTypesafeConfig = ExclusionRule(organization = "com.typesafe", name = "config")
   val excludeTypesafeSslConfig = ExclusionRule(organization = "com.typesafe", name = "ssl-config-core")
   val excludeGoogleError = ExclusionRule(organization = "com.google.errorprone", name = "error_prone_annotations")
@@ -59,7 +57,7 @@ object Dependencies {
   val excludeBigQuery = ExclusionRule(organization = "com.google.cloud", name = "google-cloud-bigquery")
   val excludeCloudBilling = ExclusionRule(organization = "com.google.cloud", name = "google-cloud-billing")
 
-  val logbackClassic: ModuleID =  "ch.qos.logback"              % "logback-classic" % "1.2.6"
+  val logbackClassic: ModuleID =  "ch.qos.logback"              % "logback-classic" % "1.2.7"
   val scalaLogging: ModuleID =    "com.typesafe.scala-logging"  %% "scala-logging"  % scalaLoggingV
   val swaggerUi: ModuleID =       "org.webjars"                 % "swagger-ui"      % "3.52.5"
   val ficus: ModuleID =           "com.iheart"                  %% "ficus"          % "1.5.1"
@@ -141,7 +139,7 @@ object Dependencies {
     workbenchOpenTelemetryTest,
     helmScalaSdk,
     helmScalaSdkTest,
-    "net.logstash.logback" % "logstash-logback-encoder" % "6.6", // for structured logging in logback
+    "net.logstash.logback" % "logstash-logback-encoder" % "7.0.1", // for structured logging in logback
     "com.github.julien-truffaut" %%  "monocle-core"  % monocleV,
     "com.github.julien-truffaut" %%  "monocle-macro" % monocleV,
     // using provided because `http` depends on `core`, and `http`'s `opencensus-exporter-trace-stackdriver`

--- a/project/Merging.scala
+++ b/project/Merging.scala
@@ -8,6 +8,7 @@ object Merging {
     //[error] /root/.cache/coursier/v1/https/repo1.maven.org/maven2/com/google/protobuf/protobuf-java/3.11.4/protobuf-java-3.11.4.jar:google/protobuf/field_mask.proto
     //[error] /root/.cache/coursier/v1/https/repo1.maven.org/maven2/com/typesafe/akka/akka-protobuf-v3_2.12/2.6.5/akka-protobuf-v3_2.12-2.6.5.jar:google/protobuf/field_mask.proto
     case PathList("google", "protobuf", _ @_*) => MergeStrategy.first
+    case x if x.endsWith("/module-info.class") => MergeStrategy.discard
     case "module-info.class" =>
       MergeStrategy.discard // JDK 8 does not use the file module-info.class so it is safe to discard the file.
     case "reference.conf" => MergeStrategy.concat


### PR DESCRIPTION
`serviceContext` was added in [this PR](https://github.com/DataBiosphere/leonardo/pull/2415), but it wasn't logged properly still becuz it's logged as `String` instead of json object. This PR should fix that. Here's an example log generated with latest change.

```
{"@timestamp":"2021-11-25T04:56:47.3Z","@version":"1","logger_name":"org.broadinstitute.dsde.workbench.leonardo.http.Boot","level":"INFO","version":"5a638602","thread_name":"io-compute-7","serviceContext":{"service":"leonardo","version":"5a638602"},"message":"acking message: Event(DeleteRuntimeMessage(5,None,Some(TraceId(BootMonitoring2021-11-25T04:56:45.247Z))),Some(TraceId(BootMonitoring2021-11-25T04:56:45.247Z)),seconds: 1637816205\nnanos: 672000000\n,com.google.cloud.pubsub.v1.MessageDispatcher$3@9db391f)"}
```

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
