### PR TITLE
IA-3756 Improve delete VM error handling

### DIFF
--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterErrorComponent.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterErrorComponent.scala
@@ -27,8 +27,6 @@ class ClusterErrorTable(tag: Tag) extends Table[ClusterErrorRecord](tag, "CLUSTE
 
   def timestamp = column[Timestamp]("timestamp", O.SqlType("TIMESTAMP(6)"))
 
-  def cluster = foreignKey("FK_CLUSTER_ID", clusterId, clusterQuery)(_.id)
-
   def traceId = column[Option[TraceId]]("traceId")
 
   def * =
@@ -43,13 +41,13 @@ class ClusterErrorTable(tag: Tag) extends Table[ClusterErrorRecord](tag, "CLUSTE
 
 object clusterErrorQuery extends TableQuery(new ClusterErrorTable(_)) {
 
-  def save(clusterId: Long, clusterError: RuntimeError): DBIO[Int] =
+  def save(clusterId: Long, runtimeError: RuntimeError): DBIO[Int] =
     clusterErrorQuery += ClusterErrorRecord(0,
                                             clusterId,
-                                            clusterError.errorMessage.take(1024),
-                                            clusterError.errorCode,
-                                            Timestamp.from(clusterError.timestamp),
-                                            clusterError.traceId
+                                            runtimeError.errorMessage.take(1024),
+                                            runtimeError.errorCode,
+                                            Timestamp.from(runtimeError.timestamp),
+                                            runtimeError.traceId
     )
 
   def get(clusterId: Long)(implicit ec: ExecutionContext): DBIO[List[RuntimeError]] =
@@ -59,6 +57,10 @@ object clusterErrorQuery extends TableQuery(new ClusterErrorTable(_)) {
     }
 
   def unmarshallClusterErrorRecord(clusterErrorRecord: ClusterErrorRecord): RuntimeError =
-    RuntimeError(clusterErrorRecord.errorMessage, clusterErrorRecord.errorCode, clusterErrorRecord.timestamp.toInstant)
+    RuntimeError(clusterErrorRecord.errorMessage,
+                 clusterErrorRecord.errorCode,
+                 clusterErrorRecord.timestamp.toInstant,
+                 clusterErrorRecord.traceId
+    )
 
 }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
@@ -147,6 +147,8 @@ class LeoPubsubMessageSubscriber[F[_]](
                     )
                   case ee: AzureRuntimeCreationError =>
                     azurePubsubHandler.handleAzureRuntimeCreationError(ee, now)
+                  case ee: AzureRuntimeDeletionError =>
+                    azurePubsubHandler.handleAzureRuntimeDeletionError(ee)
                   case _ => logger.error(ctx.loggingCtx, ee)(s"Failed to process pubsub message.")
                 }
                 _ <-

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
@@ -114,7 +114,13 @@ class LeoPubsubMessageSubscriber[F[_]](
             )
           }
         case msg: DeleteAzureRuntimeMessage =>
-          azurePubsubHandler.deleteAndPollRuntime(msg)
+          azurePubsubHandler.deleteAndPollRuntime(msg).adaptError { case e =>
+            PubsubHandleMessageError.AzureRuntimeDeletionError(
+              msg.runtimeId,
+              msg.workspaceId,
+              e.getMessage
+            )
+          }
       }
     } yield resp
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandler.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandler.scala
@@ -581,7 +581,7 @@ class AzurePubsubHandlerInterp[F[_]: Parallel](
     ctx <- ev.ask
     _ <- logger.error(ctx.loggingCtx, e)(s"Failed to delete Azure VM ${e.runtimeId}")
     _ <- clusterErrorQuery
-      .save(e.runtimeId, RuntimeError(e.errorMsg.take(1024), None, ctx.now))
+      .save(e.runtimeId, RuntimeError(e.errorMsg.take(1024), None, ctx.now, traceId = Some(ctx.traceId)))
       .transaction
     _ <- clusterQuery.updateClusterStatus(e.runtimeId, RuntimeStatus.Error, ctx.now).transaction
   } yield ()

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandlerAlgeba.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandlerAlgeba.scala
@@ -9,7 +9,10 @@ import org.broadinstitute.dsde.workbench.leonardo.monitor.LeoPubsubMessage.{
   DeleteAzureRuntimeMessage
 }
 import org.broadinstitute.dsde.workbench.leonardo.monitor.PollMonitorConfig
-import org.broadinstitute.dsde.workbench.leonardo.monitor.PubsubHandleMessageError.AzureRuntimeCreationError
+import org.broadinstitute.dsde.workbench.leonardo.monitor.PubsubHandleMessageError.{
+  AzureRuntimeCreationError,
+  AzureRuntimeDeletionError
+}
 import org.http4s.Uri
 
 import java.time.Instant
