### PR TITLE
IA-3509 add notnull constraint for cloudContext for KUBERNETES_CLUSTER 

### DIFF
--- a/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changelog.xml
+++ b/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changelog.xml
@@ -89,4 +89,5 @@
     <include file="changesets/20220628_add_non_null_for_cloud_context.xml" relativeToChangelogFile="true" />
     <include file="changesets/20220626_add_disk_source.xml" relativeToChangelogFile="true" />
     <include file="changesets/20220726_support_azure_for_app.xml" relativeToChangelogFile="true" />
+    <include file="changesets/20220804_add_non_null_for_cloud_context_app.xml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/20220804_add_non_null_for_cloud_context_app.xml
+++ b/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/20220804_add_non_null_for_cloud_context_app.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog logicalFilePath="leonardo" xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+
+    <changeSet logicalFilePath="leonardo" author="qi" id="add_non_null_for_cloud_context_app">
+        <addNotNullConstraint columnDataType="varchar(254)"
+                              columnName="cloudContext"
+                              constraintName="non_nullabel_cloudContext_app"
+                              defaultNullValue="This is wrong"
+                              tableName="KUBERNETES_CLUSTER"/>
+    </changeSet>
+</databaseChangeLog>


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-3509

`cloudContext` field shouldn't be nullable. Add the DB constraint properly

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
