### PR TITLE
[IA-3799] remove custom app lifecycle tests from alpha tests

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/AppLifecycleSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/AppLifecycleSpec.scala
@@ -48,29 +48,31 @@ class AppLifecycleSpec
     descriptorPath = descriptorPath
   )
 
-
   // Test galaxy app first so that there will be a GKE cluster created already for the next two tests
   "create GALAXY app, start/stop, delete it and re-create it with same disk" in { googleProject =>
     test(googleProject, createAppRequest(AppType.Galaxy, "Galaxy-Workshop-ASHG_2020_GWAS_Demo", None), true, true)
   }
 
-  "create CROMWELL app, delete it and re-create it with same disk" taggedAs (Tags.SmokeTest, Retryable) in { googleProject =>
-    test(googleProject, createAppRequest(AppType.Cromwell, "cromwell-test-workspace", None), false, true)
+  "create CROMWELL app, delete it and re-create it with same disk" taggedAs (Tags.SmokeTest, Retryable) in {
+    googleProject =>
+      test(googleProject, createAppRequest(AppType.Cromwell, "cromwell-test-workspace", None), false, true)
   }
 
   "create CUSTOM app, start/stop, delete it" taggedAs Retryable in { googleProject =>
-    test(googleProject,
+    test(
+      googleProject,
       createAppRequest(
         AppType.Custom,
-          "custom-test-workspace",
-          Some(
-            org.http4s.Uri.unsafeFromString(
-              "https://raw.githubusercontent.com/DataBiosphere/terra-app/acb66d96045e199d2cae6876723e028296794292/apps/ucsc_genome_browser/app.yaml"
-            )
+        "custom-test-workspace",
+        Some(
+          org.http4s.Uri.unsafeFromString(
+            "https://raw.githubusercontent.com/DataBiosphere/terra-app/acb66d96045e199d2cae6876723e028296794292/apps/ucsc_genome_browser/app.yaml"
           )
-        ),
+        )
+      ),
       true,
-      false)
+      false
+    )
   }
 
   def test(googleProject: GoogleProject,

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/AppLifecycleSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/AppLifecycleSpec.scala
@@ -48,37 +48,29 @@ class AppLifecycleSpec
     descriptorPath = descriptorPath
   )
 
-  private val appTestCases = Table(
-    ("description", "createAppRequest", "testStartStop", "testPersistentDisk"),
-    ("create CROMWELL app, delete it and re-create it with same disk",
-     createAppRequest(AppType.Cromwell, "cromwell-test-workspace", None),
-     false,
-     true
-    ),
-    ("create CUSTOM app, start/stop, delete it",
-     createAppRequest(
-       AppType.Custom,
-       "custom-test-workspace",
-       Some(
-         org.http4s.Uri.unsafeFromString(
-           "https://raw.githubusercontent.com/DataBiosphere/terra-app/acb66d96045e199d2cae6876723e028296794292/apps/ucsc_genome_browser/app.yaml"
-         )
-       )
-     ),
-     true,
-     false
-    )
-  )
 
   // Test galaxy app first so that there will be a GKE cluster created already for the next two tests
   "create GALAXY app, start/stop, delete it and re-create it with same disk" in { googleProject =>
     test(googleProject, createAppRequest(AppType.Galaxy, "Galaxy-Workshop-ASHG_2020_GWAS_Demo", None), true, true)
   }
 
-  forAll(appTestCases) { (description, createAppRequest, testStartStop, testPD) =>
-    description taggedAs (Tags.SmokeTest, Retryable) in { googleProject =>
-      test(googleProject, createAppRequest, testStartStop, testPD)
-    }
+  "create CROMWELL app, delete it and re-create it with same disk" taggedAs (Tags.SmokeTest, Retryable) in { googleProject =>
+    test(googleProject, createAppRequest(AppType.Cromwell, "cromwell-test-workspace", None), false, true)
+  }
+
+  "create CUSTOM app, start/stop, delete it" taggedAs Retryable in { googleProject =>
+    test(googleProject,
+      createAppRequest(
+        AppType.Custom,
+          "custom-test-workspace",
+          Some(
+            org.http4s.Uri.unsafeFromString(
+              "https://raw.githubusercontent.com/DataBiosphere/terra-app/acb66d96045e199d2cae6876723e028296794292/apps/ucsc_genome_browser/app.yaml"
+            )
+          )
+        ),
+      true,
+      false)
   }
 
   def test(googleProject: GoogleProject,


### PR DESCRIPTION
Removing tag from custom app lifecycle test to unblock release

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
