### PR TITLE
IA-3396 detach disk properly on runtime creation failure

### DIFF
--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/BaseCloudServiceRuntimeMonitor.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/BaseCloudServiceRuntimeMonitor.scala
@@ -144,6 +144,7 @@ abstract class BaseCloudServiceRuntimeMonitor[F[_]] {
           curStatusOpt,
           new Exception(s"Cluster with id ${runtimeAndRuntimeConfig.runtime.id} not found in the database")
         )
+        _ <- clusterQuery.detachPersistentDisk(runtimeAndRuntimeConfig.runtime.id, ctx.now).transaction
         _ <- curStatus match {
           case RuntimeStatus.Deleted =>
             logger.info(ctx.loggingCtx)(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -8,4 +8,4 @@ addSbtPlugin(
   "com.github.cb372" % "sbt-explicit-dependencies" % "0.2.16"
 ) // Use `unusedCompileDependencies` to see unused dependencies
 
-addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.10.0")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.34")


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-3396

Forgot to test e2e in last PR. Turns out we're addressing failures in a different place as well..So not all failure cases will end up handled by `createRuntimeErrorHandler`, but instead some are handled by `failedRuntime` method

Tested e2e as well.

Here's the test payload
```
{
  "userScriptUri": "https://raw.githubusercontent.com/DataBiosphere/leonardo/dfe49dfcf0291070ff04634ed760a09ceefe7dfb/automation/src/test/resources/bucket-tests/invalid_user_script.sh",
  "runtimeConfig": {
    "cloudService": "gce",
    "machineType": "n1-standard-4",
    "persistentDisk": {
      "name": "qi-disk-617-0",
      "size": 120
    }
  }
}
```

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
