### PR TITLE
IA-3432 IA-3440 Improve metrics and deletion bug fix

### DIFF
--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpWsmDao.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpWsmDao.scala
@@ -162,6 +162,26 @@ class HttpWsmDao[F[_]](httpClient: Client[F], config: HttpWsmDaoConfig)(
       )(onError)
     } yield res
 
+  override def getDeleteVmJobResult(request: GetJobResultRequest, authorization: Authorization)(
+    implicit ev: Ask[F, AppContext]
+  ): F[GetDeleteJobResult] =
+    for {
+      ctx <- ev.ask
+      res <- httpClient.expectOr[GetDeleteJobResult](
+        Request[F](
+          method = Method.GET,
+          uri = config.uri
+            .withPath(
+              Uri.Path
+                .unsafeFromString(
+                  s"/api/workspaces/v1/${request.workspaceId.value.toString}/resources/controlled/azure/vm/delete-result/${request.jobId.value}"
+                )
+            ),
+          headers = headers(authorization, ctx.traceId, false)
+        )
+      )(onError)
+    } yield res
+
   def getRelayNamespace(workspaceId: WorkspaceId,
                         region: com.azure.core.management.Region,
                         authorization: Authorization)(

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/WsmDao.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/WsmDao.scala
@@ -64,6 +64,10 @@ trait WsmDao[F[_]] {
     implicit ev: Ask[F, AppContext]
   ): F[GetCreateVmJobResult]
 
+  def getDeleteVmJobResult(request: GetJobResultRequest, authorization: Authorization)(
+    implicit ev: Ask[F, AppContext]
+  ): F[GetDeleteJobResult]
+
   def getWorkspace(workspaceId: WorkspaceId, authorization: Authorization)(
     implicit ev: Ask[F, AppContext]
   ): F[Option[WorkspaceDescription]]
@@ -113,6 +117,7 @@ final case class DeleteWsmResourceRequest(workspaceId: WorkspaceId,
 
 final case class CreateVmResult(jobReport: WsmJobReport, errorReport: Option[WsmErrorReport])
 final case class GetCreateVmJobResult(vm: Option[WsmVm], jobReport: WsmJobReport, errorReport: Option[WsmErrorReport])
+final case class GetDeleteJobResult(jobReport: WsmJobReport, errorReport: Option[WsmErrorReport])
 final case class WsmRelayNamespace(namespaceName: RelayNamespace, region: com.azure.core.management.Region)
 final case class ResourceAttributes(relayNamespace: WsmRelayNamespace)
 final case class WsmResource(resourceAttributes: ResourceAttributes)
@@ -365,6 +370,8 @@ object WsmDecoders {
 
   implicit val getCreateVmResultDecoder: Decoder[GetCreateVmJobResult] =
     Decoder.forProduct3("azureVm", "jobReport", "errorReport")(GetCreateVmJobResult.apply)
+  implicit val getDeleteVmResultDecoder: Decoder[GetDeleteJobResult] =
+    Decoder.forProduct2("jobReport", "errorReport")(GetDeleteJobResult.apply)
 }
 
 object WsmEncoders {

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/RuntimeControlledResourceComponent.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/RuntimeControlledResourceComponent.scala
@@ -22,11 +22,6 @@ class RuntimeControlledResourceTable(tag: Tag)
 }
 
 object controlledResourceQuery extends TableQuery(new RuntimeControlledResourceTable(_)) {
-  def deleteAllForRuntime(runtimeId: Long): DBIO[Int] =
-    controlledResourceQuery
-      .filter(_.runtimeId === runtimeId)
-      .delete
-
   def save(runtimeId: Long, resourceId: WsmControlledResourceId, resourceType: WsmResourceType): DBIO[Int] =
     controlledResourceQuery += RuntimeControlledResourceRecord(runtimeId, resourceId, resourceType)
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/leoPubsubMessageSubscriberModels.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/leoPubsubMessageSubscriberModels.scala
@@ -898,6 +898,13 @@ object PubsubHandleMessageError {
       s"\n\truntimeId: ${runtimeId}, \n\tmsg: ${errorMsg})"
     val isRetryable: Boolean = false
   }
+
+  final case class AzureRuntimeDeletioinError(runtimeId: Long, workspaceId: WorkspaceId, errorMsg: String)
+      extends PubsubHandleMessageError {
+    override def getMessage: String =
+      s"\n\truntimeId: ${runtimeId}, \n\tmsg: ${errorMsg})"
+    val isRetryable: Boolean = false
+  }
 }
 
 final case class PersistentDiskMonitor(maxAttempts: Int, interval: FiniteDuration)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/leoPubsubMessageSubscriberModels.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/leoPubsubMessageSubscriberModels.scala
@@ -899,7 +899,7 @@ object PubsubHandleMessageError {
     val isRetryable: Boolean = false
   }
 
-  final case class AzureRuntimeDeletioinError(runtimeId: Long, workspaceId: WorkspaceId, errorMsg: String)
+  final case class AzureRuntimeDeletionError(runtimeId: Long, workspaceId: WorkspaceId, errorMsg: String)
       extends PubsubHandleMessageError {
     override def getMessage: String =
       s"\n\truntimeId: ${runtimeId}, \n\tmsg: ${errorMsg})"

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandler.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandler.scala
@@ -21,7 +21,7 @@ import org.broadinstitute.dsde.workbench.leonardo.monitor.LeoPubsubMessage.{
 import org.broadinstitute.dsde.workbench.leonardo.monitor.PubsubHandleMessageError
 import org.broadinstitute.dsde.workbench.leonardo.monitor.PubsubHandleMessageError.{
   AzureRuntimeCreationError,
-  AzureRuntimeDeletioinError,
+  AzureRuntimeDeletionError,
   ClusterError
 }
 import org.broadinstitute.dsde.workbench.model.{IP, WorkbenchEmail}
@@ -432,15 +432,15 @@ class AzurePubsubHandlerInterp[F[_]: Parallel](
             } yield ()
           case WsmJobStatus.Failed =>
             F.raiseError[Unit](
-              AzureRuntimeDeletioinError(
+              AzureRuntimeDeletionError(
                 msg.runtimeId,
                 msg.workspaceId,
-                s"WSM delete VM job failed due due to ${resp.errorReport.map(_.message).getOrElse("unknown")}"
+                s"WSM delete VM job failed due to ${resp.errorReport.map(_.message).getOrElse("unknown")}"
               )
             )
           case WsmJobStatus.Running =>
             F.raiseError[Unit](
-              AzureRuntimeDeletioinError(
+              AzureRuntimeDeletionError(
                 msg.runtimeId,
                 msg.workspaceId,
                 s"WSM delete VM job was not completed within ${config.deleteVmPollConfig.maxAttempts} attempts with ${config.deleteVmPollConfig.interval} delay"

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandler.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandler.scala
@@ -21,6 +21,7 @@ import org.broadinstitute.dsde.workbench.leonardo.monitor.LeoPubsubMessage.{
 import org.broadinstitute.dsde.workbench.leonardo.monitor.PubsubHandleMessageError
 import org.broadinstitute.dsde.workbench.leonardo.monitor.PubsubHandleMessageError.{
   AzureRuntimeCreationError,
+  AzureRuntimeDeletioinError,
   ClusterError
 }
 import org.broadinstitute.dsde.workbench.model.{IP, WorkbenchEmail}
@@ -40,6 +41,8 @@ class AzurePubsubHandlerInterp[F[_]: Parallel](
   azureManager: AzureManagerDao[F]
 )(implicit val executionContext: ExecutionContext, dbRef: DbReference[F], logger: StructuredLogger[F], F: Async[F])
     extends AzurePubsubHandlerAlgebra[F] {
+  implicit val wsmDeleteVmDoneCheckable: DoneCheckable[GetDeleteJobResult] = (v: GetDeleteJobResult) =>
+    v.jobReport.status.equals(WsmJobStatus.Succeeded) || v.jobReport.status == WsmJobStatus.Failed
 
   override def createAndPollRuntime(msg: CreateAzureRuntimeMessage)(implicit ev: Ask[F, AppContext]): F[Unit] =
     for {
@@ -316,6 +319,7 @@ class AzurePubsubHandlerInterp[F[_]: Parallel](
       runtime <- F.fromOption(runtimeOpt, PubsubHandleMessageError.ClusterNotFound(msg.runtimeId, msg))
       auth <- samDAO.getLeoAuthToken
 
+      deleteJobId = WsmJobId(s"delete-vm-${ctx.traceId.asString.take(10)}")
       _ <- msg.wsmResourceId.fold(
         logger
           .info(ctx.loggingCtx)(s"No wsmResourceId found for delete azure runtime msg $msg. No-op for wsmDao.deleteVm.")
@@ -326,7 +330,7 @@ class AzurePubsubHandlerInterp[F[_]: Parallel](
               msg.workspaceId,
               wsmResourceId,
               DeleteControlledAzureResourceRequest(
-                WsmJobControl(WsmJobId(s"delete-vm-${ctx.traceId.asString.take(10)}"))
+                WsmJobControl(deleteJobId)
               )
             ),
             auth
@@ -334,98 +338,116 @@ class AzurePubsubHandlerInterp[F[_]: Parallel](
           .void
       }
 
-      diskResourceOpt <- controlledResourceQuery
-        .getWsmRecordForRuntime(runtime.id, WsmResourceType.AzureDisk)
-        .transaction
-      _ <- logger
-        .info(ctx.loggingCtx)(s"No disk resource found for delete azure runtime msg $msg. No-op for wsmDao.deleteDisk.")
-        .whenA(diskResourceOpt.isEmpty)
-      deleteDisk = diskResourceOpt.traverse { disk =>
-        wsmDao.deleteDisk(
-          DeleteWsmResourceRequest(
-            msg.workspaceId,
-            disk.resourceId,
-            DeleteControlledAzureResourceRequest(
-              WsmJobControl(WsmJobId(s"delete-disk-${ctx.traceId.asString.take(10)}"))
-            )
-          ),
-          auth
-        )
-      }.void
-
-      networkResourceOpt <- controlledResourceQuery
-        .getWsmRecordForRuntime(runtime.id, WsmResourceType.AzureNetwork)
-        .transaction
-      _ <- logger
-        .info(ctx.loggingCtx)(
-          s"No network resource found for delete azure runtime msg $msg. No-op for wsmDao.deleteNetworks."
-        )
-        .whenA(networkResourceOpt.isEmpty)
-      deleteNetworks = networkResourceOpt.traverse { network =>
-        wsmDao.deleteNetworks(
-          DeleteWsmResourceRequest(
-            msg.workspaceId,
-            network.resourceId,
-            DeleteControlledAzureResourceRequest(
-              WsmJobControl(WsmJobId(s"delete-networks-${ctx.traceId.asString.take(10)}"))
-            )
-          ),
-          auth
-        )
-      }.void
-
-      deleteHybridConnection = for {
-        leoAuth <- samDAO.getLeoAuthToken
-        runtimeConfig <- RuntimeConfigQueries.getRuntimeConfig(runtime.runtimeConfigId).transaction
-        azureRuntimeConfig <- runtimeConfig match {
-          case x: RuntimeConfig.AzureConfig => F.pure(x)
-          case _ =>
-            F.raiseError(ClusterError(msg.runtimeId, ctx.traceId, s"Runtime should have Azure config, but it doesn't"))
-        }
-        relayNamespaceOpt <- wsmDao.getRelayNamespace(msg.workspaceId, azureRuntimeConfig.region, leoAuth)
-        cloudContext <- runtime.cloudContext match {
-          case _: CloudContext.Gcp =>
-            F.raiseError[AzureCloudContext](
-              PubsubHandleMessageError.ClusterError(msg.runtimeId,
-                                                    ctx.traceId,
-                                                    "Azure runtime should not have GCP cloud context")
-            )
-          case x: CloudContext.Azure => F.pure(x.value)
-        }
-        _ <- relayNamespaceOpt.traverse(ns =>
-          azureManager.createRelayHybridConnection(
-            ns,
-            RelayHybridConnectionName(runtime.runtimeName.asString),
-            cloudContext
+      // Delete hybrid connection for this VM
+      leoAuth <- samDAO.getLeoAuthToken
+      runtimeConfig <- RuntimeConfigQueries.getRuntimeConfig(runtime.runtimeConfigId).transaction
+      azureRuntimeConfig <- runtimeConfig match {
+        case x: RuntimeConfig.AzureConfig => F.pure(x)
+        case _ =>
+          F.raiseError(
+            ClusterError(msg.runtimeId, ctx.traceId, s"Runtime should have Azure config, but it doesn't")
           )
-        )
-      } yield ()
-
-      _ <- List(deleteDisk, deleteNetworks, deleteHybridConnection).parSequence
+      }
+      relayNamespaceOpt <- wsmDao.getRelayNamespace(msg.workspaceId, azureRuntimeConfig.region, leoAuth)
       cloudContext <- runtime.cloudContext match {
         case _: CloudContext.Gcp =>
           F.raiseError[AzureCloudContext](
-            PubsubHandleMessageError.ClusterError(runtime.id,
+            PubsubHandleMessageError.ClusterError(msg.runtimeId,
                                                   ctx.traceId,
                                                   "Azure runtime should not have GCP cloud context")
           )
         case x: CloudContext.Azure => F.pure(x.value)
       }
+      _ <- relayNamespaceOpt.traverse(ns =>
+        azureManager.createRelayHybridConnection(
+          ns,
+          RelayHybridConnectionName(runtime.runtimeName.asString),
+          cloudContext
+        )
+      )
 
-      getDeleteResult = azureManager.getAzureVm(runtime.runtimeName, cloudContext)
+      getDeleteJobResult = wsmDao.getDeleteVmJobResult(
+        GetJobResultRequest(msg.workspaceId, deleteJobId),
+        auth
+      )
 
       taskToRun = for {
-        _ <- streamUntilDoneOrTimeout(
-          getDeleteResult,
+        // We need to wait until WSM deletion job to be done because if the VM still exists, we won't be able to delete disk, and networks
+        resp <- streamFUntilDone(
+          getDeleteJobResult,
           config.deleteVmPollConfig.maxAttempts,
-          config.deleteVmPollConfig.interval,
-          s"Azure vm still exists after ${config.deleteVmPollConfig.maxAttempts} attempts with ${config.deleteVmPollConfig.interval} delay"
-        )
-        _ <- dbRef.inTransaction(clusterQuery.updateClusterStatus(runtime.id, RuntimeStatus.Deleted, ctx.now))
-        _ <- msg.diskId.traverse(diskId =>
-          dbRef.inTransaction(persistentDiskQuery.updateStatus(diskId, DiskStatus.Deleted, ctx.now))
-        )
-        - <- dbRef.inTransaction(controlledResourceQuery.deleteAllForRuntime(runtime.id))
+          config.deleteVmPollConfig.interval
+        ).compile.lastOrError
+
+        _ <- resp.jobReport.status match {
+          case WsmJobStatus.Succeeded =>
+            for {
+              diskResourceOpt <- controlledResourceQuery
+                .getWsmRecordForRuntime(runtime.id, WsmResourceType.AzureDisk)
+                .transaction
+              _ <- logger
+                .info(ctx.loggingCtx)(
+                  s"No disk resource found for delete azure runtime msg $msg. No-op for wsmDao.deleteDisk."
+                )
+                .whenA(diskResourceOpt.isEmpty)
+              deleteDisk = diskResourceOpt.traverse { disk =>
+                wsmDao.deleteDisk(
+                  DeleteWsmResourceRequest(
+                    msg.workspaceId,
+                    disk.resourceId,
+                    DeleteControlledAzureResourceRequest(
+                      WsmJobControl(WsmJobId(s"delete-disk-${ctx.traceId.asString.take(10)}"))
+                    )
+                  ),
+                  auth
+                )
+              }.void
+
+              networkResourceOpt <- controlledResourceQuery
+                .getWsmRecordForRuntime(runtime.id, WsmResourceType.AzureNetwork)
+                .transaction
+              _ <- logger
+                .info(ctx.loggingCtx)(
+                  s"No network resource found for delete azure runtime msg $msg. No-op for wsmDao.deleteNetworks."
+                )
+                .whenA(networkResourceOpt.isEmpty)
+              deleteNetworks = networkResourceOpt.traverse { network =>
+                wsmDao.deleteNetworks(
+                  DeleteWsmResourceRequest(
+                    msg.workspaceId,
+                    network.resourceId,
+                    DeleteControlledAzureResourceRequest(
+                      WsmJobControl(WsmJobId(s"delete-networks-${ctx.traceId.asString.take(10)}"))
+                    )
+                  ),
+                  auth
+                )
+              }.void
+
+              _ <- List(deleteDisk, deleteNetworks).parSequence
+              _ <- dbRef.inTransaction(clusterQuery.updateClusterStatus(runtime.id, RuntimeStatus.Deleted, ctx.now))
+              _ <- msg.diskId.traverse(diskId =>
+                dbRef.inTransaction(persistentDiskQuery.updateStatus(diskId, DiskStatus.Deleted, ctx.now))
+              )
+              - <- dbRef.inTransaction(controlledResourceQuery.deleteAllForRuntime(runtime.id))
+            } yield ()
+          case WsmJobStatus.Failed =>
+            F.raiseError[Unit](
+              AzureRuntimeDeletioinError(
+                msg.runtimeId,
+                msg.workspaceId,
+                s"WSM delete VM job failed due due to ${resp.errorReport.map(_.message).getOrElse("unknown")}"
+              )
+            )
+          case WsmJobStatus.Running =>
+            F.raiseError[Unit](
+              AzureRuntimeDeletioinError(
+                msg.runtimeId,
+                msg.workspaceId,
+                s"WSM delete VM job was not completed within ${config.deleteVmPollConfig.maxAttempts} attempts with ${config.deleteVmPollConfig.interval} delay"
+              )
+            )
+        }
       } yield ()
 
       _ <- asyncTasks.offer(

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandler.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandler.scala
@@ -429,7 +429,6 @@ class AzurePubsubHandlerInterp[F[_]: Parallel](
               _ <- msg.diskId.traverse(diskId =>
                 dbRef.inTransaction(persistentDiskQuery.updateStatus(diskId, DiskStatus.Deleted, ctx.now))
               )
-              - <- dbRef.inTransaction(controlledResourceQuery.deleteAllForRuntime(runtime.id))
             } yield ()
           case WsmJobStatus.Failed =>
             F.raiseError[Unit](

--- a/http/src/test/resources/reference.conf
+++ b/http/src/test/resources/reference.conf
@@ -305,7 +305,7 @@ azure {
        }
        delete-vm-poll-config {
            initial-delay = 1 seconds
-           max-attempts = 120
+           max-attempts = 20
            interval = 1 seconds
        }
        runtime-defaults {

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/MockWsmDAO.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/MockWsmDAO.scala
@@ -206,4 +206,29 @@ class MockWsmDAO(jobStatus: WsmJobStatus = WsmJobStatus.Succeeded) extends WsmDa
   override def getRelayNamespace(workspaceId: WorkspaceId, region: Region, authorization: Authorization)(
     implicit ev: Ask[IO, AppContext]
   ): IO[Option[RelayNamespace]] = IO.pure(Some(RelayNamespace("fake-relay-ns")))
+
+  override def getDeleteVmJobResult(request: GetJobResultRequest, authorization: Authorization)(
+    implicit ev: Ask[IO, AppContext]
+  ): IO[GetDeleteJobResult] = IO.pure(
+    GetDeleteJobResult(
+      WsmJobReport(
+        request.jobId,
+        "desc",
+        jobStatus,
+        200,
+        ZonedDateTime.parse("2022-03-18T15:02:29.264756Z"),
+        Some(ZonedDateTime.parse("2022-03-18T15:02:29.264756Z")),
+        "resultUrl"
+      ),
+      if (jobStatus.equals(WsmJobStatus.Failed))
+        Some(
+          WsmErrorReport(
+            "error",
+            500,
+            List.empty
+          )
+        )
+      else None
+    )
+  )
 }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/RuntimeControlledResourceComponentSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/RuntimeControlledResourceComponentSpec.scala
@@ -61,27 +61,4 @@ class RuntimeControlledResourceComponentSpec extends AnyFlatSpecLike with TestCo
       res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
     }
   }
-
-  it should "delete all controlled resources for a runtime" in isolatedDbTest {
-    val res = for {
-      disk <- makePersistentDisk().copy(status = DiskStatus.Ready).save()
-      azureRuntimeConfig = RuntimeConfig.AzureConfig(MachineTypeName(VirtualMachineSizeTypes.STANDARD_A1.toString),
-                                                     disk.id,
-                                                     azureRegion)
-      runtime = makeCluster(1)
-        .copy(
-          cloudContext = CloudContext.Azure(azureCloudContext)
-        )
-        .saveWithRuntimeConfig(azureRuntimeConfig)
-
-      _ <- controlledResourceQuery
-        .save(runtime.id, WsmControlledResourceId(UUID.randomUUID()), WsmResourceType.AzureNetwork)
-        .transaction
-      _ <- controlledResourceQuery.deleteAllForRuntime(runtime.id).transaction
-      controlledResources <- controlledResourceQuery.getAllForRuntime(runtime.id).transaction
-    } yield {
-      controlledResources.length shouldBe 0
-    }
-    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
-  }
 }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/ConfigReaderSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/ConfigReaderSpec.scala
@@ -34,7 +34,7 @@ class ConfigReaderSpec extends AnyFlatSpec with Matchers {
         AzurePubsubHandlerConfig(
           Uri.unsafeFromString("https://sam.test.org:443"),
           PollMonitorConfig(1 seconds, 120, 1 seconds),
-          PollMonitorConfig(1 seconds, 120, 1 seconds),
+          PollMonitorConfig(1 seconds, 20, 1 seconds),
           AzureRuntimeDefaults(
             "Azure Ip",
             "ip",

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandlerSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandlerSpec.scala
@@ -195,12 +195,79 @@ class AzurePubsubHandlerSpec
 
   it should "handle error in delete azure vm async task properly" in isolatedDbTest {
     val exceptionMsg = "test exception"
-    val mockComputeManagerDao = new MockComputeManagerDao {
-      override def getAzureVm(name: RuntimeName, cloudContext: AzureCloudContext): IO[Option[VirtualMachine]] =
-        IO.raiseError(new Exception(exceptionMsg))
-    }
     val queue = QueueFactory.asyncTaskQueue()
-    val azureInterp = makeAzureInterp(asyncTaskQueue = queue, computeManagerDao = mockComputeManagerDao)
+    val wsm = new MockWsmDAO {
+      override def getDeleteVmJobResult(request: GetJobResultRequest, authorization: Authorization)(
+        implicit ev: Ask[IO, AppContext]
+      ): IO[GetDeleteJobResult] = IO.raiseError(new Exception("test exception"))
+    }
+    val azureInterp = makeAzureInterp(asyncTaskQueue = queue, wsmDAO = wsm)
+
+    val res =
+      for {
+        disk <- makePersistentDisk().copy(status = DiskStatus.Ready).save()
+
+        azureRuntimeConfig = RuntimeConfig.AzureConfig(MachineTypeName(VirtualMachineSizeTypes.STANDARD_A1.toString),
+                                                       disk.id,
+                                                       azureRegion)
+        runtime = makeCluster(2)
+          .copy(
+            status = RuntimeStatus.Running,
+            cloudContext = CloudContext.Azure(azureCloudContext)
+          )
+          .saveWithRuntimeConfig(azureRuntimeConfig)
+
+        //Here we manually save a controlled resource with the runtime because we want too ensure it isn't deleted on error
+        _ <- controlledResourceQuery
+          .save(runtime.id, WsmControlledResourceId(UUID.randomUUID()), WsmResourceType.AzureNetwork)
+          .transaction
+        _ <- controlledResourceQuery
+          .save(runtime.id, WsmControlledResourceId(UUID.randomUUID()), WsmResourceType.AzureDisk)
+          .transaction
+
+        assertions = for {
+          getRuntimeOpt <- clusterQuery.getClusterById(runtime.id).transaction
+          getRuntime = getRuntimeOpt.get
+          error <- clusterErrorQuery.get(runtime.id).transaction
+        } yield {
+          getRuntime.status shouldBe RuntimeStatus.Error
+          error.map(_.errorMessage).head should include(exceptionMsg)
+        }
+
+        msg = DeleteAzureRuntimeMessage(runtime.id, Some(disk.id), workspaceId, Some(wsmResourceId), None)
+
+        asyncTaskProcessor = AsyncTaskProcessor(AsyncTaskProcessor.Config(10, 10), queue)
+        _ <- azureInterp.deleteAndPollRuntime(msg)
+
+        _ <- withInfiniteStream(asyncTaskProcessor.process, assertions)
+      } yield ()
+
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
+  }
+
+  it should "fail if WSM delete VM job doesn't complete in time" in isolatedDbTest {
+    val exceptionMsg = "WSM delete VM job was not completed within 20 attempts with 1 second delay"
+    val queue = QueueFactory.asyncTaskQueue()
+    val wsm = new MockWsmDAO {
+      override def getDeleteVmJobResult(request: GetJobResultRequest, authorization: Authorization)(
+        implicit ev: Ask[IO, AppContext]
+      ): IO[GetDeleteJobResult] =
+        IO.pure(
+          GetDeleteJobResult(
+            WsmJobReport(
+              request.jobId,
+              "desc",
+              WsmJobStatus.Running,
+              200,
+              ZonedDateTime.parse("2022-03-18T15:02:29.264756Z"),
+              Some(ZonedDateTime.parse("2022-03-18T15:02:29.264756Z")),
+              "resultUrl"
+            ),
+            None
+          )
+        )
+    }
+    val azureInterp = makeAzureInterp(asyncTaskQueue = queue, wsmDAO = wsm)
 
     val res =
       for {
@@ -246,7 +313,7 @@ class AzurePubsubHandlerSpec
   // Needs to be made for each test its used in, otherwise queue will overlap
   def makeAzureInterp(asyncTaskQueue: Queue[IO, Task[IO]] = QueueFactory.asyncTaskQueue(),
                       computeManagerDao: AzureManagerDao[IO] = new MockComputeManagerDao(),
-                      wsmDAO: MockWsmDAO = new MockWsmDAO): AzurePubsubHandlerInterp[IO] =
+                      wsmDAO: WsmDao[IO] = new MockWsmDAO): AzurePubsubHandlerInterp[IO] =
     new AzurePubsubHandlerInterp[IO](
       ConfigReader.appConfig.azure.pubsubHandler,
       asyncTaskQueue,

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandlerSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandlerSpec.scala
@@ -129,7 +129,7 @@ class AzurePubsubHandlerSpec
           controlledResources <- controlledResourceQuery.getAllForRuntime(runtime.id).transaction
         } yield {
           getRuntime.status shouldBe RuntimeStatus.Deleted
-          (controlledResources.length > 0) shouldBe (true)
+          controlledResources.length shouldBe (2)
         }
 
         _ <- controlledResourceQuery

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandlerSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandlerSpec.scala
@@ -129,7 +129,7 @@ class AzurePubsubHandlerSpec
           controlledResources <- controlledResourceQuery.getAllForRuntime(runtime.id).transaction
         } yield {
           getRuntime.status shouldBe RuntimeStatus.Deleted
-          controlledResources.length shouldBe 0
+          (controlledResources.length > 0) shouldBe (true)
         }
 
         _ <- controlledResourceQuery


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-3416

* Previously we only have metrics for measuring from pubsub message that was published to when the message is enqueued into `AsyncTaskProcessor`. Now we're also adding metrics for measruring pubsub message published time to when the task completes in `AsyncTaskProcessor`
* Fix a bug in deletion where `deleteDisk` and `deleteNetworks` apis is called immediately after `deleteVM` wsm api, this can cause race condition where if `deleteVM` job doesn't finish by the time we try to delete disk and networks, the job will fail because disk and network would've still been associated the VM.
* When we delete a VM, previously we're deleting all the info in `RUNTIME_CONTROLLED_RESOURCE` table, but I think those are useful info to keep in case of error and it'll be useful for debugging purpose as well.

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
