### PR TITLE
IA-3145 validate saturn-iframe-extension

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
@@ -75,7 +75,9 @@ trait LeonardoTestUtils
   val getAfterCreatePatience = PatienceConfig(timeout = scaled(Span(5, Minutes)), interval = scaled(Span(2, Seconds)))
 
   val multiExtensionClusterRequest = UserJupyterExtensionConfig(
-    nbExtensions = Map("saturn-iframe-extension" -> "https://app.terra.bio/jupyter-iframe-extension.js")
+    // This is not a valid saturn-iframe-extension. But only this is allowed when running tests in a fiab.
+    // When running NotebookGCECustomizationSpec locally, update this to https://localhost:3000/jupyter-iframe-extension.js
+    nbExtensions = Map("saturn-iframe-extension" -> "https://*/jupyter-iframe-extension.js")
   )
   val jupyterLabExtensionClusterRequest = UserJupyterExtensionConfig(
     serverExtensions = Map("jupyterlab" -> "jupyterlab")

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
@@ -74,11 +74,6 @@ trait LeonardoTestUtils
   val startPatience = PatienceConfig(timeout = scaled(Span(5, Minutes)), interval = scaled(Span(1, Seconds)))
   val getAfterCreatePatience = PatienceConfig(timeout = scaled(Span(5, Minutes)), interval = scaled(Span(2, Seconds)))
 
-  val multiExtensionClusterRequest = UserJupyterExtensionConfig(
-    // This is not a valid saturn-iframe-extension. But only this is allowed when running tests in a fiab.
-    // When running NotebookGCECustomizationSpec locally, update this to https://localhost:3000/jupyter-iframe-extension.js
-    nbExtensions = Map("saturn-iframe-extension" -> "https://*/jupyter-iframe-extension.js")
-  )
   val jupyterLabExtensionClusterRequest = UserJupyterExtensionConfig(
     serverExtensions = Map("jupyterlab" -> "jupyterlab")
   )

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookGCECustomizationSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookGCECustomizationSpec.scala
@@ -4,7 +4,7 @@ import cats.effect.unsafe.implicits.global
 import org.broadinstitute.dsde.workbench.ResourceFile
 import org.broadinstitute.dsde.workbench.auth.AuthToken
 import org.broadinstitute.dsde.workbench.leonardo.TestUser.{getAuthTokenAndAuthorization, Ron}
-import org.broadinstitute.dsde.workbench.leonardo.{GPAllocFixtureSpec, LeonardoApiClient}
+import org.broadinstitute.dsde.workbench.leonardo.{GPAllocFixtureSpec, LeonardoApiClient, UserJupyterExtensionConfig}
 import org.scalatest.{DoNotDiscover, ParallelTestExecution}
 
 import scala.concurrent.duration._
@@ -26,9 +26,8 @@ final class NotebookGCECustomizationSpec extends GPAllocFixtureSpec with Paralle
       val translateExtensionFile = ResourceFile("bucket-tests/translate_nbextension.tar.gz")
       withResourceFileInBucket(billingProject, translateExtensionFile, "application/x-gzip") {
         translateExtensionBucketPath =>
-          val extensionConfig = multiExtensionClusterRequest.copy(
-            nbExtensions =
-              multiExtensionClusterRequest.nbExtensions + ("translate" -> translateExtensionBucketPath.toUri)
+          val extensionConfig = UserJupyterExtensionConfig(
+            nbExtensions = Map("translate" -> translateExtensionBucketPath.toUri)
           )
           withNewRuntime(
             billingProject,

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookGCECustomizationSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookGCECustomizationSpec.scala
@@ -39,8 +39,6 @@ final class NotebookGCECustomizationSpec extends GPAllocFixtureSpec with Paralle
                 // Check the extensions were installed
                 val nbExt = notebookPage.executeCell("! jupyter nbextension list")
 
-                nbExt.get should include("jupyter-iframe-extension/main  enabled")
-
                 nbExt.get should include("translate_nbextension/main  enabled")
                 // should be installed by default
                 nbExt.get should include("toc2/main  enabled")

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/HttpRoutes.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/HttpRoutes.scala
@@ -40,7 +40,7 @@ class HttpRoutes(
   private val statusRoutes = new StatusRoutes(statusService)
   private val corsSupport = new CorsSupport(contentSecurityPolicy)
   private val proxyRoutes = new ProxyRoutes(proxyService, corsSupport, refererConfig)
-  private val runtimeRoutes = new RuntimeRoutes(runtimeService, userInfoDirectives)
+  private val runtimeRoutes = new RuntimeRoutes(refererConfig, runtimeService, userInfoDirectives)
   private val diskRoutes = new DiskRoutes(diskService, userInfoDirectives)
   private val kubernetesRoutes = new AppRoutes(kubernetesService, userInfoDirectives)
 


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-3145

The way [terra ui](https://github.com/DataBiosphere/terra-ui/blob/ef88f396a61383ee08beb65a37af7cae9476cc20/src/libs/ajax.js#L1358) constructs the url is `${window.location.hostname === 'localhost' ? getConfig().devUrlRoot : window.location.origin}/jupyter-iframe-extension.js`, hence we're re-using referer config to get all the valid hosts to construct the allowed list of `saturn-iframe-extension`

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
