### PR TITLE
IA-3223 more getting rid of fullClusterQuery

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/runtimeModels.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/runtimeModels.scala
@@ -7,7 +7,6 @@ import enumeratum.{Enum, EnumEntry}
 import monocle.Prism
 import org.broadinstitute.dsde.workbench.leonardo.SamResourceId._
 import org.broadinstitute.dsde.workbench.google2.{MachineTypeName, OperationName, RegionName, ZoneName}
-import org.broadinstitute.dsde.workbench.google2.DataprocRole.SecondaryWorker
 import org.broadinstitute.dsde.workbench.leonardo.RuntimeContainerServiceType.JupyterService
 import org.broadinstitute.dsde.workbench.leonardo.RuntimeImageType.{BootSource, Jupyter, RStudio, Welder}
 import org.broadinstitute.dsde.workbench.model.google.{parseGcsPath, GcsBucketName, GcsPath, GoogleProject}
@@ -33,7 +32,6 @@ final case class Runtime(id: Long,
                          userScriptUri: Option[UserScriptPath],
                          startUserScriptUri: Option[UserScriptPath],
                          errors: List[RuntimeError],
-                         dataprocInstances: Set[DataprocInstance],
                          userJupyterExtensionConfig: Option[UserJupyterExtensionConfig],
                          autopauseThreshold: Int,
                          defaultClientId: Option[String],
@@ -45,7 +43,6 @@ final case class Runtime(id: Long,
                          runtimeConfigId: RuntimeConfigId,
                          patchInProgress: Boolean) {
   def projectNameString: String = s"${cloudContext.asStringWithProvider}/${runtimeName.asString}"
-  def nonPreemptibleInstances: Set[DataprocInstance] = dataprocInstances.filterNot(_.dataprocRole == SecondaryWorker)
 }
 
 object Runtime {

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponent.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponent.scala
@@ -345,7 +345,7 @@ object clusterQuery extends TableQuery(new ClusterTable(_)) {
       .on(_._1.id === _.clusterId)
       .result map { recs =>
       recs.map { rec =>
-        val asyncFileds = (rec._1._1.googleId, rec._1._1.operationName, rec._1._1.stagingBucket).mapN {
+        val asyncFields = (rec._1._1.googleId, rec._1._1.operationName, rec._1._1.stagingBucket).mapN {
           (googleId, operationName, stagingBucket) =>
             AsyncRuntimeFields(googleId,
                                OperationName(operationName),
@@ -360,7 +360,7 @@ object clusterQuery extends TableQuery(new ClusterTable(_)) {
           rec._2.map(_.inProgress).getOrElse(false),
           rec._1._2.runtimeConfig,
           rec._1._1.serviceAccountInfo,
-          asyncFileds,
+          asyncFields,
           rec._1._1.auditInfo,
           rec._1._1.userScriptUri,
           rec._1._1.startUserScriptUri,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponent.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponent.scala
@@ -379,7 +379,7 @@ object clusterQuery extends TableQuery(new ClusterTable(_)) {
       extention <- extensionQuery.getAllForCluster(runtimeId)
       images <- clusterImageQuery.getAllImagesForCluster(runtimeId)
       scopes <- scopeQuery.getAllForCluster(runtimeId)
-    } yield ExtraInfoForCreateRuntime(images.toSet, Some(extention), scopes)
+    } yield ExtraInfoForCreateRuntime(images.toSet, extention, scopes)
 
   def listRunningOnly(implicit ec: ExecutionContext): DBIO[Seq[RunningRuntime]] =
     clusterJoinClusterImageQuery.filter(_._1.status === (RuntimeStatus.Running: RuntimeStatus)).result map {

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterImageComponent.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterImageComponent.scala
@@ -65,6 +65,12 @@ object clusterImageQuery extends TableQuery(new ClusterImageTable(_)) {
       .result
       .map(_.map(_.imageType))
 
+  def getAllImagesForCluster(clusterId: Long)(implicit ec: ExecutionContext): DBIO[Seq[RuntimeImage]] =
+    clusterImageQuery
+      .filter(_.clusterId === clusterId)
+      .result
+      .map(_.map(x => unmarshalClusterImage(x)))
+
   def marshallClusterImage(clusterId: Long, clusterImage: RuntimeImage): ClusterImageRecord =
     ClusterImageRecord(
       clusterId,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/ExtensionComponent.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/ExtensionComponent.scala
@@ -34,7 +34,7 @@ object extensionQuery extends TableQuery(new ExtensionTable(_)) {
       case None      => DBIO.successful(0)
     }
 
-  def getAllForCluster(clusterId: Long)(implicit ec: ExecutionContext): DBIO[UserJupyterExtensionConfig] =
+  def getAllForCluster(clusterId: Long)(implicit ec: ExecutionContext): DBIO[Option[UserJupyterExtensionConfig]] =
     extensionQuery.filter {
       _.clusterId === clusterId
     }.result map { recs =>
@@ -48,7 +48,11 @@ object extensionQuery extends TableQuery(new ExtensionTable(_)) {
       }).toMap
       val labExtensions =
         (recs.filter(_.extensionType == ExtensionType.LabExtension.toString) map { rec => rec.name -> rec.value }).toMap
-      UserJupyterExtensionConfig(nbExtensions, serverExtensions, combinedExtensions, labExtensions)
+
+      if (nbExtensions.isEmpty && serverExtensions.isEmpty && combinedExtensions.isEmpty && labExtensions.isEmpty)
+        None
+      else
+        Some(UserJupyterExtensionConfig(nbExtensions, serverExtensions, combinedExtensions, labExtensions))
     }
 
   def marshallExtensions(clusterId: Long,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterp.scala
@@ -201,7 +201,11 @@ class RuntimeServiceInterp[F[_]: Parallel](config: RuntimeServiceConfig,
               }
             _ <- context.span.traverse(s => F.delay(s.addAnnotation("Done Sam notifyClusterCreated")))
             runtimeConfigToSave = LeoLenses.runtimeConfigPrism.reverseGet(runtimeConfig)
-            saveRuntime = SaveCluster(cluster = runtime, runtimeConfig = runtimeConfigToSave, now = context.now)
+            saveRuntime = SaveCluster(
+              cluster = runtime,
+              runtimeConfig = runtimeConfigToSave,
+              now = context.now
+            )
             runtime <- clusterQuery.save(saveRuntime).transaction
             _ <- publisherQueue.offer(
               CreateRuntimeMessage.fromRuntime(runtime, runtimeConfig, Some(context.traceId))
@@ -893,7 +897,6 @@ object RuntimeServiceInterp {
       userScriptUri = req.userScriptUri,
       startUserScriptUri = req.startUserScriptUri,
       errors = List.empty,
-      dataprocInstances = Set.empty,
       userJupyterExtensionConfig = req.userJupyterExtensionConfig,
       autopauseThreshold = autopauseThreshold,
       defaultClientId = req.defaultClientId,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/DataprocRuntimeMonitor.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/DataprocRuntimeMonitor.scala
@@ -473,10 +473,6 @@ class DataprocRuntimeMonitor[F[_]: Parallel](
                                          config.runtimeBucketConfig.stagingBucketExpiration)
 
           _ <- dbRef.inTransaction {
-            clusterQuery.mergeInstances(runtimeAndRuntimeConfig.runtime)
-          }.void //TODO: confirm this is reasonable
-
-          _ <- dbRef.inTransaction {
             clusterQuery.completeDeletion(runtimeAndRuntimeConfig.runtime.id, ctx.now)
           }
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/MonitorAtBoot.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/MonitorAtBoot.scala
@@ -214,7 +214,7 @@ class MonitorAtBoot[F[_]](publisherQueue: Queue[F, LeoPubsubMessage], computeSer
           case x: RuntimeConfig.GceConfig =>
             for {
               bootDiskSize <- x.bootDiskSize.toRight(
-                s"disk Size field not found for ${runtime.id}. This should never happen"
+                s"Disk Size field not found for ${runtime.id}. This should never happen"
               )
             } yield RuntimeConfigInCreateRuntimeMessage.GceConfig(
               x.machineType,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/MonitorAtBoot.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/MonitorAtBoot.scala
@@ -11,7 +11,7 @@ import org.broadinstitute.dsde.workbench.leonardo.db._
 import org.broadinstitute.dsde.workbench.leonardo.http._
 import org.broadinstitute.dsde.workbench.leonardo.model.LeoException
 import org.broadinstitute.dsde.workbench.leonardo.monitor.LeoPubsubMessage.{CreateAppMessage, DeleteAppMessage}
-import org.broadinstitute.dsde.workbench.model.TraceId
+import org.broadinstitute.dsde.workbench.model.{TraceId, WorkbenchEmail}
 import org.broadinstitute.dsde.workbench.openTelemetry.OpenTelemetryMetrics
 import org.typelevel.log4cats.Logger
 
@@ -210,46 +210,56 @@ class MonitorAtBoot[F[_]](publisherQueue: Queue[F, LeoPubsubMessage], computeSer
           )
         )
       case RuntimeStatus.Creating =>
-        for {
-          fullRuntime <- clusterQuery.getClusterById(runtime.id).transaction
-          rt <- F.fromOption(fullRuntime, new Exception(s"can't find ${runtime.id} in DB"))
-          rtConfig <- RuntimeConfigQueries.getRuntimeConfig(rt.runtimeConfigId).transaction
-          r = rtConfig match {
-            case x: RuntimeConfig.GceConfig =>
-              for {
-                bootDiskSize <- x.bootDiskSize.toRight(
-                  s"disk Size field not found for ${rt.id}. This should never happen"
-                )
-              } yield RuntimeConfigInCreateRuntimeMessage.GceConfig(
-                x.machineType,
-                x.diskSize,
-                bootDiskSize,
-                x.zone,
-                x.gpuConfig
-              ): RuntimeConfigInCreateRuntimeMessage
-            case x: RuntimeConfig.GceWithPdConfig =>
-              for {
-                diskId <- x.persistentDiskId.toRight(
-                  s"disk id field not found for ${rt.id}. This should never happen"
-                )
-              } yield RuntimeConfigInCreateRuntimeMessage.GceWithPdConfig(
-                x.machineType,
-                diskId,
-                x.bootDiskSize,
-                x.zone,
-                x.gpuConfig
-              ): RuntimeConfigInCreateRuntimeMessage
-            case _: RuntimeConfig.DataprocConfig =>
-              Right(
-                LeoLenses.runtimeConfigPrism.getOption(rtConfig).get: RuntimeConfigInCreateRuntimeMessage
+        val message: Either[String, RuntimeConfigInCreateRuntimeMessage] = runtime.runtimeConfig match {
+          case x: RuntimeConfig.GceConfig =>
+            for {
+              bootDiskSize <- x.bootDiskSize.toRight(
+                s"disk Size field not found for ${runtime.id}. This should never happen"
               )
-            case _: RuntimeConfig.AzureVmConfig =>
-              throw AzureUnimplementedException("Azure are not yet handled with existing monitor at boot code")
-          }
-          rtConfigInMessage <- F.fromEither(r.leftMap(s => MonitorAtBootException(s, traceId)))
+            } yield RuntimeConfigInCreateRuntimeMessage.GceConfig(
+              x.machineType,
+              x.diskSize,
+              bootDiskSize,
+              x.zone,
+              x.gpuConfig
+            ): RuntimeConfigInCreateRuntimeMessage
+          case x: RuntimeConfig.GceWithPdConfig =>
+            for {
+              diskId <- x.persistentDiskId.toRight(
+                s"disk id field not found for ${runtime.id}. This should never happen"
+              )
+            } yield RuntimeConfigInCreateRuntimeMessage.GceWithPdConfig(
+              x.machineType,
+              diskId,
+              x.bootDiskSize,
+              x.zone,
+              x.gpuConfig
+            ): RuntimeConfigInCreateRuntimeMessage
+          case _: RuntimeConfig.DataprocConfig =>
+            Right(
+              LeoLenses.runtimeConfigPrism.getOption(runtime.runtimeConfig).get: RuntimeConfigInCreateRuntimeMessage
+            )
+          case _: RuntimeConfig.AzureVmConfig =>
+            "Azure are not yet handled with existing monitor at boot code".asLeft[RuntimeConfigInCreateRuntimeMessage]
+        }
+        for {
+          rtConfigInMessage <- F.fromEither(message.leftMap(s => MonitorAtBootException(s, traceId)))
+          extra <- clusterQuery.getExtraInfo(runtime.id).transaction
         } yield {
-          LeoPubsubMessage.CreateRuntimeMessage.fromRuntime(
-            rt,
+          LeoPubsubMessage.CreateRuntimeMessage(
+            runtime.id,
+            RuntimeProjectAndName(runtime.cloudContext, runtime.runtimeName),
+            runtime.serviceAccount,
+            runtime.asyncRuntimeFields,
+            runtime.auditInfo,
+            runtime.userScriptUri,
+            runtime.startUserScriptUri,
+            extra.userJupyterExtensionConfig,
+            runtime.defaultClientId,
+            extra.runtimeImages,
+            extra.scopes,
+            runtime.welderEnabled,
+            runtime.customEnvironmentVariables,
             rtConfigInMessage,
             Some(traceId)
           )
@@ -260,10 +270,24 @@ class MonitorAtBoot[F[_]](publisherQueue: Queue[F, LeoPubsubMessage], computeSer
 
 final case class RuntimeToMonitor(
   id: Long,
-  cloudService: CloudService,
+  cloudContext: CloudContext,
+  runtimeName: RuntimeName,
   status: RuntimeStatus,
-  patchInProgress: Boolean
+  patchInProgress: Boolean,
+  runtimeConfig: RuntimeConfig,
+  serviceAccount: WorkbenchEmail,
+  asyncRuntimeFields: Option[AsyncRuntimeFields],
+  auditInfo: AuditInfo,
+  userScriptUri: Option[UserScriptPath],
+  startUserScriptUri: Option[UserScriptPath],
+  defaultClientId: Option[String],
+  welderEnabled: Boolean,
+  customEnvironmentVariables: Map[String, String]
 )
+
+final case class ExtraInfoForCreateRuntime(runtimeImages: Set[RuntimeImage],
+                                           userJupyterExtensionConfig: Option[UserJupyterExtensionConfig],
+                                           scopes: Set[String])
 
 final case class MonitorAtBootException(msg: String, traceId: TraceId)
     extends Exception(s"MonitorAtBoot: $msg | trace id: ${traceId.asString}")

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/RuntimeAlgebra.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/RuntimeAlgebra.scala
@@ -78,7 +78,8 @@ object BootSource {
 final case class CreateGoogleRuntimeResponse(asyncRuntimeFields: AsyncRuntimeFields,
                                              initBucket: GcsBucketName,
                                              bootSource: BootSource)
-final case class DeleteRuntimeParams(runtimeAndRuntimeConfig: RuntimeAndRuntimeConfig)
+final case class DeleteRuntimeParams(runtimeAndRuntimeConfig: RuntimeAndRuntimeConfig,
+                                     masterInstance: Option[DataprocInstance])
 final case class FinalizeDeleteParams(runtime: Runtime)
 final case class StopRuntimeParams(runtimeAndRuntimeConfig: RuntimeAndRuntimeConfig,
                                    now: Instant,

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/CommonTestData.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/CommonTestData.scala
@@ -281,7 +281,6 @@ object CommonTestData {
       userScriptUri = None,
       startUserScriptUri = None,
       errors = List.empty,
-      dataprocInstances = Set.empty,
       userJupyterExtensionConfig = None,
       autopauseThreshold = 30,
       defaultClientId = Some("defaultClientId"),
@@ -312,7 +311,6 @@ object CommonTestData {
     userScriptUri = Some(UserScriptPath.Gcs(GcsPath(GcsBucketName("bucket-name"), GcsObjectName("userScript")))),
     startUserScriptUri = Some(UserScriptPath.Gcs(GcsPath(GcsBucketName("bucket-name"), GcsObjectName("startScript")))),
     errors = List.empty,
-    dataprocInstances = Set.empty,
     userJupyterExtensionConfig =
       Some(UserJupyterExtensionConfig(nbExtensions = Map("notebookExtension" -> "gs://bucket-name/extension"))),
     autopauseThreshold = if (autopause) autopauseThreshold else 0,

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/TestUtils.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/TestUtils.scala
@@ -204,11 +204,7 @@ object TestUtils extends Matchers {
   }
 
   def stripFieldsForListCluster: Runtime => Runtime = { cluster =>
-    cluster.copy(errors = List.empty,
-                 dataprocInstances = Set.empty,
-                 userJupyterExtensionConfig = None,
-                 runtimeImages = Set.empty,
-                 scopes = Set.empty)
+    cluster.copy(errors = List.empty, userJupyterExtensionConfig = None, runtimeImages = Set.empty, scopes = Set.empty)
   }
 
   def sslContext(implicit as: ActorSystem): SSLContext =

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/ExtensionComponentSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/ExtensionComponentSpec.scala
@@ -18,15 +18,13 @@ class ExtensionComponentSpec extends AnyFlatSpecLike with TestComponent with Gcs
     val savedCluster2 = makeCluster(2).save()
 
     val missingId = Random.nextLong()
-    dbFutureValue(extensionQuery.getAllForCluster(missingId)) shouldEqual UserJupyterExtensionConfig(Map(),
-                                                                                                     Map(),
-                                                                                                     Map())
+    dbFutureValue(extensionQuery.getAllForCluster(missingId)) shouldEqual None
     dbFailure(extensionQuery.save(missingId, ExtensionType.NBExtension.toString, "extName", "extValue")) shouldBe a[
       SQLException
     ]
 
     dbFutureValue(extensionQuery.saveAllForCluster(savedCluster1.id, Some(userExtConfig)))
-    dbFutureValue(extensionQuery.getAllForCluster(savedCluster1.id)) shouldEqual userExtConfig
+    dbFutureValue(extensionQuery.getAllForCluster(savedCluster1.id)) shouldEqual Some(userExtConfig)
 
     dbFutureValue(extensionQuery.save(savedCluster2.id, ExtensionType.NBExtension.toString, "extName", "extValue")) shouldBe 1
   }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/TestComponent.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/TestComponent.scala
@@ -95,10 +95,43 @@ trait TestComponent extends LeonardoTestSuite with ScalaFutures with GcsPathUtil
   protected def getClusterId(getClusterIdRequest: GetClusterKey): Long =
     getClusterId(getClusterIdRequest.cloudContext, getClusterIdRequest.clusterName, getClusterIdRequest.destroyedDate)
 
+  private def getIdByUniqueKey(
+    cloudContext: CloudContext,
+    clusterName: RuntimeName,
+    destroyedDateOpt: Option[Instant]
+  ): DBIO[Option[Long]] =
+    getClusterByUniqueKey(cloudContext, clusterName, destroyedDateOpt).map(_.map(_.id))
+
+  private[leonardo] def getClusterByUniqueKey(
+    cloudContext: CloudContext,
+    clusterName: RuntimeName,
+    destroyedDateOpt: Option[Instant]
+  ): DBIO[Option[Runtime]] = {
+    import org.broadinstitute.dsde.workbench.leonardo.db.LeoProfile.api._
+    fullClusterQueryByUniqueKey(cloudContext, clusterName, destroyedDateOpt).result map { recs =>
+      clusterQuery.unmarshalFullCluster(recs).headOption
+    }
+  }
+
+  def fullClusterQueryByUniqueKey(cloudContext: CloudContext,
+                                  clusterName: RuntimeName,
+                                  destroyedDateOpt: Option[Instant]) = {
+    import org.broadinstitute.dsde.workbench.leonardo.db.LeoProfile.mappedColumnImplicits._
+    import org.broadinstitute.dsde.workbench.leonardo.db.LeoProfile.api._
+
+    val destroyedDate = destroyedDateOpt.getOrElse(dummyDate)
+    val baseQuery = clusterQuery
+      .filter(_.cloudContextDb === cloudContext.asCloudContextDb)
+      .filter(_.runtimeName === clusterName)
+      .filter(_.destroyedDate === destroyedDate)
+
+    clusterQuery.fullClusterQuery(baseQuery)
+  }
+
   protected def getClusterId(cloudContext: CloudContext,
                              clusterName: RuntimeName,
                              destroyedDateOpt: Option[Instant]): Long =
-    dbFutureValue(clusterQuery.getIdByUniqueKey(cloudContext, clusterName, destroyedDateOpt)).get
+    dbFutureValue(getIdByUniqueKey(cloudContext, clusterName, destroyedDateOpt)).get
 
   implicit class ClusterExtensions(cluster: Runtime) {
     def save(serviceAccountKeyId: Option[ServiceAccountKeyId] = Some(defaultServiceAccountKeyId)): Runtime =

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterpSpec.scala
@@ -260,7 +260,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
           request
         )
         .attempt
-      runtime <- clusterQuery.getActiveClusterByName(cloudContext, runtimeName).transaction
+      runtime <- clusterQuery.getActiveClusterByNameMinimal(cloudContext, runtimeName).transaction
       _ <- publisherQueue.take //dequeue the message so that it doesn't affect other tests
     } yield {
       r shouldBe Right(())
@@ -440,18 +440,18 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
         .attempt
 
       runtimeOpt1 <- clusterQuery
-        .getActiveClusterByName(cloudContext, runtimeName1)(scala.concurrent.ExecutionContext.global)
+        .getActiveClusterByNameMinimal(cloudContext, runtimeName1)(scala.concurrent.ExecutionContext.global)
         .transaction
       runtime1 = runtimeOpt1.get
       welder1 = runtime1.runtimeImages.filter(_.imageType == RuntimeImageType.Welder).headOption
       _ <- publisherQueue.take
 
-      runtimeOpt2 <- clusterQuery.getActiveClusterByName(cloudContext, runtimeName2).transaction
+      runtimeOpt2 <- clusterQuery.getActiveClusterByNameMinimal(cloudContext, runtimeName2).transaction
       runtime2 = runtimeOpt2.get
       welder2 = runtime2.runtimeImages.filter(_.imageType == RuntimeImageType.Welder).headOption
       _ <- publisherQueue.take
 
-      runtimeOpt3 <- clusterQuery.getActiveClusterByName(cloudContext, runtimeName3).transaction
+      runtimeOpt3 <- clusterQuery.getActiveClusterByNameMinimal(cloudContext, runtimeName3).transaction
       runtime3 = runtimeOpt3.get
       welder3 = runtime3.runtimeImages.filter(_.imageType == RuntimeImageType.Welder).headOption
       _ <- publisherQueue.take
@@ -500,13 +500,13 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
         .attempt
 
       runtimeOpt1 <- clusterQuery
-        .getActiveClusterByName(cloudContext, runtimeName1)(scala.concurrent.ExecutionContext.global)
+        .getActiveClusterByNameMinimal(cloudContext, runtimeName1)(scala.concurrent.ExecutionContext.global)
         .transaction
       runtime1 = runtimeOpt1.get
       _ <- publisherQueue.take
 
       runtimeOpt2 <- clusterQuery
-        .getActiveClusterByName(cloudContext, runtimeName2)(scala.concurrent.ExecutionContext.global)
+        .getActiveClusterByNameMinimal(cloudContext, runtimeName2)(scala.concurrent.ExecutionContext.global)
         .transaction
       runtime2 = runtimeOpt2.get
       _ <- publisherQueue.take

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterpSpec.scala
@@ -1367,19 +1367,21 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
     )
     val res = for {
       ctx <- appContext.ask[AppContext]
-      cluster = testCluster.copy(dataprocInstances =
-        Set(
-          DataprocInstance(
-            DataprocInstanceKey(GoogleProject(testCluster.cloudContext.asString), zone, InstanceName("instance-0")),
-            1,
-            GceInstanceStatus.Running,
-            Some(IP("")),
-            DataprocRole.Master,
-            ctx.now
+      _ <- IO(
+        testCluster.saveWithRuntimeConfig(
+          defaultDataprocRuntimeConfig,
+          dataprocInstances = List(
+            DataprocInstance(
+              DataprocInstanceKey(GoogleProject(testCluster.cloudContext.asString), zone, InstanceName("instance-0")),
+              1,
+              GceInstanceStatus.Running,
+              Some(IP("")),
+              DataprocRole.Master,
+              ctx.now
+            )
           )
         )
       )
-      _ <- IO(cluster.saveWithRuntimeConfig(defaultDataprocRuntimeConfig))
       clusterRecord <- clusterQuery
         .getActiveClusterRecordByName(testCluster.cloudContext, testCluster.runtimeName)(
           scala.concurrent.ExecutionContext.global
@@ -1424,19 +1426,23 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
     val res = for {
       ctx <- appContext.ask[AppContext]
       cluster = testCluster.copy(
-        status = RuntimeStatus.Running,
-        dataprocInstances = Set(
-          DataprocInstance(
-            DataprocInstanceKey(GoogleProject(testCluster.cloudContext.asString), zone, InstanceName("instance-0")),
-            1,
-            GceInstanceStatus.Running,
-            Some(IP("")),
-            DataprocRole.Master,
-            ctx.now
+        status = RuntimeStatus.Running
+      )
+      _ <- IO(
+        cluster.saveWithRuntimeConfig(
+          defaultDataprocRuntimeConfig,
+          dataprocInstances = List(
+            DataprocInstance(
+              DataprocInstanceKey(GoogleProject(testCluster.cloudContext.asString), zone, InstanceName("instance-0")),
+              1,
+              GceInstanceStatus.Running,
+              Some(IP("")),
+              DataprocRole.Master,
+              ctx.now
+            )
           )
         )
       )
-      _ <- IO(cluster.saveWithRuntimeConfig(defaultDataprocRuntimeConfig))
       clusterRecord <- clusterQuery
         .getActiveClusterRecordByName(cluster.cloudContext, cluster.runtimeName)
         .transaction
@@ -1461,19 +1467,21 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
     val req = UpdateRuntimeConfigRequest.DataprocConfig(Some(MachineTypeName("n1-micro-2")), None, None, None)
     val res = for {
       ctx <- appContext.ask[AppContext]
-      cluster = testCluster.copy(dataprocInstances =
-        Set(
-          DataprocInstance(
-            DataprocInstanceKey(GoogleProject(testCluster.cloudContext.asString), zone, InstanceName("instance-0")),
-            1,
-            GceInstanceStatus.Running,
-            Some(IP("")),
-            DataprocRole.Master,
-            ctx.now
+      _ <- IO(
+        testCluster.saveWithRuntimeConfig(
+          defaultDataprocRuntimeConfig,
+          dataprocInstances = List(
+            DataprocInstance(
+              DataprocInstanceKey(GoogleProject(testCluster.cloudContext.asString), zone, InstanceName("instance-0")),
+              1,
+              GceInstanceStatus.Running,
+              Some(IP("")),
+              DataprocRole.Master,
+              ctx.now
+            )
           )
         )
       )
-      _ <- IO(cluster.saveWithRuntimeConfig(defaultDataprocRuntimeConfig))
       clusterRecord <- clusterQuery
         .getActiveClusterRecordByName(testCluster.cloudContext, testCluster.runtimeName)(
           scala.concurrent.ExecutionContext.global
@@ -1500,19 +1508,21 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
     val req = UpdateRuntimeConfigRequest.DataprocConfig(Some(MachineTypeName("n1-micro-2")), None, None, None)
     val res = for {
       ctx <- appContext.ask[AppContext]
-      cluster = testCluster.copy(dataprocInstances =
-        Set(
-          DataprocInstance(
-            DataprocInstanceKey(GoogleProject(testCluster.cloudContext.asString), zone, InstanceName("instance-0")),
-            1,
-            GceInstanceStatus.Running,
-            Some(IP("")),
-            DataprocRole.Master,
-            ctx.now
+      _ <- IO(
+        testCluster.saveWithRuntimeConfig(
+          defaultDataprocRuntimeConfig,
+          dataprocInstances = List(
+            DataprocInstance(
+              DataprocInstanceKey(GoogleProject(testCluster.cloudContext.asString), zone, InstanceName("instance-0")),
+              1,
+              GceInstanceStatus.Running,
+              Some(IP("")),
+              DataprocRole.Master,
+              ctx.now
+            )
           )
         )
       )
-      _ <- IO(cluster.saveWithRuntimeConfig(defaultDataprocRuntimeConfig))
       clusterRecord <- clusterQuery
         .getActiveClusterRecordByName(testCluster.cloudContext, testCluster.runtimeName)(
           scala.concurrent.ExecutionContext.global
@@ -1570,12 +1580,12 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
         DataprocRole.Master,
         ctx.now
       )
-      cluster = testCluster.copy(dataprocInstances =
-        Set(
-          masterInstance
-        )
+      _ <- IO(
+        testCluster.saveWithRuntimeConfig(defaultDataprocRuntimeConfig,
+                                          dataprocInstances = List(
+                                            masterInstance
+                                          ))
       )
-      _ <- IO(cluster.saveWithRuntimeConfig(defaultDataprocRuntimeConfig))
       clusterRecord <- clusterQuery
         .getActiveClusterRecordByName(testCluster.cloudContext, testCluster.runtimeName)(
           scala.concurrent.ExecutionContext.global
@@ -1599,19 +1609,21 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
     val req = UpdateRuntimeConfigRequest.DataprocConfig(None, Some(DiskSize(50)), None, None)
     val res = for {
       ctx <- appContext.ask[AppContext]
-      cluster = testCluster.copy(dataprocInstances =
-        Set(
-          DataprocInstance(
-            DataprocInstanceKey(GoogleProject(testCluster.cloudContext.asString), zone, InstanceName("instance-0")),
-            1,
-            GceInstanceStatus.Running,
-            Some(IP("")),
-            DataprocRole.Master,
-            ctx.now
+      _ <- IO(
+        testCluster.saveWithRuntimeConfig(
+          defaultDataprocRuntimeConfig,
+          dataprocInstances = List(
+            DataprocInstance(
+              DataprocInstanceKey(GoogleProject(testCluster.cloudContext.asString), zone, InstanceName("instance-0")),
+              1,
+              GceInstanceStatus.Running,
+              Some(IP("")),
+              DataprocRole.Master,
+              ctx.now
+            )
           )
         )
       )
-      _ <- IO(cluster.saveWithRuntimeConfig(defaultDataprocRuntimeConfig))
       clusterRecord <- clusterQuery
         .getActiveClusterRecordByName(testCluster.cloudContext, testCluster.runtimeName)(
           scala.concurrent.ExecutionContext.global

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriberSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriberSpec.scala
@@ -157,9 +157,9 @@ class LeoPubsubMessageSubscriberSpec
   val runningCluster = makeCluster(1).copy(
     serviceAccount = serviceAccount,
     asyncRuntimeFields = Some(makeAsyncRuntimeFields(1).copy(hostIp = None)),
-    status = RuntimeStatus.Running,
-    dataprocInstances = Set(masterInstance, workerInstance1, workerInstance2)
+    status = RuntimeStatus.Running
   )
+  val runnningClusterInstances = List(masterInstance, workerInstance1, workerInstance2)
 
   val stoppedCluster = makeCluster(2).copy(serviceAccount = serviceAccount,
                                            asyncRuntimeFields = Some(makeAsyncRuntimeFields(1).copy(hostIp = None)),

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/MonitorAtBootSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/MonitorAtBootSpec.scala
@@ -26,6 +26,7 @@ import org.broadinstitute.dsde.workbench.leonardo.monitor.ClusterNodepoolAction.
   CreateNodepool
 }
 import org.broadinstitute.dsde.workbench.leonardo.monitor.LeoPubsubMessage.{CreateAppMessage, DeleteAppMessage}
+import org.broadinstitute.dsde.workbench.model.TraceId
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
@@ -101,12 +102,13 @@ class MonitorAtBootSpec extends AnyFlatSpec with TestComponent with LeonardoTest
       msg <- queue.tryTake
     } yield {
       val runtimeConfigInCreateRuntimeMessage = LeoLenses.runtimeConfigPrism.getOption(defaultDataprocRuntimeConfig).get
+      val expectedMessage = LeoPubsubMessage.CreateRuntimeMessage.fromRuntime(
+        runtime,
+        runtimeConfigInCreateRuntimeMessage,
+        None
+      )
       (msg eqv Some(
-        LeoPubsubMessage.CreateRuntimeMessage.fromRuntime(
-          runtime,
-          runtimeConfigInCreateRuntimeMessage,
-          None
-        )
+        expectedMessage
       )) shouldBe (true)
     }
     res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/MonitorAtBootSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/MonitorAtBootSpec.scala
@@ -26,7 +26,6 @@ import org.broadinstitute.dsde.workbench.leonardo.monitor.ClusterNodepoolAction.
   CreateNodepool
 }
 import org.broadinstitute.dsde.workbench.leonardo.monitor.LeoPubsubMessage.{CreateAppMessage, DeleteAppMessage}
-import org.broadinstitute.dsde.workbench.model.TraceId
 
 import scala.concurrent.ExecutionContext.Implicits.global
 


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-3223

* Moved some queries using `fullClusterQuery` usage to test since they're only used in test. Slowly I think we should deprecate use of `fullClusterQuery` if possible
* Removed `clusterQuery.getClusterById(runtime.id).transaction` from `MonitorAtBoot`, which uses `fullClusterQuery`
* Remove `dataprocInstances` field from `Runtime`. This allows us to avoid joining Instance table in retrieving runtime in all the places I'm aware of. This in theory should make leo much more stable when users are using large dataproc clusters...We might be able to just avoid persisting non master instances entirely, but I'll leave that to another time

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
