### PR TITLE
IA-3363 Don't fail deletion if staging bucket or init bucket don't exist

### DIFF
--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/DataprocRuntimeMonitor.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/DataprocRuntimeMonitor.scala
@@ -457,9 +457,7 @@ class DataprocRuntimeMonitor[F[_]: Parallel](
         for {
           ctx <- ev.ask
           duration = (ctx.now.toEpochMilli - monitorContext.start.toEpochMilli).millis
-          _ <- logger.info(monitorContext.loggingContext)(
-            s"Runtime ${runtimeAndRuntimeConfig.runtime.projectNameString} has been deleted after ${duration.toSeconds} seconds."
-          )
+
           googleProject <- F.fromOption(
             LeoLenses.cloudContextToGoogleProject.get(runtimeAndRuntimeConfig.runtime.cloudContext),
             new RuntimeException(
@@ -476,6 +474,10 @@ class DataprocRuntimeMonitor[F[_]: Parallel](
           _ <- dbRef.inTransaction {
             clusterQuery.completeDeletion(runtimeAndRuntimeConfig.runtime.id, ctx.now)
           }
+
+          _ <- logger.info(monitorContext.loggingContext)(
+            s"Runtime ${runtimeAndRuntimeConfig.runtime.projectNameString} has been deleted after ${duration.toSeconds} seconds."
+          )
 
           _ <- authProvider
             .notifyResourceDeleted(

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/GceRuntimeMonitor.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/GceRuntimeMonitor.scala
@@ -351,9 +351,6 @@ class GceRuntimeMonitor[F[_]: Parallel](
     for {
       ctx <- ev.ask
       duration = (ctx.now.toEpochMilli - monitorContext.start.toEpochMilli).millis
-      _ <- logger.info(monitorContext.loggingContext)(
-        s"Runtime ${runtimeAndRuntimeConfig.runtime.projectNameString} has been deleted after ${duration.toSeconds} seconds."
-      )
 
       googleProject <- F.fromOption(
         LeoLenses.cloudContextToGoogleProject.get(runtimeAndRuntimeConfig.runtime.cloudContext),
@@ -369,6 +366,10 @@ class GceRuntimeMonitor[F[_]: Parallel](
       _ <- dbRef.inTransaction {
         clusterQuery.completeDeletion(runtimeAndRuntimeConfig.runtime.id, ctx.now)
       }
+
+      _ <- logger.info(monitorContext.loggingContext)(
+        s"Runtime ${runtimeAndRuntimeConfig.runtime.projectNameString} has been deleted after ${duration.toSeconds} seconds."
+      )
 
       //TODO: this call is only needed for non-WSM resources
       _ <- authProvider


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-3363

The original deletion request did fail for the runtime in the ticket

```
Error
2022-04-28 16:08:37.238 EDT
com.google.cloud.storage.Storage.update(BucketInfo{name=leostaging-all-of-us-1737-dba01a51-9755-4e4e-92a1-b48cc8600ea2})
leonardo-backend-app
{"response":null, "result":"Failed"}

{
insertId: "5tf1hauw4teqs2t6"
jsonPayload: {
@timestamp: "2022-04-28T20:08:37.237Z"
@version: "1"
duration: "39"
googleCall: "com.google.cloud.storage.Storage.update(BucketInfo{name=leostaging-all-of-us-1737-dba01a51-9755-4e4e-92a1-b48cc8600ea2})"
logger_name: "org.broadinstitute.dsde.workbench.leonardo.http.Boot"
message: {
response: null
result: "Failed"
}
result: "Failed"
serviceContext: {
service: "leonardo"
version: "bfa8ef7"
}
stack_trace: "com.google.cloud.storage.StorageException: The specified bucket does not exist.
	at com.google.cloud.storage.spi.v1.HttpStorageRpc.translate(HttpStorageRpc.java:233)
	at com.google.cloud.storage.spi.v1.HttpStorageRpc.patch(HttpStorageRpc.java:500)
```

The PR will recover 404 for both deleting staging bucket and init bucket

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
