### PR TITLE
PROD-698 Replace GKM with v1.6.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,8 +25,8 @@ ENV HELM_DEBUG 1
 # WARNING: If you are changing any versions here, update it in the reference.conf
 ENV TERRA_APP_SETUP_VERSION 0.0.2
 ENV TERRA_APP_VERSION 0.3.0
-# This is galaxykubeman 1.2.2, which references Galaxy 21.09
-ENV GALAXY_VERSION 1.2.2
+# This is galaxykubeman 1.6.0, which references Galaxy 21.09
+ENV GALAXY_VERSION 1.6.0
 ENV NGINX_VERSION 3.23.0
 # If you update this here, make sure to also update reference.conf:
 ENV CROMWELL_CHART_VERSION 0.2.39

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/AppCreationSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/AppCreationSpec.scala
@@ -54,203 +54,201 @@ class AppCreationSpec
     )
   )
 
-  // TODO: enable once Galaxy supports newer version of GKE: https://broadworkbench.atlassian.net/browse/PROD-698
+  forAll(appTestCases) { (description, createAppRequest) =>
+    description taggedAs (Tags.SmokeTest, Retryable) in { _ =>
+      withNewProject { googleProject =>
+        val appName = randomAppName
+        val restoreAppName = AppName(s"restore-${appName.value}")
 
-//  forAll(appTestCases) { (description, createAppRequest) =>
-//    description taggedAs (Tags.SmokeTest, Retryable) in { _ =>
-//      withNewProject { googleProject =>
-//        val appName = randomAppName
-//        val restoreAppName = AppName(s"restore-${appName.value}")
-//
-//        LeonardoApiClient.client.use { implicit client =>
-//          for {
-//            _ <- loggerIO.info(s"AppCreationSpec: About to create app ${googleProject.value}/${appName.value}")
-//
-//            rat <- Ron.authToken()
-//            implicit0(auth: Authorization) = Authorization(Credentials.Token(AuthScheme.Bearer, rat.value))
-//
-//            // Create the app
-//            _ <- LeonardoApiClient.createApp(googleProject, appName, createAppRequest)
-//
-//            // Verify the initial getApp call
-//            getApp = LeonardoApiClient.getApp(googleProject, appName)
-//            getAppResponse <- getApp
-//            _ = getAppResponse.status should (be(AppStatus.Provisioning) or be(AppStatus.Precreating))
-//
-//            // Verify the app eventually becomes Running
-//            _ <- IO.sleep(120 seconds)
-//            monitorCreateResult <- streamUntilDoneOrTimeout(
-//              getApp,
-//              120,
-//              10 seconds,
-//              s"AppCreationSpec: app ${googleProject.value}/${appName.value} did not finish creating after 20 minutes"
-//            )(implicitly, appInStateOrError(AppStatus.Running))
-//            _ <- loggerIO.info(
-//              s"AppCreationSpec: app ${googleProject.value}/${appName.value} monitor result: ${monitorCreateResult}"
-//            )
-//            _ = monitorCreateResult.status shouldBe AppStatus.Running
-//
-//            _ <- IO.sleep(1 minute)
-//
-//            // Delete the app
-//            _ <- LeonardoApiClient.deleteApp(googleProject, appName, false)
-//
-//            // Verify getApp again
-//            getAppResponse <- getApp
-//            _ = getAppResponse.status should (be(AppStatus.Deleting) or be(AppStatus.Predeleting))
-//
-//            // Verify the app eventually becomes Deleted
-//            // Don't fail the test if the deletion times out because the app pre-delete job can sporadically fail.
-//            // See https://broadworkbench.atlassian.net/browse/IA-2471
-//            listApps = LeonardoApiClient.listApps(googleProject, true)
-//            implicit0(deletedDoneCheckable: DoneCheckable[List[ListAppResponse]]) = appDeleted(appName)
-//            monitorDeleteResult <- streamFUntilDone(
-//              listApps,
-//              120,
-//              10 seconds
-//            ).compile.lastOrError
-//            // TODO remove first case in below if statement when app deletion is reliable
-//            _ <-
-//              if (!deletedDoneCheckable.isDone(monitorDeleteResult)) {
-//                loggerIO.warn(
-//                  s"AppCreationSpec: app ${googleProject.value}/${appName.value} did not finish deleting after 20 minutes. Result: $monitorDeleteResult"
-//                )
-//                // IO(Sam.user.deleteResource("kubernetes-app", appName.value)(ronCreds.makeAuthToken()))
-//              } else {
-//                // Verify creating another app with the same disk doesn't error out
-//                for {
-//                  _ <- loggerIO.info(
-//                    s"AppCreationSpec: app ${googleProject.value}/${appName.value} delete result: $monitorDeleteResult"
-//                  )
-//                  _ <- LeonardoApiClient.createAppWithWait(googleProject, restoreAppName, createAppRequest)(
-//                    client,
-//                    ronAuthorization,
-//                    loggerIO
-//                  )
-//                  _ <- LeonardoApiClient.deleteAppWithWait(googleProject, restoreAppName)
-//                } yield ()
-//              }
-//          } yield ()
-//        }
-//      }
-//    }
-//  }
+        LeonardoApiClient.client.use { implicit client =>
+          for {
+            _ <- loggerIO.info(s"AppCreationSpec: About to create app ${googleProject.value}/${appName.value}")
 
-//  "stop and start an app" taggedAs (Tags.SmokeTest, Retryable) in { _ =>
-//    withNewProject { googleProject =>
-//      val appName = randomAppName
-//      val diskName = Generators.genDiskName.sample.get
-//
-//      val createAppRequest = defaultCreateAppRequest.copy(
-//        diskConfig = Some(
-//          PersistentDiskRequest(
-//            diskName,
-//            Some(DiskSize(500)),
-//            None,
-//            Map.empty
-//          )
-//        )
-//      )
-//
-//      LeonardoApiClient.client.use { implicit client =>
-//        for {
-//          _ <- loggerIO.info(s"AppCreationSpec: About to create app ${googleProject.value}/${appName.value}")
-//
-//          // Create the app
-//          _ <- LeonardoApiClient.createApp(googleProject, appName, createAppRequest)
-//
-//          // Verify the initial getApp call
-//          getApp = LeonardoApiClient.getApp(googleProject, appName)
-//          getAppResponse <- getApp
-//          _ = getAppResponse.status should (be(AppStatus.Provisioning) or be(AppStatus.Precreating))
-//
-//          // Verify the app eventually becomes Running
-//          _ <- IO.sleep(90 seconds)
-//          monitorCreateResult <- streamUntilDoneOrTimeout(
-//            getApp,
-//            120,
-//            10 seconds,
-//            s"AppCreationSpec: app ${googleProject.value}/${appName.value} did not finish creating after 20 minutes"
-//          )(implicitly, appInStateOrError(AppStatus.Running))
-//          _ <- loggerIO.info(
-//            s"AppCreationSpec: app ${googleProject.value}/${appName.value} monitor result: ${monitorCreateResult}"
-//          )
-//          _ = monitorCreateResult.status shouldBe AppStatus.Running
-//
-//          // Stop the app
-//          _ <- LeonardoApiClient.stopApp(googleProject, appName)
-//
-//          // Verify getApp again
-//          getAppResponse <- getApp
-//          _ = getAppResponse.status should (be(AppStatus.Stopping) or be(AppStatus.PreStopping))
-//
-//          // Verify the app eventually becomes Stopped
-//          _ <- IO.sleep(60 seconds)
-//          monitorStopResult <- streamUntilDoneOrTimeout(
-//            getApp,
-//            180,
-//            10 seconds,
-//            s"AppCreationSpec: app ${googleProject.value}/${appName.value} did not finish stopping after 30 minutes"
-//          )(implicitly, appInStateOrError(AppStatus.Stopped))
-//          _ <- loggerIO.info(
-//            s"AppCreationSpec: app ${googleProject.value}/${appName.value} stop result: $monitorStopResult"
-//          )
-//          _ = monitorStopResult.status shouldBe AppStatus.Stopped
-//
-//          // Start the app
-//          _ <- LeonardoApiClient.startApp(googleProject, appName)
-//
-//          // Verify getApp again
-//          getAppResponse <- getApp
-//          _ = getAppResponse.status should (be(AppStatus.Starting) or be(AppStatus.PreStarting))
-//
-//          // Verify the app eventually becomes Running
-//          _ <- IO.sleep(30 seconds)
-//          monitorStartResult <- streamUntilDoneOrTimeout(
-//            getApp,
-//            120,
-//            10 seconds,
-//            s"AppCreationSpec: app ${googleProject.value}/${appName.value} did not finish starting after 20 minutes"
-//          )(implicitly, appInStateOrError(AppStatus.Running))
-//          _ <- loggerIO.info(
-//            s"AppCreationSpec: app ${googleProject.value}/${appName.value} start result: $monitorStartResult"
-//          )
-//          _ = monitorStartResult.status shouldBe AppStatus.Running
-//
-//          _ <- IO.sleep(60 seconds)
-//
-//          // Delete the app
-//          _ <- LeonardoApiClient.deleteApp(googleProject, appName, true)
-//          _ <- IO.sleep(30 seconds)
-//
-//          // Verify getApp again
-//          getAppResponse <- getApp
-//          _ = getAppResponse.status should (be(AppStatus.Deleting) or be(AppStatus.Predeleting))
-//
-//          // Verify the app eventually becomes Deleted
-//          // Don't fail the test if the deletion times out because the Galaxy pre-delete job can sporadically fail.
-//          // See https://broadworkbench.atlassian.net/browse/IA-2471
-//          listApps = LeonardoApiClient.listApps(googleProject, true)
-//          implicit0(doneCheckable: DoneCheckable[List[ListAppResponse]]) = appDeleted(appName)
-//          monitorDeleteResult <- streamFUntilDone(listApps, 200, 10 seconds).compile.lastOrError
-//          // TODO remove first case in below if statement when Galaxy deletion is reliable
-//          _ <-
-//            if (!doneCheckable.isDone(monitorDeleteResult)) {
-//              loggerIO.warn(
-//                s"AppCreationSpec: app ${googleProject.value}/${appName.value} did not finish deleting after 30 minutes. Result: $monitorDeleteResult"
-//              )
-//            } else {
-//              // verify disk is also deleted
-//              for {
-//                _ <- loggerIO.info(
-//                  s"AppCreationSpec: app ${googleProject.value}/${appName.value} delete result: $monitorDeleteResult"
-//                )
-//                getDiskResp <- LeonardoApiClient.getDisk(googleProject, diskName).attempt
-//              } yield getDiskResp.toOption shouldBe None
-//            }
-//        } yield ()
-//      }
-//    }
-//  }
+            rat <- Ron.authToken()
+            implicit0(auth: Authorization) = Authorization(Credentials.Token(AuthScheme.Bearer, rat.value))
+
+            // Create the app
+            _ <- LeonardoApiClient.createApp(googleProject, appName, createAppRequest)
+
+            // Verify the initial getApp call
+            getApp = LeonardoApiClient.getApp(googleProject, appName)
+            getAppResponse <- getApp
+            _ = getAppResponse.status should (be(AppStatus.Provisioning) or be(AppStatus.Precreating))
+
+            // Verify the app eventually becomes Running
+            _ <- IO.sleep(120 seconds)
+            monitorCreateResult <- streamUntilDoneOrTimeout(
+              getApp,
+              120,
+              10 seconds,
+              s"AppCreationSpec: app ${googleProject.value}/${appName.value} did not finish creating after 20 minutes"
+            )(implicitly, appInStateOrError(AppStatus.Running))
+            _ <- loggerIO.info(
+              s"AppCreationSpec: app ${googleProject.value}/${appName.value} monitor result: ${monitorCreateResult}"
+            )
+            _ = monitorCreateResult.status shouldBe AppStatus.Running
+
+            _ <- IO.sleep(1 minute)
+
+            // Delete the app
+            _ <- LeonardoApiClient.deleteApp(googleProject, appName, false)
+
+            // Verify getApp again
+            getAppResponse <- getApp
+            _ = getAppResponse.status should (be(AppStatus.Deleting) or be(AppStatus.Predeleting))
+
+            // Verify the app eventually becomes Deleted
+            // Don't fail the test if the deletion times out because the app pre-delete job can sporadically fail.
+            // See https://broadworkbench.atlassian.net/browse/IA-2471
+            listApps = LeonardoApiClient.listApps(googleProject, true)
+            implicit0(deletedDoneCheckable: DoneCheckable[List[ListAppResponse]]) = appDeleted(appName)
+            monitorDeleteResult <- streamFUntilDone(
+              listApps,
+              120,
+              10 seconds
+            ).compile.lastOrError
+            // TODO remove first case in below if statement when app deletion is reliable
+            _ <-
+              if (!deletedDoneCheckable.isDone(monitorDeleteResult)) {
+                loggerIO.warn(
+                  s"AppCreationSpec: app ${googleProject.value}/${appName.value} did not finish deleting after 20 minutes. Result: $monitorDeleteResult"
+                )
+                // IO(Sam.user.deleteResource("kubernetes-app", appName.value)(ronCreds.makeAuthToken()))
+              } else {
+                // Verify creating another app with the same disk doesn't error out
+                for {
+                  _ <- loggerIO.info(
+                    s"AppCreationSpec: app ${googleProject.value}/${appName.value} delete result: $monitorDeleteResult"
+                  )
+                  _ <- LeonardoApiClient.createAppWithWait(googleProject, restoreAppName, createAppRequest)(
+                    client,
+                    ronAuthorization,
+                    loggerIO
+                  )
+                  _ <- LeonardoApiClient.deleteAppWithWait(googleProject, restoreAppName)
+                } yield ()
+              }
+          } yield ()
+        }
+      }
+    }
+  }
+
+  "stop and start an app" taggedAs (Tags.SmokeTest, Retryable) in { _ =>
+    withNewProject { googleProject =>
+      val appName = randomAppName
+      val diskName = Generators.genDiskName.sample.get
+
+      val createAppRequest = defaultCreateAppRequest.copy(
+        diskConfig = Some(
+          PersistentDiskRequest(
+            diskName,
+            Some(DiskSize(500)),
+            None,
+            Map.empty
+          )
+        )
+      )
+
+      LeonardoApiClient.client.use { implicit client =>
+        for {
+          _ <- loggerIO.info(s"AppCreationSpec: About to create app ${googleProject.value}/${appName.value}")
+
+          // Create the app
+          _ <- LeonardoApiClient.createApp(googleProject, appName, createAppRequest)
+
+          // Verify the initial getApp call
+          getApp = LeonardoApiClient.getApp(googleProject, appName)
+          getAppResponse <- getApp
+          _ = getAppResponse.status should (be(AppStatus.Provisioning) or be(AppStatus.Precreating))
+
+          // Verify the app eventually becomes Running
+          _ <- IO.sleep(90 seconds)
+          monitorCreateResult <- streamUntilDoneOrTimeout(
+            getApp,
+            120,
+            10 seconds,
+            s"AppCreationSpec: app ${googleProject.value}/${appName.value} did not finish creating after 20 minutes"
+          )(implicitly, appInStateOrError(AppStatus.Running))
+          _ <- loggerIO.info(
+            s"AppCreationSpec: app ${googleProject.value}/${appName.value} monitor result: ${monitorCreateResult}"
+          )
+          _ = monitorCreateResult.status shouldBe AppStatus.Running
+
+          // Stop the app
+          _ <- LeonardoApiClient.stopApp(googleProject, appName)
+
+          // Verify getApp again
+          getAppResponse <- getApp
+          _ = getAppResponse.status should (be(AppStatus.Stopping) or be(AppStatus.PreStopping))
+
+          // Verify the app eventually becomes Stopped
+          _ <- IO.sleep(60 seconds)
+          monitorStopResult <- streamUntilDoneOrTimeout(
+            getApp,
+            180,
+            10 seconds,
+            s"AppCreationSpec: app ${googleProject.value}/${appName.value} did not finish stopping after 30 minutes"
+          )(implicitly, appInStateOrError(AppStatus.Stopped))
+          _ <- loggerIO.info(
+            s"AppCreationSpec: app ${googleProject.value}/${appName.value} stop result: $monitorStopResult"
+          )
+          _ = monitorStopResult.status shouldBe AppStatus.Stopped
+
+          // Start the app
+          _ <- LeonardoApiClient.startApp(googleProject, appName)
+
+          // Verify getApp again
+          getAppResponse <- getApp
+          _ = getAppResponse.status should (be(AppStatus.Starting) or be(AppStatus.PreStarting))
+
+          // Verify the app eventually becomes Running
+          _ <- IO.sleep(30 seconds)
+          monitorStartResult <- streamUntilDoneOrTimeout(
+            getApp,
+            120,
+            10 seconds,
+            s"AppCreationSpec: app ${googleProject.value}/${appName.value} did not finish starting after 20 minutes"
+          )(implicitly, appInStateOrError(AppStatus.Running))
+          _ <- loggerIO.info(
+            s"AppCreationSpec: app ${googleProject.value}/${appName.value} start result: $monitorStartResult"
+          )
+          _ = monitorStartResult.status shouldBe AppStatus.Running
+
+          _ <- IO.sleep(60 seconds)
+
+          // Delete the app
+          _ <- LeonardoApiClient.deleteApp(googleProject, appName, true)
+          _ <- IO.sleep(30 seconds)
+
+          // Verify getApp again
+          getAppResponse <- getApp
+          _ = getAppResponse.status should (be(AppStatus.Deleting) or be(AppStatus.Predeleting))
+
+          // Verify the app eventually becomes Deleted
+          // Don't fail the test if the deletion times out because the Galaxy pre-delete job can sporadically fail.
+          // See https://broadworkbench.atlassian.net/browse/IA-2471
+          listApps = LeonardoApiClient.listApps(googleProject, true)
+          implicit0(doneCheckable: DoneCheckable[List[ListAppResponse]]) = appDeleted(appName)
+          monitorDeleteResult <- streamFUntilDone(listApps, 200, 10 seconds).compile.lastOrError
+          // TODO remove first case in below if statement when Galaxy deletion is reliable
+          _ <-
+            if (!doneCheckable.isDone(monitorDeleteResult)) {
+              loggerIO.warn(
+                s"AppCreationSpec: app ${googleProject.value}/${appName.value} did not finish deleting after 30 minutes. Result: $monitorDeleteResult"
+              )
+            } else {
+              // verify disk is also deleted
+              for {
+                _ <- loggerIO.info(
+                  s"AppCreationSpec: app ${googleProject.value}/${appName.value} delete result: $monitorDeleteResult"
+                )
+                getDiskResp <- LeonardoApiClient.getDisk(googleProject, diskName).attempt
+              } yield getDiskResp.toOption shouldBe None
+            }
+        } yield ()
+      }
+    }
+  }
 
 }

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/AppLifecycleSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/AppLifecycleSpec.scala
@@ -50,64 +50,62 @@ class AppLifecycleSpec
     ("create and delete a CUSTOM app", customCreateAppRequest)
   )
 
