### PR TITLE
IA-2965 Fix a bug where files under previous home dir will be lost

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/RuntimeFixtureSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/RuntimeFixtureSpec.scala
@@ -122,10 +122,7 @@ abstract class RuntimeFixtureSpec
       case Some(msg) if msg.startsWith(gpallocErrorPrefix) =>
         clusterCreationFailureMsg = msg
       case Some(googleProjectId) =>
-        Either.catchNonFatal(createRonRuntime(GoogleProject(googleProjectId))).handleError { e =>
-          clusterCreationFailureMsg = e.getMessage
-          ronCluster = null
-        }
+        createRonRuntime(GoogleProject(googleProjectId))
       case None =>
         clusterCreationFailureMsg = "leonardo.googleProject system property is not set"
     }

--- a/http/src/main/resources/init-resources/shutdown.sh
+++ b/http/src/main/resources/init-resources/shutdown.sh
@@ -16,6 +16,8 @@ if [ ! -z "$RSTUDIO_DOCKER_IMAGE" ] ; then
     docker exec -u rstudio -i $RSTUDIO_SERVER_NAME rstudio-server stop
 fi
 
+# Remove jupyter related files if user decides to delete the VM
 if [ -d '/mnt/disks/work/.jupyter' ] && [ "SHOULD_DELETE_JUPYTER_DIR" = "true" ] ; then
     rm -rf /mnt/disks/work/.jupyter
+    rm -rf /mnt/disks/work/.local || true
 fi

--- a/http/src/main/resources/init-resources/shutdown.sh
+++ b/http/src/main/resources/init-resources/shutdown.sh
@@ -7,8 +7,6 @@ set -e -x
 ##
 
 # Templated values
-export JUPYTER_USER_HOME=$(jupyterHomeDirectory)
-export JUPYTER_SERVER_NAME=$(jupyterServerName)
 export RSTUDIO_DOCKER_IMAGE=$(rstudioDockerImage)
 export RSTUDIO_SERVER_NAME=$(rstudioServerName)
 export SHOULD_DELETE_JUPYTER_DIR=$(shouldDeleteJupyterDir)
@@ -17,8 +15,6 @@ export SHOULD_DELETE_JUPYTER_DIR=$(shouldDeleteJupyterDir)
 if [ ! -z "$RSTUDIO_DOCKER_IMAGE" ] ; then
     docker exec -u rstudio -i $RSTUDIO_SERVER_NAME rstudio-server stop
 fi
-
-docker exec $JUPYTER_SERVER_NAME /bin/bash -c [ -d $JUPYTER_USER_HOME/notebooks ] && rsync -av --progress . $JUPYTER_USER_HOME/notebooks --exclude $JUPYTER_USER_HOME/notebooks --exclude $JUPYTER_USER_HOME/.jupyter
 
 if [ -d '/mnt/disks/work/.jupyter' ] && [ "SHOULD_DELETE_JUPYTER_DIR" = "true" ] ; then
     echo "deleting .jupyter $SHOULD_DELETE_JUPYTER_DIR"

--- a/http/src/main/resources/init-resources/shutdown.sh
+++ b/http/src/main/resources/init-resources/shutdown.sh
@@ -17,6 +17,5 @@ if [ ! -z "$RSTUDIO_DOCKER_IMAGE" ] ; then
 fi
 
 if [ -d '/mnt/disks/work/.jupyter' ] && [ "SHOULD_DELETE_JUPYTER_DIR" = "true" ] ; then
-    echo "deleting .jupyter $SHOULD_DELETE_JUPYTER_DIR"
     rm -rf /mnt/disks/work/.jupyter
 fi

--- a/http/src/main/resources/init-resources/shutdown.sh
+++ b/http/src/main/resources/init-resources/shutdown.sh
@@ -7,6 +7,8 @@ set -e -x
 ##
 
 # Templated values
+export JUPYTER_USER_HOME=$(jupyterHomeDirectory)
+export JUPYTER_SERVER_NAME=$(jupyterServerName)
 export RSTUDIO_DOCKER_IMAGE=$(rstudioDockerImage)
 export RSTUDIO_SERVER_NAME=$(rstudioServerName)
 export SHOULD_DELETE_JUPYTER_DIR=$(shouldDeleteJupyterDir)
@@ -16,6 +18,9 @@ if [ ! -z "$RSTUDIO_DOCKER_IMAGE" ] ; then
     docker exec -u rstudio -i $RSTUDIO_SERVER_NAME rstudio-server stop
 fi
 
