### PR TITLE
[IA-2903] use default SA for GKE nodepools

### DIFF
--- a/automation/hotswap.sh
+++ b/automation/hotswap.sh
@@ -16,7 +16,7 @@ ENV=${2:-dev}
 
 printf "Generating the Leo jar...\n\n"
 # Example: /Users/qi/workspace/leonardo/http/target/scala-2.12/http-assembly-0.1-437ee4a9-SNAPSHOT.jar
-sbt -Dsbt.log.noformat=true "project http" clean assembly
+sbt -J-Xmx4g -J-Xss2M -J-Xms4G -Dsbt.log.noformat=true "project http" clean assembly
 LEO_JAR_PATH=$(ls http/target/scala-2.13/http*)
 
 printf "\n\nJar successfully generated."

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/Boot.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/Boot.scala
@@ -264,7 +264,8 @@ object Boot extends IOApp {
             googleDependencies.googleIamDAO,
             googleDependencies.googleDiskService,
             appDependencies.appDescriptorDAO,
-            appDependencies.nodepoolLock
+            appDependencies.nodepoolLock,
+            googleDependencies.googleResourceService
           )
 
           val azureAlg = new AzureInterpreter[IO](ConfigReader.appConfig.azure.runtimeDefaults,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
@@ -1244,35 +1244,33 @@ class GKEInterpreter[F[_]](
           .setAutoRepair(true)
       )
 
-    serviceAccount match {
-      case Some(sa) => {
+    val nodepoolBuilderWithSa = serviceAccount match {
+      case Some(sa) =>
         nodepoolBuilder.setConfig(
           NodeConfig
             .newBuilder()
             .setMachineType(nodepool.machineType.value)
             .setServiceAccount(sa)
         )
-      }
-      case _ => {
+      case _ =>
         nodepoolBuilder.setConfig(
           NodeConfig
             .newBuilder()
             .setMachineType(nodepool.machineType.value)
         )
-      }
     }
 
-    val builderWithAutoscaling = nodepool.autoscalingConfig.fold(nodepoolBuilder)(config =>
+    val builderWithAutoscaling = nodepool.autoscalingConfig.fold(nodepoolBuilderWithSa)(config =>
       nodepool.autoscalingEnabled match {
         case true =>
-          nodepoolBuilder.setAutoscaling(
+          nodepoolBuilderWithSa.setAutoscaling(
             NodePoolAutoscaling
               .newBuilder()
               .setEnabled(true)
               .setMinNodeCount(config.autoscalingMin.amount)
               .setMaxNodeCount(config.autoscalingMax.amount)
           )
-        case false => nodepoolBuilder
+        case false => nodepoolBuilderWithSa
       }
     )
 
@@ -1293,7 +1291,7 @@ class GKEInterpreter[F[_]](
         new com.google.api.services.container.model.NodeManagement().setAutoUpgrade(true).setAutoRepair(true)
       )
 
-    serviceAccount match {
+    val legacyGoogleNodepoolWithSa = serviceAccount match {
       case Some(sa) => {
         legacyGoogleNodepool.setConfig(
           new com.google.api.services.container.model.NodeConfig()
@@ -1309,16 +1307,16 @@ class GKEInterpreter[F[_]](
       }
     }
 
-    nodepool.autoscalingConfig.fold(legacyGoogleNodepool)(config =>
+    nodepool.autoscalingConfig.fold(legacyGoogleNodepoolWithSa)(config =>
       nodepool.autoscalingEnabled match {
         case true =>
-          legacyGoogleNodepool.setAutoscaling(
+          legacyGoogleNodepoolWithSa.setAutoscaling(
             new com.google.api.services.container.model.NodePoolAutoscaling()
               .setEnabled(true)
               .setMinNodeCount(config.autoscalingMin.amount)
               .setMaxNodeCount(config.autoscalingMax.amount)
           )
-        case false => legacyGoogleNodepool
+        case false => legacyGoogleNodepoolWithSa
       }
     )
   }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
@@ -27,6 +27,7 @@ import org.broadinstitute.dsde.workbench.google2.{
   tracedRetryF,
   DiskName,
   GoogleDiskService,
+  GoogleResourceService,
   KubernetesClusterNotFoundException,
   PvName,
   ZoneName
@@ -63,7 +64,8 @@ class GKEInterpreter[F[_]](
   googleIamDAO: GoogleIamDAO,
   googleDiskService: GoogleDiskService[F],
   appDescriptorDAO: AppDescriptorDAO[F],
-  nodepoolLock: KeyLock[F, KubernetesClusterId]
+  nodepoolLock: KeyLock[F, KubernetesClusterId],
+  googleResourceService: GoogleResourceService[F]
 )(implicit val executionContext: ExecutionContext, logger: StructuredLogger[F], dbRef: DbReference[F], F: Async[F])
     extends GKEAlgebra[F] {
 
@@ -87,9 +89,10 @@ class GKEInterpreter[F[_]](
       )
 
       // Get nodepools to pass in the create cluster request
+      projectLabels <- googleResourceService.getLabels(params.googleProject)
       nodepools = dbCluster.nodepools
         .filter(n => params.nodepoolsToCreate.contains(n.id))
-        .map(buildLegacyGoogleNodepool)
+        .map(np => buildLegacyGoogleNodepool(np, params.googleProject, projectLabels))
 
       _ <- if (nodepools.size != params.nodepoolsToCreate.size)
         F.raiseError[Unit](
@@ -250,9 +253,10 @@ class GKEInterpreter[F[_]](
         s"Beginning nodepool creation for nodepool ${dbNodepool.nodepoolName.value} in cluster ${dbCluster.getGkeClusterId.toString}"
       )
 
+      projectLabels <- googleResourceService.getLabels(params.googleProject)
       req = KubernetesCreateNodepoolRequest(
         dbCluster.getGkeClusterId,
-        buildGoogleNodepool(dbNodepool)
+        buildGoogleNodepool(dbNodepool, params.googleProject, projectLabels)
       )
 
       operationOpt <- nodepoolLock.withKeyLock(dbCluster.getGkeClusterId) {
@@ -1216,14 +1220,21 @@ class GKEInterpreter[F[_]](
 
     } yield helmAuthContext
 
-  private[util] def buildGoogleNodepool(nodepool: Nodepool): com.google.container.v1.NodePool = {
+  private[util] def getNodepoolServiceAccount(projectLabels: Option[Map[String, String]],
+                                              googleProject: GoogleProject): Option[String] =
+    projectLabels.flatMap { x =>
+      x.get("gke-default-sa").map(v => s"${v}@${googleProject.value}.iam.gserviceaccount.com")
+    }
+
+  private[util] def buildGoogleNodepool(
+    nodepool: Nodepool,
+    googleProject: GoogleProject,
+    projectLabels: Option[Map[String, String]]
+  ): com.google.container.v1.NodePool = {
+    val serviceAccount = getNodepoolServiceAccount(projectLabels, googleProject)
+
     val nodepoolBuilder = NodePool
       .newBuilder()
-      .setConfig(
-        NodeConfig
-          .newBuilder()
-          .setMachineType(nodepool.machineType.value)
-      )
       .setInitialNodeCount(nodepool.numNodes.amount)
       .setName(nodepool.nodepoolName.value)
       .setManagement(
@@ -1232,6 +1243,24 @@ class GKEInterpreter[F[_]](
           .setAutoUpgrade(true)
           .setAutoRepair(true)
       )
+
+    serviceAccount match {
+      case Some(sa) => {
+        nodepoolBuilder.setConfig(
+          NodeConfig
+            .newBuilder()
+            .setMachineType(nodepool.machineType.value)
+            .setServiceAccount(sa)
+        )
+      }
+      case _ => {
+        nodepoolBuilder.setConfig(
+          NodeConfig
+            .newBuilder()
+            .setMachineType(nodepool.machineType.value)
+        )
+      }
+    }
 
     val builderWithAutoscaling = nodepool.autoscalingConfig.fold(nodepoolBuilder)(config =>
       nodepool.autoscalingEnabled match {
@@ -1250,14 +1279,35 @@ class GKEInterpreter[F[_]](
     builderWithAutoscaling.build()
   }
 
-  private[util] def buildLegacyGoogleNodepool(nodepool: Nodepool): com.google.api.services.container.model.NodePool = {
+  private[util] def buildLegacyGoogleNodepool(
+    nodepool: Nodepool,
+    googleProject: GoogleProject,
+    projectLabels: Option[Map[String, String]]
+  ): com.google.api.services.container.model.NodePool = {
+    val serviceAccount = getNodepoolServiceAccount(projectLabels, googleProject)
+
     val legacyGoogleNodepool = new com.google.api.services.container.model.NodePool()
-      .setConfig(new com.google.api.services.container.model.NodeConfig().setMachineType(nodepool.machineType.value))
       .setInitialNodeCount(nodepool.numNodes.amount)
       .setName(nodepool.nodepoolName.value)
       .setManagement(
         new com.google.api.services.container.model.NodeManagement().setAutoUpgrade(true).setAutoRepair(true)
       )
+
+    serviceAccount match {
+      case Some(sa) => {
+        legacyGoogleNodepool.setConfig(
+          new com.google.api.services.container.model.NodeConfig()
+            .setMachineType(nodepool.machineType.value)
+            .setServiceAccount(sa)
+        )
+      }
+      case _ => {
+        legacyGoogleNodepool.setConfig(
+          new com.google.api.services.container.model.NodeConfig()
+            .setMachineType(nodepool.machineType.value)
+        )
+      }
+    }
 
     nodepool.autoscalingConfig.fold(legacyGoogleNodepool)(config =>
       nodepool.autoscalingEnabled match {

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriberSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriberSpec.scala
@@ -113,6 +113,9 @@ class LeoPubsubMessageSubscriberSpec
   val resourceService = new FakeGoogleResourceService {
     override def getProjectNumber(project: GoogleProject)(implicit ev: Ask[IO, TraceId]): IO[Option[Long]] =
       IO(Some(1L))
+
+    override def getLabels(project: GoogleProject)(implicit ev: Ask[IO, TraceId]): IO[Option[Map[String, String]]] =
+      IO(Some(Map("gke-default-sa" -> "gke-node-default-sa")))
   }
   val authProvider = mock[LeoAuthProvider[IO]]
   val currentTime = Instant.now
@@ -1073,7 +1076,8 @@ class LeoPubsubMessageSubscriberSpec
                                           iamDAOKubernetes,
                                           makeDetachingDiskInterp(),
                                           MockAppDescriptorDAO,
-                                          nodepoolLock)
+                                          nodepoolLock,
+                                          resourceService)
     val leoSubscriber = makeLeoSubscriber(asyncTaskQueue = queue, gkeAlgebra = gkeInter)
 
     val res =
@@ -1228,7 +1232,8 @@ class LeoPubsubMessageSubscriberSpec
                                            iamDAOKubernetes,
                                            makeDetachingDiskInterp(),
                                            MockAppDescriptorDAO,
-                                           nodepoolLock)
+                                           nodepoolLock,
+                                           resourceService)
     val leoSubscriber =
       makeLeoSubscriber(asyncTaskQueue = queue, diskInterp = makeDetachingDiskInterp(), gkeAlgebra = gkeInterp)
 
@@ -1368,7 +1373,8 @@ class LeoPubsubMessageSubscriberSpec
                                            iamDAO,
                                            makeDetachingDiskInterp(),
                                            MockAppDescriptorDAO,
-                                           nodepoolLock)
+                                           nodepoolLock,
+                                           resourceService)
     val leoSubscriber =
       makeLeoSubscriber(asyncTaskQueue = queue, diskInterp = makeDetachingDiskInterp(), gkeAlgebra = gkeInterp)
 
@@ -1457,7 +1463,8 @@ class LeoPubsubMessageSubscriberSpec
                                            iamDAOKubernetes,
                                            makeDetachingDiskInterp(),
                                            MockAppDescriptorDAO,
-                                           nodepoolLock)
+                                           nodepoolLock,
+                                           resourceService)
 
     val leoSubscriber =
       makeLeoSubscriber(asyncTaskQueue = queue, diskInterp = makeDetachingDiskInterp(), gkeAlgebra = gkeInterp)
@@ -1726,7 +1733,8 @@ class LeoPubsubMessageSubscriberSpec
                            iamDAOKubernetes,
                            makeDetachingDiskInterp(),
                            MockAppDescriptorDAO,
-                           lock)
+                           lock,
+                           resourceService)
 
   def makeLeoSubscriber(
     runtimeMonitor: RuntimeMonitor[IO, CloudService] = MockRuntimeMonitor,


### PR DESCRIPTION
Tested by adding unit test and testing in a Fiab. All nodepools that are created when creating galaxy get the newly expected serviceAccount: 
<img width="731" alt="Screen Shot 2022-02-10 at 5 41 29 PM" src="https://user-images.githubusercontent.com/23626109/153508920-93faa31f-7fdc-4c58-ac00-d9c4e6a885a4.png">


There are two methods of interest in nodepool creation: [buildGoogleNodepool](https://github.com/DataBiosphere/leonardo/blob/develop/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala#L1219) and [buildLegacyGoodNodepool](https://github.com/DataBiosphere/leonardo/blob/develop/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala#L1253)

`buildGoogleNodepool` is called by [createAndPollNodepool](https://github.com/DataBiosphere/leonardo/blob/develop/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala#L255) for new node pools
`buildLegacyNodepool` is called when we create a k8s cluster. The reason we need to do this is because we use an older google client library to create the GKE cluster because the newer client does not offer `.setWorkloadIdentity` on a k8s cluster. So we need to pass the older Nodepool object to the create cluster request.

Both methods are used. One for cluster creation, the other for nodepool creation. So we update both methods in this PR



---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
