### PR TITLE
IA-3219 Fix GPU enabled runtime start up issue

### DIFF
--- a/http/src/main/resources/init-resources/startup.sh
+++ b/http/src/main/resources/init-resources/startup.sh
@@ -119,12 +119,6 @@ then
 
     # (1/6/22) Restart Jupyter Container to reset `NOTEBOOKS_DIR` for existing runtimes. This code can probably be removed after a year
     if [ ! -z "$JUPYTER_DOCKER_IMAGE" ] ; then
-#        # Loop to wait for jupyter container to come up; This is only needed when it's a GPU enabled VM in reality
-#        until [ "`docker inspect -f {{.State.Running}} $JUPYTER_SERVER_NAME`"=="true" ]; do
-#            echo "Waiting for jupyter-server to come up"
-#            sleep 0.1;
-#        done;
-
         echo "Restarting Jupyter Container $GOOGLE_PROJECT / $CLUSTER_NAME..."
 
         # This line is only for migration (1/26/2022). Say you have an existing runtime where jupyter container's PD is mapped at $HOME/notebooks,

--- a/http/src/main/resources/init-resources/startup.sh
+++ b/http/src/main/resources/init-resources/startup.sh
@@ -85,7 +85,6 @@ FILE=/var/certs/jupyter-server.crt
 USER_DISK_DEVICE_ID=$(lsblk -o name,serial | grep 'user-disk' | awk '{print $1}')
 DISK_DEVICE_ID=${USER_DISK_DEVICE_ID:-sdb}
 
-# Make this run conditionally
 if [ "${GPU_ENABLED}" == "true" ] ; then
   log 'Installing GPU driver...'
   cos-extensions install gpu

--- a/http/src/main/resources/init-resources/startup.sh
+++ b/http/src/main/resources/init-resources/startup.sh
@@ -108,6 +108,10 @@ then
     if [ ! -z "$JUPYTER_DOCKER_IMAGE" ] ; then
         echo "Restarting Jupyter Container $GOOGLE_PROJECT / $CLUSTER_NAME..."
 
+        # Loop to wait for jupyter container to come up; This is only needed when it's a GPU enabled VM in reality
+        until [ "`docker inspect -f {{.State.Running}} $JUPYTER_SERVER_NAME`"=="true" ]; do
+            sleep 0.1;
+        done;
         # This line is only for migration (1/26/2022). Say you have an existing runtime where jupyter container's PD is mapped at $HOME/notebooks,
         # then all jupyter related files (.jupyter, .local) and things like bash history etc all lives under $HOME. The home diretory change will
         # make it so that next time this runtime starts up, PD will be mapped to $HOME, but this means that the previous files under $HOME (.jupyter, .local etc)


### PR DESCRIPTION
The bug is that in startup script, we assume jupyter container is already up and running, which is usually the case. But for GPU, jupyter container will fail to start up until certain volumes are mounted, hence we need to move that code up before we do anything with jupyter container

Tested manually in fiab

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
