### PR TITLE
IA-3698 use newer listener 

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/runtimeModels.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/runtimeModels.scala
@@ -345,6 +345,7 @@ object RuntimeImageType extends Enum[RuntimeImageType] {
   case object Jupyter extends RuntimeImageType
   case object RStudio extends RuntimeImageType
   case object Welder extends RuntimeImageType
+  case object Listener extends RuntimeImageType
   // This is not strictly an image type. It can either be a custom VM image for dataproc,
   // or boot disk snapshot for GCE VMs
   case object BootSource extends RuntimeImageType

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -194,7 +194,7 @@ azure {
         minor-version-auto-upgrade = true,
         file-uris = ["https://raw.githubusercontent.com/DataBiosphere/leonardo/b9c7fc1ec10697f8d8e278188ebbf30f6d124d67/http/src/main/resources/init-resources/azure_vm_init_script.sh"]
      }
-     listener-image = "terradevacrpublic.azurecr.io/terra-azure-relay-listeners:9a6e51f"
+     listener-image = "terradevacrpublic.azurecr.io/terra-azure-relay-listeners:a9576c8"
     }
    }
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/Boot.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/Boot.scala
@@ -145,7 +145,9 @@ object Boot extends IOApp {
         AzureServiceConfig(
           // For now azure disks share same defaults as normal disks
           ConfigReader.appConfig.persistentDisk,
-          ConfigReader.appConfig.azure.pubsubHandler.runtimeDefaults.image
+          ConfigReader.appConfig.azure.pubsubHandler.runtimeDefaults.image,
+          ConfigReader.appConfig.azure.pubsubHandler.runtimeDefaults.listenerImage,
+          ConfigReader.appConfig.azure.pubsubHandler.welderImage
         )
       )
       val runtimeService = RuntimeService(

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeV2Service.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeV2Service.scala
@@ -48,7 +48,11 @@ final case class CustomScriptExtensionConfig(name: String,
                                              minorVersionAutoUpgrade: Boolean,
                                              fileUris: List[String]
 )
-final case class AzureServiceConfig(diskConfig: PersistentDiskConfig, image: AzureImage)
+final case class AzureServiceConfig(diskConfig: PersistentDiskConfig,
+                                    image: AzureImage,
+                                    listenerImage: String,
+                                    welderImage: String
+)
 final case class VMCredential(username: String, password: String)
 
 final case class AzureRuntimeDefaults(ipControlledResourceDesc: String,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeV2ServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeV2ServiceInterp.scala
@@ -100,6 +100,18 @@ class RuntimeV2ServiceInterp[F[_]: Parallel](config: RuntimeServiceConfig,
         None,
         ctx.now
       )
+      listenerImage: RuntimeImage = RuntimeImage(
+        RuntimeImageType.Listener,
+        config.azureConfig.listenerImage,
+        None,
+        ctx.now
+      )
+      welderImage: RuntimeImage = RuntimeImage(
+        RuntimeImageType.Welder,
+        config.azureConfig.welderImage,
+        None,
+        ctx.now
+      )
 
       _ <- runtimeOpt match {
         case Some(status) => F.raiseError[Unit](RuntimeAlreadyExistsException(cloudContext, runtimeName, status))
@@ -116,15 +128,16 @@ class RuntimeV2ServiceInterp[F[_]: Parallel](config: RuntimeServiceConfig,
               )
             )
 
-            runtime = convertToRuntime(workspaceId,
-                                       runtimeName,
-                                       cloudContext,
-                                       userInfo,
-                                       req,
-                                       RuntimeSamResourceId(samResource.resourceId),
-                                       Set(runtimeImage),
-                                       Set.empty,
-                                       ctx.now
+            runtime = convertToRuntime(
+              workspaceId,
+              runtimeName,
+              cloudContext,
+              userInfo,
+              req,
+              RuntimeSamResourceId(samResource.resourceId),
+              Set(runtimeImage, listenerImage, welderImage),
+              Set.empty,
+              ctx.now
             )
 
             disk <- persistentDiskQuery.save(diskToSave).transaction

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/CommonTestData.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/CommonTestData.scala
@@ -155,7 +155,9 @@ object CommonTestData {
   val azureServiceConfig = AzureServiceConfig(
     // For now azure disks share same defaults as normal disks
     ConfigReader.appConfig.persistentDisk,
-    ConfigReader.appConfig.azure.pubsubHandler.runtimeDefaults.image
+    ConfigReader.appConfig.azure.pubsubHandler.runtimeDefaults.image,
+    ConfigReader.appConfig.azure.pubsubHandler.runtimeDefaults.listenerImage,
+    ConfigReader.appConfig.azure.pubsubHandler.welderImageHash
   )
   val singleNodeDefaultMachineConfig = dataprocConfig.runtimeConfigDefaults
   val singleNodeDefaultMachineConfigRequest = RuntimeConfigRequest.DataprocConfig(

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/ConfigReaderSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/ConfigReaderSpec.scala
@@ -65,7 +65,7 @@ class ConfigReaderSpec extends AnyFlatSpec with Matchers {
                 "https://raw.githubusercontent.com/DataBiosphere/leonardo/b9c7fc1ec10697f8d8e278188ebbf30f6d124d67/http/src/main/resources/init-resources/azure_vm_init_script.sh"
               )
             ),
-            "terradevacrpublic.azurecr.io/terra-azure-relay-listeners:9a6e51f",
+            "terradevacrpublic.azurecr.io/terra-azure-relay-listeners:a9576c8",
             VMCredential(username = "username", password = "password")
           )
         ),

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceV2InterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceV2InterpSpec.scala
@@ -131,14 +131,28 @@ class RuntimeServiceV2InterpSpec extends AnyFlatSpec with LeonardoTestSuite with
       azureRuntimeConfig.region shouldBe azureRegion
       disk.name.value shouldBe defaultCreateAzureRuntimeReq.azureDiskConfig.name.value
 
-      val expectedRuntimeImage = RuntimeImage(
-        RuntimeImageType.Azure,
-        "microsoft-dsvm, ubuntu-2004, 2004-gen2, 22.04.27",
-        None,
-        context.now
+      val expectedRuntimeImage = Set(
+        RuntimeImage(
+          RuntimeImageType.Azure,
+          "microsoft-dsvm, ubuntu-2004, 2004-gen2, 22.04.27",
+          None,
+          context.now
+        ),
+        RuntimeImage(
+          RuntimeImageType.Listener,
+          ConfigReader.appConfig.azure.pubsubHandler.runtimeDefaults.listenerImage,
+          None,
+          context.now
+        ),
+        RuntimeImage(
+          RuntimeImageType.Welder,
+          ConfigReader.appConfig.azure.pubsubHandler.welderImageHash,
+          None,
+          context.now
+        )
       )
 
-      fullClusterOpt.map(_.runtimeImages) shouldBe Some(Set(expectedRuntimeImage))
+      fullClusterOpt.map(_.runtimeImages) shouldBe Some(expectedRuntimeImage)
 
       val expectedMessage = CreateAzureRuntimeMessage(
         cluster.id,


### PR DESCRIPTION
* Listener PR https://github.com/DataBiosphere/terra-azure-relay-listeners/pull/21
*  Persist listener and welder images to DB

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
