### PR TITLE
PROD-635 IA-3204 poll setMetadata result before calling startVM

### DIFF
--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -116,8 +116,6 @@ gce {
   }
   gceReservedMemory = 1g
 
-  waitBeforeStartingVM = 5 seconds
-
   monitor {
     initialDelay = 20 seconds
     # Defines polling for runtime status transitions. Used commonly for all statuses.

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -116,6 +116,9 @@ gce {
   }
   gceReservedMemory = 1g
 
+  setMetadataPollDelay = 1 seconds
+  setMetadataPollMaxAttempts = 30
+
   monitor {
     initialDelay = 20 seconds
     # Defines polling for runtime status transitions. Used commonly for all statuses.

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
@@ -111,7 +111,9 @@ object Config {
       config.as[DeviceName]("userDiskDeviceName"),
       config.getStringList("defaultScopes").asScala.toSet,
       config.getAs[MemorySize]("gceReservedMemory"),
-      config.as[RuntimeConfig.GceConfig]("runtimeDefaults")
+      config.as[RuntimeConfig.GceConfig]("runtimeDefaults"),
+      config.as[FiniteDuration]("setMetadataPollDelay"),
+      config.as[Int]("setMetadataPollMaxAttempts")
     )
   }
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
@@ -111,8 +111,7 @@ object Config {
       config.as[DeviceName]("userDiskDeviceName"),
       config.getStringList("defaultScopes").asScala.toSet,
       config.getAs[MemorySize]("gceReservedMemory"),
-      config.as[RuntimeConfig.GceConfig]("runtimeDefaults"),
-      config.as[FiniteDuration]("waitBeforeStartingVM")
+      config.as[RuntimeConfig.GceConfig]("runtimeDefaults")
     )
   }
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/GceConfig.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/GceConfig.scala
@@ -4,8 +4,12 @@ package config
 import org.broadinstitute.dsde.workbench.google2.DeviceName
 import org.broadinstitute.dsde.workbench.leonardo.CustomImage.GceCustomImage
 
+import scala.concurrent.duration.FiniteDuration
+
 case class GceConfig(sourceImage: GceCustomImage,
                      userDiskDeviceName: DeviceName,
                      defaultScopes: Set[String],
                      gceReservedMemory: Option[MemorySize],
-                     runtimeConfigDefaults: RuntimeConfig.GceConfig)
+                     runtimeConfigDefaults: RuntimeConfig.GceConfig,
+                     setMetadataPollDelay: FiniteDuration,
+                     setMetadataPollMaxAttempts: Int)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/GceConfig.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/GceConfig.scala
@@ -4,11 +4,8 @@ package config
 import org.broadinstitute.dsde.workbench.google2.DeviceName
 import org.broadinstitute.dsde.workbench.leonardo.CustomImage.GceCustomImage
 
