### PR TITLE
IA-3865 Add `saturnAutoCreated` label for apps created by Terra

### DIFF
--- a/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changelog.xml
+++ b/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changelog.xml
@@ -93,4 +93,5 @@
     <include file="changesets/20221017_add_workspace_id_to_kubernetes_cluster.xml" relativeToChangelogFile="true" />
     <include file="changesets/20221115_azure_app_refactor.xml" relativeToChangelogFile="true" />
     <include file="changesets/20221117_move_workspace_id_to_app_table.xml" relativeToChangelogFile="true" />
+    <include file="changesets/20221122_add_saturnAutoCreated_label.xml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/20221122_add_saturnAutoCreated_label.xml
+++ b/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/20221122_add_saturnAutoCreated_label.xml
@@ -4,7 +4,7 @@
         <sql>
             INSERT into `LABEL` (`key`, `value`, `resourceType`, `resourceId`)
             SELECT "saturnAutoCreated", "true", "app", APP.id
-            FROM APP where status != "DELETED" and status != "ERROR" and (appName LIKE "saturn%" or appName LIKE "terra-app%");
+            FROM APP where status != "DELETED" and (appName LIKE "saturn%" or appName LIKE "terra-app%");
         </sql>
     </changeSet>
 </databaseChangeLog>

--- a/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/20221122_add_saturnAutoCreated_label.xml
+++ b/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/20221122_add_saturnAutoCreated_label.xml
@@ -4,7 +4,7 @@
         <sql>
             INSERT into `LABEL` (`key`, `value`, `resourceType`, `resourceId`)
             SELECT "saturnAutoCreated", "true", "app", APP.id
-            FROM APP where status != "DELETED" and status != "ERROR" and (appName LIKE "saturn%" or appName LIKE "terra-app");
+            FROM APP where status != "DELETED" and status != "ERROR" and (appName LIKE "saturn%" or appName LIKE "terra-app%");
         </sql>
     </changeSet>
 </databaseChangeLog>

--- a/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/20221122_add_saturnAutoCreated_label.xml
+++ b/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/20221122_add_saturnAutoCreated_label.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog logicalFilePath="leonardo" xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+    <changeSet logicalFilePath="leonardo" author="qi" id="add_saturnAutoCreated_label">
+        <sql>
+            INSERT into `LABEL` (`key`, `value`, `resourceType`, `resourceId`)
+            SELECT "saturnAutoCreated", "true", "app", APP.id
+            FROM APP where status != "DELETED" and status != "ERROR" and (appName LIKE "saturn%" or appName LIKE "terra-app");
+        </sql>
+    </changeSet>
+</databaseChangeLog>


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-3865

`saturnAutoCreated` label is used in runtime to differentiate runtimes created through Terra vs ones created outside terra (such as via direct API calls or created via AoU). We should have something similar for apps as well.

Tested against dev DB and removed the labels I added manually


Should have https://github.com/DataBiosphere/terra-ui/pull/3533 merge/deployed first before this PR is merged

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
