### PR TITLE
Update GKM chart version to 1.2.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,8 +25,8 @@ ENV HELM_DEBUG 1
 # WARNING: If you are changing any versions here, update it in the reference.conf
 ENV TERRA_APP_SETUP_VERSION 0.0.2
 ENV TERRA_APP_VERSION 0.3.0
-# This is galaxykubeman 1.2.1, which references Galaxy 21.09
-ENV GALAXY_VERSION 1.2.1
+# This is galaxykubeman 1.2.2, which references Galaxy 21.09
+ENV GALAXY_VERSION 1.2.2
 ENV NGINX_VERSION 3.23.0
 # If you update this here, make sure to also update reference.conf:
 ENV CROMWELL_CHART_VERSION 0.2.23

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -452,8 +452,8 @@ gke {
     releaseNameSuffix = "gxy-rls"
     chartName = "/leonardo/galaxykubeman"
     # If you change this here, be sure to update it in the dockerfile
-    # This is galaxykubeman 1.2.1, which references Galaxy 21.09
-    chartVersion = "1.2.1"
+    # This is galaxykubeman 1.2.2, which references Galaxy 21.09
+    chartVersion = "1.2.2"
     namespaceNameSuffix = "gxy-ns"
     serviceAccountName = "gxy-ksa"
     # Setting uninstallKeepHistory will cause the `helm uninstall` command to keep a record of

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/KubernetesTestData.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/KubernetesTestData.scala
@@ -37,7 +37,7 @@ object KubernetesTestData {
   val galaxyApp = AppType.Galaxy
 
   val galaxyChartName = ChartName("/leonardo/galaxykubeman")
-  val galaxyChartVersion = ChartVersion("1.2.1")
+  val galaxyChartVersion = ChartVersion("1.2.2")
   val galaxyChart = Chart(galaxyChartName, galaxyChartVersion)
 
   val galaxyReleasePrefix = "gxy-release"


### PR DESCRIPTION
Update the GalaxkKubeMan chart to 1.2.2, which includes resource requirement specifications for single-cell tools.

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
