### PR TITLE
[IA-3796] Add appName, cloudContext and lables into GetAppResponse

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/appRoutesModels.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/appRoutesModels.scala
@@ -31,14 +31,17 @@ final case class CreateAppRequest(kubernetesRuntimeConfig: Option[KubernetesRunt
 
 final case class DeleteAppRequest(userInfo: UserInfo, cloudContext: CloudContext, appName: AppName, deleteDisk: Boolean)
 
-final case class GetAppResponse(kubernetesRuntimeConfig: KubernetesRuntimeConfig,
+final case class GetAppResponse(appName: AppName,
+                                cloudContext: CloudContext,
+                                kubernetesRuntimeConfig: KubernetesRuntimeConfig,
                                 errors: List[AppError],
                                 status: AppStatus, // TODO: do we need some sort of aggregate status?
                                 proxyUrls: Map[ServiceName, URL],
                                 diskName: Option[DiskName],
                                 customEnvironmentVariables: Map[String, String],
                                 auditInfo: AuditInfo,
-                                appType: AppType
+                                appType: AppType,
+                                labels: LabelMap
 )
 
 final case class ListAppResponse(cloudContext: CloudContext,
@@ -86,6 +89,7 @@ object GetAppResponse {
   def fromDbResult(appResult: GetAppResult, proxyUrlBase: String): GetAppResponse =
     GetAppResponse(
       appResult.app.appName,
+      appResult.cluster.cloudContext,
       KubernetesRuntimeConfig(
         appResult.nodepool.numNodes,
         appResult.nodepool.machineType,

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/appRoutesModels.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/appRoutesModels.scala
@@ -3,7 +3,6 @@ package org.broadinstitute.dsde.workbench.leonardo.http
 import org.broadinstitute.dsde.workbench.google2.DiskName
 import org.broadinstitute.dsde.workbench.google2.KubernetesSerializableName.ServiceName
 import org.broadinstitute.dsde.workbench.leonardo.{
-  autoPauseOffValue,
   App,
   AppError,
   AppName,

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/appRoutesModels.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/appRoutesModels.scala
@@ -2,7 +2,20 @@ package org.broadinstitute.dsde.workbench.leonardo.http
 
 import org.broadinstitute.dsde.workbench.google2.DiskName
 import org.broadinstitute.dsde.workbench.google2.KubernetesSerializableName.ServiceName
-import org.broadinstitute.dsde.workbench.leonardo.{App, AppError, AppName, AppStatus, AppType, AuditInfo, CloudContext, KubernetesCluster, KubernetesRuntimeConfig, LabelMap, Nodepool, autoPauseOffValue}
+import org.broadinstitute.dsde.workbench.leonardo.{
+  autoPauseOffValue,
+  App,
+  AppError,
+  AppName,
+  AppStatus,
+  AppType,
+  AuditInfo,
+  CloudContext,
+  KubernetesCluster,
+  KubernetesRuntimeConfig,
+  LabelMap,
+  Nodepool
+}
 import org.broadinstitute.dsde.workbench.model.UserInfo
 import org.http4s.Uri
 
@@ -88,6 +101,6 @@ object GetAppResponse {
       appResult.app.customEnvironmentVariables,
       appResult.app.auditInfo,
       appResult.app.appType,
-      appResult.app.labels,
+      appResult.app.labels
     )
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/appRoutesModels.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/appRoutesModels.scala
@@ -2,19 +2,7 @@ package org.broadinstitute.dsde.workbench.leonardo.http
 
 import org.broadinstitute.dsde.workbench.google2.DiskName
 import org.broadinstitute.dsde.workbench.google2.KubernetesSerializableName.ServiceName
-import org.broadinstitute.dsde.workbench.leonardo.{
-  App,
-  AppError,
-  AppName,
-  AppStatus,
-  AppType,
-  AuditInfo,
-  CloudContext,
-  KubernetesCluster,
-  KubernetesRuntimeConfig,
-  LabelMap,
-  Nodepool
-}
+import org.broadinstitute.dsde.workbench.leonardo.{App, AppError, AppName, AppStatus, AppType, AuditInfo, CloudContext, KubernetesCluster, KubernetesRuntimeConfig, LabelMap, Nodepool, autoPauseOffValue}
 import org.broadinstitute.dsde.workbench.model.UserInfo
 import org.http4s.Uri
 
@@ -85,6 +73,7 @@ object ListAppResponse {
 object GetAppResponse {
   def fromDbResult(appResult: GetAppResult, proxyUrlBase: String): GetAppResponse =
     GetAppResponse(
+      appResult.app.appName,
       KubernetesRuntimeConfig(
         appResult.nodepool.numNodes,
         appResult.nodepool.machineType,
@@ -98,6 +87,7 @@ object GetAppResponse {
       appResult.app.appResources.disk.map(_.name),
       appResult.app.customEnvironmentVariables,
       appResult.app.auditInfo,
-      appResult.app.appType
+      appResult.app.appType,
+      appResult.app.labels,
     )
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/AppRoutesTestJsonCodec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/AppRoutesTestJsonCodec.scala
@@ -36,14 +36,18 @@ object AppRoutesTestJsonCodec {
     Decoder.decodeMap[ServiceName, URL](KeyDecoder.decodeKeyString.map(ServiceName), urlDecoder)
 
   implicit val getAppResponseDecoder: Decoder[GetAppResponse] =
-    Decoder.forProduct8("kubernetesRuntimeConfig",
-                        "errors",
-                        "status",
-                        "proxyUrls",
-                        "diskName",
-                        "customEnvironmentVariables",
-                        "auditInfo",
-                        "appType"
+    Decoder.forProduct8(
+      "appName",
+      "cloudContext",
+      "kubernetesRuntimeConfig",
+      "errors",
+      "status",
+      "proxyUrls",
+      "diskName",
+      "customEnvironmentVariables",
+      "auditInfo",
+      "appType",
+      "labels"
     )(GetAppResponse.apply)
 
   implicit val listAppResponseDecoder: Decoder[ListAppResponse] =

--- a/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/AppRoutesTestJsonCodec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/AppRoutesTestJsonCodec.scala
@@ -36,7 +36,7 @@ object AppRoutesTestJsonCodec {
     Decoder.decodeMap[ServiceName, URL](KeyDecoder.decodeKeyString.map(ServiceName), urlDecoder)
 
   implicit val getAppResponseDecoder: Decoder[GetAppResponse] =
-    Decoder.forProduct8(
+    Decoder.forProduct11(
       "appName",
       "cloudContext",
       "kubernetesRuntimeConfig",

--- a/http/src/main/resources/swagger/api-docs.yaml
+++ b/http/src/main/resources/swagger/api-docs.yaml
@@ -3498,7 +3498,6 @@ components:
         cloudResource:
           type: string
           description: Cloud resource name. Google project if cloud provider is GCP OR Azure's tenantId/subscriptionId/managedResourceGroupId if in Azure
-          example: n1-standard-1
 
     KubernetesRuntimeConfig:
       description: configuration for a kubernetes app runtime

--- a/http/src/main/resources/swagger/api-docs.yaml
+++ b/http/src/main/resources/swagger/api-docs.yaml
@@ -3411,6 +3411,12 @@ components:
         - auditInfo
       type: object
       properties:
+        appName:
+          type: string
+          description: the name of the app
+        googleProject:
+          type: string
+          description: Deprecated. The project this app is associated with
         kubernetesRuntimeConfig:
           $ref: '#/components/schemas/KubernetesRuntimeConfig'
         errors:
@@ -3433,6 +3439,9 @@ components:
           $ref: "#/components/schemas/AuditInfo"
         appType:
           $ref: '#/components/schemas/AppType'
+        labels:
+          type: object
+          description: The labels of each app in the response whose key is in includeLabels in the request. Of type Map[String,String]
 
     ListAppResponse:
       description: the configuration of an app

--- a/http/src/main/resources/swagger/api-docs.yaml
+++ b/http/src/main/resources/swagger/api-docs.yaml
@@ -2438,6 +2438,11 @@ components:
         - pd-standard
         - pd-ssd
         - pd-balanced
+    CloudProvider:
+      type: string
+      enum:
+        - GCP
+        - AZURE
     ClusterStatus:
       type: string
       enum:
@@ -3415,8 +3420,7 @@ components:
           type: string
           description: the name of the app
         cloudContext:
-          type: string
-          description: Google project this app is associated with if the app is created in GCP; Azure's tenantId/subscriptionId/managedResourceGroupId if the app is created in Azure
+          $ref: '#/components/schemas/CloudContext'
         kubernetesRuntimeConfig:
           $ref: '#/components/schemas/KubernetesRuntimeConfig'
         errors:
@@ -3455,8 +3459,7 @@ components:
           type: string
           description: Deprecated. The project this app is associated with
         cloudContext:
-          type: string
-          description: Google project this app is associated with if the app is created in GCP; Azure's tenantId/subscriptionId/managedResourceGroupId if the app is created in Azure
+          $ref: '#/components/schemas/CloudContext'
         kubernetesRuntimeConfig:
           $ref: '#/components/schemas/KubernetesRuntimeConfig'
         errors:
@@ -3482,6 +3485,20 @@ components:
         labels:
           type: object
           description: The labels of each app in the response whose key is in includeLabels in the request. Of type Map[String,String]
+
+    CloudContext:
+      description: Cloud platform which holds context for a workspace.
+      type: object
+      required:
+        - cloudProvider
+        - cloudResource
+      properties:
+        cloudProvider:
+          $ref: '#/components/schemas/CloudProvider'
+        cloudResource:
+          type: string
+          description: Cloud resource name. Google project if cloud provider is GCP OR Azure's tenantId/subscriptionId/managedResourceGroupId if in Azure
+          example: n1-standard-1
 
     KubernetesRuntimeConfig:
       description: configuration for a kubernetes app runtime

--- a/http/src/main/resources/swagger/api-docs.yaml
+++ b/http/src/main/resources/swagger/api-docs.yaml
@@ -3414,9 +3414,9 @@ components:
         appName:
           type: string
           description: the name of the app
-        googleProject:
+        cloudContext:
           type: string
-          description: Deprecated. The project this app is associated with
+          description: Google project this app is associated with if the app is created in GCP; Azure's tenantId/subscriptionId/managedResourceGroupId if the app is created in Azure
         kubernetesRuntimeConfig:
           $ref: '#/components/schemas/KubernetesRuntimeConfig'
         errors:

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/AppRoutes.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/AppRoutes.scala
@@ -265,12 +265,13 @@ object AppRoutes {
       "appName",
       "googleProject",
       "kubernetesRuntimeConfig",
-                        "errors",
-                        "status",
-                        "proxyUrls",
-                        "diskName",
-                        "customEnvironmentVariables",
-                        "auditInfo",
-                        "appType", "labels",
+      "errors",
+      "status",
+      "proxyUrls",
+      "diskName",
+      "customEnvironmentVariables",
+      "auditInfo",
+      "appType",
+      "labels"
     )(x => GetAppResponse.unapply(x).get)
 }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/AppRoutes.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/AppRoutes.scala
@@ -263,7 +263,7 @@ object AppRoutes {
   implicit val getAppResponseEncoder: Encoder[GetAppResponse] =
     Encoder.forProduct11(
       "appName",
-      "googleProject",
+      "cloudContext",
       "kubernetesRuntimeConfig",
       "errors",
       "status",

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/AppRoutes.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/AppRoutes.scala
@@ -261,13 +261,16 @@ object AppRoutes {
     )
 
   implicit val getAppResponseEncoder: Encoder[GetAppResponse] =
-    Encoder.forProduct8("kubernetesRuntimeConfig",
+    Encoder.forProduct11(
+      "appName",
+      "googleProject",
+      "kubernetesRuntimeConfig",
                         "errors",
                         "status",
                         "proxyUrls",
                         "diskName",
                         "customEnvironmentVariables",
                         "auditInfo",
-                        "appType"
+                        "appType", "labels",
     )(x => GetAppResponse.unapply(x).get)
 }


### PR DESCRIPTION
It is helpful to make GetAppResponse returns simialr field as listAppResponse. And it is easier for us to write mapper from LeoResponse to AoU APP object

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
