### PR TITLE
IA-3215 add resize2fs in GCE init script

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoApiClient.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoApiClient.scala
@@ -379,7 +379,7 @@ object LeonardoApiClient {
         )
         .use { resp =>
           if (!resp.status.isSuccess) {
-            onError(s"Failed to create disk ${googleProject.value}/${diskName.value}")(resp)
+            onError(s"Failed to patch disk ${googleProject.value}/${diskName.value}")(resp)
               .flatMap(IO.raiseError)
           } else
             IO.unit

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeCreationDiskSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeCreationDiskSpec.scala
@@ -10,7 +10,7 @@ import org.broadinstitute.dsde.workbench.google2.{streamFUntilDone, DiskName, Go
 import org.broadinstitute.dsde.workbench.leonardo.DiskModelGenerators._
 import org.broadinstitute.dsde.workbench.leonardo.LeonardoApiClient._
 import org.broadinstitute.dsde.workbench.leonardo.TestUser.{getAuthTokenAndAuthorization, Ron}
-import org.broadinstitute.dsde.workbench.leonardo.http.{PersistentDiskRequest, RuntimeConfigRequest}
+import org.broadinstitute.dsde.workbench.leonardo.http.{PersistentDiskRequest, RuntimeConfigRequest, UpdateDiskRequest}
 import org.broadinstitute.dsde.workbench.leonardo.notebooks.{NotebookTestUtils, Python3}
 import org.http4s.client.Client
 import org.http4s.Status
@@ -165,7 +165,8 @@ class RuntimeCreationDiskSpec
     val runtimeName = randomeName.copy(asString = randomeName.asString + "pd-spec") // just to make sure the test runtime name is unique
     val runtimeWithDataName = randomeName.copy(asString = randomeName.asString + "pd-spec-data-persist")
     val diskName = genDiskName.sample.get
-    val diskSize = genDiskSize.sample.get
+    val diskSize = DiskSize(110)
+    val newDiskSize = DiskSize(150)
 
     val res = dependencies.use { dep =>
       implicit val client = dep.httpClient
@@ -219,19 +220,29 @@ class RuntimeCreationDiskSpec
           }
         })
         _ <- deleteRuntimeWithWait(googleProject, runtimeName, false)
+        _ <- LeonardoApiClient.patchDisk(googleProject, diskName, UpdateDiskRequest(Map.empty, newDiskSize))
+        _ <- IO.sleep(5 seconds)
 
         // Creating new runtime with existing disk should have test.txt file and user installed package
         runtimeWithData <- createRuntimeWithWait(googleProject, runtimeWithDataName, createRuntime2Request)
         clusterCopyWithData = ClusterCopy.fromGetRuntimeResponseCopy(runtimeWithData)
         _ <- IO(withWebDriver { implicit driver =>
-          withNewNotebook(clusterCopyWithData, Python3) { notebookPage =>
-            val persistedData =
-              """! cat /home/jupyter/test.txt""".stripMargin
-            notebookPage.executeCell(persistedData).get should include("this should save")
-            val persistedPackage = "! pip show beautifulSoup4"
-            notebookPage.executeCell(persistedPackage).get should include(
-              "/home/jupyter/.local/lib/python3.7/site-packages"
-            )
+          withNewNotebook(clusterCopyWithData, Python3) {
+            notebookPage =>
+              val persistedData =
+                """! cat /home/jupyter/test.txt""".stripMargin
+              notebookPage.executeCell(persistedData).get should include("this should save")
+              val persistedPackage = "! pip show beautifulSoup4"
+              notebookPage.executeCell(persistedPackage).get should include(
+                "/home/jupyter/.local/lib/python3.7/site-packages"
+              )
+
+              val res = notebookPage
+                .executeCell(
+                  "! df -H |grep sdb"
+                )
+                .get
+              res should include("158G")
           }
         })
         _ <- deleteRuntimeWithWait(googleProject, runtimeWithDataName, deleteDisk = true)

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeCreationDiskSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeCreationDiskSpec.scala
@@ -239,7 +239,7 @@ class RuntimeCreationDiskSpec
 
               val res = notebookPage
                 .executeCell(
-                  "! df -H |grep sdb"
+                  "! df -h --output=size $HOME"
                 )
                 .get
               res should include("158G")

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeCreationDiskSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeCreationDiskSpec.scala
@@ -242,7 +242,7 @@ class RuntimeCreationDiskSpec
                   "! df -h --output=size $HOME"
                 )
                 .get
