### PR TITLE
IA-3223 PROD-641 fix OOM issue

### DIFF
--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/AutopauseMonitor.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/AutopauseMonitor.scala
@@ -14,6 +14,7 @@ import org.broadinstitute.dsde.workbench.leonardo.http.dbioToIO
 import org.broadinstitute.dsde.workbench.model.TraceId
 import org.broadinstitute.dsde.workbench.openTelemetry.OpenTelemetryMetrics
 
+import java.time.Instant
 import scala.concurrent.ExecutionContext
 
 /**
@@ -95,4 +96,11 @@ object AutopauseMonitor {
     ec: ExecutionContext
   ): AutopauseMonitor[F] =
     new AutopauseMonitor(config, jupyterDAO, publisherQueue)
+}
+
+final case class RuntimeToAutoPause(id: Long,
+                                    runtimeName: RuntimeName,
+                                    cloudContext: CloudContext,
+                                    kernelFoundBusyDate: Option[Instant]) {
+  def projectNameString: String = s"${cloudContext.asStringWithProvider}/${runtimeName.asString}"
 }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponentSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponentSpec.scala
@@ -199,12 +199,12 @@ class ClusterComponentSpec extends AnyFlatSpecLike with TestComponent with GcsPa
             autopauseThreshold = 0)
       .save()
 
-    val autoFreezeList = dbFutureValue(clusterQuery.getClustersReadyToAutoFreeze)
-    autoFreezeList should contain(runningCluster1)
+    val autoFreezeList = dbFutureValue(clusterQuery.getClustersReadyToAutoFreeze).map(_.id)
+    autoFreezeList should contain(runningCluster1.id)
     //cluster2 is already stopped
-    autoFreezeList should not contain stoppedCluster
-    autoFreezeList should not contain runningCluster2
-    autoFreezeList should not contain autopauseDisabledCluster
+    autoFreezeList should not contain stoppedCluster.id
+    autoFreezeList should not contain runningCluster2.id
+    autoFreezeList should not contain autopauseDisabledCluster.id
   }
 
   it should "get for dns cache" in isolatedDbTest {


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-3223

The theory is that when there's a large dataproc cluster running, autopause is retrieving the candiate runtimes to pause periodically and this query today joins many tables including `INSTANCE` table, which for large dataproc clusters, it'll be quite ineffcient since there will be many instances for that cluster.

The change is instead of using the query that combines all tables, we're just querying one table to get the exact info we need for autopause process

Huge thanks to @rtitle for identifying the query

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