-import scala.concurrent.duration.FiniteDuration
-
 case class GceConfig(sourceImage: GceCustomImage,
                      userDiskDeviceName: DeviceName,
                      defaultScopes: Set[String],
                      gceReservedMemory: Option[MemorySize],
-                     runtimeConfigDefaults: RuntimeConfig.GceConfig,
-                     waitBeforeStartingVM: FiniteDuration)
+                     runtimeConfigDefaults: RuntimeConfig.GceConfig)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/Boot.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/Boot.scala
@@ -122,6 +122,7 @@ object Boot extends IOApp {
 
       val gceInterp = new GceInterpreter(
         gceInterpreterConfig,
+        googleDependencies.computePollOperation,
         bucketHelper,
         vpcInterp,
         googleDependencies.googleComputeService,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
@@ -108,7 +108,7 @@ class LeoPubsubMessageSubscriber[F[_]](
                     logger.error(ctx.loggingCtx, e)(s"Encountered an error for app ${ee.appId}, ${ee.getMessage}") >> handleKubernetesError(
                       ee
                     )
-                  case _ => logger.error(ctx.loggingCtx, ee)(s"Fail to process pubsub message")
+                  case _ => logger.error(ctx.loggingCtx, ee)(s"Failed to process pubsub message.")
                 }
                 _ <- if (ee.isRetryable)
                   logger.error(ctx.loggingCtx, e)("Fail to process retryable pubsub message") >> F

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
@@ -108,7 +108,7 @@ class LeoPubsubMessageSubscriber[F[_]](
                     logger.error(ctx.loggingCtx, e)(s"Encountered an error for app ${ee.appId}, ${ee.getMessage}") >> handleKubernetesError(
                       ee
                     )
-                  case _ => F.unit
+                  case _ => logger.error(ctx.loggingCtx, ee)(s"Fail to process pubsub message")
                 }
                 _ <- if (ee.isRetryable)
                   logger.error(ctx.loggingCtx, e)("Fail to process retryable pubsub message") >> F

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/leoPubsubMessageSubscriberModels.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/leoPubsubMessageSubscriberModels.scala
@@ -797,6 +797,13 @@ object PubsubHandleMessageError {
       s"An error occurred with a kubernetes operation from source ${dbError.source} during action ${dbError.action}. \nOriginal message: ${dbError.errorMessage}"
   }
 
+  final case class ClusterError(clusterId: Long, msg: String) extends PubsubHandleMessageError {
+    override def getMessage: String =
+      s"${clusterId}: ${msg}"
+
+    override def isRetryable: Boolean = true
+  }
+
   final case class ClusterNotFound(clusterId: Long, message: LeoPubsubMessage) extends PubsubHandleMessageError {
     override def getMessage: String =
       s"Unable to process transition finished message ${message} for cluster ${clusterId} because it was not found in the database"

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GceInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GceInterpreter.scala
@@ -370,10 +370,6 @@ class GceInterpreter[F[_]](
         metadataToAdd = metadata,
         metadataToRemove = Set("startup-script-url")
       )
-      // This sleep is added here because as of 2/1/2022, we started seeing increased amount of `RESOURCE_NOT_READY` error.
-      // Google support says this is due to the setMetadata API and start VM API is called too close to each other.
-      // https://console.cloud.google.com/support/cases/detail/29414506?authuser=0&organizationId=548622027621&supportedpurview=project
-      _ <- F.sleep(config.gceConfig.waitBeforeStartingVM)
       _ <- googleComputeService.startInstance(googleProject,
                                               zoneParam,
                                               InstanceName(params.runtimeAndRuntimeConfig.runtime.runtimeName.asString))

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/TestLeoRoutes.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/TestLeoRoutes.scala
@@ -89,6 +89,7 @@ trait TestLeoRoutes {
                                 MockWelderDAO)
   val gceInterp =
     new GceInterpreter[IO](Config.gceInterpreterConfig,
+                           new MockComputePollOperation(),
                            bucketHelper,
                            vpcInterp,
                            FakeGoogleComputeService,

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriberSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriberSpec.scala
@@ -2,7 +2,6 @@ package org.broadinstitute.dsde.workbench.leonardo
 package monitor
 
 import java.time.Instant
-
 import akka.actor.ActorSystem
 import akka.testkit.TestKit
 import cats.data.Kleisli
@@ -131,6 +130,7 @@ class LeoPubsubMessageSubscriberSpec
                                                    resourceService,
                                                    mockWelderDAO)
   val gceInterp = new GceInterpreter[IO](Config.gceInterpreterConfig,
+                                         new MockComputePollOperation(),
                                          bucketHelper,
                                          vpcInterp,
                                          FakeGoogleComputeService,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -15,7 +15,7 @@ object Dependencies {
   val monocleV = "2.1.0"
   val opencensusV = "0.29.0"
 
-  private val workbenchLibsHash = "96e189ca-SNAP"
+  private val workbenchLibsHash = "1c5f5dc"
   val serviceTestV = s"0.21-$workbenchLibsHash"
   val workbenchModelV = s"0.15-$workbenchLibsHash"
   val workbenchGoogleV = s"0.21-$workbenchLibsHash"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -15,7 +15,7 @@ object Dependencies {
   val monocleV = "2.1.0"
   val opencensusV = "0.29.0"
 
-  private val workbenchLibsHash = "ea061ce"
+  private val workbenchLibsHash = "96e189ca-SNAP"
   val serviceTestV = s"0.21-$workbenchLibsHash"
   val workbenchModelV = s"0.15-$workbenchLibsHash"
   val workbenchGoogleV = s"0.21-$workbenchLibsHash"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -15,7 +15,7 @@ object Dependencies {
   val monocleV = "2.1.0"
   val opencensusV = "0.29.0"
 
-  private val workbenchLibsHash = "8f668ec"
+  private val workbenchLibsHash = "ea061ce"
   val serviceTestV = s"0.21-$workbenchLibsHash"
   val workbenchModelV = s"0.15-$workbenchLibsHash"
   val workbenchGoogleV = s"0.21-$workbenchLibsHash"


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/PROD-635

Depends on https://github.com/broadinstitute/workbench-libs/pull/896

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