-  // TODO: enable once Galaxy supports newer version of GKE: https://broadworkbench.atlassian.net/browse/PROD-698
+  forAll(appTestCases) { (description, createAppRequest) =>
+    description taggedAs Retryable in { _ =>
+      withNewProject { googleProject =>
+        val appName = randomAppName
 
-//  forAll(appTestCases) { (description, createAppRequest) =>
-//    description taggedAs Retryable in { _ =>
-//      withNewProject { googleProject =>
-//        val appName = randomAppName
-//
-//        LeonardoApiClient.client.use { implicit client =>
-//          for {
-//            _ <- loggerIO.info(s"AppLifecycleSpec: About to create app ${googleProject.value}/${appName.value}")
-//
-//            // Create the app
-//            _ <- LeonardoApiClient.createApp(googleProject, appName, createAppRequest)
-//
-//            // Verify the initial getApp call
-//            getApp = LeonardoApiClient.getApp(googleProject, appName)
-//            getAppResponse <- getApp
-//            _ = getAppResponse.status should (be(AppStatus.Provisioning) or be(AppStatus.Precreating))
-//
-//            // Verify the app eventually becomes Running
-//            _ <- IO.sleep(60 seconds)
-//            monitorCreateResult <- streamUntilDoneOrTimeout(
-//              getApp,
-//              120,
-//              10 seconds,
-//              s"AppLifecycleSpec: app ${googleProject.value}/${appName.value} did not finish creating after 20 minutes"
-//            )(implicitly, appInStateOrError(AppStatus.Running))
-//            _ <- loggerIO.info(
-//              s"AppLifecycleSpec: app ${googleProject.value}/${appName.value} monitor result: ${monitorCreateResult}"
-//            )
-//            _ = monitorCreateResult.status shouldBe AppStatus.Running
-//
-//            _ <- IO.sleep(1 minute)
-//
-//            // Delete the app
-//            _ <- LeonardoApiClient.deleteApp(googleProject, appName)
-//
-//            // Verify getApp again
-//            getAppResponse <- getApp
-//            _ = getAppResponse.status should (be(AppStatus.Deleting) or be(AppStatus.Predeleting))
-//
-//            // Verify the app eventually becomes Deleted
-//            listApps = LeonardoApiClient.listApps(googleProject, true)
-//            implicit0(deletedDoneCheckable: DoneCheckable[List[ListAppResponse]]) = appDeleted(appName)
-//            monitorDeleteResult <- streamFUntilDone(
-//              listApps,
-//              120,
-//              10 seconds
-//            ).compile.lastOrError
-//
-//            _ <- loggerIO.info(
-//              s"AppLifecycleSpec: app ${googleProject.value}/${appName.value} delete result: $monitorDeleteResult"
-//            )
-//
-//            _ = monitorDeleteResult.map(_.status) shouldBe List(AppStatus.Deleted)
-//          } yield ()
-//        }
-//      }
-//    }
-  // }
+        LeonardoApiClient.client.use { implicit client =>
+          for {
+            _ <- loggerIO.info(s"AppLifecycleSpec: About to create app ${googleProject.value}/${appName.value}")
+
+            // Create the app
+            _ <- LeonardoApiClient.createApp(googleProject, appName, createAppRequest)
+
+            // Verify the initial getApp call
+            getApp = LeonardoApiClient.getApp(googleProject, appName)
+            getAppResponse <- getApp
+            _ = getAppResponse.status should (be(AppStatus.Provisioning) or be(AppStatus.Precreating))
+
+            // Verify the app eventually becomes Running
+            _ <- IO.sleep(60 seconds)
+            monitorCreateResult <- streamUntilDoneOrTimeout(
+              getApp,
+              120,
+              10 seconds,
+              s"AppLifecycleSpec: app ${googleProject.value}/${appName.value} did not finish creating after 20 minutes"
+            )(implicitly, appInStateOrError(AppStatus.Running))
+            _ <- loggerIO.info(
+              s"AppLifecycleSpec: app ${googleProject.value}/${appName.value} monitor result: ${monitorCreateResult}"
+            )
+            _ = monitorCreateResult.status shouldBe AppStatus.Running
+
+            _ <- IO.sleep(1 minute)
+
+            // Delete the app
+            _ <- LeonardoApiClient.deleteApp(googleProject, appName)
+
+            // Verify getApp again
+            getAppResponse <- getApp
+            _ = getAppResponse.status should (be(AppStatus.Deleting) or be(AppStatus.Predeleting))
+
+            // Verify the app eventually becomes Deleted
+            listApps = LeonardoApiClient.listApps(googleProject, true)
+            implicit0(deletedDoneCheckable: DoneCheckable[List[ListAppResponse]]) = appDeleted(appName)
+            monitorDeleteResult <- streamFUntilDone(
+              listApps,
+              120,
+              10 seconds
+            ).compile.lastOrError
+
+            _ <- loggerIO.info(
+              s"AppLifecycleSpec: app ${googleProject.value}/${appName.value} delete result: $monitorDeleteResult"
+            )
+
+            _ = monitorDeleteResult.map(_.status) shouldBe List(AppStatus.Deleted)
+          } yield ()
+        }
+      }
+    }
+  }
 }

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -414,7 +414,7 @@ gke {
                           "69.173.112.0/21"
     ]
     # See https://cloud.google.com/kubernetes-engine/docs/release-notes
