### PR TITLE
IA-3289 Actually apply addNotNullConstraint

### DIFF
--- a/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changelog.xml
+++ b/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changelog.xml
@@ -86,4 +86,5 @@
     <include file="changesets/20220118_update_runtime_controlled_resource.xml" relativeToChangelogFile="true" />
     <include file="changesets/20220211_cluster_workspace_unique.xml" relativeToChangelogFile="true" />
     <include file="changesets/20220428_add_service_path.xml" relativeToChangelogFile="true" />
+    <include file="changesets/20220628_add_non_null_for_cloud_context.xml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/20220628_add_non_null_for_cloud_context.xml
+++ b/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/20220628_add_non_null_for_cloud_context.xml
@@ -8,6 +8,18 @@
                               defaultNullValue="This is wrong"
                               tableName="CLUSTER"/>
 
+        <addNotNullConstraint columnDataType="varchar(255)"
+                              columnName="runtimeName"
+                              constraintName="non_nullabel_runtimeName_cluster"
+                              defaultNullValue="This is wrong"
+                              tableName="CLUSTER"/>
+
+        <addNotNullConstraint columnDataType="enum('DATAPROC','GCE','AZURE_VM')"
+                              columnName="cloudService"
+                              constraintName="non_nullabel_cloudService_runtimeconfig"
+                              defaultNullValue="GCE"
+                              tableName="RUNTIME_CONFIG"/>
+
         <addNotNullConstraint columnDataType="varchar(254)"
                               columnName="cloudContext"
                               constraintName="non_nullabel_cloudContext_pd"


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-3289

Missed [changelog.xml](https://github.com/DataBiosphere/leonardo/compare/oneMore?expand=1#diff-628b300134ad62b9b90c9bbb79e5b942bb6798e58560bf34280a0504e6af1286) change in last PR, so it wasn't actually doing anything 

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
