### PR TITLE
IA-3693 fix logging

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -57,12 +57,11 @@ object Dependencies {
   val excludeBigQuery = ExclusionRule(organization = "com.google.cloud", name = "google-cloud-bigquery")
   val excludeCloudBilling = ExclusionRule(organization = "com.google.cloud", name = "google-cloud-billing")
 
-  val logbackClassic: ModuleID =  "ch.qos.logback"              % "logback-classic" % "1.2.11"
+  val logbackClassic: ModuleID =  "ch.qos.logback"              % "logback-classic" % "1.4.0"
   val scalaLogging: ModuleID =    "com.typesafe.scala-logging"  %% "scala-logging"  % scalaLoggingV
   val ficus: ModuleID =           "com.iheart"                  %% "ficus"          % "1.5.2"
   val enumeratum: ModuleID =      "com.beachape"                %% "enumeratum"     % "1.7.0"
 
-  val akkaSlf4j: ModuleID =         "com.typesafe.akka" %% "akka-slf4j"           % akkaV
   val akkaHttp: ModuleID =          "com.typesafe.akka" %% "akka-http"            % akkaHttpV
   val akkaHttpSprayJson: ModuleID = "com.typesafe.akka" %% "akka-http-spray-json" % akkaHttpV
   val akkaStream: ModuleID = "com.typesafe.akka" %% "akka-stream" % akkaV
@@ -166,7 +165,6 @@ object Dependencies {
     scalaLogging,
     ficus,
     enumeratum,
-    akkaSlf4j,
     akkaHttp,
     akkaHttpSprayJson,
     akkaTestKit,


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-3693

https://github.com/DataBiosphere/leonardo/pull/2831 broke logging with the following error
```
SLF4J: No SLF4J providers were found.
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#noProviders for further details.
```

This is becuz slick 3.4.0 has upgraded to slf4j-api 2.0.0, while logback-classic 1.2.11 is still on slf4j-api 1.7.32.

```
➜  leonardo git:(e5bc247bf) cs resolve com.typesafe.slick::slick:3.4.0-RC3  
com.typesafe:config:1.4.2:default
com.typesafe.slick:slick_2.13:3.4.0-RC3:default
org.reactivestreams:reactive-streams:1.0.4:default
org.scala-lang:scala-library:2.13.8:default
org.scala-lang.modules:scala-collection-compat_2.13:2.8.0:default
org.slf4j:slf4j-api:1.7.36:default
➜  leonardo git:(e5bc247bf) cs resolve com.typesafe.slick::slick:3.4.0    
com.typesafe:config:1.4.2:default
com.typesafe.slick:slick_2.13:3.4.0:default
org.reactivestreams:reactive-streams:1.0.4:default
org.scala-lang:scala-library:2.13.8:default
org.scala-lang.modules:scala-collection-compat_2.13:2.8.1:default
org.slf4j:slf4j-api:2.0.0:default
```

Upgrading to logback-classic 1.4.0 fixes the issue




---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
