### PR TITLE
[No Ticket] Bump dependencies (from scala-steward PRs 2406, 2487, 2502, 2504)

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -114,7 +114,7 @@ object Dependencies {
 
   val slick: ModuleID =           "com.typesafe.slick"  %% "slick"                % slickV excludeAll (excludeTypesafeConfig, excludeReactiveStream)
   val hikariCP: ModuleID =        "com.typesafe.slick"  %% "slick-hikaricp"       % slickV excludeAll (excludeSlf4j)
-  val mysql: ModuleID =           "mysql"               % "mysql-connector-java"  % "8.0.22"
+  val mysql: ModuleID =           "mysql"               % "mysql-connector-java"  % "8.0.28"
   val liquibase: ModuleID =       "org.liquibase"       % "liquibase-core"        % "4.6.2"
   val sealerate: ModuleID =       "ca.mrvisser"         %% "sealerate"            % "0.0.6"
   val googleCloudNio: ModuleID =  "com.google.cloud"    % "google-cloud-nio"      % "0.123.16" % Test // brought in for FakeStorageInterpreter
@@ -140,7 +140,7 @@ object Dependencies {
     "com.github.julien-truffaut" %%  "monocle-macro" % monocleV,
     // using provided because `http` depends on `core`, and `http`'s `opencensus-exporter-trace-stackdriver`
     // brings in an older version of `pureconfig`
-    "com.github.pureconfig" %% "pureconfig" % "0.17.0" % Provided,
+    "com.github.pureconfig" %% "pureconfig" % "0.17.1" % Provided,
     sealerate,
     enumeratum,
     circeYaml,

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -87,7 +87,7 @@ object Settings {
   val commonSettings =
     commonBuildSettings ++ List(
     organization  := "org.broadinstitute.dsde.workbench",
-    scalaVersion  := "2.13.7",
+    scalaVersion  := "2.13.8",
     resolvers ++= commonResolvers,
     scalacOptions ++= commonCompilerSettings
   )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "1.1.0")
 
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.9.2")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.9.3")
 
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.6")
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,7 +2,7 @@ addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "1.1.0")
 
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.9.2")
 
-addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.5")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.6")
 
 addSbtPlugin(
   "com.github.cb372" % "sbt-explicit-dependencies" % "0.2.16"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -8,4 +8,4 @@ addSbtPlugin(
   "com.github.cb372" % "sbt-explicit-dependencies" % "0.2.16"
 ) // Use `unusedCompileDependencies` to see unused dependencies
 
-addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.33")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.34")


### PR DESCRIPTION
- `dependency-bot` run failed so taking the manual route.
- Decided not to subsume #2501 as it doesn't even seem to be a patch update.
- `sbt-scalafix` upgrade was to fix `[error] sbt.librarymanagement.ResolveException: Error downloading org.scalameta:semanticdb-scalac_2.13.8:4.4.30` which seemed to be due to the `scalac` upgrade causing a conflict when `sbt-scalafix` isn't also upgraded 🤷🏼 
- Similarly for the `sbt-scoverage` upgrade