### PR TITLE
IA-3396 Detach disk when runtime creation fail

### DIFF
--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponent.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponent.scala
@@ -248,7 +248,7 @@ object clusterQuery extends TableQuery(new ClusterTable(_)) {
   def detachPersistentDisk(runtimeId: Long, now: Instant)(implicit ec: ExecutionContext): DBIO[Unit] = for {
     runtimeConfigIdOpt <- findByIdQuery(runtimeId).map(_.runtimeConfigId).result.headOption
     _ <- runtimeConfigIdOpt match {
-      case None => DBIO.successful(())
+      case None                  => DBIO.successful(())
       case Some(runtimeConfigId) => RuntimeConfigQueries.updatePersistentDiskId(runtimeConfigId, None, now)
     }
   } yield ()

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponent.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponent.scala
@@ -245,6 +245,14 @@ object clusterQuery extends TableQuery(new ClusterTable(_)) {
       (cluster, image) <- clusterQuery join clusterImageQuery on (_.id === _.clusterId)
     } yield (cluster, image)
 
+  def detachPersistentDisk(runtimeId: Long, now: Instant)(implicit ec: ExecutionContext): DBIO[Unit] = for {
+    runtimeConfigIdOpt <- findByIdQuery(runtimeId).map(_.runtimeConfigId).result.headOption
+    _ <- runtimeConfigIdOpt match {
+      case None => DBIO.successful(())
+      case Some(runtimeConfigId) => RuntimeConfigQueries.updatePersistentDiskId(runtimeConfigId, None, now)
+    }
+  } yield ()
+
   def getRuntimeQueryByUniqueKey(cloudContext: CloudContext,
                                  clusterName: RuntimeName,
                                  destroyedDateOpt: Option[Instant]

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
@@ -1244,6 +1244,8 @@ class LeoPubsubMessageSubscriber[F[_]](
         (clusterErrorQuery.save(runtimeId, RuntimeError(m.take(1024), None, now)) >>
           clusterQuery.updateClusterStatus(runtimeId, RuntimeStatus.Error, now)).transaction[F]
       )
+      // want to detach persistent disk for runtime
+      _ <- clusterQuery.detachPersistentDisk(runtimeId, now).transaction
     } yield ()
 
   private def handleRuntimeMessageError(runtimeId: Long, now: Instant, msg: String)(

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/CommonTestData.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/CommonTestData.scala
@@ -264,6 +264,13 @@ object CommonTestData {
                             zone = ZoneName("us-west2-b"),
                             None
     )
+  def defaultGceRuntimeWithPDConfig(persistentDiskId: Option[DiskId]) =
+    RuntimeConfig.GceWithPdConfig(MachineTypeName("n1-standard-4"),
+                                  bootDiskSize = DiskSize(50),
+                                  persistentDiskId = None,
+                                  zone = ZoneName("us-west2-b"),
+                                  gpuConfig = None
+    )
   val defaultRuntimeConfigRequest =
     RuntimeConfigRequest.DataprocConfig(
       Some(0),


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-3396

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
