### PR TITLE
IA-3337 Fix deletion bug

### DIFF
--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterp.scala
@@ -323,7 +323,7 @@ class RuntimeServiceInterp[F[_]: Parallel](config: RuntimeServiceConfig,
                 F.blocking(op.get()).void.recoverWith {
                   case e: java.util.concurrent.ExecutionException =>
                     if (e.getMessage.contains("Not Found"))
-                      log.info("Fail to detach disk because the runtime doesn't exist")
+                      log.info(ctx.loggingCtx)("Fail to detach disk because the runtime doesn't exist")
                     else F.raiseError(e)
                 }
               }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterpSpec.scala
@@ -1121,6 +1121,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
       // remove some existing items in the queue just to be safe
       _ <- publisherQueue.tryTake
       _ <- publisherQueue.tryTake
+      _ <- publisherQueue.tryTake
       samResource <- IO(RuntimeSamResourceId(UUID.randomUUID.toString))
       testRuntime <- IO(makeCluster(1).copy(samResource = samResource, status = RuntimeStatus.Running).save())
       req = UpdateRuntimeRequest(None, false, Some(true), Some(120.minutes), Map.empty, Set.empty)

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterpSpec.scala
@@ -6,12 +6,24 @@ import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import cats.effect.IO
 import cats.effect.std.Queue
+import cats.mtl.Ask
+import com.google.api.gax.longrunning.OperationFuture
+import com.google.cloud.compute.v1.Operation
 import org.broadinstitute.dsde.workbench.google2.mock.{
+  FakeComputeOperationFuture,
   FakeGoogleComputeService,
   FakeGooglePublisher,
   FakeGoogleStorageInterpreter
 }
-import org.broadinstitute.dsde.workbench.google2.{DataprocRole, DiskName, InstanceName, MachineTypeName, ZoneName}
+import org.broadinstitute.dsde.workbench.google2.{
+  DataprocRole,
+  DeviceName,
+  DiskName,
+  GoogleComputeService,
+  InstanceName,
+  MachineTypeName,
+  ZoneName
+}
 import org.broadinstitute.dsde.workbench.leonardo.CommonTestData._
 import org.broadinstitute.dsde.workbench.leonardo.RuntimeImageType.{CryptoDetector, Jupyter, Welder}
 import org.broadinstitute.dsde.workbench.leonardo.SamResourceId._
@@ -30,7 +42,7 @@ import org.broadinstitute.dsde.workbench.leonardo.monitor.{
 }
 import org.broadinstitute.dsde.workbench.leonardo.util.QueueFactory
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
-import org.broadinstitute.dsde.workbench.model.{IP, UserInfo, WorkbenchEmail, WorkbenchUserId}
+import org.broadinstitute.dsde.workbench.model.{IP, TraceId, UserInfo, WorkbenchEmail, WorkbenchUserId}
 import org.scalatest.Assertion
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatestplus.mockito.MockitoSugar
@@ -43,7 +55,8 @@ import scala.concurrent.duration._
 
 class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with TestComponent with MockitoSugar {
   val publisherQueue = QueueFactory.makePublisherQueue()
-  def makeRuntimeService(publisherQueue: Queue[IO, LeoPubsubMessage]) =
+  def makeRuntimeService(publisherQueue: Queue[IO, LeoPubsubMessage],
+                         computeService: GoogleComputeService[IO] = FakeGoogleComputeService) =
     new RuntimeServiceInterp(
       RuntimeServiceConfig(
         Config.proxyConfig.proxyUrlBase,
@@ -59,7 +72,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
       serviceAccountProvider,
       new MockDockerDAO,
       FakeGoogleStorageInterpreter,
-      FakeGoogleComputeService,
+      computeService,
       publisherQueue
     )
   val runtimeService = makeRuntimeService(publisherQueue)
@@ -974,6 +987,51 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
         }
       }
     } yield res
