### PR TITLE
IA-3463 Add a flag for enabling group check for customApp creation api

### DIFF
--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -875,3 +875,8 @@ terra-app-setup-chart {
   # If you change this here, be sure to update it in the dockerfile
   chart-version = "0.0.2"
 }
+
+app-service {
+  # Defaults to true, but disabled for fiab runs
+  enable-custom-app-group-permission-check = true
+}

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
@@ -26,6 +26,7 @@ import org.broadinstitute.dsde.workbench.leonardo.auth.SamAuthProviderConfig
 import org.broadinstitute.dsde.workbench.leonardo.config.ContentSecurityPolicyComponent._
 import org.broadinstitute.dsde.workbench.leonardo.dao.{GroupName, HttpSamDaoConfig}
 import org.broadinstitute.dsde.workbench.leonardo.http.ConfigReader
+import org.broadinstitute.dsde.workbench.leonardo.http.service.AppServiceConfig
 import org.broadinstitute.dsde.workbench.leonardo.http.service.LeoAppServiceInterp.LeoKubernetesConfig
 import org.broadinstitute.dsde.workbench.leonardo.model.ServiceAccountProviderConfig
 import org.broadinstitute.dsde.workbench.leonardo.monitor.MonitorConfig.{DataprocMonitorConfig, GceMonitorConfig}
@@ -702,6 +703,10 @@ object Config {
     gkeCustomAppConfig
   )
 
+  val appServiceConfig = AppServiceConfig(
+    config.getBoolean("app-service.enable-custom-app-group-permission-check"),
+    leoKubernetesConfig
+  )
   val pubsubConfig = config.as[PubsubConfig]("pubsub")
   val topic = ProjectTopicName.of(pubsubConfig.pubsubGoogleProject.value, pubsubConfig.topicName)
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/Boot.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/Boot.scala
@@ -138,9 +138,9 @@ object Boot extends IOApp {
       )
 
       val leoKubernetesService: LeoAppServiceInterp[IO] =
-        new LeoAppServiceInterp(appDependencies.authProvider,
+        new LeoAppServiceInterp(appServiceConfig,
+                                appDependencies.authProvider,
                                 appDependencies.serviceAccountProvider,
-                                leoKubernetesConfig,
                                 appDependencies.publisherQueue,
                                 appDependencies.googleDependencies.googleComputeService)
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/AppService.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/AppService.scala
@@ -2,6 +2,7 @@ package org.broadinstitute.dsde.workbench.leonardo.http
 package service
 
 import cats.mtl.Ask
+import org.broadinstitute.dsde.workbench.leonardo.http.service.LeoAppServiceInterp.LeoKubernetesConfig
 import org.broadinstitute.dsde.workbench.leonardo.{AppContext, AppName}
 import org.broadinstitute.dsde.workbench.model.UserInfo
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
@@ -38,3 +39,6 @@ trait AppService[F[_]] {
     implicit as: Ask[F, AppContext]
   ): F[Unit]
 }