+docker exec $JUPYTER_SERVER_NAME /bin/bash -c [ -d $JUPYTER_USER_HOME/notebooks ] && rsync -av --progress . $JUPYTER_USER_HOME/notebooks --exclude $JUPYTER_USER_HOME/notebooks --exclude $JUPYTER_USER_HOME/.jupyter
+
 if [ -d '/mnt/disks/work/.jupyter' ] && [ "SHOULD_DELETE_JUPYTER_DIR" = "true" ] ; then
+    echo "deleting .jupyter $SHOULD_DELETE_JUPYTER_DIR"
     rm -rf /mnt/disks/work/.jupyter
 fi

--- a/http/src/main/resources/init-resources/startup.sh
+++ b/http/src/main/resources/init-resources/startup.sh
@@ -108,7 +108,7 @@ then
     if [ ! -z "$JUPYTER_DOCKER_IMAGE" ] ; then
         echo "Restarting Jupyter Container $GOOGLE_PROJECT / $CLUSTER_NAME..."
 
-        docker exec $JUPYTER_SERVER_NAME /bin/bash -c "[ -d $JUPYTER_USER_HOME/notebooks ] && rsync -av --progress . $JUPYTER_USER_HOME/notebooks --exclude $JUPYTER_USER_HOME/notebooks || true"
+        docker exec $JUPYTER_SERVER_NAME /bin/bash -c "[ -d $JUPYTER_USER_HOME/notebooks ] && [ ! -d $JUPYTER_USER_HOME/notebooks/.jupyter ] && rsync -av --progress . $JUPYTER_USER_HOME/notebooks --exclude $JUPYTER_USER_HOME/notebooks || true"
 
         # Make sure when runtimes restarts, they'll get a new version of jupyter docker compose file
         $GSUTIL_CMD cp gs://${INIT_BUCKET_NAME}/`basename ${JUPYTER_DOCKER_COMPOSE}` $JUPYTER_DOCKER_COMPOSE

--- a/http/src/main/resources/init-resources/startup.sh
+++ b/http/src/main/resources/init-resources/startup.sh
@@ -141,7 +141,7 @@ else
     if [ ! -z "$JUPYTER_DOCKER_IMAGE" ] ; then
         echo "Restarting Jupyter Container $GOOGLE_PROJECT / $CLUSTER_NAME..."
 
-        docker exec $JUPYTER_SERVER_NAME /bin/bash -c "[ -d $JUPYTER_USER_HOME/notebooks ] && rsync -av --progress . $JUPYTER_USER_HOME/notebooks --exclude $JUPYTER_USER_HOME/notebooks || true"
+        docker exec $JUPYTER_SERVER_NAME /bin/bash -c "[ -d $JUPYTER_USER_HOME/notebooks ] && [ ! -d $JUPYTER_USER_HOME/notebooks/.jupyter ] && rsync -avr --progress --exclude $JUPYTER_USER_HOME/notebooks . $JUPYTER_USER_HOME/notebooks || true"
 
         # Make sure when runtimes restarts, they'll get a new version of jupyter docker compose file
         $GSUTIL_CMD cp gs://${INIT_BUCKET_NAME}/`basename ${JUPYTER_DOCKER_COMPOSE}` $JUPYTER_DOCKER_COMPOSE

--- a/http/src/main/resources/init-resources/startup.sh
+++ b/http/src/main/resources/init-resources/startup.sh
@@ -108,6 +108,8 @@ then
     if [ ! -z "$JUPYTER_DOCKER_IMAGE" ] ; then
         echo "Restarting Jupyter Container $GOOGLE_PROJECT / $CLUSTER_NAME..."
 
+        docker exec $JUPYTER_SERVER_NAME /bin/bash -c "[ -d $JUPYTER_USER_HOME/notebooks ] && rsync -av --progress . $JUPYTER_USER_HOME/notebooks --exclude $JUPYTER_USER_HOME/notebooks || true"
+
         # Make sure when runtimes restarts, they'll get a new version of jupyter docker compose file
         $GSUTIL_CMD cp gs://${INIT_BUCKET_NAME}/`basename ${JUPYTER_DOCKER_COMPOSE}` $JUPYTER_DOCKER_COMPOSE
 