@@ -24,6 +27,10 @@ trait AzurePubsubHandlerAlgebra[F[_]] {
   def deleteAndPollRuntime(msg: DeleteAzureRuntimeMessage)(implicit ev: Ask[F, AppContext]): F[Unit]
 
   def handleAzureRuntimeCreationError(e: AzureRuntimeCreationError, pubsubMessageSentTime: Instant)(implicit
+    ev: Ask[F, AppContext]
+  ): F[Unit]
+
+  def handleAzureRuntimeDeletionError(e: AzureRuntimeDeletionError)(implicit
     ev: Ask[F, AppContext]
   ): F[Unit]
 }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterErrorComponentSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterErrorComponentSpec.scala
@@ -3,18 +3,22 @@ package db
 
 import java.time.Instant
 import java.time.temporal.ChronoUnit
-
 import CommonTestData._
+import org.broadinstitute.dsde.workbench.model.TraceId
+
 import scala.concurrent.ExecutionContext.Implicits.global
 import org.scalatest.flatspec.AnyFlatSpecLike
+
+import java.util.UUID
 
 class ClusterErrorComponentSpec extends AnyFlatSpecLike with TestComponent with GcsPathUtils {
 
   "ClusterErrorComponent" should "save, and get" in isolatedDbTest {
     val savedCluster1 = makeCluster(1).save()
 
+    val traceId = TraceId(UUID.randomUUID())
     lazy val timestamp = Instant.now().truncatedTo(ChronoUnit.SECONDS)
-    val clusterError = RuntimeError("Some Error", Some(10), timestamp)
+    val clusterError = RuntimeError("Some Error", Some(10), timestamp, traceId = Some(traceId))
 
     dbFutureValue(clusterErrorQuery.get(savedCluster1.id)) shouldEqual List.empty
     dbFutureValue(clusterErrorQuery.save(savedCluster1.id, clusterError))

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -158,11 +158,11 @@ object Dependencies {
     http4sDsl,
     scalaTestScalaCheck,
     workbenchAzure,
-    workbenchAzureTest
+    workbenchAzureTest,
+    logbackClassic,
   )
 
   val httpDependencies = Seq(
-    logbackClassic,
     scalaLogging,
     ficus,
     enumeratum,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -69,7 +69,7 @@ object Dependencies {
   val akkaTestKit: ModuleID =       "com.typesafe.akka" %% "akka-testkit"         % akkaV     % "test"
   val akkaHttpTestKit: ModuleID =   "com.typesafe.akka" %% "akka-http-testkit"    % akkaHttpV % "test"
 
-  val googleRpc: ModuleID =                 "io.grpc"         % "grpc-core"                       % "1.49.0" excludeAll (excludeGuava, excludeGson, excludeFindbugsJsr)
+  val googleRpc: ModuleID =                 "io.grpc"         % "grpc-core"                       % "1.49.1" excludeAll (excludeGuava, excludeGson, excludeFindbugsJsr)
 
   val scalaTest: ModuleID = "org.scalatest" %% "scalatest" % scalaTestV  % Test
   val scalaTestScalaCheck = "org.scalatestplus" %% "scalacheck-1-16" % s"${scalaTestV}.0" % Test // https://github.com/scalatest/scalatestplus-scalacheck
@@ -125,7 +125,7 @@ object Dependencies {
   val mysql: ModuleID =           "mysql"               % "mysql-connector-java"  % "8.0.30"
   val liquibase: ModuleID =       "org.liquibase"       % "liquibase-core"        % "4.16.1"
   val sealerate: ModuleID =       "ca.mrvisser"         %% "sealerate"            % "0.0.6"
-  val googleCloudNio: ModuleID =  "com.google.cloud"    % "google-cloud-nio"      % "0.124.14" % Test // brought in for FakeStorageInterpreter
+  val googleCloudNio: ModuleID =  "com.google.cloud"    % "google-cloud-nio"      % "0.124.15" % Test // brought in for FakeStorageInterpreter
 
   val circeYaml =         "io.circe"          %% "circe-yaml"           % "0.14.1"
   val http4sBlazeServer = "org.http4s"        %% "http4s-blaze-server"  % http4sVersion

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "1.2.0")
 
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.0.2")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.0.4")
 
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.6")
 
@@ -8,4 +8,4 @@ addSbtPlugin(
   "com.github.cb372" % "sbt-explicit-dependencies" % "0.2.16"
 ) // Use `unusedCompileDependencies` to see unused dependencies
 
-addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.10.1")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.10.3")


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-3756

I notice a few of my Azure VMs are stuck in `Deleting`, after looking at them. A few of them failed because WSM was not available when the deletion happened. I think this could happen pretty often (especially during WSM deployments). So adding a `handleAzureRuntimeDeletionError` function to update runtime status to `Error` if deletion fails. This way, user can retry deletion if they'd like instead of stuck in `Deleting`

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
