### PR TITLE
[WM-1556] increase automerge timeouts to accommodate jenkins check

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -27,9 +27,9 @@ jobs:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           MERGE_METHOD: squash
           MERGE_FORKS: false
-          MERGE_RETRIES: 72 # Retry for 6 minutes instead of 30s
-          MERGE_RETRY_SLEEP: 5000 # 5 seconds
+          MERGE_RETRIES: 180 # Retry for 3 hours
+          MERGE_RETRY_SLEEP: 60000 # 60 seconds
           UPDATE_METHOD: rebase
-          UPDATE_RETRIES: 72 # Retry updates for 6 minutes instead of once
-          UPDATE_RETRY_SLEEP: 5000 # 5 seconds
+          UPDATE_RETRIES: 180 # Retry for 3 hours
+          UPDATE_RETRY_SLEEP: 60000 # 60 seconds
           MERGE_REQUIRED_APPROVALS: 0


### PR DESCRIPTION
Automerge action runs in parallel with all the other checks. It would be better to create a dependency in the automerge action on the other checks, but my tests have indicated that this will be more complicated than expected, and I believe this is a good enough solution for now.

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
