### PR TITLE
IA-3217 set network tags for GKE nodes

### DIFF
--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
@@ -803,6 +803,7 @@ object Config {
 
   val gkeInterpConfig =
     GKEInterpreterConfig(
+      vpcConfig.networkTag,
       org.broadinstitute.dsde.workbench.leonardo.http.ConfigReader.appConfig.terraAppSetupChart,
       gkeIngressConfig,
       gkeGalaxyAppConfig,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
@@ -1277,7 +1277,7 @@ class GKEInterpreter[F[_]](
         nodepoolBuilder.setConfig(
           NodeConfig
             .newBuilder()
-            .setTags(0, config.vpcNetworkTag.value)
+            .addTags(config.vpcNetworkTag.value)
             .setMachineType(nodepool.machineType.value)
             .setServiceAccount(sa)
         )
@@ -1286,7 +1286,7 @@ class GKEInterpreter[F[_]](
           NodeConfig
             .newBuilder()
             .setMachineType(nodepool.machineType.value)
-            .setTags(0, config.vpcNetworkTag.value)
+            .addTags(config.vpcNetworkTag.value)
         )
     }
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
@@ -32,6 +32,7 @@ import org.broadinstitute.dsde.workbench.google2.{
   PvName,
   ZoneName
 }
+import org.broadinstitute.dsde.workbench.leonardo.AppRestore.{CromwellRestore, GalaxyRestore}
 import org.broadinstitute.dsde.workbench.leonardo.config._
 import org.broadinstitute.dsde.workbench.leonardo.dao.{AppDAO, AppDescriptorDAO, CustomAppService}
 import org.broadinstitute.dsde.workbench.leonardo.db._
@@ -46,8 +47,6 @@ import org.broadinstitute.dsp._
 import org.http4s.Uri
 
 import java.util.Base64
-import org.broadinstitute.dsde.workbench.leonardo.AppRestore.{CromwellRestore, GalaxyRestore}
-
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 import scala.jdk.CollectionConverters._
@@ -1313,7 +1312,6 @@ class GKEInterpreter[F[_]](
     googleProject: GoogleProject,
     projectLabels: Option[Map[String, String]]
   ): com.google.api.services.container.model.NodePool = {
-    import com.google.api.services.container.model.NodeConfig
     import scala.jdk.CollectionConverters._
     val serviceAccount = getNodepoolServiceAccount(projectLabels, googleProject)
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
@@ -46,7 +46,6 @@ import org.broadinstitute.dsp._
 import org.http4s.Uri
 
 import java.util.Base64
-
 import org.broadinstitute.dsde.workbench.leonardo.AppRestore.{CromwellRestore, GalaxyRestore}
 
 import scala.concurrent.ExecutionContext
@@ -1279,6 +1278,7 @@ class GKEInterpreter[F[_]](
         nodepoolBuilder.setConfig(
           NodeConfig
             .newBuilder()
+            .setTags(0, config.vpcNetworkTag.value)
             .setMachineType(nodepool.machineType.value)
             .setServiceAccount(sa)
         )
@@ -1287,6 +1287,7 @@ class GKEInterpreter[F[_]](
           NodeConfig
             .newBuilder()
             .setMachineType(nodepool.machineType.value)
+            .setTags(0, config.vpcNetworkTag.value)
         )
     }
 
@@ -1312,6 +1313,8 @@ class GKEInterpreter[F[_]](
     googleProject: GoogleProject,
     projectLabels: Option[Map[String, String]]
   ): com.google.api.services.container.model.NodePool = {
+    import com.google.api.services.container.model.NodeConfig
+    import scala.jdk.CollectionConverters._
     val serviceAccount = getNodepoolServiceAccount(projectLabels, googleProject)
 
     val legacyGoogleNodepool = new com.google.api.services.container.model.NodePool()
@@ -1326,12 +1329,14 @@ class GKEInterpreter[F[_]](
         legacyGoogleNodepool.setConfig(
           new com.google.api.services.container.model.NodeConfig()
             .setMachineType(nodepool.machineType.value)
+            .setTags(List(config.vpcNetworkTag.value).asJava)
             .setServiceAccount(sa)
         )
       case _ =>
         legacyGoogleNodepool.setConfig(
           new com.google.api.services.container.model.NodeConfig()
             .setMachineType(nodepool.machineType.value)
+            .setTags(List(config.vpcNetworkTag.value).asJava)
         )
     }
 
@@ -1630,7 +1635,8 @@ final case class DeleteNodepoolResult(nodepoolId: NodepoolLeoId,
                                       getAppResult: GetAppResult
 )
 
-final case class GKEInterpreterConfig(terraAppSetupChartConfig: TerraAppSetupChartConfig,
+final case class GKEInterpreterConfig(vpcNetworkTag: NetworkTag,
+                                      terraAppSetupChartConfig: TerraAppSetupChartConfig,
                                       ingressConfig: KubernetesIngressConfig,
                                       galaxyAppConfig: GalaxyAppConfig,
                                       cromwellAppConfig: CromwellAppConfig,


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-3217

Tested on fiab. See network tags for GKE nodes:
<img width="583" alt="Screen Shot 2022-06-21 at 1 27 44 PM" src="https://user-images.githubusercontent.com/32771737/174861421-b68fe69f-3279-44aa-9d46-987bab751a49.png">


---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