+
+final case class AppServiceConfig(enableCustomAppGroupPermissionCheck: Boolean,
+                                  leoKubernetesConfig: LeoKubernetesConfig)

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/TestLeoRoutes.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/TestLeoRoutes.scala
@@ -102,9 +102,9 @@ trait TestLeoRoutes {
   val runtimeInstances = new RuntimeInstances[IO](dataprocInterp, gceInterp)
 
   val leoKubernetesService: LeoAppServiceInterp[IO] = new LeoAppServiceInterp[IO](
+    Config.appServiceConfig,
     whitelistAuthProvider,
     serviceAccountProvider,
-    Config.leoKubernetesConfig,
     QueueFactory.makePublisherQueue(),
     FakeGoogleComputeService
   )

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/AppServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/AppServiceInterpSpec.scala
@@ -134,7 +134,7 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
       .createApp(userInfo, project, AppName("foo"), createAppRequest.copy(appType = AppType.Custom))
       .attempt
       .unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
-    res.isRight shouldBe true
+    res.swap.toOption.get.isInstanceOf[ForbiddenError] shouldBe false
   }
 
   it should "determine patch version bump correctly" in isolatedDbTest {

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/AppServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/AppServiceInterpSpec.scala
@@ -35,21 +35,23 @@ import org.broadinstitute.dsde.workbench.leonardo.TestUtils.appContext
 
 import java.time.Instant
 import org.broadinstitute.dsde.workbench.leonardo.AppRestore.{CromwellRestore, GalaxyRestore}
+import org.broadinstitute.dsde.workbench.leonardo.config.Config
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
 final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with TestComponent {
+  val appServiceConfig = Config.appServiceConfig
 
   //used when we care about queue state
   def makeInterp(queue: Queue[IO, LeoPubsubMessage]) =
-    new LeoAppServiceInterp[IO](whitelistAuthProvider,
+    new LeoAppServiceInterp[IO](appServiceConfig,
+                                whitelistAuthProvider,
                                 serviceAccountProvider,
-                                leoKubernetesConfig,
                                 queue,
                                 FakeGoogleComputeService)
-  val appServiceInterp = new LeoAppServiceInterp[IO](whitelistAuthProvider,
+  val appServiceInterp = new LeoAppServiceInterp[IO](appServiceConfig,
+                                                     whitelistAuthProvider,
                                                      serviceAccountProvider,
-                                                     leoKubernetesConfig,
                                                      QueueFactory.makePublisherQueue(),
                                                      FakeGoogleComputeService)
 
@@ -74,19 +76,19 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
         IO.pure(Some(MachineType.newBuilder().setName("notEnoughMemory").setMemoryMb(6 * 1024).setGuestCpus(2).build()))
     }
 
-    val passAppService = new LeoAppServiceInterp[IO](whitelistAuthProvider,
+    val passAppService = new LeoAppServiceInterp[IO](appServiceConfig,
+                                                     whitelistAuthProvider,
                                                      serviceAccountProvider,
-                                                     leoKubernetesConfig,
                                                      QueueFactory.makePublisherQueue(),
                                                      passComputeService)
-    val notEnoughMemoryAppService = new LeoAppServiceInterp[IO](whitelistAuthProvider,
+    val notEnoughMemoryAppService = new LeoAppServiceInterp[IO](appServiceConfig,
+                                                                whitelistAuthProvider,
                                                                 serviceAccountProvider,
-                                                                leoKubernetesConfig,
                                                                 QueueFactory.makePublisherQueue(),
                                                                 notEnoughMemoryComputeService)
-    val notEnoughCpuAppService = new LeoAppServiceInterp[IO](whitelistAuthProvider,
+    val notEnoughCpuAppService = new LeoAppServiceInterp[IO](appServiceConfig,
+                                                             whitelistAuthProvider,
                                                              serviceAccountProvider,
-                                                             leoKubernetesConfig,
                                                              QueueFactory.makePublisherQueue(),
                                                              notEnoughCpuComputeService)
 
@@ -106,9 +108,9 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
       override def isCustomAppAllowed(userEmail: WorkbenchEmail)(implicit ev: Ask[IO, TraceId]): IO[Boolean] =
         IO.pure(false)
     }
-    val interp = new LeoAppServiceInterp[IO](authProvider,
+    val interp = new LeoAppServiceInterp[IO](appServiceConfig,
+                                             authProvider,
                                              serviceAccountProvider,
-                                             leoKubernetesConfig,
                                              QueueFactory.makePublisherQueue(),
                                              FakeGoogleComputeService)
     val res = interp
@@ -116,6 +118,23 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
       .attempt
       .unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
     res shouldBe (Left(ForbiddenError(userInfo.userEmail)))
+  }
+
+  it should "not fail customApp request if group check is not enabled" in {
+    val authProvider = new BaseMockAuthProvider {
+      override def isCustomAppAllowed(userEmail: WorkbenchEmail)(implicit ev: Ask[IO, TraceId]): IO[Boolean] =
+        IO.pure(false)
+    }
+    val interp = new LeoAppServiceInterp[IO](AppServiceConfig(false, leoKubernetesConfig),
+                                             authProvider,
+                                             serviceAccountProvider,
+                                             QueueFactory.makePublisherQueue(),
+                                             FakeGoogleComputeService)
+    val res = interp
+      .createApp(userInfo, project, AppName("foo"), createAppRequest.copy(appType = AppType.Custom))
+      .attempt
+      .unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
+    res.isRight shouldBe true
   }
 
   it should "determine patch version bump correctly" in isolatedDbTest {


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-3463

Fiab tests are failing becuz the group doesn't exist. Add a flag to disable the check during automation tests

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
