### PR TITLE
IA-3289 fix a bug where cloudContext is nullable

### DIFF
--- a/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/20220628_add_non_null_for_cloud_context.xml
+++ b/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/20220628_add_non_null_for_cloud_context.xml
@@ -2,10 +2,16 @@
 <databaseChangeLog logicalFilePath="leonardo" xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
 
     <changeSet logicalFilePath="leonardo" author="qi" id="add_non_null_for_cloud_context">
-        <addColumn tableName="CLUSTER">
-            <column name="cloudContext" type="varchar(254)">
-                <constraints nullable="false"/>
-            </column>
-        </addColumn>
+        <addNotNullConstraint columnDataType="varchar(254)"
+                              columnName="cloudContext"
+                              constraintName="non_nullabel_cloudContext_cluster"
+                              defaultNullValue="This is wrong"
+                              tableName="CLUSTER"/>
+
+        <addNotNullConstraint columnDataType="varchar(254)"
+                              columnName="cloudContext"
+                              constraintName="non_nullabel_cloudContext_pd"
+                              defaultNullValue="This is wrong"
+                              tableName="PERSISTENT_DISK"/>
     </changeSet>
 </databaseChangeLog>

--- a/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/20220628_add_non_null_for_cloud_context.xml
+++ b/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/20220628_add_non_null_for_cloud_context.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog logicalFilePath="leonardo" xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+
+    <changeSet logicalFilePath="leonardo" author="qi" id="add_non_null_for_cloud_context">
+        <addColumn tableName="CLUSTER">
+            <column name="cloudContext" type="varchar(254)">
+                <constraints nullable="false"/>
+            </column>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-3289

`cloudContext` shouldn't really be nullable, think it was an oversight that this column was marked as nullable.

Double checked that is the case in both dev and prod DB

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
