### PR TITLE
[TOAZ-272] Cleanup: validate appType in request, create Azure app asynchronously

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/kubernetesModels.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/kubernetesModels.scala
@@ -321,19 +321,15 @@ object AppType {
   case object Custom extends AppType {
     override def toString: String = "CUSTOM"
   }
-  case object CromwellOnAzure extends AppType {
-    override def toString: String = "CROMWELL_ON_AZURE"
-  }
 
   def values: Set[AppType] = sealerate.values[AppType]
   def stringToObject: Map[String, AppType] = values.map(v => v.toString -> v).toMap
 
   def appTypeToFormattedByType(appType: AppType): FormattedBy =
     appType match {
-      case Galaxy          => FormattedBy.Galaxy
-      case Cromwell        => FormattedBy.Cromwell
-      case Custom          => FormattedBy.Custom
-      case CromwellOnAzure => FormattedBy.Cromwell
+      case Galaxy   => FormattedBy.Galaxy
+      case Cromwell => FormattedBy.Cromwell
+      case Custom   => FormattedBy.Custom
     }
 }
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/AppServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/AppServiceInterp.scala
@@ -1331,7 +1331,7 @@ case class AppMachineConfigNotSupportedException(traceId: TraceId)
 
 case class AppTypeNotSupportedExecption(cloudProvider: CloudProvider, appType: AppType, traceId: TraceId)
     extends LeoException(
-      s"Apps of type ${appType.toString} not support on ${cloudProvider.asString}. Trace ID: ${traceId.asString}",
+      s"Apps of type ${appType.toString} not supported on ${cloudProvider.asString}. Trace ID: ${traceId.asString}",
       StatusCodes.BadRequest,
       traceId = Some(traceId)
     )

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
@@ -1422,7 +1422,11 @@ class LeoPubsubMessageSubscriber[F[_]](
       ctx <- ev.ask
       _ <- msg.cloudContext match {
         case CloudContext.Azure(c) =>
-          azurePubsubHandler.createAndPollApp(msg.appId, msg.appName, msg.workspaceId, msg.landingZoneResourcesOpt, c)
+          val task =
+            azurePubsubHandler.createAndPollApp(msg.appId, msg.appName, msg.workspaceId, msg.landingZoneResourcesOpt, c)
+          asyncTasks.offer(
+            Task(ctx.traceId, task, Some(handleKubernetesError), ctx.now, "createAppV2")
+          )
         case CloudContext.Gcp(c) =>
           F.raiseError(
             PubsubKubernetesError(

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
@@ -455,8 +455,6 @@ class GKEInterpreter[F[_]](
             app.extraArgs,
             app.customEnvironmentVariables
           )
-        case AppType.CromwellOnAzure =>
-          F.raiseError(AppCreationException(s"CromwellOnAzure app type not supported on GKE", Some(ctx.traceId)))
       }
 
       _ <- logger.info(ctx.loggingCtx)(
@@ -505,8 +503,6 @@ class GKEInterpreter[F[_]](
             } yield ()
         case AppType.Cromwell => persistentDiskQuery.updateLastUsedBy(diskId, app.id).transaction
         case AppType.Custom   => F.unit
-        case AppType.CromwellOnAzure =>
-          F.raiseError(AppCreationException(s"CromwellOnAzure app type not supported on GKE", Some(ctx.traceId)))
       }
 
       _ <- appQuery.updateStatus(params.appId, AppStatus.Running).transaction
@@ -880,8 +876,6 @@ class GKEInterpreter[F[_]](
               config.monitorConfig.startApp.interval
             ).interruptAfter(config.monitorConfig.startApp.interruptAfter).compile.lastOrError
           } yield last.isDone
-        case AppType.CromwellOnAzure =>
-          F.raiseError(AppStartException(s"CromwellOnAzure app type not supported on GKE"))
       }
 
       _ <-

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/AppServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/AppServiceInterpSpec.scala
@@ -1491,7 +1491,7 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
     val appName = AppName("app1")
     val customEnvVars = Map("WORKSPACE_NAME" -> "testWorkspace")
     val appReq = createAppRequest.copy(kubernetesRuntimeConfig = None,
-                                       appType = AppType.CromwellOnAzure,
+                                       appType = AppType.Cromwell,
                                        diskConfig = None,
                                        customEnvironmentVariables = customEnvVars
     )
@@ -1530,7 +1530,7 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
   it should "V2 Azure - throw an error when providing a machine config" in isolatedDbTest {
     val appName = AppName("app1")
     val appReq = createAppRequest.copy(
-      appType = AppType.CromwellOnAzure,
+      appType = AppType.Cromwell,
       diskConfig = None
     )
 
@@ -1544,7 +1544,7 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
     val appName = AppName("app1")
     val appReq = createAppRequest.copy(
       kubernetesRuntimeConfig = None,
-      appType = AppType.CromwellOnAzure,
+      appType = AppType.Cromwell,
       diskConfig = Some(PersistentDiskRequest(diskName, None, None, Map.empty))
     )
 
@@ -1590,7 +1590,7 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
     val appName = AppName("app1")
     val customEnvVars = Map("WORKSPACE_NAME" -> "testWorkspace")
     val appReq = createAppRequest.copy(kubernetesRuntimeConfig = None,
-                                       appType = AppType.CromwellOnAzure,
+                                       appType = AppType.Cromwell,
                                        diskConfig = None,
                                        customEnvironmentVariables = customEnvVars
     )
@@ -1672,10 +1672,10 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
 
   it should "V2 Azure - delete an Azure app V2, update status appropriately, and queue a message" in isolatedDbTest {
     val publisherQueue = QueueFactory.makePublisherQueue()
-    val kubeServiceInterp = makeGcpWorkspaceInterp(publisherQueue)
+    val kubeServiceInterp = makeInterp(publisherQueue)
     val appName = AppName("app1")
     val appReq =
-      createAppRequest.copy(kubernetesRuntimeConfig = None, appType = AppType.CromwellOnAzure, diskConfig = None)
+      createAppRequest.copy(kubernetesRuntimeConfig = None, appType = AppType.Cromwell, diskConfig = None)
 
     kubeServiceInterp
       .createAppV2(userInfo, workspaceId, appName, appReq)
@@ -1772,7 +1772,7 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
     val appName1 = AppName("app1")
     val appReq1 = createAppRequest.copy(labels = Map("key1" -> "val1", "key2" -> "val2", "key3" -> "val3"),
                                         kubernetesRuntimeConfig = None,
-                                        appType = AppType.CromwellOnAzure,
+                                        appType = AppType.Cromwell,
                                         diskConfig = None
     )
     appServiceInterp
@@ -1786,7 +1786,7 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
 
     val appName2 = AppName("app2")
     val appReq2 =
-      createAppRequest.copy(kubernetesRuntimeConfig = None, appType = AppType.CromwellOnAzure, diskConfig = None)
+      createAppRequest.copy(kubernetesRuntimeConfig = None, appType = AppType.Cromwell, diskConfig = None)
 
     appServiceInterp
       .createAppV2(userInfo, workspaceId, appName2, appReq2)
@@ -1794,7 +1794,7 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
 
     val appName3 = AppName("app3")
     val appReq3 =
-      createAppRequest.copy(kubernetesRuntimeConfig = None, appType = AppType.CromwellOnAzure, diskConfig = None)
+      createAppRequest.copy(kubernetesRuntimeConfig = None, appType = AppType.Cromwell, diskConfig = None)
 
     appServiceInterp
       .createAppV2(userInfo, workspaceId3, appName3, appReq3)


### PR DESCRIPTION
Fixes a few things I noticed in testing:

1. Removed the `CromwellOnAzure` AppType -- I don't think it adds any real value, makes sense to reuse the `Cromwell` AppType for Azure.
2. Make Azure app creation and polling async to the pubsub message. This is our usual pattern. (I noticed 1 PubSub timeout in testing.)

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
