### PR TITLE
IA-3450 don't error if deleteVM returns 404

### DIFF
--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpWsmDao.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpWsmDao.scala
@@ -125,21 +125,24 @@ class HttpWsmDao[F[_]](httpClient: Client[F], config: HttpWsmDaoConfig)(
       )(onError)
     } yield res
 
-  override def deleteVm(request: DeleteWsmResourceRequest,
-                        authorization: Authorization)(implicit ev: Ask[F, AppContext]): F[DeleteWsmResourceResult] =
+  override def deleteVm(request: DeleteWsmResourceRequest, authorization: Authorization)(
+    implicit ev: Ask[F, AppContext]
+  ): F[Option[DeleteWsmResourceResult]] =
     deleteHelper(request, authorization, "vm")
 
-  override def deleteDisk(request: DeleteWsmResourceRequest,
-                          authorization: Authorization)(implicit ev: Ask[F, AppContext]): F[DeleteWsmResourceResult] =
+  override def deleteDisk(request: DeleteWsmResourceRequest, authorization: Authorization)(
+    implicit ev: Ask[F, AppContext]
+  ): F[Option[DeleteWsmResourceResult]] =
     deleteHelper(request, authorization, "disks")
 
-  override def deleteIp(request: DeleteWsmResourceRequest,
-                        authorization: Authorization)(implicit ev: Ask[F, AppContext]): F[DeleteWsmResourceResult] =
+  override def deleteIp(request: DeleteWsmResourceRequest, authorization: Authorization)(
+    implicit ev: Ask[F, AppContext]
+  ): F[Option[DeleteWsmResourceResult]] =
     deleteHelper(request, authorization, "ip")
 
   override def deleteNetworks(request: DeleteWsmResourceRequest, authorization: Authorization)(
     implicit ev: Ask[F, AppContext]
-  ): F[DeleteWsmResourceResult] =
+  ): F[Option[DeleteWsmResourceResult]] =
     deleteHelper(request, authorization, "network")
 
   override def getCreateVmJobResult(request: GetJobResultRequest, authorization: Authorization)(
@@ -210,10 +213,10 @@ class HttpWsmDao[F[_]](httpClient: Client[F], config: HttpWsmDaoConfig)(
 
   private def deleteHelper(req: DeleteWsmResourceRequest, authorization: Authorization, resource: String)(
     implicit ev: Ask[F, AppContext]
-  ): F[DeleteWsmResourceResult] =
+  ): F[Option[DeleteWsmResourceResult]] =
     for {
       ctx <- ev.ask
-      res <- httpClient.expectOr[DeleteWsmResourceResult](
+      res <- httpClient.expectOptionOr[DeleteWsmResourceResult](
         Request[F](
           method = Method.POST,
           uri = config.uri

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/WsmDao.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/WsmDao.scala
@@ -46,19 +46,19 @@ trait WsmDao[F[_]] {
 
   def deleteVm(request: DeleteWsmResourceRequest, authorization: Authorization)(
     implicit ev: Ask[F, AppContext]
-  ): F[DeleteWsmResourceResult]
+  ): F[Option[DeleteWsmResourceResult]]
 
   def deleteDisk(request: DeleteWsmResourceRequest, authorization: Authorization)(
     implicit ev: Ask[F, AppContext]
-  ): F[DeleteWsmResourceResult]
+  ): F[Option[DeleteWsmResourceResult]]
 
   def deleteIp(request: DeleteWsmResourceRequest, authorization: Authorization)(
     implicit ev: Ask[F, AppContext]
-  ): F[DeleteWsmResourceResult]
+  ): F[Option[DeleteWsmResourceResult]]
 
   def deleteNetworks(request: DeleteWsmResourceRequest, authorization: Authorization)(
     implicit ev: Ask[F, AppContext]
-  ): F[DeleteWsmResourceResult]
+  ): F[Option[DeleteWsmResourceResult]]
 
   def getCreateVmJobResult(request: GetJobResultRequest, authorization: Authorization)(
     implicit ev: Ask[F, AppContext]

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandler.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandler.scala
@@ -429,6 +429,7 @@ class AzurePubsubHandlerInterp[F[_]: Parallel](
               _ <- msg.diskId.traverse(diskId =>
                 dbRef.inTransaction(persistentDiskQuery.updateStatus(diskId, DiskStatus.Deleted, ctx.now))
               )
+              _ <- logger.info(ctx.loggingCtx)("runtime is deleted successfully")
             } yield ()
           case WsmJobStatus.Failed =>
             F.raiseError[Unit](

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandler.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandler.scala
@@ -359,7 +359,7 @@ class AzurePubsubHandlerInterp[F[_]: Parallel](
         case x: CloudContext.Azure => F.pure(x.value)
       }
       _ <- relayNamespaceOpt.traverse(ns =>
-        azureManager.createRelayHybridConnection(
+        azureManager.deleteRelayHybridConnection(
           ns,
           RelayHybridConnectionName(runtime.runtimeName.asString),
           cloudContext

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpSamDAOSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpSamDAOSpec.scala
@@ -124,15 +124,13 @@ class HttpSamDAOSpec extends AnyFlatSpec with LeonardoTestSuite with BeforeAndAf
       HttpApp(_ => IO.fromEither(parse(response)).flatMap(r => IO(Response(status = Status.Ok).withEntity(r))))
     )
 
-    val res = Dispatcher[IO].use { d =>
-      val samDao = new HttpSamDAO(okSam, config, petTokenCache)
-      val expectedResponse =
-        StatusCheckResponse(false,
-                            Map(GoogleIam -> SubsystemStatus(true, None),
-                                OpenDJ -> SubsystemStatus(false, Some(List("OpenDJ is down. Panic!")))))
+    val samDao = new HttpSamDAO(okSam, config, petTokenCache)
+    val expectedResponse =
+      StatusCheckResponse(false,
+                          Map(GoogleIam -> SubsystemStatus(true, None),
+                              OpenDJ -> SubsystemStatus(false, Some(List("OpenDJ is down. Panic!")))))
 
-      samDao.getStatus.map(s => s shouldBe expectedResponse)
-    }
+    val res = samDao.getStatus.map(s => s shouldBe expectedResponse)
 
     res.unsafeRunSync
 

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpWsmDaoSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpWsmDaoSpec.scala
@@ -1,3 +1,35 @@
 package org.broadinstitute.dsde.workbench.leonardo.dao
 
-class HttpWsmDaoSpec {}
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import org.broadinstitute.dsde.workbench.leonardo.TestUtils.appContext
+import org.broadinstitute.dsde.workbench.leonardo.config.HttpWsmDaoConfig
+import org.broadinstitute.dsde.workbench.leonardo.{LeonardoTestSuite, WorkspaceId, WsmControlledResourceId, WsmJobId}
+import org.http4s.client.Client
+import org.http4s.headers.Authorization
+import org.http4s._
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.flatspec.AnyFlatSpec
+
+import java.util.UUID
+
+class HttpWsmDaoSpec extends AnyFlatSpec with LeonardoTestSuite with BeforeAndAfterAll {
+  val config = HttpWsmDaoConfig(Uri.unsafeFromString("127.0.0.1"))
+  it should "not error when getting 404 during resource deletion" in {
+    val wsmClient = Client.fromHttpApp[IO](
+      HttpApp(_ => IO(Response(status = Status.NotFound)))
+    )
+
+    val wsmDao = new HttpWsmDao[IO](wsmClient, config)
+    val res = wsmDao
+      .deleteVm(
+        DeleteWsmResourceRequest(WorkspaceId(UUID.randomUUID()),
+                                 WsmControlledResourceId(UUID.randomUUID()),
+                                 DeleteControlledAzureResourceRequest(WsmJobControl(WsmJobId("job")))),
+        Authorization(Credentials.Token(AuthScheme.Bearer, "dummy"))
+      )
+      .attempt
+
+    res.unsafeRunSync().isRight shouldBe true
+  }
+}

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/MockWsmDAO.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/MockWsmDAO.scala
@@ -89,9 +89,108 @@ class MockWsmDAO(jobStatus: WsmJobStatus = WsmJobStatus.Succeeded) extends WsmDa
       )
     )
 
-  override def deleteVm(request: DeleteWsmResourceRequest,
-                        authorization: Authorization)(implicit ev: Ask[IO, AppContext]): IO[DeleteWsmResourceResult] =
+  override def deleteVm(request: DeleteWsmResourceRequest, authorization: Authorization)(
+    implicit ev: Ask[IO, AppContext]
+  ): IO[Option[DeleteWsmResourceResult]] =
     IO.pure(
+      Some(
+        DeleteWsmResourceResult(
+          WsmJobReport(
+            request.deleteRequest.jobControl.id,
+            "desc",
+            jobStatus,
+            200,
+            ZonedDateTime.parse("2022-03-18T15:02:29.264756Z"),
+            Some(ZonedDateTime.parse("2022-03-18T15:02:29.264756Z")),
+            "resultUrl"
+          ),
+          if (jobStatus.equals(WsmJobStatus.Failed))
+            Some(
+              WsmErrorReport(
+                "error",
+                500,
+                List.empty
+              )
+            )
+          else None
+        )
+      )
+    )
+
+  override def getWorkspace(workspaceId: WorkspaceId, authorization: Authorization)(
+    implicit ev: Ask[IO, AppContext]
+  ): IO[Option[WorkspaceDescription]] =
+    IO.pure(
+      Some(
+        WorkspaceDescription(
+          workspaceId,
+          "workspaceName",
+          Some(CommonTestData.azureCloudContext),
+          None
+        )
+      )
+    )
+
+  override def deleteDisk(request: DeleteWsmResourceRequest, authorization: Authorization)(
+    implicit ev: Ask[IO, AppContext]
+  ): IO[Option[DeleteWsmResourceResult]] =
+    IO.pure(
+      Some(
+        DeleteWsmResourceResult(
+          WsmJobReport(
+            request.deleteRequest.jobControl.id,
+            "desc",
+            jobStatus,
+            200,
+            ZonedDateTime.parse("2022-03-18T15:02:29.264756Z"),
+            Some(ZonedDateTime.parse("2022-03-18T15:02:29.264756Z")),
+            "resultUrl"
+          ),
+          if (jobStatus.equals(WsmJobStatus.Failed))
+            Some(
+              WsmErrorReport(
+                "error",
+                500,
+                List.empty
+              )
+            )
+          else None
+        )
+      )
+    )
+
+  override def deleteIp(request: DeleteWsmResourceRequest, authorization: Authorization)(
+    implicit ev: Ask[IO, AppContext]
+  ): IO[Option[DeleteWsmResourceResult]] =
+    IO.pure(
+      Some(
+        DeleteWsmResourceResult(
+          WsmJobReport(
+            request.deleteRequest.jobControl.id,
+            "desc",
+            jobStatus,
+            200,
+            ZonedDateTime.parse("2022-03-18T15:02:29.264756Z"),
+            Some(ZonedDateTime.parse("2022-03-18T15:02:29.264756Z")),
+            "resultUrl"
+          ),
+          if (jobStatus.equals(WsmJobStatus.Failed))
+            Some(
+              WsmErrorReport(
+                "error",
+                500,
+                List.empty
+              )
+            )
+          else None
+        )
+      )
+    )
+
+  override def deleteNetworks(request: DeleteWsmResourceRequest, authorization: Authorization)(
+    implicit ev: Ask[IO, AppContext]
+  ): IO[Option[DeleteWsmResourceResult]] = IO.pure(
+    Some(
       DeleteWsmResourceResult(
         WsmJobReport(
           request.deleteRequest.jobControl.id,
@@ -112,94 +211,6 @@ class MockWsmDAO(jobStatus: WsmJobStatus = WsmJobStatus.Succeeded) extends WsmDa
           )
         else None
       )
-    )
-
-  override def getWorkspace(workspaceId: WorkspaceId, authorization: Authorization)(
-    implicit ev: Ask[IO, AppContext]
-  ): IO[Option[WorkspaceDescription]] =
-    IO.pure(
-      Some(
-        WorkspaceDescription(
-          workspaceId,
-          "workspaceName",
-          Some(CommonTestData.azureCloudContext),
-          None
-        )
-      )
-    )
-
-  override def deleteDisk(request: DeleteWsmResourceRequest, authorization: Authorization)(
-    implicit ev: Ask[IO, AppContext]
-  ): IO[DeleteWsmResourceResult] = IO.pure(
-    DeleteWsmResourceResult(
-      WsmJobReport(
-        request.deleteRequest.jobControl.id,
-        "desc",
-        jobStatus,
-        200,
-        ZonedDateTime.parse("2022-03-18T15:02:29.264756Z"),
-        Some(ZonedDateTime.parse("2022-03-18T15:02:29.264756Z")),
-        "resultUrl"
-      ),
-      if (jobStatus.equals(WsmJobStatus.Failed))
-        Some(
-          WsmErrorReport(
-            "error",
-            500,
-            List.empty
-          )
-        )
-      else None
-    )
-  )
-
-  override def deleteIp(request: DeleteWsmResourceRequest, authorization: Authorization)(
-    implicit ev: Ask[IO, AppContext]
-  ): IO[DeleteWsmResourceResult] = IO.pure(
-    DeleteWsmResourceResult(
-      WsmJobReport(
-        request.deleteRequest.jobControl.id,
-        "desc",
-        jobStatus,
-        200,
-        ZonedDateTime.parse("2022-03-18T15:02:29.264756Z"),
-        Some(ZonedDateTime.parse("2022-03-18T15:02:29.264756Z")),
-        "resultUrl"
-      ),
-      if (jobStatus.equals(WsmJobStatus.Failed))
-        Some(
-          WsmErrorReport(
-            "error",
-            500,
-            List.empty
-          )
-        )
-      else None
-    )
-  )
-
-  override def deleteNetworks(request: DeleteWsmResourceRequest, authorization: Authorization)(
-    implicit ev: Ask[IO, AppContext]
-  ): IO[DeleteWsmResourceResult] = IO.pure(
-    DeleteWsmResourceResult(
-      WsmJobReport(
-        request.deleteRequest.jobControl.id,
-        "desc",
-        jobStatus,
-        200,
-        ZonedDateTime.parse("2022-03-18T15:02:29.264756Z"),
-        Some(ZonedDateTime.parse("2022-03-18T15:02:29.264756Z")),
-        "resultUrl"
-      ),
-      if (jobStatus.equals(WsmJobStatus.Failed))
-        Some(
-          WsmErrorReport(
-            "error",
-            500,
-            List.empty
-          )
-        )
-      else None
     )
   )
 


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-3450

This PR makes it so that for all delete requests in WsmDao, we won't error if we get a 404 response

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