@@ -123,7 +125,8 @@ MEM_LIMIT=${MEM_LIMIT}
 END
 
         ${DOCKER_COMPOSE} -f ${JUPYTER_DOCKER_COMPOSE} stop
-        ${DOCKER_COMPOSE} -f ${JUPYTER_DOCKER_COMPOSE} rm -f
+#        ${DOCKER_COMPOSE} -f ${JUPYTER_DOCKER_COMPOSE} rm -f
+# will notebooks under /notebooks still exist?
         ${DOCKER_COMPOSE} --env-file=/var/variables.env -f ${JUPYTER_DOCKER_COMPOSE} up -d
     fi
 else

--- a/http/src/main/resources/init-resources/startup.sh
+++ b/http/src/main/resources/init-resources/startup.sh
@@ -125,8 +125,7 @@ MEM_LIMIT=${MEM_LIMIT}
 END
 
         ${DOCKER_COMPOSE} -f ${JUPYTER_DOCKER_COMPOSE} stop
-#        ${DOCKER_COMPOSE} -f ${JUPYTER_DOCKER_COMPOSE} rm -f
-# will notebooks under /notebooks still exist?
+        ${DOCKER_COMPOSE} -f ${JUPYTER_DOCKER_COMPOSE} rm -f
         ${DOCKER_COMPOSE} --env-file=/var/variables.env -f ${JUPYTER_DOCKER_COMPOSE} up -d
     fi
 else
@@ -141,6 +140,8 @@ else
 
     if [ ! -z "$JUPYTER_DOCKER_IMAGE" ] ; then
         echo "Restarting Jupyter Container $GOOGLE_PROJECT / $CLUSTER_NAME..."
+
+        docker exec $JUPYTER_SERVER_NAME /bin/bash -c "[ -d $JUPYTER_USER_HOME/notebooks ] && rsync -av --progress . $JUPYTER_USER_HOME/notebooks --exclude $JUPYTER_USER_HOME/notebooks || true"
 
         # Make sure when runtimes restarts, they'll get a new version of jupyter docker compose file
         $GSUTIL_CMD cp gs://${INIT_BUCKET_NAME}/`basename ${JUPYTER_DOCKER_COMPOSE}` $JUPYTER_DOCKER_COMPOSE

--- a/http/src/main/resources/init-resources/startup.sh
+++ b/http/src/main/resources/init-resources/startup.sh
@@ -108,7 +108,7 @@ then
     if [ ! -z "$JUPYTER_DOCKER_IMAGE" ] ; then
         echo "Restarting Jupyter Container $GOOGLE_PROJECT / $CLUSTER_NAME..."
 
-        docker exec $JUPYTER_SERVER_NAME /bin/bash -c "[ -d $JUPYTER_USER_HOME/notebooks ] && [ ! -d $JUPYTER_USER_HOME/notebooks/.jupyter ] && rsync -av --progress . $JUPYTER_USER_HOME/notebooks --exclude $JUPYTER_USER_HOME/notebooks || true"
+        docker exec $JUPYTER_SERVER_NAME /bin/bash -c "[ -d $JUPYTER_USER_HOME/notebooks ] && [ ! -d $JUPYTER_USER_HOME/notebooks/.jupyter ] && rsync -av --progress --exclude notebooks . $JUPYTER_USER_HOME/notebooks || true"
 
         # Make sure when runtimes restarts, they'll get a new version of jupyter docker compose file
         $GSUTIL_CMD cp gs://${INIT_BUCKET_NAME}/`basename ${JUPYTER_DOCKER_COMPOSE}` $JUPYTER_DOCKER_COMPOSE
@@ -141,7 +141,7 @@ else
     if [ ! -z "$JUPYTER_DOCKER_IMAGE" ] ; then
         echo "Restarting Jupyter Container $GOOGLE_PROJECT / $CLUSTER_NAME..."
 
-        docker exec $JUPYTER_SERVER_NAME /bin/bash -c "[ -d $JUPYTER_USER_HOME/notebooks ] && [ ! -d $JUPYTER_USER_HOME/notebooks/.jupyter ] && rsync -avr --progress --exclude $JUPYTER_USER_HOME/notebooks . $JUPYTER_USER_HOME/notebooks || true"
+        docker exec $JUPYTER_SERVER_NAME /bin/bash -c "[ -d $JUPYTER_USER_HOME/notebooks ] && [ ! -d $JUPYTER_USER_HOME/notebooks/.jupyter ] && rsync -avr --progress --exclude notebooks . $JUPYTER_USER_HOME/notebooks || true"
 
         # Make sure when runtimes restarts, they'll get a new version of jupyter docker compose file
         $GSUTIL_CMD cp gs://${INIT_BUCKET_NAME}/`basename ${JUPYTER_DOCKER_COMPOSE}` $JUPYTER_DOCKER_COMPOSE

