### PR TITLE
IA-2965 update home dir for jupyter

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookPyKernelSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookPyKernelSpec.scala
@@ -33,7 +33,7 @@ class NotebookPyKernelSpec extends RuntimeFixtureSpec with NotebookTestUtils {
             notebookPage.executeCell(getPythonVersion).get should include("3.7")
             notebookPage.executeCell(getBxPython).get should include("Copyright (c)")
             notebookPage.executeCell(getPandasLocation).get should include("/opt/conda/lib/python3.7/site-packages")
-            notebookPage.executeCell("! pwd").get shouldBe ("/home/jupyter/notebooks")
+            notebookPage.executeCell("! pwd").get shouldBe ("/home/jupyter")
           }
         }
     }
@@ -54,7 +54,7 @@ class NotebookPyKernelSpec extends RuntimeFixtureSpec with NotebookTestUtils {
             // user installed packages should be in directory where PD is mounted
             val getFuzzyWuzzyLocation = "! pip3 show fuzzywuzzy"
             notebookPage.executeCell(getFuzzyWuzzyLocation, cellNumberOpt = Some(1)).get should include(
-              "/home/jupyter/notebooks/packages"
+              "/home/jupyter/packages"
             )
           }
         }

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookPyKernelSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookPyKernelSpec.scala
@@ -193,7 +193,7 @@ class NotebookPyKernelSpec extends RuntimeFixtureSpec with NotebookTestUtils {
               // TODO: remove when PPW is rolled out to all workspaces
               // and Leo removes the kernel_bootstrap logic.
               // See https://broadworkbench.atlassian.net/browse/IA-2936
-              "WORKSPACE_NAME" -> "jupyter"
+              "WORKSPACE_NAME" -> "home"
             )
         withNewNotebook(runtimeFixture.runtime, Python3) { notebookPage =>
           notebookPage.executeCell("import os")

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookRKernelSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookRKernelSpec.scala
@@ -158,7 +158,7 @@ class NotebookRKernelSpec extends RuntimeFixtureSpec with NotebookTestUtils {
               // TODO: remove when PPW is rolled out to all workspaces
               // and Leo removes the kernel_bootstrap logic.
               // See https://broadworkbench.atlassian.net/browse/IA-2936
-              "WORKSPACE_NAME" -> "jupyter"
+              "WORKSPACE_NAME" -> "home"
             )
         withNewNotebook(runtimeFixture.runtime, RKernel) { notebookPage =>
           expectedEVs.foreach {

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookRKernelSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookRKernelSpec.scala
@@ -78,7 +78,7 @@ class NotebookRKernelSpec extends RuntimeFixtureSpec with NotebookTestUtils {
           val output = notebookPage.executeCell("""install.packages("httr")""", installTimeout)
           output shouldBe defined
           output.get should include("Installing package into")
-          output.get should include("/home/jupyter/notebooks/packages")
+          output.get should include("/home/jupyter/packages")
 
           val httpGetTest =
             """library(httr)
@@ -104,7 +104,7 @@ class NotebookRKernelSpec extends RuntimeFixtureSpec with NotebookTestUtils {
           val installOutput = notebookPage.executeCell("""install.packages('mlr')""", installTimeout)
           installOutput shouldBe defined
           installOutput.get should include("Installing package into")
-          installOutput.get should include("/home/jupyter/notebooks/packages")
+          installOutput.get should include("/home/jupyter/packages")
           installOutput.get should not include ("Installation failed")
 
           // Make sure it was installed correctly; if not, this will return an error
@@ -140,7 +140,7 @@ class NotebookRKernelSpec extends RuntimeFixtureSpec with NotebookTestUtils {
           val installOutput = notebookPage.executeCell("""install.packages('qwraps2')""", installTimeout)
           installOutput shouldBe defined
           installOutput.get should include("Installing package into")
-          installOutput.get should include("/home/jupyter/notebooks/packages")
+          installOutput.get should include("/home/jupyter/packages")
           installOutput.get should not include ("cannot find -lgfortran")
         }
       }

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeCreationDiskSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeCreationDiskSpec.scala
@@ -70,7 +70,7 @@ class RuntimeCreationDiskSpec
                 )
                 .get
               res should include("/dev/sdb")
-              res should include("/home/jupyter/notebooks")
+              res should include("/home/jupyter")
             }
           }
         )
@@ -197,7 +197,7 @@ class RuntimeCreationDiskSpec
         _ <- IO(withWebDriver { implicit driver =>
           withNewNotebook(clusterCopy, Python3) { notebookPage =>
             val createNewFile =
-              """! echo 'this should save' >> /home/jupyter/notebooks/test.txt""".stripMargin
+              """! echo 'this should save' >> /home/jupyter/test.txt""".stripMargin
             notebookPage.executeCell(createNewFile)
             notebookPage.executeCell("! pip install beautifulSoup4")
           }
@@ -211,7 +211,7 @@ class RuntimeCreationDiskSpec
           withNewNotebook(clusterCopy, Python3) { notebookPage =>
             val res = notebookPage.executeCell("! df -H").get
             res should include("/dev/sdb")
-            res should include("/home/jupyter/notebooks")
+            res should include("/home/jupyter")
           }
         })
         _ <- deleteRuntimeWithWait(googleProject, runtimeName, false)
@@ -222,10 +222,10 @@ class RuntimeCreationDiskSpec
         _ <- IO(withWebDriver { implicit driver =>
           withNewNotebook(clusterCopyWithData, Python3) { notebookPage =>
             val persistedData =
-              """! cat /home/jupyter/notebooks/test.txt""".stripMargin
+              """! cat /home/jupyter/test.txt""".stripMargin
             notebookPage.executeCell(persistedData).get should include("this should save")
             val persistedPackage = "! pip show beautifulSoup4"
-            notebookPage.executeCell(persistedPackage).get should include("/home/jupyter/notebooks/packages")
+            notebookPage.executeCell(persistedPackage).get should include("/home/jupyter/packages")
           }
         })
         _ <- deleteRuntimeWithWait(googleProject, runtimeWithDataName, deleteDisk = true)

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeCreationDiskSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeCreationDiskSpec.scala
@@ -186,6 +186,10 @@ class RuntimeCreationDiskSpec
         )
       )
 
+      val createRuntime2Request = createRuntimeRequest.copy(toolDockerImage =
+        Some(ContainerImage(LeonardoConfig.Leonardo.pythonImageUrl, ContainerRegistry.GCR))
+      ) //this just needs to be a different image from default image Leonardo uses, which is gatk
+
       for {
         _ <- LeonardoApiClient.createDiskWithWait(googleProject,
                                                   diskName,
@@ -217,7 +221,7 @@ class RuntimeCreationDiskSpec
         _ <- deleteRuntimeWithWait(googleProject, runtimeName, false)
 
         // Creating new runtime with existing disk should have test.txt file and user installed package
-        runtimeWithData <- createRuntimeWithWait(googleProject, runtimeWithDataName, createRuntimeRequest)
+        runtimeWithData <- createRuntimeWithWait(googleProject, runtimeWithDataName, createRuntime2Request)
         clusterCopyWithData = ClusterCopy.fromGetRuntimeResponseCopy(runtimeWithData)
         _ <- IO(withWebDriver { implicit driver =>
           withNewNotebook(clusterCopyWithData, Python3) { notebookPage =>

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimePatchSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimePatchSpec.scala
@@ -258,7 +258,6 @@ class RuntimePatchSpec
           )
           clusterCopy = ClusterCopy.fromGetRuntimeResponseCopy(getRuntimeResult)
           implicit0(authToken: AuthToken) <- Ron.authToken()
-          _ <- IO.sleep(30 seconds) // Wait 30 seconds before we try to make a notebooks on the cluster
           _ <- IO(
             withWebDriver { implicit driver =>
               withNewNotebook(clusterCopy, Python3) { notebookPage =>

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimePatchSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimePatchSpec.scala
@@ -258,6 +258,7 @@ class RuntimePatchSpec
           )
           clusterCopy = ClusterCopy.fromGetRuntimeResponseCopy(getRuntimeResult)
           implicit0(authToken: AuthToken) <- Ron.authToken()
+          _ <- IO.sleep(30 seconds) // Wait 30 seconds before we try to make a notebooks on the cluster
           _ <- IO(
             withWebDriver { implicit driver =>
               withNewNotebook(clusterCopy, Python3) { notebookPage =>

--- a/http/src/main/resources/init-resources/gce-init.sh
+++ b/http/src/main/resources/init-resources/gce-init.sh
@@ -291,12 +291,12 @@ if [ ! -z "$RSTUDIO_DOCKER_IMAGE" ] ; then
 fi
 
 # This condition is needed for supporting existing Runtime/PDs created before this change
-if [ -d $WORK_DIRECTORY/notebooks ]
-then
-    export NOTEBOOKS_DIR=$(notebooksDir)/notebooks
-else
-    export NOTEBOOKS_DIR=$(notebooksDir)
-fi
+#if [ -d $WORK_DIRECTORY/notebooks ]
+#then
+#    export NOTEBOOKS_DIR=$(notebooksDir)/notebooks
+#else
+export NOTEBOOKS_DIR=$(notebooksDir)
+#fi
 
 tee /var/variables.env << END
 CERT_DIRECTORY=${CERT_DIRECTORY}

--- a/http/src/main/resources/init-resources/gce-init.sh
+++ b/http/src/main/resources/init-resources/gce-init.sh
@@ -92,7 +92,6 @@ export STAGING_BUCKET=$(stagingBucketName)
 export OWNER_EMAIL=$(loginHint)
 export JUPYTER_SERVER_NAME=$(jupyterServerName)
 export JUPYTER_DOCKER_IMAGE=$(jupyterDockerImage)
-export NOTEBOOKS_DIR=$(notebooksDir)
 export WELDER_SERVER_NAME=$(welderServerName)
 export WELDER_DOCKER_IMAGE=$(welderDockerImage)
 export RSTUDIO_SERVER_NAME=$(rstudioServerName)
@@ -289,6 +288,14 @@ if [ ! -z "$RSTUDIO_DOCKER_IMAGE" ] ; then
   TOOL_SERVER_NAME=${RSTUDIO_SERVER_NAME}
   COMPOSE_FILES+=(-f ${DOCKER_COMPOSE_FILES_DIRECTORY}/`basename ${RSTUDIO_DOCKER_COMPOSE}`)
   cat ${DOCKER_COMPOSE_FILES_DIRECTORY}/`basename ${RSTUDIO_DOCKER_COMPOSE}`
+fi
+
+# This condition is needed for supporting existing Runtime/PDs created before this change
+if [ -d $WORK_DIRECTORY/notebooks ]
+then
+    export NOTEBOOKS_DIR=$(notebooksDir)/notebooks
+else
+    export NOTEBOOKS_DIR=$(notebooksDir)
 fi
 
 tee /var/variables.env << END

--- a/http/src/main/resources/init-resources/gce-init.sh
+++ b/http/src/main/resources/init-resources/gce-init.sh
@@ -496,6 +496,10 @@ if [ ! -z "$JUPYTER_DOCKER_IMAGE" ] ; then
        && cp $JUPYTER_HOME/custom/edit-mode.js $JUPYTER_USER_HOME/.jupyter/custom/ \
        && mkdir -p $JUPYTER_HOME/nbconfig"
 
+  # In new jupyter images, we should update jupyter_notebook_config.py in terra-docker.
+  # This is to make it so that older images will still work after we change notebooks location to home dir
+  docker exec ${JUPYTER_SERVER_NAME} sed -i '/^# to mount there as it effectively deletes existing files on the image/,+5d' ${JUPYTER_HOME}/jupyter_notebook_config.py
+
   log 'Starting Jupyter Notebook...'
   retry 3 docker exec -d $JUPYTER_SERVER_NAME /bin/bash -c "${JUPYTER_SCRIPTS}/run-jupyter.sh ${NOTEBOOKS_DIR}"
 

--- a/http/src/main/resources/init-resources/gce-init.sh
+++ b/http/src/main/resources/init-resources/gce-init.sh
@@ -105,6 +105,8 @@ export WELDER_MEM_LIMIT=$(welderMemLimit)
 export PROXY_SERVER_HOST_NAME=$(proxyServerHostName)
 export WELDER_ENABLED=$(welderEnabled)
 export IS_RSTUDIO_RUNTIME="false" # TODO: update to commented out code once we release Rmd file syncing
+export NOTEBOOKS_DIR=$(notebooksDir)
+
 #if [ ! -z "$RSTUDIO_DOCKER_IMAGE" ] ; then
 #  export IS_RSTUDIO_RUNTIME="true"
 #else
@@ -289,14 +291,6 @@ if [ ! -z "$RSTUDIO_DOCKER_IMAGE" ] ; then
   COMPOSE_FILES+=(-f ${DOCKER_COMPOSE_FILES_DIRECTORY}/`basename ${RSTUDIO_DOCKER_COMPOSE}`)
   cat ${DOCKER_COMPOSE_FILES_DIRECTORY}/`basename ${RSTUDIO_DOCKER_COMPOSE}`
 fi
-
-# This condition is needed for supporting existing Runtime/PDs created before this change
-#if [ -d $WORK_DIRECTORY/notebooks ]
-#then
-#    export NOTEBOOKS_DIR=$(notebooksDir)/notebooks
-#else
-export NOTEBOOKS_DIR=$(notebooksDir)
-#fi
 
 tee /var/variables.env << END
 CERT_DIRECTORY=${CERT_DIRECTORY}

--- a/http/src/main/resources/init-resources/init-actions.sh
+++ b/http/src/main/resources/init-resources/init-actions.sh
@@ -495,6 +495,10 @@ END
       # A better to do this might be to take welder host as an argument to the script
       docker exec $JUPYTER_SERVER_NAME /bin/bash -c "sed -i 's/http:\/\/welder/http:\/\/127.0.0.1/g' /etc/jupyter/custom/jupyter_delocalize.py"
 
+      # In new jupyter images, we should update jupyter_notebook_config.py in terra-docker.
+      # This is to make it so that older images will still work after we change notebooks location to home dir
+      docker exec ${JUPYTER_SERVER_NAME} sed -i '/^# to mount there as it effectively deletes existing files on the image/,+5d' ${JUPYTER_HOME}/jupyter_notebook_config.py
+
       docker exec -u 0 $JUPYTER_SERVER_NAME /bin/bash -c "$JUPYTER_HOME/scripts/extension/install_jupyter_contrib_nbextensions.sh \
            && mkdir -p $JUPYTER_USER_HOME/.jupyter/custom/ \
            && cp $JUPYTER_HOME/custom/google_sign_in.js $JUPYTER_USER_HOME/.jupyter/custom/ \

--- a/http/src/main/resources/init-resources/jupyter-docker-compose-gce.yaml
+++ b/http/src/main/resources/init-resources/jupyter-docker-compose-gce.yaml
@@ -31,6 +31,10 @@ services:
       PIP_USER: "false"
       PIP_TARGET: "${NOTEBOOKS_DIR}/packages"
       R_LIBS: "${NOTEBOOKS_DIR}/packages"
+      # The next two lines aren't great. But they're for updating PYTHONPATH, PATH in older than (inclusive) us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:1.0.2
+      # We should remove the two lines once we no longer support older images. In the meantime, we need to be careful updating Jupyter base images.
+      PYTHONPATH: "/etc/jupyter/custom:/usr/lib/spark/python:${NOTEBOOKS_DIR}/packages"
+      PATH: "/opt/conda/bin:/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:${NOTEBOOKS_DIR}/.local/bin:${NOTEBOOKS_DIR}/packages/bin"
     env_file:
       - /var/google_application_credentials.env
       - /var/custom_env_vars.env

--- a/http/src/main/resources/init-resources/jupyter-docker-compose.yaml
+++ b/http/src/main/resources/init-resources/jupyter-docker-compose.yaml
@@ -45,8 +45,10 @@ services:
       WELDER_ENABLED: "${WELDER_ENABLED}"
       NOTEBOOKS_DIR: "${NOTEBOOKS_DIR}"
       MEM_LIMIT: "${MEM_LIMIT}"
+      # (1/6/2022) When it's a year from now, consider removing the next two lines.
       # The next two lines aren't great. But they're for updating PYTHONPATH, PATH in older than (inclusive) us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:1.0.2.
-      # We should remove the two lines once we no longer support older images
+      # We should remove the two lines once we no longer support older images.
+      # When we update base image in terra-docker next time, we should verify the paths are still valid
       PYTHONPATH: "/etc/jupyter/custom:/usr/lib/spark/python:${NOTEBOOKS_DIR}/packages"
       PATH: "/opt/conda/bin:/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:${NOTEBOOKS_DIR}/.local/bin:${NOTEBOOKS_DIR}/packages/bin"
     env_file:

--- a/http/src/main/resources/init-resources/jupyter-docker-compose.yaml
+++ b/http/src/main/resources/init-resources/jupyter-docker-compose.yaml
@@ -45,6 +45,10 @@ services:
       WELDER_ENABLED: "${WELDER_ENABLED}"
       NOTEBOOKS_DIR: "${NOTEBOOKS_DIR}"
       MEM_LIMIT: "${MEM_LIMIT}"
+      # The next two lines aren't great. But they're for updating PYTHONPATH, PATH in older than (inclusive) us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:1.0.2.
+      # We should remove the two lines once we no longer support older images
+      PYTHONPATH: "/etc/jupyter/custom:/usr/lib/spark/python:${NOTEBOOKS_DIR}/packages"
+      PATH: "/opt/conda/bin:/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:${NOTEBOOKS_DIR}/.local/bin:${NOTEBOOKS_DIR}/packages/bin"
     env_file:
       - /var/google_application_credentials.env
       - /var/custom_env_vars.env

--- a/http/src/main/resources/init-resources/shutdown.sh
+++ b/http/src/main/resources/init-resources/shutdown.sh
@@ -9,8 +9,13 @@ set -e -x
 # Templated values
 export RSTUDIO_DOCKER_IMAGE=$(rstudioDockerImage)
 export RSTUDIO_SERVER_NAME=$(rstudioServerName)
+export SHOULD_DELETE_JUPYTER_DIR=$(shouldDeleteJupyterDir)
 
 # If RStudio is installed, cleanly shut it down
 if [ ! -z "$RSTUDIO_DOCKER_IMAGE" ] ; then
     docker exec -u rstudio -i $RSTUDIO_SERVER_NAME rstudio-server stop
+fi
+
+if [ -d '/mnt/disks/work/.jupyter' ] && [ "SHOULD_DELETE_JUPYTER_DIR" = "true" ] ; then
+    rm -rf /mnt/disks/work/.jupyter
 fi

--- a/http/src/main/resources/init-resources/startup.sh
+++ b/http/src/main/resources/init-resources/startup.sh
@@ -40,7 +40,6 @@ function retry {
 function log() {
   echo "[$(date +'%Y-%m-%dT%H:%M:%S%z')]: $@"
 }
-
 #
 # Main
 #
@@ -231,11 +230,11 @@ if [ ! -z ${START_USER_SCRIPT_URI} ] ; then
   START_USER_SCRIPT=`basename ${START_USER_SCRIPT_URI}`
   log "Executing user start script [$START_USER_SCRIPT]..."
 
-  docker cp /var/${START_USER_SCRIPT} ${JUPYTER_SERVER_NAME}:${JUPYTER_HOME}/${START_USER_SCRIPT}
-  retry 3 docker exec -u root ${JUPYTER_SERVER_NAME} chmod +x ${JUPYTER_HOME}/${START_USER_SCRIPT}
-
   if [ ! -z "$JUPYTER_DOCKER_IMAGE" ] ; then
     if [ "$USE_GCE_STARTUP_SCRIPT" == "true" ] ; then
+      docker cp /var/${START_USER_SCRIPT} ${JUPYTER_SERVER_NAME}:${JUPYTER_HOME}/${START_USER_SCRIPT}
+      retry 3 docker exec -u root ${JUPYTER_SERVER_NAME} chmod +x ${JUPYTER_HOME}/${START_USER_SCRIPT}
+
       docker exec --privileged -u root -e PIP_TARGET=/usr/local/lib/python3.7/dist-packages ${JUPYTER_SERVER_NAME} ${JUPYTER_HOME}/${START_USER_SCRIPT} &> /var/start_output.txt || EXIT_CODE=$?
     else
       docker exec --privileged -u root -e PIP_USER=false ${JUPYTER_SERVER_NAME} ${JUPYTER_HOME}/${START_USER_SCRIPT} &> /var/start_output.txt || EXIT_CODE=$?
@@ -243,6 +242,9 @@ if [ ! -z ${START_USER_SCRIPT_URI} ] ; then
   fi
 
   if [ ! -z "$RSTUDIO_DOCKER_IMAGE" ] ; then
+    docker cp /var/${START_USER_SCRIPT} ${RSTUDIO_SERVER_NAME}:${RSTUDIO_SCRIPTS}/${START_USER_SCRIPT}
+    retry 3 docker exec -u root ${RSTUDIO_SERVER_NAME} chmod +x ${RSTUDIO_SCRIPTS}/${START_USER_SCRIPT}
+
     docker exec --privileged -u root ${RSTUDIO_SERVER_NAME} ${RSTUDIO_SCRIPTS}/${START_USER_SCRIPT} &> /var/start_output.txt || EXIT_CODE=$?
   fi
 

--- a/http/src/main/resources/init-resources/startup.sh
+++ b/http/src/main/resources/init-resources/startup.sh
@@ -97,8 +97,6 @@ then
     DOCKER_COMPOSE='docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v /var:/var docker/compose:1.29.1'
     WELDER_DOCKER_COMPOSE=$(ls ${DOCKER_COMPOSE_FILES_DIRECTORY}/welder*)
     JUPYTER_DOCKER_COMPOSE=$(ls ${DOCKER_COMPOSE_FILES_DIRECTORY}/jupyter-docker*)
-    START_USER_SCRIPT_BASE_PATH="/var"
-
     export WORK_DIRECTORY='/mnt/disks/work'
 
     fsck.ext4 -tvy /dev/${DISK_DEVICE_ID}
@@ -135,8 +133,6 @@ else
     DOCKER_COMPOSE='docker-compose'
     WELDER_DOCKER_COMPOSE=$(ls ${DOCKER_COMPOSE_FILES_DIRECTORY}/welder*)
     JUPYTER_DOCKER_COMPOSE=$(ls ${DOCKER_COMPOSE_FILES_DIRECTORY}/jupyter-docker*)
-    START_USER_SCRIPT_BASE_PATH="/etc"
-
     export WORK_DIRECTORY=/work
 
     if [ ! -z "$JUPYTER_DOCKER_IMAGE" ] ; then
@@ -232,18 +228,18 @@ fi
 # If a start user script was specified, execute it now. It should already be in the docker container
 # via initialization in init-actions.sh (we explicitly do not want to recopy it from GCS on every cluster resume).
 if [ ! -z ${START_USER_SCRIPT_URI} ] ; then
-  START_USER_SCRIPT="${START_USER_SCRIPT_BASE_PATH}/`basename ${START_USER_SCRIPT_URI}`"
+  START_USER_SCRIPT=`basename ${START_USER_SCRIPT_URI}`
   log "Executing user start script [$START_USER_SCRIPT]..."
   if [ ! -z "$JUPYTER_DOCKER_IMAGE" ] ; then
     if [ "$USE_GCE_STARTUP_SCRIPT" == "true" ] ; then
-      docker exec --privileged -u root -e PIP_TARGET=/usr/local/lib/python3.7/dist-packages ${JUPYTER_SERVER_NAME} ${START_USER_SCRIPT} || EXIT_CODE=$?
+      docker exec --privileged -u root -e PIP_TARGET=/usr/local/lib/python3.7/dist-packages ${JUPYTER_SERVER_NAME} ${JUPYTER_HOME}/${START_USER_SCRIPT} &> /var/start_output.txt || EXIT_CODE=$?
     else
-      docker exec --privileged -u root -e PIP_USER=false ${JUPYTER_SERVER_NAME} ${START_USER_SCRIPT} || EXIT_CODE=$?
+      docker exec --privileged -u root -e PIP_USER=false ${JUPYTER_SERVER_NAME} ${JUPYTER_HOME}/${START_USER_SCRIPT} &> /var/start_output.txt || EXIT_CODE=$?
     fi
   fi
 
   if [ ! -z "$RSTUDIO_DOCKER_IMAGE" ] ; then
-    docker exec --privileged -u root ${RSTUDIO_SERVER_NAME} ${RSTUDIO_SCRIPTS}/${START_USER_SCRIPT} || EXIT_CODE=$?
+    docker exec --privileged -u root ${RSTUDIO_SERVER_NAME} ${RSTUDIO_SCRIPTS}/${START_USER_SCRIPT} &> /var/start_output.txt || EXIT_CODE=$?
   fi
 
   failScriptIfError

--- a/http/src/main/resources/init-resources/startup.sh
+++ b/http/src/main/resources/init-resources/startup.sh
@@ -119,7 +119,8 @@ MEM_LIMIT=${MEM_LIMIT}
 END
 
         ${DOCKER_COMPOSE} -f ${JUPYTER_DOCKER_COMPOSE} stop
-        ${DOCKER_COMPOSE} --env-file=/var/variables.env -f ${JUPYTER_DOCKER_COMPOSE} up -d &> /var/start_output.txt || EXIT_CODE=$?
+        ${DOCKER_COMPOSE} -f ${JUPYTER_DOCKER_COMPOSE} rm -f
+        ${DOCKER_COMPOSE} --env-file=/var/variables.env -f ${JUPYTER_DOCKER_COMPOSE} up -d
     fi
 else
     CERT_DIRECTORY='/certs'
@@ -135,7 +136,8 @@ else
         echo "Restarting Jupyter Container $GOOGLE_PROJECT / $CLUSTER_NAME..."
 
         ${DOCKER_COMPOSE} -f ${JUPYTER_DOCKER_COMPOSE} stop
-        ${DOCKER_COMPOSE} -f ${JUPYTER_DOCKER_COMPOSE} up -d &> /var/start_output.txt || EXIT_CODE=$?
+        ${DOCKER_COMPOSE} -f ${JUPYTER_DOCKER_COMPOSE} rm -f
+        ${DOCKER_COMPOSE} -f ${JUPYTER_DOCKER_COMPOSE} up -d
     fi
 
     if [ "$WELDER_ENABLED" == "true" ] ; then

--- a/http/src/main/resources/init-resources/startup.sh
+++ b/http/src/main/resources/init-resources/startup.sh
@@ -231,10 +231,11 @@ if [ ! -z ${START_USER_SCRIPT_URI} ] ; then
   log "Executing user start script [$START_USER_SCRIPT]..."
 
   if [ ! -z "$JUPYTER_DOCKER_IMAGE" ] ; then
-    if [ "$USE_GCE_STARTUP_SCRIPT" == "true" ] ; then
-      docker cp /var/${START_USER_SCRIPT} ${JUPYTER_SERVER_NAME}:${JUPYTER_HOME}/${START_USER_SCRIPT}
-      retry 3 docker exec -u root ${JUPYTER_SERVER_NAME} chmod +x ${JUPYTER_HOME}/${START_USER_SCRIPT}
+    docker cp /var/${START_USER_SCRIPT} ${JUPYTER_SERVER_NAME}:${JUPYTER_HOME}/${START_USER_SCRIPT}
+    retry 3 docker exec -u root ${JUPYTER_SERVER_NAME} chmod +x ${JUPYTER_HOME}/${START_USER_SCRIPT}
 
+
+    if [ "$USE_GCE_STARTUP_SCRIPT" == "true" ] ; then
       docker exec --privileged -u root -e PIP_TARGET=/usr/local/lib/python3.7/dist-packages ${JUPYTER_SERVER_NAME} ${JUPYTER_HOME}/${START_USER_SCRIPT} &> /var/start_output.txt || EXIT_CODE=$?
     else
       docker exec --privileged -u root -e PIP_USER=false ${JUPYTER_SERVER_NAME} ${JUPYTER_HOME}/${START_USER_SCRIPT} &> /var/start_output.txt || EXIT_CODE=$?

--- a/http/src/main/resources/init-resources/startup.sh
+++ b/http/src/main/resources/init-resources/startup.sh
@@ -256,7 +256,7 @@ if [ ! -z "$JUPYTER_DOCKER_IMAGE" ] ; then
     # kernel tries to connect to it.
     docker exec $JUPYTER_SERVER_NAME /bin/bash -c "R -e '1+1'" || true
 
-    docker exec -d $JUPYTER_SERVER_NAME /bin/bash -c "export WELDER_ENABLED=$WELDER_ENABLED && export NOTEBOOKS_DIR=$NOTEBOOKS_DIR && (/etc/jupyter/scripts/run-jupyter.sh $NOTEBOOKS_DIR || /opt/conda/bin/jupyter notebook)"
+    docker exec -d $JUPYTER_SERVER_NAME /bin/bash -c "export WELDER_ENABLED=$WELDER_ENABLED && export NOTEBOOKS_DIR=$NOTEBOOKS_DIR && export PYTHONPATH=${PYTHONPATH:+$PYTHONPATH:}${NOTEBOOKS_DIR}/packages && export PATH=${PATH:+$PATH:}${NOTEBOOKS_DIR}/packages/bin && (/etc/jupyter/scripts/run-jupyter.sh $NOTEBOOKS_DIR || /opt/conda/bin/jupyter notebook)"
 
     if [ "$WELDER_ENABLED" == "true" ] ; then
         # fix for https://broadworkbench.atlassian.net/browse/IA-1453

--- a/http/src/main/resources/init-resources/startup.sh
+++ b/http/src/main/resources/init-resources/startup.sh
@@ -156,7 +156,7 @@ fi
 
 function failScriptIfError() {
   if [ $EXIT_CODE -ne 0 ]; then
-    echo "Fail to docker-compose start welder ${EXIT_CODE}. Output is saved to ${START_USER_SCRIPT_OUTPUT_URI}"
+    echo "Fail to docker-compose start container ${EXIT_CODE}. Output is saved to ${START_USER_SCRIPT_OUTPUT_URI}"
     retry 3 ${GSUTIL_CMD} -h "x-goog-meta-passed":"false" cp /var/start_output.txt ${START_USER_SCRIPT_OUTPUT_URI}
     exit $EXIT_CODE
   else
@@ -230,6 +230,10 @@ fi
 if [ ! -z ${START_USER_SCRIPT_URI} ] ; then
   START_USER_SCRIPT=`basename ${START_USER_SCRIPT_URI}`
   log "Executing user start script [$START_USER_SCRIPT]..."
+
+  docker cp /var/${START_USER_SCRIPT} ${JUPYTER_SERVER_NAME}:${JUPYTER_HOME}/${START_USER_SCRIPT}
+  retry 3 docker exec -u root ${JUPYTER_SERVER_NAME} chmod +x ${JUPYTER_HOME}/${START_USER_SCRIPT}
+
   if [ ! -z "$JUPYTER_DOCKER_IMAGE" ] ; then
     if [ "$USE_GCE_STARTUP_SCRIPT" == "true" ] ; then
       docker exec --privileged -u root -e PIP_TARGET=/usr/local/lib/python3.7/dist-packages ${JUPYTER_SERVER_NAME} ${JUPYTER_HOME}/${START_USER_SCRIPT} &> /var/start_output.txt || EXIT_CODE=$?

--- a/http/src/main/resources/init-resources/startup.sh
+++ b/http/src/main/resources/init-resources/startup.sh
@@ -97,6 +97,8 @@ then
     DOCKER_COMPOSE='docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v /var:/var docker/compose:1.29.1'
     WELDER_DOCKER_COMPOSE=$(ls ${DOCKER_COMPOSE_FILES_DIRECTORY}/welder*)
     JUPYTER_DOCKER_COMPOSE=$(ls ${DOCKER_COMPOSE_FILES_DIRECTORY}/jupyter-docker*)
+    START_USER_SCRIPT_BASE_PATH="/var"
+
     export WORK_DIRECTORY='/mnt/disks/work'
 
     fsck.ext4 -tvy /dev/${DISK_DEVICE_ID}
@@ -133,6 +135,8 @@ else
     DOCKER_COMPOSE='docker-compose'
     WELDER_DOCKER_COMPOSE=$(ls ${DOCKER_COMPOSE_FILES_DIRECTORY}/welder*)
     JUPYTER_DOCKER_COMPOSE=$(ls ${DOCKER_COMPOSE_FILES_DIRECTORY}/jupyter-docker*)
+    START_USER_SCRIPT_BASE_PATH="/etc"
+
     export WORK_DIRECTORY=/work
 
     if [ ! -z "$JUPYTER_DOCKER_IMAGE" ] ; then
@@ -228,18 +232,18 @@ fi
 # If a start user script was specified, execute it now. It should already be in the docker container
 # via initialization in init-actions.sh (we explicitly do not want to recopy it from GCS on every cluster resume).
 if [ ! -z ${START_USER_SCRIPT_URI} ] ; then
-  START_USER_SCRIPT=`basename ${START_USER_SCRIPT_URI}`
+  START_USER_SCRIPT="${START_USER_SCRIPT_BASE_PATH}/`basename ${START_USER_SCRIPT_URI}`"
   log "Executing user start script [$START_USER_SCRIPT]..."
   if [ ! -z "$JUPYTER_DOCKER_IMAGE" ] ; then
     if [ "$USE_GCE_STARTUP_SCRIPT" == "true" ] ; then
-      docker exec --privileged -u root -e PIP_TARGET=/usr/local/lib/python3.7/dist-packages ${JUPYTER_SERVER_NAME} ${JUPYTER_HOME}/${START_USER_SCRIPT} &> /var/start_output.txt || EXIT_CODE=$?
+      docker exec --privileged -u root -e PIP_TARGET=/usr/local/lib/python3.7/dist-packages ${JUPYTER_SERVER_NAME} ${START_USER_SCRIPT} || EXIT_CODE=$?
     else
-      docker exec --privileged -u root -e PIP_USER=false ${JUPYTER_SERVER_NAME} ${JUPYTER_HOME}/${START_USER_SCRIPT} &> /var/start_output.txt || EXIT_CODE=$?
+      docker exec --privileged -u root -e PIP_USER=false ${JUPYTER_SERVER_NAME} ${START_USER_SCRIPT} || EXIT_CODE=$?
     fi
   fi
 
   if [ ! -z "$RSTUDIO_DOCKER_IMAGE" ] ; then
-    docker exec --privileged -u root ${RSTUDIO_SERVER_NAME} ${RSTUDIO_SCRIPTS}/${START_USER_SCRIPT} &> /var/start_output.txt || EXIT_CODE=$?
+    docker exec --privileged -u root ${RSTUDIO_SERVER_NAME} ${RSTUDIO_SCRIPTS}/${START_USER_SCRIPT} || EXIT_CODE=$?
   fi
 
   failScriptIfError

--- a/http/src/main/resources/init-resources/startup.sh
+++ b/http/src/main/resources/init-resources/startup.sh
@@ -85,6 +85,7 @@ FILE=/var/certs/jupyter-server.crt
 USER_DISK_DEVICE_ID=$(lsblk -o name,serial | grep 'user-disk' | awk '{print $1}')
 DISK_DEVICE_ID=${USER_DISK_DEVICE_ID:-sdb}
 
+# https://broadworkbench.atlassian.net/browse/IA-3186
 # This condition assumes Dataproc's cert directory is different from GCE's cert directory, a better condition would be
 # a dedicated flag that distinguishes gce and dataproc. But this will do for now
 if [ -f "$FILE" ]
@@ -103,7 +104,7 @@ then
     mount -t ext4 -O discard,defaults /dev/${DISK_DEVICE_ID} ${WORK_DIRECTORY}
     chmod a+rwx /mnt/disks/work
 
-    # Restart Jupyter Container to reset `NOTEBOOKS_DIR` for existing runtimes. This code can probably be removed after a year
+    # (1/6/22) Restart Jupyter Container to reset `NOTEBOOKS_DIR` for existing runtimes. This code can probably be removed after a year
     if [ ! -z "$JUPYTER_DOCKER_IMAGE" ] ; then
         echo "Restarting Jupyter Container $GOOGLE_PROJECT / $CLUSTER_NAME..."
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/BaseRuntimeInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/BaseRuntimeInterpreter.scala
@@ -193,7 +193,7 @@ abstract private[util] class BaseRuntimeInterpreter[F[_]](
 
     for {
       ctx <- ev.ask
-      replacements = RuntimeTemplateValues(templateConfig, Some(ctx.now))
+      replacements = RuntimeTemplateValues(templateConfig, Some(ctx.now), false)
       mp <- TemplateHelper
         .templateResource[F](replacements.toMap, config.clusterResourcesConfig.startupScript)
         .through(fs2.text.utf8.decode)
@@ -209,7 +209,8 @@ abstract private[util] class BaseRuntimeInterpreter[F[_]](
   }
 
   // Shutdown script to run after the runtime is paused
-  protected def getShutdownScript(runtimeAndRuntimeConfig: RuntimeAndRuntimeConfig): F[Map[String, String]] = {
+  protected def getShutdownScript(runtimeAndRuntimeConfig: RuntimeAndRuntimeConfig,
+                                  shouldDeleteJupyterDir: Boolean): F[Map[String, String]] = {
     val googleKey = "shutdown-script" // required; see https://cloud.google.com/compute/docs/shutdownscript
 
     val templateConfig = RuntimeTemplateValuesConfig.fromRuntime(
@@ -226,7 +227,7 @@ abstract private[util] class BaseRuntimeInterpreter[F[_]](
       None,
       false
     )
-    val replacements = RuntimeTemplateValues(templateConfig, None).toMap
+    val replacements = RuntimeTemplateValues(templateConfig, None, shouldDeleteJupyterDir).toMap
 
     TemplateHelper
       .templateResource[F](replacements, config.clusterResourcesConfig.shutdownScript)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/BucketHelper.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/BucketHelper.scala
@@ -90,6 +90,13 @@ class BucketHelper[F[_]](
         .drain
     } yield ()
 
+  def uploadFileToInitBucket(initBucketName: GcsBucketName, runtimeResource: RuntimeResource): F[Unit] =
+    (TemplateHelper.resourceStream[F](runtimeResource) through google2StorageDAO
+      .streamUploadBlob(
+        initBucketName,
+        GcsBlobName(runtimeResource.asString)
+      )).compile.drain
+
   def initializeBucketObjects(
     initBucketName: GcsBucketName,
     serviceAccountKey: Option[ServiceAccountKey],

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/DataprocInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/DataprocInterpreter.scala
@@ -105,7 +105,7 @@ class DataprocInterpreter[F[_]: Parallel](
   metrics: OpenTelemetryMetrics[F],
   logger: StructuredLogger[F],
   dbRef: DbReference[F])
-    extends BaseRuntimeInterpreter[F](config, welderDao)
+    extends BaseRuntimeInterpreter[F](config, welderDao, bucketHelper)
     with RuntimeAlgebra[F]
     with LazyLogging {
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/DataprocInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/DataprocInterpreter.scala
@@ -173,7 +173,7 @@ class DataprocInterpreter[F[_]: Parallel](
           Some(resourceConstraints),
           false
         )
-        templateValues = RuntimeTemplateValues(templateParams, Some(ctx.now))
+        templateValues = RuntimeTemplateValues(templateParams, Some(ctx.now), false)
         _ <- bucketHelper
           .initializeBucketObjects(initBucketName,
                                    templateParams.serviceAccountKey,
@@ -363,7 +363,7 @@ class DataprocInterpreter[F[_]: Parallel](
           LeoLenses.dataprocRegion.getOption(params.runtimeAndRuntimeConfig.runtimeConfig),
           new RuntimeException("DataprocInterpreter shouldn't get a GCE request")
         )
-        metadata <- getShutdownScript(params.runtimeAndRuntimeConfig)
+        metadata <- getShutdownScript(params.runtimeAndRuntimeConfig, false)
         _ <- params.runtimeAndRuntimeConfig.runtime.dataprocInstances.find(_.dataprocRole == Master).traverse {
           instance =>
             googleComputeService
@@ -399,7 +399,7 @@ class DataprocInterpreter[F[_]: Parallel](
         LeoLenses.dataprocRegion.getOption(params.runtimeAndRuntimeConfig.runtimeConfig),
         new RuntimeException("DataprocInterpreter shouldn't get a GCE request")
       )
-      metadata <- getShutdownScript(params.runtimeAndRuntimeConfig)
+      metadata <- getShutdownScript(params.runtimeAndRuntimeConfig, false)
       googleProject <- F.fromOption(
         LeoLenses.cloudContextToGoogleProject.get(params.runtimeAndRuntimeConfig.runtime.cloudContext),
         new RuntimeException("this should never happen. Dataproc runtime's cloud context should be a google project")

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GceInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GceInterpreter.scala
@@ -209,7 +209,7 @@ class GceInterpreter[F[_]](
         isFormatted
       )
 
-      templateValues = RuntimeTemplateValues(templateParams, Some(ctx.now))
+      templateValues = RuntimeTemplateValues(templateParams, Some(ctx.now), false)
 
       _ <- bucketHelper
         .initializeBucketObjects(initBucketName,
@@ -327,7 +327,7 @@ class GceInterpreter[F[_]](
         LeoLenses.cloudContextToGoogleProject.get(params.runtimeAndRuntimeConfig.runtime.cloudContext),
         new RuntimeException("this should never happen. GCE runtime's cloud context should be a google project")
       )
-      metadata <- getShutdownScript(params.runtimeAndRuntimeConfig)
+      metadata <- getShutdownScript(params.runtimeAndRuntimeConfig, false)
       _ <- googleComputeService.addInstanceMetadata(
         googleProject,
         zoneParam,
@@ -408,7 +408,7 @@ class GceInterpreter[F[_]](
             "GceInterpreter shouldn't get a dataproc runtime creation request. Something is very wrong"
           )
         )
-        metadata <- getShutdownScript(params.runtimeAndRuntimeConfig)
+        metadata <- getShutdownScript(params.runtimeAndRuntimeConfig, true)
         googleProject <- F.fromOption(
           LeoLenses.cloudContextToGoogleProject.get(params.runtimeAndRuntimeConfig.runtime.cloudContext),
           new RuntimeException("this should never happen. GCE runtime's cloud context should be a google project")

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GceInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GceInterpreter.scala
@@ -52,7 +52,7 @@ class GceInterpreter[F[_]](
   dbRef: DbReference[F],
   F: Async[F],
   logger: StructuredLogger[F])
-    extends BaseRuntimeInterpreter[F](config, welderDao)
+    extends BaseRuntimeInterpreter[F](config, welderDao, bucketHelper)
     with RuntimeAlgebra[F] {
   override def createRuntime(
     params: CreateRuntimeParams

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GceInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GceInterpreter.scala
@@ -343,7 +343,7 @@ class GceInterpreter[F[_]](
     implicit ev: Ask[F, AppContext]
   ): F[Unit] =
     for {
-      ctx <- ev.ask
+      _ <- ev.ask
       googleProject <- F.fromOption(
         LeoLenses.cloudContextToGoogleProject.get(params.runtimeAndRuntimeConfig.runtime.cloudContext),
         new RuntimeException("this should never happen. GCE runtime's cloud context should be a google project")

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/RuntimeTemplateValues.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/RuntimeTemplateValues.scala
@@ -60,7 +60,7 @@ case class RuntimeTemplateValues private (googleProject: String,
                                           proxyServerHostName: String,
                                           isGceFormatted: String,
                                           useGceStartupScript: String,
-                                          shouldDeleteJupyterDir: Boolean) {
+                                          shouldDeleteJupyterDir: String) {
 
   def toMap: Map[String, String] =
     this.productElementNames
@@ -279,7 +279,7 @@ object RuntimeTemplateValues {
       config.proxyConfig.getProxyServerHostName,
       config.isGceFormatted.toString,
       config.useGceStartupScript.toString,
-      shouldDeleteJupyterDir
+      shouldDeleteJupyterDir.toString
     )
   }
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/RuntimeTemplateValues.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/RuntimeTemplateValues.scala
@@ -59,7 +59,8 @@ case class RuntimeTemplateValues private (googleProject: String,
                                           rstudioLicenseFile: String,
                                           proxyServerHostName: String,
                                           isGceFormatted: String,
-                                          useGceStartupScript: String) {
+                                          useGceStartupScript: String,
+                                          shouldDeleteJupyterDir: Boolean) {
 
   def toMap: Map[String, String] =
     this.productElementNames
@@ -184,7 +185,9 @@ object RuntimeTemplateValues {
   val serviceAccountCredentialsFilename = "service-account-credentials.json"
   val customEnvVarFilename = "custom_env_vars.env"
 
-  def apply(config: RuntimeTemplateValuesConfig, now: Option[Instant]): RuntimeTemplateValues = {
+  def apply(config: RuntimeTemplateValuesConfig,
+            now: Option[Instant],
+            shouldDeleteJupyterDir: Boolean): RuntimeTemplateValues = {
     val jupyterUserhome =
       config.runtimeImages
         .find(_.imageType == Jupyter)
@@ -261,7 +264,7 @@ object RuntimeTemplateValues {
         .getOrElse(""),
       config.defaultClientId.getOrElse(""),
       config.welderEnabled.toString, // TODO: remove this and conditional below when welder is rolled out to all clusters
-      s"${jupyterUserhome}/notebooks",
+      notebooksDir = s"${jupyterUserhome}",
       config.initBucketName
         .map(n => GcsPath(n, GcsObjectName(config.clusterResourcesConfig.customEnvVarsConfigUri.asString)).toUri)
         .getOrElse(""),
@@ -275,7 +278,8 @@ object RuntimeTemplateValues {
         .getOrElse(""),
       config.proxyConfig.getProxyServerHostName,
       config.isGceFormatted.toString,
-      config.useGceStartupScript.toString
+      config.useGceStartupScript.toString,
+      shouldDeleteJupyterDir
     )
   }
 

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/RuntimeTemplateValuesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/RuntimeTemplateValuesSpec.scala
@@ -25,7 +25,7 @@ class RuntimeTemplateValuesSpec extends LeonardoTestSuite with AnyFlatSpecLike {
 
     val test = for {
       now <- IO.realTimeInstant
-      result = RuntimeTemplateValues(config, Some(now))
+      result = RuntimeTemplateValues(config, Some(now), false)
     } yield {
       // note: alphabetized
       result.clusterName shouldBe CommonTestData.testCluster.runtimeName.asString
@@ -63,7 +63,7 @@ class RuntimeTemplateValuesSpec extends LeonardoTestSuite with AnyFlatSpecLike {
       result.userScriptUri shouldBe GcsPath(GcsBucketName("bucket-name"), GcsObjectName("userScript")).toUri
       result.loginHint shouldBe CommonTestData.auditInfo.creator.value
       result.memLimit shouldBe "3758096384b" // 3.5 GB
-      result.notebooksDir shouldBe "/home/jupyter/notebooks"
+      result.notebooksDir shouldBe "/home/jupyter"
       result.proxyDockerCompose shouldBe GcsPath(CommonTestData.initBucketName,
                                                  GcsObjectName("test-proxy-docker-compose.yaml")).toUri
       result.proxyDockerImage shouldBe CommonTestData.proxyImage.imageUrl
@@ -84,6 +84,7 @@ class RuntimeTemplateValuesSpec extends LeonardoTestSuite with AnyFlatSpecLike {
       result.welderEnabled shouldBe "true"
       result.welderMemLimit shouldBe "805306368b" // 768 MB
       result.welderServerName shouldBe "welder-server"
+      result.shouldDeleteJupyterDir shouldBe "false"
     }
 
     test.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -68,7 +68,7 @@ object Dependencies {
   val akkaTestKit: ModuleID =       "com.typesafe.akka" %% "akka-testkit"         % akkaV     % "test"
   val akkaHttpTestKit: ModuleID =   "com.typesafe.akka" %% "akka-http-testkit"    % akkaHttpV % "test"
 
-  val googleRpc: ModuleID =                 "io.grpc"         % "grpc-core"                       % "1.43.1" excludeAll (excludeGuava, excludeGson, excludeFindbugsJsr)
+  val googleRpc: ModuleID =                 "io.grpc"         % "grpc-core"                       % "1.43.2" excludeAll (excludeGuava, excludeGson, excludeFindbugsJsr)
 
   val scalaTest: ModuleID = "org.scalatest"                 %% "scalatest"     % scalaTestV  % Test
   val scalaTestScalaCheck = "org.scalatestplus" %% "scalacheck-1-15" % s"${scalaTestV}.0" % Test // https://github.com/scalatest/scalatestplus-scalacheck
@@ -119,7 +119,7 @@ object Dependencies {
   val mysql: ModuleID =           "mysql"               % "mysql-connector-java"  % "8.0.28"
   val liquibase: ModuleID =       "org.liquibase"       % "liquibase-core"        % "4.7.1"
   val sealerate: ModuleID =       "ca.mrvisser"         %% "sealerate"            % "0.0.6"
-  val googleCloudNio: ModuleID =  "com.google.cloud"    % "google-cloud-nio"      % "0.123.16" % Test // brought in for FakeStorageInterpreter
+  val googleCloudNio: ModuleID =  "com.google.cloud"    % "google-cloud-nio"      % "0.123.18" % Test // brought in for FakeStorageInterpreter
 
   val circeYaml =         "io.circe"          %% "circe-yaml"           % "0.14.1"
   val http4sBlazeServer = "org.http4s"        %% "http4s-blaze-server"  % http4sVersion

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -55,7 +55,7 @@ object Dependencies {
   val excludeBigQuery = ExclusionRule(organization = "com.google.cloud", name = "google-cloud-bigquery")
   val excludeCloudBilling = ExclusionRule(organization = "com.google.cloud", name = "google-cloud-billing")
 
-  val logbackClassic: ModuleID =  "ch.qos.logback"              % "logback-classic" % "1.2.9"
+  val logbackClassic: ModuleID =  "ch.qos.logback"              % "logback-classic" % "1.2.10"
   val scalaLogging: ModuleID =    "com.typesafe.scala-logging"  %% "scala-logging"  % scalaLoggingV
   val swaggerUi: ModuleID =       "org.webjars"                 % "swagger-ui"      % "4.1.3"
   val ficus: ModuleID =           "com.iheart"                  %% "ficus"          % "1.5.1"
@@ -162,7 +162,7 @@ object Dependencies {
     akkaTestKit,
     akkaHttpTestKit,
     akkaStream,
-    "de.heikoseeberger" %% "akka-http-circe" % "1.38.2" excludeAll(excludeAkkaHttp, excludeAkkaStream),
+    "de.heikoseeberger" %% "akka-http-circe" % "1.39.2" excludeAll(excludeAkkaHttp, excludeAkkaStream),
     googleRpc,
 
     hikariCP,


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-2756
https://broadworkbench.atlassian.net/browse/IA-2965

Main changes:
1. PD is now mapped to $HOME inside Jupyter container
2. `<work>/.jupyter` dir on the VM is deleted when runtimes are deleted so that when we create a new one, new jupyter process have a clean start
3. Jupyter container is restarted in startup script becuz we're resetting `PYTHONPATH` and `PATH` to new path that doesn't have `/notebooks`. Because of this we need to re-copy startup script into the new container, and re-fix welder path for dataproc.
4. We're updating `jupyter_notebook_config.py` so that it doesn't have `/notebooks` as dir for notebooks


Tested manually:
Create a VM with `develop` branch that has `home/jupyter/notebooks` as work dir. Deploy a new leo with this branch, and see if the following works as expected on the same VM
- [x] pausing
- [x] resuming
- [x] deleting but keep the VM, and create a new VM with the same PD


---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
