### PR TITLE
IA-3447 don't error when we receive multiple create runtime requests in subscriber

### DIFF
--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GceInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GceInterpreter.scala
@@ -310,9 +310,19 @@ class GceInterpreter[F[_]](
         .createInstance(googleProject, zoneParam, instance)
 
       hostname <- F.delay(UUID.randomUUID().getLeastSignificantBits.toHexString)
-      res = operation.map(o =>
+
+//       When there's already an on-ging create request, `.getName` will error with `Conflict`
+      opName <- operation.flatTraverse { op =>
+        F.delay(op.getName.some)
+          .recoverWith {
+            case e: java.util.concurrent.ExecutionException if (e.getMessage.contains("Conflict")) =>
+              F.pure(none[String])
+          }
+      }
+
+      res = opName.map(name =>
         CreateGoogleRuntimeResponse(
-          AsyncRuntimeFields(ProxyHostName(hostname), OperationName(o.getName), stagingBucketName, None),
+          AsyncRuntimeFields(ProxyHostName(hostname), OperationName(name), stagingBucketName, None),
           initBucketName,
           BootSource.VmImage(config.gceConfig.sourceImage)
         )

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/GceInterpreterSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/GceInterpreterSpec.scala
@@ -3,8 +3,9 @@ package org.broadinstitute.dsde.workbench.leonardo.util
 import cats.effect.IO
 import cats.mtl.Ask
 import com.google.api.gax.longrunning.OperationFuture
-import com.google.cloud.compute.v1.Operation
+import com.google.cloud.compute.v1.{Instance, Operation}
 import org.broadinstitute.dsde.workbench.google2.mock.{
+  FakeComputeOperationFuture,
   FakeGoogleComputeService,
   FakeGoogleResourceService,
   MockGoogleDiskService
@@ -15,11 +16,14 @@ import org.broadinstitute.dsde.workbench.leonardo.TestUtils.appContext
 import org.broadinstitute.dsde.workbench.leonardo.config.Config
 import org.broadinstitute.dsde.workbench.leonardo.dao.MockWelderDAO
 import org.broadinstitute.dsde.workbench.leonardo.db.{clusterQuery, TestComponent, UpdateAsyncClusterCreationFields}
+import org.broadinstitute.dsde.workbench.leonardo.monitor.RuntimeConfigInCreateRuntimeMessage
 import org.broadinstitute.dsde.workbench.leonardo.{
   CommonTestData,
+  DiskSize,
   FakeGoogleStorageService,
   LeonardoTestSuite,
   RuntimeAndRuntimeConfig,
+  RuntimeProjectAndName,
   RuntimeStatus
 }
 import org.broadinstitute.dsde.workbench.model.TraceId
@@ -50,6 +54,55 @@ class GceInterpreterSpec extends AnyFlatSpecLike with TestComponent with Leonard
                            computeService,
                            MockGoogleDiskService,
                            MockWelderDAO)
+
+  it should "not error if create runtime has conflict" in isolatedDbTest {
+    val response = new FakeComputeOperationFuture {
+      override def getName(): String =
+        throw new java.util.concurrent.ExecutionException("Conflict", new Exception("bad"))
+    }
+    val computeService = new FakeGoogleComputeService {
+      override def createInstance(project: GoogleProject, zone: ZoneName, instance: Instance)(
+        implicit ev: Ask[IO, TraceId]
+      ): IO[Option[OperationFuture[Operation, Operation]]] = IO.pure(Some(response))
+
+    }
+
+    val gce = gceInterp(computeService)
+    val res = for {
+      runtime <- IO(
+        makeCluster(1)
+          .copy(status = RuntimeStatus.Deleting)
+          .saveWithRuntimeConfig(CommonTestData.defaultGceRuntimeConfig)
+      )
+      runtimeConfig = RuntimeConfigInCreateRuntimeMessage.GceConfig(
+        CommonTestData.defaultGceRuntimeConfig.machineType,
+        CommonTestData.defaultGceRuntimeConfig.diskSize,
+        CommonTestData.defaultGceRuntimeConfig.bootDiskSize.getOrElse((DiskSize(120))),
+        CommonTestData.defaultGceRuntimeConfig.zone,
+        None
+      )
+      res <- gce.createRuntime(
+        CreateRuntimeParams(
+          runtime.id,
+          RuntimeProjectAndName(runtime.cloudContext, runtime.runtimeName),
+          runtime.serviceAccount,
+          None,
+          runtime.auditInfo,
+          None,
+          None,
+          None,
+          None,
+          runtime.runtimeImages,
+          Set.empty,
+          true,
+          Map.empty,
+          runtimeConfig
+        )
+      )
+    } yield (res shouldBe (None))
+    res.unsafeRunSync()(cats.effect.unsafe.implicits.global)
+  }
+
   it should "don't error if runtime is already deleted" in isolatedDbTest {
     val computeService = new FakeGoogleComputeService {
       override def modifyInstanceMetadata(


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-3447

Today we'll error when subscriber gets a second createRuntime message. This PR makes it not error out, but instead it should continue to the monitoring process and poll runtime status in GCP as it would normally.

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