--- a/http/src/main/resources/init-resources/startup.sh
+++ b/http/src/main/resources/init-resources/startup.sh
@@ -108,6 +108,12 @@ then
     if [ ! -z "$JUPYTER_DOCKER_IMAGE" ] ; then
         echo "Restarting Jupyter Container $GOOGLE_PROJECT / $CLUSTER_NAME..."
 
+        # This line is only for migration (1/26/2022). Say you have an existing runtime where jupyter container's PD is mapped at $HOME/notebooks,
+        # then all jupyter related files (.jupyter, .local) and things like bash history etc all lives under $HOME. The home diretory change will
+        # make it so that next time this runtime starts up, PD will be mapped to $HOME, but this means that the previous files under $HOME (.jupyter, .local etc)
+        # will be lost....So this one line is to before we restart jupyter container with updated home directory mapping,
+        # we will copy all files under $HOME to $HOME/notebooks first, which will live on PD...So when it starts up,
+        # what was previously under $HOME will now appear in new $HOME as well
         docker exec $JUPYTER_SERVER_NAME /bin/bash -c "[ -d $JUPYTER_USER_HOME/notebooks ] && [ ! -d $JUPYTER_USER_HOME/notebooks/.jupyter ] && rsync -av --progress --exclude notebooks . $JUPYTER_USER_HOME/notebooks || true"
 
         # Make sure when runtimes restarts, they'll get a new version of jupyter docker compose file
@@ -141,6 +147,12 @@ else
     if [ ! -z "$JUPYTER_DOCKER_IMAGE" ] ; then
         echo "Restarting Jupyter Container $GOOGLE_PROJECT / $CLUSTER_NAME..."
 
+        # This line is only for migration (1/26/2022). Say you have an existing runtime where jupyter container's PD is mapped at $HOME/notebooks,
+        # then all jupyter related files (.jupyter, .local) and things like bash history etc all lives under $HOME. The home diretory change will
+        # make it so that next time this runtime starts up, PD will be mapped to $HOME, but this means that the previous files under $HOME (.jupyter, .local etc)
+        # will be lost....So this one line is to before we restart jupyter container with updated home directory mapping,
+        # we will copy all files under $HOME to $HOME/notebooks first, which will live on PD...So when it starts up,
+        # what was previously under $HOME will now appear in new $HOME as well
         docker exec $JUPYTER_SERVER_NAME /bin/bash -c "[ -d $JUPYTER_USER_HOME/notebooks ] && [ ! -d $JUPYTER_USER_HOME/notebooks/.jupyter ] && rsync -avr --progress --exclude notebooks . $JUPYTER_USER_HOME/notebooks || true"
 
         # Make sure when runtimes restarts, they'll get a new version of jupyter docker compose file

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -130,7 +130,7 @@ gce {
     # a timeout will transition it to Error status.
     statusTimeouts {
       creating = 30 minutes
-      starting = 50 minutes
+      starting = 20 minutes
       deleting = 30 minutes
     }
     # Defines polling for tool checking. This is only done for Creating and Starting status transitions.

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -130,7 +130,7 @@ gce {
     # a timeout will transition it to Error status.
     statusTimeouts {
       creating = 30 minutes
-      starting = 20 minutes
+      starting = 50 minutes
       deleting = 30 minutes
     }
     # Defines polling for tool checking. This is only done for Creating and Starting status transitions.


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-2965

The fix essentially copies everything under `$HOME` to `notebooks` so that those files will live on PD and re-mapped into the juptyer container the we make a new one, and we shouldn't copy again if this has already happened when next time the VM restarts.

Test case:
1. Create a runtime with pre home dir change branch
2. Create a test file under $HOME
3. Stop and restart runtime with this PR's change
4. Veirfy that the test file still exists under new $HOME dir, and there's no more `notebooks` directory

The above tests is done on both GCE VM and Dataproc cluster. Start/stop runtimes a few times and things still work as expected and `rsync` is only run the first time it starts up with new directory change

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
