### PR TITLE
Cache AoU 2.0.1 and 2.0.4 to experiment with reduced e2e flakes

### DIFF
--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -64,7 +64,7 @@ dataproc {
     numberOfPreemptibleWorkers = 0
     region = "us-central1"
   }
-  customDataprocImage = "projects/broad-dsp-gcr-public/global/images/yonghao3-image-dataproc-1-4-51-debian10-e03c007"
+  customDataprocImage = "projects/broad-dsp-gcr-public/global/images/calbach-image-dataproc-1-4-51-debian10-7438706"
 
   dataprocReservedMemory = 6g
 
@@ -97,7 +97,7 @@ dataproc {
 }
 
 gce {
-  customGceImage = "projects/broad-dsp-gcr-public/global/images/yonghao3-gce-cos-image-e03c007"
+  customGceImage = "projects/broad-dsp-gcr-public/global/images/calbach-gce-cos-image-7438706"
   userDiskDeviceName = "user-disk"
   defaultScopes = [
     "https://www.googleapis.com/auth/userinfo.email",

--- a/jenkins/dataproc-custom-images/prepare-custom-leonardo-jupyter-dataproc-image.sh
+++ b/jenkins/dataproc-custom-images/prepare-custom-leonardo-jupyter-dataproc-image.sh
@@ -28,7 +28,7 @@ openidc_proxy="broadinstitute/openidc-proxy:2.3.1_2"
 anvil_rstudio_bioconductor="us.gcr.io/anvil-gcr-public/anvil-rstudio-bioconductor:3.14.0"
 
 # The _old variables are NOT replaced by the Jenkins job; they must be manually updated
-terra_jupyter_aou_old="us.gcr.io/broad-dsp-gcr-public/terra-jupyter-aou:2.0.3"
+terra_jupyter_aou_old="us.gcr.io/broad-dsp-gcr-public/terra-jupyter-aou:2.0.1"
 
 # Not replaced by Jenkins. If you change this you must also change Leo reference.conf!
 cryptomining_detector="us.gcr.io/broad-dsp-gcr-public/cryptomining-detector:0.0.2"

--- a/jenkins/gce-custom-images/prepare_gce_image.sh
+++ b/jenkins/gce-custom-images/prepare_gce_image.sh
@@ -27,7 +27,7 @@ openidc_proxy="broadinstitute/openidc-proxy:2.3.1_2"
 anvil_rstudio_bioconductor="us.gcr.io/anvil-gcr-public/anvil-rstudio-bioconductor:3.14.0"
 
 # The _old variables are NOT replaced by the Jenkins job; they must be manually updated
-terra_jupyter_aou_old="us.gcr.io/broad-dsp-gcr-public/terra-jupyter-aou:2.0.3"
+terra_jupyter_aou_old="us.gcr.io/broad-dsp-gcr-public/terra-jupyter-aou:2.0.1"
 
 # Not replaced by Jenkins
 cos_gpu_installer="gcr.io/cos-cloud/cos-gpu-installer:v2.0.3"


### PR DESCRIPTION
**Do not merge**: before this week's (~12/7) Terra release

With >2.0.1, we're seeing high numbers of flakes in the AoU test env. Reverting to 2.0.1 causes runtime creation to fail, presumably because 2.0.1 is uncached and is too large.