-              res should include("158G")
+              res should include("148G")
           }
         })
         _ <- deleteRuntimeWithWait(googleProject, runtimeWithDataName, deleteDisk = true)

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/diskRoutesModels.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/diskRoutesModels.scala
@@ -50,3 +50,5 @@ final case class GetPersistentDiskResponse(id: DiskId,
                                            diskType: DiskType,
                                            blockSize: BlockSize,
                                            labels: LabelMap)
+
+final case class UpdateDiskRequest(labels: LabelMap, size: DiskSize)

--- a/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/DiskRoutesTestJsonCodec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/DiskRoutesTestJsonCodec.scala
@@ -84,4 +84,9 @@ object DiskRoutesTestJsonCodec {
       labels
     )
   }
+
+  implicit val updateDiskRequestEncoder: Encoder[UpdateDiskRequest] = Encoder.forProduct2(
+    "labels",
+    "size"
+  )(x => UpdateDiskRequest.unapply(x).get)
 }

--- a/http/src/main/resources/init-resources/gce-init.sh
+++ b/http/src/main/resources/init-resources/gce-init.sh
@@ -541,3 +541,12 @@ log 'All done!'
 ELAPSED_TIME=$(($END_TIME - $START_TIME))
 log "gce-init.sh took $(display_time $ELAPSED_TIME)"
 log "Step timings: ${STEP_TIMINGS[@]}"
+
+# Resize persistent disk if needed.
+# This condition assumes Dataproc's cert directory is different from GCE's cert directory, a better condition would be
+# a dedicated flag that distinguishes gce and dataproc. But this will do for now
+# If it's GCE, we resize the PD. Dataproc doesn't have PD
+if [ -f "/var/certs/jupyter-server.crt" ]; then
+  echo "Resizing persistent disk attached to runtime $GOOGLE_PROJECT / $CLUSTER_NAME if disk size changed..."
+  resize2fs /dev/${DISK_DEVICE_ID}
+fi

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/DiskRoutes.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/DiskRoutes.scala
@@ -256,5 +256,3 @@ object DiskRoutes {
   )
 
 }
-
-final case class UpdateDiskRequest(labels: LabelMap, size: DiskSize)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/DiskService.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/DiskService.scala
@@ -4,7 +4,6 @@ package service
 import cats.mtl.Ask
 import org.broadinstitute.dsde.workbench.google2.DiskName
 import org.broadinstitute.dsde.workbench.leonardo.{AppContext, CloudContext}
-import org.broadinstitute.dsde.workbench.leonardo.http.api.UpdateDiskRequest
 import org.broadinstitute.dsde.workbench.model.UserInfo
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/DiskServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/DiskServiceInterp.scala
@@ -14,7 +14,6 @@ import org.broadinstitute.dsde.workbench.google2.DiskName
 import org.broadinstitute.dsde.workbench.leonardo.JsonCodec._
 import org.broadinstitute.dsde.workbench.leonardo.config.PersistentDiskConfig
 import org.broadinstitute.dsde.workbench.leonardo.db._
