### PR TITLE
PROD-635 add a wait before start vm

### DIFF
--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -116,6 +116,8 @@ gce {
   }
   gceReservedMemory = 1g
 
+  waitBeforeStartVm = 5 seconds
+
   monitor {
     initialDelay = 20 seconds
     # Defines polling for runtime status transitions. Used commonly for all statuses.

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -116,7 +116,7 @@ gce {
   }
   gceReservedMemory = 1g
 
-  waitBeforeStartVm = 5 seconds
+  waitBeforeStartingVM = 5 seconds
 
   monitor {
     initialDelay = 20 seconds

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
@@ -111,7 +111,8 @@ object Config {
       config.as[DeviceName]("userDiskDeviceName"),
       config.getStringList("defaultScopes").asScala.toSet,
       config.getAs[MemorySize]("gceReservedMemory"),
-      config.as[RuntimeConfig.GceConfig]("runtimeDefaults")
+      config.as[RuntimeConfig.GceConfig]("runtimeDefaults"),
+      config.as[FiniteDuration]("GceConfig")
     )
   }
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
@@ -112,7 +112,7 @@ object Config {
       config.getStringList("defaultScopes").asScala.toSet,
       config.getAs[MemorySize]("gceReservedMemory"),
       config.as[RuntimeConfig.GceConfig]("runtimeDefaults"),
-      config.as[FiniteDuration]("waitBeforeStartVm")
+      config.as[FiniteDuration]("waitBeforeStartingVM")
     )
   }
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
@@ -112,7 +112,7 @@ object Config {
       config.getStringList("defaultScopes").asScala.toSet,
       config.getAs[MemorySize]("gceReservedMemory"),
       config.as[RuntimeConfig.GceConfig]("runtimeDefaults"),
-      config.as[FiniteDuration]("GceConfig")
+      config.as[FiniteDuration]("waitBeforeStartVm")
     )
   }
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/GceConfig.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/GceConfig.scala
@@ -4,8 +4,11 @@ package config
 import org.broadinstitute.dsde.workbench.google2.DeviceName
 import org.broadinstitute.dsde.workbench.leonardo.CustomImage.GceCustomImage
 
+import scala.concurrent.duration.FiniteDuration
+
 case class GceConfig(sourceImage: GceCustomImage,
                      userDiskDeviceName: DeviceName,
                      defaultScopes: Set[String],
                      gceReservedMemory: Option[MemorySize],
-                     runtimeConfigDefaults: RuntimeConfig.GceConfig)
+                     runtimeConfigDefaults: RuntimeConfig.GceConfig,
+                     waitBeforeStartVM: FiniteDuration)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/GceConfig.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/GceConfig.scala
@@ -11,4 +11,4 @@ case class GceConfig(sourceImage: GceCustomImage,
                      defaultScopes: Set[String],
                      gceReservedMemory: Option[MemorySize],
                      runtimeConfigDefaults: RuntimeConfig.GceConfig,
-                     waitBeforeStartVM: FiniteDuration)
+                     waitBeforeStartingVM: FiniteDuration)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GceInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GceInterpreter.scala
@@ -372,7 +372,8 @@ class GceInterpreter[F[_]](
       )
       // This sleep is added here because as of 2/1/2022, we started seeing increased amount of `RESOURCE_NOT_READY` error.
       // Google support says this is due to the setMetadata API and start VM API is called too close to each other.
-      _ <- F.sleep(config.gceConfig.waitBeforeStartVM)
+      // https://console.cloud.google.com/support/cases/detail/29414506?authuser=0&organizationId=548622027621&supportedpurview=project
+      _ <- F.sleep(config.gceConfig.waitBeforeStartingVM)
       _ <- googleComputeService.startInstance(googleProject,
                                               zoneParam,
                                               InstanceName(params.runtimeAndRuntimeConfig.runtime.runtimeName.asString))

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GceInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GceInterpreter.scala
@@ -30,7 +30,6 @@ import org.typelevel.log4cats.StructuredLogger
 import org.broadinstitute.dsde.workbench.leonardo.http.ctxConversion
 import scala.concurrent.ExecutionContext
 import scala.jdk.CollectionConverters._
-import scala.concurrent.duration._
 
 final case class InstanceResourceConstraintsException(project: GoogleProject, machineType: MachineTypeName)
     extends LeoException(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -15,7 +15,7 @@ object Dependencies {
   val monocleV = "2.1.0"
   val opencensusV = "0.29.0"
 
-  private val workbenchLibsHash = "ea061ce"
+  private val workbenchLibsHash = "8f668ec"
   val serviceTestV = s"0.21-$workbenchLibsHash"
   val workbenchModelV = s"0.15-$workbenchLibsHash"
   val workbenchGoogleV = s"0.21-$workbenchLibsHash"


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/PROD-635

We're seeing lots of `RESOURCE_NOT_READY` error when starting VM. Google support says this is due to the setMetadata API and start VM API is called too close to each other. It's odd this starts happening jsut now since the code hasn't changed for a while, but hopefully adding the wait will make things better

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
