### PR TITLE
IA-3416 add autopause in createAzureRuntime API

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoApiClient.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoApiClient.scala
@@ -128,7 +128,8 @@ object LeonardoApiClient {
       AzureDiskName(UUID.randomUUID().toString.substring(0, 8)),
       None,
       None
-    )
+    ),
+    Some(0)
   )
 
   def createRuntime(

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/JsonCodec.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/JsonCodec.scala
@@ -562,18 +562,14 @@ object JsonCodec {
     )
 
   implicit val workspaceIdDecoder: Decoder[WorkspaceId] =
-    Decoder.decodeString.emap(x =>
+    Decoder.decodeString.emap { x =>
       Either
         .catchNonFatal(WorkspaceId(UUID.fromString(x)))
         .leftMap(_.getMessage)
-    )
+    }
 
   implicit val workspaceSamResourceIdDecoder: Decoder[WorkspaceResourceSamResourceId] =
-    Decoder.decodeString.emap(x =>
-      Either
-        .catchNonFatal(WorkspaceResourceSamResourceId(WorkspaceId(UUID.fromString(x))))
-        .leftMap(_.getMessage)
-    )
+    workspaceIdDecoder.map(WorkspaceResourceSamResourceId.apply)
 
   implicit val errorSourceDecoder: Decoder[ErrorSource] =
     Decoder.decodeString.emap(s => ErrorSource.stringToObject.get(s).toRight(s"Invalid error source ${s}"))

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/azureRoutesModels.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/azureRoutesModels.scala
@@ -7,7 +7,8 @@ final case class CreateAzureRuntimeRequest(labels: LabelMap,
                                            region: Region,
                                            machineSize: VirtualMachineSizeTypes,
                                            customEnvironmentVariables: Map[String, String],
-                                           azureDiskConfig: CreateAzureDiskRequest)
+                                           azureDiskConfig: CreateAzureDiskRequest,
+                                           autoPauseThreshold: Option[Int])
 
 final case class CreateAzureDiskRequest(labels: LabelMap,
                                         name: AzureDiskName,

--- a/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/RuntimeRoutesTestJsonCodec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/RuntimeRoutesTestJsonCodec.scala
@@ -81,8 +81,8 @@ object RuntimeRoutesTestJsonCodec {
   implicit val azureDiskConfigEncoder: Encoder[CreateAzureDiskRequest] =
     Encoder.forProduct4("labels", "name", "size", "diskType")(x => CreateAzureDiskRequest.unapply(x).get)
   implicit val createAzureRuntimeRequestEncoder: Encoder[CreateAzureRuntimeRequest] =
-    Encoder.forProduct5("labels", "region", "machineSize", "customEnvironmentVariables", "disk")(x =>
-      CreateAzureRuntimeRequest.unapply(x).get
+    Encoder.forProduct6("labels", "region", "machineSize", "customEnvironmentVariables", "disk", "autopauseThreshold")(
+      x => CreateAzureRuntimeRequest.unapply(x).get
     )
 
   implicit val createRuntime2RequestEncoder: Encoder[CreateRuntime2Request] = Encoder.forProduct12(

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/RuntimeRoutes.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/RuntimeRoutes.scala
@@ -398,7 +398,7 @@ object RuntimeRoutes {
     } yield r
   }
 
-  implicit val createRuntimeRequestDecoder: Decoder[CreateRuntime2Request] = Decoder.instance { c =>
+  implicit val createRuntime2RequestDecoder: Decoder[CreateRuntime2Request] = Decoder.instance { c =>
     for {
       l <- c.downField("labels").as[Option[LabelMap]]
       _ <- l.fold(().asRight[DecodingFailure]) { labelMap =>

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/RuntimeV2Routes.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/RuntimeV2Routes.scala
@@ -222,7 +222,13 @@ class RuntimeV2Routes(saturnIframeExtentionHostConfig: RefererConfig,
         .downField("customEnvironmentVariables")
         .as[Option[Map[String, String]]]
       azureDiskReq <- c.downField("disk").as[CreateAzureDiskRequest]
-    } yield CreateAzureRuntimeRequest(labels, region, machineSize, customEnvVars.getOrElse(Map.empty), azureDiskReq)
+      apt <- c.downField("autopauseThreshold").as[Option[Int]]
+    } yield CreateAzureRuntimeRequest(labels,
+                                      region,
+                                      machineSize,
+                                      customEnvVars.getOrElse(Map.empty),
+                                      azureDiskReq,
+                                      apt)
   }
 
   implicit val updateAzureRuntimeRequestDecoder: Decoder[UpdateAzureRuntimeRequest] =

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeV2ServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeV2ServiceInterp.scala
@@ -418,7 +418,7 @@ class RuntimeV2ServiceInterp[F[_]: Parallel](config: RuntimeServiceConfig,
       startUserScriptUri = None,
       errors = List.empty,
       userJupyterExtensionConfig = None,
-      autopauseThreshold = 30,
+      autopauseThreshold = request.autoPauseThreshold.getOrElse(0), //TODO: default to 30 once we start supporting autopause
       defaultClientId = None,
       allowStop = false,
       runtimeImages = runtimeImages,

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/CommonTestData.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/CommonTestData.scala
@@ -500,7 +500,8 @@ object CommonTestData {
       AzureDiskName("diskName1"),
       Some(DiskSize(100)),
       None
-    )
+    ),
+    Some(0)
   )
 
   def modifyInstance(instance: DataprocInstance): DataprocInstance =


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-3416

* Add autopause option in request
* Add a unit test for getResourcePolicy Sam API decoder test

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
