### PR TITLE
IA-3399 fix branch / for scalasteward

### DIFF
--- a/docker/build.sh
+++ b/docker/build.sh
@@ -46,6 +46,9 @@ DOCKER_TAG=""
 DOCKER_TAG_TESTS=""
 ENV=${ENV:-""}  # if env is not set, push an image with branch name
 SERVICE_ACCOUNT_KEY_FILE=""  # default to no service account
+REGEX_TO_REPLACE_ILLEGAL_CHARACTERS_WITH_DASHES="s/[^a-zA-Z0-9_.\-]/-/g"
+REGEX_TO_REMOVE_DASHES_AND_PERIODS_FROM_BEGINNING="s/^[.\-]*//g"
+DOCKERTAG_SAFE_NAME=$(echo $BRANCH | sed -e $REGEX_TO_REPLACE_ILLEGAL_CHARACTERS_WITH_DASHES -e $REGEX_TO_REMOVE_DASHES_AND_PERIODS_FROM_BEGINNING | cut -c 1-127) # https://docs.docker.com/engine/reference/commandline/tag/#:~:text=A%20tag%20name%20must%20be,a%20maximum%20of%20128%20characters.
 
 MAKE_JAR=false
 RUN_DOCKER=false
@@ -184,8 +187,8 @@ function docker_cmd()
             # Push tests image no matter what. Currently this is only supported in Dockerhub.
             echo "pushing $TESTS_IMAGE docker image..."
             $DOCKER_REMOTES_BINARY push $TESTS_IMAGE:${DOCKER_TAG_TESTS}
-            $DOCKER_REMOTES_BINARY tag $TESTS_IMAGE:${DOCKER_TAG_TESTS} $TESTS_IMAGE:${GIT_BRANCH}
-            $DOCKER_REMOTES_BINARY push $TESTS_IMAGE:${GIT_BRANCH}
+            $DOCKER_REMOTES_BINARY tag $TESTS_IMAGE:${DOCKER_TAG_TESTS} $TESTS_IMAGE:${DOCKERTAG_SAFE_NAME}
+            $DOCKER_REMOTES_BINARY push $TESTS_IMAGE:${DOCKERTAG_SAFE_NAME}
         fi
     else
         echo "Not a valid docker option!  Choose either build or push (which includes build)"


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-3399

Similar to https://github.com/broadinstitute/sam/pull/672

This will hopefully make automation tests run properly for PRs from scala-steward

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
