### PR TITLE
[IA-3142] Bump Dataproc image version to 2.0.26

### DIFF
--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -64,7 +64,7 @@ dataproc {
     numberOfPreemptibleWorkers = 0
     region = "us-central1"
   }
-  customDataprocImage = "projects/broad-dsp-gcr-public/global/images/aou-1216-image-dataproc-2-0-25-debian10-41f17aa"
+  customDataprocImage = "projects/broad-dsp-gcr-public/global/images/custom-leo-image-dataproc-2-0-26-debian10-6bd9f29"
 
   dataprocReservedMemory = 6g
 

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -471,6 +471,7 @@ pipeline {
                     }
                 }
         }
+
         stage('Update custom leo images in conf') {
             when { expression { !shouldAbortBuild } }
                 steps {

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -151,7 +151,7 @@ pipeline {
             description: "The path for the bucket where the custom Dataproc image generation logs will be stored")
         string(name: "GCE_IMAGE_BUCKET", defaultValue: "gs://leo-gce-image-creation-logs",
             description: "The path for the bucket where the custom GCE image generation logs will be stored")
-        string(name: "DATAPROC_VERSIONS", defaultValue: "2.0.25-debian10",
+        string(name: "DATAPROC_VERSIONS", defaultValue: "2.0.26-debian10",
             description: "A custom image will be build for each of these dataproc versions")
         string(name: "branch", defaultValue: "develop",
             description: "The branch that will be used to run the job")

--- a/jenkins/dataproc-custom-images/create_dataproc_image.sh
+++ b/jenkins/dataproc-custom-images/create_dataproc_image.sh
@@ -25,7 +25,7 @@ gsutil ls $TEST_BUCKET || gsutil mb -b on -p $GOOGLE_PROJECT -l $REGION "$TEST_B
 pushd $WORK_DIR
 
 customDataprocImageBaseName="test"
-dp_version_formatted="2-0-25-debian10"
+dp_version_formatted="2-0-26-debian10"
 # This needs to be unique for each run
 imageID=$(whoami)-$(date +"%Y-%m-%d-%H-%M-%S")
 
@@ -33,7 +33,7 @@ gcloud config set dataproc/region us-central1
 
 python generate_custom_image.py \
     --image-name "$customDataprocImageBaseName-$dp_version_formatted-$imageID" \
-    --dataproc-version "2.0.25-debian10" \
+    --dataproc-version "2.0.26-debian10" \
     --customization-script ../prepare-custom-leonardo-jupyter-dataproc-image.sh \
     --zone $ZONE \
     --gcs-bucket $TEST_BUCKET \

--- a/jenkins/dataproc-custom-images/prepare-custom-leonardo-jupyter-dataproc-image.sh
+++ b/jenkins/dataproc-custom-images/prepare-custom-leonardo-jupyter-dataproc-image.sh
@@ -103,10 +103,6 @@ retry 5 apt-key update
 #TODO: Remove this flag once we migrate to debian11
 retry 5 apt-get --allow-releaseinfo-change update
 
-# install Docker
-# https://docs.docker.com/install/linux/docker-ce/debian/
-# export DOCKER_CE_VERSION="19.03.2~ce~3-0~debian"
-
 # retry 5 betterAptGet
 retry 5 apt-get install -y -q \
     apt-transport-https \


### PR DESCRIPTION
The upgrade is to include Dataproc's addressing of log4j security vulnerabilities as of 12/16/2021.