### PR TITLE
IA-3726 Front leo update for supporting start/stop Azure runtime

### DIFF
--- a/http/src/main/resources/swagger/api-docs.yaml
+++ b/http/src/main/resources/swagger/api-docs.yaml
@@ -632,6 +632,84 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorReport"
+  "/api/v2/runtimes/{workspaceId}/{name}/start":
+    post:
+      summary: Start runtime.
+      description: >
+        Returns information about an existing azure runtime managed by Leo.
+        Poll this to find out when your runtime has finished starting up.
+      operationId: startRuntimeV2
+      tags:
+        - runtimes
+      parameters:
+        - in: path
+          name: workspaceId
+          description: workspaceId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: name
+          description: runtimeName
+          required: true
+          schema:
+            type: string
+      responses:
+        "202":
+          description: Runtime start request accepted
+        "403":
+          description: User does not have permission to perform action on runtime
+        "404":
+          description: Runtime not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorReport"
+        "500":
+          description: Internal Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorReport"
+  "/api/v2/runtimes/{workspaceId}/{name}/stop":
+    post:
+      summary: Stop runtime.
+      description: >
+        Returns information about an existing azure runtime managed by Leo.
+        Poll this to find out when your runtime has finished starting up.
+      operationId: stopRuntimeV2
+      tags:
+        - runtimes
+      parameters:
+        - in: path
+          name: workspaceId
+          description: workspaceId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: name
+          description: runtimeName
+          required: true
+          schema:
+            type: string
+      responses:
+        "202":
+          description: Runtime stop request accepted
+        "403":
+          description: User does not have permission to perform action on runtime
+        "404":
+          description: Runtime not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorReport"
+        "500":
+          description: Internal Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorReport"
   "/api/v2/runtimes/{workspaceId}/azure/{name}":
     get:
       summary: Get details of an azure runtime

--- a/http/src/main/resources/swagger/api-docs.yaml
+++ b/http/src/main/resources/swagger/api-docs.yaml
@@ -636,8 +636,7 @@ paths:
     post:
       summary: Start runtime (WIP).
       description: >
-        Returns information about an existing azure runtime managed by Leo.
-        Poll this to find out when your runtime has finished starting up.
+        Start an existing Leonardo managed runtime
       operationId: startRuntimeV2
       tags:
         - runtimes
@@ -675,8 +674,7 @@ paths:
     post:
       summary: Stop runtime (WIP).
       description: >
-        Returns information about an existing azure runtime managed by Leo.
-        Poll this to find out when your runtime has finished starting up.
+        Stop an existing Leonardo managed runtime
       operationId: stopRuntimeV2
       tags:
         - runtimes

--- a/http/src/main/resources/swagger/api-docs.yaml
+++ b/http/src/main/resources/swagger/api-docs.yaml
@@ -634,7 +634,7 @@ paths:
                 $ref: "#/components/schemas/ErrorReport"
   "/api/v2/runtimes/{workspaceId}/{name}/start":
     post:
-      summary: Start runtime.
+      summary: Start runtime (WIP).
       description: >
         Returns information about an existing azure runtime managed by Leo.
         Poll this to find out when your runtime has finished starting up.
@@ -673,7 +673,7 @@ paths:
                 $ref: "#/components/schemas/ErrorReport"
   "/api/v2/runtimes/{workspaceId}/{name}/stop":
     post:
