### PR TITLE
TOAZ-248 part 1 -- Fix front Leo routes to prepare for pubsub integration

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/appRoutesModels.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/appRoutesModels.scala
@@ -17,7 +17,6 @@ import org.broadinstitute.dsde.workbench.leonardo.{
   Nodepool,
   WorkspaceId
 }
-import org.broadinstitute.dsde.workbench.model.UserInfo
 import org.http4s.Uri
 
 import java.net.URL
@@ -30,8 +29,6 @@ final case class CreateAppRequest(kubernetesRuntimeConfig: Option[KubernetesRunt
                                   descriptorPath: Option[Uri],
                                   extraArgs: List[String]
 )
-
-final case class DeleteAppRequest(userInfo: UserInfo, cloudContext: CloudContext, appName: AppName, deleteDisk: Boolean)
 
 final case class GetAppResponse(appName: AppName,
                                 cloudContext: CloudContext,

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/kubernetesModels.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/kubernetesModels.scala
@@ -321,15 +321,19 @@ object AppType {
   case object Custom extends AppType {
     override def toString: String = "CUSTOM"
   }
+  case object CromwellOnAzure extends AppType {
+    override def toString: String = "CROMWELL_ON_AZURE"
+  }
 
   def values: Set[AppType] = sealerate.values[AppType]
   def stringToObject: Map[String, AppType] = values.map(v => v.toString -> v).toMap
 
   def appTypeToFormattedByType(appType: AppType): FormattedBy =
     appType match {
-      case Galaxy   => FormattedBy.Galaxy
-      case Cromwell => FormattedBy.Cromwell
-      case Custom   => FormattedBy.Custom
+      case Galaxy          => FormattedBy.Galaxy
+      case Cromwell        => FormattedBy.Cromwell
+      case Custom          => FormattedBy.Custom
+      case CromwellOnAzure => FormattedBy.Cromwell
     }
 }
 

--- a/http/src/main/resources/swagger/api-docs.yaml
+++ b/http/src/main/resources/swagger/api-docs.yaml
@@ -1186,11 +1186,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorReport"
-      security:
-        - googleoauth:
-            - openid
-            - email
-            - profile
   "/api/google/v1/apps/{googleProject}":
     get:
       summary: List apps within a project
@@ -1254,11 +1249,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorReport"
-      security:
-        - googleoauth:
-            - openid
-            - email
-            - profile
   "/api/google/v1/apps/{googleProject}/{appName}":
     post:
       summary: Creates a new app in the given project with the given appName
@@ -1306,11 +1296,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorReport"
-      security:
-        - googleoauth:
-            - openid
-            - email
-            - profile
     get:
       summary: Get details of an app
       description: >
@@ -1353,11 +1338,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorReport"
-      security:
-        - googleoauth:
-            - openid
-            - email
-            - profile
     delete:
       summary: Deletes an existing app in the given project
       description: deletes an App
@@ -1538,11 +1518,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorReport"
-      security:
-        - googleoauth:
-            - openid
-            - email
-            - profile
     get:
       summary:  Get details of an app
       description: >
@@ -1585,11 +1560,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorReport"
-      security:
-        - googleoauth:
-            - openid
-            - email
-            - profile
 
     delete:
       summary: Deletes an existing app in the given project

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/auth/PetClusterServiceAccountProvider.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/auth/PetClusterServiceAccountProvider.scala
@@ -18,8 +18,8 @@ class PetClusterServiceAccountProvider[F[_]: Monad](sam: SamDAO[F]) extends Serv
   ): F[Option[WorkbenchEmail]] = {
     val authHeader = Authorization(Credentials.Token(AuthScheme.Bearer, userInfo.accessToken.token))
     cloudContext match {
-      case CloudContext.Gcp(googleProject) => sam.getPetServiceAccount(authHeader, googleProject)
-      case CloudContext.Azure(_)           => sam.getPetManagedIdentity(authHeader)
+      case CloudContext.Gcp(googleProject)       => sam.getPetServiceAccount(authHeader, googleProject)
+      case CloudContext.Azure(azureCloudContext) => sam.getPetManagedIdentity(authHeader, azureCloudContext)
     }
   }
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/auth/SamAuthProvider.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/auth/SamAuthProvider.scala
@@ -194,8 +194,8 @@ class SamAuthProvider[F[_]: OpenTelemetryMetrics](
     creatorEmail: WorkbenchEmail,
     googleProject: GoogleProject
   )(implicit sr: SamResource[R], encoder: Encoder[R], ev: Ask[F, TraceId]): F[Unit] =
-    // TODO: consider using v2 for all existing entities if this works out for apps https://broadworkbench.atlassian.net/browse/IA-2569
-    // Apps are modeled different in SAM than other leo resources.
+    // Note: apps on GCP are defined with a google-project as a parent Sam resource.
+    // Otherwise the Sam resource has no parent.
     if (sr.resourceType != SamResourceType.App)
       samDao.createResourceAsGcpPet(samResource, creatorEmail, googleProject)
     else
@@ -208,6 +208,8 @@ class SamAuthProvider[F[_]: OpenTelemetryMetrics](
     workspaceId: WorkspaceId,
     userInfo: UserInfo
   )(implicit sr: SamResource[R], encoder: Encoder[R], ev: Ask[F, TraceId]): F[Unit] =
+    // Note: apps on GCP are defined with a google-project as a parent Sam resource.
+    // Otherwise the Sam resource has no parent.
     if (sr.resourceType == SamResourceType.App && cloudContext.cloudProvider == CloudProvider.Gcp)
       samDao.createResourceWithParent(samResource, creatorEmail, GoogleProject(cloudContext.asString))
     else
@@ -218,7 +220,7 @@ class SamAuthProvider[F[_]: OpenTelemetryMetrics](
     creatorEmail: WorkbenchEmail,
     googleProject: GoogleProject
   )(implicit sr: SamResource[R], ev: Ask[F, TraceId]): F[Unit] =
-    samDao.deleteResource(samResource, creatorEmail, googleProject)
+    samDao.deleteResourceAsGcpPet(samResource, creatorEmail, googleProject)
 
   override def notifyResourceDeletedV2[R](
     samResource: R,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/SamDAO.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/SamDAO.scala
@@ -3,6 +3,7 @@ package dao
 
 import cats.mtl.Ask
 import io.circe.{Decoder, Encoder}
+import org.broadinstitute.dsde.workbench.azure.AzureCloudContext
 import org.broadinstitute.dsde.workbench.leonardo.model.{SamResource, SamResourceAction}
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.broadinstitute.dsde.workbench.model.{TraceId, UserInfo, WorkbenchEmail}
@@ -74,7 +75,7 @@ trait SamDAO[F[_]] {
     ev: Ask[F, TraceId]
   ): F[Option[WorkbenchEmail]]
 
-  def getPetManagedIdentity(authorization: Authorization)(implicit
+  def getPetManagedIdentity(authorization: Authorization, cloudContext: AzureCloudContext)(implicit
     ev: Ask[F, TraceId]
   ): F[Option[WorkbenchEmail]]
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/SamDAO.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/SamDAO.scala
@@ -11,10 +11,14 @@ import org.broadinstitute.dsde.workbench.util.health.StatusCheckResponse
 import org.http4s.headers.Authorization
 
 trait SamDAO[F[_]] {
+
+  /** Registers the Leo SA as a user in Sam. */
   def registerLeo(implicit ev: Ask[F, TraceId]): F[Unit]
 
+  /** Calls Sam /status endpoint. */
   def getStatus(implicit ev: Ask[F, TraceId]): F[StatusCheckResponse]
 
+  /** Checks whether the calling user has permission to do action A on a given resource R. */
   def hasResourcePermission[R, A](resource: R, action: A, authHeader: Authorization)(implicit
     sr: SamResourceAction[R, A],
     ev: Ask[F, TraceId]
@@ -25,7 +29,7 @@ trait SamDAO[F[_]] {
                                    authHeader
     )
 
-  // This exists because of guava cache
+  /** Similar to `hasResourcePermission`, but makes it cacheable in Guava cache. */
   private[leonardo] def hasResourcePermissionUnchecked(resourceType: SamResourceType,
                                                        resource: String,
                                                        action: String,
@@ -34,65 +38,81 @@ trait SamDAO[F[_]] {
     ev: Ask[F, TraceId]
   ): F[Boolean]
 
+  /** Returns all actions A the calling user has permission to perform on a given resource R. */
+  def getListOfResourcePermissions[R, A](resource: R, authHeader: Authorization)(implicit
+    sr: SamResourceAction[R, A],
+    ev: Ask[F, TraceId]
+  ): F[List[A]]
+
+  /** Returns all resources and actions (policies) the calling user has permission to for a given resource type.*/
   def getResourcePolicies[R](authHeader: Authorization)(implicit
     sr: SamResource[R],
     decoder: Decoder[R],
     ev: Ask[F, TraceId]
   ): F[List[(R, SamPolicyName)]]
 
+  /** Creates a Sam resource R using a GCP pet credential for the given email/project. */
   def createResourceAsGcpPet[R](resource: R, creatorEmail: WorkbenchEmail, googleProject: GoogleProject)(implicit
     sr: SamResource[R],
     ev: Ask[F, TraceId]
   ): F[Unit]
 
+  /** Creates a Sam resource R using the provided user token. */
   def createResourceWithUserInfo[R](resource: R, userInfo: UserInfo)(implicit
     sr: SamResource[R],
     ev: Ask[F, TraceId]
   ): F[Unit]
 
+  /** Creates a Sam resource R with the provided google project as the parent resource using a GCP pet credential
+     for the given email/project. */
   def createResourceWithParent[R](resource: R, creatorEmail: WorkbenchEmail, googleProject: GoogleProject)(implicit
     sr: SamResource[R],
     encoder: Encoder[R],
     ev: Ask[F, TraceId]
   ): F[Unit]
 
-  def deleteResource[R](resource: R, creatorEmail: WorkbenchEmail, googleProject: GoogleProject)(implicit
+  /** Deletes a Sam resource R using a GCP pet credential for the given email/project. */
+  def deleteResourceAsGcpPet[R](resource: R, creatorEmail: WorkbenchEmail, googleProject: GoogleProject)(implicit
     sr: SamResource[R],
     ev: Ask[F, TraceId]
   ): F[Unit]
 
+  /** Deletes a Sam resource R using the provided user token. */
   def deleteResourceWithUserInfo[R](resource: R, userInfo: UserInfo)(implicit
     sr: SamResource[R],
     ev: Ask[F, TraceId]
   ): F[Unit]
 
-  def getListOfResourcePermissions[R, A](resource: R, authHeader: Authorization)(implicit
-    sr: SamResourceAction[R, A],
-    ev: Ask[F, TraceId]
-  ): F[List[A]]
-
+  /** Gets a pet GCP service account for the calling user. */
   def getPetServiceAccount(authorization: Authorization, googleProject: GoogleProject)(implicit
     ev: Ask[F, TraceId]
   ): F[Option[WorkbenchEmail]]
 
+  /** Gets a pet Azure managed identity for the calling user. */
   def getPetManagedIdentity(authorization: Authorization, cloudContext: AzureCloudContext)(implicit
     ev: Ask[F, TraceId]
   ): F[Option[WorkbenchEmail]]
 
+  /** Gets the GCP proxy group for provided user email. */
   def getUserProxy(userEmail: WorkbenchEmail)(implicit ev: Ask[F, TraceId]): F[Option[WorkbenchEmail]]
 
+  /** Gets a GCP pet access token from cache for the provider user/project. */
   def getCachedPetAccessToken(userEmail: WorkbenchEmail, googleProject: GoogleProject)(implicit
     ev: Ask[F, TraceId]
   ): F[Option[String]]
 
+  /** Gets the subject ID for the provided user email using a GCP pet access token. */
   def getUserSubjectId(userEmail: WorkbenchEmail, googleProject: GoogleProject)(implicit
     ev: Ask[F, TraceId]
   ): F[Option[UserSubjectId]]
 
+  /** Gets the Sam user info for the calling user. */
   def getSamUserInfo(token: String)(implicit ev: Ask[F, TraceId]): F[Option[SamUserInfo]]
 
+  /** Gets the auth token for the Leo service account. */
   def getLeoAuthToken: F[Authorization]
 
+  /** Returns whether the provided user is a member or admin of the given Sam group. */
   def isGroupMembersOrAdmin(groupName: GroupName, workbenchEmail: WorkbenchEmail)(implicit
     ev: Ask[F, TraceId]
   ): F[Boolean]

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/AppRoutes.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/AppRoutes.scala
@@ -168,14 +168,11 @@ class AppRoutes(kubernetesService: AppService[IO], userInfoDirectives: UserInfoD
       ctx <- ev.ask[AppContext]
       // if `deleteDisk` is explicitly set to true, then we delete disk; otherwise, we don't
       deleteDisk = params.get("deleteDisk").exists(_ == "true")
-      deleteParams = DeleteAppRequest(
+      apiCall = kubernetesService.deleteApp(
         userInfo,
         CloudContext.Gcp(googleProject),
         appName,
         deleteDisk
-      )
-      apiCall = kubernetesService.deleteApp(
-        deleteParams
       )
       _ <- ctx.span.fold(apiCall)(span => spanResource[IO](span, "deleteApp").use(_ => apiCall))
     } yield StatusCodes.Accepted

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/AppService.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/AppService.scala
@@ -9,7 +9,7 @@ import org.broadinstitute.dsde.workbench.model.UserInfo
 trait AppService[F[_]] {
   def createApp(
     userInfo: UserInfo,
-    cloudContext: CloudContext,
+    cloudContext: CloudContext.Gcp,
     appName: AppName,
     req: CreateAppRequest,
     workspaceId: Option[WorkspaceId] = None
@@ -17,25 +17,25 @@ trait AppService[F[_]] {
 
   def getApp(
     userInfo: UserInfo,
-    cloudContext: CloudContext,
+    cloudContext: CloudContext.Gcp,
     appName: AppName
   )(implicit as: Ask[F, AppContext]): F[GetAppResponse]
 
   def listApp(
     userInfo: UserInfo,
-    cloudContext: Option[CloudContext],
+    cloudContext: Option[CloudContext.Gcp],
     params: Map[String, String]
   )(implicit as: Ask[F, AppContext]): F[Vector[ListAppResponse]]
 
-  def deleteApp(request: DeleteAppRequest)(implicit
+  def deleteApp(userInfo: UserInfo, cloudContext: CloudContext.Gcp, appName: AppName, deleteDisk: Boolean)(implicit
     as: Ask[F, AppContext]
   ): F[Unit]
 
-  def stopApp(userInfo: UserInfo, cloudContext: CloudContext, appName: AppName)(implicit
+  def stopApp(userInfo: UserInfo, cloudContext: CloudContext.Gcp, appName: AppName)(implicit
     as: Ask[F, AppContext]
   ): F[Unit]
 
-  def startApp(userInfo: UserInfo, cloudContext: CloudContext, appName: AppName)(implicit
+  def startApp(userInfo: UserInfo, cloudContext: CloudContext.Gcp, appName: AppName)(implicit
     as: Ask[F, AppContext]
   ): F[Unit]
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/AppServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/AppServiceInterp.scala
@@ -968,10 +968,11 @@ final class LeoAppServiceInterp[F[_]: Parallel](config: AppServiceConfig,
       // Galaxy, Cromwell, and Custom app types require a disk.
       // Cromwell on Azure requires _no_ disk.
       _ <- (req.appType, diskOpt) match {
+        case (Galaxy | Cromwell | Custom, None) =>
+          Left(AppRequiresDiskException(cloudContext, appName, req.appType, ctx.traceId))
         case (CromwellOnAzure, Some(_)) =>
           Left(AppDiskNotSupportedException(cloudContext, appName, req.appType, ctx.traceId))
-        case (_, None) => Left(AppRequiresDiskException(cloudContext, appName, req.appType, ctx.traceId))
-        case _         => Right(())
+        case _ => Right(())
       }
 
       // Generate namespace and app release names using a random 6-character string prefix.

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
@@ -455,6 +455,8 @@ class GKEInterpreter[F[_]](
             app.extraArgs,
             app.customEnvironmentVariables
           )
+        case AppType.CromwellOnAzure =>
+          F.raiseError(AppCreationException(s"CromwellOnAzure app type not supported on GKE", Some(ctx.traceId)))
       }
 
       _ <- logger.info(ctx.loggingCtx)(
@@ -503,6 +505,8 @@ class GKEInterpreter[F[_]](
             } yield ()
         case AppType.Cromwell => persistentDiskQuery.updateLastUsedBy(diskId, app.id).transaction
         case AppType.Custom   => F.unit
+        case AppType.CromwellOnAzure =>
+          F.raiseError(AppCreationException(s"CromwellOnAzure app type not supported on GKE", Some(ctx.traceId)))
       }
 
       _ <- appQuery.updateStatus(params.appId, AppStatus.Running).transaction
@@ -876,6 +880,8 @@ class GKEInterpreter[F[_]](
               config.monitorConfig.startApp.interval
             ).interruptAfter(config.monitorConfig.startApp.interruptAfter).compile.lastOrError
           } yield last.isDone
+        case AppType.CromwellOnAzure =>
+          F.raiseError(AppStartException(s"CromwellOnAzure app type not supported on GKE"))
       }
 
       _ <-

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/auth/MockPetClusterServiceAccountProvider.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/auth/MockPetClusterServiceAccountProvider.scala
@@ -23,8 +23,8 @@ class MockPetClusterServiceAccountProvider extends ServiceAccountProvider[IO] {
     val authHeader = Authorization(Credentials.Token(AuthScheme.Bearer, s"TokenFor${userInfo.userEmail}"))
     // Pretend we're asking Sam for the pet
     cloudContext match {
-      case CloudContext.Gcp(googleProject) => samDao.getPetServiceAccount(authHeader, googleProject)
-      case CloudContext.Azure(_)           => samDao.getPetManagedIdentity(authHeader)
+      case CloudContext.Gcp(googleProject)  => samDao.getPetServiceAccount(authHeader, googleProject)
+      case CloudContext.Azure(cloudContext) => samDao.getPetManagedIdentity(authHeader, cloudContext)
     }
   }
 

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/MockSamDAO.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/MockSamDAO.scala
@@ -208,7 +208,8 @@ class MockSamDAO extends SamDAO[IO] {
     }
   }
 
-  def deleteResource[R](resource: R, creatorEmail: WorkbenchEmail, googleProject: GoogleProject)(implicit
+  override def deleteResourceAsGcpPet[R](resource: R, creatorEmail: WorkbenchEmail, googleProject: GoogleProject)(
+    implicit
     sr: SamResource[R],
     ev: Ask[IO, TraceId]
   ): IO[Unit] =

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/MockSamDAO.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/MockSamDAO.scala
@@ -5,6 +5,7 @@ import cats.effect.IO
 import cats.mtl.Ask
 import cats.syntax.all._
 import io.circe.{Decoder, Encoder}
+import org.broadinstitute.dsde.workbench.azure.AzureCloudContext
 import org.broadinstitute.dsde.workbench.leonardo.SamResourceId._
 import org.broadinstitute.dsde.workbench.leonardo.dao.MockSamDAO._
 import org.broadinstitute.dsde.workbench.leonardo.model.{SamResource, SamResourceAction}
@@ -228,10 +229,10 @@ class MockSamDAO extends SamDAO[IO] {
   ): IO[Option[WorkbenchEmail]] =
     IO.pure(Some(petSA))
 
-  override def getPetManagedIdentity(authorization: Authorization)(implicit
+  override def getPetManagedIdentity(authorization: Authorization, cloudContext: AzureCloudContext)(implicit
     ev: Ask[IO, TraceId]
   ): IO[Option[WorkbenchEmail]] =
-    IO.pure(Some(petSA))
+    IO.pure(Some(petMI))
 
   override def getUserProxy(
     userEmail: WorkbenchEmail
@@ -321,6 +322,7 @@ class MockSamDAO extends SamDAO[IO] {
 
 object MockSamDAO {
   val petSA = WorkbenchEmail("pet-1234567890@test-project.iam.gserviceaccount.com")
+  val petMI = WorkbenchEmail("/subscriptions/foo/resourceGroups/bar/userAssignedManagedIdentities/pet-1234")
   val projectOwnerEmail = WorkbenchEmail("project-owner@test.org")
   val appManagerActions = Set(AppAction.GetAppStatus, AppAction.DeleteApp)
   def userEmailToAuthorization(workbenchEmail: WorkbenchEmail): Authorization =

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/KubernetesServiceDbQueriesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/KubernetesServiceDbQueriesSpec.scala
@@ -1,18 +1,10 @@
 package org.broadinstitute.dsde.workbench.leonardo.db
 
 import cats.effect.unsafe.IORuntime
-import org.broadinstitute.dsde.workbench.leonardo.CommonTestData.project
-import org.broadinstitute.dsde.workbench.leonardo.{
-  AppStatus,
-  CloudContext,
-  KubernetesClusterStatus,
-  NodepoolStatus,
-  WorkspaceId
-}
 import org.broadinstitute.dsde.workbench.leonardo.KubernetesTestData.{makeApp, makeKubeCluster, makeNodepool}
-import org.broadinstitute.dsde.workbench.model.google.GoogleProject
-import org.scalatest.flatspec.AnyFlatSpecLike
 import org.broadinstitute.dsde.workbench.leonardo.http.dbioToIO
+import org.broadinstitute.dsde.workbench.leonardo.{AppStatus, KubernetesClusterStatus, NodepoolStatus, WorkspaceId}
+import org.scalatest.flatspec.AnyFlatSpecLike
 
 import java.util.UUID
 import scala.concurrent.ExecutionContext.Implicits.global

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/HttpRoutesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/HttpRoutesSpec.scala
@@ -21,7 +21,7 @@ import org.broadinstitute.dsde.workbench.leonardo.http.RuntimeRoutesTestJsonCode
 import org.broadinstitute.dsde.workbench.leonardo.http.api.RuntimeRoutes._
 import org.broadinstitute.dsde.workbench.leonardo.http.service._
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
-import org.broadinstitute.dsde.workbench.model.{ErrorReport, ErrorReportSource}
+import org.broadinstitute.dsde.workbench.model.{ErrorReport, ErrorReportSource, UserInfo}
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -286,12 +286,12 @@ class HttpRoutesSpec
 
   it should "not delete disk when deleting a kubernetes app with PD enabled if deleteDisk is not set" in {
     val kubernetesService = new MockAppService {
-      override def deleteApp(request: DeleteAppRequest)(implicit
-        as: Ask[IO, AppContext]
+      override def deleteApp(userInfo: UserInfo, cloudContext: CloudContext.Gcp, appName: AppName, deleteDisk: Boolean)(
+        implicit as: Ask[IO, AppContext]
       ): IO[Unit] = IO {
-        val expectedDeleteApp =
-          DeleteAppRequest(timedUserInfo, CloudContext.Gcp(GoogleProject("googleProject1")), AppName("app1"), false)
-        request shouldBe expectedDeleteApp
+        cloudContext shouldBe CloudContext.Gcp(GoogleProject("googleProject1"))
+        appName shouldBe AppName("app1")
+        deleteDisk shouldBe false
       }
     }
     Delete("/api/google/v1/apps/googleProject1/app1") ~> fakeRoutes(kubernetesService).route ~> check {

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/MockAppService.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/MockAppService.scala
@@ -4,18 +4,12 @@ package service
 
 import cats.effect.IO
 import cats.mtl.Ask
-import KubernetesTestData._
-import org.broadinstitute.dsde.workbench.leonardo.http.{
-  CreateAppRequest,
-  DeleteAppRequest,
-  GetAppResponse,
-  ListAppResponse
-}
+import org.broadinstitute.dsde.workbench.leonardo.KubernetesTestData._
 import org.broadinstitute.dsde.workbench.model.UserInfo
 
 class MockAppService extends AppService[IO] {
   override def createApp(userInfo: UserInfo,
-                         cloudContext: CloudContext,
+                         cloudContext: CloudContext.Gcp,
                          appName: AppName,
                          req: CreateAppRequest,
                          workspaceId: Option[WorkspaceId] = None
@@ -24,26 +18,26 @@ class MockAppService extends AppService[IO] {
   ): IO[Unit] =
     IO.unit
 
-  override def getApp(userInfo: UserInfo, cloudContext: CloudContext, appName: AppName)(implicit
+  override def getApp(userInfo: UserInfo, cloudContext: CloudContext.Gcp, appName: AppName)(implicit
     as: Ask[IO, AppContext]
   ): IO[GetAppResponse] =
     IO.pure(getAppResponse)
 
-  override def listApp(userInfo: UserInfo, cloudContext: Option[CloudContext], params: Map[String, String])(implicit
+  override def listApp(userInfo: UserInfo, cloudContext: Option[CloudContext.Gcp], params: Map[String, String])(implicit
     as: Ask[IO, AppContext]
   ): IO[Vector[ListAppResponse]] =
     IO.pure(listAppResponse)
 
-  override def deleteApp(request: DeleteAppRequest)(implicit
-    as: Ask[IO, AppContext]
+  override def deleteApp(userInfo: UserInfo, cloudContext: CloudContext.Gcp, appName: AppName, deleteDisk: Boolean)(
+    implicit as: Ask[IO, AppContext]
   ): IO[Unit] =
     IO.unit
 
-  override def stopApp(userInfo: UserInfo, cloudContext: CloudContext, appName: AppName)(implicit
+  override def stopApp(userInfo: UserInfo, cloudContext: CloudContext.Gcp, appName: AppName)(implicit
     as: Ask[IO, AppContext]
   ): IO[Unit] = IO.unit
 
-  override def startApp(userInfo: UserInfo, cloudContext: CloudContext, appName: AppName)(implicit
+  override def startApp(userInfo: UserInfo, cloudContext: CloudContext.Gcp, appName: AppName)(implicit
     as: Ask[IO, AppContext]
   ): IO[Unit] = IO.unit
 


### PR DESCRIPTION
Part 1 of https://broadworkbench.atlassian.net/browse/TOAZ-248

This PR makes some fixes/cleanup of front Leo app v2 handling, after testing on a BEE against a real Azure workspace. I tested the CRUD routes in Swagger and inspected the Leo DB on a BEE.

Part 2 will be the actual pubsub handling in Back Leo + tests.

See comments inline.

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
