### PR TITLE
[PROD-698] disable galaxy tests

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/AppCreationSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/AppCreationSpec.scala
@@ -54,201 +54,203 @@ class AppCreationSpec
     )
   )
 
-  forAll(appTestCases) { (description, createAppRequest) =>
-    description taggedAs (Tags.SmokeTest, Retryable) in { _ =>
-      withNewProject { googleProject =>
-        val appName = randomAppName
-        val restoreAppName = AppName(s"restore-${appName.value}")
+  // TODO: enable once Galaxy supports newer version of GKE
 
-        LeonardoApiClient.client.use { implicit client =>
-          for {
-            _ <- loggerIO.info(s"AppCreationSpec: About to create app ${googleProject.value}/${appName.value}")
+//  forAll(appTestCases) { (description, createAppRequest) =>
+//    description taggedAs (Tags.SmokeTest, Retryable) in { _ =>
+//      withNewProject { googleProject =>
+//        val appName = randomAppName
+//        val restoreAppName = AppName(s"restore-${appName.value}")
+//
+//        LeonardoApiClient.client.use { implicit client =>
+//          for {
+//            _ <- loggerIO.info(s"AppCreationSpec: About to create app ${googleProject.value}/${appName.value}")
+//
+//            rat <- Ron.authToken()
+//            implicit0(auth: Authorization) = Authorization(Credentials.Token(AuthScheme.Bearer, rat.value))
+//
+//            // Create the app
+//            _ <- LeonardoApiClient.createApp(googleProject, appName, createAppRequest)
+//
+//            // Verify the initial getApp call
+//            getApp = LeonardoApiClient.getApp(googleProject, appName)
+//            getAppResponse <- getApp
+//            _ = getAppResponse.status should (be(AppStatus.Provisioning) or be(AppStatus.Precreating))
+//
+//            // Verify the app eventually becomes Running
+//            _ <- IO.sleep(120 seconds)
+//            monitorCreateResult <- streamUntilDoneOrTimeout(
+//              getApp,
+//              120,
+//              10 seconds,
+//              s"AppCreationSpec: app ${googleProject.value}/${appName.value} did not finish creating after 20 minutes"
+//            )(implicitly, appInStateOrError(AppStatus.Running))
+//            _ <- loggerIO.info(
+//              s"AppCreationSpec: app ${googleProject.value}/${appName.value} monitor result: ${monitorCreateResult}"
+//            )
+//            _ = monitorCreateResult.status shouldBe AppStatus.Running
+//
+//            _ <- IO.sleep(1 minute)
+//
+//            // Delete the app
+//            _ <- LeonardoApiClient.deleteApp(googleProject, appName, false)
+//
+//            // Verify getApp again
+//            getAppResponse <- getApp
+//            _ = getAppResponse.status should (be(AppStatus.Deleting) or be(AppStatus.Predeleting))
+//
+//            // Verify the app eventually becomes Deleted
+//            // Don't fail the test if the deletion times out because the app pre-delete job can sporadically fail.
+//            // See https://broadworkbench.atlassian.net/browse/IA-2471
+//            listApps = LeonardoApiClient.listApps(googleProject, true)
+//            implicit0(deletedDoneCheckable: DoneCheckable[List[ListAppResponse]]) = appDeleted(appName)
+//            monitorDeleteResult <- streamFUntilDone(
+//              listApps,
+//              120,
+//              10 seconds
+//            ).compile.lastOrError
+//            // TODO remove first case in below if statement when app deletion is reliable
+//            _ <-
+//              if (!deletedDoneCheckable.isDone(monitorDeleteResult)) {
+//                loggerIO.warn(
+//                  s"AppCreationSpec: app ${googleProject.value}/${appName.value} did not finish deleting after 20 minutes. Result: $monitorDeleteResult"
+//                )
+//                // IO(Sam.user.deleteResource("kubernetes-app", appName.value)(ronCreds.makeAuthToken()))
+//              } else {
+//                // Verify creating another app with the same disk doesn't error out
+//                for {
+//                  _ <- loggerIO.info(
+//                    s"AppCreationSpec: app ${googleProject.value}/${appName.value} delete result: $monitorDeleteResult"
+//                  )
+//                  _ <- LeonardoApiClient.createAppWithWait(googleProject, restoreAppName, createAppRequest)(
+//                    client,
+//                    ronAuthorization,
+//                    loggerIO
+//                  )
+//                  _ <- LeonardoApiClient.deleteAppWithWait(googleProject, restoreAppName)
+//                } yield ()
+//              }
+//          } yield ()
+//        }
+//      }
+//    }
+//  }
 
-            rat <- Ron.authToken()
-            implicit0(auth: Authorization) = Authorization(Credentials.Token(AuthScheme.Bearer, rat.value))
-
-            // Create the app
-            _ <- LeonardoApiClient.createApp(googleProject, appName, createAppRequest)
-
-            // Verify the initial getApp call
-            getApp = LeonardoApiClient.getApp(googleProject, appName)
-            getAppResponse <- getApp
-            _ = getAppResponse.status should (be(AppStatus.Provisioning) or be(AppStatus.Precreating))
-
-            // Verify the app eventually becomes Running
-            _ <- IO.sleep(120 seconds)
-            monitorCreateResult <- streamUntilDoneOrTimeout(
-              getApp,
-              120,
-              10 seconds,
-              s"AppCreationSpec: app ${googleProject.value}/${appName.value} did not finish creating after 20 minutes"
-            )(implicitly, appInStateOrError(AppStatus.Running))
-            _ <- loggerIO.info(
-              s"AppCreationSpec: app ${googleProject.value}/${appName.value} monitor result: ${monitorCreateResult}"
-            )
-            _ = monitorCreateResult.status shouldBe AppStatus.Running
-
-            _ <- IO.sleep(1 minute)
-
-            // Delete the app
-            _ <- LeonardoApiClient.deleteApp(googleProject, appName, false)
-
-            // Verify getApp again
-            getAppResponse <- getApp
-            _ = getAppResponse.status should (be(AppStatus.Deleting) or be(AppStatus.Predeleting))
-
-            // Verify the app eventually becomes Deleted
-            // Don't fail the test if the deletion times out because the app pre-delete job can sporadically fail.
-            // See https://broadworkbench.atlassian.net/browse/IA-2471
-            listApps = LeonardoApiClient.listApps(googleProject, true)
-            implicit0(deletedDoneCheckable: DoneCheckable[List[ListAppResponse]]) = appDeleted(appName)
-            monitorDeleteResult <- streamFUntilDone(
-              listApps,
-              120,
-              10 seconds
-            ).compile.lastOrError
-            // TODO remove first case in below if statement when app deletion is reliable
-            _ <-
-              if (!deletedDoneCheckable.isDone(monitorDeleteResult)) {
-                loggerIO.warn(
-                  s"AppCreationSpec: app ${googleProject.value}/${appName.value} did not finish deleting after 20 minutes. Result: $monitorDeleteResult"
-                )
-                // IO(Sam.user.deleteResource("kubernetes-app", appName.value)(ronCreds.makeAuthToken()))
-              } else {
-                // Verify creating another app with the same disk doesn't error out
-                for {
-                  _ <- loggerIO.info(
-                    s"AppCreationSpec: app ${googleProject.value}/${appName.value} delete result: $monitorDeleteResult"
-                  )
-                  _ <- LeonardoApiClient.createAppWithWait(googleProject, restoreAppName, createAppRequest)(
-                    client,
-                    ronAuthorization,
-                    loggerIO
-                  )
-                  _ <- LeonardoApiClient.deleteAppWithWait(googleProject, restoreAppName)
-                } yield ()
-              }
-          } yield ()
-        }
-      }
-    }
-  }
-
-  "stop and start an app" taggedAs (Tags.SmokeTest, Retryable) in { _ =>
-    withNewProject { googleProject =>
-      val appName = randomAppName
-      val diskName = Generators.genDiskName.sample.get
-
-      val createAppRequest = defaultCreateAppRequest.copy(
-        diskConfig = Some(
-          PersistentDiskRequest(
-            diskName,
-            Some(DiskSize(500)),
-            None,
-            Map.empty
-          )
-        )
-      )
-
-      LeonardoApiClient.client.use { implicit client =>
-        for {
-          _ <- loggerIO.info(s"AppCreationSpec: About to create app ${googleProject.value}/${appName.value}")
-
-          // Create the app
-          _ <- LeonardoApiClient.createApp(googleProject, appName, createAppRequest)
-
-          // Verify the initial getApp call
-          getApp = LeonardoApiClient.getApp(googleProject, appName)
-          getAppResponse <- getApp
-          _ = getAppResponse.status should (be(AppStatus.Provisioning) or be(AppStatus.Precreating))
-
-          // Verify the app eventually becomes Running
-          _ <- IO.sleep(90 seconds)
-          monitorCreateResult <- streamUntilDoneOrTimeout(
-            getApp,
-            120,
-            10 seconds,
-            s"AppCreationSpec: app ${googleProject.value}/${appName.value} did not finish creating after 20 minutes"
-          )(implicitly, appInStateOrError(AppStatus.Running))
-          _ <- loggerIO.info(
-            s"AppCreationSpec: app ${googleProject.value}/${appName.value} monitor result: ${monitorCreateResult}"
-          )
-          _ = monitorCreateResult.status shouldBe AppStatus.Running
-
-          // Stop the app
-          _ <- LeonardoApiClient.stopApp(googleProject, appName)
-
-          // Verify getApp again
-          getAppResponse <- getApp
-          _ = getAppResponse.status should (be(AppStatus.Stopping) or be(AppStatus.PreStopping))
-
-          // Verify the app eventually becomes Stopped
-          _ <- IO.sleep(60 seconds)
-          monitorStopResult <- streamUntilDoneOrTimeout(
-            getApp,
-            180,
-            10 seconds,
-            s"AppCreationSpec: app ${googleProject.value}/${appName.value} did not finish stopping after 30 minutes"
-          )(implicitly, appInStateOrError(AppStatus.Stopped))
-          _ <- loggerIO.info(
-            s"AppCreationSpec: app ${googleProject.value}/${appName.value} stop result: $monitorStopResult"
-          )
-          _ = monitorStopResult.status shouldBe AppStatus.Stopped
-
-          // Start the app
-          _ <- LeonardoApiClient.startApp(googleProject, appName)
-
-          // Verify getApp again
-          getAppResponse <- getApp
-          _ = getAppResponse.status should (be(AppStatus.Starting) or be(AppStatus.PreStarting))
-
-          // Verify the app eventually becomes Running
-          _ <- IO.sleep(30 seconds)
-          monitorStartResult <- streamUntilDoneOrTimeout(
-            getApp,
-            120,
-            10 seconds,
-            s"AppCreationSpec: app ${googleProject.value}/${appName.value} did not finish starting after 20 minutes"
-          )(implicitly, appInStateOrError(AppStatus.Running))
-          _ <- loggerIO.info(
-            s"AppCreationSpec: app ${googleProject.value}/${appName.value} start result: $monitorStartResult"
-          )
-          _ = monitorStartResult.status shouldBe AppStatus.Running
-
-          _ <- IO.sleep(60 seconds)
-
-          // Delete the app
-          _ <- LeonardoApiClient.deleteApp(googleProject, appName, true)
-          _ <- IO.sleep(30 seconds)
-
-          // Verify getApp again
-          getAppResponse <- getApp
-          _ = getAppResponse.status should (be(AppStatus.Deleting) or be(AppStatus.Predeleting))
-
-          // Verify the app eventually becomes Deleted
-          // Don't fail the test if the deletion times out because the Galaxy pre-delete job can sporadically fail.
-          // See https://broadworkbench.atlassian.net/browse/IA-2471
-          listApps = LeonardoApiClient.listApps(googleProject, true)
-          implicit0(doneCheckable: DoneCheckable[List[ListAppResponse]]) = appDeleted(appName)
-          monitorDeleteResult <- streamFUntilDone(listApps, 200, 10 seconds).compile.lastOrError
-          // TODO remove first case in below if statement when Galaxy deletion is reliable
-          _ <-
-            if (!doneCheckable.isDone(monitorDeleteResult)) {
-              loggerIO.warn(
-                s"AppCreationSpec: app ${googleProject.value}/${appName.value} did not finish deleting after 30 minutes. Result: $monitorDeleteResult"
-              )
-            } else {
-              // verify disk is also deleted
-              for {
-                _ <- loggerIO.info(
-                  s"AppCreationSpec: app ${googleProject.value}/${appName.value} delete result: $monitorDeleteResult"
-                )
-                getDiskResp <- LeonardoApiClient.getDisk(googleProject, diskName).attempt
-              } yield getDiskResp.toOption shouldBe None
-            }
-        } yield ()
-      }
-    }
-  }
+//  "stop and start an app" taggedAs (Tags.SmokeTest, Retryable) in { _ =>
+//    withNewProject { googleProject =>
+//      val appName = randomAppName
+//      val diskName = Generators.genDiskName.sample.get
+//
+//      val createAppRequest = defaultCreateAppRequest.copy(
+//        diskConfig = Some(
+//          PersistentDiskRequest(
+//            diskName,
+//            Some(DiskSize(500)),
+//            None,
+//            Map.empty
+//          )
+//        )
+//      )
+//
+//      LeonardoApiClient.client.use { implicit client =>
+//        for {
+//          _ <- loggerIO.info(s"AppCreationSpec: About to create app ${googleProject.value}/${appName.value}")
+//
+//          // Create the app
+//          _ <- LeonardoApiClient.createApp(googleProject, appName, createAppRequest)
+//
+//          // Verify the initial getApp call
+//          getApp = LeonardoApiClient.getApp(googleProject, appName)
+//          getAppResponse <- getApp
+//          _ = getAppResponse.status should (be(AppStatus.Provisioning) or be(AppStatus.Precreating))
+//
+//          // Verify the app eventually becomes Running
+//          _ <- IO.sleep(90 seconds)
+//          monitorCreateResult <- streamUntilDoneOrTimeout(
+//            getApp,
+//            120,
+//            10 seconds,
+//            s"AppCreationSpec: app ${googleProject.value}/${appName.value} did not finish creating after 20 minutes"
+//          )(implicitly, appInStateOrError(AppStatus.Running))
+//          _ <- loggerIO.info(
+//            s"AppCreationSpec: app ${googleProject.value}/${appName.value} monitor result: ${monitorCreateResult}"
+//          )
+//          _ = monitorCreateResult.status shouldBe AppStatus.Running
+//
+//          // Stop the app
+//          _ <- LeonardoApiClient.stopApp(googleProject, appName)
+//
+//          // Verify getApp again
+//          getAppResponse <- getApp
+//          _ = getAppResponse.status should (be(AppStatus.Stopping) or be(AppStatus.PreStopping))
+//
+//          // Verify the app eventually becomes Stopped
+//          _ <- IO.sleep(60 seconds)
+//          monitorStopResult <- streamUntilDoneOrTimeout(
+//            getApp,
+//            180,
+//            10 seconds,
+//            s"AppCreationSpec: app ${googleProject.value}/${appName.value} did not finish stopping after 30 minutes"
+//          )(implicitly, appInStateOrError(AppStatus.Stopped))
+//          _ <- loggerIO.info(
+//            s"AppCreationSpec: app ${googleProject.value}/${appName.value} stop result: $monitorStopResult"
+//          )
+//          _ = monitorStopResult.status shouldBe AppStatus.Stopped
+//
+//          // Start the app
+//          _ <- LeonardoApiClient.startApp(googleProject, appName)
+//
+//          // Verify getApp again
+//          getAppResponse <- getApp
+//          _ = getAppResponse.status should (be(AppStatus.Starting) or be(AppStatus.PreStarting))
+//
+//          // Verify the app eventually becomes Running
+//          _ <- IO.sleep(30 seconds)
+//          monitorStartResult <- streamUntilDoneOrTimeout(
+//            getApp,
+//            120,
+//            10 seconds,
+//            s"AppCreationSpec: app ${googleProject.value}/${appName.value} did not finish starting after 20 minutes"
+//          )(implicitly, appInStateOrError(AppStatus.Running))
+//          _ <- loggerIO.info(
+//            s"AppCreationSpec: app ${googleProject.value}/${appName.value} start result: $monitorStartResult"
+//          )
+//          _ = monitorStartResult.status shouldBe AppStatus.Running
+//
+//          _ <- IO.sleep(60 seconds)
+//
+//          // Delete the app
+//          _ <- LeonardoApiClient.deleteApp(googleProject, appName, true)
+//          _ <- IO.sleep(30 seconds)
+//
+//          // Verify getApp again
+//          getAppResponse <- getApp
+//          _ = getAppResponse.status should (be(AppStatus.Deleting) or be(AppStatus.Predeleting))
+//
+//          // Verify the app eventually becomes Deleted
+//          // Don't fail the test if the deletion times out because the Galaxy pre-delete job can sporadically fail.
+//          // See https://broadworkbench.atlassian.net/browse/IA-2471
+//          listApps = LeonardoApiClient.listApps(googleProject, true)
+//          implicit0(doneCheckable: DoneCheckable[List[ListAppResponse]]) = appDeleted(appName)
+//          monitorDeleteResult <- streamFUntilDone(listApps, 200, 10 seconds).compile.lastOrError
+//          // TODO remove first case in below if statement when Galaxy deletion is reliable
+//          _ <-
+//            if (!doneCheckable.isDone(monitorDeleteResult)) {
+//              loggerIO.warn(
+//                s"AppCreationSpec: app ${googleProject.value}/${appName.value} did not finish deleting after 30 minutes. Result: $monitorDeleteResult"
+//              )
+//            } else {
+//              // verify disk is also deleted
+//              for {
+//                _ <- loggerIO.info(
+//                  s"AppCreationSpec: app ${googleProject.value}/${appName.value} delete result: $monitorDeleteResult"
+//                )
+//                getDiskResp <- LeonardoApiClient.getDisk(googleProject, diskName).attempt
+//              } yield getDiskResp.toOption shouldBe None
+//            }
+//        } yield ()
+//      }
+//    }
+//  }
 
 }

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/AppCreationSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/AppCreationSpec.scala
@@ -54,7 +54,7 @@ class AppCreationSpec
     )
   )
 