+
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
+  }
+
+  it should "fail to delete a runtime if detaching disk fails" in isolatedDbTest {
+    val userInfo = UserInfo(OAuth2BearerToken(""), WorkbenchUserId("userId"), WorkbenchEmail("user1@example.com"), 0) // this email is white listed
+    val operationFuture = new FakeComputeOperationFuture {
+      override def get(): Operation = {
+        val exception = new java.util.concurrent.ExecutionException(
+          "com.google.api.gax.rpc.NotFoundException: Not Found",
+          new Exception("bad")
+        )
+        throw exception
+      }
+    }
+    val computeService = new FakeGoogleComputeService {
+      override def detachDisk(
+        project: GoogleProject,
+        zone: ZoneName,
+        instanceName: InstanceName,
+        deviceName: DeviceName
+      )(implicit ev: Ask[IO, TraceId]): IO[Option[OperationFuture[Operation, Operation]]] =
+        IO.pure(Some(operationFuture))
+    }
+    val runtimeService = makeRuntimeService(publisherQueue, computeService)
+    val res = for {
+      pd <- makePersistentDisk().save()
+      testRuntime <- IO(
+        makeCluster(1).saveWithRuntimeConfig(
+          RuntimeConfig
+            .GceWithPdConfig(MachineTypeName("n1-standard-4"),
+                             Some(pd.id),
+                             bootDiskSize = DiskSize(50),
+                             zone = ZoneName("us-central1-a"),
+                             None)
+        )
+      )
+      r <- runtimeService
+        .deleteRuntime(
+          DeleteRuntimeRequest(userInfo, GoogleProject(cloudContext.asString), testRuntime.runtimeName, false)
+        )
+        .attempt
+    } yield {
+      r.isRight shouldBe true
+    }
 
     res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/GceInterpreterSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/GceInterpreterSpec.scala
@@ -1,0 +1,83 @@
+package org.broadinstitute.dsde.workbench.leonardo.util
+
+import cats.effect.IO
+import cats.mtl.Ask
+import com.google.api.gax.longrunning.OperationFuture
+import com.google.cloud.compute.v1.Operation
+import org.broadinstitute.dsde.workbench.google2.mock.{
+  FakeGoogleComputeService,
+  FakeGoogleResourceService,
+  MockGoogleDiskService
+}
+import org.broadinstitute.dsde.workbench.google2.{GoogleComputeService, InstanceName, ZoneName}
+import org.broadinstitute.dsde.workbench.leonardo.CommonTestData._
+import org.broadinstitute.dsde.workbench.leonardo.TestUtils.appContext
+import org.broadinstitute.dsde.workbench.leonardo.config.Config
+import org.broadinstitute.dsde.workbench.leonardo.dao.MockWelderDAO
+import org.broadinstitute.dsde.workbench.leonardo.db.{clusterQuery, TestComponent, UpdateAsyncClusterCreationFields}
+import org.broadinstitute.dsde.workbench.leonardo.{
+  CommonTestData,
+  FakeGoogleStorageService,
+  LeonardoTestSuite,
+  RuntimeAndRuntimeConfig,
+  RuntimeStatus
+}
+import org.broadinstitute.dsde.workbench.model.TraceId
+import org.broadinstitute.dsde.workbench.model.google.GoogleProject
+import org.scalatest.flatspec.AnyFlatSpecLike
+
+import java.time.Instant
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class GceInterpreterSpec extends AnyFlatSpecLike with TestComponent with LeonardoTestSuite {
+  val bucketHelperConfig =
+    BucketHelperConfig(imageConfig, welderConfig, proxyConfig, clusterFilesConfig)
+  val bucketHelper =
+    new BucketHelper[IO](bucketHelperConfig, FakeGoogleStorageService, serviceAccountProvider)
+
+  val mockGoogleResourceService = new FakeGoogleResourceService {
+    override def getProjectNumber(project: GoogleProject)(implicit ev: Ask[IO, TraceId]): IO[Option[Long]] =
+      IO(Some(1L))
+  }
+
+  val vpcInterp =
+    new VPCInterpreter[IO](Config.vpcInterpreterConfig, mockGoogleResourceService, FakeGoogleComputeService)
+
+  def gceInterp(computeService: GoogleComputeService[IO] = FakeGoogleComputeService) =
+    new GceInterpreter[IO](Config.gceInterpreterConfig,
+                           bucketHelper,
+                           vpcInterp,
+                           computeService,
+                           MockGoogleDiskService,
+                           MockWelderDAO)
+  it should "don't error if runtime is already deleted" in isolatedDbTest {
+    val computeService = new FakeGoogleComputeService {
+      override def modifyInstanceMetadata(
+        project: GoogleProject,
+        zone: ZoneName,
+        instanceName: InstanceName,
+        metadataToAdd: Map[String, String],
+        metadataToRemove: Set[String]
+      )(implicit ev: Ask[IO, TraceId]): IO[Option[OperationFuture[Operation, Operation]]] =
+        IO.raiseError(new org.broadinstitute.dsde.workbench.model.WorkbenchException("Instance not found: "))
+    }
+
+    val gce = gceInterp(computeService)
+    val res = for {
+      runtime <- IO(
+        makeCluster(1)
+          .copy(status = RuntimeStatus.Deleting)
+          .saveWithRuntimeConfig(CommonTestData.defaultGceRuntimeConfig)
+      )
+      _ <- IO(
+        dbFutureValue(
+          clusterQuery.updateAsyncClusterCreationFields(UpdateAsyncClusterCreationFields(None, 1, None, Instant.now))
+        )
+      )
+      updatedRuntme <- IO(dbFutureValue(clusterQuery.getClusterById(runtime.id)))
+      runtimeAndRuntimeConfig = RuntimeAndRuntimeConfig(updatedRuntme.get, CommonTestData.defaultGceRuntimeConfig)
+      res <- gce.deleteRuntime(DeleteRuntimeParams(runtimeAndRuntimeConfig, None))
+    } yield (res shouldBe (None))
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+  }
+}


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-3337

The bug is that when users runtime creation fail, and then they try to delete runtime, `detach` disk will fail becuz the runtime doesn't exist, hence throwing exception right away. A second similar bug is that in back leo's delete runtime handler, we're erroring out when `setMetadata` call fails becuz the runtime doesn't exist. In both cases, we should ignore the exception to let delete flow to go through

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
