### PR TITLE
IA-3432 expand asynctask metrics in a way that records duration with different message types

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/AsyncTaskProcessor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/AsyncTaskProcessor.scala
@@ -28,8 +28,9 @@ final class AsyncTaskProcessor[F[_]](config: AsyncTaskProcessor.Config, asyncTas
   private def handler(task: Task[F]): F[Unit] =
     for {
       now <- F.realTimeInstant
-      latency = (now.toEpochMilli - task.enqueuedTime.toEpochMilli).millis
-      _ <- recordLatency(latency)
+      latency = (now.toEpochMilli - task.metricsStartTime.toEpochMilli).millis
+      tags = Map("taskName" -> task.taskName)
+      _ <- recordLatency(latency, tags)
       _ <- logger.info(Map("traceId" -> task.traceId.asString))(
         s"Executing task with latency of ${latency.toSeconds} seconds"
       )
@@ -51,7 +52,7 @@ final class AsyncTaskProcessor[F[_]](config: AsyncTaskProcessor.Config, asyncTas
   }
 
   // record the latency between message being enqueued and task gets executed
-  private def recordLatency(latency: FiniteDuration): F[Unit] =
+  private def recordLatency(latency: FiniteDuration, tags: Map[String, String]): F[Unit] =
     metrics.recordDuration("asyncTaskLatency",
                            latency,
                            List(
@@ -62,7 +63,8 @@ final class AsyncTaskProcessor[F[_]](config: AsyncTaskProcessor.Config, asyncTas
                              8 minutes,
                              16 minutes,
                              32 minutes
-                           ))
+                           ),
+                           tags)
 }
 
 object AsyncTaskProcessor {
@@ -75,6 +77,7 @@ object AsyncTaskProcessor {
   final case class Task[F[_]](traceId: TraceId,
                               op: F[Unit],
                               errorHandler: Option[Throwable => F[Unit]] = None,
-                              enqueuedTime: Instant)
+                              metricsStartTime: Instant,
+                              taskName: String)
   final case class Config(queueBound: Int, maxConcurrentTasks: Int)
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/AsyncTaskProcessorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/AsyncTaskProcessorSpec.scala
@@ -40,7 +40,7 @@ class AsyncTaskProcessorSpec extends AnyFlatSpec with Matchers with LeonardoTest
       val tasks = Stream
         .emits(1 to 10)
         .covary[IO]
-        .map(x => Task(traceId, io(x), None, Instant.now()))
+        .map(x => Task(traceId, io(x), None, Instant.now(), "test"))
 
       val stream = tasks.through(in => in.evalMap(queue.offer(_))) ++ asyncTaskProcessor.process
       stream.interruptWhen(signalToStop.get.attempt.map(_.map(_ => ())))

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/NonLeoMessageSubscriber.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/NonLeoMessageSubscriber.scala
@@ -189,7 +189,8 @@ class NonLeoMessageSubscriber[F[_]](gkeAlg: GKEAlgebra[F],
         Task(ctx.traceId,
              task,
              Some(logError(s"${msg.nodepoolId}/${msg.googleProject}", DeleteNodepool.toString)),
-             ctx.now)
+             ctx.now,
+             "deleteNodepool")
       )
     } yield ()
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandler.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandler.scala
@@ -299,7 +299,8 @@ class AzurePubsubHandlerInterp[F[_]: Parallel](
                                                                       e.getMessage),
                                             ctx.now)
           ),
-          ctx.now
+          ctx.now,
+          "createAzureRuntime"
         )
       )
     } yield ()
@@ -440,7 +441,8 @@ class AzurePubsubHandlerInterp[F[_]: Parallel](
               )
               .void
           ),
-          ctx.now
+          ctx.now,
+          "deleteAzureRuntime"
         )
       )
     } yield ()


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-3432

Previously asyncTaskProcessor records just the duration of a task. Now it adds a tag as well, this way, we can create metrics for how long a specific pubsub message takes to complete from when the message was published. I renamed `enqueuedTime` to `metricsStartTime` to give it a bit more flexibility what start time will be for each duration we're recording. In the case of pubsub messages, we're always recording when the pubsub message was published as the  `metricsStartTime`

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
