### PR TITLE
IA-3108 increase timeout for detaching disk

### DIFF
--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterp.scala
@@ -328,7 +328,7 @@ class RuntimeServiceInterp[F[_]: Parallel](config: RuntimeServiceConfig,
                       disk.zone,
                       OperationName(op.getName),
                       1 seconds,
-                      30,
+                      60,
                       None
                     )(
                       F.unit,


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-3108

This PR updates maxAttempts to 60 instead of 30 (basically increase timeout to 1 min)


There're 44 occurences where disk fail to detach due to timeout
![Screen Shot 2021-12-06 at 2 59 26 PM](https://user-images.githubusercontent.com/32771737/144914230-27470576-be89-49dc-807f-abd55e265d02.png)

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
