### PR TITLE
Extend script with additional jupyter parameters and docker configuration

### DIFF
--- a/http/src/main/resources/init-resources/msdsvmcontent/ms_dsvm_script_v5_cat.sh
+++ b/http/src/main/resources/init-resources/msdsvmcontent/ms_dsvm_script_v5_cat.sh
@@ -15,11 +15,13 @@ apt-get install -y --no-install-recommends apt-utils
 SERVER_APP_PORT=8080
 SERVER_APP_TOKEN=''
 SERVER_APP_IP=''
+SERVER_APP_CERTFILE=''
+SERVER_APP_KEYFILE=''
 
 # Variables for listener
-#SERVER_APP_BASE_URL=''
-#SERVER_APP_ALLOW_ORIGIN='*'
-#SERVER_APP_WEBSOCKET_URL=''
+SERVER_APP_BASE_URL=/$2/
+SERVER_APP_ALLOW_ORIGIN='*'
+SERVER_APP_WEBSOCKET_URL="wss://$1.servicebus.windows.net/\$hc/$2"
 
 # Install relevant libraries
 
@@ -33,8 +35,29 @@ SERVER_APP_IP=''
 
 # Start Jupyter server with custom parameters
 
-/anaconda/bin/jupyter server --ServerApp.port=$SERVER_APP_PORT --ServerApp.token=$SERVER_APP_TOKEN --autoreload --ServerApp.ip=$SERVER_APP_IP --allow-root >/dev/null 2>&1&
+/anaconda/bin/jupyter server \
+--ServerApp.certfile=$SERVER_APP_CERTFILE \
+--ServerApp.keyfile=$SERVER_APP_KEYFILE \
+--ServerApp.port=$SERVER_APP_PORT \
+--ServerApp.token=$SERVER_APP_TOKEN \
+--ServerApp.ip=$SERVER_APP_IP \
+--ServerApp.base_url=$SERVER_APP_BASE_URL \
+--ServerApp.websocket_url=$SERVER_APP_WEBSOCKET_URL \
+--ServerApp.allow_origin=$SERVER_APP_ALLOW_ORIGIN \
+--autoreload --allow-root >/dev/null 2>&1&
 
 # Store Jupyter Server parameters for reboot process
 
-sudo crontab -l 2>/dev/null| cat - <(echo "@reboot /anaconda/bin/jupyter server --ServerApp.port=$SERVER_APP_PORT --ServerApp.token=$SERVER_APP_TOKEN --autoreload --ServerApp.ip=$SERVER_APP_IP --allow-root >/dev/null 2>&1&") | crontab -
+sudo crontab -l 2>/dev/null| cat - <(echo "@reboot /anaconda/bin/jupyter server --ServerApp.certfile=$SERVER_APP_CERTFILE --ServerApp.keyfile=$SERVER_APP_KEYFILE --ServerApp.port=$SERVER_APP_PORT --ServerApp.token=$SERVER_APP_TOKEN --ServerApp.ip=$SERVER_APP_IP --ServerApp.base_url=$SERVER_APP_BASE_URL --ServerApp.websocket_url=$SERVER_APP_WEBSOCKET_URL --ServerApp.allow_origin=$SERVER_APP_ALLOW_ORIGIN --autoreload --allow-root >/dev/null 2>&1&") | crontab -
+
+# Login to ACR repo to pull the image for Relay Listener
+
+docker login terradevacrpublic.azurecr.io -u $6 -p $7
+
+#Run docker container with Relay Listener
+
+docker run -d --restart always --name RelayListener \
+--env LISTENER_RELAYCONNECTIONSTRING="Endpoint=sb://$1.servicebus.windows.net/;SharedAccessKeyName=$4;SharedAccessKey=$5;EntityPath=$2" \
+--env LISTENER_RELAYCONNECTIONNAME="$2" \
+--env LISTENER_TARGETPROPERTIES_TARGETHOST="http://$3:8080" \
+terradevacrpublic.azurecr.io/terra-azure-relay-listeners:53d7992


### PR DESCRIPTION
Added:
-additional parameters for jupyter to turn off https
-docker configuration to run relay listener

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
