### PR TITLE
IA-3784 fix listRuntime

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/runtimeModels.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/runtimeModels.scala
@@ -310,12 +310,15 @@ object UserScriptPath {
     case UserScriptPath.Http(_) => None
   }(identity)
 
-  def stringToUserScriptPath(string: String): Either[Throwable, UserScriptPath] =
+  /**
+   * @param additionalValidate: checking if the string is a valid URI with org.http4s.Uri.fromString
+   */
+  def stringToUserScriptPath(string: String, additionalValidate: Boolean = true): Either[Throwable, UserScriptPath] =
     parseGcsPath(string) match {
       case Right(value) => Right(Gcs(value))
       case Left(_) =>
         for {
-          _ <- Uri.fromString(string)
+          _ <- if (additionalValidate) Uri.fromString(string) else Right(())
           res <- Either.catchNonFatal(new URL(string))
         } yield UserScriptPath.Http(res)
     }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterp.scala
@@ -236,7 +236,9 @@ class RuntimeServiceInterp[F[_]: Parallel](config: RuntimeServiceConfig,
     for {
       ctx <- as.ask
       paramMap <- F.fromEither(processListParameters(params))
-      runtimes <- RuntimeServiceDbQueries.listRuntimes(paramMap._1, paramMap._2, cloudContext).transaction
+      runtimes <- RuntimeServiceDbQueries
+        .listRuntimes(paramMap._1, paramMap._2, cloudContext)
+        .transaction
       _ <- ctx.span.traverse(s => F.delay(s.addAnnotation("DB | Done listRuntime db query")))
       runtimesAndProjects = runtimes.map(r => (GoogleProject(r.cloudContext.asString), r.samResource))
       samVisibleRuntimesOpt <- NonEmptyList.fromList(runtimesAndProjects).traverse { rs =>

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/MonitorAtBoot.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/MonitorAtBoot.scala
@@ -295,7 +295,12 @@ class MonitorAtBoot[F[_]](publisherQueue: Queue[F, LeoPubsubMessage],
   private def runtimeStatusToMessageAzure(runtime: RuntimeToMonitor, traceId: TraceId): F[LeoPubsubMessage] =
     runtime.status match {
       case RuntimeStatus.Stopping =>
-        F.raiseError(MonitorAtBootException("Stopping Azure runtime is not supported yet", traceId))
+        F.pure(
+          LeoPubsubMessage.StopRuntimeMessage(
+            runtimeId = runtime.id,
+            traceId = Some(traceId)
+          )
+        )
       case RuntimeStatus.Deleting =>
         for {
           wid <- F.fromOption(runtime.workspaceId,


### PR DESCRIPTION
* Because we added extra validation on userStartupScript in https://github.com/DataBiosphere/leonardo/pull/2884, when we retrieve runtimes with `listRuntime`, we'll see the following error
```
[ERROR] [10/12/2022 13:04:09.771] [leonardo-akka.actor.default-dispatcher-9] [akka.actor.ActorSystemImpl(leonardo)] HttpMethod(GET) http://app:8080/api/google/v1/runtimes?includeDeleted=false: 500 Internal Server Error entity: {"source":"leonardo","message":"Invalid URI: Error(75, NonEmptyList(EndOfString(75,86)))","statusCode":500,"exceptionClass":"class org.http4s.ParseFailure","traceId":null}
```
* A few other bug fixes that inlined

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
