### PR TITLE
[IA-3042] Copy terra-docker-versions-candidate file into Docker root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,6 +65,10 @@ RUN cd /leonardo && \
 # Install https://github.com/apangin/jattach to get access to JDK tools
 RUN apt-get update && \
     apt-get install jattach
+    
+# Copy Terra-docker-versions-candidate.json from bucket into docker root
+RUN curl -fsSL -o /terra-docker-versions-candidate.json \
+    https://storage.googleapis.com/terra-docker-image-documentation/terra-docker-versions-candidate.json
 
 # Add Leonardo as a service (it will start when the container starts)
 CMD java $JAVA_OPTS -jar $(find /leonardo -name 'leonardo*.jar')

--- a/Dockerfile
+++ b/Dockerfile
@@ -65,7 +65,7 @@ RUN cd /leonardo && \
 # Install https://github.com/apangin/jattach to get access to JDK tools
 RUN apt-get update && \
     apt-get install jattach
-    
+
 # Copy Terra-docker-versions-candidate.json from bucket into docker root
 RUN curl -fsSL -o /terra-docker-versions-candidate.json \
     https://storage.googleapis.com/terra-docker-image-documentation/terra-docker-versions-candidate.json


### PR DESCRIPTION
Companion work for the following Terra-UI PR: https://github.com/DataBiosphere/terra-ui/pull/3094

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
