### PR TITLE
IA-3211 run asyncTask processor in front leo as well

### DIFF
--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/Boot.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/Boot.scala
@@ -323,15 +323,14 @@ object Boot extends IOApp {
           )
         }
 
-        val frontLeoOnlyProcesses = List(
-          dateAccessedUpdater.process, // We only need to update dateAccessed in front leo
-          asyncTasks.process
+        val uniquefrontLeoOnlyProcesses = List(
+          dateAccessedUpdater.process // We only need to update dateAccessed in front leo
         ) ++ appDependencies.recordCacheMetrics
 
         val extraProcesses = leoExecutionModeConfig match {
           case LeoExecutionModeConfig.BackLeoOnly  => backLeoOnlyProcesses
-          case LeoExecutionModeConfig.FrontLeoOnly => frontLeoOnlyProcesses
-          case LeoExecutionModeConfig.Combined     => backLeoOnlyProcesses ++ frontLeoOnlyProcesses
+          case LeoExecutionModeConfig.FrontLeoOnly => asyncTasks.process :: uniquefrontLeoOnlyProcesses
+          case LeoExecutionModeConfig.Combined     => backLeoOnlyProcesses ++ uniquefrontLeoOnlyProcesses
         }
 
         List(

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/Boot.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/Boot.scala
@@ -229,6 +229,8 @@ object Boot extends IOApp {
       } yield ()
 
       val allStreams = {
+        val asyncTasks = AsyncTaskProcessor(asyncTaskProcessorConfig, appDependencies.asyncTasksQueue)
+
         val backLeoOnlyProcesses = {
           implicit val clusterToolToToolDao =
             ToolDAO.clusterToolToToolDao(appDependencies.jupyterDAO,
@@ -262,8 +264,6 @@ object Boot extends IOApp {
             new MonitorAtBoot[IO](appDependencies.publisherQueue, googleDependencies.googleComputeService)
 
           val googleDiskService = googleDependencies.googleDiskService
-
-          val asyncTasks = AsyncTaskProcessor(asyncTaskProcessorConfig, appDependencies.asyncTasksQueue)
 
           val gkeAlg = new GKEInterpreter[IO](
             gkeInterpConfig,
@@ -325,7 +325,7 @@ object Boot extends IOApp {
 
         val frontLeoOnlyProcesses = List(
           dateAccessedUpdater.process, // We only need to update dateAccessed in front leo
-          asyncTasks
+          asyncTasks.process
         ) ++ appDependencies.recordCacheMetrics
 
         val extraProcesses = leoExecutionModeConfig match {

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/Boot.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/Boot.scala
@@ -263,7 +263,6 @@ object Boot extends IOApp {
 
           val googleDiskService = googleDependencies.googleDiskService
 
-          // only needed for backleo
           val asyncTasks = AsyncTaskProcessor(asyncTaskProcessorConfig, appDependencies.asyncTasksQueue)
 
           val gkeAlg = new GKEInterpreter[IO](
@@ -325,7 +324,8 @@ object Boot extends IOApp {
         }
 
         val frontLeoOnlyProcesses = List(
-          dateAccessedUpdater.process // We only need to update dateAccessed in front leo
+          dateAccessedUpdater.process, // We only need to update dateAccessed in front leo
+          asyncTasks
         ) ++ appDependencies.recordCacheMetrics
 
         val extraProcesses = leoExecutionModeConfig match {


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-3211

We used to not run `AsyncTaskProcessor` in front leo. But for Azure, in last PR, for createAzureRuntime API, we're making the WSM calls asynchronously, which uses `AsyncTaskProcessor`. Hence, we need to run `AsyncTaskProcessor` in Front leo as well

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
