### PR TITLE
[IA-2967] Adding autopauseEnabled value to runtime

### DIFF
--- a/http/src/main/resources/swagger/api-docs.yaml
+++ b/http/src/main/resources/swagger/api-docs.yaml
@@ -2404,8 +2404,8 @@ components:
         autopause:
           type: boolean
           description: Whether autopause feature is enabled for this specific cluster. If
-            unset, autopause will be enabled and the threshold value will be set to the one 
-            specified or a system default if unset.
+            unset, autopause will be enabled and the threshold value will be set to either the autopauseThreshold value
+            or the system default if autopauseThreshold is also unset.
         autopauseThreshold:
           type: integer
           description: The number of minutes of idle time to elapse before the cluster is

--- a/http/src/main/resources/swagger/api-docs.yaml
+++ b/http/src/main/resources/swagger/api-docs.yaml
@@ -2404,8 +2404,8 @@ components:
         autopause:
           type: boolean
           description: Whether autopause feature is enabled for this specific cluster. If
-            unset, autopause will be enabled and a system default threshold will
-            be used.
+            unset, autopause will be enabled and the threshold value will be set to the one 
+            specified or a system default if unset.
         autopauseThreshold:
           type: integer
           description: The number of minutes of idle time to elapse before the cluster is

--- a/http/src/main/resources/swagger/api-docs.yaml
+++ b/http/src/main/resources/swagger/api-docs.yaml
@@ -4,7 +4,7 @@ info:
   description: |
     Workbench notebooks service.
   # Follow semantic versioning https://semver.org/
-  version: "1.3.2"
+  version: "1.3.3"
   license:
     name: BSD
     url: http://opensource.org/licenses/BSD-3-Clause

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterp.scala
@@ -1014,12 +1014,13 @@ object RuntimeServiceInterp {
                                                    autoFreezeConfig: AutoFreezeConfig): Int =
     autopause match {
       case None =>
-        autoFreezeConfig.autoFreezeAfter.toMinutes.toInt
+        if (autopauseThreshold.isEmpty) autoFreezeConfig.autoFreezeAfter.toMinutes.toInt
+        else autopauseThreshold.get
       case Some(false) =>
         autoPauseOffValue
       case _ =>
         if (autopauseThreshold.isEmpty) autoFreezeConfig.autoFreezeAfter.toMinutes.toInt
-        else Math.max(autoPauseOffValue, autopauseThreshold.get)
+        else autopauseThreshold.get
     }
 }
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterp.scala
@@ -1013,14 +1013,13 @@ object RuntimeServiceInterp {
                                                    autopauseThreshold: Option[Int],
                                                    autoFreezeConfig: AutoFreezeConfig): Int =
     autopause match {
-      case None =>
-        if (autopauseThreshold.isEmpty) autoFreezeConfig.autoFreezeAfter.toMinutes.toInt
-        else autopauseThreshold.get
       case Some(false) =>
         autoPauseOffValue
       case _ =>
-        if (autopauseThreshold.isEmpty) autoFreezeConfig.autoFreezeAfter.toMinutes.toInt
-        else autopauseThreshold.get
+        autopauseThreshold match {
+          case Some(v) => v
+          case None    => autoFreezeConfig.autoFreezeAfter.toMinutes.toInt
+        }
     }
 }
 


### PR DESCRIPTION
RELATED TO: https://github.com/DataBiosphere/terra-ui/pull/2815

- Changed logic in calculateAutopauseThreshold to accommodate no autopauseEnabled value being passed in on update

Testing:
- Ran tests locally
- Tested manually through the UI and checked corresponding database values for validity
- See https://github.com/DataBiosphere/terra-ui/pull/2815 for other testing there

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
