### PR TITLE
IA-3136 fix to 1.19.15

### DIFF
--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -356,7 +356,7 @@ gke {
                           "69.173.112.0/21"
     ]
     # See https://cloud.google.com/kubernetes-engine/docs/release-notes
-    version = "1.19"
+    version = "1.19.15"
     nodepoolLockCacheExpiryTime = 1 hour
     nodepoolLockCacheMaxSize = 200
   }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/config/ConfigSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/config/ConfigSpec.scala
@@ -76,7 +76,7 @@ final class ConfigSpec extends AnyFlatSpec with Matchers {
         "69.173.127.240/28",
         "69.173.112.0/21"
       ).map(CidrIP),
-      KubernetesClusterVersion("1.19"),
+      KubernetesClusterVersion("1.19.15"),
       1 hour,
       200
     )


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-3136

Google security team came back saying the issue is not seen in 1.19.15 1801 nor with 1.20.12 1500. Galaxy doesn't support 1.20+ yet. So this PR pins gke version to 1.19.15 to see if things will work in prod with KTD enabled.

cc @davidbernick @dinvlad @zbedo 

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
