### PR TITLE
[IA-2684] Adding RMD file syncing test

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookGCEDataSyncingSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookGCEDataSyncingSpec.scala
@@ -47,10 +47,11 @@ class NotebookGCEDataSyncingSpec extends RuntimeFixtureSpec with NotebookTestUti
               notebookPage.addCodeAndExecute("1+1")
               notebookPage.saveNotebook()
 
-              val localContent: NotebookContentItem = Notebook.getNotebookItem(runtimeFixture.runtime.googleProject,
-                                                                               runtimeFixture.runtime.clusterName,
-                                                                               Welder.getLocalPath(gcsPath, isEditMode, isRStudio)
-              )
+              val localContent: NotebookContentItem =
+                Notebook.getNotebookItem(runtimeFixture.runtime.googleProject,
+                                         runtimeFixture.runtime.clusterName,
+                                         Welder.getLocalPath(gcsPath, isEditMode, isRStudio)
+                )
               logger.info(s"[edit mode] local content is ${localContent}")
               val localContentSize: Int = localContent.size
 

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookTestUtils.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookTestUtils.scala
@@ -185,7 +185,12 @@ trait NotebookTestUtils extends LeonardoTestUtils {
   }
 
   // initializes storageLinks/ and localizes the file to the passed gcsPath
