### PR TITLE
[IA-2947] make RStudio user owner of rstudio-prefs.json not directory

### DIFF
--- a/http/src/main/resources/init-resources/gce-init.sh
+++ b/http/src/main/resources/init-resources/gce-init.sh
@@ -538,7 +538,7 @@ RSTUDIO_USER_HOME=$RSTUDIO_USER_HOME" >> /usr/local/lib/R/etc/Renviron.site'
 \"auto_save_idle_ms\": 10000
 }" > $RSTUDIO_USER_HOME/.config/rstudio/rstudio-prefs-temp.json \
     && mv $RSTUDIO_USER_HOME/.config/rstudio/rstudio-prefs-temp.json $RSTUDIO_USER_HOME/.config/rstudio/rstudio-prefs.json \
-    && chmod a+rwx $RSTUDIO_USER_HOME/.config/rstudio'
+    && chmod a+rwx $RSTUDIO_USER_HOME/.config/rstudio/rstudio-prefs.json'
 
   # Start RStudio server
   retry 3 docker exec -d ${RSTUDIO_SERVER_NAME} /init


### PR DESCRIPTION
Was doing autosave testing in dev and found that users were not able to write to `rstudio-prefs.json` meaning they couldn't change some settings in the rstudio ui (like autosave). tested by validating that after spinning up rstudio, i could change my settings in the rstudio ui through Tools --> Global Options... --> Code --> Saving and changing the interval at which rstudio autosaves to 5 seconds instead of the default 10

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
