### PR TITLE
IA-3083 fix log level

### DIFF
--- a/http/src/main/resources/logback.xml
+++ b/http/src/main/resources/logback.xml
@@ -5,14 +5,9 @@
             <providers>
                 <omitEmptyFields>true</omitEmptyFields>
 
-                <fieldNames>
-                    <level>severity</level>
-                </fieldNames>
-
                 <timestamp/>
                 <version/>
                 <loggerName/>
-                <logLevel/>
                 <mdc>
                     <excludeMdcKeyName>serviceContext</excludeMdcKeyName>
                 </mdc>
@@ -22,6 +17,7 @@
                 <pattern>
                     <pattern>
                         {
+                            "severity": "%level",
                             "serviceContext": "#tryJson{%mdc{serviceContext}}",
                             "message": "#tryJson{%message}"
                         }


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-3083

In previous [PR](https://github.com/DataBiosphere/leonardo/pull/2420), I was able to set `serviceContext` properly, but with that change, log level wasn't set properly in cloud logging. Cloud logging expect log level as `severity`, this PR should fix that.

See example log. Note `serviceContext` is null becuz this log was from unit tests, and `serviceContext` doesn't populate properly in unit tests.
```
{"@timestamp":"2021-11-29T20:45:49.491Z","@version":"1","logger_name":"com.zaxxer.hikari.HikariDataSource","thread_name":"io-compute-15","severity":"INFO","serviceContext":null,"message":"mysql.db - Starting..."}
```

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