-  def withWelderInitialized[T](cluster: ClusterCopy, gcsPath: GcsPath, pattern: String, shouldLocalizeFileInEditMode: Boolean, isRStudio: Boolean)(
+  def withWelderInitialized[T](cluster: ClusterCopy,
+                               gcsPath: GcsPath,
+                               pattern: String,
+                               shouldLocalizeFileInEditMode: Boolean,
+                               isRStudio: Boolean
+  )(
     testCode: File => T
   )(implicit token: AuthToken): T = {
     Welder.postStorageLink(cluster, gcsPath, pattern, isRStudio)

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookTestUtils.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookTestUtils.scala
@@ -185,13 +185,13 @@ trait NotebookTestUtils extends LeonardoTestUtils {
   }
 
   // initializes storageLinks/ and localizes the file to the passed gcsPath
-  def withWelderInitialized[T](cluster: ClusterCopy, gcsPath: GcsPath, shouldLocalizeFileInEditMode: Boolean)(
+  def withWelderInitialized[T](cluster: ClusterCopy, gcsPath: GcsPath, pattern: String, shouldLocalizeFileInEditMode: Boolean, isRStudio: Boolean)(
     testCode: File => T
   )(implicit token: AuthToken): T = {
-    Welder.postStorageLink(cluster, gcsPath)
-    Welder.localize(cluster, gcsPath, shouldLocalizeFileInEditMode)
+    Welder.postStorageLink(cluster, gcsPath, pattern, isRStudio)
+    Welder.localize(cluster, gcsPath, shouldLocalizeFileInEditMode, isRStudio)
 
-    val localPath: String = Welder.getLocalPath(gcsPath, shouldLocalizeFileInEditMode)
+    val localPath: String = Welder.getLocalPath(gcsPath, shouldLocalizeFileInEditMode, isRStudio)
     val localFile: File = new File(localPath)
 
     logger.info("Initialized welder via /storageLinks and /localize")

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/Welder.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/Welder.scala
@@ -46,27 +46,28 @@ object Welder extends RestClient with LazyLogging {
     } yield body
   }
 
-  //The patterns for R/Rmd and Python are below:
-  //.+(\\.R|\\.Rmd)$
-  //.*.ipynb
-  def postStorageLink(cluster: ClusterCopy, cloudStoragePath: GcsPath, pattern: String, isRStudio: Boolean)(implicit token: AuthToken): String = {
+  def postStorageLink(cluster: ClusterCopy, cloudStoragePath: GcsPath, pattern: String, isRStudio: Boolean)(implicit
+    token: AuthToken
+  ): String = {
     val path = welderBasePath(cluster.googleProject, cluster.clusterName) + "/storageLinks"
     val referer = Referer(Uri(refererUrl))
 
     val payload = isRStudio match {
-      case true => Map(
-        "localBaseDirectory" -> "",
-        "localSafeModeBaseDirectory" -> "",
-        "cloudStorageDirectory" -> s"gs://${cloudStoragePath.bucketName.value}",
-        "pattern" -> s"${pattern}"
-      )
+      case true =>
+        Map(
+          "localBaseDirectory" -> "",
+          "localSafeModeBaseDirectory" -> "",
+          "cloudStorageDirectory" -> s"gs://${cloudStoragePath.bucketName.value}",
+          "pattern" -> s"${pattern}"
+        )
 
-      case false =>  Map(
-        "localBaseDirectory" -> localBaseDirectory,
-        "localSafeModeBaseDirectory" -> localSafeModeBaseDirectory,
-        "cloudStorageDirectory" -> s"gs://${cloudStoragePath.bucketName.value}",
-        "pattern" -> s"${pattern}"
-      )
+      case false =>
+        Map(
+          "localBaseDirectory" -> localBaseDirectory,
+          "localSafeModeBaseDirectory" -> localSafeModeBaseDirectory,
+          "cloudStorageDirectory" -> s"gs://${cloudStoragePath.bucketName.value}",
+          "pattern" -> s"${pattern}"
+        )
     }
 
     val cookie = Cookie(HttpCookiePair("LeoToken", token.value))
@@ -117,17 +118,16 @@ object Welder extends RestClient with LazyLogging {
   def parseMetadataResponse(response: String): Metadata =
     mapper.readValue(response, classOf[Metadata])
 
-  def getLocalPath(cloudStoragePath: GcsPath,  isEditMode: Boolean, isRStudio: Boolean): String =
+  def getLocalPath(cloudStoragePath: GcsPath, isEditMode: Boolean, isRStudio: Boolean): String =
     (if (!isRStudio) {
-      (if (isEditMode) {
-        localBaseDirectory
-      } else {
-        localSafeModeBaseDirectory
-      }) + "/"
-    }
-    else {
-      ""
-    }) + cloudStoragePath.objectName.value
+       (if (isEditMode) {
+          localBaseDirectory
+        } else {
+          localSafeModeBaseDirectory
+        }) + "/"
+     } else {
+       ""
+     }) + cloudStoragePath.objectName.value
 }
 
 object WelderJsonCodec {

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/Welder.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/Welder.scala
@@ -46,7 +46,7 @@ object Welder extends RestClient with LazyLogging {
     } yield body
   }
 
-  //use whatever pattern we are using in the UI
+  //The patterns for R/Rmd and Python are below:
   //.+(\\.R|\\.Rmd)$
   //.*.ipynb
   def postStorageLink(cluster: ClusterCopy, cloudStoragePath: GcsPath, pattern: String, isRStudio: Boolean)(implicit token: AuthToken): String = {

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/rstudio/RStudioDataSyncingSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/rstudio/RStudioDataSyncingSpec.scala
@@ -26,7 +26,7 @@ class RStudioDataSyncingSpec extends RuntimeFixtureSpec with NotebookTestUtils w
       val resp = Welder.getWelderStatus(runtimeFixture.runtime)
       resp.attempt.unsafeRunSync().isRight shouldBe true
     }
-    
+
     "test Rmd file syncing" in { runtimeFixture =>
       val sampleNotebook = ResourceFile("bucket-tests/gcsFile.Rmd")
       val isEditMode = false

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/rstudio/RStudioDataSyncingSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/rstudio/RStudioDataSyncingSpec.scala
@@ -3,22 +3,11 @@ package org.broadinstitute.dsde.workbench.leonardo.rstudio
 import cats.effect.unsafe.implicits.global
 import org.broadinstitute.dsde.workbench.ResourceFile
 import org.broadinstitute.dsde.workbench.auth.AuthToken
-import org.broadinstitute.dsde.workbench.dao.Google.googleStorageDAO
 import org.broadinstitute.dsde.workbench.google2.GcsBlobName
 import org.broadinstitute.dsde.workbench.leonardo._
 import org.broadinstitute.dsde.workbench.leonardo.notebooks._
-import org.broadinstitute.dsde.workbench.model.google.{GcsObjectName, GcsPath}
 import org.openqa.selenium.Keys
 import org.scalatest.DoNotDiscover
-import org.scalatest.tagobjects.Retryable
-import org.scalatest.time.{Minutes, Seconds, Span}
-
-import java.io.{ByteArrayInputStream, File}
-import java.math.BigInteger
-import java.nio.file.Files
-import java.security.MessageDigest
-import java.time.Instant
-import scala.concurrent.duration._
 
 /**
  * This spec verifies data syncing functionality, including notebook edit mode, playground mode,

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/rstudio/RStudioDataSyncingSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/rstudio/RStudioDataSyncingSpec.scala
@@ -14,7 +14,7 @@ import org.scalatest.DoNotDiscover
  * and welder localization/delocalization.
  */
 @DoNotDiscover
-class RStudioDataSyncingSpec extends RuntimeFixtureSpec with NotebookTestUtils with RStudioTestUtils{
+class RStudioDataSyncingSpec extends RuntimeFixtureSpec with NotebookTestUtils with RStudioTestUtils {
   override def enableWelder: Boolean = true
 
   override val toolDockerImage: Option[String] = Some(LeonardoConfig.Leonardo.rstudioBioconductorImage.imageUrl)
@@ -28,12 +28,12 @@ class RStudioDataSyncingSpec extends RuntimeFixtureSpec with NotebookTestUtils w
       resp.attempt.unsafeRunSync().isRight shouldBe true
     }
 
- // Create file make sure it syncs to bucket
- // Update file with out saving, wait for auto save, and verify file has update (content size changes)
+    // Create file make sure it syncs to bucket
+    // Update file with out saving, wait for auto save, and verify file has update (content size changes)
 
     "test Rmd file syncing" in { runtimeFixture =>
       val sampleNotebook = ResourceFile("bucket-tests/gcsFile.Rmd")
-      val isEditMode= false
+      val isEditMode = false
       val isRStudio = true
       withResourceFileInBucket(runtimeFixture.runtime.googleProject, sampleNotebook, "text/plain") { gcsPath =>
         withWelderInitialized(runtimeFixture.runtime, gcsPath, ".+(.R|.Rmd)$", isEditMode, isRStudio) { localizedFile =>
@@ -42,12 +42,12 @@ class RStudioDataSyncingSpec extends RuntimeFixtureSpec with NotebookTestUtils w
               rstudioPage.pressKeys("install.packages('markdown')")
               rstudioPage.pressKeys(Keys.ENTER.toString)
 
-              //Test to make sure that a file created in RStudio syncs properly
+              // Test to make sure that a file created in RStudio syncs properly
               rstudioPage.pressKeys("system(\"touch tests.Rmd\")")
               rstudioPage.pressKeys(Keys.ENTER.toString)
               await visible cssSelector("[title~='tests.Rmd']")
 
-              //Sleep is used to give time for background syncing to take place
+              // Sleep is used to give time for background syncing to take place
               Thread.sleep(30000)
 
               logger.info(s"gcsPath ${gcsPath}")
@@ -63,7 +63,6 @@ class RStudioDataSyncingSpec extends RuntimeFixtureSpec with NotebookTestUtils w
               rstudioPage.pressKeys("system(\"cat tests.Rmd\")")
               rstudioPage.pressKeys(Keys.ENTER.toString)
 
-
               Thread.sleep(30000)
 
               val newCreatedContentSize: Int =
@@ -73,13 +72,11 @@ class RStudioDataSyncingSpec extends RuntimeFixtureSpec with NotebookTestUtils w
 
               newCreatedContentSize should be > oldCreatedContentSize
 
-              //Verify that a File in a bucket can be selected, updated, and synced
+              // Verify that a File in a bucket can be selected, updated, and synced
               val oldRemoteContentSize: Int =
                 getObjectSize(gcsPath.bucketName, GcsBlobName(gcsPath.objectName.value))
                   .unsafeRunSync()
               logger.info(s"Resource File's original size is ${oldRemoteContentSize}")
-
-
 
               rstudioPage.pressKeys("system(\"echo 'teterererrdffsfsfsfafafafafafafafafaffwewew' >> gcsFile.Rmd\")")
               rstudioPage.pressKeys(Keys.ENTER.toString)
@@ -92,7 +89,7 @@ class RStudioDataSyncingSpec extends RuntimeFixtureSpec with NotebookTestUtils w
 
               newRemoteContentSize should be > oldRemoteContentSize
 
-              //Verify that a File with an incorrect extension is not picked up
+              // Verify that a File with an incorrect extension is not picked up
               rstudioPage.pressKeys("system(\"touch tested.lmd\")")
               rstudioPage.pressKeys(Keys.ENTER.toString)
               await visible cssSelector("[title~='tested.lmd']")

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/rstudio/RStudioDataSyncingSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/rstudio/RStudioDataSyncingSpec.scala
@@ -1,0 +1,131 @@
+package org.broadinstitute.dsde.workbench.leonardo.rstudio
+
+import cats.effect.unsafe.implicits.global
+import org.broadinstitute.dsde.workbench.ResourceFile
+import org.broadinstitute.dsde.workbench.auth.AuthToken
+import org.broadinstitute.dsde.workbench.dao.Google.googleStorageDAO
+import org.broadinstitute.dsde.workbench.google2.GcsBlobName
+import org.broadinstitute.dsde.workbench.leonardo._
+import org.broadinstitute.dsde.workbench.leonardo.notebooks._
+import org.broadinstitute.dsde.workbench.model.google.{GcsObjectName, GcsPath}
+import org.openqa.selenium.Keys
+import org.scalatest.DoNotDiscover
+import org.scalatest.tagobjects.Retryable
+import org.scalatest.time.{Minutes, Seconds, Span}
+
+import java.io.{ByteArrayInputStream, File}
+import java.math.BigInteger
+import java.nio.file.Files
+import java.security.MessageDigest
+import java.time.Instant
+import scala.concurrent.duration._
+
+/**
+ * This spec verifies data syncing functionality, including notebook edit mode, playground mode,
+ * and welder localization/delocalization.
+ */
+@DoNotDiscover
+class RStudioDataSyncingSpec extends RuntimeFixtureSpec with NotebookTestUtils with RStudioTestUtils{
+  override def enableWelder: Boolean = true
+
+  override val toolDockerImage: Option[String] = Some(LeonardoConfig.Leonardo.rstudioBioconductorImage.imageUrl)
+
+  implicit def ronToken: AuthToken = ronAuthToken.unsafeRunSync()
+
+  "RStudioDataSyncingSpec" - {
+
+    "Welder should be up" in { runtimeFixture =>
+      val resp = Welder.getWelderStatus(runtimeFixture.runtime)
+      resp.attempt.unsafeRunSync().isRight shouldBe true
+    }
+
+ // Create file make sure it syncs to bucket
+ // Update file with out saving, wait for auto save, and verify file has update (content size changes)
+
+    "test Rmd file syncing" in { runtimeFixture =>
+      val sampleNotebook = ResourceFile("bucket-tests/gcsFile.Rmd")
+      val isEditMode= false
+      val isRStudio = true
+      withResourceFileInBucket(runtimeFixture.runtime.googleProject, sampleNotebook, "text/plain") { gcsPath =>
+        withWelderInitialized(runtimeFixture.runtime, gcsPath, ".+(.R|.Rmd)$", isEditMode, isRStudio) { localizedFile =>
+          withWebDriver { implicit driver =>
+            withNewRStudio(runtimeFixture.runtime) { rstudioPage =>
+              rstudioPage.pressKeys("install.packages('markdown')")
+              rstudioPage.pressKeys(Keys.ENTER.toString)
+
+              //Test to make sure that a file created in RStudio syncs properly
+              rstudioPage.pressKeys("system(\"touch tests.Rmd\")")
+              rstudioPage.pressKeys(Keys.ENTER.toString)
+              await visible cssSelector("[title~='tests.Rmd']")
+
+              //Sleep is used to give time for background syncing to take place
+              Thread.sleep(30000)
+
+              logger.info(s"gcsPath ${gcsPath}")
+
+              val oldCreatedContentSize: Int =
+                getObjectSize(gcsPath.bucketName, GcsBlobName("tests.Rmd"))
+                  .unsafeRunSync()
+              logger.info(s"New Created File's original size is ${oldCreatedContentSize}")
+
+              rstudioPage.variableExists("tests.Rmd") shouldBe true
+              rstudioPage.pressKeys("system(\"echo 'teterererrdffsfsfsfafafafafafafafafaffwewew' >> tests.Rmd\")")
+              rstudioPage.pressKeys(Keys.ENTER.toString)
+              rstudioPage.pressKeys("system(\"cat tests.Rmd\")")
+              rstudioPage.pressKeys(Keys.ENTER.toString)
+
+
+              Thread.sleep(30000)
+
+              val newCreatedContentSize: Int =
+                getObjectSize(gcsPath.bucketName, GcsBlobName("tests.Rmd"))
+                  .unsafeRunSync()
+              logger.info(s"New Created File's new size is ${newCreatedContentSize}")
+
+              newCreatedContentSize should be > oldCreatedContentSize
+
+              //Verify that a File in a bucket can be selected, updated, and synced
+              val oldRemoteContentSize: Int =
+                getObjectSize(gcsPath.bucketName, GcsBlobName(gcsPath.objectName.value))
+                  .unsafeRunSync()
+              logger.info(s"Resource File's original size is ${oldRemoteContentSize}")
+
+
+
+              rstudioPage.pressKeys("system(\"echo 'teterererrdffsfsfsfafafafafafafafafaffwewew' >> gcsFile.Rmd\")")
+              rstudioPage.pressKeys(Keys.ENTER.toString)
+
+              Thread.sleep(30000)
+              val newRemoteContentSize: Int =
+                getObjectSize(gcsPath.bucketName, GcsBlobName(gcsPath.objectName.value))
+                  .unsafeRunSync()
+              logger.info(s"Resource File's new size is ${newRemoteContentSize}")
+
+              newRemoteContentSize should be > oldRemoteContentSize
+
+              //Verify that a File with an incorrect extension is not picked up
+              rstudioPage.pressKeys("system(\"touch tested.lmd\")")
+              rstudioPage.pressKeys(Keys.ENTER.toString)
+              await visible cssSelector("[title~='tested.lmd']")
+
+              Thread.sleep(30000)
+
+              rstudioPage.pressKeys("system(\"echo 'teterererrdffsfsfsfafafafafafafafafaffwewew' >> tested.lmd\")")
+              rstudioPage.pressKeys(Keys.ENTER.toString)
+
+              Thread.sleep(30000)
+
+              val incorrectFileEndingContentSize: Int =
+                getObjectSize(gcsPath.bucketName, GcsBlobName("tested.lmd"))
+                  .unsafeRunSync()
+              logger.info(s"Incorrect File's new size is ${incorrectFileEndingContentSize}")
+
+              incorrectFileEndingContentSize should be < newRemoteContentSize
+            }
+          }
+        }
+      }
+    }
+
+  }
+}

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/rstudio/RStudioDataSyncingSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/rstudio/RStudioDataSyncingSpec.scala
@@ -48,8 +48,6 @@ class RStudioDataSyncingSpec extends RuntimeFixtureSpec with NotebookTestUtils w
               await visible cssSelector("[title~='tests.Rmd']")
 
               // Sleep is used to give time for background syncing to take place
-              Thread.sleep(30000)
-
               logger.info(s"gcsPath ${gcsPath}")
 
               val oldCreatedContentSize: Int =
@@ -63,7 +61,7 @@ class RStudioDataSyncingSpec extends RuntimeFixtureSpec with NotebookTestUtils w
               rstudioPage.pressKeys("system(\"cat tests.Rmd\")")
               rstudioPage.pressKeys(Keys.ENTER.toString)
 
-              Thread.sleep(30000)
+              Thread.sleep(25000)
 
               val newCreatedContentSize: Int =
                 getObjectSize(gcsPath.bucketName, GcsBlobName("tests.Rmd"))
@@ -81,7 +79,7 @@ class RStudioDataSyncingSpec extends RuntimeFixtureSpec with NotebookTestUtils w
               rstudioPage.pressKeys("system(\"echo 'teterererrdffsfsfsfafafafafafafafafaffwewew' >> gcsFile.Rmd\")")
               rstudioPage.pressKeys(Keys.ENTER.toString)
 
-              Thread.sleep(30000)
+              Thread.sleep(25000)
               val newRemoteContentSize: Int =
                 getObjectSize(gcsPath.bucketName, GcsBlobName(gcsPath.objectName.value))
                   .unsafeRunSync()
@@ -94,12 +92,10 @@ class RStudioDataSyncingSpec extends RuntimeFixtureSpec with NotebookTestUtils w
               rstudioPage.pressKeys(Keys.ENTER.toString)
               await visible cssSelector("[title~='tested.lmd']")
 
-              Thread.sleep(30000)
-
               rstudioPage.pressKeys("system(\"echo 'teterererrdffsfsfsfafafafafafafafafaffwewew' >> tested.lmd\")")
               rstudioPage.pressKeys(Keys.ENTER.toString)
 
-              Thread.sleep(30000)
+              Thread.sleep(25000)
 
               val incorrectFileEndingContentSize: Int =
                 getObjectSize(gcsPath.bucketName, GcsBlobName("tested.lmd"))

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/rstudio/RStudioDataSyncingSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/rstudio/RStudioDataSyncingSpec.scala
@@ -10,8 +10,7 @@ import org.openqa.selenium.Keys
 import org.scalatest.DoNotDiscover
 
 /**
- * This spec verifies data syncing functionality, including notebook edit mode, playground mode,
- * and welder localization/delocalization.
+ * This spec verifies Rmd data syncing functionality with welder
  */
 @DoNotDiscover
 class RStudioDataSyncingSpec extends RuntimeFixtureSpec with NotebookTestUtils with RStudioTestUtils {
@@ -27,10 +26,7 @@ class RStudioDataSyncingSpec extends RuntimeFixtureSpec with NotebookTestUtils w
       val resp = Welder.getWelderStatus(runtimeFixture.runtime)
       resp.attempt.unsafeRunSync().isRight shouldBe true
     }
-
-    // Create file make sure it syncs to bucket
-    // Update file with out saving, wait for auto save, and verify file has update (content size changes)
-
+    
     "test Rmd file syncing" in { runtimeFixture =>
       val sampleNotebook = ResourceFile("bucket-tests/gcsFile.Rmd")
       val isEditMode = false
@@ -46,9 +42,6 @@ class RStudioDataSyncingSpec extends RuntimeFixtureSpec with NotebookTestUtils w
               rstudioPage.pressKeys("system(\"touch tests.Rmd\")")
               rstudioPage.pressKeys(Keys.ENTER.toString)
               await visible cssSelector("[title~='tests.Rmd']")
-
-              // Sleep is used to give time for background syncing to take place
-              logger.info(s"gcsPath ${gcsPath}")
 
               val oldCreatedContentSize: Int =
                 getObjectSize(gcsPath.bucketName, GcsBlobName("tests.Rmd"))

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/rstudio/RStudioTestUtils.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/rstudio/RStudioTestUtils.scala
@@ -2,9 +2,12 @@ package org.broadinstitute.dsde.workbench.leonardo.rstudio
 
 import org.broadinstitute.dsde.workbench.auth.AuthToken
 import org.broadinstitute.dsde.workbench.leonardo._
+import org.broadinstitute.dsde.workbench.leonardo.notebooks.Welder
+import org.broadinstitute.dsde.workbench.model.google.GcsPath
 import org.openqa.selenium.WebDriver
 import org.scalatest.TestSuite
 
+import java.io.File
 import scala.concurrent._
 import scala.concurrent.duration._
 

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/rstudio/RStudioTestUtils.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/rstudio/RStudioTestUtils.scala
@@ -2,12 +2,9 @@ package org.broadinstitute.dsde.workbench.leonardo.rstudio
 
 import org.broadinstitute.dsde.workbench.auth.AuthToken
 import org.broadinstitute.dsde.workbench.leonardo._
-import org.broadinstitute.dsde.workbench.leonardo.notebooks.Welder
-import org.broadinstitute.dsde.workbench.model.google.GcsPath
 import org.openqa.selenium.WebDriver
 import org.scalatest.TestSuite
 
-import java.io.File
 import scala.concurrent._
 import scala.concurrent.duration._
 


### PR DESCRIPTION
Added the RStudioDataSyncingSpec to test RMD File syncing.

Added the isRStudio variable to help with setting up Welder and Runtimes to have to do with RStudio.

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
