### PR TITLE
[IA-3553] bump timeout

### DIFF
--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -609,7 +609,7 @@ mysql {
     #url = "jdbc:mysql://mysql/leonardo
     #user = "dbUser"
     #password = "pass"
-    connectionTimeout = 5000
+    connectionTimeout = 15000
     numThreads = 200
   }
   concurrency = 120


### PR DESCRIPTION
I see this in a lot of the dev logs, and some articles point to bumping connection timeout. Theory being that some requests from the UI take a while, and if a DB connection lives to long it can 'die' and cause that connection pool to be unstable...

```
mysql.db - Connection com.mysql.cj.jdbc.ConnectionImpl@3dcdb3c4 marked as broken because of SQLSTATE(08S01), ErrorCode(0)
```