### PR TITLE
IA-3399 use DOCKERTAG_SAFE_NAME for GCR as well

### DIFF
--- a/docker/build.sh
+++ b/docker/build.sh
@@ -180,8 +180,8 @@ function docker_cmd()
                 echo "pushing $GCR_IMAGE docker image..."
                 $DOCKER_REMOTES_BINARY tag $DEFAULT_IMAGE:${DOCKER_TAG} ${GCR_IMAGE}:${DOCKER_TAG}
                 $GCR_REMOTES_BINARY push ${GCR_IMAGE}:${DOCKER_TAG}
-                $DOCKER_REMOTES_BINARY tag $DEFAULT_IMAGE:${DOCKER_TAG} ${GCR_IMAGE}:${GIT_BRANCH}
-                $GCR_REMOTES_BINARY push ${GCR_IMAGE}:${GIT_BRANCH}
+                $DOCKER_REMOTES_BINARY tag $DEFAULT_IMAGE:${DOCKER_TAG} ${GCR_IMAGE}:${DOCKERTAG_SAFE_NAME}
+                $GCR_REMOTES_BINARY push ${GCR_IMAGE}:${DOCKERTAG_SAFE_NAME}
             fi
 
             # Push tests image no matter what. Currently this is only supported in Dockerhub.


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-3399

Think this is the last piece to make automation tests run for scalasteward PRs

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
