### PR TITLE
Stop caching Galaxy's chart

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ RUN curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/master
 
 # Add the repos containing nginx and galaxy charts
 RUN helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx && \
-    helm repo add galaxy https://raw.githubusercontent.com/cloudve/helm-charts/anvil/ && \
+    helm repo add galaxy https://storage.cloud.google.com/galaxy-anvil/helm && \
     helm repo add terra-app-setup-charts https://storage.googleapis.com/terra-app-setup-chart && \
     helm repo add terra https://terra-app-charts.storage.googleapis.com && \
     helm repo add cromwell-helm https://broadinstitute.github.io/cromwhelm/charts/ && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,6 @@ RUN helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx && \
 
 RUN cd /leonardo && \
     helm pull terra-app-setup-charts/terra-app-setup --version $TERRA_APP_SETUP_VERSION --untar && \
-    helm pull galaxy/galaxykubeman --version $GALAXY_VERSION --untar && \
     helm pull terra/terra-app --version $TERRA_APP_VERSION --untar  && \
     helm pull ingress-nginx/ingress-nginx --version $NGINX_VERSION --untar && \
     helm pull cromwell-helm/cromwell --version $CROMWELL_CHART_VERSION --untar && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ RUN curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/master
 
 # Add the repos containing nginx and galaxy charts
 RUN helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx && \
-    helm repo add galaxy https://storage.cloud.google.com/galaxy-anvil/helm && \
+    helm repo add galaxy https://storage.googleapis.com/galaxy-anvil/helm && \
     helm repo add terra-app-setup-charts https://storage.googleapis.com/terra-app-setup-chart && \
     helm repo add terra https://terra-app-charts.storage.googleapis.com && \
     helm repo add cromwell-helm https://broadinstitute.github.io/cromwhelm/charts/ && \

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -389,7 +389,7 @@ gke {
     # only need to be unique within a namespace, but something in the Galaxy chart requires them
     # to be unique within a cluster.
     releaseNameSuffix = "gxy-rls"
-    chartName = "/leonardo/galaxykubeman"
+    chartName = "galaxy/galaxykubeman"
     # If you change this here, be sure to update it in the dockerfile
     # This is galaxykubeman 1.2.0, which references Galaxy 21.09
     chartVersion = "1.2.0"

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/KubernetesTestData.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/KubernetesTestData.scala
@@ -31,7 +31,7 @@ object KubernetesTestData {
 
   val galaxyApp = AppType.Galaxy
 
-  val galaxyChartName = ChartName("/leonardo/galaxykubeman")
+  val galaxyChartName = ChartName("galaxy/galaxykubeman")
   val galaxyChartVersion = ChartVersion("1.2.0")
   val galaxyChart = Chart(galaxyChartName, galaxyChartVersion)
 


### PR DESCRIPTION
Reverts https://github.com/DataBiosphere/leonardo/pull/1940 for Galaxy which will allow us to make small within-version updates/bugfixes/tool updates/etc to Galaxy without having to ask or wait for a Leo rebuild, as was the case before the PR above.
Also changes the helm repository to a GCS repository, to remove any Github server issues when pulling the repo at helm install time.