### PR TITLE
[TOAZ-279] Fix app unique constraint; DDL update

### DIFF
--- a/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changelog.xml
+++ b/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changelog.xml
@@ -91,4 +91,5 @@
     <include file="changesets/20220726_support_azure_for_app.xml" relativeToChangelogFile="true" />
     <include file="changesets/20220804_add_non_null_for_cloud_context_app.xml" relativeToChangelogFile="true" />
     <include file="changesets/20221017_add_workspace_id_to_kubernetes_cluster.xml" relativeToChangelogFile="true" />
+    <include file="changesets/20221115_azure_app_refactor.xml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/20221115_azure_app_refactor.xml
+++ b/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/20221115_azure_app_refactor.xml
@@ -6,9 +6,9 @@
     </changeSet>
 
     <changeSet logicalFilePath="leonardo" author="rtitle" id="app_error_ddl_update">
-        <sql>UPDATE APP_ERROR SET action = 'createApp' WHERE error = 'createGalaxyApp'</sql>
-        <sql>UPDATE APP_ERROR SET action = 'deleteApp' WHERE error = 'deleteGalaxyApp'</sql>
-        <sql>UPDATE APP_ERROR SET action = 'stopApp' WHERE error = 'stopGalaxyApp'</sql>
-        <sql>UPDATE APP_ERROR SET action = 'startApp' WHERE error = 'startGalaxyApp'</sql>
+        <sql>UPDATE APP_ERROR SET action = 'createApp' WHERE action = 'createGalaxyApp'</sql>
+        <sql>UPDATE APP_ERROR SET action = 'deleteApp' WHERE action = 'deleteGalaxyApp'</sql>
+        <sql>UPDATE APP_ERROR SET action = 'stopApp' WHERE action = 'stopGalaxyApp'</sql>
+        <sql>UPDATE APP_ERROR SET action = 'startApp' WHERE action = 'startGalaxyApp'</sql>
     </changeSet>
 </databaseChangeLog>

--- a/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/20221115_azure_app_refactor.xml
+++ b/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/20221115_azure_app_refactor.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog logicalFilePath="leonardo" xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+    <changeSet logicalFilePath="leonardo" author="rtitle" id="update_app_unique_constraint">
+        <dropUniqueConstraint tableName="APP" constraintName="IDX_APP_UNIQUE"/>
+        <addUniqueConstraint columnNames="appName, nodepoolId, destroyedDate" constraintName="IDX_APP_UNIQUE" tableName="APP"/>
+    </changeSet>
+
+    <changeSet logicalFilePath="leonardo" author="rtitle" id="app_error_ddl_update">
+        <sql>UPDATE APP_ERROR SET action = 'createApp' WHERE error = 'createGalaxyApp'</sql>
+        <sql>UPDATE APP_ERROR SET action = 'deleteApp' WHERE error = 'deleteGalaxyApp'</sql>
+        <sql>UPDATE APP_ERROR SET action = 'stopApp' WHERE error = 'stopGalaxyApp'</sql>
+        <sql>UPDATE APP_ERROR SET action = 'startApp' WHERE error = 'startGalaxyApp'</sql>
+    </changeSet>
+</databaseChangeLog>


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/TOAZ-279

Fixing a couple things I noticed on dev.

1. `APP` table unique constraint was on `(appName, nodepoolId)`. This meant we couldn't delete & recreate Azure apps with the same name. Normally we include `destroyedDate` in the index to allow this. (Note APP already has a non-null `destroyedDate` column so I think this should be fine.)

2. I had renamed the values in [this enum](https://github.com/DataBiosphere/leonardo/blob/develop/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/kubernetesModels.scala#L253-L277) but there are existing DB records with the old values -- so it was throwing a deserialization exception when I tried to list my existing apps in the DB. Added a DDL update to fix existing records.

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
