### PR TITLE
[IA-3260] Fix deletion and misc changes

### DIFF
--- a/http/src/main/resources/swagger/api-docs.yaml
+++ b/http/src/main/resources/swagger/api-docs.yaml
@@ -2296,7 +2296,7 @@ components:
           example:
             labels: { saturnRuntimeName: "saturn-ab9134" }
             region: "eastus"
-            machineSize: "Standard_D1_v2"
+            machineSize: "Standard_DS1_v2"
             disk: { labels: {}, name: "disk1", size: 50 }
 
   securitySchemes:

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeV2ServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeV2ServiceInterp.scala
@@ -246,11 +246,9 @@ class RuntimeV2ServiceInterp[F[_]: Parallel](config: RuntimeServiceConfig,
       // For now, azure disk life cycle is tied to vm life cycle and incompatible with disk routes
       _ <- persistentDiskQuery.markPendingDeletion(diskId, ctx.now).transaction
 
-      _ <- wsmResourceIdOpt.traverse { wsmResourceId =>
-        publisherQueue.offer(
-          DeleteAzureRuntimeMessage(runtime.id, Some(diskId), workspaceId, wsmResourceId, Some(ctx.traceId))
-        )
-      }
+      _ <- publisherQueue.offer(
+        DeleteAzureRuntimeMessage(runtime.id, Some(diskId), workspaceId, wsmResourceIdOpt, Some(ctx.traceId))
+      )
     } yield ()
 
   override def listRuntimes(

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeV2ServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeV2ServiceInterp.scala
@@ -158,10 +158,19 @@ class RuntimeV2ServiceInterp[F[_]: Parallel](config: RuntimeServiceConfig,
 
       runtime <- RuntimeServiceDbQueries.getRuntime(cloudContext, runtimeName).transaction
 
+      controlledResourceOpt <- controlledResourceQuery
+        .getWsmRecordForRuntime(runtime.id, WsmResourceType.AzureVm)
+        .transaction
+
+      azureRuntimeControlledResource <- F.fromOption(
+        controlledResourceOpt,
+        AzureRuntimeControlledResourceNotFoundException(cloudContext, runtimeName, ctx.traceId)
+      )
+
       // If user is creator of the runtime, they should definitely be able to see the runtime.
       hasPermission <- if (runtime.auditInfo.creator == userInfo.userEmail) F.pure(true)
       else
-        checkSamPermission(cloudContext, runtime.id, runtimeName, userInfo, WsmResourceAction.Read).map(_._1)
+        checkSamPermission(azureRuntimeControlledResource, userInfo, WsmResourceAction.Read).map(_._1)
 
       _ <- ctx.span.traverse(s => F.delay(s.addAnnotation("Done auth call for get azure runtime permission")))
       _ <- F
@@ -210,11 +219,22 @@ class RuntimeV2ServiceInterp[F[_]: Parallel](config: RuntimeServiceConfig,
           )
       }
 
-      (hasPermission, wmsResourceId) <- checkSamPermission(cloudContext,
-                                                           runtime.id,
-                                                           runtimeName,
-                                                           userInfo,
-                                                           WsmResourceAction.Write)
+      controlledResourceOpt <- controlledResourceQuery
+        .getWsmRecordForRuntime(runtime.id, WsmResourceType.AzureVm)
+        .transaction
+
+      // If there's no controlled resource record, that means we created the DB record in front leo but failed somewhere in back leo (possibly in polling WSM)
+      // This is non-fatal, as we still want to allow users to clean up the db record if they have permission.
+      // We must check if they have permission other ways if we did not get an ID back from WSM though
+      (hasPermission, wsmResourceIdOpt) <- controlledResourceOpt.fold(
+        authProvider
+          .isUserWorkspaceOwner(workspaceId, WorkspaceResourceSamResourceId(workspaceId), userInfo)
+          .map(isOwner => isOwner || runtime.auditInfo.creator == userInfo.userEmail)
+          .map(hasPermission => (hasPermission, none[WsmControlledResourceId]))
+      ) { controlledResource =>
+        checkSamPermission(controlledResource, userInfo, WsmResourceAction.Write)
+          .map(x => (x._1, Some(x._2)))
+      }
 
       _ <- ctx.span.traverse(s => F.delay(s.addAnnotation("Done auth call for delete azure runtime permission")))
       _ <- F
@@ -226,9 +246,11 @@ class RuntimeV2ServiceInterp[F[_]: Parallel](config: RuntimeServiceConfig,
       // For now, azure disk life cycle is tied to vm life cycle and incompatible with disk routes
       _ <- persistentDiskQuery.markPendingDeletion(diskId, ctx.now).transaction
 
-      _ <- publisherQueue.offer(
-        DeleteAzureRuntimeMessage(runtime.id, Some(diskId), workspaceId, wmsResourceId, Some(ctx.traceId))
-      )
+      _ <- wsmResourceIdOpt.traverse { wsmResourceId =>
+        publisherQueue.offer(
+          DeleteAzureRuntimeMessage(runtime.id, Some(diskId), workspaceId, wsmResourceId, Some(ctx.traceId))
+        )
+      }
     } yield ()
 
   override def listRuntimes(
@@ -468,9 +490,7 @@ class RuntimeV2ServiceInterp[F[_]: Parallel](config: RuntimeServiceConfig,
       )
     )
 
-  private def checkSamPermission(cloudContext: CloudContext,
-                                 runtimeId: Long,
-                                 runtimeName: RuntimeName,
+  private def checkSamPermission(azureRuntimeControlledResource: RuntimeControlledResourceRecord,
                                  userInfo: UserInfo,
                                  wsmResourceAction: WsmResourceAction)(
     implicit ctx: Ask[F, AppContext]
@@ -478,13 +498,6 @@ class RuntimeV2ServiceInterp[F[_]: Parallel](config: RuntimeServiceConfig,
     for {
       context <- ctx.ask
       //TODO: generalize for google
-      controlledResourceOpt <- controlledResourceQuery
-        .getWsmRecordForRuntime(runtimeId, WsmResourceType.AzureVm)
-        .transaction
-      azureRuntimeControlledResource <- F.fromOption(
-        controlledResourceOpt,
-        AzureRuntimeControlledResourceNotFoundException(cloudContext, runtimeName, context.traceId)
-      )
       res <- authProvider.hasPermission(
         WsmResourceSamResourceId(azureRuntimeControlledResource.resourceId),
         wsmResourceAction,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeV2ServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeV2ServiceInterp.scala
@@ -119,10 +119,10 @@ class RuntimeV2ServiceInterp[F[_]: Parallel](config: RuntimeServiceConfig,
             savedRuntime <- clusterQuery.save(runtimeToSave).transaction
 
             task = for {
-              _ <-  createRuntime(CreateAzureRuntimeParams(workspaceId, savedRuntime, runtimeConfig, disk, runtimeImage),
-                WsmJobControl(createVmJobId))
+              _ <- createRuntime(CreateAzureRuntimeParams(workspaceId, savedRuntime, runtimeConfig, disk, runtimeImage),
+                                 WsmJobControl(createVmJobId))
               _ <- publisherQueue.offer(
-              CreateAzureRuntimeMessage(savedRuntime.id, workspaceId, createVmJobId, Some(ctx.traceId))
+                CreateAzureRuntimeMessage(savedRuntime.id, workspaceId, createVmJobId, Some(ctx.traceId))
               )
             } yield ()
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeoAuthProvider.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeoAuthProvider.scala
@@ -192,4 +192,10 @@ trait LeoAuthProvider[F[_]] {
     creatorEmail: WorkbenchEmail,
     googleProject: GoogleProject
   )(implicit sr: SamResource[R], ev: Ask[F, TraceId]): F[Unit]
+
+  def isUserWorkspaceOwner[R](
+    workspaceId: WorkspaceId,
+    workspaceResource: R,
+    userInfo: UserInfo
+  )(implicit sr: SamResource[R], decoder: Decoder[R], ev: Ask[F, TraceId]): F[Boolean]
 }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/leoPubsubMessageSubscriberModels.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/leoPubsubMessageSubscriberModels.scala
@@ -322,7 +322,7 @@ object LeoPubsubMessage {
   final case class DeleteAzureRuntimeMessage(runtimeId: Long,
                                              diskId: Option[DiskId],
                                              workspaceId: WorkspaceId,
-                                             wsmResourceId: WsmControlledResourceId,
+                                             wsmResourceId: Option[WsmControlledResourceId],
                                              traceId: Option[TraceId])
       extends LeoPubsubMessage {
     val messageType: LeoPubsubMessageType = LeoPubsubMessageType.DeleteAzureRuntime

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/auth/WhitelistAuthProvider.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/auth/WhitelistAuthProvider.scala
@@ -103,4 +103,11 @@ class WhitelistAuthProvider(config: Config, saProvider: ServiceAccountProvider[I
         case false => None
       }
     }
+
+  override def isUserWorkspaceOwner[R](
+    workspaceId: WorkspaceId,
+    workspaceResource: R,
+    userInfo: UserInfo
+  )(implicit sr: SamResource[R], decoder: Decoder[R], ev: Ask[IO, TraceId]): IO[Boolean] =
+    checkWhitelist(userInfo)
 }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceV2InterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceV2InterpSpec.scala
@@ -351,7 +351,11 @@ class RuntimeServiceV2InterpSpec extends AnyFlatSpec with LeonardoTestSuite with
       disk.status shouldBe DiskStatus.Deleting
 
       val expectedMessage =
-        DeleteAzureRuntimeMessage(preDeleteCluster.id, Some(disk.id), workspaceId, wsmResourceId, Some(context.traceId))
+        DeleteAzureRuntimeMessage(preDeleteCluster.id,
+                                  Some(disk.id),
+                                  workspaceId,
+                                  Some(wsmResourceId),
+                                  Some(context.traceId))
       message shouldBe expectedMessage
     }
 

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/mocks.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/mocks.scala
@@ -130,6 +130,12 @@ object MockAuthProvider extends LeoAuthProvider[IO] {
     resources: NonEmptyList[(WorkspaceId, R)],
     userInfo: UserInfo
   )(implicit sr: SamResource[R], decoder: Decoder[R], ev: Ask[IO, TraceId]): IO[List[(WorkspaceId, R)]] = ???
+
+  override def isUserWorkspaceOwner[R](workspaceId: WorkspaceId, workspaceResource: R, userInfo: UserInfo)(
+    implicit sr: SamResource[R],
+    decoder: Decoder[R],
+    ev: Ask[IO, TraceId]
+  ): IO[Boolean] = ???
 }
 
 class FakeGoogleSubcriber[A] extends GoogleSubscriber[IO, A] {

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriberSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriberSpec.scala
@@ -1653,7 +1653,7 @@ class LeoPubsubMessageSubscriberSpec
           )
           .saveWithRuntimeConfig(azureRuntimeConfig)
 
-        msg = DeleteAzureRuntimeMessage(runtime.id, Some(disk.id), workspaceId, wsmResourceId, None)
+        msg = DeleteAzureRuntimeMessage(runtime.id, Some(disk.id), workspaceId, Some(wsmResourceId), None)
 
         //Here we manually save a controlled resource with the runtime because we want too ensure it isn't deleted on error
         _ <- controlledResourceQuery

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandlerSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandlerSpec.scala
@@ -140,7 +140,7 @@ class AzurePubsubHandlerSpec
         _ <- controlledResourceQuery
           .save(runtime.id, WsmControlledResourceId(UUID.randomUUID()), WsmResourceType.AzureNetwork)
           .transaction
-        msg = DeleteAzureRuntimeMessage(runtime.id, Some(disk.id), workspaceId, wsmResourceId, None)
+        msg = DeleteAzureRuntimeMessage(runtime.id, Some(disk.id), workspaceId, Some(wsmResourceId), None)
 
         asyncTaskProcessor = AsyncTaskProcessor(AsyncTaskProcessor.Config(10, 10), queue)
         _ <- azureInterp.deleteAndPollRuntime(msg)
@@ -240,7 +240,7 @@ class AzurePubsubHandlerSpec
           error.map(_.errorMessage).head should include(exceptionMsg)
         }
 
-        msg = DeleteAzureRuntimeMessage(runtime.id, Some(disk.id), workspaceId, wsmResourceId, None)
+        msg = DeleteAzureRuntimeMessage(runtime.id, Some(disk.id), workspaceId, Some(wsmResourceId), None)
 
         asyncTaskProcessor = AsyncTaskProcessor(AsyncTaskProcessor.Config(10, 10), queue)
         _ <- azureInterp.deleteAndPollRuntime(msg)


### PR DESCRIPTION
Currently, deletion is over-eager to error-out when something unexpected happens instead of deleting as much as possible given the system state. 

The changes here seem desirable to prevent users from getting stuck with Errored runtimes. I have gotten stuck a few times during UI development due to partial resource creation, which results in the deletion code erroring out and not actually letting me delete my runtime. This requires manual editting the database to recover from.

Another odd thing I ran that this PR addresses is the frontend code hitting and error at some point in the async flow, and then the backend code hitting a somewhat related error. I addressed this by including the back leo message sending sequentially in the async task, such that it won't be sent if front leo encounters an error in the proceeding steps.  Otherwise, what happens in the case of an error in the async task and an error in back leo is the runtime ends up with two errors in the database, and its very confusing to debug without digging deep into stackdriver with timestamps with frontend/backend log labels; especially since the UI truncates and only displays the first error currently. 