### PR TITLE
[BW-939] Pass GSA to Cromwell helm chart to run compute as pet account

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ ENV TERRA_APP_VERSION 0.3.0
 ENV GALAXY_VERSION 1.2.0
 ENV NGINX_VERSION 3.23.0
 # If you update this here, make sure to also update reference.conf:
-ENV CROMWELL_CHART_VERSION 0.1.8
+ENV CROMWELL_CHART_VERSION 0.1.9
 
 RUN mkdir /leonardo
 COPY ./leonardo*.jar /leonardo

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -427,7 +427,7 @@ gke {
   cromwellApp {
     # If you update the chart name or version here, make sure to also update it in the dockerfile:
     chartName = "/leonardo/cromwell"
-    chartVersion = "0.1.8"
+    chartVersion = "0.1.9"
     services = [
       {
         name = "cromwell-service"

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
@@ -411,7 +411,6 @@ class GKEInterpreter[F[_]](
             dbApp.nodepool.nodepoolName,
             namespaceName,
             nfsDisk,
-            ksaName,
             app.customEnvironmentVariables
           )
         case AppType.Custom =>
@@ -1014,7 +1013,6 @@ class GKEInterpreter[F[_]](
     nodepoolName: NodepoolName,
     namespaceName: NamespaceName,
     disk: PersistentDisk,
-    ksaName: ServiceAccountName,
     customEnvironmentVariables: Map[String, String]
   )(implicit ev: Ask[F, AppContext]): F[Unit] = {
     // TODO: Use the chart from the database instead of re-looking it up in config:
@@ -1032,7 +1030,6 @@ class GKEInterpreter[F[_]](
                                                               nodepoolName,
                                                               namespaceName,
                                                               disk,
-                                                              ksaName,
                                                               customEnvironmentVariables)
       _ <- logger.info(ctx.loggingCtx)(s"Chart override values are: $chartValues")
 
@@ -1276,7 +1273,6 @@ class GKEInterpreter[F[_]](
     nodepoolName: NodepoolName,
     namespaceName: NamespaceName,
     disk: PersistentDisk,
-    ksaName: ServiceAccountName,
     customEnvironmentVariables: Map[String, String]
   ): List[String] = {
     val proxyPath = s"/proxy/google/v1/apps/${cluster.googleProject.value}/${appName.value}/cromwell-service"
@@ -1308,9 +1304,7 @@ class GKEInterpreter[F[_]](
       raw"""env.swaggerBasePath=$proxyPath""",
       // cromwellConfig
       raw"""config.gcsProject=${cluster.googleProject.value}""",
-      raw"""config.gcsBucket=$gcsBucket/cromwell-execution""",
-      // Service Account
-      raw"""config.serviceAccount.name=${ksaName.value}"""
+      raw"""config.gcsBucket=$gcsBucket/cromwell-execution"""
     ) ++ ingress
   }
 

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreterSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreterSpec.scala
@@ -159,7 +159,27 @@ class GKEInterpreterSpec extends AnyFlatSpecLike with TestComponent with Leonard
       customEnvironmentVariables = envVariables
     )
 
-    res.mkString(",") shouldBe """nodeSelector.cloud\.google\.com/gke-nodepool=pool1,persistence.size=250G,persistence.gcePersistentDisk=disk1,env.swaggerBasePath=/proxy/google/v1/apps/dsp-leo-test1/app1/cromwell-service,config.gcsProject=dsp-leo-test1,config.gcsBucket=gs://test-bucket/cromwell-execution,config.serviceAccount.name=app1-cromwell-ksa,config.serviceAccount.annotations.gcpServiceAccount=pet123-abc@terra-test-abc.iam.gserviceaccount.com,ingress.enabled=true,ingress.annotations.nginx\.ingress\.kubernetes\.io/proxy-redirect-from=https://1455694897.jupyter.firecloud.org,ingress.annotations.nginx\.ingress\.kubernetes\.io/proxy-redirect-to=https://leo,ingress.annotations.nginx\.ingress\.kubernetes\.io/rewrite-target=/$2,ingress.annotations.nginx\.ingress\.kubernetes\.io/auth-tls-secret=ns/ca-secret,ingress.path=/proxy/google/v1/apps/dsp-leo-test1/app1/cromwell-service,ingress.hosts[0].host=1455694897.jupyter.firecloud.org,ingress.hosts[0].paths[0]=/proxy/google/v1/apps/dsp-leo-test1/app1/cromwell-service(/|$)(.*),ingress.tls[0].secretName=tls-secret,ingress.tls[0].hosts[0]=1455694897.jupyter.firecloud.org,db.password=replace-me"""
+    res.mkString(",") shouldBe
+      """nodeSelector.cloud\.google\.com/gke-nodepool=pool1,""" +
+        """persistence.size=250G,""" +
+        """persistence.gcePersistentDisk=disk1,""" +
+        """env.swaggerBasePath=/proxy/google/v1/apps/dsp-leo-test1/app1/cromwell-service,""" +
+        """config.gcsProject=dsp-leo-test1,""" +
+        """config.gcsBucket=gs://test-bucket/cromwell-execution,""" +
+        """config.serviceAccount.name=app1-cromwell-ksa,""" +
+        """config.serviceAccount.annotations.gcpServiceAccount=pet123-abc@terra-test-abc.iam.gserviceaccount.com,""" +
+        """ingress.enabled=true,""" +
+        """ingress.annotations.nginx\.ingress\.kubernetes\.io/proxy-redirect-from=https://1455694897.jupyter.firecloud.org,""" +
+        """ingress.annotations.nginx\.ingress\.kubernetes\.io/proxy-redirect-to=https://leo,""" +
+        """ingress.annotations.nginx\.ingress\.kubernetes\.io/rewrite-target=/$2,""" +
+        """ingress.annotations.nginx\.ingress\.kubernetes\.io/auth-tls-secret=ns/ca-secret,""" +
+        """ingress.path=/proxy/google/v1/apps/dsp-leo-test1/app1/cromwell-service,""" +
+        """ingress.hosts[0].host=1455694897.jupyter.firecloud.org,""" +
+        """ingress.hosts[0].paths[0]=/proxy/google/v1/apps/dsp-leo-test1/app1/cromwell-service(/|$)(.*),""" +
+        """ingress.tls[0].secretName=tls-secret,""" +
+        """ingress.tls[0].hosts[0]=1455694897.""" +
+        """jupyter.firecloud.org,""" +
+        """db.password=replace-me"""
   }
 
   it should "check if a pod is done" in {

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreterSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreterSpec.scala
@@ -24,7 +24,7 @@ import org.broadinstitute.dsde.workbench.leonardo.db.{
 }
 import org.broadinstitute.dsde.workbench.leonardo.http.dbioToIO
 import org.broadinstitute.dsde.workbench.leonardo.http.service.AppNotFoundException
-import org.broadinstitute.dsde.workbench.model.TraceId
+import org.broadinstitute.dsde.workbench.model.{TraceId, WorkbenchEmail}
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.broadinstitute.dsp.Release
 import org.broadinstitute.dsp.mocks._
@@ -154,10 +154,12 @@ class GKEInterpreterSpec extends AnyFlatSpecLike with TestComponent with Leonard
       nodepoolName = NodepoolName("pool1"),
       namespaceName = NamespaceName("ns"),
       disk = savedDisk1,
+      ksaName = ServiceAccountName("app1-cromwell-ksa"),
+      gsa = WorkbenchEmail("pet123-abc@terra-test-abc.iam.gserviceaccount.com"),
       customEnvironmentVariables = envVariables
     )
 
-    res.mkString(",") shouldBe """nodeSelector.cloud\.google\.com/gke-nodepool=pool1,persistence.size=250G,persistence.gcePersistentDisk=disk1,env.swaggerBasePath=/proxy/google/v1/apps/dsp-leo-test1/app1/cromwell-service,config.gcsProject=dsp-leo-test1,config.gcsBucket=gs://test-bucket/cromwell-execution,ingress.enabled=true,ingress.annotations.nginx\.ingress\.kubernetes\.io/proxy-redirect-from=https://1455694897.jupyter.firecloud.org,ingress.annotations.nginx\.ingress\.kubernetes\.io/proxy-redirect-to=https://leo,ingress.annotations.nginx\.ingress\.kubernetes\.io/rewrite-target=/$2,ingress.annotations.nginx\.ingress\.kubernetes\.io/auth-tls-secret=ns/ca-secret,ingress.path=/proxy/google/v1/apps/dsp-leo-test1/app1/cromwell-service,ingress.hosts[0].host=1455694897.jupyter.firecloud.org,ingress.hosts[0].paths[0]=/proxy/google/v1/apps/dsp-leo-test1/app1/cromwell-service(/|$)(.*),ingress.tls[0].secretName=tls-secret,ingress.tls[0].hosts[0]=1455694897.jupyter.firecloud.org,db.password=replace-me"""
+    res.mkString(",") shouldBe """nodeSelector.cloud\.google\.com/gke-nodepool=pool1,persistence.size=250G,persistence.gcePersistentDisk=disk1,env.swaggerBasePath=/proxy/google/v1/apps/dsp-leo-test1/app1/cromwell-service,config.gcsProject=dsp-leo-test1,config.gcsBucket=gs://test-bucket/cromwell-execution,config.serviceAccount.name=app1-cromwell-ksa,config.serviceAccount.annotations.gcpServiceAccount=pet123-abc@terra-test-abc.iam.gserviceaccount.com,ingress.enabled=true,ingress.annotations.nginx\.ingress\.kubernetes\.io/proxy-redirect-from=https://1455694897.jupyter.firecloud.org,ingress.annotations.nginx\.ingress\.kubernetes\.io/proxy-redirect-to=https://leo,ingress.annotations.nginx\.ingress\.kubernetes\.io/rewrite-target=/$2,ingress.annotations.nginx\.ingress\.kubernetes\.io/auth-tls-secret=ns/ca-secret,ingress.path=/proxy/google/v1/apps/dsp-leo-test1/app1/cromwell-service,ingress.hosts[0].host=1455694897.jupyter.firecloud.org,ingress.hosts[0].paths[0]=/proxy/google/v1/apps/dsp-leo-test1/app1/cromwell-service(/|$)(.*),ingress.tls[0].secretName=tls-secret,ingress.tls[0].hosts[0]=1455694897.jupyter.firecloud.org,db.password=replace-me"""
   }
 
   it should "check if a pod is done" in {

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreterSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreterSpec.scala
@@ -154,11 +154,10 @@ class GKEInterpreterSpec extends AnyFlatSpecLike with TestComponent with Leonard
       nodepoolName = NodepoolName("pool1"),
       namespaceName = NamespaceName("ns"),
       disk = savedDisk1,
-      ksaName = ServiceAccountName("app1-cromwell-ksa"),
       customEnvironmentVariables = envVariables
     )
 
-    res.mkString(",") shouldBe """nodeSelector.cloud\.google\.com/gke-nodepool=pool1,persistence.size=250G,persistence.gcePersistentDisk=disk1,env.swaggerBasePath=/proxy/google/v1/apps/dsp-leo-test1/app1/cromwell-service,config.gcsProject=dsp-leo-test1,config.gcsBucket=gs://test-bucket/cromwell-execution,config.serviceAccount.name=app1-cromwell-ksa,ingress.enabled=true,ingress.annotations.nginx\.ingress\.kubernetes\.io/proxy-redirect-from=https://1455694897.jupyter.firecloud.org,ingress.annotations.nginx\.ingress\.kubernetes\.io/proxy-redirect-to=https://leo,ingress.annotations.nginx\.ingress\.kubernetes\.io/rewrite-target=/$2,ingress.annotations.nginx\.ingress\.kubernetes\.io/auth-tls-secret=ns/ca-secret,ingress.path=/proxy/google/v1/apps/dsp-leo-test1/app1/cromwell-service,ingress.hosts[0].host=1455694897.jupyter.firecloud.org,ingress.hosts[0].paths[0]=/proxy/google/v1/apps/dsp-leo-test1/app1/cromwell-service(/|$)(.*),ingress.tls[0].secretName=tls-secret,ingress.tls[0].hosts[0]=1455694897.jupyter.firecloud.org,db.password=replace-me"""
+    res.mkString(",") shouldBe """nodeSelector.cloud\.google\.com/gke-nodepool=pool1,persistence.size=250G,persistence.gcePersistentDisk=disk1,env.swaggerBasePath=/proxy/google/v1/apps/dsp-leo-test1/app1/cromwell-service,config.gcsProject=dsp-leo-test1,config.gcsBucket=gs://test-bucket/cromwell-execution,ingress.enabled=true,ingress.annotations.nginx\.ingress\.kubernetes\.io/proxy-redirect-from=https://1455694897.jupyter.firecloud.org,ingress.annotations.nginx\.ingress\.kubernetes\.io/proxy-redirect-to=https://leo,ingress.annotations.nginx\.ingress\.kubernetes\.io/rewrite-target=/$2,ingress.annotations.nginx\.ingress\.kubernetes\.io/auth-tls-secret=ns/ca-secret,ingress.path=/proxy/google/v1/apps/dsp-leo-test1/app1/cromwell-service,ingress.hosts[0].host=1455694897.jupyter.firecloud.org,ingress.hosts[0].paths[0]=/proxy/google/v1/apps/dsp-leo-test1/app1/cromwell-service(/|$)(.*),ingress.tls[0].secretName=tls-secret,ingress.tls[0].hosts[0]=1455694897.jupyter.firecloud.org,db.password=replace-me"""
   }
 
   it should "check if a pod is done" in {


### PR DESCRIPTION
Edit: Cromwhelm PR has now been merged! ~**Note: This should merge after cromwhelm PR: https://github.com/broadinstitute/cromwhelm/pull/18. It is currently a draft because without the cromwhelm changes, the tests will fail.**~

Closes https://broadworkbench.atlassian.net/browse/BW-939

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
