### PR TITLE
IA-3463 Add group check for createApp API

### DIFF
--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -716,6 +716,7 @@ auth {
     notebookAuthCacheExpiryTime = 15 minutes
     notebookAuthCacheMaxSize = 1000
     providerTimeout = 30 seconds
+    customAppCreationAllowedGroup = "custom_app_users"
   }
 }
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/auth/SamAuthProvider.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/auth/SamAuthProvider.scala
@@ -231,7 +231,7 @@ class SamAuthProvider[F[_]: OpenTelemetryMetrics](
         )
     } yield samUserInfo.userEmail
 
-  override def isAllowed(userEmail: WorkbenchEmail)(implicit ev: Ask[F, TraceId]): F[Boolean] =
+  override def isCustomAppAllowed(userEmail: WorkbenchEmail)(implicit ev: Ask[F, TraceId]): F[Boolean] =
     samDao.isGroupMembersOrAdmin(config.customAppCreationAllowedGroup, userEmail)
 
 }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
@@ -327,7 +327,9 @@ object Config {
         config.getOrElse("notebookAuthCacheEnabled", true),
         config.getAs[Int]("notebookAuthCacheMaxSize").getOrElse(1000),
         config.getAs[FiniteDuration]("notebookAuthCacheExpiryTime").getOrElse(15 minutes),
-        config.getAs[GroupName]("SamAuthProviderConfig").getOrElse(GroupName("custom_app_user"))
+        config
+          .getAs[GroupName]("customAppCreationAllowedGroup")
+          .getOrElse(throw new Exception("No customAppCreationAllowedGroup key found"))
       )
   }
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
@@ -328,8 +328,8 @@ object Config {
         config.getAs[Int]("notebookAuthCacheMaxSize").getOrElse(1000),
         config.getAs[FiniteDuration]("notebookAuthCacheExpiryTime").getOrElse(15 minutes),
         config
-          .getAs[GroupName]("customAppCreationAllowedGroup")
-          .getOrElse(throw new Exception("No customAppCreationAllowedGroup key found"))
+          .getOrElse[GroupName]("customAppCreationAllowedGroup",
+                                throw new Exception("No customAppCreationAllowedGroup key found"))
       )
   }
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
@@ -24,7 +24,7 @@ import org.broadinstitute.dsde.workbench.google2.{
 import org.broadinstitute.dsde.workbench.leonardo.CustomImage.{DataprocCustomImage, GceCustomImage}
 import org.broadinstitute.dsde.workbench.leonardo.auth.SamAuthProviderConfig
 import org.broadinstitute.dsde.workbench.leonardo.config.ContentSecurityPolicyComponent._
-import org.broadinstitute.dsde.workbench.leonardo.dao.HttpSamDaoConfig
+import org.broadinstitute.dsde.workbench.leonardo.dao.{GroupName, HttpSamDaoConfig}
 import org.broadinstitute.dsde.workbench.leonardo.http.ConfigReader
 import org.broadinstitute.dsde.workbench.leonardo.http.service.LeoAppServiceInterp.LeoKubernetesConfig
 import org.broadinstitute.dsde.workbench.leonardo.model.ServiceAccountProviderConfig
@@ -46,8 +46,8 @@ import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.broadinstitute.dsde.workbench.util.toScalaDuration
 import org.broadinstitute.dsp.{ChartName, ChartVersion, Release}
 import org.http4s.Uri
-import java.nio.file.{Path, Paths}
 
+import java.nio.file.{Path, Paths}
 import scala.concurrent.duration._
 import scala.jdk.CollectionConverters._
 
@@ -55,6 +55,7 @@ object Config {
   val config = ConfigFactory.parseResources("leonardo.conf").withFallback(ConfigFactory.load()).resolve()
 
   implicit private val deviceNameReader: ValueReader[DeviceName] = stringValueReader.map(DeviceName)
+  implicit private val groupNameReader: ValueReader[GroupName] = stringValueReader.map(GroupName)
 
   implicit private val applicationConfigReader: ValueReader[ApplicationConfig] = ValueReader.relative { config =>
     ApplicationConfig(
@@ -325,7 +326,8 @@ object Config {
       SamAuthProviderConfig(
         config.getOrElse("notebookAuthCacheEnabled", true),
         config.getAs[Int]("notebookAuthCacheMaxSize").getOrElse(1000),
-        config.getAs[FiniteDuration]("notebookAuthCacheExpiryTime").getOrElse(15 minutes)
+        config.getAs[FiniteDuration]("notebookAuthCacheExpiryTime").getOrElse(15 minutes),
+        config.getAs[GroupName]("SamAuthProviderConfig").getOrElse(GroupName("custom_app_user"))
       )
   }
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/SamDAO.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/SamDAO.scala
@@ -75,6 +75,11 @@ trait SamDAO[F[_]] {
   def getSamUserInfo(token: String)(implicit ev: Ask[F, TraceId]): F[Option[SamUserInfo]]
 
   def getLeoAuthToken: F[Authorization]
+
+  def isGroupMembersOrAdmin(groupName: GroupName, workbenchEmail: WorkbenchEmail)(
+    implicit ev: Ask[F, TraceId]
+  ): F[Boolean]
 }
 
 final case class UserSubjectId(asString: String) extends AnyVal
+final case class GroupName(asString: String) extends AnyVal

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/AppServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/AppServiceInterp.scala
@@ -65,7 +65,7 @@ final class LeoAppServiceInterp[F[_]: Parallel](
                                                   userInfo)
       _ <- F.raiseWhen(!hasPermission)(ForbiddenError(userInfo.userEmail))
       isUserAllowed <- req.appType match {
-        case AppType.Custom => authProvider.isAllowed(userInfo.userEmail)
+        case AppType.Custom => authProvider.isCustomAppAllowed(userInfo.userEmail)
         case _              => F.pure(true)
       }
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/AppServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/AppServiceInterp.scala
@@ -63,7 +63,13 @@ final class LeoAppServiceInterp[F[_]: Parallel](
       hasPermission <- authProvider.hasPermission(ProjectSamResourceId(googleProject),
                                                   ProjectAction.CreateApp,
                                                   userInfo)
-      _ <- if (hasPermission) F.unit else F.raiseError[Unit](ForbiddenError(userInfo.userEmail))
+      _ <- F.raiseWhen(!hasPermission)(ForbiddenError(userInfo.userEmail))
+      isUserAllowed <- req.appType match {
+        case AppType.Custom => authProvider.isAllowed(userInfo.userEmail)
+        case _              => F.pure(true)
+      }
+
+      _ <- F.raiseWhen(!isUserAllowed)(ForbiddenError(userInfo.userEmail))
 
       appOpt <- KubernetesServiceDbQueries.getActiveFullAppByName(googleProject, appName).transaction
       _ <- appOpt.fold(F.unit)(c =>

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeoAuthProvider.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeoAuthProvider.scala
@@ -202,5 +202,5 @@ trait LeoAuthProvider[F[_]] {
   // Get user info from Sam. If petOrUserInfo is a pet SA, Sam will return it's associated user account info
   def lookupOriginatingUserEmail[R](petOrUserInfo: UserInfo)(implicit ev: Ask[F, TraceId]): F[WorkbenchEmail]
 
-  def isAllowed(userEmail: WorkbenchEmail)(implicit ev: Ask[F, TraceId]): F[Boolean]
+  def isCustomAppAllowed(userEmail: WorkbenchEmail)(implicit ev: Ask[F, TraceId]): F[Boolean]
 }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeoAuthProvider.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeoAuthProvider.scala
@@ -201,4 +201,6 @@ trait LeoAuthProvider[F[_]] {
 
   // Get user info from Sam. If petOrUserInfo is a pet SA, Sam will return it's associated user account info
   def lookupOriginatingUserEmail[R](petOrUserInfo: UserInfo)(implicit ev: Ask[F, TraceId]): F[WorkbenchEmail]
+
+  def isAllowed(userEmail: WorkbenchEmail)(implicit ev: Ask[F, TraceId]): F[Boolean]
 }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/auth/SamAuthProviderSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/auth/SamAuthProviderSpec.scala
@@ -24,11 +24,13 @@ import org.broadinstitute.dsde.workbench.leonardo.http.ctxConversion
 import org.broadinstitute.dsde.workbench.leonardo.TestUtils.appContext
 
 class SamAuthProviderSpec extends AnyFlatSpec with LeonardoTestSuite with BeforeAndAfter {
-  val samAuthProviderConfigWithoutCache: SamAuthProviderConfig = SamAuthProviderConfig(false)
+  val samAuthProviderConfigWithoutCache: SamAuthProviderConfig =
+    SamAuthProviderConfig(false, customAppCreationAllowedGroup = GroupName("custom_app_users"))
   val samAuthProviderConfigWithCache: SamAuthProviderConfig = SamAuthProviderConfig(
     true,
     10,
-    1.minutes
+    1.minutes,
+    customAppCreationAllowedGroup = GroupName("custom_app_users")
   )
 
   val userInfo =

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/auth/WhitelistAuthProvider.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/auth/WhitelistAuthProvider.scala
@@ -119,5 +119,5 @@ class WhitelistAuthProvider(config: Config, saProvider: ServiceAccountProvider[I
     case _                         => IO(petOrUserInfo.userEmail)
   }
 
-  override def isAllowed(userEmail: WorkbenchEmail)(implicit ev: Ask[IO, TraceId]): IO[Boolean] = ???
+  override def isCustomAppAllowed(userEmail: WorkbenchEmail)(implicit ev: Ask[IO, TraceId]): IO[Boolean] = ???
 }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/auth/WhitelistAuthProvider.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/auth/WhitelistAuthProvider.scala
@@ -118,4 +118,6 @@ class WhitelistAuthProvider(config: Config, saProvider: ServiceAccountProvider[I
     case serviceAccountEmail.value => IO(userEmail)
     case _                         => IO(petOrUserInfo.userEmail)
   }
+
+  override def isAllowed(userEmail: WorkbenchEmail)(implicit ev: Ask[IO, TraceId]): IO[Boolean] = ???
 }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/MockSamDAO.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/MockSamDAO.scala
@@ -296,6 +296,10 @@ class MockSamDAO extends SamDAO[IO] {
 
   def getSamUserInfo(token: String)(implicit ev: Ask[IO, TraceId]): IO[Option[SamUserInfo]] =
     IO.pure(Some(SamUserInfo(UserSubjectId("test"), WorkbenchEmail("test@gmail.com"), enabled = true)))
+
+  override def isGroupMembersOrAdmin(groupName: GroupName, workbenchEmail: WorkbenchEmail)(
+    implicit ev: Ask[IO, TraceId]
+  ): IO[Boolean] = IO.pure(true)
 }
 
 object MockSamDAO {

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/AppServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/AppServiceInterpSpec.scala
@@ -103,7 +103,7 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
 
   it should "fail request if user is not in custom_app_users group" in {
     val authProvider = new BaseMockAuthProvider {
-      override def isAllowed(userEmail: WorkbenchEmail)(implicit ev: Ask[IO, TraceId]): IO[Boolean] =
+      override def isCustomAppAllowed(userEmail: WorkbenchEmail)(implicit ev: Ask[IO, TraceId]): IO[Boolean] =
         IO.pure(false)
     }
     val interp = new LeoAppServiceInterp[IO](authProvider,

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/mocks.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/mocks.scala
@@ -141,7 +141,7 @@ class BaseMockAuthProvider extends LeoAuthProvider[IO] {
     implicit ev: Ask[IO, TraceId]
   ): IO[WorkbenchEmail] = ???
 
-  override def isAllowed(userEmail: WorkbenchEmail)(implicit ev: Ask[IO, TraceId]): IO[Boolean] = ???
+  override def isCustomAppAllowed(userEmail: WorkbenchEmail)(implicit ev: Ask[IO, TraceId]): IO[Boolean] = ???
 }
 
 object MockAuthProvider extends BaseMockAuthProvider

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/mocks.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/mocks.scala
@@ -78,13 +78,13 @@ object NoDeleteGoogleStorage extends BaseFakeGoogleStorage {
     throw new Exception("this shouldn't get called")
 }
 
-object MockAuthProvider extends LeoAuthProvider[IO] {
+class BaseMockAuthProvider extends LeoAuthProvider[IO] {
   override def serviceAccountProvider: ServiceAccountProvider[IO] = ???
 
   override def hasPermission[R, A](samResource: R, action: A, userInfo: UserInfo)(
     implicit sr: SamResourceAction[R, A],
     ev: Ask[IO, TraceId]
-  ): IO[Boolean] = ???
+  ): IO[Boolean] = IO.pure(true)
 
   override def hasPermissionWithProjectFallback[R, A](
     samResource: R,
@@ -92,7 +92,7 @@ object MockAuthProvider extends LeoAuthProvider[IO] {
     projectAction: ProjectAction,
     userInfo: UserInfo,
     googleProject: GoogleProject
-  )(implicit sr: SamResourceAction[R, A], ev: Ask[IO, TraceId]): IO[Boolean] = ???
+  )(implicit sr: SamResourceAction[R, A], ev: Ask[IO, TraceId]): IO[Boolean] = IO.pure(true)
 
   override def getActions[R, A](samResource: R, userInfo: UserInfo)(
     implicit sr: SamResourceAction[R, A],
@@ -140,7 +140,11 @@ object MockAuthProvider extends LeoAuthProvider[IO] {
   override def lookupOriginatingUserEmail[R](petOrUserInfo: UserInfo)(
     implicit ev: Ask[IO, TraceId]
   ): IO[WorkbenchEmail] = ???
+
+  override def isAllowed(userEmail: WorkbenchEmail)(implicit ev: Ask[IO, TraceId]): IO[Boolean] = ???
 }
+
+object MockAuthProvider extends BaseMockAuthProvider
 
 class FakeGoogleSubcriber[A] extends GoogleSubscriber[IO, A] {
   def messages: Stream[IO, Event[A]] = Stream.empty


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-3463

Security team wants to make it so that creating CUSTOM app is only allowed for a specific group

I tested locally with both a user in the group and a user isn't in the group with local leo against dev everything else.


<img width="1466" alt="Screen Shot 2022-06-02 at 3 29 22 PM" src="https://user-images.githubusercontent.com/32771737/171723048-370ba4b9-d4dc-4c56-9227-eefb63be21f7.png">



---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
