### PR TITLE
[IA-3362] fix ownership of rstudio .config dir

### DIFF
--- a/http/src/main/resources/init-resources/gce-init.sh
+++ b/http/src/main/resources/init-resources/gce-init.sh
@@ -540,10 +540,10 @@ RSTUDIO_USER_HOME=$RSTUDIO_USER_HOME" >> /usr/local/lib/R/etc/Renviron.site'
 \"auto_save_idle_ms\": 10000
 }" > $RSTUDIO_USER_HOME/.config/rstudio/rstudio-prefs-temp.json \
     && mv $RSTUDIO_USER_HOME/.config/rstudio/rstudio-prefs-temp.json $RSTUDIO_USER_HOME/.config/rstudio/rstudio-prefs.json \
-    && chmod a+rwx $RSTUDIO_USER_HOME/.config/rstudio/rstudio-prefs.json'
+    && chown -R rstudio:users $RSTUDIO_USER_HOME/.config'
 
-  # /home/rstudio/.config should be owned by the rstudio user: https://broadworkbench.atlassian.net/browse/IA-3362
-  docker exec ${RSTUDIO_SERVER_NAME} /bin/bash -c 'chown -R rstudio:users $RSTUDIO_USER_HOME/.config'
+#  # /home/rstudio/.config should be owned by the rstudio user: https://broadworkbench.atlassian.net/browse/IA-3362
+#  docker exec ${RSTUDIO_SERVER_NAME} /bin/bash -c 'chown -R rstudio:users $RSTUDIO_USER_HOME/.config'
 
   # Start RStudio server
   retry 3 docker exec -d ${RSTUDIO_SERVER_NAME} /init

--- a/http/src/main/resources/init-resources/gce-init.sh
+++ b/http/src/main/resources/init-resources/gce-init.sh
@@ -542,6 +542,9 @@ RSTUDIO_USER_HOME=$RSTUDIO_USER_HOME" >> /usr/local/lib/R/etc/Renviron.site'
     && mv $RSTUDIO_USER_HOME/.config/rstudio/rstudio-prefs-temp.json $RSTUDIO_USER_HOME/.config/rstudio/rstudio-prefs.json \
     && chmod a+rwx $RSTUDIO_USER_HOME/.config/rstudio/rstudio-prefs.json'
 
+  # /home/rstudio/.config should be owned by the rstudio user: https://broadworkbench.atlassian.net/browse/IA-3362
+  docker exec ${RSTUDIO_SERVER_NAME} /bin/bash -c 'chown -R rstudio:users $RSTUDIO_USER_HOME/.config'
+
   # Start RStudio server
   retry 3 docker exec -d ${RSTUDIO_SERVER_NAME} /init
 fi

--- a/http/src/main/resources/init-resources/gce-init.sh
+++ b/http/src/main/resources/init-resources/gce-init.sh
@@ -542,9 +542,6 @@ RSTUDIO_USER_HOME=$RSTUDIO_USER_HOME" >> /usr/local/lib/R/etc/Renviron.site'
     && mv $RSTUDIO_USER_HOME/.config/rstudio/rstudio-prefs-temp.json $RSTUDIO_USER_HOME/.config/rstudio/rstudio-prefs.json \
     && chown -R rstudio:users $RSTUDIO_USER_HOME/.config'
 
-#  # /home/rstudio/.config should be owned by the rstudio user: https://broadworkbench.atlassian.net/browse/IA-3362
-#  docker exec ${RSTUDIO_SERVER_NAME} /bin/bash -c 'chown -R rstudio:users $RSTUDIO_USER_HOME/.config'
-
   # Start RStudio server
   retry 3 docker exec -d ${RSTUDIO_SERVER_NAME} /init
 fi


### PR DESCRIPTION
tested in @cstrandw's fiab because mine is still in fiab-start. verified that `.config` directory and all its subdirectories and files are now owned by the rstudio user and not root:

![Screen Shot 2022-04-28 at 3 47 02 PM](https://user-images.githubusercontent.com/23626109/165834720-a90f1e7f-985b-44b2-a0e7-b312632c6018.png)


---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
