### PR TITLE
[IA-3620] added source control to all users

### DIFF
--- a/http/src/main/resources/init-resources/gce-init.sh
+++ b/http/src/main/resources/init-resources/gce-init.sh
@@ -472,6 +472,16 @@ if [ ! -z "$JUPYTER_DOCKER_IMAGE" ] ; then
   # For older jupyter images, jupyter_delocalize.py is using 127.0.0.1 as welder's url, which won't work now that we're no longer using `network_mode: host` for GCE VMs
   docker exec $JUPYTER_SERVER_NAME /bin/bash -c "sed -i 's/127.0.0.1/welder/g' /etc/jupyter/custom/jupyter_delocalize.py"
 
+  # Copy gitignore into jupyter container
+
+  docker exec $JUPYTER_SERVER_NAME /bin/bash -c "wget https://raw.githubusercontent.com/DataBiosphere/terra-docker/045a139dbac19fbf2b8c4080b8bc7fff7fc8b177/terra-jupyter-aou/gitignore_global"
+
+  # Install nbstripout and set gitignore in Git Config
+
+  docker exec $JUPYTER_SERVER_NAME /bin/bash -c "pip install nbstripout \
+        && nbstripout --install --global \
+        && git config --global core.excludesfile $JUPYTER_USER_HOME/gitignore_global"
+
   docker exec -u 0 $JUPYTER_SERVER_NAME /bin/bash -c "$JUPYTER_HOME/scripts/extension/install_jupyter_contrib_nbextensions.sh \
        && mkdir -p $JUPYTER_USER_HOME/.jupyter/custom/ \
        && cp $JUPYTER_HOME/custom/google_sign_in.js $JUPYTER_USER_HOME/.jupyter/custom/ \

--- a/http/src/main/resources/init-resources/init-actions.sh
+++ b/http/src/main/resources/init-resources/init-actions.sh
@@ -498,6 +498,17 @@ END
       # This is to make it so that older images will still work after we change notebooks location to home dir
       docker exec ${JUPYTER_SERVER_NAME} sed -i '/^# to mount there as it effectively deletes existing files on the image/,+5d' ${JUPYTER_HOME}/jupyter_notebook_config.py
 
+      # Copy gitignore into jupyter container
+
+      docker exec $JUPYTER_SERVER_NAME /bin/bash -c "wget https://raw.githubusercontent.com/DataBiosphere/terra-docker/045a139dbac19fbf2b8c4080b8bc7fff7fc8b177/terra-jupyter-aou/gitignore_global"
+
+      # Install nbstripout and set gitignore in Git Config
+
+      docker exec $JUPYTER_SERVER_NAME /bin/bash -c "pip install nbstripout \
+            && python -m nbstripout --install --global \
+            && git config --global core.excludesfile $JUPYTER_USER_HOME/gitignore_global"
+
+
       docker exec -u 0 $JUPYTER_SERVER_NAME /bin/bash -c "$JUPYTER_HOME/scripts/extension/install_jupyter_contrib_nbextensions.sh \
            && mkdir -p $JUPYTER_USER_HOME/.jupyter/custom/ \
            && cp $JUPYTER_HOME/custom/google_sign_in.js $JUPYTER_USER_HOME/.jupyter/custom/ \


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-3620

Added nbstripoff and gitignore global to adopt source control for all users. Currently it is used my the AOU image. The changes are added to the init scripts. 

Test steps: 

- start a terminal on Leo

- git clone [GitHub - DataBiosphere/terra-examples: Example notebooks for use in data analysis.](https://github.com/DataBiosphere/terra-examples.git)
 
- cd terra-examples/
 
- touch fake_data.csv
 
- git add fake_data.csv <--- THIS SHOULD FAIL

- in the Jupyter console, navigate to the git clone directory and open one of the notebooks such as terra_notebooks_playground/Py3\ -\ How\ to\ read\ data\ from\ Cloud\ Storage.ipynb
 
- make a small change in the notebook such as in a markdown cell and run all cells in the notebook
 
- git diff <--- YOU SHOULD SEE THE CHANGE YOU MADE, BUT YOU SHOULD NOT SEE ANY CELL OUTPUTS IN THE DIFF

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
