### PR TITLE
[IA-3142] Bump Dataproc image version to 2.0.27

### DIFF
--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -45,6 +45,7 @@ dataproc {
     "australia-southeast1",
     "northamerica-northeast2"
   ]
+
   defaultScopes = [
     "https://www.googleapis.com/auth/userinfo.email",
     "https://www.googleapis.com/auth/source.read_only",
@@ -54,6 +55,7 @@ dataproc {
     "https://www.googleapis.com/auth/cloud.useraccounts.readonly",
     "https://www.googleapis.com/auth/bigquery"
   ]
+
   runtimeDefaults {
     numberOfWorkers = 0
     masterMachineType = "n1-standard-4"
@@ -64,7 +66,8 @@ dataproc {
     numberOfPreemptibleWorkers = 0
     region = "us-central1"
   }
-  customDataprocImage = "projects/broad-dsp-gcr-public/global/images/custom-leo-image-dataproc-2-0-26-debian10-6bd9f29"
+
+  customDataprocImage = "projects/broad-dsp-gcr-public/global/images/custom-leo-image-dataproc-2-0-27-debian10-389af66"
 
   dataprocReservedMemory = 6g
 

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -151,7 +151,7 @@ pipeline {
             description: "The path for the bucket where the custom Dataproc image generation logs will be stored")
         string(name: "GCE_IMAGE_BUCKET", defaultValue: "gs://leo-gce-image-creation-logs",
             description: "The path for the bucket where the custom GCE image generation logs will be stored")
-        string(name: "DATAPROC_VERSIONS", defaultValue: "2.0.26-debian10",
+        string(name: "DATAPROC_VERSIONS", defaultValue: "2.0.27-debian10",
             description: "A custom image will be build for each of these dataproc versions")
         string(name: "branch", defaultValue: "develop",
             description: "The branch that will be used to run the job")

--- a/jenkins/dataproc-custom-images/create_dataproc_image.sh
+++ b/jenkins/dataproc-custom-images/create_dataproc_image.sh
@@ -25,7 +25,7 @@ gsutil ls $TEST_BUCKET || gsutil mb -b on -p $GOOGLE_PROJECT -l $REGION "$TEST_B
 pushd $WORK_DIR
 
 customDataprocImageBaseName="test"
-dp_version_formatted="2-0-26-debian10"
+dp_version_formatted="2-0-27-debian10"
 # This needs to be unique for each run
 imageID=$(whoami)-$(date +"%Y-%m-%d-%H-%M-%S")
 
@@ -33,7 +33,7 @@ gcloud config set dataproc/region us-central1
 
 python generate_custom_image.py \
     --image-name "$customDataprocImageBaseName-$dp_version_formatted-$imageID" \
-    --dataproc-version "2.0.26-debian10" \
+    --dataproc-version "2.0.27-debian10" \
     --customization-script ../prepare-custom-leonardo-jupyter-dataproc-image.sh \
     --zone $ZONE \
     --gcs-bucket $TEST_BUCKET \


### PR DESCRIPTION
The upgrade is to include Dataproc's addressing of log4j security vulnerabilities as of 12/18/2021.