-  // TODO: enable once Galaxy supports newer version of GKE
+  // TODO: enable once Galaxy supports newer version of GKE: https://broadworkbench.atlassian.net/browse/PROD-698
 
 //  forAll(appTestCases) { (description, createAppRequest) =>
 //    description taggedAs (Tags.SmokeTest, Retryable) in { _ =>

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/AppLifecycleSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/AppLifecycleSpec.scala
@@ -109,5 +109,5 @@ class AppLifecycleSpec
 //        }
 //      }
 //    }
-  }
+  // }
 }

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/AppLifecycleSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/AppLifecycleSpec.scala
@@ -50,62 +50,64 @@ class AppLifecycleSpec
     ("create and delete a CUSTOM app", customCreateAppRequest)
   )
 
-  forAll(appTestCases) { (description, createAppRequest) =>
-    description taggedAs Retryable in { _ =>
-      withNewProject { googleProject =>
-        val appName = randomAppName
+  // TODO: enable once Galaxy supports newer version of GKE
 
-        LeonardoApiClient.client.use { implicit client =>
-          for {
-            _ <- loggerIO.info(s"AppLifecycleSpec: About to create app ${googleProject.value}/${appName.value}")
-
-            // Create the app
-            _ <- LeonardoApiClient.createApp(googleProject, appName, createAppRequest)
-
-            // Verify the initial getApp call
-            getApp = LeonardoApiClient.getApp(googleProject, appName)
-            getAppResponse <- getApp
-            _ = getAppResponse.status should (be(AppStatus.Provisioning) or be(AppStatus.Precreating))
-
-            // Verify the app eventually becomes Running
-            _ <- IO.sleep(60 seconds)
-            monitorCreateResult <- streamUntilDoneOrTimeout(
-              getApp,
-              120,
-              10 seconds,
-              s"AppLifecycleSpec: app ${googleProject.value}/${appName.value} did not finish creating after 20 minutes"
-            )(implicitly, appInStateOrError(AppStatus.Running))
-            _ <- loggerIO.info(
-              s"AppLifecycleSpec: app ${googleProject.value}/${appName.value} monitor result: ${monitorCreateResult}"
-            )
-            _ = monitorCreateResult.status shouldBe AppStatus.Running
-
-            _ <- IO.sleep(1 minute)
-
-            // Delete the app
-            _ <- LeonardoApiClient.deleteApp(googleProject, appName)
-
-            // Verify getApp again
-            getAppResponse <- getApp
-            _ = getAppResponse.status should (be(AppStatus.Deleting) or be(AppStatus.Predeleting))
-
-            // Verify the app eventually becomes Deleted
-            listApps = LeonardoApiClient.listApps(googleProject, true)
-            implicit0(deletedDoneCheckable: DoneCheckable[List[ListAppResponse]]) = appDeleted(appName)
-            monitorDeleteResult <- streamFUntilDone(
-              listApps,
-              120,
-              10 seconds
-            ).compile.lastOrError
-
-            _ <- loggerIO.info(
-              s"AppLifecycleSpec: app ${googleProject.value}/${appName.value} delete result: $monitorDeleteResult"
-            )
-
-            _ = monitorDeleteResult.map(_.status) shouldBe List(AppStatus.Deleted)
-          } yield ()
-        }
-      }
-    }
+//  forAll(appTestCases) { (description, createAppRequest) =>
+//    description taggedAs Retryable in { _ =>
+//      withNewProject { googleProject =>
+//        val appName = randomAppName
+//
+//        LeonardoApiClient.client.use { implicit client =>
+//          for {
+//            _ <- loggerIO.info(s"AppLifecycleSpec: About to create app ${googleProject.value}/${appName.value}")
+//
+//            // Create the app
+//            _ <- LeonardoApiClient.createApp(googleProject, appName, createAppRequest)
+//
+//            // Verify the initial getApp call
+//            getApp = LeonardoApiClient.getApp(googleProject, appName)
+//            getAppResponse <- getApp
+//            _ = getAppResponse.status should (be(AppStatus.Provisioning) or be(AppStatus.Precreating))
+//
+//            // Verify the app eventually becomes Running
+//            _ <- IO.sleep(60 seconds)
+//            monitorCreateResult <- streamUntilDoneOrTimeout(
+//              getApp,
+//              120,
+//              10 seconds,
+//              s"AppLifecycleSpec: app ${googleProject.value}/${appName.value} did not finish creating after 20 minutes"
+//            )(implicitly, appInStateOrError(AppStatus.Running))
+//            _ <- loggerIO.info(
+//              s"AppLifecycleSpec: app ${googleProject.value}/${appName.value} monitor result: ${monitorCreateResult}"
+//            )
+//            _ = monitorCreateResult.status shouldBe AppStatus.Running
+//
+//            _ <- IO.sleep(1 minute)
+//
+//            // Delete the app
+//            _ <- LeonardoApiClient.deleteApp(googleProject, appName)
+//
+//            // Verify getApp again
+//            getAppResponse <- getApp
+//            _ = getAppResponse.status should (be(AppStatus.Deleting) or be(AppStatus.Predeleting))
+//
+//            // Verify the app eventually becomes Deleted
+//            listApps = LeonardoApiClient.listApps(googleProject, true)
+//            implicit0(deletedDoneCheckable: DoneCheckable[List[ListAppResponse]]) = appDeleted(appName)
+//            monitorDeleteResult <- streamFUntilDone(
+//              listApps,
+//              120,
+//              10 seconds
+//            ).compile.lastOrError
+//
+//            _ <- loggerIO.info(
+//              s"AppLifecycleSpec: app ${googleProject.value}/${appName.value} delete result: $monitorDeleteResult"
+//            )
+//
+//            _ = monitorDeleteResult.map(_.status) shouldBe List(AppStatus.Deleted)
+//          } yield ()
+//        }
+//      }
+//    }
   }
 }

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/AppLifecycleSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/AppLifecycleSpec.scala
@@ -50,7 +50,7 @@ class AppLifecycleSpec
     ("create and delete a CUSTOM app", customCreateAppRequest)
   )
 
-  // TODO: enable once Galaxy supports newer version of GKE
+  // TODO: enable once Galaxy supports newer version of GKE: https://broadworkbench.atlassian.net/browse/PROD-698
 
 //  forAll(appTestCases) { (description, createAppRequest) =>
 //    description taggedAs Retryable in { _ =>


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/PROD-698

We are disabling app creation specs until galaxy upgrades the version of GKE that it uses


<img width="1781" alt="image (3)" src="https://user-images.githubusercontent.com/23626109/179574267-8da788ff-b8ab-421d-baa6-93d84c580dc1.png">

