### PR TITLE
IA-3211 Automation tests for createVM flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ ERROR 2003 (HY000): Can't connect to MySQL server on 'mysql' (113)
 Warning: Using a password on the command line interface can be insecure.
 ERROR 2003 (HY000): Can't connect to MySQL server on 'mysql' (113)
 ```
-Run `docker system prune -a`
+Run `docker system prune -a`. If the error persists, try restart your laptop.
 
 Build Leonardo and run all unit tests.
 ```

--- a/automation/src/test/resources/reference.conf
+++ b/automation/src/test/resources/reference.conf
@@ -11,6 +11,9 @@ leonardo.rstudioBioconductorImageUrl = "us.gcr.io/broad-dsp-gcr-public/anvil-rst
 //each fiab will have a unique topic name sourced from leonardo.conf, this is never published to in automation tests to ensure pub/sub components can auth properly, but never read from to avoid conflicts.
 leonardo.topicName = "leonardo-pubsub-test"
 leonardo.location = "us-central1-a"
-leonardo.tenantId= "fad90753-2022-4456-9b0a-c7e5b934e408"
-leonardo.managedResourceGroup= "mrg-qi-1-preview-20210517084351"
-leonardo.subscriptionId= "3efc5bdf-be0e-44e7-b1d7-c08931e3c16c"
+azure {
+    tenantId= "fad90753-2022-4456-9b0a-c7e5b934e408"
+    managedResourceGroup= "mrg-terra-integration-test-20211118"
+    subscriptionId= "3efc5bdf-be0e-44e7-b1d7-c08931e3c16c"
+    workspaceId="e1aaf25b-b298-46eb-891b-e4c326f29b0c"
+}

--- a/automation/src/test/resources/reference.conf
+++ b/automation/src/test/resources/reference.conf
@@ -11,3 +11,6 @@ leonardo.rstudioBioconductorImageUrl = "us.gcr.io/broad-dsp-gcr-public/anvil-rst
 //each fiab will have a unique topic name sourced from leonardo.conf, this is never published to in automation tests to ensure pub/sub components can auth properly, but never read from to avoid conflicts.
 leonardo.topicName = "leonardo-pubsub-test"
 leonardo.location = "us-central1-a"
+leonardo.tenantId= "fad90753-2022-4456-9b0a-c7e5b934e408"
+leonardo.managedResourceGroup= "mrg-qi-1-preview-20210517084351"
+leonardo.subscriptionId= "3efc5bdf-be0e-44e7-b1d7-c08931e3c16c"

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoApiClient.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoApiClient.scala
@@ -1,15 +1,12 @@
 package org.broadinstitute.dsde.workbench.leonardo
 
+import java.io.FileInputStream
+import java.util
+
 import cats.effect.{IO, Resource}
 import org.broadinstitute.dsde.workbench.DoneCheckable
 import org.broadinstitute.dsde.workbench.DoneCheckableSyntax._
-import org.broadinstitute.dsde.workbench.google2.{
-  streamFUntilDone,
-  streamUntilDoneOrTimeout,
-  DiskName,
-  MachineTypeName,
-  ZoneName
-}
+import org.broadinstitute.dsde.workbench.google2.{streamFUntilDone, streamUntilDoneOrTimeout, DiskName, MachineTypeName, ZoneName}
 import org.broadinstitute.dsde.workbench.leonardo.ApiJsonDecoder._
 import org.broadinstitute.dsde.workbench.leonardo.http.AppRoutesTestJsonCodec._
 import org.broadinstitute.dsde.workbench.leonardo.http.DiskRoutesTestJsonCodec._
@@ -21,13 +18,16 @@ import org.http4s._
 import org.http4s.blaze.client.BlazeClientBuilder
 import org.http4s.circe.CirceEntityEncoder._
 import org.http4s.client.Client
-import org.http4s.client.middleware.{Logger, Retry, RetryPolicy}
+import org.http4s.client.middleware.{Retry, Logger, RetryPolicy}
 import org.http4s.headers._
 import org.typelevel.log4cats.StructuredLogger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
-
 import java.util.UUID
 import java.util.concurrent.TimeoutException
+
+import com.azure.core.management.Region
+import com.azure.resourcemanager.compute.models.VirtualMachineSizeTypes
+
 import scala.concurrent.duration._
 import scala.util.control.NoStackTrace
 
@@ -114,6 +114,20 @@ object LeonardoApiClient {
     Map.empty,
     None,
     List.empty
+  )
+
+  val defaultCreateAzureRuntimeRequest = CreateAzureRuntimeRequest(
+    Map.empty,
+    Region.US_EAST2,
+    VirtualMachineSizeTypes.STANDARD_A1,
+    None,
+    Map.empty,
+    CreateAzureDiskRequest(
+      Map.empty,
+      AzureDiskName(UUID.randomUUID().toString.substring(0,8)),
+      None,
+      None
+    )
   )
 
   def createRuntime(
@@ -646,33 +660,72 @@ object LeonardoApiClient {
         }
     } yield r
 
-  def createAzureRuntime(
+  def createAzureRuntime(workspaceId: WorkspaceId,
                      runtimeName: RuntimeName,
-                     workspaceId: WorkspaceId,
-                     createRuntime2Request: CreateRuntime2Request = defaultCreateRuntime2Request
+                     createAzureRuntimeRequest: CreateAzureRuntimeRequest = defaultCreateAzureRuntimeRequest
                    )(implicit client: Client[IO], authorization: IO[Authorization]): IO[Unit] =
     for {
       traceIdHeader <- genTraceIdHeader()
       authHeader <- authorization
-//      r <- client
-//        .run(
-//          Request[IO](
-//            method = Method.POST,
-//            headers = Headers(authHeader, defaultMediaType, traceIdHeader),
-//            uri = rootUri.withPath(
-//              Uri.Path.unsafeFromString(s"/api/google/v1/runtimes/${googleProject.value}/${runtimeName.asString}")
-//            ),
-//            body = createRuntime2Request
-//          )
-//        )
-//        .use { resp =>
-//          if (!resp.status.isSuccess) {
-//            onError(s"Failed to create runtime ${googleProject.value}/${runtimeName.asString}")(resp)
-//              .flatMap(IO.raiseError)
-//          } else
-//            IO.unit
-//        }
+      r <- client
+        .run(
+          Request[IO](
+            method = Method.POST,
+            headers = Headers(authHeader, defaultMediaType, traceIdHeader),
+            uri = rootUri.withPath(
+              Uri.Path.unsafeFromString(s"/api/v2/runtimes/${workspaceId.value.toString}/azure/${runtimeName.asString}")
+            ),
+            body = createAzureRuntimeRequest
+          )
+        )
+        .use { resp =>
+          if (!resp.status.isSuccess) {
+            onError(s"Failed to create runtime ${workspaceId.value.toString}/${runtimeName.asString}")(resp)
+              .flatMap(IO.raiseError)
+          } else
+            IO.unit
+        }
     } yield ()
+
+  def getAzureRuntime(workspaceId: WorkspaceId,
+                         runtimeName: RuntimeName
+                        )(implicit client: Client[IO], authorization: IO[Authorization]): IO[GetRuntimeResponseCopy] =
+    for {
+      traceIdHeader <- genTraceIdHeader()
+      authHeader <- authorization
+      r <- client.expectOr[GetRuntimeResponseCopy](
+          Request[IO](
+            method = Method.GET,
+            headers = Headers(authHeader, traceIdHeader),
+            uri = rootUri.withPath(
+              Uri.Path.unsafeFromString(s"/api/v2/runtimes/${workspaceId.value.toString}/azure/${runtimeName.asString}")
+            )
+          )
+        )(onError(s"Failed to get runtime ${workspaceId.value.toString}/${runtimeName.asString}"))
+    } yield r
+
+  def deleteAzureRuntime(workspaceId: WorkspaceId,
+                      runtimeName: RuntimeName
+                     )(implicit client: Client[IO], authorization: IO[Authorization]): IO[Unit] =
+    for {
+      traceIdHeader <- genTraceIdHeader()
+      authHeader <- authorization
+      r <- client.run(
+        Request[IO](
+          method = Method.DELETE,
+          headers = Headers(authHeader, traceIdHeader),
+          uri = rootUri.withPath(
+            Uri.Path.unsafeFromString(s"/api/v2/runtimes/${workspaceId.value.toString}/azure/${runtimeName.asString}")
+          )
+        )
+      ).use { resp =>
+        if (!resp.status.isSuccess) {
+          onError(s"Failed to create runtime ${workspaceId.value.toString}/${runtimeName.asString}")(resp)
+            .flatMap(IO.raiseError)
+        } else
+          IO.unit
+      }
+    } yield r
 
 //  def createAzureRuntimeWithWait(
 //                             googleProject: GoogleProject,
@@ -716,7 +769,8 @@ object LeonardoApiClient {
     val digitString = "3939911508519804487"
     IO(uuid + "/" + digitString).map(uuid => Header.Raw(traceIdHeaderString, uuid))
   }
-}
+
+ }
 
 final case class RestError(message: String, statusCode: Status, body: Option[String]) extends NoStackTrace {
   override def getMessage: String = s"message: ${message}, status: ${statusCode} body: ${body.getOrElse("")}"

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoApiClient.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoApiClient.scala
@@ -646,6 +646,44 @@ object LeonardoApiClient {
         }
     } yield r
 
