### PR TITLE
[IA-3232] bumping version to 1.19.16

### DIFF
--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -396,7 +396,7 @@ gke {
                           "69.173.112.0/21"
     ]
     # See https://cloud.google.com/kubernetes-engine/docs/release-notes
-    version = "1.19.15"
+    version = "1.19.16"
     nodepoolLockCacheExpiryTime = 1 hour
     nodepoolLockCacheMaxSize = 200
   }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/config/ConfigSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/config/ConfigSpec.scala
@@ -81,7 +81,7 @@ final class ConfigSpec extends AnyFlatSpec with Matchers {
         "69.173.127.240/28",
         "69.173.112.0/21"
       ).map(CidrIP),
-      KubernetesClusterVersion("1.19.15"),
+      KubernetesClusterVersion("1.19.16"),
       1 hour,
       200
     )


### PR DESCRIPTION
Seeing automation tests failures with the following error:
{
"code" : 400,
"errors" : [ {
"domain" : "global",
"message" : "No valid versions with the prefix "1.19.15" found.",
"reason" : "badRequest"
} ],
"message" : "No valid versions with the prefix "1.19.15" found.",
"status" : "INVALID_ARGUMENT"
}

Bumping version to see if this resolves the issue

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