-    version = "1.19.16"
+    version = "1.21"
     nodepoolLockCacheExpiryTime = 1 hour
     nodepoolLockCacheMaxSize = 200
   }

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -452,8 +452,8 @@ gke {
     releaseNameSuffix = "gxy-rls"
     chartName = "/leonardo/galaxykubeman"
     # If you change this here, be sure to update it in the dockerfile
-    # This is galaxykubeman 1.2.2, which references Galaxy 21.09
-    chartVersion = "1.2.2"
+    # This is galaxykubeman 1.6.0, which references Galaxy 21.09
+    chartVersion = "1.6.0"
     namespaceNameSuffix = "gxy-ns"
     serviceAccountName = "gxy-ksa"
     # Setting uninstallKeepHistory will cause the `helm uninstall` command to keep a record of

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/KubernetesTestData.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/KubernetesTestData.scala
@@ -37,7 +37,7 @@ object KubernetesTestData {
   val galaxyApp = AppType.Galaxy
 
   val galaxyChartName = ChartName("/leonardo/galaxykubeman")
-  val galaxyChartVersion = ChartVersion("1.2.2")
+  val galaxyChartVersion = ChartVersion("1.6.0")
   val galaxyChart = Chart(galaxyChartName, galaxyChartVersion)
 
   val galaxyReleasePrefix = "gxy-release"

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/config/ConfigSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/config/ConfigSpec.scala
@@ -81,7 +81,7 @@ final class ConfigSpec extends AnyFlatSpec with Matchers {
         "69.173.127.240/28",
         "69.173.112.0/21"
       ).map(CidrIP),
-      KubernetesClusterVersion("1.19.16"),
+      KubernetesClusterVersion("1.21"),
       1 hour,
       200
     )


### PR DESCRIPTION
Update the GalaxkKubeMan chart to 1.6.0, which replaces use of CVMFS in favor of S3FS for Galaxy's reference data. This implementation has been tested (and working) on K8s up to 1.21.

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
