### PR TITLE
IA-3050: Injecting headers for automation tests

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoApiClient.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoApiClient.scala
@@ -3,13 +3,7 @@ package org.broadinstitute.dsde.workbench.leonardo
 import cats.effect.{IO, Resource}
 import org.broadinstitute.dsde.workbench.DoneCheckable
 import org.broadinstitute.dsde.workbench.DoneCheckableSyntax._
-import org.broadinstitute.dsde.workbench.google2.{
-  streamFUntilDone,
-  streamUntilDoneOrTimeout,
-  DiskName,
-  MachineTypeName,
-  ZoneName
-}
+import org.broadinstitute.dsde.workbench.google2.{DiskName, MachineTypeName, ZoneName, streamFUntilDone, streamUntilDoneOrTimeout}
 import org.broadinstitute.dsde.workbench.leonardo.ApiJsonDecoder._
 import org.broadinstitute.dsde.workbench.leonardo.http.AppRoutesTestJsonCodec._
 import org.broadinstitute.dsde.workbench.leonardo.http.DiskRoutesTestJsonCodec._
@@ -26,7 +20,7 @@ import org.http4s.headers._
 import org.typelevel.log4cats.StructuredLogger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 
-import java.util.UUID
+import java.util.{Random, UUID}
 import java.util.concurrent.TimeoutException
 import scala.concurrent.duration._
 import scala.util.control.NoStackTrace
@@ -646,8 +640,13 @@ object LeonardoApiClient {
         }
     } yield ()
 
-  private def genTraceIdHeader(): IO[Header.Raw] =
-    IO(UUID.randomUUID().toString).map(uuid => Header.Raw(traceIdHeaderString, uuid))
+  //replace the dashes in UUID to get just a string of characters.
+  //Add a slash to mimic this format: f4c5f1a44adf79f54c18c96ccf4f12f3/3939911508519804487"
+  private def genTraceIdHeader(): IO[Header.Raw] = {
+    val uuid = UUID.randomUUID().toString.replaceAll("\\-","")
+    val numid = new Random().nextInt(999999999).toString + new Random().nextInt(9999999).toString + new Random().nextInt(999)
+    IO(traceIdValue).map(uuid => Header.Raw(traceIdHeaderString, uuid))
+  }
 }
 
 final case class RestError(message: String, statusCode: Status, body: Option[String]) extends NoStackTrace {

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoApiClient.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoApiClient.scala
@@ -640,12 +640,10 @@ object LeonardoApiClient {
         }
     } yield ()
 
-  //replace the dashes in UUID to get just a string of characters.
-  //Add a slash to mimic this format: f4c5f1a44adf79f54c18c96ccf4f12f3/3939911508519804487"
   private def genTraceIdHeader(): IO[Header.Raw] = {
     val uuid = UUID.randomUUID().toString.replaceAll("\\-","")
-    val numid = new Random().nextInt(999999999).toString + new Random().nextInt(9999999).toString + new Random().nextInt(999)
-    IO(traceIdValue).map(uuid => Header.Raw(traceIdHeaderString, uuid))
+    val digitString = "3939911508519804487"
+    IO(uuid+"/"+digitString).map(uuid => Header.Raw(traceIdHeaderString, uuid))
   }
 }
 

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoApiClient.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoApiClient.scala
@@ -3,7 +3,13 @@ package org.broadinstitute.dsde.workbench.leonardo
 import cats.effect.{IO, Resource}
 import org.broadinstitute.dsde.workbench.DoneCheckable
 import org.broadinstitute.dsde.workbench.DoneCheckableSyntax._
-import org.broadinstitute.dsde.workbench.google2.{DiskName, MachineTypeName, ZoneName, streamFUntilDone, streamUntilDoneOrTimeout}
+import org.broadinstitute.dsde.workbench.google2.{
+  streamFUntilDone,
+  streamUntilDoneOrTimeout,
+  DiskName,
+  MachineTypeName,
+  ZoneName
+}
 import org.broadinstitute.dsde.workbench.leonardo.ApiJsonDecoder._
 import org.broadinstitute.dsde.workbench.leonardo.http.AppRoutesTestJsonCodec._
 import org.broadinstitute.dsde.workbench.leonardo.http.DiskRoutesTestJsonCodec._
@@ -641,9 +647,9 @@ object LeonardoApiClient {
     } yield ()
 
   private def genTraceIdHeader(): IO[Header.Raw] = {
-    val uuid = UUID.randomUUID().toString.replaceAll("\\-","")
+    val uuid = UUID.randomUUID().toString.replaceAll("\\-", "")
     val digitString = "3939911508519804487"
-    IO(uuid+"/"+digitString).map(uuid => Header.Raw(traceIdHeaderString, uuid))
+    IO(uuid + "/" + digitString).map(uuid => Header.Raw(traceIdHeaderString, uuid))
   }
 }
 

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoApiClient.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoApiClient.scala
@@ -20,7 +20,7 @@ import org.http4s.headers._
 import org.typelevel.log4cats.StructuredLogger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 
-import java.util.{Random, UUID}
+import java.util.UUID
 import java.util.concurrent.TimeoutException
 import scala.concurrent.duration._
 import scala.util.control.NoStackTrace

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookGCECustomizationSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookGCECustomizationSpec.scala
@@ -42,7 +42,7 @@ final class NotebookGCECustomizationSpec extends GPAllocFixtureSpec with Paralle
 
                 nbExt.get should include("jupyter-iframe-extension/main  enabled")
 
-                nbExt.get should include("translate_nbextension/main  enable  d")
+                nbExt.get should include("translate_nbextension/main  enabled")
                 // should be installed by default
                 nbExt.get should include("toc2/main  enabled")
 

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookGCECustomizationSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookGCECustomizationSpec.scala
@@ -42,7 +42,7 @@ final class NotebookGCECustomizationSpec extends GPAllocFixtureSpec with Paralle
 
                 nbExt.get should include("jupyter-iframe-extension/main  enabled")
 
-                nbExt.get should include("translate_nbextension/main  enabled")
+                nbExt.get should include("translate_nbextension/main  enable  d")
                 // should be installed by default
                 nbExt.get should include("toc2/main  enabled")
 


### PR DESCRIPTION
We wanted to follow the format that Google uses for TraceId:

<img width="678" alt="Screen Shot 2021-11-29 at 12 00 12 PM" src="https://user-images.githubusercontent.com/62293969/143910817-64c2abdb-0ad4-4085-a85a-f95bede3fb9d.png">

Updating the genTraceIdHeader to use a UUID/"static number"

The static number might need to be evaluated a bit more, but have been able to test this and it looks like the header generates correctly:

<img width="1789" alt="Screen Shot 2021-11-29 at 12 01 57 PM" src="https://user-images.githubusercontent.com/62293969/143911210-422ffb67-13c1-4e63-8c21-41480e0bf6ff.png">

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