-import org.broadinstitute.dsde.workbench.leonardo.http.api.UpdateDiskRequest
 import org.broadinstitute.dsde.workbench.leonardo.http.service.DiskServiceInterp._
 import org.broadinstitute.dsde.workbench.leonardo.model.SamResourceAction._
 import org.broadinstitute.dsde.workbench.leonardo.model._

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/HttpRoutesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/HttpRoutesSpec.scala
@@ -7,9 +7,9 @@ import akka.http.scaladsl.testkit.ScalatestRouteTest
 import cats.effect.IO
 import cats.mtl.Ask
 import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
+import io.circe.Decoder
 import io.circe.parser.decode
 import io.circe.syntax._
-import io.circe.{Decoder, Encoder}
 import org.broadinstitute.dsde.workbench.google2.{DiskName, MachineTypeName, RegionName, ZoneName}
 import org.broadinstitute.dsde.workbench.leonardo.CommonTestData._
 import org.broadinstitute.dsde.workbench.leonardo.JsonCodec._
@@ -22,8 +22,8 @@ import org.broadinstitute.dsde.workbench.leonardo.http.RuntimeRoutesTestJsonCode
 import org.broadinstitute.dsde.workbench.leonardo.http.api.HttpRoutesSpec._
 import org.broadinstitute.dsde.workbench.leonardo.http.api.RuntimeRoutes._
 import org.broadinstitute.dsde.workbench.leonardo.http.service._
-import org.broadinstitute.dsde.workbench.model.{ErrorReport, ErrorReportSource}
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
+import org.broadinstitute.dsde.workbench.model.{ErrorReport, ErrorReportSource}
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -625,16 +625,6 @@ class HttpRoutesSpec
 }
 
 object HttpRoutesSpec {
-  implicit val updateDiskRequestEncoder: Encoder[UpdateDiskRequest] = Encoder.forProduct2(
-    "labels",
-    "size"
-  )(x =>
-    (
-      x.labels,
-      x.size
-    )
-  )
-
   implicit val listClusterResponseDecoder: Decoder[ListRuntimeResponse2] = Decoder.instance { x =>
     for {
       id <- x.downField("id").as[Long]

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/DiskServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/DiskServiceInterpSpec.scala
@@ -11,7 +11,6 @@ import org.broadinstitute.dsde.workbench.google2.{DiskName, MachineTypeName, Zon
 import org.broadinstitute.dsde.workbench.leonardo.CommonTestData._
 import org.broadinstitute.dsde.workbench.leonardo.SamResourceId.PersistentDiskSamResourceId
 import org.broadinstitute.dsde.workbench.leonardo.db._
-import org.broadinstitute.dsde.workbench.leonardo.http.api.UpdateDiskRequest
 import org.broadinstitute.dsde.workbench.leonardo.model.ForbiddenError
 import org.broadinstitute.dsde.workbench.leonardo.monitor.LeoPubsubMessage._
 import org.broadinstitute.dsde.workbench.leonardo.util.QueueFactory

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/MockDiskServiceInterp.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/MockDiskServiceInterp.scala
@@ -5,9 +5,6 @@ package service
 import cats.effect.IO
 import cats.mtl.Ask
 import org.broadinstitute.dsde.workbench.google2.DiskName
-import org.broadinstitute.dsde.workbench.leonardo.http.CreateDiskRequest
-import org.broadinstitute.dsde.workbench.leonardo.http.api.{UpdateDiskRequest}
-import org.broadinstitute.dsde.workbench.leonardo.http.{GetPersistentDiskResponse, ListPersistentDiskResponse}
 import org.broadinstitute.dsde.workbench.model.UserInfo
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-3215

In AoU, UI allows users to update size of an existing disk, while also enabling GPU.
![image](https://user-images.githubusercontent.com/32771737/153666854-a6567812-f79e-421c-9390-72d3e91f3c13.png)

In this flow, AoU will need
1. call updateDisk API to increase disk size
2. Delete old VM, and recreate a new VM with GPU

In this flow, resize2fs needs to be called when during VM creation. `resize2fs` is pretty low cost cmd, so running it regardless should be fine.

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
