### PR TITLE
BT-620 Add proxy path configuration

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/kubernetesModels.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/kubernetesModels.scala
@@ -367,7 +367,7 @@ final case class App(id: AppId,
     appResources.services.map { service =>
       val proxyPath = s"google/v1/apps/${project.value}/${appName.value}/${service.config.name.value}"
       val servicePath = service.config.path match {
-        case Some(path) => path.replace("{proxyPath}", proxyPath)
+        case Some(path) => path.value.replace("{proxyPath}", proxyPath)
         case None       => ""
       }
       (service.config.name, new URL(s"${proxyUrlBase}${proxyPath}${servicePath}"))
@@ -446,8 +446,9 @@ object AppStatus {
 
 final case class KubernetesService(id: ServiceId, config: ServiceConfig)
 final case class ServiceId(id: Long) extends AnyVal
-final case class ServiceConfig(name: ServiceName, kind: KubernetesServiceKindName, path: Option[String] = None)
+final case class ServiceConfig(name: ServiceName, kind: KubernetesServiceKindName, path: Option[ServicePath] = None)
 final case class KubernetesServiceKindName(value: String) extends AnyVal
+final case class ServicePath(value: String) extends AnyVal
 
 final case class KubernetesRuntimeConfig(numNodes: NumNodes, machineType: MachineTypeName, autoscalingEnabled: Boolean)
 final case class NumNodepools(value: Int) extends AnyVal

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/kubernetesModels.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/kubernetesModels.scala
@@ -20,7 +20,6 @@ import org.broadinstitute.dsde.workbench.google2.{
   RegionName,
   SubnetworkName
 }
-import org.broadinstitute.dsde.workbench.leonardo.AppType.Cromwell
 import org.broadinstitute.dsde.workbench.model.{IP, TraceId, WorkbenchEmail}
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.broadinstitute.dsp.{ChartName, ChartVersion, Release}
@@ -364,13 +363,17 @@ final case class App(id: AppId,
                      customEnvironmentVariables: Map[String, String],
                      descriptorPath: Option[Uri],
                      extraArgs: List[String]) {
-  def getProxyUrls(project: GoogleProject, proxyUrlBase: String): Map[ServiceName, URL] =
+  def getProxyUrls(project: GoogleProject, proxyUrlBase: String): Map[ServiceName, URL] = {
     appResources.services.map { service =>
       val proxyPath = s"google/v1/apps/${project.value}/${appName.value}/${service.config.name.value}"
-      // Holding fix until BW-620. For Cromwell only, a trailing '/' is appended:
-      val url = if (appType == Cromwell) s"${proxyUrlBase}${proxyPath}/" else s"${proxyUrlBase}${proxyPath}"
-      (service.config.name, new URL(url))
+      val servicePath = service.config.path match {
+        case Some(path) => path.replace("{proxyPath}", proxyPath)
+        case None => ""
+      }
+      (service.config.name,
+        new URL(s"${proxyUrlBase}${proxyPath}${servicePath}"))
     }.toMap
+  }
 }
 
 sealed abstract class AppStatus
@@ -445,7 +448,7 @@ object AppStatus {
 
 final case class KubernetesService(id: ServiceId, config: ServiceConfig)
 final case class ServiceId(id: Long) extends AnyVal
-final case class ServiceConfig(name: ServiceName, kind: KubernetesServiceKindName)
+final case class ServiceConfig(name: ServiceName, kind: KubernetesServiceKindName, path: Option[String] = None)
 final case class KubernetesServiceKindName(value: String) extends AnyVal
 
 final case class KubernetesRuntimeConfig(numNodes: NumNodes, machineType: MachineTypeName, autoscalingEnabled: Boolean)

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/kubernetesModels.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/kubernetesModels.scala
@@ -363,17 +363,15 @@ final case class App(id: AppId,
                      customEnvironmentVariables: Map[String, String],
                      descriptorPath: Option[Uri],
                      extraArgs: List[String]) {
-  def getProxyUrls(project: GoogleProject, proxyUrlBase: String): Map[ServiceName, URL] = {
+  def getProxyUrls(project: GoogleProject, proxyUrlBase: String): Map[ServiceName, URL] =
     appResources.services.map { service =>
       val proxyPath = s"google/v1/apps/${project.value}/${appName.value}/${service.config.name.value}"
       val servicePath = service.config.path match {
         case Some(path) => path.replace("{proxyPath}", proxyPath)
-        case None => ""
+        case None       => ""
       }
-      (service.config.name,
-        new URL(s"${proxyUrlBase}${proxyPath}${servicePath}"))
+      (service.config.name, new URL(s"${proxyUrlBase}${proxyPath}${servicePath}"))
     }.toMap
-  }
 }
 
 sealed abstract class AppStatus

--- a/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changelog.xml
+++ b/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changelog.xml
@@ -85,4 +85,5 @@
     <include file="changesets/20211129_support_proxy_to_azure_pd.xml" relativeToChangelogFile="true" />
     <include file="changesets/20220118_update_runtime_controlled_resource.xml" relativeToChangelogFile="true" />
     <include file="changesets/20220211_cluster_workspace_unique.xml" relativeToChangelogFile="true" />
+    <include file="changesets/20220428_add_service_path.xml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/20220428_add_service_path.xml
+++ b/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/20220428_add_service_path.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog logicalFilePath="leonardo" xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+
+    <changeSet logicalFilePath="leonardo" author="breilly" id="add_service_path">
+        <addColumn tableName="SERVICE">
+            <column name="servicePath" type="varchar(254)">
+                <constraints nullable="true"/>
+            </column>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -490,7 +490,13 @@ gke {
       {
         name = "cromwell-service"
         kind = "ClusterIP"
-      }
+        path = "/swagger/index.html?url=/proxy/{proxyPath}/swagger/cromwell.yaml"
+      }#,
+      #{
+      #  name = "job-manager"
+      #  kind = "ClusterIP"
+      #  path = "/jobs"
+      #}
     ]
     # These appear to be currently unused, but BW-860 should be able to make use of them.
     releaseNameSuffix = "cromwell-rls"

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -490,12 +490,7 @@ gke {
       {
         name = "cromwell-service"
         kind = "ClusterIP"
-        path = "/swagger/index.html?url=/proxy/{proxyPath}/swagger/cromwell.yaml"
-      },
-      {
-        name = "job-manager"
-        kind = "ClusterIP"
-        path = "/jobs"
+        path = "/"
       }
     ]
     # These appear to be currently unused, but BW-860 should be able to make use of them.

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -491,12 +491,12 @@ gke {
         name = "cromwell-service"
         kind = "ClusterIP"
         path = "/swagger/index.html?url=/proxy/{proxyPath}/swagger/cromwell.yaml"
-      }#,
-      #{
-      #  name = "job-manager"
-      #  kind = "ClusterIP"
-      #  path = "/jobs"
-      #}
+      },
+      {
+        name = "job-manager"
+        kind = "ClusterIP"
+        path = "/jobs"
+      }
     ]
     # These appear to be currently unused, but BW-860 should be able to make use of them.
     releaseNameSuffix = "cromwell-rls"

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
@@ -645,7 +645,8 @@ object Config {
   implicit private val serviceReader: ValueReader[ServiceConfig] = ValueReader.relative { config =>
     ServiceConfig(
       config.as[ServiceName]("name"),
-      config.as[KubernetesServiceKindName]("kind")
+      config.as[KubernetesServiceKindName]("kind"),
+      config.as[Option[String]]("path")
     )
   }
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
@@ -646,7 +646,7 @@ object Config {
     ServiceConfig(
       config.as[ServiceName]("name"),
       config.as[KubernetesServiceKindName]("kind"),
-      config.as[Option[String]]("path")
+      config.as[Option[ServicePath]]("path")
     )
   }
 
@@ -663,6 +663,8 @@ object Config {
     stringValueReader.map(KubernetesServiceKindName)
   implicit private val kubernetesClusterVersionReader: ValueReader[KubernetesClusterVersion] =
     stringValueReader.map(KubernetesClusterVersion)
+  implicit private val servicePathReader: ValueReader[ServicePath] =
+    stringValueReader.map(ServicePath)
 
   val gkeClusterConfig = config.as[KubernetesClusterConfig]("gke.cluster")
   val gkeDefaultNodepoolConfig = config.as[DefaultNodepoolConfig]("gke.defaultNodepool")

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/LeoProfile.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/LeoProfile.scala
@@ -256,6 +256,8 @@ private[leonardo] object LeoProfile extends MySQLProfile {
       MappedColumnType.base[ServiceName, String](_.value, ServiceName.apply)
     implicit val serviceKindColumnType: BaseColumnType[KubernetesServiceKindName] =
       MappedColumnType.base[KubernetesServiceKindName, String](_.value, KubernetesServiceKindName.apply)
+    implicit val servicePathColumnType: BaseColumnType[ServicePath] =
+      MappedColumnType.base[ServicePath, String](_.value, ServicePath.apply)
 
     implicit val uriColumnType: BaseColumnType[Uri] =
       MappedColumnType.base[Uri, String](

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/ServiceComponent.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/ServiceComponent.scala
@@ -5,7 +5,8 @@ import org.broadinstitute.dsde.workbench.leonardo.{
   KubernetesService,
   KubernetesServiceKindName,
   ServiceConfig,
-  ServiceId
+  ServiceId,
+  ServicePath
 }
 import slick.lifted.Tag
 import LeoProfile.api._
@@ -20,14 +21,14 @@ final case class ServiceRecord(id: ServiceId,
                                appId: AppId,
                                serviceName: ServiceName,
                                serviceKind: KubernetesServiceKindName,
-                               servicePath: Option[String])
+                               servicePath: Option[ServicePath])
 
 class ServiceTable(tag: Tag) extends Table[ServiceRecord](tag, "SERVICE") {
   def id = column[ServiceId]("id", O.AutoInc, O.PrimaryKey)
   def appId = column[AppId]("appId")
   def serviceName = column[ServiceName]("serviceName", O.Length(254))
   def serviceKind = column[KubernetesServiceKindName]("serviceKind", O.Length(254))
-  def servicePath = column[Option[String]]("servicePath", O.Length(254))
+  def servicePath = column[Option[ServicePath]]("servicePath", O.Length(254))
 
   override def * = (id, appId, serviceName, serviceKind, servicePath) <> (ServiceRecord.tupled, ServiceRecord.unapply)
 }


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/BT-620

~In addition,~ I added service path to config to allow for different proxy endpoints for different services. A side effect of this is that the code for generating the proxy URL is back to being general for all apps, not different for Cromwell.

Update: While this no longer adds support for Job Manager (which we've pivoting away from), this code is still useful for adding a proxy for C-BAS (see https://broadworkbench.atlassian.net/browse/BW-1189 in epic https://broadworkbench.atlassian.net/browse/BW-1108)

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