+  def createAzureRuntime(
+                     runtimeName: RuntimeName,
+                     workspaceId: WorkspaceId,
+                     createRuntime2Request: CreateRuntime2Request = defaultCreateRuntime2Request
+                   )(implicit client: Client[IO], authorization: IO[Authorization]): IO[Unit] =
+    for {
+      traceIdHeader <- genTraceIdHeader()
+      authHeader <- authorization
+//      r <- client
+//        .run(
+//          Request[IO](
+//            method = Method.POST,
+//            headers = Headers(authHeader, defaultMediaType, traceIdHeader),
+//            uri = rootUri.withPath(
+//              Uri.Path.unsafeFromString(s"/api/google/v1/runtimes/${googleProject.value}/${runtimeName.asString}")
+//            ),
+//            body = createRuntime2Request
+//          )
+//        )
+//        .use { resp =>
+//          if (!resp.status.isSuccess) {
+//            onError(s"Failed to create runtime ${googleProject.value}/${runtimeName.asString}")(resp)
+//              .flatMap(IO.raiseError)
+//          } else
+//            IO.unit
+//        }
+    } yield ()
+
+//  def createAzureRuntimeWithWait(
+//                             googleProject: GoogleProject,
+//                             runtimeName: RuntimeName,
+//                             createRuntime2Request: CreateRuntime2Request
+//                           )(implicit client: Client[IO], authorization: IO[Authorization]): IO[GetRuntimeResponseCopy] =
+//    for {
+//      _ <- createRuntime(googleProject, runtimeName, createRuntime2Request)
+//      res <- waitUntilRunning(googleProject, runtimeName)
+//    } yield res
+
   def testSparkWebUi(
     googleProject: GoogleProject,
     runtimeName: RuntimeName,

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoApiClient.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoApiClient.scala
@@ -121,7 +121,7 @@ object LeonardoApiClient {
   val defaultCreateAzureRuntimeRequest = CreateAzureRuntimeRequest(
     Map.empty,
     Region.US_WEST_CENTRAL,
-    VirtualMachineSizeTypes.STANDARD_D1_V2, //Standard_D1_v2
+    VirtualMachineSizeTypes.STANDARD_D1_V2,
     None,
     Map.empty,
     CreateAzureDiskRequest(
@@ -727,7 +727,7 @@ object LeonardoApiClient {
         )
         .use { resp =>
           if (!resp.status.isSuccess) {
-            onError(s"Failed to create runtime ${workspaceId.value.toString}/${runtimeName.asString}")(resp)
+            onError(s"Failed to delete runtime ${workspaceId.value.toString}/${runtimeName.asString}")(resp)
               .flatMap(IO.raiseError)
           } else
             IO.unit

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoApiClient.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoApiClient.scala
@@ -746,16 +746,6 @@ object LeonardoApiClient {
       else IO.raiseError(new TimeoutException(s"delete runtime ${workspaceId}/${runtimeName.asString}"))
     } yield ()
 
-//  def createAzureRuntimeWithWait(
-//                             googleProject: GoogleProject,
-//                             runtimeName: RuntimeName,
-//                             createRuntime2Request: CreateRuntime2Request
-//                           )(implicit client: Client[IO], authorization: IO[Authorization]): IO[GetRuntimeResponseCopy] =
-//    for {
-//      _ <- createRuntime(googleProject, runtimeName, createRuntime2Request)
-//      res <- waitUntilRunning(googleProject, runtimeName)
-//    } yield res
-
   def testSparkWebUi(
     googleProject: GoogleProject,
     runtimeName: RuntimeName,

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoConfig.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoConfig.scala
@@ -25,11 +25,19 @@ object LeonardoConfig extends CommonConfig {
     val location: Location = Location(leonardo.getString("location"))
 
     val publisherConfig: PublisherConfig = PublisherConfig(GCS.pathToQAJson, topic)
+
+    val tenantId: String = leonardo.getString("tenantId")
+    val subscriptionId: String = leonardo.getString("subscriptionId")
+    val managedResourceGroup: String = leonardo.getString("managedResourceGroup")
   }
 
   // for qaEmail and pathToQAPem and pathToQAJson
   object GCS extends CommonGCS {
     val pathToQAJson = gcs.getString("qaJsonFile")
+  }
+
+  object WSM {
+    val wsmUri: String = "https://workspace.dsde-dev.broadinstitute.org"
   }
 
   // for NotebooksWhitelisted

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoConfig.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoConfig.scala
@@ -4,8 +4,11 @@ import com.google.pubsub.v1.ProjectTopicName
 import org.broadinstitute.dsde.workbench.config.CommonConfig
 import org.broadinstitute.dsde.workbench.google2.{Location, PublisherConfig}
 
+import java.util.UUID
+
 object LeonardoConfig extends CommonConfig {
   private val leonardo = config.getConfig("leonardo")
+  private val azure = config.getConfig("azure")
   private val gcs = config.getConfig("gcs")
 
   object Leonardo {
@@ -26,9 +29,10 @@ object LeonardoConfig extends CommonConfig {
 
     val publisherConfig: PublisherConfig = PublisherConfig(GCS.pathToQAJson, topic)
 
-    val tenantId: String = leonardo.getString("tenantId")
-    val subscriptionId: String = leonardo.getString("subscriptionId")
-    val managedResourceGroup: String = leonardo.getString("managedResourceGroup")
+    val tenantId = azure.getString("tenantId")
+    val subscriptionId = azure.getString("subscriptionId")
+    val managedResourceGroup = azure.getString("managedResourceGroup")
+    val workspaceId = WorkspaceId(UUID.fromString(azure.getString("workspaceId")))
   }
 
   // for qaEmail and pathToQAPem and pathToQAJson

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoConfig.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoConfig.scala
@@ -40,6 +40,7 @@ object LeonardoConfig extends CommonConfig {
     val pathToQAJson = gcs.getString("qaJsonFile")
   }
 
+  //TODO: this should be updated once we're able to run azure automation tests as part of CI
   object WSM {
     val wsmUri: String = "https://workspace.dsde-dev.broadinstitute.org"
   }

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoModelCopy.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoModelCopy.scala
@@ -127,7 +127,7 @@ case class DefaultLabelsCopy(runtimeName: RuntimeName,
 object ClusterStatus extends Enumeration {
   type ClusterStatus = Value
   //NOTE: Remember to update the definition of this enum in Swagger when you add new ones
-  val Unknown, Creating, Running, Updating, Error, Deleting, Deleted, Stopping, Stopped, Starting = Value
+  val Unknown, Creating, Running, Updating, Error, Deleting, Deleted, Stopping, Stopped, Starting, PreCreating, PreDeleting = Value
   val activeStatuses = Set(Unknown, Creating, Running, Updating)
   val monitoredStatuses = Set(Unknown, Creating, Updating, Deleting)
   val deletableStatuses: Set[ClusterStatus] = Set(Unknown, Running, Updating, Error, Stopping, Stopped, Starting)

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoModelCopy.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoModelCopy.scala
@@ -127,7 +127,8 @@ case class DefaultLabelsCopy(runtimeName: RuntimeName,
 object ClusterStatus extends Enumeration {
   type ClusterStatus = Value
   //NOTE: Remember to update the definition of this enum in Swagger when you add new ones
-  val Unknown, Creating, Running, Updating, Error, Deleting, Deleted, Stopping, Stopped, Starting, PreCreating, PreDeleting = Value
+  val Unknown, Creating, Running, Updating, Error, Deleting, Deleted, Stopping, Stopped, Starting, PreCreating,
+    PreDeleting = Value
   val activeStatuses = Set(Unknown, Creating, Running, Updating)
   val monitoredStatuses = Set(Unknown, Creating, Updating, Deleting)
   val deletableStatuses: Set[ClusterStatus] = Set(Unknown, Running, Updating, Error, Stopping, Stopped, Starting)

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoSuite.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoSuite.scala
@@ -7,14 +7,14 @@ import io.circe.parser._
 import org.broadinstitute.dsde.rawls.model.WorkspaceName
 import org.broadinstitute.dsde.workbench.fixture.BillingFixtures
 import org.broadinstitute.dsde.workbench.leonardo.GPAllocFixtureSpec.{shouldUnclaimProjectsKey, _}
-import org.broadinstitute.dsde.workbench.leonardo.TestUser.{Ron, Hermione}
-import org.broadinstitute.dsde.workbench.leonardo.apps.{AppLifecycleSpec, AppCreationSpec}
+import org.broadinstitute.dsde.workbench.leonardo.TestUser.{Hermione, Ron}
+import org.broadinstitute.dsde.workbench.leonardo.apps.{AppCreationSpec, AppLifecycleSpec}
 import org.broadinstitute.dsde.workbench.leonardo.lab.LabSpec
 import org.broadinstitute.dsde.workbench.leonardo.notebooks._
 import org.broadinstitute.dsde.workbench.leonardo.rstudio.RStudioSpec
 import org.broadinstitute.dsde.workbench.leonardo.runtimes._
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
-import org.broadinstitute.dsde.workbench.service.{Rawls, Orchestration, BillingProject}
+import org.broadinstitute.dsde.workbench.service.{BillingProject, Orchestration, Rawls}
 import org.scalatest._
 import org.scalatest.freespec.FixtureAnyFreeSpecLike
 import java.util.UUID

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoSuite.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoSuite.scala
@@ -7,18 +7,19 @@ import io.circe.parser._
 import org.broadinstitute.dsde.rawls.model.WorkspaceName
 import org.broadinstitute.dsde.workbench.fixture.BillingFixtures
 import org.broadinstitute.dsde.workbench.leonardo.GPAllocFixtureSpec.{shouldUnclaimProjectsKey, _}
-import org.broadinstitute.dsde.workbench.leonardo.TestUser.{Hermione, Ron}
-import org.broadinstitute.dsde.workbench.leonardo.apps.{AppCreationSpec, AppLifecycleSpec}
+import org.broadinstitute.dsde.workbench.leonardo.TestUser.{Ron, Hermione}
+import org.broadinstitute.dsde.workbench.leonardo.apps.{AppLifecycleSpec, AppCreationSpec}
 import org.broadinstitute.dsde.workbench.leonardo.lab.LabSpec
 import org.broadinstitute.dsde.workbench.leonardo.notebooks._
 import org.broadinstitute.dsde.workbench.leonardo.rstudio.RStudioSpec
 import org.broadinstitute.dsde.workbench.leonardo.runtimes._
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
-import org.broadinstitute.dsde.workbench.service.{BillingProject, Orchestration, Rawls}
+import org.broadinstitute.dsde.workbench.service.{Rawls, Orchestration, BillingProject}
 import org.scalatest._
 import org.scalatest.freespec.FixtureAnyFreeSpecLike
-
 import java.util.UUID
+
+import bio.terra.workspace.model.{CreateWorkspaceRequestBody, WorkspaceStageModel}
 
 trait GPAllocFixtureSpec extends FixtureAnyFreeSpecLike with Retries with LazyLogging {
   override type FixtureParam = GoogleProject

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoSuite.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoSuite.scala
@@ -19,8 +19,6 @@ import org.scalatest._
 import org.scalatest.freespec.FixtureAnyFreeSpecLike
 import java.util.UUID
 
-import bio.terra.workspace.model.{CreateWorkspaceRequestBody, WorkspaceStageModel}
-
 trait GPAllocFixtureSpec extends FixtureAnyFreeSpecLike with Retries with LazyLogging {
   override type FixtureParam = GoogleProject
   override def withFixture(test: OneArgTest): Outcome = {

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
@@ -736,63 +736,63 @@ trait LeonardoTestUtils
 
   def runtimeInStateOrError(status: ClusterStatus): DoneCheckable[GetRuntimeResponseCopy] =
     x => x.status == ClusterStatus.Running || x.status == ClusterStatus.Running
+//  def withNewWorkspace[T](testCode: WorkspaceId => IO[T]): T = {
+//    val test = for {
+//      _ <- loggerIO.info("Allocating a new single-test workspace")
+//      workspaceId <- createWsmWorkspace()
+//      cloudContextResult <- createAzureCloudContext(workspaceId)
+//      t <- testCode(workspaceId)
+//      _ <- loggerIO.info("Deleting wsm workspace")
+//      _ <- IO(wsmWorkspaceClient.deleteWorkspace(workspaceId.value))
+//    } yield t
+//
+//    test.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
+//  }
 
-  def withNewWorkspace[T](testCode: WorkspaceId => IO[T]): T = {
-    val test = for {
-      _ <- loggerIO.info("Allocating a new single-test workspace")
-      workspaceId <- createWsmWorkspace()
-      cloudContextResult <- createAzureCloudContext(workspaceId)
-      t <- testCode(workspaceId)
-      _ <- loggerIO.info("Deleting wsm workspace")
-      _ <- IO(wsmWorkspaceClient.deleteWorkspace(workspaceId.value))
-    } yield t
+//  protected def createWsmWorkspace(): IO[WorkspaceId] = {
+//    val workspaceId: UUID = UUID.randomUUID
+//    val requestBody: CreateWorkspaceRequestBody =
+//      new CreateWorkspaceRequestBody().id(workspaceId).stage(WorkspaceStageModel.MC_WORKSPACE)
+//    for {
+//      _ <- loggerIO.info(s"calling wsm createWorkspace")
+//      _ <- IO(wsmWorkspaceClient.createWorkspace(requestBody))
+//    } yield WorkspaceId(workspaceId)
+//  }
 
-    test.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
-  }
+//  protected def createAzureCloudContext(workspaceId: WorkspaceId): IO[CreateCloudContextResult] = {
+//    val jobControl = new JobControl().id(UUID.randomUUID().toString)
+//
+//    val azureContext = new AzureContext()
+//      .tenantId(LeonardoConfig.Leonardo.tenantId)
+//      .subscriptionId(LeonardoConfig.Leonardo.subscriptionId)
+//      .resourceGroupId(LeonardoConfig.Leonardo.managedResourceGroup)
+//
+//    val requestBody: CreateCloudContextRequest = new CreateCloudContextRequest()
+//      .jobControl(jobControl)
+//      .azureContext(azureContext)
+//      .cloudPlatform(CloudPlatform.AZURE)
+//
+//    for {
+//      _ <- loggerIO.info(s"calling wsm create cloud context")
+//      result <- IO(wsmWorkspaceClient.createCloudContext(requestBody, workspaceId.value))
+//    } yield result
+//  }
 
-  protected def createWsmWorkspace(): IO[WorkspaceId] = {
-    val workspaceId: UUID = UUID.randomUUID
-    val requestBody: CreateWorkspaceRequestBody =
-      new CreateWorkspaceRequestBody().id(workspaceId).stage(WorkspaceStageModel.MC_WORKSPACE)
-    for {
-      _ <- loggerIO.info(s"calling wsm createWorkspace")
-      _ <- IO(wsmWorkspaceClient.createWorkspace(requestBody))
-    } yield WorkspaceId(workspaceId)
-  }
-
-  protected def createAzureCloudContext(workspaceId: WorkspaceId): IO[CreateCloudContextResult] = {
-    val jobControl = new JobControl().id(UUID.randomUUID().toString)
-
-    val azureContext = new AzureContext()
-      .tenantId(LeonardoConfig.Leonardo.tenantId)
-      .subscriptionId(LeonardoConfig.Leonardo.subscriptionId)
-      .resourceGroupId(LeonardoConfig.Leonardo.managedResourceGroup)
-
-    val requestBody: CreateCloudContextRequest = new CreateCloudContextRequest()
-      .jobControl(jobControl)
-      .azureContext(azureContext)
-      .cloudPlatform(CloudPlatform.AZURE)
-
-    for {
-      _ <- loggerIO.info(s"calling wsm create cloud context")
-      result <- IO(wsmWorkspaceClient.createCloudContext(requestBody, workspaceId.value))
-    } yield result
-  }
-
-  //THIS CLIENT IS VALID FOR 1 HR
-  private def buildWsmClient(): WorkspaceApi = {
-    val apiClient = new ApiClient
-    apiClient.setBasePath(LeonardoConfig.WSM.wsmUri)
-
-    val creds = ServiceAccountCredentials
-      .fromStream(new FileInputStream(LeonardoConfig.GCS.pathToQAJson))
-      .createScoped(
-        List("openid", "email", "profile", "https://www.googleapis.com/auth/cloud-platform").asJava
-      )
-
-    apiClient.setAccessToken(creds.getAccessToken.getTokenValue)
-    new WorkspaceApi(apiClient)
-  }
+//  //THIS CLIENT IS VALID FOR 1 HR
+//  private def buildWsmClient(): WorkspaceApi = {
+//    val apiClient = new ApiClient
+//    apiClient.setBasePath(LeonardoConfig.WSM.wsmUri)
+//
+//    val creds = ServiceAccountCredentials
+//      .fromStream(new FileInputStream(LeonardoConfig.GCS.pathToQAJson))
+//      .createScoped(
+//        List("openid", "email", "profile", "https://www.googleapis.com/auth/cloud-platform").asJava
+//      )
+//
+//    val token = creds.getAccessToken
+//    apiClient.setAccessToken(token.getTokenValue)
+//    new WorkspaceApi(apiClient)
+//  }
 }
 
 // Ron and Hermione are on the dev Leo's allowed list, and Hermione is a Project Owner

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
@@ -437,26 +437,6 @@ trait LeonardoTestUtils
   def stopAndMonitorRuntime(googleProject: GoogleProject, runtimeName: RuntimeName)(implicit token: AuthToken): Unit =
     stopRuntime(googleProject, runtimeName, monitor = true)(token)
 
-  def startAndMonitorRuntime(googleProject: GoogleProject, runtimeName: RuntimeName)(
-    implicit token: AuthToken,
-    authorization: IO[Authorization]
-  ): Unit = {
-    // verify with get()
-    val waitForRunning = LeonardoApiClient.client.use { implicit c =>
-      LeonardoApiClient.startRuntimeWithWait(googleProject, runtimeName)
-    }
-
-    waitForRunning.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
-
-    logger.info(s"Checking if ${googleProject.value}/${runtimeName.asString} is proxyable yet")
-    val getResult = Try(Notebook.getApi(googleProject, runtimeName))
-    getResult.isSuccess shouldBe true
-    getResult.get should not include "ProxyException"
-
-    // Grab the jupyter.log and welder.log files for debugging.
-    saveClusterLogFiles(googleProject, runtimeName, List("jupyter.log", "welder.log"), "start")
-  }
-
   def randomClusterName: RuntimeName = RuntimeName(s"automation-test-a${makeRandomId().toLowerCase}z")
 
   def defaultClusterRequest: ClusterRequest =

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
@@ -27,8 +27,6 @@ import org.broadinstitute.dsde.workbench.service.test.{RandomUtil, WebBrowserSpe
 import org.broadinstitute.dsde.workbench.service.{RestException, Sam}
 import org.broadinstitute.dsde.workbench.util._
 import org.broadinstitute.dsde.workbench.{DoneCheckable, ResourceFile}
-import org.http4s.{AuthScheme, Credentials}
-import org.broadinstitute.dsde.workbench.{DoneCheckable, ResourceFile}
 import org.http4s.client.Client
 import org.http4s.headers.Authorization
 import org.http4s.{AuthScheme, Credentials}
@@ -37,26 +35,11 @@ import org.scalatest.concurrent.PatienceConfiguration.Timeout
 import org.scalatest.concurrent.{Eventually, ScalaFutures}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.time.{Minutes, Seconds, Span}
-import java.io.{ByteArrayInputStream, File, FileInputStream, FileOutputStream}
+
+import java.io.{ByteArrayInputStream, File, FileOutputStream}
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
-import java.util.UUID
-
-import bio.terra.workspace.api.WorkspaceApi
-import bio.terra.workspace.client.ApiClient
-import bio.terra.workspace.model.{
-  AzureContext,
-  CloudPlatform,
-  CreateCloudContextRequest,
-  CreateCloudContextResult,
-  CreateWorkspaceRequestBody,
-  JobControl,
-  WorkspaceStageModel
-}
-import com.google.auth.oauth2.ServiceAccountCredentials
-
 import scala.concurrent.duration._
-import scala.jdk.CollectionConverters._
 import scala.util.{Failure, Random, Success, Try}
 
 case class KernelNotReadyException(timeElapsed: Timeout)

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/AppCreationSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/AppCreationSpec.scala
@@ -16,14 +16,13 @@ import org.scalatest.{DoNotDiscover, ParallelTestExecution}
 
 import scala.concurrent.duration._
 
-//@DoNotDiscover
+@DoNotDiscover
 class AppCreationSpec
     extends GPAllocFixtureSpec
     with LeonardoTestUtils
     with GPAllocUtils
     with ParallelTestExecution
-    with TableDrivenPropertyChecks
-    with GPAllocBeforeAndAfterAll {
+    with TableDrivenPropertyChecks {
   implicit val (ronAuthToken, ronAuthorization) = getAuthTokenAndAuthorization(Ron)
 
   override def withFixture(test: NoArgTest) =

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/AppCreationSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/AppCreationSpec.scala
@@ -16,13 +16,14 @@ import org.scalatest.{DoNotDiscover, ParallelTestExecution}
 
 import scala.concurrent.duration._
 
-@DoNotDiscover
+//@DoNotDiscover
 class AppCreationSpec
     extends GPAllocFixtureSpec
     with LeonardoTestUtils
     with GPAllocUtils
     with ParallelTestExecution
-    with TableDrivenPropertyChecks {
+    with TableDrivenPropertyChecks
+    with GPAllocBeforeAndAfterAll {
   implicit val (ronAuthToken, ronAuthorization) = getAuthTokenAndAuthorization(Ron)
 
   override def withFixture(test: NoArgTest) =

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/azure/AzureRuntimeSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/azure/AzureRuntimeSpec.scala
@@ -48,17 +48,16 @@ class AzureRuntimeSpec
         )
         _ = monitorCreateResult.status shouldBe ClusterStatus.Running
 
-        _ <- IO.sleep(1 minute)
+        _ <- IO.sleep(1 minutes)
 
         // Delete the app
-        _ <- LeonardoApiClient.deleteAzureRuntime(workspaceId, runtimeName)
+        _ <- LeonardoApiClient.deleteRuntimeV2WithWait(workspaceId, runtimeName)
 
         // Verify getApp again
         getRuntimeResponse <- getRuntime
-        _ = getRuntimeResponse.status should (be(ClusterStatus.Deleting) or be(ClusterStatus.PreDeleting))
-
-        //TODO: eventually with list we can verify deleted
-      } yield ()
+      } yield {
+        getRuntimeResponse.status shouldBe ClusterStatus.Deleted
+      }
     }
     res.unsafeRunSync()
   }

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/azure/AzureRuntimeSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/azure/AzureRuntimeSpec.scala
@@ -1,0 +1,5 @@
+package org.broadinstitute.dsde.workbench.leonardo.azure
+
+class AzureRuntimeSpec {
+
+}

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/azure/AzureRuntimeSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/azure/AzureRuntimeSpec.scala
@@ -36,7 +36,7 @@ class AzureRuntimeSpec
         _ = getRuntimeResponse.status should (be(ClusterStatus.Creating) or be(ClusterStatus.PreCreating))
 
         // Verify the runtime eventually becomes Running
-        _ <- IO.sleep(300 seconds)
+        _ <- IO.sleep(60 seconds)
         monitorCreateResult <- streamUntilDoneOrTimeout(
           getRuntime,
           120,
@@ -48,16 +48,11 @@ class AzureRuntimeSpec
         )
         _ = monitorCreateResult.status shouldBe ClusterStatus.Running
 
-        _ <- IO.sleep(1 minutes)
+        _ <- IO.sleep(3 seconds)
 
         // Delete the app
         _ <- LeonardoApiClient.deleteRuntimeV2WithWait(workspaceId, runtimeName)
-
-        // Verify getApp again
-        getRuntimeResponse <- getRuntime
-      } yield {
-        getRuntimeResponse.status shouldBe ClusterStatus.Deleted
-      }
+      } yield ()
     }
     res.unsafeRunSync()
   }

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/azure/AzureRuntimeSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/azure/AzureRuntimeSpec.scala
@@ -1,89 +1,74 @@
 package org.broadinstitute.dsde.workbench.leonardo.azure
 
 import cats.effect.IO
+import cats.effect.unsafe.implicits.global
 import org.broadinstitute.dsde.workbench.google2.streamUntilDoneOrTimeout
-import org.broadinstitute.dsde.workbench.leonardo.TestUser.{Ron, getAuthTokenAndAuthorization}
-import org.scalatest.prop.TableDrivenPropertyChecks
-import org.scalatest.{Outcome, Retries, ParallelTestExecution}
-import org.broadinstitute.dsde.workbench.leonardo.{ClusterStatus, AppName, RuntimeStatus, GPAllocFixtureSpec, GPAllocUtils, GPAllocBeforeAndAfterAll, LeonardoApiClient, LeonardoTestUtils}
-import org.broadinstitute.dsde.workbench.leonardo.LeonardoApiClient._
+import org.broadinstitute.dsde.workbench.leonardo.LeonardoConfig.Leonardo.workspaceId
+import org.broadinstitute.dsde.workbench.leonardo.TestUser.{getAuthTokenAndAuthorization, Ron}
+import org.broadinstitute.dsde.workbench.leonardo.{ClusterStatus, LeonardoApiClient, LeonardoTestUtils}
 import org.broadinstitute.dsde.workbench.service.util.Tags
-import org.http4s.{Credentials, AuthScheme}
 import org.http4s.headers.Authorization
-import org.scalatest.freespec.FixtureAnyFreeSpec
+import org.http4s.{AuthScheme, Credentials}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.prop.TableDrivenPropertyChecks
 import org.scalatest.tagobjects.Retryable
+import org.scalatest.{ParallelTestExecution, Retries}
 
 import scala.concurrent.duration._
 
 //@DoNotDiscover
-class AzureRuntimeSpec extends FixtureAnyFreeSpec
-  with LeonardoTestUtils
-  with ParallelTestExecution
-  with TableDrivenPropertyChecks
-  with Retries {
+class AzureRuntimeSpec
+    extends AnyFlatSpec
+    with LeonardoTestUtils
+    with ParallelTestExecution
+    with TableDrivenPropertyChecks
+    with Retries {
   implicit val (ronAuthToken, ronAuthorization) = getAuthTokenAndAuthorization(Ron)
 
-  "create, get, delete azure runtime" taggedAs (Tags.SmokeTest, Retryable) in { _ =>
-      val runtimeName = randomClusterName
+  it should "create, get, delete azure runtime" in {
+    val runtimeName = randomClusterName
+    val res = LeonardoApiClient.client.use { implicit client =>
+      for {
+        _ <- loggerIO.info(s"AzureRuntimeSpec: About to create runtime")
 
-    withNewWorkspace { workspaceId =>
-      LeonardoApiClient.client.use { implicit client =>
-        for {
-          _ <- loggerIO.info(s"AzureRuntimeSpec: About to create runtime")
-
-          rat <- Ron.authToken()
-          implicit0(auth: Authorization) = Authorization(Credentials.Token(AuthScheme.Bearer, rat.value))
+        rat <- Ron.authToken()
+        implicit0(auth: Authorization) = Authorization(Credentials.Token(AuthScheme.Bearer, rat.value))
 
 //           Create the app
-            _ <- LeonardoApiClient.createAzureRuntime(workspaceId, runtimeName)
+        _ <- LeonardoApiClient.createAzureRuntime(workspaceId, runtimeName)
 
-          _ <- LeonardoApiClient.createAzureRuntime(workspaceId, runtimeName)
+        _ <- LeonardoApiClient.createAzureRuntime(workspaceId, runtimeName)
 
-          // Verify the initial getApp call
-          getRuntime = LeonardoApiClient.getAzureRuntime(workspaceId, runtimeName)
-          getRuntimeResponse <- getRuntime
-          _ = getRuntimeResponse.status should (be(ClusterStatus.Creating) or be(ClusterStatus.PreCreating))
+        // Verify the initial getApp call
+        getRuntime = LeonardoApiClient.getAzureRuntime(workspaceId, runtimeName)
+        getRuntimeResponse <- getRuntime
+        _ = getRuntimeResponse.status should (be(ClusterStatus.Creating) or be(ClusterStatus.PreCreating))
 
-          // Verify the runtime eventually becomes Running
-          _ <- IO.sleep(120 seconds)
-          monitorCreateResult <- streamUntilDoneOrTimeout(
-            getRuntime,
-            120,
-            10 seconds,
-            s"AzureRuntimeSpec: runtime ${workspaceId.value}/${runtimeName.asString} did not finish creating after 20 minutes"
-          )(implicitly, runtimeInStateOrError(ClusterStatus.Running))
-          _ <- loggerIO.info(
-            s"AzureRuntime: runtime ${workspaceId.value}/${runtimeName.asString} monitor result: $monitorCreateResult"
-          )
-          _ = monitorCreateResult.status shouldBe ClusterStatus.Running
+        // Verify the runtime eventually becomes Running
+        _ <- IO.sleep(120 seconds)
+        monitorCreateResult <- streamUntilDoneOrTimeout(
+          getRuntime,
+          120,
+          10 seconds,
+          s"AzureRuntimeSpec: runtime ${workspaceId.value}/${runtimeName.asString} did not finish creating after 20 minutes"
+        )(implicitly, runtimeInStateOrError(ClusterStatus.Running))
+        _ <- loggerIO.info(
+          s"AzureRuntime: runtime ${workspaceId.value}/${runtimeName.asString} monitor result: $monitorCreateResult"
+        )
+        _ = monitorCreateResult.status shouldBe ClusterStatus.Running
 
-          _ <- IO.sleep(1 minute)
+        _ <- IO.sleep(1 minute)
 
-          // Delete the app
-          _ <- LeonardoApiClient.deleteAzureRuntime(workspaceId, runtimeName)
+        // Delete the app
+        _ <- LeonardoApiClient.deleteAzureRuntime(workspaceId, runtimeName)
 
-          // Verify getApp again
-          getRuntimeResponse <- getRuntime
-          _ = getRuntimeResponse.status should (be(ClusterStatus.Deleting) or be(ClusterStatus.PreDeleting))
+        // Verify getApp again
+        getRuntimeResponse <- getRuntime
+        _ = getRuntimeResponse.status should (be(ClusterStatus.Deleting) or be(ClusterStatus.PreDeleting))
 
         //TODO: eventually with list we can verify deleted
-        } yield ()
-      }
+      } yield ()
     }
+    res.unsafeRunSync()
   }
-
-  override def withFixture(test: NoArgTest) =
-    if (isRetryable(test))
-      withRetry(super.withFixture(test))
-    else
-      super.withFixture(test)
-
-  override type FixtureParam = this.type
-
-  override protected def withFixture(test: OneArgTest): Outcome =
-    if (isRetryable(test))
-      withRetry(super.withFixture(test))
-    else {
-      super.withFixture(test)
-    }
 }

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/azure/AzureRuntimeSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/azure/AzureRuntimeSpec.scala
@@ -32,20 +32,16 @@ class AzureRuntimeSpec
         _ <- loggerIO.info(s"AzureRuntimeSpec: About to create runtime")
 
         rat <- Ron.authToken()
-        implicit0(auth: Authorization) = Authorization(Credentials.Token(AuthScheme.Bearer, rat.value))
-
 //           Create the app
-        _ <- LeonardoApiClient.createAzureRuntime(workspaceId, runtimeName)
-
         _ <- LeonardoApiClient.createAzureRuntime(workspaceId, runtimeName)
 
         // Verify the initial getApp call
         getRuntime = LeonardoApiClient.getAzureRuntime(workspaceId, runtimeName)
-        getRuntimeResponse <- getRuntime
-        _ = getRuntimeResponse.status should (be(ClusterStatus.Creating) or be(ClusterStatus.PreCreating))
+//        getRuntimeResponse <- getRuntime
+//        _ = getRuntimeResponse.status should (be(ClusterStatus.Creating) or be(ClusterStatus.PreCreating))
 
         // Verify the runtime eventually becomes Running
-        _ <- IO.sleep(120 seconds)
+        _ <- IO.sleep(300 seconds)
         monitorCreateResult <- streamUntilDoneOrTimeout(
           getRuntime,
           120,

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/azure/AzureRuntimeSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/azure/AzureRuntimeSpec.scala
@@ -6,12 +6,8 @@ import org.broadinstitute.dsde.workbench.google2.streamUntilDoneOrTimeout
 import org.broadinstitute.dsde.workbench.leonardo.LeonardoConfig.Leonardo.workspaceId
 import org.broadinstitute.dsde.workbench.leonardo.TestUser.{getAuthTokenAndAuthorization, Ron}
 import org.broadinstitute.dsde.workbench.leonardo.{ClusterStatus, LeonardoApiClient, LeonardoTestUtils}
-import org.broadinstitute.dsde.workbench.service.util.Tags
-import org.http4s.headers.Authorization
-import org.http4s.{AuthScheme, Credentials}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.prop.TableDrivenPropertyChecks
-import org.scalatest.tagobjects.Retryable
 import org.scalatest.{ParallelTestExecution, Retries}
 
 import scala.concurrent.duration._
@@ -30,15 +26,14 @@ class AzureRuntimeSpec
     val res = LeonardoApiClient.client.use { implicit client =>
       for {
         _ <- loggerIO.info(s"AzureRuntimeSpec: About to create runtime")
-
-        rat <- Ron.authToken()
+//        rat <- Ron.authToken()
 //           Create the app
         _ <- LeonardoApiClient.createAzureRuntime(workspaceId, runtimeName)
 
         // Verify the initial getApp call
         getRuntime = LeonardoApiClient.getAzureRuntime(workspaceId, runtimeName)
-//        getRuntimeResponse <- getRuntime
-//        _ = getRuntimeResponse.status should (be(ClusterStatus.Creating) or be(ClusterStatus.PreCreating))
+        getRuntimeResponse <- getRuntime
+        _ = getRuntimeResponse.status should (be(ClusterStatus.Creating) or be(ClusterStatus.PreCreating))
 
         // Verify the runtime eventually becomes Running
         _ <- IO.sleep(300 seconds)

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/azure/AzureRuntimeSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/azure/AzureRuntimeSpec.scala
@@ -1,5 +1,89 @@
 package org.broadinstitute.dsde.workbench.leonardo.azure
 
-class AzureRuntimeSpec {
+import cats.effect.IO
+import org.broadinstitute.dsde.workbench.google2.streamUntilDoneOrTimeout
+import org.broadinstitute.dsde.workbench.leonardo.TestUser.{Ron, getAuthTokenAndAuthorization}
+import org.scalatest.prop.TableDrivenPropertyChecks
+import org.scalatest.{Outcome, Retries, ParallelTestExecution}
+import org.broadinstitute.dsde.workbench.leonardo.{ClusterStatus, AppName, RuntimeStatus, GPAllocFixtureSpec, GPAllocUtils, GPAllocBeforeAndAfterAll, LeonardoApiClient, LeonardoTestUtils}
+import org.broadinstitute.dsde.workbench.leonardo.LeonardoApiClient._
+import org.broadinstitute.dsde.workbench.service.util.Tags
+import org.http4s.{Credentials, AuthScheme}
+import org.http4s.headers.Authorization
+import org.scalatest.freespec.FixtureAnyFreeSpec
+import org.scalatest.tagobjects.Retryable
 
+import scala.concurrent.duration._
+
+//@DoNotDiscover
+class AzureRuntimeSpec extends FixtureAnyFreeSpec
+  with LeonardoTestUtils
+  with ParallelTestExecution
+  with TableDrivenPropertyChecks
+  with Retries {
+  implicit val (ronAuthToken, ronAuthorization) = getAuthTokenAndAuthorization(Ron)
+
+  "create, get, delete azure runtime" taggedAs (Tags.SmokeTest, Retryable) in { _ =>
+      val runtimeName = randomClusterName
+
+    withNewWorkspace { workspaceId =>
+      LeonardoApiClient.client.use { implicit client =>
+        for {
+          _ <- loggerIO.info(s"AzureRuntimeSpec: About to create runtime")
+
+          rat <- Ron.authToken()
+          implicit0(auth: Authorization) = Authorization(Credentials.Token(AuthScheme.Bearer, rat.value))
+
+//           Create the app
+            _ <- LeonardoApiClient.createAzureRuntime(workspaceId, runtimeName)
+
+          _ <- LeonardoApiClient.createAzureRuntime(workspaceId, runtimeName)
+
+          // Verify the initial getApp call
+          getRuntime = LeonardoApiClient.getAzureRuntime(workspaceId, runtimeName)
+          getRuntimeResponse <- getRuntime
+          _ = getRuntimeResponse.status should (be(ClusterStatus.Creating) or be(ClusterStatus.PreCreating))
+
+          // Verify the runtime eventually becomes Running
+          _ <- IO.sleep(120 seconds)
+          monitorCreateResult <- streamUntilDoneOrTimeout(
+            getRuntime,
+            120,
+            10 seconds,
+            s"AzureRuntimeSpec: runtime ${workspaceId.value}/${runtimeName.asString} did not finish creating after 20 minutes"
+          )(implicitly, runtimeInStateOrError(ClusterStatus.Running))
+          _ <- loggerIO.info(
+            s"AzureRuntime: runtime ${workspaceId.value}/${runtimeName.asString} monitor result: $monitorCreateResult"
+          )
+          _ = monitorCreateResult.status shouldBe ClusterStatus.Running
+
+          _ <- IO.sleep(1 minute)
+
+          // Delete the app
+          _ <- LeonardoApiClient.deleteAzureRuntime(workspaceId, runtimeName)
+
+          // Verify getApp again
+          getRuntimeResponse <- getRuntime
+          _ = getRuntimeResponse.status should (be(ClusterStatus.Deleting) or be(ClusterStatus.PreDeleting))
+
+        //TODO: eventually with list we can verify deleted
+        } yield ()
+      }
+    }
+  }
+
+  override def withFixture(test: NoArgTest) =
+    if (isRetryable(test))
+      withRetry(super.withFixture(test))
+    else
+      super.withFixture(test)
+
+  override type FixtureParam = this.type
+
+  override protected def withFixture(test: OneArgTest): Outcome =
+    if (isRetryable(test))
+      withRetry(super.withFixture(test))
+    else {
+      super.withFixture(test)
+    }
 }

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/azure/AzureRuntimeSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/azure/AzureRuntimeSpec.scala
@@ -8,11 +8,11 @@ import org.broadinstitute.dsde.workbench.leonardo.TestUser.{getAuthTokenAndAutho
 import org.broadinstitute.dsde.workbench.leonardo.{ClusterStatus, LeonardoApiClient, LeonardoTestUtils}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.prop.TableDrivenPropertyChecks
-import org.scalatest.{ParallelTestExecution, Retries}
+import org.scalatest.{DoNotDiscover, ParallelTestExecution, Retries}
 
 import scala.concurrent.duration._
 
-//@DoNotDiscover
+@DoNotDiscover
 class AzureRuntimeSpec
     extends AnyFlatSpec
     with LeonardoTestUtils
@@ -21,7 +21,7 @@ class AzureRuntimeSpec
     with Retries {
   implicit val (ronAuthToken, ronAuthorization) = getAuthTokenAndAuthorization(Ron)
 
-  it should "create, get, delete azure runtime" in {
+  it should "create, get, delete azure runtime" ignore {
     val runtimeName = randomClusterName
     val res = LeonardoApiClient.client.use { implicit client =>
       for {

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/JsonCodec.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/JsonCodec.scala
@@ -2,7 +2,6 @@ package org.broadinstitute.dsde.workbench.leonardo
 
 import java.net.URL
 import java.time.Instant
-
 import cats.syntax.all._
 import io.circe.syntax._
 import io.circe.{Decoder, DecodingFailure, Encoder, Json}
@@ -33,10 +32,10 @@ import org.broadinstitute.dsde.workbench.model.google.{
   GoogleProject
 }
 import org.http4s.Uri
+
 import java.nio.file.{Path, Paths}
 import java.util.UUID
 import java.util.stream.Collectors
-
 import com.azure.core.management.Region
 import com.azure.resourcemanager.compute.models.VirtualMachineSizeTypes
 import org.broadinstitute.dsde.workbench.google2.JsonCodec.traceIdEncoder
@@ -261,6 +260,8 @@ object JsonCodec {
   implicit val networkNameEncoder: Encoder[NetworkName] = Encoder.encodeString.contramap(_.value)
   implicit val subNetworkNameEncoder: Encoder[SubnetworkName] = Encoder.encodeString.contramap(_.value)
   implicit val ipRangeEncoder: Encoder[IpRange] = Encoder.encodeString.contramap(_.value)
+  implicit val wsmJobIdEncoder: Encoder[WsmJobId] = Encoder.encodeString.contramap(_.value.toString)
+
   implicit val networkFieldsEncoder: Encoder[NetworkFields] =
     Encoder.forProduct3("networkName", "subNetworkName", "subNetworkIpRange")(x => NetworkFields.unapply(x).get)
   implicit val kubeAsyncFieldEncoder: Encoder[KubernetesClusterAsyncFields] =
@@ -634,6 +635,9 @@ object JsonCodec {
     Decoder.decodeString.emap(s => Uri.fromString(s).leftMap(_.getMessage()))
 
   implicit val uuidDecoder: Decoder[UUID] = Decoder.decodeString.map(s => UUID.fromString(s))
+
+  implicit val wsmJobIdDecoder: Decoder[WsmJobId] =
+    uuidDecoder.map(uuid => WsmJobId(uuid))
 
   implicit val workspaceIdDecoder: Decoder[WorkspaceId] =
     Decoder.decodeString.map(x => WorkspaceId(UUID.fromString(x)))

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/JsonCodec.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/JsonCodec.scala
@@ -637,7 +637,7 @@ object JsonCodec {
   implicit val uuidDecoder: Decoder[UUID] = Decoder.decodeString.map(s => UUID.fromString(s))
 
   implicit val wsmJobIdDecoder: Decoder[WsmJobId] =
-    uuidDecoder.map(uuid => WsmJobId(uuid))
+    Decoder.decodeString.map(s => WsmJobId(s))
 
   implicit val workspaceIdDecoder: Decoder[WorkspaceId] =
     Decoder.decodeString.map(x => WorkspaceId(UUID.fromString(x)))

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/azureModels.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/azureModels.scala
@@ -40,4 +40,4 @@ object AzureCloudContext {
   }
 }
 
-final case class WsmJobId(value: UUID) extends AnyVal
+final case class WsmJobId(value: String) extends AnyVal

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/azureModels.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/azureModels.scala
@@ -39,3 +39,5 @@ object AzureCloudContext {
     res.leftMap(t => s"Fail to decode $s as Azure Cloud Context due to ${t.getMessage}")
   }
 }
+
+final case class WsmJobId(value: UUID) extends AnyVal

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/samModels.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/samModels.scala
@@ -190,8 +190,11 @@ sealed trait WorkspaceAction extends Product with Serializable {
   def asString: String
 }
 object WorkspaceAction {
-  final case object CreateControlledResource extends WorkspaceAction {
+  final case object CreateControlledApplicationResource extends WorkspaceAction {
     val asString = "create_controlled_application_private"
+  }
+  final case object CreateControlledUserResource extends WorkspaceAction {
+    val asString = "create_controlled_user_private"
   }
 
   val allActions = sealerate.values[WorkspaceAction]

--- a/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestSuite.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestSuite.scala
@@ -6,6 +6,7 @@ import com.github.benmanes.caffeine.cache.Caffeine
 import fs2.Stream
 import org.broadinstitute.dsde.workbench.google2.GKEModels.KubernetesClusterId
 import org.broadinstitute.dsde.workbench.openTelemetry.FakeOpenTelemetryMetricsInterpreter
+import org.http4s.{AuthScheme, Credentials}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.prop.Configuration
 import org.scalatest.{Assertion, Assertions}
@@ -22,6 +23,7 @@ trait LeonardoTestSuite extends Matchers {
   implicit val loggerIO: StructuredLogger[IO] = Slf4jLogger.getLogger[IO]
 
   def ioAssertion(test: => IO[Assertion]): Assertion = test.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
+  val dummyAuth = org.http4s.headers.Authorization(Credentials.Token(AuthScheme.Bearer, ""))
 
   val semaphore = Semaphore[IO](10).unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   val underlyingCache =

--- a/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/RuntimeRoutesTestJsonCodec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/RuntimeRoutesTestJsonCodec.scala
@@ -80,8 +80,8 @@ object RuntimeRoutesTestJsonCodec {
   implicit val azureDiskConfigEncoder: Encoder[CreateAzureDiskRequest] =
     Encoder.forProduct4("labels", "name", "size", "diskType")(x => CreateAzureDiskRequest.unapply(x).get)
   implicit val createAzureRuntimeRequestEncoder: Encoder[CreateAzureRuntimeRequest] =
-    Encoder.forProduct6("labels", "region", "machineSize", "imageUri", "customEnvironmentVariables", "azureDiskConfig")(
-      x => CreateAzureRuntimeRequest.unapply(x).get
+    Encoder.forProduct6("labels", "region", "machineSize", "imageUri", "customEnvironmentVariables", "disk")(x =>
+      CreateAzureRuntimeRequest.unapply(x).get
     )
 
   implicit val createRuntime2RequestEncoder: Encoder[CreateRuntime2Request] = Encoder.forProduct12(

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -149,9 +149,15 @@ gce {
 
 azure {
    monitor {
-    poll-status {
+    create-vm-poll-config {
+      initial-delay = 2 minutes
       max-attempts = 120 # 15 seconds * 120 is 30 min
-      interval = 15 seconds
+      interval = 10 seconds
+    }
+    delete-vm-poll-config {
+      initial-delay = 30 seconds
+      max-attempts = 120 # 15 seconds * 120 is 30 min
+      interval = 10 seconds
     }
    }
 

--- a/http/src/main/resources/swagger/api-docs.yaml
+++ b/http/src/main/resources/swagger/api-docs.yaml
@@ -2111,7 +2111,7 @@ components:
           example:
             labels: { saturnRuntimeName: "saturn-ab9134" }
             region: "eastus"
-            machineSize: "Standard_A1"
+            machineSize: "Standard_D1_v2"
             azureDiskConfig: { labels: {}, name: "disk1", size: 50 }
 
   securitySchemes:

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
@@ -276,6 +276,7 @@ object Config {
 
   implicit private val pollMonitorConfigReader: ValueReader[PollMonitorConfig] = ValueReader.relative { config =>
     PollMonitorConfig(
+      config.as[Option[FiniteDuration]]("initial-delay").getOrElse(2 seconds),
       config.as[Int]("max-attempts"),
       config.as[FiniteDuration]("interval")
     )

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/ComputeManagerDao.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/ComputeManagerDao.scala
@@ -6,7 +6,7 @@ import cats.syntax.all._
 import com.azure.core.management.AzureEnvironment
 import com.azure.core.management.exception.ManagementException
 import com.azure.core.management.profile.AzureProfile
-import com.azure.identity.{ClientSecretCredential, ClientSecretCredentialBuilder}
+import com.azure.identity.ClientSecretCredentialBuilder
 import com.azure.resourcemanager.compute.ComputeManager
 import com.azure.resourcemanager.compute.models.VirtualMachine
 
@@ -24,11 +24,10 @@ class HttpComputerManagerDao[F[_]](azureConfig: AzureAppRegistrationConfig)(impl
         .delay(
           azureComputeManager
             .virtualMachines()
-            .getByResourceGroup(name.asString, cloudContext.managedResourceGroupName.value)
+            .getByResourceGroup(cloudContext.managedResourceGroupName.value, name.asString)
         )
         .map(Option(_))
         .handleErrorWith {
-          //TODO: this is untested
           case e: ManagementException if e.getValue.getCode().equals("ResourceNotFound") => F.pure(none[VirtualMachine])
           case e                                                                         => F.raiseError[Option[VirtualMachine]](e)
         }
@@ -36,17 +35,14 @@ class HttpComputerManagerDao[F[_]](azureConfig: AzureAppRegistrationConfig)(impl
 
   private def buildComputeManager(azureCloudContext: AzureCloudContext,
                                   azureConfig: AzureAppRegistrationConfig): ComputeManager = {
-    val azureCreds = getManagedAppCredentials(azureConfig)
+    val azureCreds = new ClientSecretCredentialBuilder()
+      .clientId(azureConfig.clientId.value)
+      .clientSecret(azureConfig.clientSecret.value)
+      .tenantId(azureConfig.managedAppTenantId.value)
+      .build
     val azureProfile =
       new AzureProfile(azureCloudContext.tenantId.value, azureCloudContext.subscriptionId.value, AzureEnvironment.AZURE)
 
     ComputeManager.authenticate(azureCreds, azureProfile)
   }
-
-  private def getManagedAppCredentials(azureConfig: AzureAppRegistrationConfig): ClientSecretCredential =
-    new ClientSecretCredentialBuilder()
-      .clientId(azureConfig.clientId.value)
-      .clientSecret(azureConfig.clientSecret.value)
-      .tenantId(azureConfig.clientSecret.value)
-      .build
 }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpSamDAO.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpSamDAO.scala
@@ -7,7 +7,7 @@ import _root_.io.circe.syntax._
 import _root_.org.typelevel.log4cats.Logger
 import akka.http.scaladsl.model.StatusCode._
 import akka.http.scaladsl.model.{StatusCode, StatusCodes}
-import cats.effect.{Async, Resource}
+import cats.effect.{Async, Ref}
 import cats.mtl.Ask
 import cats.syntax.all._
 import com.google.api.services.plus.PlusScopes
@@ -24,15 +24,15 @@ import org.broadinstitute.dsde.workbench.openTelemetry.OpenTelemetryMetrics
 import org.broadinstitute.dsde.workbench.util.health.Subsystems.Subsystem
 import org.broadinstitute.dsde.workbench.util.health.{StatusCheckResponse, SubsystemStatus, Subsystems}
 import org.http4s._
+import org.http4s.circe.CirceEntityDecoder._
 import org.http4s.client.Client
 import org.http4s.client.dsl.Http4sClientDsl
 import org.http4s.headers.{`Content-Type`, Authorization}
 import scalacache.Cache
+
 import java.io.ByteArrayInputStream
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets.UTF_8
-import org.http4s.circe.CirceEntityDecoder._
-
 import scala.concurrent.duration._
 import scala.jdk.CollectionConverters._
 import scala.util.control.NoStackTrace
@@ -46,13 +46,16 @@ class HttpSamDAO[F[_]](httpClient: Client[F],
 ) extends SamDAO[F]
     with Http4sClientDsl[F] {
   private val saScopes = Seq(PlusScopes.USERINFO_EMAIL, PlusScopes.USERINFO_PROFILE, StorageScopes.DEVSTORAGE_READ_ONLY)
+  private val leoSaTokenRef = Ref.ofEffect(getLeoAuthTokenInteral)
 
   def registerLeo(implicit ev: Ask[F, TraceId]): F[Unit] =
     for {
+      leoToken <- getLeoAuthToken
       isRegistered <- httpClient.expectOr[RegisterInfoResponse](
         Request[F](
           method = Method.GET,
-          uri = config.samUri.withPath(Uri.Path.unsafeFromString(s"/register/user/v2/self/info"))
+          uri = config.samUri.withPath(Uri.Path.unsafeFromString(s"/register/user/v2/self/info")),
+          headers = Headers(leoToken)
         )
       )(onError)
       _ <- httpClient
@@ -60,7 +63,8 @@ class HttpSamDAO[F[_]](httpClient: Client[F],
           Request[F](
             method = Method.POST,
             uri = config.samUri.withPath(Uri.Path.unsafeFromString(s"/register/user/v2/self")),
-            body = Stream.emits("app.terra.bio/#terms-of-service".getBytes(UTF_8))
+            body = Stream.emits("app.terra.bio/#terms-of-service".getBytes(UTF_8)),
+            headers = Headers(leoToken)
           )
         )
         .whenA(!isRegistered.enabled)
@@ -267,8 +271,7 @@ class HttpSamDAO[F[_]](httpClient: Client[F],
       )(onError)
 
   def getUserProxy(userEmail: WorkbenchEmail)(implicit ev: Ask[F, TraceId]): F[Option[WorkbenchEmail]] =
-    getAccessTokenUsingLeoJson.use { leoToken =>
-      val authHeader = Authorization(Credentials.Token(AuthScheme.Bearer, leoToken))
+    getLeoAuthToken.flatMap { leoToken =>
       metrics.incrementCounter("sam/getUserProxy") >>
         httpClient.expectOptionOr[WorkbenchEmail](
           Request[F](
@@ -278,7 +281,7 @@ class HttpSamDAO[F[_]](httpClient: Client[F],
                 Uri.Path
                   .unsafeFromString(s"/api/google/v1/user/proxyGroup/${URLEncoder.encode(userEmail.value, UTF_8.name)}")
               ),
-            headers = Headers(authHeader)
+            headers = Headers(leoToken)
           )
         )(onError)
     }
@@ -294,41 +297,53 @@ class HttpSamDAO[F[_]](httpClient: Client[F],
       getPetAccessToken(userEmail, googleProject)
     }
 
-  private def getAccessTokenUsingLeoJson: Resource[F, String] =
+  def getLeoAuthToken: F[Authorization] =
     for {
-      credential <- credentialResource(
-        config.serviceAccountProviderConfig.leoServiceAccountJsonFile.toAbsolutePath.toString
-      )
-      scopedCredential = credential.createScoped(saScopes.asJava)
-      _ <- Resource.eval(F.delay(scopedCredential.refresh))
-    } yield scopedCredential.getAccessToken.getTokenValue
+      ref <- leoSaTokenRef
+      accessToken <- ref.get
+      now <- F.realTimeInstant
+      validAccessToken <- if (accessToken.getExpirationTime.getTime > now.toEpochMilli)
+        getLeoAuthTokenInteral
+      else F.pure(accessToken)
+    } yield {
+      val token = validAccessToken.getTokenValue
+
+      Authorization(Credentials.Token(AuthScheme.Bearer, token))
+    }
+
+  private def getLeoAuthTokenInteral: F[com.google.auth.oauth2.AccessToken] =
+    credentialResource(
+      config.serviceAccountProviderConfig.leoServiceAccountJsonFile.toAbsolutePath.toString
+    ).use { credential =>
+      val scopedCredential = credential.createScoped(saScopes.asJava)
+
+      F.delay(scopedCredential.refresh).map(_ => scopedCredential.getAccessToken)
+    }
 
   private def getPetAccessToken(userEmail: WorkbenchEmail, googleProject: GoogleProject)(
     implicit ev: Ask[F, TraceId]
   ): F[Option[String]] =
-    getAccessTokenUsingLeoJson.use { leoToken =>
-      val leoAuth = Authorization(Credentials.Token(AuthScheme.Bearer, leoToken))
-      for {
-        _ <- metrics.incrementCounter("sam/getPetServiceAccount")
-        // fetch user's pet SA key with leo's authorization token
-        userPetKey <- httpClient.expectOptionOr[Json](
-          Request[F](
-            method = Method.GET,
-            uri = config.samUri.withPath(
-              Uri.Path.unsafeFromString(
-                s"/api/google/v1/petServiceAccount/${googleProject.value}/${URLEncoder.encode(userEmail.value, UTF_8.name)}"
-              )
-            ),
-            headers = Headers(leoAuth)
-          )
-        )(onError)
-        token <- userPetKey.traverse { key =>
-          val keyStream = new ByteArrayInputStream(key.toString().getBytes)
-          F.delay(ServiceAccountCredentials.fromStream(keyStream).createScoped(saScopes.asJava))
-            .map(_.refreshAccessToken.getTokenValue)
-        }
-      } yield token
-    }
+    for {
+      leoAuth <- getLeoAuthToken
+      _ <- metrics.incrementCounter("sam/getPetServiceAccount")
+      // fetch user's pet SA key with leo's authorization token
+      userPetKey <- httpClient.expectOptionOr[Json](
+        Request[F](
+          method = Method.GET,
+          uri = config.samUri.withPath(
+            Uri.Path.unsafeFromString(
+              s"/api/google/v1/petServiceAccount/${googleProject.value}/${URLEncoder.encode(userEmail.value, UTF_8.name)}"
+            )
+          ),
+          headers = Headers(leoAuth)
+        )
+      )(onError)
+      token <- userPetKey.traverse { key =>
+        val keyStream = new ByteArrayInputStream(key.toString().getBytes)
+        F.delay(ServiceAccountCredentials.fromStream(keyStream).createScoped(saScopes.asJava))
+          .map(_.refreshAccessToken.getTokenValue)
+      }
+    } yield token
 
   private def onError(response: Response[F])(implicit ev: Ask[F, TraceId]): F[Throwable] =
     for {

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpWsmDao.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpWsmDao.scala
@@ -1,29 +1,37 @@
 package org.broadinstitute.dsde.workbench.leonardo
 package dao
 
-import org.typelevel.log4cats.StructuredLogger
-import org.broadinstitute.dsde.workbench.openTelemetry.OpenTelemetryMetrics
+import _root_.io.circe.syntax._
 import cats.effect.Async
+import cats.implicits._
 import cats.mtl.Ask
+import fs2.Stream
 import org.broadinstitute.dsde.workbench.leonardo.config.HttpWsmDaoConfig
-import org.http4s.{AuthScheme, Credentials, Headers, Method, Request, Response, Uri}
+import org.broadinstitute.dsde.workbench.leonardo.dao.WsmDecoders._
+import org.broadinstitute.dsde.workbench.leonardo.dao.WsmEncoders._
+import org.broadinstitute.dsde.workbench.openTelemetry.OpenTelemetryMetrics
+import org.http4s._
+import org.http4s.circe.CirceEntityDecoder._
+import org.http4s.circe.CirceEntityEncoder._
 import org.http4s.client.Client
 import org.http4s.client.dsl.Http4sClientDsl
-import cats.implicits._
-import org.http4s.circe.CirceEntityDecoder._
-import _root_.io.circe.syntax._
-import WsmDecoders._
-import WsmEncoders._
-import fs2.Stream
-import org.http4s.headers.Authorization
+import org.http4s.headers.{`Content-Type`, Authorization}
+import org.typelevel.log4cats.StructuredLogger
 
-class HttpWsmDao[F[_]](httpClient: Client[F], config: HttpWsmDaoConfig)(implicit logger: StructuredLogger[F],
-                                                                        F: Async[F],
-                                                                        metrics: OpenTelemetryMetrics[F])
-    extends WsmDao[F]
+class HttpWsmDao[F[_]](httpClient: Client[F], config: HttpWsmDaoConfig)(
+  implicit logger: StructuredLogger[F],
+  F: Async[F],
+  metrics: OpenTelemetryMetrics[F]
+) extends WsmDao[F]
     with Http4sClientDsl[F] {
 
-  override def createIp(request: CreateIpRequest)(implicit ev: Ask[F, AppContext]): F[CreateIpResponse] =
+  implicit def http4sBody[A](body: A)(implicit encoder: EntityEncoder[F, A]): EntityBody[F] =
+    encoder.toEntity(body).body
+
+  val defaultMediaType = `Content-Type`(MediaType.application.json)
+
+  override def createIp(request: CreateIpRequest,
+                        authorization: Authorization)(implicit ev: Ask[F, AppContext]): F[CreateIpResponse] =
     httpClient.expectOr[CreateIpResponse](
       Request[F](
         method = Method.POST,
@@ -34,12 +42,13 @@ class HttpWsmDao[F[_]](httpClient: Client[F], config: HttpWsmDaoConfig)(implicit
                 s"/api/workspaces/v1/${request.workspaceId.value.toString}/resources/controlled/azure/ip"
               )
           ),
-        body = Stream.emits(request.asJson.noSpaces.getBytes),
-        headers = Headers(fakeAuth()) //TODO
+        body = request,
+        headers = Headers(authorization, defaultMediaType)
       )
     )(onError)
 
-  override def createDisk(request: CreateDiskRequest)(implicit ev: Ask[F, AppContext]): F[CreateDiskResponse] =
+  override def createDisk(request: CreateDiskRequest,
+                          authorization: Authorization)(implicit ev: Ask[F, AppContext]): F[CreateDiskResponse] =
     httpClient.expectOr[CreateDiskResponse](
       Request[F](
         method = Method.POST,
@@ -47,15 +56,16 @@ class HttpWsmDao[F[_]](httpClient: Client[F], config: HttpWsmDaoConfig)(implicit
           .withPath(
             Uri.Path
               .unsafeFromString(
-                s"/api/workspaces/v1/${request.workspaceId.value.toString}/resources/controlled/azure/disk"
+                s"/api/workspaces/v1/${request.workspaceId.value.toString}/resources/controlled/azure/disks"
               )
           ),
-        body = Stream.emits(request.asJson.noSpaces.getBytes),
-        headers = Headers(fakeAuth())
+        body = request,
+        headers = Headers(authorization, defaultMediaType)
       )
     )(onError)
 
-  override def createNetwork(request: CreateNetworkRequest)(implicit ev: Ask[F, AppContext]): F[CreateNetworkResponse] =
+  override def createNetwork(request: CreateNetworkRequest,
+                             authorization: Authorization)(implicit ev: Ask[F, AppContext]): F[CreateNetworkResponse] =
     httpClient.expectOr[CreateNetworkResponse](
       Request[F](
         method = Method.POST,
@@ -63,15 +73,16 @@ class HttpWsmDao[F[_]](httpClient: Client[F], config: HttpWsmDaoConfig)(implicit
           .withPath(
             Uri.Path
               .unsafeFromString(
-                s"/api/workspaces/v1/${request.workspaceId.value.toString}/resources/controlled/azure/disk"
+                s"/api/workspaces/v1/${request.workspaceId.value.toString}/resources/controlled/azure/network"
               )
           ),
-        body = Stream.emits(request.asJson.noSpaces.getBytes),
-        headers = Headers(fakeAuth())
+        body = request,
+        headers = Headers(authorization, defaultMediaType)
       )
     )(onError)
 
-  override def createVm(request: CreateVmRequest)(implicit ev: Ask[F, AppContext]): F[CreateVmResult] =
+  override def createVm(request: CreateVmRequest,
+                        authorization: Authorization)(implicit ev: Ask[F, AppContext]): F[CreateVmResult] =
     httpClient.expectOr[CreateVmResult](
       Request[F](
         method = Method.POST,
@@ -82,12 +93,13 @@ class HttpWsmDao[F[_]](httpClient: Client[F], config: HttpWsmDaoConfig)(implicit
                 s"/api/workspaces/v1/${request.workspaceId.value.toString}/resources/controlled/azure/vm"
               )
           ),
-        body = Stream.emits(request.asJson.noSpaces.getBytes),
-        headers = Headers(fakeAuth())
+        body = request,
+        headers = Headers(authorization, defaultMediaType)
       )
     )(onError)
 
-  override def getWorkspace(workspaceId: WorkspaceId)(implicit ev: Ask[F, AppContext]): F[WorkspaceDescription] =
+  override def getWorkspace(workspaceId: WorkspaceId,
+                            authorization: Authorization)(implicit ev: Ask[F, AppContext]): F[WorkspaceDescription] =
     httpClient.expectOr[WorkspaceDescription](
       Request[F](
         method = Method.GET,
@@ -96,11 +108,12 @@ class HttpWsmDao[F[_]](httpClient: Client[F], config: HttpWsmDaoConfig)(implicit
             Uri.Path
               .unsafeFromString(s"/api/workspaces/v1/${workspaceId.value.toString}")
           ),
-        headers = Headers(fakeAuth())
+        headers = Headers(authorization)
       )
     )(onError)
 
-  override def deleteVm(request: DeleteVmRequest)(implicit ev: Ask[F, AppContext]): F[DeleteVmResult] =
+  override def deleteVm(request: DeleteVmRequest,
+                        authorization: Authorization)(implicit ev: Ask[F, AppContext]): F[DeleteVmResult] =
     httpClient.expectOr[DeleteVmResult](
       Request[F](
         method = Method.POST,
@@ -112,12 +125,14 @@ class HttpWsmDao[F[_]](httpClient: Client[F], config: HttpWsmDaoConfig)(implicit
               )
           ),
         body = Stream.emits(request.deleteRequest.asJson.noSpaces.getBytes),
-        headers = Headers(fakeAuth())
+        headers = Headers(authorization, defaultMediaType)
       )
     )(onError)
 
-  override def getCreateVmJobResult(request: GetJobResultRequest)(implicit ev: Ask[F, AppContext]): F[CreateVmResult] =
-    httpClient.expectOr[CreateVmResult](
+  override def getCreateVmJobResult(request: GetJobResultRequest, authorization: Authorization)(
+    implicit ev: Ask[F, AppContext]
+  ): F[GetCreateVmJobResult] =
+    httpClient.expectOr[GetCreateVmJobResult](
       Request[F](
         method = Method.GET,
         uri = config.uri
@@ -127,7 +142,7 @@ class HttpWsmDao[F[_]](httpClient: Client[F], config: HttpWsmDaoConfig)(implicit
                 s"/api/workspaces/v1/${request.workspaceId.value.toString}/resources/controlled/azure/vm/create-result/${request.jobId.value}"
               )
           ),
-        headers = Headers(fakeAuth())
+        headers = Headers(authorization)
       )
     )(onError)
 
@@ -138,8 +153,4 @@ class HttpWsmDao[F[_]](httpClient: Client[F], config: HttpWsmDaoConfig)(implicit
       _ <- logger.error(context.loggingCtx)(s"WSM call failed: $body")
       _ <- metrics.incrementCounter("wsm/errorResponse")
     } yield WsmException(context.traceId, body)
-
-  private def fakeAuth(): Authorization =
-    Authorization(Credentials.Token(AuthScheme.Bearer, ""))
-
 }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/SamDAO.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/SamDAO.scala
@@ -10,6 +10,8 @@ import org.broadinstitute.dsde.workbench.util.health.StatusCheckResponse
 import org.http4s.headers.Authorization
 
 trait SamDAO[F[_]] {
+  def registerLeo(implicit ev: Ask[F, TraceId]): F[Unit]
+
   def getStatus(implicit ev: Ask[F, TraceId]): F[StatusCheckResponse]
 
   def hasResourcePermission[R, A](resource: R, action: A, authHeader: Authorization)(
@@ -71,6 +73,8 @@ trait SamDAO[F[_]] {
   ): F[Option[UserSubjectId]]
 
   def getUserSubjectIdFromToken(token: String)(implicit ev: Ask[F, TraceId]): F[Option[UserSubjectId]]
+
+  def getLeoAuthToken: F[Authorization]
 }
 
 final case class UserSubjectId(asString: String) extends AnyVal

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/WsmDao.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/WsmDao.scala
@@ -40,10 +40,19 @@ trait WsmDao[F[_]] {
     implicit ev: Ask[F, AppContext]
   ): F[GetCreateVmJobResult]
 
-  def deleteVm(request: DeleteVmRequest, authorization: Authorization)(
+  def deleteVm(request: DeleteWsmResourceRequest, authorization: Authorization)(
     implicit ev: Ask[F, AppContext]
-  ): F[DeleteVmResult]
+  ): F[DeleteWsmResourceResult]
 
+  def deleteDisk(request: DeleteWsmResourceRequest, authorization: Authorization)(
+    implicit ev: Ask[F, AppContext]
+  ): F[DeleteWsmResourceResult]
+  def deleteIp(request: DeleteWsmResourceRequest, authorization: Authorization)(
+    implicit ev: Ask[F, AppContext]
+  ): F[DeleteWsmResourceResult]
+  def deleteNetworks(request: DeleteWsmResourceRequest, authorization: Authorization)(
+    implicit ev: Ask[F, AppContext]
+  ): F[DeleteWsmResourceResult]
   def getWorkspace(workspaceId: WorkspaceId, authorization: Authorization)(
     implicit ev: Ask[F, AppContext]
   ): F[WorkspaceDescription]
@@ -68,9 +77,9 @@ final case class CreateVmRequestData(name: RuntimeName,
 final case class WsmVMMetadata(resourceId: WsmControlledResourceId)
 final case class WsmVm(metadata: WsmVMMetadata)
 
-final case class DeleteVmRequest(workspaceId: WorkspaceId,
-                                 resourceId: WsmControlledResourceId,
-                                 deleteRequest: DeleteControlledAzureResourceRequest)
+final case class DeleteWsmResourceRequest(workspaceId: WorkspaceId,
+                                          resourceId: WsmControlledResourceId,
+                                          deleteRequest: DeleteControlledAzureResourceRequest)
 
 final case class CreateVmResult(jobReport: WsmJobReport, errorReport: Option[WsmErrorReport])
 final case class GetCreateVmJobResult(vm: Option[WsmVm], jobReport: WsmJobReport, errorReport: Option[WsmErrorReport])
@@ -138,7 +147,7 @@ final case class WsmJobReport(id: WsmJobId,
 final case class WsmJobControl(id: WsmJobId)
 final case class DeleteControlledAzureResourceRequest(jobControl: WsmJobControl)
 
-final case class DeleteVmResult(jobReport: WsmJobReport, errorReport: Option[WsmErrorReport])
+final case class DeleteWsmResourceResult(jobReport: WsmJobReport, errorReport: Option[WsmErrorReport])
 
 sealed abstract class WsmJobStatus
 object WsmJobStatus {
@@ -294,11 +303,11 @@ object WsmDecoders {
   implicit val wsmErrorReportDecoder: Decoder[WsmErrorReport] =
     Decoder.forProduct3("message", "statusCode", "causes")(WsmErrorReport.apply)
 
-  implicit val deleteControlledAzureResourceResponseDecoder: Decoder[DeleteVmResult] = Decoder.instance { c =>
+  implicit val deleteControlledAzureResourceResponseDecoder: Decoder[DeleteWsmResourceResult] = Decoder.instance { c =>
     for {
       jobReport <- c.downField("jobReport").as[WsmJobReport]
       errorReport <- c.downField("errorReport").as[Option[WsmErrorReport]]
-    } yield DeleteVmResult(jobReport, errorReport)
+    } yield DeleteWsmResourceResult(jobReport, errorReport)
   }
 
   implicit val createVmResultDecoder: Decoder[CreateVmResult] =

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterErrorComponent.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterErrorComponent.scala
@@ -39,7 +39,7 @@ object clusterErrorQuery extends TableQuery(new ClusterErrorTable(_)) {
   def save(clusterId: Long, clusterError: RuntimeError): DBIO[Int] =
     clusterErrorQuery += ClusterErrorRecord(0,
                                             clusterId,
-                                            clusterError.errorMessage,
+                                            clusterError.errorMessage.take(1024),
                                             clusterError.errorCode,
                                             Timestamp.from(clusterError.timestamp),
                                             clusterError.traceId)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/RuntimeControlledResourceComponent.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/RuntimeControlledResourceComponent.scala
@@ -30,8 +30,8 @@ object controlledResourceQuery extends TableQuery(new RuntimeControlledResourceT
   def save(runtimeId: Long, resourceId: WsmControlledResourceId, resourceType: WsmResourceType): DBIO[Int] =
     controlledResourceQuery += RuntimeControlledResourceRecord(runtimeId, resourceId, resourceType)
 
-  def getResourceTypeForRuntime(runtimeId: Long,
-                                resourceType: WsmResourceType): DBIO[Option[RuntimeControlledResourceRecord]] =
+  def getWsmRecordForRuntime(runtimeId: Long,
+                             resourceType: WsmResourceType): DBIO[Option[RuntimeControlledResourceRecord]] =
     controlledResourceQuery
       .filter(_.runtimeId === runtimeId)
       .filter(_.resourceType === resourceType)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/Boot.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/Boot.scala
@@ -185,6 +185,7 @@ object Boot extends IOApp {
         appDependencies.authProvider,
         appDependencies.wsmDAO,
         appDependencies.samDAO,
+        appDependencies.asyncTasksQueue,
         appDependencies.publisherQueue
       )
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/Boot.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/Boot.scala
@@ -206,7 +206,9 @@ object Boot extends IOApp {
         implicit0(ctx: Ask[IO, AppContext]) = Ask.const[IO, AppContext](
           AppContext(TraceId(s"Boot_${start}"), start)
         )
-        _ <- appDependencies.samDAO.registerLeo
+//       TODO: this will be needed once we support more environments.
+//        Disable for now since this causes fiab start to fail
+//        _ <- appDependencies.samDAO.registerLeo
 
         _ <- if (leoExecutionModeConfig == LeoExecutionModeConfig.BackLeoOnly) {
           dataprocInterp.setupDataprocImageGoogleGroup

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/ConfigReader.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/ConfigReader.scala
@@ -4,13 +4,9 @@ package http
 import pureconfig.ConfigSource
 import _root_.pureconfig.generic.auto._
 import ConfigImplicits._
-import org.broadinstitute.dsde.workbench.leonardo.util.{
-  AzureInterpretorConfig,
-  AzureMonitorConfig,
-  TerraAppSetupChartConfig
-}
+import org.broadinstitute.dsde.workbench.leonardo.util.{AzureMonitorConfig, TerraAppSetupChartConfig}
 import org.broadinstitute.dsde.workbench.leonardo.config.{HttpWsmDaoConfig, PersistentDiskConfig}
-import org.broadinstitute.dsde.workbench.leonardo.http.service.AzureRuntimeConfig
+import org.broadinstitute.dsde.workbench.leonardo.http.service.{AzureRuntimeConfig, AzureRuntimeDefaults}
 
 object ConfigReader {
   lazy val appConfig =
@@ -21,7 +17,7 @@ object ConfigReader {
 
 final case class AzureConfig(
   monitor: AzureMonitorConfig,
-  runtimeDefaults: AzureInterpretorConfig,
+  runtimeDefaults: AzureRuntimeDefaults,
   wsm: HttpWsmDaoConfig,
   appRegistration: AzureAppRegistrationConfig,
   service: AzureRuntimeConfig

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/RuntimeV2Routes.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/RuntimeV2Routes.scala
@@ -163,9 +163,16 @@ class RuntimeV2Routes(saturnIframeExtentionHostConfig: RefererConfig,
       region <- c.downField("region").as[Region]
       machineSize <- c.downField("machineSize").as[VirtualMachineSizeTypes]
       imageUri <- c.downField("imageUri").as[Option[AzureImageUri]]
-      customEnvVars <- c.downField("customEnvironmentVariables").as[Map[String, String]]
+      customEnvVars <- c
+        .downField("customEnvironmentVariables")
+        .as[Option[Map[String, String]]]
       azureDiskReq <- c.downField("disk").as[CreateAzureDiskRequest]
-    } yield CreateAzureRuntimeRequest(labels, region, machineSize, imageUri, customEnvVars, azureDiskReq)
+    } yield CreateAzureRuntimeRequest(labels,
+                                      region,
+                                      machineSize,
+                                      imageUri,
+                                      customEnvVars.getOrElse(Map.empty),
+                                      azureDiskReq)
   }
 
   implicit val updateAzureRuntimeRequestDecoder: Decoder[UpdateAzureRuntimeRequest] =

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/RuntimeV2Routes.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/RuntimeV2Routes.scala
@@ -101,7 +101,6 @@ class RuntimeV2Routes(saturnIframeExtentionHostConfig: RefererConfig,
   ): IO[ToResponseMarshallable] =
     for {
       ctx <- ev.ask[AppContext]
-      _ = println("routes here1")
       apiCall = azureService.createRuntime(userInfo, runtimeName, workspaceId, req)
       _ <- metrics.incrementCounter("createAzureRuntime")
       _ <- ctx.span.fold(apiCall)(span =>

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/RuntimeV2Routes.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/RuntimeV2Routes.scala
@@ -19,8 +19,6 @@ import JsonCodec._
 import com.azure.core.management.Region
 import com.azure.resourcemanager.compute.models.VirtualMachineSizeTypes
 
-import java.util.UUID
-
 class RuntimeV2Routes(saturnIframeExtentionHostConfig: RefererConfig,
                       azureService: AzureService[IO],
                       userInfoDirectives: UserInfoDirectives)(
@@ -103,7 +101,7 @@ class RuntimeV2Routes(saturnIframeExtentionHostConfig: RefererConfig,
     for {
       ctx <- ev.ask[AppContext]
 
-      jobUUID <- IO.delay(UUID.randomUUID()).map(WsmJobId)
+      jobUUID = WsmJobId(s"create-${runtimeName.asString}")
       apiCall = azureService.createRuntime(userInfo, runtimeName, workspaceId, req, jobUUID)
       _ <- metrics.incrementCounter("createAzureRuntime")
       _ <- ctx.span.fold(apiCall)(span =>

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/AzureService.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/AzureService.scala
@@ -6,10 +6,12 @@ import org.broadinstitute.dsde.workbench.leonardo.config.PersistentDiskConfig
 import org.broadinstitute.dsde.workbench.leonardo.{
   AppContext,
   AzureImageUri,
+  CidrIP,
   CreateAzureRuntimeRequest,
   RuntimeName,
   UpdateAzureRuntimeRequest,
-  WorkspaceId
+  WorkspaceId,
+  WsmJobId
 }
 import org.broadinstitute.dsde.workbench.model.UserInfo
 
@@ -17,7 +19,8 @@ trait AzureService[F[_]] {
   def createRuntime(userInfo: UserInfo,
                     runtimeName: RuntimeName,
                     workspaceId: WorkspaceId,
-                    req: CreateAzureRuntimeRequest)(
+                    req: CreateAzureRuntimeRequest,
+                    createVmJobId: WsmJobId)(
     implicit as: Ask[F, AppContext]
   ): F[Unit]
 
@@ -39,3 +42,13 @@ trait AzureService[F[_]] {
 
 final case class AzureServiceConfig(diskConfig: PersistentDiskConfig, runtimeConfig: AzureRuntimeConfig)
 final case class AzureRuntimeConfig(imageUri: AzureImageUri, defaultScopes: Set[String])
+
+final case class AzureRuntimeDefaults(ipControlledResourceDesc: String,
+                                      ipNamePrefix: String,
+                                      networkControlledResourceDesc: String,
+                                      networkNamePrefix: String,
+                                      subnetNamePrefix: String,
+                                      addressSpaceCidr: CidrIP,
+                                      subnetAddressCidr: CidrIP,
+                                      diskControlledResourceDesc: String,
+                                      vmControlledResourceDesc: String)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/AzureServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/AzureServiceInterp.scala
@@ -375,7 +375,7 @@ class AzureServiceInterp[F[_]: Parallel](config: RuntimeServiceConfig,
     for {
       context <- ctx.ask
       controlledResourceOpt <- controlledResourceQuery
-        .getResourceTypeForRuntime(runtimeId, WsmResourceType.AzureVm)
+        .getWsmRecordForRuntime(runtimeId, WsmResourceType.AzureVm)
         .transaction
       azureRuntimeControlledResource <- F.fromOption(
         controlledResourceOpt,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterp.scala
@@ -1030,7 +1030,8 @@ final case class RuntimeServiceConfig(proxyUrlBase: String,
                                       autoFreezeConfig: AutoFreezeConfig,
                                       dataprocConfig: DataprocConfig,
                                       gceConfig: GceConfig,
-                                      azureConfig: AzureServiceConfig)
+                                      azureConfig: AzureServiceConfig,
+                                      azureRuntimeDefaults: AzureRuntimeDefaults)
 
 final case class WrongCloudServiceException(runtimeCloudService: CloudService,
                                             updateCloudService: CloudService,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeoAuthProvider.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeoAuthProvider.scala
@@ -113,7 +113,8 @@ object SamResourceAction {
       type ActionCategory = WorkspaceAction
       val decoder = Decoder[WorkspaceAction]
       val allActions = WorkspaceAction.allActions.toList
-      val cacheableActions = List(WorkspaceAction.CreateControlledResource)
+      val cacheableActions =
+        List(WorkspaceAction.CreateControlledUserResource, WorkspaceAction.CreateControlledApplicationResource)
       def actionAsString(a: A): String = a.asString
     }
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
@@ -1254,7 +1254,7 @@ class LeoPubsubMessageSubscriber[F[_]](
           Some(s"Failed to create cluster ${runtimeId} due to ${e.getMessage}")
       }
       _ <- errorMessage.traverse(m =>
-        (clusterErrorQuery.save(runtimeId, RuntimeError(m, None, now)) >>
+        (clusterErrorQuery.save(runtimeId, RuntimeError(m.take(1024), None, now)) >>
           clusterQuery.updateClusterStatus(runtimeId, RuntimeStatus.Error, now)).transaction[F]
       )
     } yield ()

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/leoPubsubMessageSubscriberModels.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/leoPubsubMessageSubscriberModels.scala
@@ -313,7 +313,7 @@ object LeoPubsubMessage {
 
   final case class CreateAzureRuntimeMessage(runtimeId: Long,
                                              workspaceId: WorkspaceId,
-                                             vmImage: RuntimeImage,
+                                             jobId: WsmJobId,
                                              traceId: Option[TraceId])
       extends LeoPubsubMessage {
     val messageType: LeoPubsubMessageType = LeoPubsubMessageType.CreateAzureRuntime
@@ -472,8 +472,8 @@ object LeoPubsubCodec {
   implicit val startAppDecoder: Decoder[StartAppMessage] =
     Decoder.forProduct4("appId", "appName", "project", "traceId")(StartAppMessage.apply)
 
-  implicit val createAzureRuntimeDecoder: Decoder[CreateAzureRuntimeMessage] =
-    Decoder.forProduct4("runtimeId", "workspaceId", "vmImage", "traceId")(CreateAzureRuntimeMessage.apply)
+  implicit val createAzureRuntimeMessageDecoder: Decoder[CreateAzureRuntimeMessage] =
+    Decoder.forProduct4("runtimeId", "workspaceId", "jobId", "traceId")(CreateAzureRuntimeMessage.apply)
 
   implicit val deleteAzureRuntimeDecoder: Decoder[DeleteAzureRuntimeMessage] =
     Decoder.forProduct5("runtimeId", "diskId", "workspaceId", "wsmResourceId", "traceId")(
@@ -802,9 +802,9 @@ object LeoPubsubCodec {
       (x.messageType, x.appId, x.appName, x.project, x.traceId)
     )
 
-  implicit val createAzureMessageEncoder: Encoder[CreateAzureRuntimeMessage] =
-    Encoder.forProduct5("messageType", "runtimeId", "workspaceId", "vmImage", "traceId")(x =>
-      (x.messageType, x.runtimeId, x.workspaceId, x.vmImage, x.traceId)
+  implicit val createAzureRuntimeMessageEncoder: Encoder[CreateAzureRuntimeMessage] =
+    Encoder.forProduct5("messageType", "runtimeId", "workspaceId", "jobId", "traceId")(x =>
+      (x.messageType, x.runtimeId, x.workspaceId, x.jobId, x.traceId)
     )
 
   implicit val deleteAzureMessageEncoder: Encoder[DeleteAzureRuntimeMessage] =

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/leoPubsubMessageSubscriberModels.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/leoPubsubMessageSubscriberModels.scala
@@ -903,8 +903,8 @@ object PubsubHandleMessageError {
 
 final case class PersistentDiskMonitor(maxAttempts: Int, interval: FiniteDuration)
 
-final case class PollMonitorConfig(maxAttempts: Int, interval: FiniteDuration) {
-  def totalDuration: FiniteDuration = interval * maxAttempts
+final case class PollMonitorConfig(initialDelay: FiniteDuration, maxAttempts: Int, interval: FiniteDuration) {
+  def totalDuration: FiniteDuration = initialDelay + interval * maxAttempts
 }
 
 final case class InterruptablePollMonitorConfig(maxAttempts: Int,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandler.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandler.scala
@@ -198,7 +198,7 @@ class AzureInterpreter[F[_]](
             dbRef
               .inTransaction(
                 clusterErrorQuery
-                  .save(runtime.id, RuntimeError(e.getMessage.take(1024), None, ctx.now, Some(ctx.traceId))) >>
+                  .save(runtime.id, RuntimeError(e.getMessage, None, ctx.now, Some(ctx.traceId))) >>
                   clusterQuery.updateClusterStatus(runtime.id, RuntimeStatus.Error, ctx.now)
               )
               .void

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandlerAlgeba.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandlerAlgeba.scala
@@ -1,15 +1,7 @@
-package org.broadinstitute.dsde.workbench.leonardo.util
+package org.broadinstitute.dsde.workbench.leonardo
+package util
 
-import org.broadinstitute.dsde.workbench.leonardo.{
-  AppContext,
-  PersistentDisk,
-  Runtime,
-  RuntimeConfig,
-  RuntimeImage,
-  WorkspaceId
-}
 import cats.mtl.Ask
-import org.broadinstitute.dsde.workbench.leonardo.dao.WsmJobId
 import org.broadinstitute.dsde.workbench.leonardo.monitor.LeoPubsubMessage.{
   CreateAzureRuntimeMessage,
   DeleteAzureRuntimeMessage
@@ -32,4 +24,4 @@ final case class CreateAzureRuntimeParams(workspaceId: WorkspaceId,
                                           vmImage: RuntimeImage)
 final case class DeleteAzureRuntimeParams(workspaceId: WorkspaceId, runtime: Runtime)
 
-final case class PollRuntimeParams(workspaceId: WorkspaceId, runtime: Runtime, jobId: WsmJobId, disk: PersistentDisk)
+final case class PollRuntimeParams(workspaceId: WorkspaceId, runtime: Runtime, jobId: WsmJobId)

--- a/http/src/test/resources/reference.conf
+++ b/http/src/test/resources/reference.conf
@@ -292,10 +292,16 @@ akka.ssl-config {
 
 azure {
    monitor {
-    poll-status {
-      max-attempts = 120
-      interval = 1 seconds
-    }
+       create-vm-poll-config {
+           initial-delay = 1 seconds
+           max-attempts = 120
+           interval = 1 seconds
+       }
+       delete-vm-poll-config {
+           initial-delay = 1 seconds
+           max-attempts = 120
+           interval = 1 seconds
+       }
    }
 
    wsm {

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/config/ConfigSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/config/ConfigSpec.scala
@@ -22,9 +22,9 @@ final class ConfigSpec extends AnyFlatSpec with Matchers {
       100,
       295 seconds,
       PersistentDiskMonitorConfig(
-        PollMonitorConfig(5, 3 seconds),
-        PollMonitorConfig(5, 3 seconds),
-        PollMonitorConfig(5, 3 seconds)
+        PollMonitorConfig(2 seconds, 5, 3 seconds),
+        PollMonitorConfig(2 seconds, 5, 3 seconds),
+        PollMonitorConfig(2 seconds, 5, 3 seconds)
       ),
       GalaxyDiskConfig(
         "nfs-disk",
@@ -42,7 +42,7 @@ final class ConfigSpec extends AnyFlatSpec with Matchers {
   it should "read gce.monitor properly" in {
     val expected = GceMonitorConfig(
       20 seconds,
-      PollMonitorConfig(120, 15 seconds),
+      PollMonitorConfig(2 seconds, 120, 15 seconds),
       Map(
         RuntimeStatus.Creating -> 30.minutes,
         RuntimeStatus.Starting -> 20.minutes,

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/MockSamDAO.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/MockSamDAO.scala
@@ -35,6 +35,8 @@ class MockSamDAO extends SamDAO[IO] {
   var runtimeCreators: Map[Authorization, Set[(RuntimeSamResourceId, SamPolicyName)]] = Map.empty
   var diskCreators: Map[Authorization, Set[(PersistentDiskSamResourceId, SamPolicyName)]] = Map.empty
   var appCreators: Map[Authorization, Set[(AppSamResourceId, SamPolicyName)]] = Map.empty
+  var wmsResourceCreators: Map[Authorization, Set[(AppSamResourceId, SamPolicyName)]] = Map.empty
+  var workspaceCreators: Map[Authorization, Set[(AppSamResourceId, SamPolicyName)]] = Map.empty
 
   //we don't care much about traceId in unit tests, hence providing a constant UUID here
   implicit val traceId = Ask.const[IO, TraceId](TraceId(UUID.randomUUID()))
@@ -103,6 +105,14 @@ class MockSamDAO extends SamDAO[IO] {
         IO.pure(diskCreators.get(authHeader).map(_.toList).getOrElse(List.empty).asInstanceOf[List[(R, SamPolicyName)]])
       case SamResourceType.App =>
         IO.pure(appCreators.get(authHeader).map(_.toList).getOrElse(List.empty).asInstanceOf[List[(R, SamPolicyName)]])
+      case SamResourceType.Workspace =>
+        IO.pure(
+          workspaceCreators.get(authHeader).map(_.toList).getOrElse(List.empty).asInstanceOf[List[(R, SamPolicyName)]]
+        )
+      case SamResourceType.WsmResource =>
+        IO.pure(
+          wmsResourceCreators.get(authHeader).map(_.toList).getOrElse(List.empty).asInstanceOf[List[(R, SamPolicyName)]]
+        )
     }
 
   override def createResource[R](resource: R, creatorEmail: WorkbenchEmail, googleProject: GoogleProject)(
@@ -257,6 +267,20 @@ class MockSamDAO extends SamDAO[IO] {
       case SamResourceType.App =>
         val res = apps
           .get((resource.asInstanceOf[AppSamResourceId], authHeader))
+          .map(_.toList)
+          .getOrElse(List.empty)
+          .asInstanceOf[List[sr.ActionCategory]]
+        IO.pure(res)
+      case SamResourceType.Workspace =>
+        val res = workspaces
+          .get((resource.asInstanceOf[WorkspaceResourceSamResourceId], authHeader))
+          .map(_.toList)
+          .getOrElse(List.empty)
+          .asInstanceOf[List[sr.ActionCategory]]
+        IO.pure(res)
+      case SamResourceType.WsmResource =>
+        val res = wsmResources
+          .get((resource.asInstanceOf[WsmResourceSamResourceId], authHeader))
           .map(_.toList)
           .getOrElse(List.empty)
           .asInstanceOf[List[sr.ActionCategory]]

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/MockSamDAO.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/MockSamDAO.scala
@@ -1,11 +1,9 @@
 package org.broadinstitute.dsde.workbench.leonardo
 package dao
 
-import java.util.UUID
-
 import cats.effect.IO
-import cats.syntax.all._
 import cats.mtl.Ask
+import cats.syntax.all._
 import io.circe.{Decoder, Encoder}
 import org.broadinstitute.dsde.workbench.leonardo.SamResourceId._
 import org.broadinstitute.dsde.workbench.leonardo.dao.MockSamDAO._
@@ -16,6 +14,7 @@ import org.broadinstitute.dsde.workbench.util.health.StatusCheckResponse
 import org.http4s.headers.Authorization
 import org.http4s.{AuthScheme, Credentials}
 
+import java.util.UUID
 import scala.collection.concurrent.TrieMap
 import scala.collection.mutable
 
@@ -25,6 +24,10 @@ class MockSamDAO extends SamDAO[IO] {
   val billingProjects: mutable.Map[(ProjectSamResourceId, Authorization), Set[ProjectAction]] = new TrieMap()
   val runtimes: mutable.Map[(RuntimeSamResourceId, Authorization), Set[RuntimeAction]] = new TrieMap()
   val persistentDisks: mutable.Map[(PersistentDiskSamResourceId, Authorization), Set[PersistentDiskAction]] =
+    new TrieMap()
+  val workspaces: mutable.Map[(WorkspaceResourceSamResourceId, Authorization), Set[WorkspaceAction]] =
+    new TrieMap()
+  val wsmResources: mutable.Map[(WsmResourceSamResourceId, Authorization), Set[WsmResourceAction]] =
     new TrieMap()
   val apps: mutable.Map[(AppSamResourceId, Authorization), Set[AppAction]] = new TrieMap()
 
@@ -36,6 +39,7 @@ class MockSamDAO extends SamDAO[IO] {
   //we don't care much about traceId in unit tests, hence providing a constant UUID here
   implicit val traceId = Ask.const[IO, TraceId](TraceId(UUID.randomUUID()))
 
+  override def registerLeo(implicit ev: Ask[IO, TraceId]): IO[Unit] = IO.unit
   override def hasResourcePermissionUnchecked(resourceType: SamResourceType,
                                               resource: String,
                                               action: String,
@@ -64,6 +68,18 @@ class MockSamDAO extends SamDAO[IO] {
       case SamResourceType.App =>
         val res = apps
           .get((AppSamResourceId(resource), authHeader))
+          .map(_.map(_.asString).contains(action))
+          .getOrElse(false)
+        IO.pure(res)
+      case SamResourceType.Workspace =>
+        val res = workspaces
+          .get((WorkspaceResourceSamResourceId(resource), authHeader))
+          .map(_.map(_.asString).contains(action))
+          .getOrElse(false)
+        IO.pure(res)
+      case SamResourceType.WsmResource =>
+        val res = wsmResources
+          .get((WsmResourceSamResourceId(WsmControlledResourceId(UUID.fromString(resource))), authHeader))
           .map(_.map(_.asString).contains(action))
           .getOrElse(false)
         IO.pure(res)
@@ -253,6 +269,9 @@ class MockSamDAO extends SamDAO[IO] {
 
   def getUserSubjectIdFromToken(token: String)(implicit ev: Ask[IO, TraceId]): IO[Option[UserSubjectId]] =
     IO.pure(Some(UserSubjectId("test")))
+
+  override def getLeoAuthToken: IO[Authorization] =
+    IO.pure(Authorization(Credentials.Token(AuthScheme.Bearer, "")))
 }
 
 object MockSamDAO {

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/MockWsmDAO.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/MockWsmDAO.scala
@@ -40,7 +40,7 @@ class MockWsmDAO(jobStatus: WsmJobStatus = WsmJobStatus.Succeeded) extends WsmDa
     IO.pure(
       CreateVmResult(
         WsmJobReport(
-          WsmJobId(UUID.randomUUID()),
+          WsmJobId("job1"),
           "desc",
           jobStatus,
           200,
@@ -88,7 +88,7 @@ class MockWsmDAO(jobStatus: WsmJobStatus = WsmJobStatus.Succeeded) extends WsmDa
       )
     )
 
-  override def deleteVm(request: DeleteVmRequest,
+  override def deleteVm(request: DeleteWsmResourceRequest,
                         authorization: Authorization)(implicit ev: Ask[IO, AppContext]): IO[DeleteWsmResourceResult] =
     IO.pure(
       DeleteWsmResourceResult(
@@ -127,4 +127,78 @@ class MockWsmDAO(jobStatus: WsmJobStatus = WsmJobStatus.Succeeded) extends WsmDa
       )
     )
 
+  override def deleteDisk(request: DeleteWsmResourceRequest, authorization: Authorization)(
+    implicit ev: Ask[IO, AppContext]
+  ): IO[DeleteWsmResourceResult] = IO.pure(
+    DeleteWsmResourceResult(
+      WsmJobReport(
+        request.deleteRequest.jobControl.id,
+        "desc",
+        jobStatus,
+        200,
+        ZonedDateTime.parse("2022-03-18T15:02:29.264756Z"),
+        Some(ZonedDateTime.parse("2022-03-18T15:02:29.264756Z")),
+        "resultUrl"
+      ),
+      if (jobStatus.equals(WsmJobStatus.Failed))
+        Some(
+          WsmErrorReport(
+            "error",
+            500,
+            List.empty
+          )
+        )
+      else None
+    )
+  )
+
+  override def deleteIp(request: DeleteWsmResourceRequest, authorization: Authorization)(
+    implicit ev: Ask[IO, AppContext]
+  ): IO[DeleteWsmResourceResult] = IO.pure(
+    DeleteWsmResourceResult(
+      WsmJobReport(
+        request.deleteRequest.jobControl.id,
+        "desc",
+        jobStatus,
+        200,
+        ZonedDateTime.parse("2022-03-18T15:02:29.264756Z"),
+        Some(ZonedDateTime.parse("2022-03-18T15:02:29.264756Z")),
+        "resultUrl"
+      ),
+      if (jobStatus.equals(WsmJobStatus.Failed))
+        Some(
+          WsmErrorReport(
+            "error",
+            500,
+            List.empty
+          )
+        )
+      else None
+    )
+  )
+
+  override def deleteNetworks(request: DeleteWsmResourceRequest, authorization: Authorization)(
+    implicit ev: Ask[IO, AppContext]
+  ): IO[DeleteWsmResourceResult] = IO.pure(
+    DeleteWsmResourceResult(
+      WsmJobReport(
+        request.deleteRequest.jobControl.id,
+        "desc",
+        jobStatus,
+        200,
+        ZonedDateTime.parse("2022-03-18T15:02:29.264756Z"),
+        Some(ZonedDateTime.parse("2022-03-18T15:02:29.264756Z")),
+        "resultUrl"
+      ),
+      if (jobStatus.equals(WsmJobStatus.Failed))
+        Some(
+          WsmErrorReport(
+            "error",
+            500,
+            List.empty
+          )
+        )
+      else None
+    )
+  )
 }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/MockWsmDAO.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/MockWsmDAO.scala
@@ -1,17 +1,9 @@
-package org.broadinstitute.dsde.workbench.leonardo.dao
+package org.broadinstitute.dsde.workbench.leonardo
+package dao
 
 import java.util.UUID
 import cats.effect.IO
 import cats.mtl.Ask
-import org.broadinstitute.dsde.workbench.leonardo.{
-  AppContext,
-  AzureCloudContext,
-  ManagedResourceGroupName,
-  SubscriptionId,
-  TenantId,
-  WorkspaceId,
-  WsmControlledResourceId
-}
 import org.http4s.headers.Authorization
 
 import java.time.ZonedDateTime
@@ -74,7 +66,7 @@ class MockWsmDAO(jobStatus: WsmJobStatus = WsmJobStatus.Succeeded) extends WsmDa
   )(implicit ev: Ask[IO, AppContext]): IO[GetCreateVmJobResult] =
     IO.pure(
       GetCreateVmJobResult(
-        Some(WsmVm(WsmControlledResourceId(UUID.randomUUID()))),
+        Some(WsmVm(WsmVMMetadata(WsmControlledResourceId(UUID.randomUUID())))),
         WsmJobReport(
           request.jobId,
           "desc",

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/MockWsmDAO.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/MockWsmDAO.scala
@@ -89,9 +89,9 @@ class MockWsmDAO(jobStatus: WsmJobStatus = WsmJobStatus.Succeeded) extends WsmDa
     )
 
   override def deleteVm(request: DeleteVmRequest,
-                        authorization: Authorization)(implicit ev: Ask[IO, AppContext]): IO[DeleteVmResult] =
+                        authorization: Authorization)(implicit ev: Ask[IO, AppContext]): IO[DeleteWsmResourceResult] =
     IO.pure(
-      DeleteVmResult(
+      DeleteWsmResourceResult(
         WsmJobReport(
           request.deleteRequest.jobControl.id,
           "desc",

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/MockWsmDAO.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/MockWsmDAO.scala
@@ -1,7 +1,6 @@
 package org.broadinstitute.dsde.workbench.leonardo.dao
 
 import java.util.UUID
-
 import cats.effect.IO
 import cats.mtl.Ask
 import org.broadinstitute.dsde.workbench.leonardo.{
@@ -13,16 +12,21 @@ import org.broadinstitute.dsde.workbench.leonardo.{
   WorkspaceId,
   WsmControlledResourceId
 }
+import org.http4s.headers.Authorization
+
+import java.time.ZonedDateTime
 
 class MockWsmDAO(jobStatus: WsmJobStatus = WsmJobStatus.Succeeded) extends WsmDao[IO] {
-  override def createIp(request: CreateIpRequest)(implicit ev: Ask[IO, AppContext]): IO[CreateIpResponse] =
+  override def createIp(request: CreateIpRequest,
+                        authorization: Authorization)(implicit ev: Ask[IO, AppContext]): IO[CreateIpResponse] =
     IO.pure(
       CreateIpResponse(
         WsmControlledResourceId(UUID.randomUUID())
       )
     )
 
-  override def createDisk(request: CreateDiskRequest)(implicit ev: Ask[IO, AppContext]): IO[CreateDiskResponse] =
+  override def createDisk(request: CreateDiskRequest,
+                          authorization: Authorization)(implicit ev: Ask[IO, AppContext]): IO[CreateDiskResponse] =
     IO.pure(
       CreateDiskResponse(
         WsmControlledResourceId(UUID.randomUUID())
@@ -30,7 +34,8 @@ class MockWsmDAO(jobStatus: WsmJobStatus = WsmJobStatus.Succeeded) extends WsmDa
     )
 
   override def createNetwork(
-    request: CreateNetworkRequest
+    request: CreateNetworkRequest,
+    authorization: Authorization
   )(implicit ev: Ask[IO, AppContext]): IO[CreateNetworkResponse] =
     IO.pure(
       CreateNetworkResponse(
@@ -38,17 +43,17 @@ class MockWsmDAO(jobStatus: WsmJobStatus = WsmJobStatus.Succeeded) extends WsmDa
       )
     )
 
-  override def createVm(request: CreateVmRequest)(implicit ev: Ask[IO, AppContext]): IO[CreateVmResult] =
+  override def createVm(request: CreateVmRequest,
+                        authorization: Authorization)(implicit ev: Ask[IO, AppContext]): IO[CreateVmResult] =
     IO.pure(
       CreateVmResult(
-        WsmVm(WsmControlledResourceId(UUID.randomUUID())),
         WsmJobReport(
           WsmJobId(UUID.randomUUID()),
           "desc",
           jobStatus,
           200,
-          "submittedTimestamp",
-          "completedTimestamp",
+          ZonedDateTime.parse("2022-03-18T15:02:29.264756Z"),
+          Some(ZonedDateTime.parse("2022-03-18T15:02:29.264756Z")),
           "resultUrl"
         ),
         if (jobStatus.equals(WsmJobStatus.Failed))
@@ -64,18 +69,19 @@ class MockWsmDAO(jobStatus: WsmJobStatus = WsmJobStatus.Succeeded) extends WsmDa
     )
 
   override def getCreateVmJobResult(
-    request: GetJobResultRequest
-  )(implicit ev: Ask[IO, AppContext]): IO[CreateVmResult] =
+    request: GetJobResultRequest,
+    authorization: Authorization
+  )(implicit ev: Ask[IO, AppContext]): IO[GetCreateVmJobResult] =
     IO.pure(
-      CreateVmResult(
-        WsmVm(WsmControlledResourceId(UUID.randomUUID())),
+      GetCreateVmJobResult(
+        Some(WsmVm(WsmControlledResourceId(UUID.randomUUID()))),
         WsmJobReport(
           request.jobId,
           "desc",
           jobStatus,
           200,
-          "submittedTimestamp",
-          "completedTimestamp",
+          ZonedDateTime.parse("2022-03-18T15:02:29.264756Z"),
+          Some(ZonedDateTime.parse("2022-03-18T15:02:29.264756Z")),
           "resultUrl"
         ),
         if (jobStatus.equals(WsmJobStatus.Failed))
@@ -90,7 +96,8 @@ class MockWsmDAO(jobStatus: WsmJobStatus = WsmJobStatus.Succeeded) extends WsmDa
       )
     )
 
-  override def deleteVm(request: DeleteVmRequest)(implicit ev: Ask[IO, AppContext]): IO[DeleteVmResult] =
+  override def deleteVm(request: DeleteVmRequest,
+                        authorization: Authorization)(implicit ev: Ask[IO, AppContext]): IO[DeleteVmResult] =
     IO.pure(
       DeleteVmResult(
         WsmJobReport(
@@ -98,8 +105,8 @@ class MockWsmDAO(jobStatus: WsmJobStatus = WsmJobStatus.Succeeded) extends WsmDa
           "desc",
           jobStatus,
           200,
-          "submittedTimestamp",
-          "completedTimestamp",
+          ZonedDateTime.parse("2022-03-18T15:02:29.264756Z"),
+          Some(ZonedDateTime.parse("2022-03-18T15:02:29.264756Z")),
           "resultUrl"
         ),
         if (jobStatus.equals(WsmJobStatus.Failed))
@@ -114,7 +121,8 @@ class MockWsmDAO(jobStatus: WsmJobStatus = WsmJobStatus.Succeeded) extends WsmDa
       )
     )
 
-  override def getWorkspace(workspaceId: WorkspaceId)(implicit ev: Ask[IO, AppContext]): IO[WorkspaceDescription] =
+  override def getWorkspace(workspaceId: WorkspaceId,
+                            authorization: Authorization)(implicit ev: Ask[IO, AppContext]): IO[WorkspaceDescription] =
     IO.pure(
       WorkspaceDescription(
         workspaceId,

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/WsmCodecSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/WsmCodecSpec.scala
@@ -147,7 +147,7 @@ class WsmCodecSpec extends AnyFlatSpec with Matchers {
         WsmControlledResourceId(fixedUUID),
         WsmControlledResourceId(fixedUUID)
       ),
-      WsmJobControl(WsmJobId(fixedUUID))
+      WsmJobControl(WsmJobId("job1"))
     ).asJson.deepDropNullValues.noSpaces
 
     req shouldBe
@@ -176,14 +176,14 @@ class WsmCodecSpec extends AnyFlatSpec with Matchers {
          |    "networkId": "${fixedUUID.toString}"
          |  },
          |  "jobControl": {
-         |    "id": "${fixedUUID.toString}"
+         |    "id": "job1"
          |  }
          |}
          |""".stripMargin.replaceAll("\\s", "")
   }
 
   it should "encode DeleteVmRequest" in {
-    val fixedUUID = UUID.randomUUID()
+    val fixedUUID = UUID.randomUUID().toString
     val req = DeleteControlledAzureResourceRequest(WsmJobControl(WsmJobId(fixedUUID)))
 
     req.asJson.deepDropNullValues.noSpaces shouldBe
@@ -252,10 +252,10 @@ class WsmCodecSpec extends AnyFlatSpec with Matchers {
   }
 
   it should "decode CreateVmResult" in {
-    val fixedUUID = UUID.randomUUID()
+    val jobId = WsmJobId("job1")
     val expected = CreateVmResult(
       WsmJobReport(
-        WsmJobId(fixedUUID),
+        jobId,
         "desc",
         WsmJobStatus.Running,
         200,
@@ -276,7 +276,7 @@ class WsmCodecSpec extends AnyFlatSpec with Matchers {
       s"""
          |{
          |  "jobReport": {
-         |    "id": "${fixedUUID.toString}",
+         |    "id": "${jobId.value}",
          |    "description": "desc",
          |    "status": "RUNNING",
          |    "statusCode": 200,
@@ -300,7 +300,7 @@ class WsmCodecSpec extends AnyFlatSpec with Matchers {
          |{
          |    "jobReport":
          |    {
-         |        "id": "1bf4d89f-53ac-4ad4-ab8e-0131c6494a69",
+         |        "id": "job2",
          |        "description": "Create controlled resource CONTROLLED_AZURE_VM; id 635e25e1-c793-4ca9-b9fe-9055cdae2f26; name automation-test-aswsimhjz",
          |        "status": "RUNNING",
          |        "statusCode": 202,
@@ -313,7 +313,7 @@ class WsmCodecSpec extends AnyFlatSpec with Matchers {
 
     val expected2 = CreateVmResult(
       WsmJobReport(
-        WsmJobId(UUID.fromString("1bf4d89f-53ac-4ad4-ab8e-0131c6494a69")),
+        WsmJobId("job2"),
         "Create controlled resource CONTROLLED_AZURE_VM; id 635e25e1-c793-4ca9-b9fe-9055cdae2f26; name automation-test-aswsimhjz",
         WsmJobStatus.Running,
         202,
@@ -327,7 +327,7 @@ class WsmCodecSpec extends AnyFlatSpec with Matchers {
   }
 
   it should "decode getCreateVmResult" in {
-    val fixedUUID = UUID.randomUUID()
+    val jobId = WsmJobId("job1")
     val expected = GetCreateVmJobResult(
       Some(
         WsmVm(
@@ -335,7 +335,7 @@ class WsmCodecSpec extends AnyFlatSpec with Matchers {
         )
       ),
       WsmJobReport(
-        WsmJobId(fixedUUID),
+        jobId,
         "desc",
         WsmJobStatus.Running,
         200,
@@ -388,7 +388,7 @@ class WsmCodecSpec extends AnyFlatSpec with Matchers {
          |        }
          |    },
          |  "jobReport": {
-         |    "id": "${fixedUUID.toString}",
+         |    "id": "${jobId.toString}",
          |    "description": "desc",
          |    "status": "RUNNING",
          |    "statusCode": 200,
@@ -409,7 +409,7 @@ class WsmCodecSpec extends AnyFlatSpec with Matchers {
   }
 
   it should "decode DeleteVmResult" in {
-    val fixedUUID = UUID.randomUUID()
+    val fixedUUID = UUID.randomUUID().toString
     val now = ZonedDateTime.now()
     val expected = DeleteWsmResourceResult(
       WsmJobReport(

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/WsmCodecSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/WsmCodecSpec.scala
@@ -1,4 +1,5 @@
-package org.broadinstitute.dsde.workbench.leonardo.dao
+package org.broadinstitute.dsde.workbench.leonardo
+package dao
 
 import java.util.UUID
 import com.azure.core.management.Region
@@ -323,6 +324,88 @@ class WsmCodecSpec extends AnyFlatSpec with Matchers {
       None
     )
     decodedResp2 shouldBe Right(expected2)
+  }
+
+  it should "decode getCreateVmResult" in {
+    val fixedUUID = UUID.randomUUID()
+    val expected = GetCreateVmJobResult(
+      Some(
+        WsmVm(
+          WsmVMMetadata(WsmControlledResourceId(UUID.fromString("dcfa6fa4-ab46-465e-a8dd-76705cbdb4ec")))
+        )
+      ),
+      WsmJobReport(
+        WsmJobId(fixedUUID),
+        "desc",
+        WsmJobStatus.Running,
+        200,
+        ZonedDateTime.parse("2022-03-18T15:02:29.264756Z"),
+        Some(ZonedDateTime.parse("2022-03-18T15:02:29.264756Z")),
+        "resultUrl"
+      ),
+      Some(
+        WsmErrorReport(
+          "error",
+          500,
+          List("testCause")
+        )
+      )
+    )
+
+    val decodedResp = decode[CreateVmResult](
+      s"""
+         |{
+         |   "azureVm": {
+         |        "metadata":
+         |        {
+         |            "workspaceId": "e1aaf25b-b298-46eb-891b-e4c326f29b0c",
+         |            "resourceId": "dcfa6fa4-ab46-465e-a8dd-76705cbdb4ec",
+         |            "name": "automation-test-afalskknz",
+         |            "description": "Azure Vm",
+         |            "resourceType": "AZURE_VM",
+         |            "stewardshipType": "CONTROLLED",
+         |            "cloningInstructions": "COPY_NOTHING",
+         |            "controlledResourceMetadata":
+         |            {
+         |                "accessScope": "PRIVATE_ACCESS",
+         |                "managedBy": "APPLICATION",
+         |                "privateResourceUser":
+         |                {
+         |                    "userName": "ron.weasley@test.firecloud.org"
+         |                },
+         |                "privateResourceState": "ACTIVE"
+         |            }
+         |        },
+         |        "attributes":
+         |        {
+         |            "vmName": "automation-test-afalskknz",
+         |            "region": "westcentralus",
+         |            "vmSize": "Standard_D1_v2",
+         |            "vmImageUri": "/subscriptions/3efc5bdf-be0e-44e7-b1d7-c08931e3c16c/resourceGroups/mrg-qi-1-preview-20210517084351/providers/Microsoft.Compute/galleries/msdsvm/images/customized_ms_dsvm/versions/0.1.0",
+         |            "ipId": "62e6dec2-94c5-4806-8594-eb6020344cbe",
+         |            "diskId": "2eddd6aa-bb94-4027-aeca-0de34a583808",
+         |            "networkId": "b414a42b-a27d-4072-8a03-44283f4c07f6"
+         |        }
+         |    },
+         |  "jobReport": {
+         |    "id": "${fixedUUID.toString}",
+         |    "description": "desc",
+         |    "status": "RUNNING",
+         |    "statusCode": 200,
+         |    "submitted": "2022-03-18T15:02:29.264756Z",
+         |    "completed": "2022-03-18T15:02:29.264756Z",
+         |    "resultURL": "resultUrl"
+         |  },
+         |  "errorReport": {
+         |     "message": "error",
+         |     "statusCode": 500,
+         |     "causes": ["testCause"]
+         |  }
+         |}
+         |""".stripMargin.replaceAll("\\s", "")
+    )
+
+    decodedResp shouldBe Right(expected)
   }
 
   it should "decode DeleteVmResult" in {

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/WsmCodecSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/WsmCodecSpec.scala
@@ -388,7 +388,7 @@ class WsmCodecSpec extends AnyFlatSpec with Matchers {
          |        }
          |    },
          |  "jobReport": {
-         |    "id": "${jobId.toString}",
+         |    "id": "${jobId.value}",
          |    "description": "desc",
          |    "status": "RUNNING",
          |    "statusCode": 200,

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/WsmCodecSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/WsmCodecSpec.scala
@@ -411,7 +411,7 @@ class WsmCodecSpec extends AnyFlatSpec with Matchers {
   it should "decode DeleteVmResult" in {
     val fixedUUID = UUID.randomUUID()
     val now = ZonedDateTime.now()
-    val expected = DeleteVmResult(
+    val expected = DeleteWsmResourceResult(
       WsmJobReport(
         WsmJobId(fixedUUID),
         "desc",
@@ -430,7 +430,7 @@ class WsmCodecSpec extends AnyFlatSpec with Matchers {
       )
     )
 
-    val decodedResp = decode[DeleteVmResult](
+    val decodedResp = decode[DeleteWsmResourceResult](
       s"""
          |{
          |  "jobReport": {

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/WsmCodecSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/WsmCodecSpec.scala
@@ -352,7 +352,7 @@ class WsmCodecSpec extends AnyFlatSpec with Matchers {
       )
     )
 
-    val decodedResp = decode[CreateVmResult](
+    val decodedResp = decode[GetCreateVmJobResult](
       s"""
          |{
          |   "azureVm": {

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/TestComponent.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/TestComponent.scala
@@ -117,12 +117,6 @@ trait TestComponent extends LeonardoTestSuite with ScalaFutures with GcsPathUtil
     }
   }
 
-  def updateCreator(id: Long, creator: WorkbenchEmail): DBIO[Int] =
-    clusterQuery
-      .filter(x => x.id === id)
-      .map(c => (c.creator))
-      .update(creator)
-
   def fullClusterQueryByUniqueKey(cloudContext: CloudContext,
                                   clusterName: RuntimeName,
                                   destroyedDateOpt: Option[Instant]) = {

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/TestComponent.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/TestComponent.scala
@@ -20,6 +20,7 @@ import org.broadinstitute.dsde.workbench.leonardo.{
   RuntimeConfig,
   RuntimeName
 }
+import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
 import org.broadinstitute.dsde.workbench.model.google.ServiceAccountKeyId
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.time.{Seconds, Span}
@@ -31,6 +32,8 @@ import slick.jdbc.JdbcProfile
 import java.time.Instant
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
+import org.broadinstitute.dsde.workbench.leonardo.db.LeoProfile.mappedColumnImplicits._
+import org.broadinstitute.dsde.workbench.leonardo.db.LeoProfile.api._
 
 trait TestComponent extends LeonardoTestSuite with ScalaFutures with GcsPathUtils with BeforeAndAfterAll {
 
@@ -103,7 +106,7 @@ trait TestComponent extends LeonardoTestSuite with ScalaFutures with GcsPathUtil
   ): DBIO[Option[Long]] =
     getClusterByUniqueKey(cloudContext, clusterName, destroyedDateOpt).map(_.map(_.id))
 
-  private[leonardo] def getClusterByUniqueKey(
+  def getClusterByUniqueKey(
     cloudContext: CloudContext,
     clusterName: RuntimeName,
     destroyedDateOpt: Option[Instant]
@@ -113,6 +116,12 @@ trait TestComponent extends LeonardoTestSuite with ScalaFutures with GcsPathUtil
       clusterQuery.unmarshalFullCluster(recs).headOption
     }
   }
+
+  def updateCreator(id: Long, creator: WorkbenchEmail): DBIO[Int] =
+    clusterQuery
+      .filter(x => x.id === id)
+      .map(c => (c.creator))
+      .update(creator)
 
   def fullClusterQueryByUniqueKey(cloudContext: CloudContext,
                                   clusterName: RuntimeName,

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/ConfigReaderSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/ConfigReaderSpec.scala
@@ -1,25 +1,11 @@
-package org.broadinstitute.dsde.workbench.leonardo.http
+package org.broadinstitute.dsde.workbench.leonardo
+package http
 
 import org.broadinstitute.dsde.workbench.google2.ZoneName
 import org.broadinstitute.dsde.workbench.leonardo.config.{HttpWsmDaoConfig, PersistentDiskConfig}
-import org.broadinstitute.dsde.workbench.leonardo.http.service.AzureRuntimeConfig
+import org.broadinstitute.dsde.workbench.leonardo.http.service.{AzureRuntimeConfig, AzureRuntimeDefaults}
 import org.broadinstitute.dsde.workbench.leonardo.monitor.PollMonitorConfig
-import org.broadinstitute.dsde.workbench.leonardo.{
-  AzureAppRegistrationConfig,
-  AzureImageUri,
-  BlockSize,
-  CidrIP,
-  ClientId,
-  ClientSecret,
-  DiskSize,
-  DiskType,
-  ManagedAppTenantId
-}
-import org.broadinstitute.dsde.workbench.leonardo.util.{
-  AzureInterpretorConfig,
-  AzureMonitorConfig,
-  TerraAppSetupChartConfig
-}
+import org.broadinstitute.dsde.workbench.leonardo.util.{AzureMonitorConfig, TerraAppSetupChartConfig}
 import org.broadinstitute.dsp.{ChartName, ChartVersion}
 import org.http4s.Uri
 import org.scalatest.flatspec.AnyFlatSpec
@@ -41,15 +27,15 @@ class ConfigReaderSpec extends AnyFlatSpec with Matchers {
       ),
       AzureConfig(
         AzureMonitorConfig(PollMonitorConfig(120, 1 seconds)),
-        AzureInterpretorConfig("Azure Ip",
-                               "ip",
-                               "Azure Network",
-                               "network",
-                               "subnet",
-                               CidrIP("192.168.0.0/16"),
-                               CidrIP("192.168.0.0/24"),
-                               "Azure Disk",
-                               "Azure Vm"),
+        AzureRuntimeDefaults("Azure Ip",
+                             "ip",
+                             "Azure Network",
+                             "network",
+                             "subnet",
+                             CidrIP("192.168.0.0/16"),
+                             CidrIP("192.168.0.0/24"),
+                             "Azure Disk",
+                             "Azure Vm"),
         HttpWsmDaoConfig(Uri.unsafeFromString("https://localhost:8000")),
         AzureAppRegistrationConfig(ClientId(""), ClientSecret(""), ManagedAppTenantId("")),
         AzureRuntimeConfig(

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/ConfigReaderSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/ConfigReaderSpec.scala
@@ -26,7 +26,7 @@ class ConfigReaderSpec extends AnyFlatSpec with Matchers {
         DiskSize(250)
       ),
       AzureConfig(
-        AzureMonitorConfig(PollMonitorConfig(120, 1 seconds)),
+        AzureMonitorConfig(PollMonitorConfig(1 seconds, 120, 1 seconds), PollMonitorConfig(1 seconds, 120, 1 seconds)),
         AzureRuntimeDefaults("Azure Ip",
                              "ip",
                              "Azure Network",

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/TestLeoRoutes.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/TestLeoRoutes.scala
@@ -17,6 +17,7 @@ import org.broadinstitute.dsde.workbench.leonardo.dao.{
   HostStatus,
   MockDockerDAO,
   MockJupyterDAO,
+  MockSamDAO,
   MockWelderDAO,
   MockWsmDAO
 }
@@ -37,9 +38,9 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.time.{Seconds, Span}
 import scalacache.Cache
 import scalacache.caffeine.CaffeineCache
+
 import java.io.ByteArrayInputStream
 import java.time.Instant
-
 import scala.concurrent.duration._
 import scala.util.matching.Regex
 trait TestLeoRoutes {
@@ -119,7 +120,11 @@ trait TestLeoRoutes {
                                            azureServiceConfig)
 
   val azureService =
-    new AzureServiceInterp[IO](serviceConfig, whitelistAuthProvider, new MockWsmDAO, QueueFactory.makePublisherQueue())
+    new AzureServiceInterp[IO](serviceConfig,
+                               whitelistAuthProvider,
+                               new MockWsmDAO,
+                               new MockSamDAO,
+                               QueueFactory.makePublisherQueue())
 
   val underlyingRuntimeDnsCache =
     Caffeine.newBuilder().maximumSize(10000L).build[RuntimeDnsCacheKey, scalacache.Entry[HostStatus]]()

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/TestLeoRoutes.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/TestLeoRoutes.scala
@@ -127,6 +127,7 @@ trait TestLeoRoutes {
                                whitelistAuthProvider,
                                new MockWsmDAO,
                                new MockSamDAO,
+                               QueueFactory.asyncTaskQueue,
                                QueueFactory.makePublisherQueue())
 
   val underlyingRuntimeDnsCache =

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/TestLeoRoutes.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/TestLeoRoutes.scala
@@ -112,12 +112,15 @@ trait TestLeoRoutes {
     FakeGoogleComputeService
   )
 
-  val serviceConfig = RuntimeServiceConfig(Config.proxyConfig.proxyUrlBase,
-                                           imageConfig,
-                                           autoFreezeConfig,
-                                           dataprocConfig,
-                                           Config.gceConfig,
-                                           azureServiceConfig)
+  val serviceConfig = RuntimeServiceConfig(
+    Config.proxyConfig.proxyUrlBase,
+    imageConfig,
+    autoFreezeConfig,
+    dataprocConfig,
+    Config.gceConfig,
+    azureServiceConfig,
+    ConfigReader.appConfig.azure.runtimeDefaults
+  )
 
   val azureService =
     new AzureServiceInterp[IO](serviceConfig,

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/AzureServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/AzureServiceInterpSpec.scala
@@ -44,13 +44,19 @@ class AzureServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with Tes
 
   //used when we care about queue state
   def makeInterp(queue: Queue[IO, LeoPubsubMessage]) =
-    new AzureServiceInterp[IO](serviceConfig, whitelistAuthProvider, wsmDao, mockSamDAO, queue)
+    new AzureServiceInterp[IO](serviceConfig,
+                               whitelistAuthProvider,
+                               wsmDao,
+                               mockSamDAO,
+                               QueueFactory.asyncTaskQueue,
+                               queue)
 
   val defaultAzureService =
     new AzureServiceInterp[IO](serviceConfig,
                                whitelistAuthProvider,
                                new MockWsmDAO,
                                mockSamDAO,
+                               QueueFactory.asyncTaskQueue,
                                QueueFactory.makePublisherQueue())
 
   it should "submit a create azure runtime message properly" in isolatedDbTest {

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/AzureServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/AzureServiceInterpSpec.scala
@@ -223,6 +223,7 @@ class AzureServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with Tes
   }
 
   it should "fail to get a runtime when no controlled resource is saved for runtime" in isolatedDbTest {
+    val badUserInfo = UserInfo(OAuth2BearerToken(""), WorkbenchUserId("badUser"), WorkbenchEmail("badEmail"), 0)
     val userInfo = UserInfo(OAuth2BearerToken(""), WorkbenchUserId("userId"), WorkbenchEmail("user1@example.com"), 0) // this email is white listed
     val runtimeName = RuntimeName("clusterName1")
     val workspaceId = WorkspaceId(UUID.randomUUID())
@@ -246,8 +247,7 @@ class AzureServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with Tes
         )
         .transaction
       cluster = clusterOpt.get
-      _ <- updateCreator(cluster.id, WorkbenchEmail("randomUser")).transaction
-      _ <- azureService.getRuntime(userInfo, runtimeName, workspaceId)
+      _ <- azureService.getRuntime(badUserInfo, runtimeName, workspaceId)
     } yield ()
 
     the[AzureRuntimeControlledResourceNotFoundException] thrownBy {

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/MockAzureServiceInterp.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/MockAzureServiceInterp.scala
@@ -13,7 +13,8 @@ class MockAzureServiceInterp extends AzureService[IO] {
   override def createRuntime(userInfo: UserInfo,
                              runtimeName: RuntimeName,
                              workspaceId: WorkspaceId,
-                             req: CreateAzureRuntimeRequest)(implicit as: Ask[IO, AppContext]): IO[Unit] = IO.pure()
+                             req: CreateAzureRuntimeRequest,
+                             createVmJobId: WsmJobId)(implicit as: Ask[IO, AppContext]): IO[Unit] = IO.pure()
 
   override def getRuntime(userInfo: UserInfo, runtimeName: RuntimeName, workspaceId: WorkspaceId)(
     implicit as: Ask[IO, AppContext]

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterpSpec.scala
@@ -46,12 +46,15 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
   val publisherQueue = QueueFactory.makePublisherQueue()
   def makeRuntimeService(publisherQueue: Queue[IO, LeoPubsubMessage]) =
     new RuntimeServiceInterp(
-      RuntimeServiceConfig(Config.proxyConfig.proxyUrlBase,
-                           imageConfig,
-                           autoFreezeConfig,
-                           dataprocConfig,
-                           Config.gceConfig,
-                           azureServiceConfig),
+      RuntimeServiceConfig(
+        Config.proxyConfig.proxyUrlBase,
+        imageConfig,
+        autoFreezeConfig,
+        dataprocConfig,
+        Config.gceConfig,
+        azureServiceConfig,
+        ConfigReader.appConfig.azure.runtimeDefaults
+      ),
       ConfigReader.appConfig.persistentDisk,
       whitelistAuthProvider,
       serviceAccountProvider,

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/BaseCloudServiceRuntimeMonitorSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/BaseCloudServiceRuntimeMonitorSpec.scala
@@ -164,7 +164,7 @@ class BaseCloudServiceRuntimeMonitorSpec extends AnyFlatSpec with Matchers with 
 
     override def monitorConfig: MonitorConfig = MonitorConfig.GceMonitorConfig(
       2 seconds,
-      PollMonitorConfig(5, 1 second),
+      PollMonitorConfig(2 seconds, 5, 1 second),
       timeouts,
       InterruptablePollMonitorConfig(60, 1 second, 10 seconds),
       RuntimeBucketConfig(3 seconds),

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/GceRuntimeMonitorSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/GceRuntimeMonitorSpec.scala
@@ -741,7 +741,7 @@ class GceRuntimeMonitorSpec
     monitorStatusTimeouts: Option[Map[RuntimeStatus, FiniteDuration]] = None
   ): GceRuntimeMonitor[IO] = {
     val config =
-      Config.gceMonitorConfig.copy(initialDelay = 2 seconds, pollStatus = PollMonitorConfig(5, 1 second))
+      Config.gceMonitorConfig.copy(initialDelay = 2 seconds, pollStatus = PollMonitorConfig(2 seconds, 5, 1 second))
     val configWithCustomTimeouts =
       monitorStatusTimeouts.fold(config)(timeouts => config.copy(monitorStatusTimeouts = timeouts))
     new GceRuntimeMonitor[IO](

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubCodecSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubCodecSpec.scala
@@ -1,4 +1,5 @@
-package org.broadinstitute.dsde.workbench.leonardo.monitor
+package org.broadinstitute.dsde.workbench.leonardo
+package monitor
 
 import java.time.Instant
 import java.util.UUID
@@ -8,28 +9,11 @@ import io.circe.Printer
 import org.broadinstitute.dsde.workbench.google2.KubernetesSerializableName.NamespaceName
 import org.broadinstitute.dsde.workbench.google2.{DiskName, MachineTypeName, ZoneName}
 import org.broadinstitute.dsde.workbench.leonardo.AppType.Galaxy
-import org.broadinstitute.dsde.workbench.leonardo.dao.WsmJobControl
 import org.broadinstitute.dsde.workbench.leonardo.monitor.LeoPubsubCodec._
 import org.broadinstitute.dsde.workbench.leonardo.monitor.LeoPubsubMessage.{
   CreateAppMessage,
   CreateAzureRuntimeMessage,
   CreateRuntimeMessage
-}
-import org.broadinstitute.dsde.workbench.leonardo.{
-  AppId,
-  AppName,
-  AuditInfo,
-  CloudContext,
-  DiskId,
-  DiskSize,
-  KubernetesClusterLeoId,
-  NodepoolLeoId,
-  RuntimeImage,
-  RuntimeImageType,
-  RuntimeName,
-  RuntimeProjectAndName,
-  WorkspaceId,
-  WsmJobId
 }
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.broadinstitute.dsde.workbench.model.{TraceId, WorkbenchEmail}

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubCodecSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubCodecSpec.scala
@@ -2,13 +2,13 @@ package org.broadinstitute.dsde.workbench.leonardo.monitor
 
 import java.time.Instant
 import java.util.UUID
-
 import _root_.io.circe.parser.decode
 import _root_.io.circe.syntax._
 import io.circe.Printer
 import org.broadinstitute.dsde.workbench.google2.KubernetesSerializableName.NamespaceName
 import org.broadinstitute.dsde.workbench.google2.{DiskName, MachineTypeName, ZoneName}
 import org.broadinstitute.dsde.workbench.leonardo.AppType.Galaxy
+import org.broadinstitute.dsde.workbench.leonardo.dao.WsmJobControl
 import org.broadinstitute.dsde.workbench.leonardo.monitor.LeoPubsubCodec._
 import org.broadinstitute.dsde.workbench.leonardo.monitor.LeoPubsubMessage.{
   CreateAppMessage,
@@ -28,7 +28,8 @@ import org.broadinstitute.dsde.workbench.leonardo.{
   RuntimeImageType,
   RuntimeName,
   RuntimeProjectAndName,
-  WorkspaceId
+  WorkspaceId,
+  WsmJobId
 }
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.broadinstitute.dsde.workbench.model.{TraceId, WorkbenchEmail}
@@ -131,10 +132,8 @@ class LeoPubsubCodecSpec extends AnyFlatSpec with Matchers {
   }
 
   it should "encode/decode CreateAzureRuntimeMessage properly" in {
-    val originalMessage = CreateAzureRuntimeMessage(1,
-                                                    WorkspaceId(UUID.randomUUID()),
-                                                    RuntimeImage(RuntimeImageType.Azure, "test", None, Instant.now),
-                                                    None)
+    val originalMessage =
+      CreateAzureRuntimeMessage(1, WorkspaceId(UUID.randomUUID()), WsmJobId(UUID.randomUUID()), None)
 
     val res = decode[CreateAzureRuntimeMessage](originalMessage.asJson.printWith(Printer.noSpaces))
 

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubCodecSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubCodecSpec.scala
@@ -117,7 +117,7 @@ class LeoPubsubCodecSpec extends AnyFlatSpec with Matchers {
 
   it should "encode/decode CreateAzureRuntimeMessage properly" in {
     val originalMessage =
-      CreateAzureRuntimeMessage(1, WorkspaceId(UUID.randomUUID()), WsmJobId(UUID.randomUUID()), None)
+      CreateAzureRuntimeMessage(1, WorkspaceId(UUID.randomUUID()), WsmJobId("job"), None)
 
     val res = decode[CreateAzureRuntimeMessage](originalMessage.asJson.printWith(Printer.noSpaces))
 

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriberSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriberSpec.scala
@@ -1654,7 +1654,8 @@ class LeoPubsubMessageSubscriberSpec
           )
           .saveWithRuntimeConfig(azureRuntimeConfig)
 
-        msg = CreateAzureRuntimeMessage(runtime.id, workspaceId, azureImage, None)
+        jobId <- IO.delay(UUID.randomUUID())
+        msg = CreateAzureRuntimeMessage(runtime.id, workspaceId, WsmJobId(jobId), None)
 
         _ <- leoSubscriber.messageHandler(Event(msg, None, timestamp, mockAckConsumer))
 
@@ -1776,7 +1777,6 @@ class LeoPubsubMessageSubscriberSpec
                       computeManagerDao: ComputeManagerDao[IO] = new MockComputeManagerDao(),
                       wsmDAO: MockWsmDAO = new MockWsmDAO): AzureInterpreter[IO] =
     new AzureInterpreter[IO](
-      ConfigReader.appConfig.azure.runtimeDefaults,
       ConfigReader.appConfig.azure.monitor,
       asyncTaskQueue,
       wsmDAO,

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriberSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriberSpec.scala
@@ -3,7 +3,6 @@ package monitor
 
 import java.time.Instant
 import java.util.UUID
-
 import akka.actor.ActorSystem
 import akka.testkit.TestKit
 import cats.data.Kleisli
@@ -61,6 +60,7 @@ import org.broadinstitute.dsde.workbench.leonardo.dao.{
   MockAppDAO,
   MockAppDescriptorDAO,
   MockComputeManagerDao,
+  MockSamDAO,
   MockWsmDAO,
   WelderDAO
 }
@@ -85,6 +85,7 @@ import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.util.{Left, Random}
 import org.broadinstitute.dsde.workbench.leonardo.TestUtils.appContext
+import org.http4s.headers.Authorization
 
 class LeoPubsubMessageSubscriberSpec
     extends TestKit(ActorSystem("leonardotest"))
@@ -1630,7 +1631,8 @@ class LeoPubsubMessageSubscriberSpec
   it should "handle top-level error in create azure vm properly" in isolatedDbTest {
     val exceptionMsg = "test exception"
     val mockWsmDao = new MockWsmDAO {
-      override def createVm(request: CreateVmRequest)(implicit ev: Ask[IO, AppContext]): IO[CreateVmResult] =
+      override def createVm(request: CreateVmRequest,
+                            authorization: Authorization)(implicit ev: Ask[IO, AppContext]): IO[CreateVmResult] =
         IO.raiseError(new Exception(exceptionMsg))
     }
     val mockAckConsumer = mock[AckReplyConsumer]
@@ -1676,7 +1678,8 @@ class LeoPubsubMessageSubscriberSpec
   it should "handle top-level error in delete azure vm properly" in isolatedDbTest {
     val exceptionMsg = "test exception"
     val mockWsmDao = new MockWsmDAO {
-      override def deleteVm(request: DeleteVmRequest)(implicit ev: Ask[IO, AppContext]): IO[DeleteVmResult] =
+      override def deleteVm(request: DeleteVmRequest,
+                            authorization: Authorization)(implicit ev: Ask[IO, AppContext]): IO[DeleteVmResult] =
         IO.raiseError(new Exception(exceptionMsg))
     }
     val mockAckConsumer = mock[AckReplyConsumer]
@@ -1777,6 +1780,7 @@ class LeoPubsubMessageSubscriberSpec
       ConfigReader.appConfig.azure.monitor,
       asyncTaskQueue,
       wsmDAO,
+      new MockSamDAO(),
       computeManagerDao
     )
 

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriberSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriberSpec.scala
@@ -1637,7 +1637,7 @@ class LeoPubsubMessageSubscriberSpec
           .saveWithRuntimeConfig(azureRuntimeConfig)
 
         jobId <- IO.delay(UUID.randomUUID())
-        msg = CreateAzureRuntimeMessage(runtime.id, workspaceId, WsmJobId(jobId), None)
+        msg = CreateAzureRuntimeMessage(runtime.id, workspaceId, WsmJobId(jobId.toString), None)
 
         _ <- leoSubscriber.messageHandler(Event(msg, None, timestamp, mockAckConsumer))
 
@@ -1659,7 +1659,7 @@ class LeoPubsubMessageSubscriberSpec
   it should "handle top-level error in delete azure vm properly" in isolatedDbTest {
     val exceptionMsg = "test exception"
     val mockWsmDao = new MockWsmDAO {
-      override def deleteVm(request: DeleteVmRequest, authorization: Authorization)(
+      override def deleteVm(request: DeleteWsmResourceRequest, authorization: Authorization)(
         implicit ev: Ask[IO, AppContext]
       ): IO[DeleteWsmResourceResult] =
         IO.raiseError(new Exception(exceptionMsg))

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriberSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriberSpec.scala
@@ -1659,8 +1659,9 @@ class LeoPubsubMessageSubscriberSpec
   it should "handle top-level error in delete azure vm properly" in isolatedDbTest {
     val exceptionMsg = "test exception"
     val mockWsmDao = new MockWsmDAO {
-      override def deleteVm(request: DeleteVmRequest,
-                            authorization: Authorization)(implicit ev: Ask[IO, AppContext]): IO[DeleteVmResult] =
+      override def deleteVm(request: DeleteVmRequest, authorization: Authorization)(
+        implicit ev: Ask[IO, AppContext]
+      ): IO[DeleteWsmResourceResult] =
         IO.raiseError(new Exception(exceptionMsg))
     }
     val mockAckConsumer = mock[AckReplyConsumer]

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandlerSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandlerSpec.scala
@@ -71,7 +71,7 @@ class AzurePubsubHandlerSpec
           getRuntime.status shouldBe RuntimeStatus.Running
         }
 
-        msg = CreateAzureRuntimeMessage(runtime.id, workspaceId, azureImage, None)
+        msg = CreateAzureRuntimeMessage(runtime.id, workspaceId, WsmJobId(UUID.randomUUID()), None)
 
         asyncTaskProcessor = AsyncTaskProcessor(AsyncTaskProcessor.Config(10, 10), queue)
         _ <- azureInterp.createAndPollRuntime(msg)
@@ -162,7 +162,7 @@ class AzurePubsubHandlerSpec
           error.map(_.errorMessage).head should include(exceptionMsg)
         }
 
-        msg = CreateAzureRuntimeMessage(runtime.id, workspaceId, azureImage, None)
+        msg = CreateAzureRuntimeMessage(runtime.id, workspaceId, WsmJobId(UUID.randomUUID()), None)
 
         asyncTaskProcessor = AsyncTaskProcessor(AsyncTaskProcessor.Config(10, 10), queue)
         _ <- azureInterp.createAndPollRuntime(msg)
@@ -233,7 +233,6 @@ class AzurePubsubHandlerSpec
                       computeManagerDao: ComputeManagerDao[IO] = new MockComputeManagerDao(),
                       wsmDAO: MockWsmDAO = new MockWsmDAO): AzureInterpreter[IO] =
     new AzureInterpreter[IO](
-      ConfigReader.appConfig.azure.runtimeDefaults,
       ConfigReader.appConfig.azure.monitor,
       asyncTaskQueue,
       wsmDAO,

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandlerSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandlerSpec.scala
@@ -55,13 +55,7 @@ class AzurePubsubHandlerSpec
         IO.pure(
           GetCreateVmJobResult(
             Some(WsmVm(WsmVMMetadata(resourceId))),
-            WsmJobReport(WsmJobId(UUID.randomUUID()),
-                         "",
-                         WsmJobStatus.Succeeded,
-                         200,
-                         ZonedDateTime.now(),
-                         None,
-                         "url"),
+            WsmJobReport(WsmJobId("job1"), "", WsmJobStatus.Succeeded, 200, ZonedDateTime.now(), None, "url"),
             None
           )
         )
@@ -93,7 +87,7 @@ class AzurePubsubHandlerSpec
           getRuntime.status shouldBe RuntimeStatus.Running
         }
 
-        msg = CreateAzureRuntimeMessage(runtime.id, workspaceId, WsmJobId(UUID.randomUUID()), None)
+        msg = CreateAzureRuntimeMessage(runtime.id, workspaceId, WsmJobId("job1"), None)
 
         asyncTaskProcessor = AsyncTaskProcessor(AsyncTaskProcessor.Config(10, 10), queue)
         _ <- azureInterp.createAndPollRuntime(msg)
@@ -182,7 +176,7 @@ class AzurePubsubHandlerSpec
           error.map(_.errorMessage).head should include(exceptionMsg)
         }
 
-        msg = CreateAzureRuntimeMessage(runtime.id, workspaceId, WsmJobId(UUID.randomUUID()), None)
+        msg = CreateAzureRuntimeMessage(runtime.id, workspaceId, WsmJobId("job1"), None)
 
         asyncTaskProcessor = AsyncTaskProcessor(AsyncTaskProcessor.Config(10, 10), queue)
         _ <- azureInterp.createAndPollRuntime(msg)

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/QueueFactory.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/QueueFactory.scala
@@ -16,5 +16,5 @@ object QueueFactory {
   def makeSubscriberQueue() =
     Queue.bounded[IO, Event[LeoPubsubMessage]](queueSize).unsafeRunSync()
 
-  def asyncTaskQueue = Queue.bounded[IO, Task[IO]](queueSize).unsafeRunSync()
+  def asyncTaskQueue() = Queue.bounded[IO, Task[IO]](queueSize).unsafeRunSync()
 }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/QueueFactory.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/QueueFactory.scala
@@ -4,6 +4,7 @@ import cats.effect.IO
 import cats.effect.std.Queue
 import cats.effect.unsafe.implicits.global
 import org.broadinstitute.dsde.workbench.google2.Event
+import org.broadinstitute.dsde.workbench.leonardo.AsyncTaskProcessor.Task
 import org.broadinstitute.dsde.workbench.leonardo.monitor.LeoPubsubMessage
 
 object QueueFactory {
@@ -14,4 +15,6 @@ object QueueFactory {
 
   def makeSubscriberQueue() =
     Queue.bounded[IO, Event[LeoPubsubMessage]](queueSize).unsafeRunSync()
+
+  def asyncTaskQueue = Queue.bounded[IO, Task[IO]](queueSize).unsafeRunSync()
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -111,6 +111,8 @@ object Dependencies {
     excludeBouncyCastlePkix)
   val workbenchOpenTelemetryTest: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-opentelemetry" % workbenchOpenTelemetryV % Test classifier "tests" excludeAll (excludeGuava)
 
+  val wsmClient: ModuleID = "bio.terra" % "workspace-manager-client" % "0.254.192-SNAPSHOT"
+
   val helmScalaSdk: ModuleID = "org.broadinstitute.dsp" %% "helm-scala-sdk" % helmScalaSdkV
   val helmScalaSdkTest: ModuleID = "org.broadinstitute.dsp" %% "helm-scala-sdk" % helmScalaSdkV % Test classifier "tests"
 
@@ -205,6 +207,7 @@ object Dependencies {
     scalaTest,
     scalaTestSelenium,
     scalaTestMockito,
-    http4sBlazeServer % Test
+    http4sBlazeServer % Test,
+    wsmClient
   )
 }


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-3211

Permission check for getRuntime is commented out for now because we'll need a change in WSM to make things work. Dan D is on vacation right now, so punt on that for this PR.

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
