### PR TITLE
SUP-630 Restart jupyter server and welder server for GPU runtime

### DIFF
--- a/http/src/main/resources/init-resources/startup.sh
+++ b/http/src/main/resources/init-resources/startup.sh
@@ -93,11 +93,6 @@ if [ "${GPU_ENABLED}" == "true" ] ; then
   cos-extensions install gpu
   mount --bind /var/lib/nvidia /var/lib/nvidia
   mount -o remount,exec /var/lib/nvidia
-
-  # Containers will usually restart just fine. But when gpu is enabled,
-  # jupyter container will fail to start until the appropriate volume/device exists.
-  # Hence restart jupyter container here
-  docker restart jupyter-server
 fi
 
 # https://broadworkbench.atlassian.net/browse/IA-3186
@@ -123,6 +118,13 @@ then
     if [ ! -z "$JUPYTER_DOCKER_IMAGE" ] ; then
         echo "Restarting Jupyter Container $GOOGLE_PROJECT / $CLUSTER_NAME..."
 
+        if [ "${GPU_ENABLED}" == "true" ] ; then
+          # Containers will usually restart just fine. But when gpu is enabled,
+          # jupyter container will fail to start until the appropriate volume/device exists.
+          # Hence restart jupyter container here
+          docker restart jupyter-server
+          docker restart welder-server
+        fi
         # This line is only for migration (1/26/2022). Say you have an existing runtime where jupyter container's PD is mapped at $HOME/notebooks,
         # then all jupyter related files (.jupyter, .local) and things like bash history etc all lives under $HOME. The home diretory change will
         # make it so that next time this runtime starts up, PD will be mapped to $HOME, but this means that the previous files under $HOME (.jupyter, .local etc)


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/SUP-630

The welder error is due to welder container was restarted before the PD disk was mounted properly (this happens automatically during VM restart). This doesn't seem to be a problem for non GPU runtimes since disk mount happens soon enough. But with installing GPU happens before PD mount, welder container gets restarted before PD mount.

This PR makes sure both jupyter and welder container get restarted after PD mount if GPU is enabled, which fixes the bug.

Tested on fiab, this should fix the bug.

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
