### PR TITLE
IA-3581 udpate to latest wb-libs

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoApiClient.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoApiClient.scala
@@ -65,7 +65,7 @@ object LeonardoApiClient {
     None
   )
 
-  val defaultCreateRuntime2Request = CreateRuntime2Request(
+  val defaultCreateRuntime2Request = CreateRuntimeRequest(
     Map("foo" -> UUID.randomUUID().toString),
     None,
     None,
@@ -80,7 +80,7 @@ object LeonardoApiClient {
     Map.empty
   )
 
-  val defaultCreateDataprocRuntimeRequest = CreateRuntime2Request(
+  val defaultCreateDataprocRuntimeRequest = CreateRuntimeRequest(
     Map("foo" -> UUID.randomUUID().toString),
     None,
     None,
@@ -136,7 +136,7 @@ object LeonardoApiClient {
   def createRuntime(
     googleProject: GoogleProject,
     runtimeName: RuntimeName,
-    createRuntime2Request: CreateRuntime2Request = defaultCreateRuntime2Request
+    createRuntime2Request: CreateRuntimeRequest = defaultCreateRuntime2Request
   )(implicit client: Client[IO], authorization: IO[Authorization]): IO[Unit] =
     for {
       traceIdHeader <- genTraceIdHeader()
@@ -164,7 +164,7 @@ object LeonardoApiClient {
   def createRuntimeWithWait(
     googleProject: GoogleProject,
     runtimeName: RuntimeName,
-    createRuntime2Request: CreateRuntime2Request
+    createRuntime2Request: CreateRuntimeRequest
   )(implicit client: Client[IO], authorization: IO[Authorization]): IO[GetRuntimeResponseCopy] =
     for {
       _ <- createRuntime(googleProject, runtimeName, createRuntime2Request)

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
@@ -18,7 +18,7 @@ import org.broadinstitute.dsde.workbench.google2.{
   RegionName
 }
 import org.broadinstitute.dsde.workbench.leonardo.ClusterStatus.{deletableStatuses, ClusterStatus}
-import org.broadinstitute.dsde.workbench.leonardo.http.{CreateRuntime2Request, GetAppResponse, ListAppResponse}
+import org.broadinstitute.dsde.workbench.leonardo.http.{CreateRuntimeRequest, GetAppResponse, ListAppResponse}
 import org.broadinstitute.dsde.workbench.leonardo.notebooks.Notebook
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
 import org.broadinstitute.dsde.workbench.model.google._
@@ -293,7 +293,7 @@ trait LeonardoTestUtils
 
   def createRuntime(googleProject: GoogleProject,
                     runtimeName: RuntimeName,
-                    runtimeRequest: CreateRuntime2Request,
+                    runtimeRequest: CreateRuntimeRequest,
                     monitor: Boolean,
                     shouldError: Boolean = true
   )(implicit token: IO[Authorization]): GetRuntimeResponseCopy = {
@@ -323,7 +323,7 @@ trait LeonardoTestUtils
   def monitorCreateRuntime(
     googleProject: GoogleProject,
     runtimeName: RuntimeName,
-    runtimeRequest: CreateRuntime2Request
+    runtimeRequest: CreateRuntimeRequest
   )(implicit token: AuthToken): GetRuntimeResponseCopy = {
     // wait for "Running", "Stopped", or error (fail fast)
     val expectedStatuses =
@@ -450,7 +450,7 @@ trait LeonardoTestUtils
 
   def createNewRuntime(googleProject: GoogleProject,
                        name: RuntimeName = randomClusterName,
-                       request: CreateRuntime2Request = LeonardoApiClient.defaultCreateRuntime2Request,
+                       request: CreateRuntimeRequest = LeonardoApiClient.defaultCreateRuntime2Request,
                        monitor: Boolean = true
   )(implicit token: IO[Authorization]): ClusterCopy = {
 
@@ -490,7 +490,7 @@ trait LeonardoTestUtils
   def withNewRuntime[T](
     googleProject: GoogleProject,
     name: RuntimeName = randomClusterName,
-    request: CreateRuntime2Request = LeonardoApiClient.defaultCreateRuntime2Request,
+    request: CreateRuntimeRequest = LeonardoApiClient.defaultCreateRuntime2Request,
     monitorCreate: Boolean = true,
     monitorDelete: Boolean = false,
     deleteRuntimeAfter: Boolean = true

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/RuntimeFixtureSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/RuntimeFixtureSpec.scala
@@ -9,7 +9,7 @@ import cats.effect.IO
 import cats.effect.unsafe.implicits.global
 import org.broadinstitute.dsde.workbench.google2.{MachineTypeName, ZoneName}
 import org.broadinstitute.dsde.workbench.leonardo.TestUser.{getAuthTokenAndAuthorization, Ron}
-import org.broadinstitute.dsde.workbench.leonardo.http.{CreateRuntime2Request, RuntimeConfigRequest}
+import org.broadinstitute.dsde.workbench.leonardo.http.{CreateRuntimeRequest, RuntimeConfigRequest}
 import org.http4s.client.Client
 import org.scalatest.freespec.FixtureAnyFreeSpec
 
@@ -153,7 +153,7 @@ object RuntimeFixtureSpec {
   def getRuntimeRequest(cloudService: CloudService,
                         toolDockerImage: Option[ContainerImage],
                         welderRegistry: Option[ContainerRegistry]
-  ): CreateRuntime2Request = {
+  ): CreateRuntimeRequest = {
     val machineConfig = cloudService match {
       case CloudService.GCE =>
         RuntimeConfigRequest.GceConfig(
@@ -180,7 +180,7 @@ object RuntimeFixtureSpec {
         throw new NotImplementedError()
     }
 
-    CreateRuntime2Request(
+    CreateRuntimeRequest(
       runtimeConfig = Some(machineConfig),
       toolDockerImage = toolDockerImage,
       autopause = Some(false),

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/runtimeRoutesModels.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/runtimeRoutesModels.scala
@@ -3,11 +3,11 @@ package http
 
 import org.broadinstitute.dsde.workbench.google2.{MachineTypeName, RegionName, ZoneName}
 import org.broadinstitute.dsde.workbench.leonardo.SamResourceId._
-import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
+import org.broadinstitute.dsde.workbench.model.{TraceId, WorkbenchEmail}
+
 import java.net.URL
 import java.time.Instant
 import JsonCodec._
-
 import io.circe.Encoder
 
 import scala.concurrent.duration.FiniteDuration
@@ -51,7 +51,7 @@ object RuntimeConfigRequest {
   }
 }
 
-final case class CreateRuntime2Request(
+final case class CreateRuntimeRequest(
   labels: LabelMap,
   userScriptUri: Option[UserScriptPath],
   startUserScriptUri: Option[UserScriptPath],
@@ -65,6 +65,8 @@ final case class CreateRuntime2Request(
   scopes: Set[String],
   customEnvironmentVariables: Map[String, String]
 )
+
+final case class CreateRuntimeResponse(traceId: TraceId)
 
 sealed trait UpdateRuntimeConfigRequest extends Product with Serializable {
   def cloudService: CloudService

--- a/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/RuntimeRoutesTestJsonCodec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/RuntimeRoutesTestJsonCodec.scala
@@ -86,7 +86,7 @@ object RuntimeRoutesTestJsonCodec {
       x => CreateAzureRuntimeRequest.unapply(x).get
     )
 
-  implicit val createRuntime2RequestEncoder: Encoder[CreateRuntime2Request] = Encoder.forProduct12(
+  implicit val createRuntime2RequestEncoder: Encoder[CreateRuntimeRequest] = Encoder.forProduct12(
     "labels",
     "userScriptUri",
     "startUserScriptUri",

--- a/http/src/main/resources/swagger/api-docs.yaml
+++ b/http/src/main/resources/swagger/api-docs.yaml
@@ -4,7 +4,7 @@ info:
   description: |
     Workbench notebooks service.
   # Follow semantic versioning https://semver.org/
-  version: "1.3.3"
+  version: "1.3.4"
   license:
     name: BSD
     url: http://opensource.org/licenses/BSD-3-Clause
@@ -252,6 +252,10 @@ paths:
       responses:
         "202":
           description: Runtime creation request accepted
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/requestBodies/CreateRuntimeResponse"
         "400":
           description: Bad Request
           content:
@@ -697,6 +701,10 @@ paths:
       responses:
         "202":
           description: Runtime creation request accepted
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/requestBodies/CreateRuntimeResponse"
         "400":
           description: Bad Request
           content:
@@ -3276,7 +3284,13 @@ components:
         blockSize:
           type: integer
           description: Block size of persistent disk in bytes
-
+    CreateRuntimeResponse:
+      description: response for create runtime APIs
+        type: object
+        properties:
+          traceId:
+            type: string
+            description: `traceId` that's useful for debugging.
     CreateAppRequest:
       description: the configuration of an app, used to create an app
       type: object

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeService.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeService.scala
@@ -23,8 +23,8 @@ trait RuntimeService[F[_]] {
   def createRuntime(userInfo: UserInfo,
                     cloudContext: CloudContext,
                     runtimeName: RuntimeName,
-                    req: CreateRuntime2Request
-  )(implicit as: Ask[F, AppContext]): F[Unit]
+                    req: CreateRuntimeRequest
+  )(implicit as: Ask[F, AppContext]): F[CreateRuntimeResponse]
 
   def getRuntime(userInfo: UserInfo, cloudContext: CloudContext, runtimeName: RuntimeName)(implicit
     as: Ask[F, AppContext]

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterp.scala
@@ -68,8 +68,8 @@ class RuntimeServiceInterp[F[_]: Parallel](config: RuntimeServiceConfig,
     userInfo: UserInfo,
     cloudContext: CloudContext,
     runtimeName: RuntimeName,
-    req: CreateRuntime2Request
-  )(implicit as: Ask[F, AppContext]): F[Unit] =
+    req: CreateRuntimeRequest
+  )(implicit as: Ask[F, AppContext]): F[CreateRuntimeResponse] =
     for {
       context <- as.ask
       googleProject <- F.fromOption(
@@ -206,7 +206,7 @@ class RuntimeServiceInterp[F[_]: Parallel](config: RuntimeServiceConfig,
             )
           } yield ()
       }
-    } yield ()
+    } yield CreateRuntimeResponse(context.traceId)
 
   override def getRuntime(userInfo: UserInfo, cloudContext: CloudContext, runtimeName: RuntimeName)(implicit
     as: Ask[F, AppContext]
@@ -847,7 +847,7 @@ object RuntimeServiceInterp {
                                         clusterInternalId: RuntimeSamResourceId,
                                         clusterImages: Set[RuntimeImage],
                                         config: RuntimeServiceConfig,
-                                        req: CreateRuntime2Request,
+                                        req: CreateRuntimeRequest,
                                         now: Instant
   ): Runtime = {
     // create a LabelMap of default labels

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeV2Service.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeV2Service.scala
@@ -14,7 +14,7 @@ trait RuntimeV2Service[F[_]] {
                     req: CreateAzureRuntimeRequest
   )(implicit
     as: Ask[F, AppContext]
-  ): F[Unit]
+  ): F[CreateRuntimeResponse]
 
   def getRuntime(userInfo: UserInfo, runtimeName: RuntimeName, workspaceId: WorkspaceId)(implicit
     as: Ask[F, AppContext]

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeV2ServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeV2ServiceInterp.scala
@@ -46,7 +46,7 @@ class RuntimeV2ServiceInterp[F[_]: Parallel](config: RuntimeServiceConfig,
                              runtimeName: RuntimeName,
                              workspaceId: WorkspaceId,
                              req: CreateAzureRuntimeRequest
-  )(implicit as: Ask[F, AppContext]): F[Unit] =
+  )(implicit as: Ask[F, AppContext]): F[CreateRuntimeResponse] =
     for {
       ctx <- as.ask
 
@@ -129,7 +129,7 @@ class RuntimeV2ServiceInterp[F[_]: Parallel](config: RuntimeServiceConfig,
           } yield ()
       }
 
-    } yield ()
+    } yield CreateRuntimeResponse(ctx.traceId)
 
   override def getRuntime(userInfo: UserInfo, runtimeName: RuntimeName, workspaceId: WorkspaceId)(implicit
     as: Ask[F, AppContext]

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/CommonTestData.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/CommonTestData.scala
@@ -50,7 +50,7 @@ import org.broadinstitute.dsde.workbench.leonardo.db.ClusterRecord
 import org.broadinstitute.dsde.workbench.leonardo.http.{
   userScriptStartupOutputUriMetadataKey,
   ConfigReader,
-  CreateRuntime2Request,
+  CreateRuntimeRequest,
   RuntimeConfigRequest
 }
 import org.broadinstitute.dsde.workbench.model._
@@ -244,7 +244,7 @@ object CommonTestData {
                                  true
     )
 
-  val defaultCreateRuntimeRequest = CreateRuntime2Request(
+  val defaultCreateRuntimeRequest = CreateRuntimeRequest(
     Map("lbl1" -> "true"),
     None,
     Some(UserScriptPath.Gcs(GcsPath(GcsBucketName("bucket"), GcsObjectName("script.sh")))),

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/RuntimeRoutesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/RuntimeRoutesSpec.scala
@@ -161,7 +161,7 @@ class RuntimeRoutesSpec extends AnyFlatSpec with Matchers with LeonardoTestSuite
 
     val decodeResult = for {
       json <- io.circe.parser.parse(inputJson)
-      r <- json.as[CreateRuntime2Request]
+      r <- json.as[CreateRuntimeRequest]
     } yield r
     decodeResult shouldBe (Right(expectedClusterRequest))
   }
@@ -286,8 +286,8 @@ class RuntimeRoutesSpec extends AnyFlatSpec with Matchers with LeonardoTestSuite
         |}
           """.stripMargin
 
-    val res = decode[CreateRuntime2Request](inputString)
-    val expected = CreateRuntime2Request(
+    val res = decode[CreateRuntimeRequest](inputString)
+    val expected = CreateRuntimeRequest(
       Map.empty,
       None,
       None,
@@ -610,7 +610,7 @@ class RuntimeRoutesSpec extends AnyFlatSpec with Matchers with LeonardoTestSuite
       """
         |{}
         |""".stripMargin
-    val expectedResult = CreateRuntime2Request(
+    val expectedResult = CreateRuntimeRequest(
       Map.empty,
       None,
       None,
@@ -624,7 +624,7 @@ class RuntimeRoutesSpec extends AnyFlatSpec with Matchers with LeonardoTestSuite
       Set.empty,
       Map.empty
     )
-    decode[CreateRuntime2Request](jsonString) shouldBe Right(expectedResult)
+    decode[CreateRuntimeRequest](jsonString) shouldBe Right(expectedResult)
   }
 
   it should "decode CreateRuntime2Request correctly" in {
@@ -639,7 +639,7 @@ class RuntimeRoutesSpec extends AnyFlatSpec with Matchers with LeonardoTestSuite
         |  }
         |}
         |""".stripMargin
-    val expectedResult = CreateRuntime2Request(
+    val expectedResult = CreateRuntimeRequest(
       Map.empty,
       None,
       None,
@@ -660,6 +660,6 @@ class RuntimeRoutesSpec extends AnyFlatSpec with Matchers with LeonardoTestSuite
       Set.empty,
       Map.empty
     )
-    decode[CreateRuntime2Request](jsonString) shouldBe Right(expectedResult)
+    decode[CreateRuntimeRequest](jsonString) shouldBe Right(expectedResult)
   }
 }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/MockRuntimeServiceInterp.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/MockRuntimeServiceInterp.scala
@@ -4,7 +4,7 @@ package service
 
 import cats.effect.IO
 import cats.mtl.Ask
-import org.broadinstitute.dsde.workbench.model.UserInfo
+import org.broadinstitute.dsde.workbench.model.{TraceId, UserInfo}
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 
 class BaseMockRuntimeServiceInterp extends RuntimeService[IO] {
@@ -12,9 +12,9 @@ class BaseMockRuntimeServiceInterp extends RuntimeService[IO] {
     userInfo: UserInfo,
     cloudContext: CloudContext,
     runtimeName: RuntimeName,
-    req: CreateRuntime2Request
-  )(implicit as: Ask[IO, AppContext]): IO[Unit] =
-    IO.unit
+    req: CreateRuntimeRequest
+  )(implicit as: Ask[IO, AppContext]): IO[CreateRuntimeResponse] =
+    IO.pure(CreateRuntimeResponse(TraceId("fakeTraceId")))
 
   override def getRuntime(userInfo: UserInfo, cloudContext: CloudContext, runtimeName: RuntimeName)(implicit
     as: Ask[IO, AppContext]

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/MockRuntimeV2Interp.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/MockRuntimeV2Interp.scala
@@ -14,7 +14,9 @@ class MockRuntimeV2Interp extends RuntimeV2Service[IO] {
                              runtimeName: RuntimeName,
                              workspaceId: WorkspaceId,
                              req: CreateAzureRuntimeRequest
-  )(implicit as: Ask[IO, AppContext]): IO[Unit] = IO.unit
+  )(implicit as: Ask[IO, AppContext]): IO[CreateRuntimeResponse] = for {
+    ctx <- as.ask[AppContext]
+  } yield CreateRuntimeResponse(ctx.traceId)
 
   override def getRuntime(userInfo: UserInfo, runtimeName: RuntimeName, workspaceId: WorkspaceId)(implicit
     as: Ask[IO, AppContext]

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterpSpec.scala
@@ -75,7 +75,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
       publisherQueue
     )
   val runtimeService = makeRuntimeService(publisherQueue)
-  val emptyCreateRuntimeReq = CreateRuntime2Request(
+  val emptyCreateRuntimeReq = CreateRuntimeRequest(
     Map.empty,
     None,
     None,

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterpSpec.scala
@@ -203,7 +203,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
       gceRuntimeConfig = runtimeConfig.asInstanceOf[RuntimeConfig.GceConfig]
       gceRuntimeConfigRequest = LeoLenses.runtimeConfigPrism.getOption(gceRuntimeConfig).get
     } yield {
-      r shouldBe Right(())
+      r shouldBe Right(CreateRuntimeResponse(context.traceId))
       runtimeConfig shouldBe (Config.gceConfig.runtimeConfigDefaults)
       cluster.cloudContext shouldBe cloudContext
       cluster.runtimeName shouldBe runtimeName
@@ -262,7 +262,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
         )
         .attempt
       _ <- publisherQueue.take // dequeue the message so that it doesn't affect other tests
-    } yield r shouldBe Right(())
+    } yield r.isRight shouldBe true
     res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
@@ -291,7 +291,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
       runtime <- clusterQuery.getActiveClusterByNameMinimal(cloudContext, runtimeName).transaction
       _ <- publisherQueue.take // dequeue the message so that it doesn't affect other tests
     } yield {
-      r shouldBe Right(())
+      r.isRight shouldBe true
       runtime.get.runtimeImages.map(_.imageType) contains (RuntimeImageType.RStudio)
     }
     res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
@@ -503,17 +503,17 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
       welder3 = runtime2Images.filter(_.imageType == RuntimeImageType.Welder).headOption
       _ <- publisherQueue.take
     } yield {
-      r1 shouldBe Right(())
+      r1.isRight shouldBe true
       runtime1.runtimeName shouldBe runtimeName1
       welder1 shouldBe defined
       welder1.get.imageUrl shouldBe Config.imageConfig.welderDockerHubImage.imageUrl
 
-      r2 shouldBe Right(())
+      r2.isRight shouldBe true
       runtime2.runtimeName shouldBe runtimeName2
       welder2 shouldBe defined
       welder2.get.imageUrl shouldBe Config.imageConfig.welderGcrImage.imageUrl
 
-      r3 shouldBe Right(())
+      r3.isRight shouldBe true
       runtime3.runtimeName shouldBe runtimeName3
       welder3 shouldBe defined
       welder3.get.imageUrl shouldBe Config.imageConfig.welderGcrImage.imageUrl
@@ -565,11 +565,11 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
       _ <- publisherQueue.take
     } yield {
       // Crypto detector not supported on DockerHub
-      r1 shouldBe Right(())
+      r1.isRight shouldBe true
       runtime1.runtimeName shouldBe runtimeName1
       runtime1Images.map(_.imageType) should contain theSameElementsAs Set(Jupyter, Welder, RuntimeImageType.Proxy)
 
-      r2 shouldBe Right(())
+      r2.isRight shouldBe true
       runtime2.runtimeName shouldBe runtimeName2
       runtime2Images.map(_.imageType) should contain theSameElementsAs Set(Jupyter,
                                                                            Welder,
@@ -626,7 +626,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
       runtimeConfigRequest = LeoLenses.runtimeConfigPrism.getOption(runtimeConfig).get
       message <- publisherQueue.take
     } yield {
-      r shouldBe Right(())
+      r shouldBe Right(CreateRuntimeResponse(context.traceId))
       runtime.cloudContext shouldBe cloudContext
       runtime.runtimeName shouldBe name0
       runtimeConfig.asInstanceOf[RuntimeConfig.GceWithPdConfig].persistentDiskId shouldBe Some(disk.id)
@@ -731,7 +731,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
         .transaction
       message <- publisherQueue.take
     } yield {
-      r shouldBe Right(())
+      r.isRight shouldBe true
       runtime.cloudContext shouldBe cloudContext
       runtime.runtimeName shouldBe name0
       runtimeConfig.asInstanceOf[RuntimeConfig.GceConfig].gpuConfig shouldBe gpuConfig

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceV2InterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceV2InterpSpec.scala
@@ -109,7 +109,7 @@ class RuntimeServiceV2InterpSpec extends AnyFlatSpec with LeonardoTestSuite with
       diskOpt <- persistentDiskQuery.getById(azureRuntimeConfig.persistentDiskId).transaction
       disk = diskOpt.get
     } yield {
-      r shouldBe Right(())
+      r shouldBe Right(CreateRuntimeResponse(context.traceId))
       cluster.cloudContext shouldBe cloudContext
       cluster.runtimeName shouldBe runtimeName
       cluster.status shouldBe RuntimeStatus.PreCreating

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -15,7 +15,7 @@ object Dependencies {
   val monocleV = "2.1.0"
   val opencensusV = "0.29.0"
 
-  private val workbenchLibsHash = "3159fd9"
+  private val workbenchLibsHash = "f2c1b5d"
   val serviceTestV = s"2.0-$workbenchLibsHash"
   val workbenchModelV = s"0.15-$workbenchLibsHash"
   val workbenchGoogleV = s"0.21-$workbenchLibsHash"

--- a/project/Merging.scala
+++ b/project/Merging.scala
@@ -12,6 +12,8 @@ object Merging {
     case x if x.endsWith("io.netty.versions.properties") => MergeStrategy.first
     case x if x.endsWith("/ModuleUtil.class")            => MergeStrategy.first
     case x if x.endsWith("/module-info.class")           => MergeStrategy.discard
+    case x if x.contains("bouncycastle") =>
+      MergeStrategy.first
     case "module-info.class" =>
       MergeStrategy.discard // JDK 8 does not use the file module-info.class so it is safe to discard the file.
     case "reference.conf" => MergeStrategy.concat


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-3581

1. update wb-libs to latest version
2. rename `CreateRuntimeRequest2` to `CreateRuntimeRequest` since we've deleted old deprecated that motivated us to add `2` in the naming
3. add `traceId` in createRuntime api response

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