-      summary: Stop runtime.
+      summary: Stop runtime (WIP).
       description: >
         Returns information about an existing azure runtime managed by Leo.
         Poll this to find out when your runtime has finished starting up.

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/RuntimeV2Routes.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/RuntimeV2Routes.scala
@@ -67,7 +67,7 @@ class RuntimeV2Routes(saturnIframeExtentionHostConfig: RefererConfig,
                   path("stop") {
                     post {
                       complete(
-                        startRuntimeHandler(
+                        stopRuntimeHandler(
                           userInfo,
                           workspaceId,
                           runtimeName
@@ -78,7 +78,7 @@ class RuntimeV2Routes(saturnIframeExtentionHostConfig: RefererConfig,
                     path("start") {
                       post {
                         complete(
-                          stopRuntimeHandler(
+                          startRuntimeHandler(
                             userInfo,
                             workspaceId,
                             runtimeName
@@ -171,7 +171,8 @@ class RuntimeV2Routes(saturnIframeExtentionHostConfig: RefererConfig,
   ): IO[ToResponseMarshallable] =
     for {
       ctx <- ev.ask[AppContext]
-      apiCall = runtimeV2Service.getRuntime(userInfo, runtimeName, workspaceId)
+      _ = println("111 starting runtime")
+      apiCall = runtimeV2Service.startRuntime(userInfo, runtimeName, workspaceId)
       _ <- metrics.incrementCounter("startRuntimeV2")
       resp <- ctx.span.fold(apiCall)(span =>
         spanResource[IO](span, "startRuntimeV2")
@@ -184,7 +185,7 @@ class RuntimeV2Routes(saturnIframeExtentionHostConfig: RefererConfig,
   ): IO[ToResponseMarshallable] =
     for {
       ctx <- ev.ask[AppContext]
-      apiCall = runtimeV2Service.getRuntime(userInfo, runtimeName, workspaceId)
+      apiCall = runtimeV2Service.stopRuntime(userInfo, runtimeName, workspaceId)
       _ <- metrics.incrementCounter("stopRuntimeV2")
       resp <- ctx.span.fold(apiCall)(span =>
         spanResource[IO](span, "stopRuntimeV2")

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/RuntimeV2Routes.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/RuntimeV2Routes.scala
@@ -63,6 +63,29 @@ class RuntimeV2Routes(saturnIframeExtentionHostConfig: RefererConfig,
                       )
                     }
                   }
+                } ~ pathPrefix(runtimeNameSegmentWithValidation) { runtimeName =>
+                  path("stop") {
+                    post {
+                      complete(
+                        startRuntimeHandler(
+                          userInfo,
+                          workspaceId,
+                          runtimeName
+                        )
+                      )
+                    }
+                  } ~
+                    path("start") {
+                      post {
+                        complete(
+                          stopRuntimeHandler(
+                            userInfo,
+                            workspaceId,
+                            runtimeName
+                          )
+                        )
+                      }
+                    }
                 } ~
                   pathPrefix("azure") {
                     pathEndOrSingleSlash {
@@ -102,33 +125,9 @@ class RuntimeV2Routes(saturnIframeExtentionHostConfig: RefererConfig,
                               deleteAzureRuntimeHandler(userInfo, workspaceId, runtimeName)
                             )
                           }
-                        } ~
-                          path("stop") {
-                            post {
-                              failWith(new NotImplementedError)
-                            }
-                          } ~
-                          path("start") {
-                            post {
-                              failWith(new NotImplementedError)
-                            }
-                          }
+                        }
                       }
-                  } // ~
-//              pathPrefix("gcp") {
-//                pathPrefix(Segment) { runtimeNameString =>
-//                  RouteValidation.validateNameDirective(runtimeNameString, RuntimeName.apply) { runtimeName =>
-//                    pathEndOrSingleSlash {
-//                      post {
-//                        entity(as[CreateRuntime2Request]) { req =>
-//                          complete(
-//                          )
-//                        }
-//                      }
-//                    }
-//                  }
-//                }
-//              }
+                  }
               }
           }
         }
@@ -166,6 +165,32 @@ class RuntimeV2Routes(saturnIframeExtentionHostConfig: RefererConfig,
           .use(_ => apiCall)
       )
     } yield StatusCodes.OK -> resp: ToResponseMarshallable
+
+  private[api] def startRuntimeHandler(userInfo: UserInfo, workspaceId: WorkspaceId, runtimeName: RuntimeName)(implicit
+    ev: Ask[IO, AppContext]
+  ): IO[ToResponseMarshallable] =
+    for {
+      ctx <- ev.ask[AppContext]
+      apiCall = runtimeV2Service.getRuntime(userInfo, runtimeName, workspaceId)
+      _ <- metrics.incrementCounter("startRuntimeV2")
+      resp <- ctx.span.fold(apiCall)(span =>
+        spanResource[IO](span, "startRuntimeV2")
+          .use(_ => apiCall)
+      )
+    } yield StatusCodes.Accepted -> resp: ToResponseMarshallable
+
+  private[api] def stopRuntimeHandler(userInfo: UserInfo, workspaceId: WorkspaceId, runtimeName: RuntimeName)(implicit
+    ev: Ask[IO, AppContext]
+  ): IO[ToResponseMarshallable] =
+    for {
+      ctx <- ev.ask[AppContext]
+      apiCall = runtimeV2Service.getRuntime(userInfo, runtimeName, workspaceId)
+      _ <- metrics.incrementCounter("stopRuntimeV2")
+      resp <- ctx.span.fold(apiCall)(span =>
+        spanResource[IO](span, "stopRuntimeV2")
+          .use(_ => apiCall)
+      )
+    } yield StatusCodes.Accepted -> resp: ToResponseMarshallable
 
   def updateAzureRuntimeHandler(userInfo: UserInfo,
                                 workspaceId: WorkspaceId,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterp.scala
@@ -464,7 +464,7 @@ class RuntimeServiceInterp[F[_]: Parallel](config: RuntimeServiceConfig,
       _ <-
         if (runtime.status.isStartable) F.unit
         else
-          F.raiseError[Unit](RuntimeCannotBeStartedException(googleProject, runtime.runtimeName, runtime.status))
+          F.raiseError[Unit](RuntimeCannotBeStartedException(cloudContext, runtime.runtimeName, runtime.status))
       // start the runtime
       ctx <- as.ask
       _ <- clusterQuery.updateClusterStatus(runtime.id, RuntimeStatus.PreStarting, ctx.now).transaction

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterp.scala
@@ -418,7 +418,7 @@ class RuntimeServiceInterp[F[_]: Parallel](config: RuntimeServiceConfig,
 
           } yield ()
         } else
-          F.raiseError[Unit](RuntimeCannotBeStoppedException(googleProject, runtime.runtimeName, runtime.status))
+          F.raiseError[Unit](RuntimeCannotBeStoppedException(cloudContext, runtime.runtimeName, runtime.status))
     } yield ()
 
   def startRuntime(userInfo: UserInfo, googleProject: GoogleProject, runtimeName: RuntimeName)(implicit

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeV2Service.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeV2Service.scala
@@ -20,6 +20,14 @@ trait RuntimeV2Service[F[_]] {
     as: Ask[F, AppContext]
   ): F[GetRuntimeResponse]
 
+  def startRuntime(userInfo: UserInfo, runtimeName: RuntimeName, workspaceId: WorkspaceId)(implicit
+    as: Ask[F, AppContext]
+  ): F[Unit]
+
+  def stopRuntime(userInfo: UserInfo, runtimeName: RuntimeName, workspaceId: WorkspaceId)(implicit
+    as: Ask[F, AppContext]
+  ): F[Unit]
+
   def updateRuntime(userInfo: UserInfo,
                     runtimeName: RuntimeName,
                     workspaceId: WorkspaceId,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeV2ServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeV2ServiceInterp.scala
@@ -24,9 +24,11 @@ import org.broadinstitute.dsde.workbench.leonardo.model._
 import org.broadinstitute.dsde.workbench.leonardo.monitor.LeoPubsubMessage
 import org.broadinstitute.dsde.workbench.leonardo.monitor.LeoPubsubMessage.{
   CreateAzureRuntimeMessage,
-  DeleteAzureRuntimeMessage
+  DeleteAzureRuntimeMessage,
+  StartRuntimeMessage,
+  StopRuntimeMessage
 }
-import org.broadinstitute.dsde.workbench.model.{TraceId, UserInfo}
+import org.broadinstitute.dsde.workbench.model.{TraceId, UserInfo, WorkbenchEmail}
 import org.http4s.AuthScheme
 import org.typelevel.log4cats.StructuredLogger
 
@@ -165,20 +167,9 @@ class RuntimeV2ServiceInterp[F[_]: Parallel](config: RuntimeServiceConfig,
     as: Ask[F, AppContext]
   ): F[GetRuntimeResponse] =
     for {
-      leoAuth <- samDAO.getLeoAuthToken
       ctx <- as.ask
 
-      workspaceDescOpt <- wsmDao.getWorkspace(workspaceId, leoAuth)
-      workspaceDesc <- F.fromOption(workspaceDescOpt, WorkspaceNotFoundException(workspaceId, ctx.traceId))
-
-      // TODO: when we fully support google here, do something intelligent instead of defaulting to azure
-      cloudContext <- (workspaceDesc.azureContext, workspaceDesc.gcpContext) match {
-        case (Some(azureContext), _) => F.pure[CloudContext](CloudContext.Azure(azureContext))
-        case (_, Some(gcpContext))   => F.pure[CloudContext](CloudContext.Gcp(gcpContext))
-        case (None, None) => F.raiseError[CloudContext](CloudContextNotFoundException(workspaceId, ctx.traceId))
-      }
-
-      runtime <- RuntimeServiceDbQueries.getRuntime(cloudContext, runtimeName).transaction
+      runtime <- RuntimeServiceDbQueries.getActiveRuntime(workspaceId, runtimeName).transaction
 
       // If user is creator of the runtime, they should definitely be able to see the runtime.
       hasPermission <-
@@ -191,7 +182,7 @@ class RuntimeV2ServiceInterp[F[_]: Parallel](config: RuntimeServiceConfig,
 
             azureRuntimeControlledResource <- F.fromOption(
               controlledResourceOpt,
-              AzureRuntimeControlledResourceNotFoundException(cloudContext, runtimeName, ctx.traceId)
+              AzureRuntimeControlledResourceNotFoundException(runtime.cloudContext, runtimeName, ctx.traceId)
             )
             res <- checkSamPermission(azureRuntimeControlledResource, userInfo, WsmResourceAction.Read).map(_._1)
           } yield res
@@ -200,7 +191,7 @@ class RuntimeV2ServiceInterp[F[_]: Parallel](config: RuntimeServiceConfig,
       _ <- ctx.span.traverse(s => F.delay(s.addAnnotation("Done auth call for get azure runtime permission")))
       _ <- F
         .raiseError[Unit](
-          RuntimeNotFoundException(cloudContext, runtimeName, "permission denied", Some(ctx.traceId))
+          RuntimeNotFoundException(runtime.cloudContext, runtimeName, "permission denied", Some(ctx.traceId))
         )
         .whenA(!hasPermission)
 
@@ -217,31 +208,20 @@ class RuntimeV2ServiceInterp[F[_]: Parallel](config: RuntimeServiceConfig,
     as: Ask[F, AppContext]
   ): F[Unit] =
     for {
-      leoAuth <- samDAO.getLeoAuthToken
       ctx <- as.ask
-
-      workspaceDescOpt <- wsmDao.getWorkspace(workspaceId, leoAuth)
-      workspaceDesc <- F.fromOption(workspaceDescOpt, WorkspaceNotFoundException(workspaceId, ctx.traceId))
-
-      // TODO: when we fully support google here, do something intelligent instead of defaulting to azure
-      cloudContext <- (workspaceDesc.azureContext, workspaceDesc.gcpContext) match {
-        case (Some(azureContext), _) => F.pure[CloudContext](CloudContext.Azure(azureContext))
-        case (_, Some(gcpContext))   => F.pure[CloudContext](CloudContext.Gcp(gcpContext))
-        case (None, None) => F.raiseError[CloudContext](CloudContextNotFoundException(workspaceId, ctx.traceId))
-      }
-
-      runtime <- RuntimeServiceDbQueries.getRuntime(cloudContext, runtimeName).transaction
+      runtime <- RuntimeServiceDbQueries.getActiveRuntime(workspaceId, runtimeName).transaction
 
       _ <- F
         .raiseUnless(runtime.status.isDeletable)(
-          RuntimeCannotBeDeletedException(cloudContext, runtime.clusterName, runtime.status)
+          RuntimeCannotBeDeletedException(runtime.cloudContext, runtime.runtimeName, runtime.status)
         )
 
-      diskId <- runtime.runtimeConfig match {
-        case config: RuntimeConfig.AzureConfig => F.pure(config.persistentDiskId)
+      diskIdOpt <- RuntimeConfigQueries.getDiskId(runtime.runtimeConfigId).transaction
+      diskId <- diskIdOpt match {
+        case Some(value) => F.pure(value)
         case _ =>
           F.raiseError[DiskId](
-            AzureRuntimeHasInvalidRuntimeConfig(cloudContext, runtime.clusterName, ctx.traceId)
+            AzureRuntimeHasInvalidRuntimeConfig(runtime.cloudContext, runtime.runtimeName, ctx.traceId)
           )
       }
 
@@ -269,7 +249,7 @@ class RuntimeV2ServiceInterp[F[_]: Parallel](config: RuntimeServiceConfig,
 
       _ <- ctx.span.traverse(s => F.delay(s.addAnnotation("Done auth call for delete azure runtime permission")))
       _ <- F
-        .raiseError[Unit](RuntimeNotFoundException(cloudContext, runtimeName, "permission denied"))
+        .raiseError[Unit](RuntimeNotFoundException(runtime.cloudContext, runtimeName, "permission denied"))
         .whenA(!hasPermission)
 
       _ <- clusterQuery.markPendingDeletion(runtime.id, ctx.now).transaction
@@ -281,6 +261,59 @@ class RuntimeV2ServiceInterp[F[_]: Parallel](config: RuntimeServiceConfig,
         DeleteAzureRuntimeMessage(runtime.id, Some(diskId), workspaceId, wsmResourceIdOpt, Some(ctx.traceId))
       )
     } yield ()
+
+  def startRuntime(userInfo: UserInfo, runtimeName: RuntimeName, workspaceId: WorkspaceId)(implicit
+    as: Ask[F, AppContext]
+  ): F[Unit] = for {
+    ctx <- as.ask
+    runtime <- RuntimeServiceDbQueries.getActiveRuntime(workspaceId, runtimeName).transaction
+
+    // If user is creator of the runtime, they should definitely be able to see the runtime.
+    hasPermission <- checkPermission(runtime.auditInfo.creator,
+                                     userInfo,
+                                     runtime.cloudContext,
+                                     runtime.runtimeName,
+                                     runtime.id
+    )
+    _ <- F
+      .raiseError[Unit](
+        RuntimeNotFoundException(runtime.cloudContext, runtimeName, "permission denied", Some(ctx.traceId))
+      )
+      .whenA(!hasPermission)
+    _ <-
+      if (runtime.status.isStartable) F.unit
+      else
+        F.raiseError[Unit](RuntimeCannotBeStartedException(runtime.cloudContext, runtime.runtimeName, runtime.status))
+    _ <- clusterQuery.updateClusterStatus(runtime.id, RuntimeStatus.PreStarting, ctx.now).transaction
+    _ <- publisherQueue.offer(StartRuntimeMessage(runtime.id, Some(ctx.traceId)))
+  } yield ()
+
+  def stopRuntime(userInfo: UserInfo, runtimeName: RuntimeName, workspaceId: WorkspaceId)(implicit
+    as: Ask[F, AppContext]
+  ): F[Unit] = for {
+    ctx <- as.ask
+    runtime <- RuntimeServiceDbQueries.getActiveRuntime(workspaceId, runtimeName).transaction
+
+    // If user is creator of the runtime, they should definitely be able to see the runtime.
+    hasPermission <- checkPermission(runtime.auditInfo.creator,
+                                     userInfo,
+                                     runtime.cloudContext,
+                                     runtime.runtimeName,
+                                     runtime.id
+    )
+
+    _ <- F
+      .raiseError[Unit](
+        RuntimeNotFoundException(runtime.cloudContext, runtimeName, "permission denied", Some(ctx.traceId))
+      )
+      .whenA(!hasPermission)
+    _ <-
+      if (runtime.status.isStartable) F.unit
+      else
+        F.raiseError[Unit](RuntimeCannotBeStartedException(runtime.cloudContext, runtime.runtimeName, runtime.status))
+    _ <- clusterQuery.updateClusterStatus(runtime.id, RuntimeStatus.PreStopping, ctx.now).transaction
+    _ <- publisherQueue.offer(StopRuntimeMessage(runtime.id, Some(ctx.traceId)))
+  } yield ()
 
   override def listRuntimes(
     userInfo: UserInfo,
@@ -398,6 +431,30 @@ class RuntimeV2ServiceInterp[F[_]: Parallel](config: RuntimeServiceConfig,
     )
   }
 
+  private def checkPermission(creator: WorkbenchEmail,
+                              userInfo: UserInfo,
+                              cloudContext: CloudContext,
+                              runtimeName: RuntimeName,
+                              runtimeId: Long
+  )(implicit
+    ev: Ask[F, AppContext]
+  ) = if (creator == userInfo.userEmail) F.pure(true)
+  else {
+    for {
+      ctx <- ev.ask
+      controlledResourceOpt <- controlledResourceQuery
+        .getWsmRecordForRuntime(runtimeId, WsmResourceType.AzureVm)
+        .transaction
+
+      azureRuntimeControlledResource <- F.fromOption(
+        controlledResourceOpt,
+        AzureRuntimeControlledResourceNotFoundException(cloudContext, runtimeName, ctx.traceId)
+      )
+      res <- checkSamPermission(azureRuntimeControlledResource, userInfo, WsmResourceAction.Read).map(_._1)
+      _ <- ctx.span.traverse(s => F.delay(s.addAnnotation("Done auth call for azure runtime permission check")))
+    } yield res
+  }
+
   private def checkSamPermission(azureRuntimeControlledResource: RuntimeControlledResourceRecord,
                                  userInfo: UserInfo,
                                  wsmResourceAction: WsmResourceAction
@@ -405,7 +462,6 @@ class RuntimeV2ServiceInterp[F[_]: Parallel](config: RuntimeServiceConfig,
     ctx: Ask[F, AppContext]
   ): F[(Boolean, WsmControlledResourceId)] =
     for {
-      context <- ctx.ask
       // TODO: generalize for google
       res <- authProvider.hasPermission(
         WsmResourceSamResourceId(azureRuntimeControlledResource.resourceId),

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeV2ServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeV2ServiceInterp.scala
@@ -209,7 +209,7 @@ class RuntimeV2ServiceInterp[F[_]: Parallel](config: RuntimeServiceConfig,
   ): F[Unit] =
     for {
       ctx <- as.ask
-      runtime <- RuntimeServiceDbQueries.getActiveRuntime(workspaceId, runtimeName).transaction
+      runtime <- RuntimeServiceDbQueries.getActiveRuntimeRecord(workspaceId, runtimeName).transaction
 
       _ <- F
         .raiseUnless(runtime.status.isDeletable)(
@@ -266,7 +266,7 @@ class RuntimeV2ServiceInterp[F[_]: Parallel](config: RuntimeServiceConfig,
     as: Ask[F, AppContext]
   ): F[Unit] = for {
     ctx <- as.ask
-    runtime <- RuntimeServiceDbQueries.getActiveRuntime(workspaceId, runtimeName).transaction
+    runtime <- RuntimeServiceDbQueries.getActiveRuntimeRecord(workspaceId, runtimeName).transaction
 
     // If user is creator of the runtime, they should definitely be able to see the runtime.
     hasPermission <- checkPermission(runtime.auditInfo.creator,
@@ -292,7 +292,7 @@ class RuntimeV2ServiceInterp[F[_]: Parallel](config: RuntimeServiceConfig,
     as: Ask[F, AppContext]
   ): F[Unit] = for {
     ctx <- as.ask
-    runtime <- RuntimeServiceDbQueries.getActiveRuntime(workspaceId, runtimeName).transaction
+    runtime <- RuntimeServiceDbQueries.getActiveRuntimeRecord(workspaceId, runtimeName).transaction
 
     // If user is creator of the runtime, they should definitely be able to see the runtime.
     hasPermission <- checkPermission(runtime.auditInfo.creator,
@@ -308,7 +308,7 @@ class RuntimeV2ServiceInterp[F[_]: Parallel](config: RuntimeServiceConfig,
       )
       .whenA(!hasPermission)
     _ <-
-      if (runtime.status.isStartable) F.unit
+      if (runtime.status.isStoppable) F.unit
       else
         F.raiseError[Unit](RuntimeCannotBeStartedException(runtime.cloudContext, runtime.runtimeName, runtime.status))
     _ <- clusterQuery.updateClusterStatus(runtime.id, RuntimeStatus.PreStopping, ctx.now).transaction

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeV2ServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeV2ServiceInterp.scala
@@ -310,7 +310,7 @@ class RuntimeV2ServiceInterp[F[_]: Parallel](config: RuntimeServiceConfig,
     _ <-
       if (runtime.status.isStoppable) F.unit
       else
-        F.raiseError[Unit](RuntimeCannotBeStartedException(runtime.cloudContext, runtime.runtimeName, runtime.status))
+        F.raiseError[Unit](RuntimeCannotBeStoppedException(runtime.cloudContext, runtime.runtimeName, runtime.status))
     _ <- clusterQuery.updateClusterStatus(runtime.id, RuntimeStatus.PreStopping, ctx.now).transaction
     _ <- publisherQueue.offer(StopRuntimeMessage(runtime.id, Some(ctx.traceId)))
   } yield ()

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeoException.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeoException.scala
@@ -69,8 +69,9 @@ final case class RuntimeNotFoundByWorkspaceIdException(workspaceId: WorkspaceId,
                                                        msg: String,
                                                        traceId: Option[TraceId] = None
 ) extends LeoException(
-      s"Runtime ${workspaceId} ${runtimeName.asString} not found. Details: ${msg}",
+      s"Runtime ${workspaceId} ${runtimeName.asString} not found",
       StatusCodes.NotFound,
+      extraMessageInLogging = s"Details: ${msg}",
       traceId = traceId
     )
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeoException.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeoException.scala
@@ -64,6 +64,16 @@ case class RuntimeNotFoundException(cloudContext: CloudContext,
       traceId = traceId
     )
 
+final case class RuntimeNotFoundByWorkspaceIdException(workspaceId: WorkspaceId,
+                                                       runtimeName: RuntimeName,
+                                                       msg: String,
+                                                       traceId: Option[TraceId] = None
+) extends LeoException(
+      s"Runtime ${workspaceId} ${runtimeName.asString} not found. Details: ${msg}",
+      StatusCodes.NotFound,
+      traceId = traceId
+    )
+
 case class RuntimeNotFoundByIdException(id: Long, msg: String)
     extends LeoException(s"Runtime with id ${id} not found. Details: ${msg}", StatusCodes.NotFound, traceId = None)
 
@@ -92,11 +102,9 @@ case class RuntimeCannotBeDeletedException(cloudContext: CloudContext,
       traceId = None
     )
 
-case class RuntimeCannotBeStartedException(googleProject: GoogleProject,
-                                           runtimeName: RuntimeName,
-                                           status: RuntimeStatus
-) extends LeoException(
-      s"Runtime ${googleProject.value}/${runtimeName.asString} cannot be started in ${status.toString} status",
+case class RuntimeCannotBeStartedException(cloudContext: CloudContext, runtimeName: RuntimeName, status: RuntimeStatus)
+    extends LeoException(
+      s"Runtime ${cloudContext.asStringWithProvider} cannot be started in ${status.toString} status",
       StatusCodes.Conflict,
       traceId = None
     )

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeoException.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeoException.scala
@@ -1,12 +1,10 @@
 package org.broadinstitute.dsde.workbench.leonardo
 package model
 
-import org.broadinstitute.dsde.workbench.model.TraceId
-import org.broadinstitute.dsde.workbench.model.google.{GcsPath, GoogleProject}
-
 import akka.http.scaladsl.model.{StatusCode, StatusCodes}
-import org.broadinstitute.dsde.workbench.model.{ErrorReport, WorkbenchEmail, WorkbenchException}
 import org.broadinstitute.dsde.workbench.leonardo.http.errorReportSource
+import org.broadinstitute.dsde.workbench.model.google.GcsPath
+import org.broadinstitute.dsde.workbench.model.{ErrorReport, TraceId, WorkbenchEmail, WorkbenchException}
 
 import scala.util.control.NoStackTrace
 
@@ -59,8 +57,9 @@ case class RuntimeNotFoundException(cloudContext: CloudContext,
                                     msg: String,
                                     traceId: Option[TraceId] = None
 ) extends LeoException(
-      s"Runtime ${cloudContext.asStringWithProvider}/${runtimeName.asString} not found. Details: ${msg}",
+      s"Runtime ${cloudContext.asStringWithProvider}/${runtimeName.asString} not found",
       StatusCodes.NotFound,
+      extraMessageInLogging = msg,
       traceId = traceId
     )
 
@@ -85,11 +84,9 @@ case class RuntimeAlreadyExistsException(cloudContext: CloudContext, runtimeName
       traceId = None
     )
 
-case class RuntimeCannotBeStoppedException(googleProject: GoogleProject,
-                                           runtimeName: RuntimeName,
-                                           status: RuntimeStatus
-) extends LeoException(
-      s"Runtime ${googleProject.value}/${runtimeName.asString} cannot be stopped in ${status.toString} status",
+case class RuntimeCannotBeStoppedException(cloudContext: CloudContext, runtimeName: RuntimeName, status: RuntimeStatus)
+    extends LeoException(
+      s"Runtime ${cloudContext.asStringWithProvider}/${runtimeName.asString} cannot be stopped in ${status.toString} status",
       StatusCodes.Conflict,
       traceId = None
     )

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/MockRuntimeV2Interp.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/MockRuntimeV2Interp.scala
@@ -69,4 +69,12 @@ class MockRuntimeV2Interp extends RuntimeV2Service[IO] {
         )
       )
     )
+
+  override def startRuntime(userInfo: UserInfo, runtimeName: RuntimeName, workspaceId: WorkspaceId)(implicit
+    as: Ask[IO, AppContext]
+  ): IO[Unit] = IO.unit
+
+  override def stopRuntime(userInfo: UserInfo, runtimeName: RuntimeName, workspaceId: WorkspaceId)(implicit
+    as: Ask[IO, AppContext]
+  ): IO[Unit] = IO.unit
 }


### PR DESCRIPTION
Tested locally via swagger

```
{"@timestamp":"2022-09-19T19:06:35.311Z","@version":"1","logger_name":"org.broadinstitute.dsde.workbench.leonardo.http.Boot","traceId":"56fc1e18-f38a-49c5-9525-cbef858fa13f","version":"8b9f5c2b6","thread_name":"io-compute-5","severity":"INFO","serviceContext":{"service":"leonardo","version":"8b9f5c2b6"},"message":"Subscriber Successfully received data: \"{\\\"messageType\\\":\\\"startRuntime\\\",\\\"runtimeId\\\":193,\\\"traceId\\\":\\\"56fc1e18-f38a-49c5-9525-cbef858fa13f\\\"}\"\nattributes {\n  key: \"leonardo\"\n  value: \"true\"\n}\nattributes {\n  key: \"traceId\"\n  value: \"56fc1e18-f38a-49c5-9525-cbef858fa13f\"\n}\nmessage_id: \"5628873310099561\"\npublish_time {\n  seconds: 1663614395\n  nanos: 371000000\n}\n."}
{"@timestamp":"2022-09-19T19:06:35.311Z","@version":"1","logger_name":"org.broadinstitute.dsde.workbench.leonardo.http.Boot","duration":"351","result":"Succeeded","googleCall":"Publishing data: \"{\\\"messageType\\\":\\\"startRuntime\\\",\\\"runtimeId\\\":193,\\\"traceId\\\":\\\"56fc1e18-f38a-49c5-9525-cbef858fa13f\\\"}\"\nattributes {\n  key: \"leonardo\"\n  value: \"true\"\n}\nattributes {\n  key: \"traceId\"\n  value: \"56fc1e18-f38a-49c5-9525-cbef858fa13f\"\n}\n","traceId":"56fc1e18-f38a-49c5-9525-cbef858fa13f","version":"8b9f5c2b6","thread_name":"io-compute-6","severity":"INFO","serviceContext":{"service":"leonardo","version":"8b9f5c2b6"},"message":{"response":"()","result":"Succeeded"}}
{"@timestamp":"2022-09-19T19:06:36.762Z","@version":"1","logger_name":"org.broadinstitute.dsde.workbench.leonardo.http.Boot","traceId":"56fc1e18-f38a-49c5-9525-cbef858fa13f","version":"8b9f5c2b6","thread_name":"io-compute-3","stack_trace":"java.lang.RuntimeException: init bucket not found for Azure/fad90753-2022-4456-9b0a-c7e5b934e408/3efc5bdf-be0e-44e7-b1d7-c08931e3c16c/mrg-terra-workspace-20220412104730/saturn-c9a9e1a4-a335-48c8-85fd-2d50fa5919a0 in DB\n\tat org.broadinstitute.dsde.workbench.leonardo.monitor.LeoPubsubMessageSubscriber.$anonfun$handleStartRuntimeMessage$10(LeoPubsubMessageSubscriber.scala:383)\n\tat cats.ApplicativeError.fromOption(ApplicativeError.scala:318)\n\tat cats.ApplicativeError.fromOption$(ApplicativeError.scala:315)\n\tat flatMap @ org.broadinstitute.dsde.workbench.leonardo.monitor.LeoPubsubMessageSubscriber.$anonfun$handleStartRuntimeMessage$8(LeoPubsubMessageSubscriber.scala:382)\n\tat modify @ fs2.internal.Scope.close(Scope.scala:262)\n\tat flatMap @ fs2.Compiler$Target.flatMap(Compiler.scala:163)\n\tat as @ org.broadinstitute.dsde.workbench.leonardo.http.Boot$.run(Boot.scala:710)\n\tat delay @ org.broadinstitute.dsde.workbench.leonardo.db.DbRef.$anonfun$inTransaction$1(DbReference.scala:96)\n\tat fromFuture @ org.broadinstitute.dsde.workbench.leonardo.db.DbRef.$anonfun$inTransaction$1(DbReference.scala:96)\n","severity":"ERROR","serviceContext":{"service":"leonardo","version":"8b9f5c2b6"},"message":"Fail to process pubsub message due to unexpected error"}
```

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
