### PR TITLE
IA-3233 Lower notebookAuthCacheExpiryTime

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/RuntimeFixtureSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/RuntimeFixtureSpec.scala
@@ -176,7 +176,8 @@ object RuntimeFixtureSpec {
           componentGatewayEnabled = true,
           workerPrivateAccess = false
         )
-
+      case CloudService.AzureVm =>
+        throw new NotImplementedError()
     }
 
     CreateRuntime2Request(

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -695,7 +695,7 @@ auth {
     petTokenCacheExpiryTime = 60 minutes
     petTokenCacheMaxSize = 1000
     notebookAuthCacheEnabled = true
-    notebookAuthCacheExpiryTime = 20 minutes
+    notebookAuthCacheExpiryTime = 15 minutes
     notebookAuthCacheMaxSize = 1000
     providerTimeout = 30 seconds
   }

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -695,7 +695,7 @@ auth {
     petTokenCacheExpiryTime = 60 minutes
     petTokenCacheMaxSize = 1000
     notebookAuthCacheEnabled = true
-    notebookAuthCacheExpiryTime = 30 minutes
+    notebookAuthCacheExpiryTime = 20 minutes
     notebookAuthCacheMaxSize = 1000
     providerTimeout = 30 seconds
   }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/auth/SamAuthProvider.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/auth/SamAuthProvider.scala
@@ -16,7 +16,7 @@ import org.broadinstitute.dsde.workbench.openTelemetry.OpenTelemetryMetrics
 import org.http4s.client.dsl.Http4sClientDsl
 import org.http4s.headers.Authorization
 import org.http4s.{AuthScheme, Credentials}
-import org.typelevel.log4cats.{Logger, StructuredLogger}
+import org.typelevel.log4cats.StructuredLogger
 import scalacache.Cache
 
 import scala.concurrent.duration._

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/Boot.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/Boot.scala
@@ -326,7 +326,7 @@ object Boot extends IOApp {
 
         val frontLeoOnlyProcesses = List(
           dateAccessedUpdater.process // We only need to update dateAccessed in front leo
-        ) // ++ appDependencies.recordCacheMetrics TODO: uncomment this
+        ) ++ appDependencies.recordCacheMetrics
 
         val extraProcesses = leoExecutionModeConfig match {
           case LeoExecutionModeConfig.BackLeoOnly  => backLeoOnlyProcesses


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-3233

Here's the stacktrace. [This line](https://github.com/DataBiosphere/leonardo/blob/develop/http%2Fsrc%2Fmain%2Fscala%2Forg%2Fbroadinstitute%2Fdsde%2Fworkbench%2Fleonardo%2Fhttp%2Fservice%2FProxyService.scala#L200) failed. I checked surrouding logs, and didn't find any log about an actual Sam call to check permission, so this is likely due to cache hit, but cache value is outdated. Hence lower the `notebookAuthCacheExpiryTime` so that the cache expires sooner.
```
 "org.broadinstitute.dsde.workbench.leonardo.model.RuntimeNotFoundException: Runtime Gcp/terra-vpc-sc-dev-ed78c34c/all-of-us-137 not found. Details: 2054fd22d850f1643026fe475d345cb9/6884274425936130497
	at org.broadinstitute.dsde.workbench.leonardo.http.service.ProxyService.$anonfun$proxyRequest$3(ProxyService.scala:202)
	at org.broadinstitute.dsde.workbench.leonardo.http.service.ProxyService.$anonfun$proxyRequest$3$adapted(ProxyService.scala:200)
	at flatMap @ org.broadinstitute.dsde.workbench.leonardo.http.service.ProxyService.$anonfun$proxyRequest$3(ProxyService.scala:201)
	at delay @ scalacache.logging.Logger.ifDebugEnabled(Logger.scala:16)
	at ifM$extension @ org.typelevel.log4cats.slf4j.internal.Slf4jLoggerInternal$.org$typelevel$log4cats$slf4j$internal$Slf4jLoggerInternal$$contextLog(Slf4jLoggerInternal.scala:55)
	at as @ org.broadinstitute.dsde.workbench.leonardo.http.Boot$.run(Boot.scala:608)
	at map @ scalacache.Entry$.isBeforeExpiration(Entry.scala:21)
	at filterA @ scalacache.caffeine.CaffeineCache.$anonfun$doGet$2(CaffeineCache.scala:26)
	at delay @ scalacache.caffeine.CaffeineCache.doGet(CaffeineCache.scala:25)
	at flatMap @ scalacache.caffeine.CaffeineCache.doGet(CaffeineCache.scala:26)
	at map @ scalacache.caffeine.CaffeineCache.doGet(CaffeineCache.scala:27)
	at flatTap @ fs2.Stream$NestedStreamOps$.$anonfun$parJoin$19(Stream.scala:4000)
	at handleErrorWith$extension @ scalacache.AbstractCache.cachingF(AbstractCache.scala:91)
	at flatMap @ scalacache.AbstractCache.cachingF(AbstractCache.scala:96)
	at flatMap @ org.broadinstitute.dsde.workbench.leonardo.http.service.ProxyService.$anonfun$proxyRequest$2(ProxyService.scala:200)
	at delay @ scalacache.logging.Logger.ifDebugEnabled(Logger.scala:16)
	at ifM$extension @ org.typelevel.log4cats.slf4j.internal.Slf4jLoggerInternal$.org$typelevel$log4cats$slf4j$internal$Slf4jLoggerInternal$$contextLog(Slf4jLoggerInternal.scala:55)
"
```

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
