### PR TITLE
IA-3522 fix bug that's preventing non cached images being created

### DIFF
--- a/http/src/main/resources/init-resources/gce-init.sh
+++ b/http/src/main/resources/init-resources/gce-init.sh
@@ -162,7 +162,7 @@ function apply_user_script() {
   log "Running user script $USER_SCRIPT_URI in $CONTAINER_NAME container..."
   USER_SCRIPT=`basename ${USER_SCRIPT_URI}`
   if [[ "$USER_SCRIPT_URI" == 'gs://'* ]]; then
-    $GSUTIL_CMD cp ${USER_SCRIPT_URI} /var
+    $GSUTIL_CMD cp ${USER_SCRIPT_URI} /var &> /var/user_script_copy_output.txt
   else
     curl $USER_SCRIPT_URI -o /var/${USER_SCRIPT}
   fi
@@ -324,7 +324,7 @@ docker network create -d bridge app_network
 
 ${DOCKER_COMPOSE} --env-file=/var/variables.env "${COMPOSE_FILES[@]}" config
 
-retry 5 ${DOCKER_COMPOSE} --env-file=/var/variables.env "${COMPOSE_FILES[@]}" pull
+retry 5 ${DOCKER_COMPOSE} --env-file=/var/variables.env "${COMPOSE_FILES[@]}" pull &> /var/docker_pull_output.txt
 
 # This needs to happen before we start up containers
 chmod a+rwx ${WORK_DIRECTORY}


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-3522

From support
```
I got an update from our Compute Engine team, they were able to reproduce this issue and the issue happens only when the startup script produces more than 64k bytes of output without a newline. 

The maximum length for a token in Go's bufio scanner is 64K. Is it possible to change the startup script to limit/redirect the output from docker pull command? 

Another possible workaround is using systemd units[1] instead of startup scripts. 

I hope this solution works for you. If you have further questions, I'd be glad to assist you. 
```

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
