### PR TITLE
[IA-3676][IA-3885] Add custom timeout option.

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/JsonCodec.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/JsonCodec.scala
@@ -42,6 +42,8 @@ import org.broadinstitute.dsde.workbench.azure.{AKSClusterName, AzureCloudContex
 import org.broadinstitute.dsde.workbench.google2.JsonCodec.traceIdEncoder
 import org.broadinstitute.dsde.workbench.google2.JsonCodec.traceIdDecoder
 
+import scala.concurrent.duration.FiniteDuration
+
 object JsonCodec {
   // Errors
   val negativeNumberDecodingFailure = DecodingFailure("Negative number is not allowed", List.empty)
@@ -485,6 +487,9 @@ object JsonCodec {
         else none[Region]
       regionOpt.toRight(s"Invalid azure region ${s}")
     }
+  implicit val timeoutMinutesDecoder: Decoder[FiniteDuration] = Decoder.decodeLong.emap { s =>
+    Right(FiniteDuration(s, "Minutes"))
+  }
 
   implicit val gpuConfigDecoder: Decoder[GpuConfig] = Decoder.forProduct2(
     "gpuType",
@@ -496,12 +501,13 @@ object JsonCodec {
     "numOfCpus"
   )(AppMachineType.apply)
 
-  implicit val gceWithPdConfigDecoder: Decoder[RuntimeConfig.GceWithPdConfig] = Decoder.forProduct5(
+  implicit val gceWithPdConfigDecoder: Decoder[RuntimeConfig.GceWithPdConfig] = Decoder.forProduct6(
     "machineType",
     "persistentDiskId",
     "bootDiskSize",
     "zone",
-    "gpuConfig"
+    "gpuConfig",
+    "timeoutMinutes"
   )(RuntimeConfig.GceWithPdConfig.apply)
   implicit val gceConfigDecoder: Decoder[RuntimeConfig.GceConfig] = Decoder.forProduct6(
     "machineType",

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/JsonCodec.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/JsonCodec.scala
@@ -503,13 +503,14 @@ object JsonCodec {
     "zone",
     "gpuConfig"
   )(RuntimeConfig.GceWithPdConfig.apply)
-  implicit val gceConfigDecoder: Decoder[RuntimeConfig.GceConfig] = Decoder.forProduct5(
+  implicit val gceConfigDecoder: Decoder[RuntimeConfig.GceConfig] = Decoder.forProduct6(
     "machineType",
     "diskSize",
     "bootDiskSize",
     "zone",
-    "gpuConfig"
-  )((mt, ds, bds, z, gpu) => RuntimeConfig.GceConfig(mt, ds, bds, z, gpu))
+    "gpuConfig",
+    "timeoutMinutes"
+  )((mt, ds, bds, z, gpu, tm) => RuntimeConfig.GceConfig(mt, ds, bds, z, gpu, tm))
 
   implicit val azureVmConfigDecoder: Decoder[RuntimeConfig.AzureConfig] = Decoder.forProduct3(
     "machineType",

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/JsonCodec.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/JsonCodec.scala
@@ -42,7 +42,7 @@ import org.broadinstitute.dsde.workbench.azure.{AKSClusterName, AzureCloudContex
 import org.broadinstitute.dsde.workbench.google2.JsonCodec.traceIdEncoder
 import org.broadinstitute.dsde.workbench.google2.JsonCodec.traceIdDecoder
 
-import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.duration.{FiniteDuration, MINUTES}
 
 object JsonCodec {
   // Errors
@@ -488,7 +488,7 @@ object JsonCodec {
       regionOpt.toRight(s"Invalid azure region ${s}")
     }
   implicit val timeoutMinutesDecoder: Decoder[FiniteDuration] = Decoder.decodeLong.emap { s =>
-    Right(FiniteDuration(s, "Minutes"))
+    Right(FiniteDuration(s, MINUTES))
   }
 
   implicit val gpuConfigDecoder: Decoder[GpuConfig] = Decoder.forProduct2(

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/runtimeRoutesModels.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/runtimeRoutesModels.scala
@@ -20,7 +20,8 @@ object RuntimeConfigRequest {
     machineType: Option[MachineTypeName],
     diskSize: Option[DiskSize],
     zone: Option[ZoneName],
-    gpuConfig: Option[GpuConfig]
+    gpuConfig: Option[GpuConfig],
+    timeoutMinutes: Option[Int]
   ) extends RuntimeConfigRequest {
     val cloudService: CloudService = CloudService.GCE
   }
@@ -63,7 +64,8 @@ final case class CreateRuntimeRequest(
   toolDockerImage: Option[ContainerImage],
   welderRegistry: Option[ContainerRegistry],
   scopes: Set[String],
-  customEnvironmentVariables: Map[String, String]
+  customEnvironmentVariables: Map[String, String],
+  timeoutMinutes: Option[Int]
 )
 
 final case class CreateRuntimeResponse(traceId: TraceId)

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/runtimeRoutesModels.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/runtimeRoutesModels.scala
@@ -30,7 +30,8 @@ object RuntimeConfigRequest {
     machineType: Option[MachineTypeName],
     persistentDisk: PersistentDiskRequest,
     zone: Option[ZoneName],
-    gpuConfig: Option[GpuConfig]
+    gpuConfig: Option[GpuConfig],
+    timeoutMinutes: Option[FiniteDuration]
   ) extends RuntimeConfigRequest {
     val cloudService: CloudService = CloudService.GCE
   }

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/runtimeRoutesModels.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/runtimeRoutesModels.scala
@@ -21,7 +21,7 @@ object RuntimeConfigRequest {
     diskSize: Option[DiskSize],
     zone: Option[ZoneName],
     gpuConfig: Option[GpuConfig],
-    timeoutMinutes: Option[Int]
+    timeoutMinutes: Option[FiniteDuration]
   ) extends RuntimeConfigRequest {
     val cloudService: CloudService = CloudService.GCE
   }
@@ -65,7 +65,7 @@ final case class CreateRuntimeRequest(
   welderRegistry: Option[ContainerRegistry],
   scopes: Set[String],
   customEnvironmentVariables: Map[String, String],
-  timeoutMinutes: Option[Int]
+  timeoutMinutes: Option[FiniteDuration]
 )
 
 final case class CreateRuntimeResponse(traceId: TraceId)

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/runtimeModels.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/runtimeModels.scala
@@ -15,6 +15,7 @@ import java.net.URL
 import java.nio.file.Path
 import java.time.Instant
 import scala.collection.immutable
+import scala.concurrent.duration.FiniteDuration
 
 /**
  * This file contains models for Leonardo runtimes.
@@ -252,7 +253,7 @@ object RuntimeConfig {
     ], // This is optional for supporting old runtimes which only have 1 disk. All new runtime will have a boot disk
     zone: ZoneName,
     gpuConfig: Option[GpuConfig], // This is optional since not all runtimes use gpus
-    timeoutMinutes: Option[Int]
+    timeoutMinutes: Option[FiniteDuration]
   ) extends RuntimeConfig {
     val cloudService: CloudService = CloudService.GCE
   }
@@ -262,7 +263,8 @@ object RuntimeConfig {
                                    persistentDiskId: Option[DiskId],
                                    bootDiskSize: DiskSize,
                                    zone: ZoneName,
-                                   gpuConfig: Option[GpuConfig]
+                                   gpuConfig: Option[GpuConfig],
+                                   timeoutMinutes: Option[FiniteDuration]
   ) extends RuntimeConfig {
     val cloudService: CloudService = CloudService.GCE
   }

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/runtimeModels.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/runtimeModels.scala
@@ -251,7 +251,8 @@ object RuntimeConfig {
       DiskSize
     ], // This is optional for supporting old runtimes which only have 1 disk. All new runtime will have a boot disk
     zone: ZoneName,
-    gpuConfig: Option[GpuConfig] // This is optional since not all runtimes use gpus
+    gpuConfig: Option[GpuConfig], // This is optional since not all runtimes use gpus
+    timeoutMinutes: Option[Int]
   ) extends RuntimeConfig {
     val cloudService: CloudService = CloudService.GCE
   }

--- a/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changelog.xml
+++ b/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changelog.xml
@@ -94,4 +94,5 @@
     <include file="changesets/20221115_azure_app_refactor.xml" relativeToChangelogFile="true" />
     <include file="changesets/20221117_move_workspace_id_to_app_table.xml" relativeToChangelogFile="true" />
     <include file="changesets/20221122_add_saturnAutoCreated_label.xml" relativeToChangelogFile="true" />
+    <include file="changesets/20221130_add_timeout_minutes_to_runtime_config.xml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/20221130_add_timeout_minutes_to_runtime_config.xml
+++ b/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/20221130_add_timeout_minutes_to_runtime_config.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog logicalFilePath="leonardo" xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+
+    <changeSet logicalFilePath="leonardo" author="nlandolt" id="add_timeout_minutes_to_runtime_config">
+        <addColumn tableName="RUNTIME_CONFIG">
+            <column name="timeoutMinutes" type="int(11)">
+                <constraints nullable="true"/>
+            </column>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/LeoLenses.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/LeoLenses.scala
@@ -97,7 +97,8 @@ object LeoLenses {
         x.diskSize,
         Some(x.bootDiskSize),
         x.zone,
-        x.gpuConfig
+        x.gpuConfig,
+        None
       )
     case x: RuntimeConfigInCreateRuntimeMessage.GceWithPdConfig =>
       RuntimeConfig.GceWithPdConfig(

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/LeoLenses.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/LeoLenses.scala
@@ -69,7 +69,8 @@ object LeoLenses {
               )
             ),
           x.zone,
-          x.gpuConfig
+          x.gpuConfig,
+          x.timeoutMinutes
         )
       )
     case x: RuntimeConfig.GceWithPdConfig =>

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/LeoLenses.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/LeoLenses.scala
@@ -107,7 +107,8 @@ object LeoLenses {
         Some(x.persistentDiskId),
         x.bootDiskSize,
         x.zone,
-        x.gpuConfig
+        x.gpuConfig,
+        None
       )
     case x: RuntimeConfigInCreateRuntimeMessage.DataprocConfig =>
       dataprocInCreateRuntimeMsgToDataprocRuntime(x)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/LeoLenses.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/LeoLenses.scala
@@ -84,7 +84,8 @@ object LeoLenses {
           ),
           x.bootDiskSize,
           x.zone,
-          x.gpuConfig
+          x.gpuConfig,
+          x.timeoutMinutes
         )
       )
     case x: RuntimeConfig.DataprocConfig =>
@@ -99,7 +100,7 @@ object LeoLenses {
         Some(x.bootDiskSize),
         x.zone,
         x.gpuConfig,
-        None
+        x.timeoutMinutes
       )
     case x: RuntimeConfigInCreateRuntimeMessage.GceWithPdConfig =>
       RuntimeConfig.GceWithPdConfig(
@@ -108,7 +109,7 @@ object LeoLenses {
         x.bootDiskSize,
         x.zone,
         x.gpuConfig,
-        None
+        x.timeoutMinutes
       )
     case x: RuntimeConfigInCreateRuntimeMessage.DataprocConfig =>
       dataprocInCreateRuntimeMsgToDataprocRuntime(x)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
@@ -94,7 +94,7 @@ object Config {
       bootDiskSize = Some(config.as[DiskSize]("bootDiskSize")),
       zone = config.as[ZoneName]("zone"),
       gpuConfig = None,
-      None
+      timeoutMinutes = None
     )
   }
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
@@ -93,7 +93,8 @@ object Config {
       diskSize = config.as[DiskSize]("diskSize"),
       bootDiskSize = Some(config.as[DiskSize]("bootDiskSize")),
       zone = config.as[ZoneName]("zone"),
-      gpuConfig = None
+      gpuConfig = None,
+      None
     )
   }
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/RuntimeConfigQueries.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/RuntimeConfigQueries.scala
@@ -52,7 +52,7 @@ object RuntimeConfigQueries {
       val diskId = runtimeConfig match {
         case Some(value) =>
           value match {
-            case RuntimeConfig.GceConfig(_, _, _, _, _)                        => none[DiskId]
+            case RuntimeConfig.GceConfig(_, _, _, _, _, _)                     => none[DiskId]
             case RuntimeConfig.GceWithPdConfig(_, persistentDiskId, _, _, _)   => persistentDiskId
             case RuntimeConfig.DataprocConfig(_, _, _, _, _, _, _, _, _, _, _) => none[DiskId]
             case RuntimeConfig.AzureConfig(_, persistentDiskId, _)             => persistentDiskId.some

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/RuntimeConfigQueries.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/RuntimeConfigQueries.scala
@@ -52,10 +52,10 @@ object RuntimeConfigQueries {
       val diskId = runtimeConfig match {
         case Some(value) =>
           value match {
-            case RuntimeConfig.GceConfig(_, _, _, _, _, _)                     => none[DiskId]
-            case RuntimeConfig.GceWithPdConfig(_, persistentDiskId, _, _, _)   => persistentDiskId
-            case RuntimeConfig.DataprocConfig(_, _, _, _, _, _, _, _, _, _, _) => none[DiskId]
-            case RuntimeConfig.AzureConfig(_, persistentDiskId, _)             => persistentDiskId.some
+            case RuntimeConfig.GceConfig(_, _, _, _, _, _)                      => none[DiskId]
+            case RuntimeConfig.GceWithPdConfig(_, persistentDiskId, _, _, _, _) => persistentDiskId
+            case RuntimeConfig.DataprocConfig(_, _, _, _, _, _, _, _, _, _, _)  => none[DiskId]
+            case RuntimeConfig.AzureConfig(_, persistentDiskId, _)              => persistentDiskId.some
           }
         case None => none[DiskId]
       }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/RuntimeConfigTable.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/RuntimeConfigTable.scala
@@ -94,7 +94,8 @@ class RuntimeConfigTable(tag: Tag) extends Table[RuntimeConfigRecord](tag, "RUNT
                     None,
                     bds,
                     zone.getOrElse(throw new SQLDataException("zone should not be null for GCE")),
-                    getGpuConfig(gpuConfig._1, gpuConfig._2)
+                    getGpuConfig(gpuConfig._1, gpuConfig._2),
+                    None
                   )
                 )(diskId =>
                   RuntimeConfig.GceWithPdConfig(
@@ -102,7 +103,8 @@ class RuntimeConfigTable(tag: Tag) extends Table[RuntimeConfigRecord](tag, "RUNT
                     Some(diskId),
                     bds,
                     zone.getOrElse(throw new SQLDataException("zone should not be null for GCE")),
-                    getGpuConfig(gpuConfig._1, gpuConfig._2)
+                    getGpuConfig(gpuConfig._1, gpuConfig._2),
+                    None
                   )
                 )
             }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/RuntimeConfigTable.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/RuntimeConfigTable.scala
@@ -77,11 +77,13 @@ class RuntimeConfigTable(tag: Tag) extends Table[RuntimeConfigRecord](tag, "RUNT
           case CloudService.GCE =>
             diskSize match {
               case Some(size) =>
-                RuntimeConfig.GceConfig(machineType,
-                                        size,
-                                        bootDiskSize,
-                                        zone.getOrElse(throw new SQLDataException("zone should not be null for GCE")),
-                                        getGpuConfig(gpuConfig._1, gpuConfig._2)
+                RuntimeConfig.GceConfig(
+                  machineType,
+                  size,
+                  bootDiskSize,
+                  zone.getOrElse(throw new SQLDataException("zone should not be null for GCE")),
+                  getGpuConfig(gpuConfig._1, gpuConfig._2),
+                  None
                 )
               case None =>
                 val bds =

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/RuntimeRoutes.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/RuntimeRoutes.scala
@@ -398,12 +398,13 @@ object RuntimeRoutes {
             pd <- x.downField("persistentDisk").as[Option[PersistentDiskRequest]]
             zone <- x.downField("zone").as[Option[ZoneName]]
             gpu <- x.downField("gpuConfig").as[Option[GpuConfig]]
+            timeoutMinutes <- x.downField("timeoutMinutes").as[Option[Int]]
             res <- pd match {
               case Some(p) => RuntimeConfigRequest.GceWithPdConfig(machineType, p, zone, gpu).asRight[DecodingFailure]
               case None =>
                 x.downField("diskSize")
                   .as[Option[DiskSize]]
-                  .map(d => RuntimeConfigRequest.GceConfig(machineType, d, zone, gpu))
+                  .map(d => RuntimeConfigRequest.GceConfig(machineType, d, zone, gpu, timeoutMinutes))
             }
           } yield res
         case CloudService.AzureVm =>
@@ -436,6 +437,7 @@ object RuntimeRoutes {
       wr <- c.downField("welderRegistry").as[Option[ContainerRegistry]]
       s <- c.downField("scopes").as[Option[Set[String]]]
       cv <- c.downField("customEnvironmentVariables").as[Option[LabelMap]]
+      tm <- c.downField("timeoutMinutes").as[Option[Int]]
     } yield CreateRuntimeRequest(
       l.getOrElse(Map.empty),
       us.orElse(jus),
@@ -448,7 +450,8 @@ object RuntimeRoutes {
       tdi,
       wr,
       s.getOrElse(Set.empty),
-      cv.getOrElse(Map.empty)
+      cv.getOrElse(Map.empty),
+      tm
     )
   }
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/RuntimeRoutes.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/RuntimeRoutes.scala
@@ -288,7 +288,8 @@ object RuntimeRoutes {
         .as[Option[DiskSize]]
       zone <- x.downField("zone").as[Option[ZoneName]]
       gpu <- x.downField("gpuConfig").as[Option[GpuConfig]]
-    } yield RuntimeConfigRequest.GceConfig(machineType, diskSize, zone, gpu)
+      timeoutMinutes <- x.downField("timeoutMinutes").as[Option[Int]]
+    } yield RuntimeConfigRequest.GceConfig(machineType, diskSize, zone, gpu, timeoutMinutes)
   }
 
   val invalidPropertiesError =

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/RuntimeRoutes.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/RuntimeRoutes.scala
@@ -277,7 +277,8 @@ object RuntimeRoutes {
         .as[PersistentDiskRequest]
       zone <- x.downField("zone").as[Option[ZoneName]]
       gpu <- x.downField("gpuConfig").as[Option[GpuConfig]]
-    } yield RuntimeConfigRequest.GceWithPdConfig(machineType, pd, zone, gpu)
+      timeoutMinutes <- x.downField("timeoutMinutes").as[Option[FiniteDuration]]
+    } yield RuntimeConfigRequest.GceWithPdConfig(machineType, pd, zone, gpu, timeoutMinutes)
   }
 
   implicit val gceConfigRequestDecoder: Decoder[RuntimeConfigRequest.GceConfig] = Decoder.instance { x =>
@@ -401,7 +402,8 @@ object RuntimeRoutes {
             gpu <- x.downField("gpuConfig").as[Option[GpuConfig]]
             timeoutMinutes <- x.downField("timeoutMinutes").as[Option[FiniteDuration]]
             res <- pd match {
-              case Some(p) => RuntimeConfigRequest.GceWithPdConfig(machineType, p, zone, gpu).asRight[DecodingFailure]
+              case Some(p) =>
+                RuntimeConfigRequest.GceWithPdConfig(machineType, p, zone, gpu, timeoutMinutes).asRight[DecodingFailure]
               case None =>
                 x.downField("diskSize")
                   .as[Option[DiskSize]]

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/RuntimeRoutes.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/RuntimeRoutes.scala
@@ -288,7 +288,7 @@ object RuntimeRoutes {
         .as[Option[DiskSize]]
       zone <- x.downField("zone").as[Option[ZoneName]]
       gpu <- x.downField("gpuConfig").as[Option[GpuConfig]]
-      timeoutMinutes <- x.downField("timeoutMinutes").as[Option[Int]]
+      timeoutMinutes <- x.downField("timeoutMinutes").as[Option[FiniteDuration]]
     } yield RuntimeConfigRequest.GceConfig(machineType, diskSize, zone, gpu, timeoutMinutes)
   }
 
@@ -399,7 +399,7 @@ object RuntimeRoutes {
             pd <- x.downField("persistentDisk").as[Option[PersistentDiskRequest]]
             zone <- x.downField("zone").as[Option[ZoneName]]
             gpu <- x.downField("gpuConfig").as[Option[GpuConfig]]
-            timeoutMinutes <- x.downField("timeoutMinutes").as[Option[Int]]
+            timeoutMinutes <- x.downField("timeoutMinutes").as[Option[FiniteDuration]]
             res <- pd match {
               case Some(p) => RuntimeConfigRequest.GceWithPdConfig(machineType, p, zone, gpu).asRight[DecodingFailure]
               case None =>
@@ -438,7 +438,7 @@ object RuntimeRoutes {
       wr <- c.downField("welderRegistry").as[Option[ContainerRegistry]]
       s <- c.downField("scopes").as[Option[Set[String]]]
       cv <- c.downField("customEnvironmentVariables").as[Option[LabelMap]]
-      tm <- c.downField("timeoutMinutes").as[Option[Int]]
+      tm <- c.downField("timeoutMinutes").as[Option[FiniteDuration]]
     } yield CreateRuntimeRequest(
       l.getOrElse(Map.empty),
       us.orElse(jus),

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/RuntimeRoutes.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/RuntimeRoutes.scala
@@ -331,6 +331,7 @@ object RuntimeRoutes {
       region <- c.downField("region").as[Option[RegionName]]
       componentGatewayEnabled <- c.downField("componentGatewayEnabled").as[Option[Boolean]]
       workerPrivateAccess <- c.downField("workerPrivateAccess").as[Option[Boolean]]
+
       res <- numberOfWorkersInput match {
         case Some(x) if x < 0 => Left(negativeNumberDecodingFailure)
         case Some(0) =>

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/RuntimeV2Routes.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/RuntimeV2Routes.scala
@@ -171,7 +171,6 @@ class RuntimeV2Routes(saturnIframeExtentionHostConfig: RefererConfig,
   ): IO[ToResponseMarshallable] =
     for {
       ctx <- ev.ask[AppContext]
-      _ = println("111 starting runtime")
       apiCall = runtimeV2Service.startRuntime(userInfo, runtimeName, workspaceId)
       _ <- metrics.incrementCounter("startRuntimeV2")
       resp <- ctx.span.fold(apiCall)(span =>

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/package.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/package.scala
@@ -25,6 +25,7 @@ import slick.dbio.DBIO
 import java.nio.file.Path
 import java.time.Instant
 import java.util.UUID
+import scala.concurrent.duration.FiniteDuration
 
 package object http {
   val includeDeletedKey = "includeDeleted"
@@ -107,8 +108,10 @@ package object http {
 final case class CloudServiceMonitorOps[F[_], A](a: A)(implicit
   monitor: RuntimeMonitor[F, A]
 ) {
-  def process(runtimeId: Long, action: RuntimeStatus)(implicit ev: Ask[F, TraceId]): Stream[F, Unit] =
-    monitor.process(a)(runtimeId, action)
+  def process(runtimeId: Long, action: RuntimeStatus, timeoutMinutes: Option[FiniteDuration])(implicit
+    ev: Ask[F, TraceId]
+  ): Stream[F, Unit] =
+    monitor.process(a)(runtimeId, action, timeoutMinutes)
 
   def handlePollCheckCompletion(monitorContext: MonitorContext,
                                 runtimeAndRuntimeConfig: RuntimeAndRuntimeConfig

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterp.scala
@@ -673,7 +673,7 @@ class RuntimeServiceInterp[F[_]: Parallel](config: RuntimeServiceConfig,
                                                context.traceId
             )
           } yield r
-        case (RuntimeConfig.GceWithPdConfig(machineType, diskIdOpt, _, _, _),
+        case (RuntimeConfig.GceWithPdConfig(machineType, diskIdOpt, _, _, _, _),
               UpdateRuntimeConfigRequest.GceConfig(newMachineType, diskSizeInRequest)
             ) =>
           for {

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterp.scala
@@ -115,6 +115,7 @@ class RuntimeServiceInterp[F[_]: Parallel](config: RuntimeServiceConfig,
               config.gceConfig.runtimeConfigDefaults.diskSize,
               bootDiskSize,
               config.gceConfig.runtimeConfigDefaults.zone,
+              None,
               None
             )
             runtimeConfig <- req.runtimeConfig
@@ -128,7 +129,8 @@ class RuntimeServiceInterp[F[_]: Parallel](config: RuntimeServiceConfig,
                           gce.diskSize.getOrElse(config.gceConfig.runtimeConfigDefaults.diskSize),
                           bootDiskSize,
                           gce.zone.getOrElse(config.gceConfig.runtimeConfigDefaults.zone),
-                          gce.gpuConfig
+                          gce.gpuConfig,
+                          gce.timeoutMinutes
                         ): RuntimeConfigInCreateRuntimeMessage
                       )
                     case dataproc: RuntimeConfigRequest.DataprocConfig =>
@@ -651,7 +653,7 @@ class RuntimeServiceInterp[F[_]: Parallel](config: RuntimeServiceConfig,
     for {
       context <- ctx.ask
       msg <- (runtimeConfig, request) match {
-        case (RuntimeConfig.GceConfig(machineType, existngDiskSize, _, _, _),
+        case (RuntimeConfig.GceConfig(machineType, existngDiskSize, _, _, _, _),
               UpdateRuntimeConfigRequest.GceConfig(newMachineType, diskSizeInRequest)
             ) =>
           for {

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterp.scala
@@ -206,7 +206,7 @@ class RuntimeServiceInterp[F[_]: Parallel](config: RuntimeServiceConfig,
             saveRuntime = SaveCluster(cluster = runtime, runtimeConfig = runtimeConfigToSave, now = context.now)
             runtime <- clusterQuery.save(saveRuntime).transaction
             _ <- publisherQueue.offer(
-              CreateRuntimeMessage.fromRuntime(runtime, runtimeConfig, Some(context.traceId))
+              CreateRuntimeMessage.fromRuntime(runtime, runtimeConfig, Some(context.traceId), req.timeoutMinutes)
             )
           } yield ()
       }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterp.scala
@@ -158,7 +158,8 @@ class RuntimeServiceInterp[F[_]: Parallel](config: RuntimeServiceConfig,
                             diskResult.disk.id,
                             bootDiskSize,
                             gce.zone.getOrElse(config.gceConfig.runtimeConfigDefaults.zone),
-                            gce.gpuConfig
+                            gce.gpuConfig,
+                            gce.timeoutMinutes
                           ): RuntimeConfigInCreateRuntimeMessage
                         )
                   }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/BaseCloudServiceRuntimeMonitor.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/BaseCloudServiceRuntimeMonitor.scala
@@ -514,8 +514,7 @@ abstract class BaseCloudServiceRuntimeMonitor[F[_]] {
               getCustomInterruptablePollMonitorConfig(monitorConfig.checkTools, timeoutMinutes)
             case None => monitorConfig.checkTools
           }
-        case runtimeConfig =>
-          monitorConfig.checkTools
+        case _ => monitorConfig.checkTools
       }
       // wait for 10 minutes for tools to start up before time out.
       availableTools <- streamFUntilDone(

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/BaseCloudServiceRuntimeMonitor.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/BaseCloudServiceRuntimeMonitor.scala
@@ -514,7 +514,8 @@ abstract class BaseCloudServiceRuntimeMonitor[F[_]] {
               getCustomInterruptablePollMonitorConfig(monitorConfig.checkTools, timeoutMinutes)
             case None => monitorConfig.checkTools
           }
-        case _ => monitorConfig.checkTools
+        case runtimeConfig =>
+          monitorConfig.checkTools
       }
       // wait for 10 minutes for tools to start up before time out.
       availableTools <- streamFUntilDone(

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/CloudServiceRuntimeMonitor.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/CloudServiceRuntimeMonitor.scala
@@ -6,15 +6,19 @@ import cats.mtl.Ask
 import fs2.Stream
 import org.broadinstitute.dsde.workbench.model.TraceId
 
+import scala.concurrent.duration.FiniteDuration
+
 class CloudServiceRuntimeMonitor[F[_]: Async](
   gceRuntimeMonitorInterp: GceRuntimeMonitor[F],
   dataprocRuntimeMonitorInterp: DataprocRuntimeMonitor[F]
 ) extends RuntimeMonitor[F, CloudService] {
   def process(
     a: CloudService
-  )(runtimeId: Long, action: RuntimeStatus)(implicit ev: Ask[F, TraceId]): Stream[F, Unit] = a match {
-    case CloudService.GCE      => gceRuntimeMonitorInterp.process(runtimeId, action)
-    case CloudService.Dataproc => dataprocRuntimeMonitorInterp.process(runtimeId, action)
+  )(runtimeId: Long, action: RuntimeStatus, timeoutMinutes: Option[FiniteDuration])(implicit
+    ev: Ask[F, TraceId]
+  ): Stream[F, Unit] = a match {
+    case CloudService.GCE => gceRuntimeMonitorInterp.process(runtimeId, action, timeoutMinutes: Option[FiniteDuration])
+    case CloudService.Dataproc => dataprocRuntimeMonitorInterp.process(runtimeId, action, None)
     case CloudService.AzureVm =>
       Stream.eval(
         Async[F].raiseError(

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/DataprocRuntimeMonitor.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/DataprocRuntimeMonitor.scala
@@ -56,7 +56,10 @@ class DataprocRuntimeMonitor[F[_]: Parallel](
    * Queries Google for the cluster status and takes appropriate action depending on the result.
    * @return ClusterMonitorMessage
    */
-  override def handleCheck(monitorContext: MonitorContext, runtimeAndRuntimeConfig: RuntimeAndRuntimeConfig)(implicit
+  override def handleCheck(monitorContext: MonitorContext,
+                           runtimeAndRuntimeConfig: RuntimeAndRuntimeConfig,
+                           timeoutMinutes: Option[FiniteDuration]
+  )(implicit
     ev: Ask[F, AppContext]
   ): F[CheckResult] =
     for {
@@ -157,11 +160,13 @@ class DataprocRuntimeMonitor[F[_]: Parallel](
                         dataprocInstance.ip match {
                           case Some(ip) =>
                             // It takes a bit for jupyter to startup, hence wait 5 seconds before we check jupyter
-                            F.sleep(8 seconds) >> handleCheckTools(monitorContext,
-                                                                   runtimeAndRuntimeConfig,
-                                                                   ip,
-                                                                   masterInstance,
-                                                                   true
+                            F.sleep(8 seconds) >> handleCheckTools(
+                              monitorContext,
+                              runtimeAndRuntimeConfig,
+                              ip,
+                              masterInstance,
+                              true,
+                              None // TODO Verify dataproc can't have custom timeout
                             )
                           case None =>
                             checkAgain(monitorContext,
@@ -313,7 +318,8 @@ class DataprocRuntimeMonitor[F[_]: Parallel](
                                                              runtimeAndRuntimeConfig,
                                                              ip,
                                                              main.map(_._1),
-                                                             false
+                                                             false,
+                                                             None
                       )
                     case None =>
                       checkAgain(monitorContext,
@@ -432,7 +438,7 @@ class DataprocRuntimeMonitor[F[_]: Parallel](
             main.flatMap(_.ip) match {
               case Some(ip) =>
                 // It takes a bit for jupyter to startup, hence wait a few seconds before we check jupyter
-                F.sleep(3 seconds) >> handleCheckTools(monitorContext, runtimeAndRuntimeConfig, ip, main, false)
+                F.sleep(3 seconds) >> handleCheckTools(monitorContext, runtimeAndRuntimeConfig, ip, main, false, None)
               case None =>
                 checkAgain(monitorContext,
                            runtimeAndRuntimeConfig,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/GceRuntimeMonitor.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/GceRuntimeMonitor.scala
@@ -109,7 +109,10 @@ class GceRuntimeMonitor[F[_]: Parallel](
    * Queries Google for the cluster status and takes appropriate action depending on the result.
    * @return ClusterMonitorMessage
    */
-  override def handleCheck(monitorContext: MonitorContext, runtimeAndRuntimeConfig: RuntimeAndRuntimeConfig)(implicit
+  override def handleCheck(monitorContext: MonitorContext,
+                           runtimeAndRuntimeConfig: RuntimeAndRuntimeConfig,
+                           timeoutMinutes: Option[FiniteDuration]
+  )(implicit
     ev: Ask[F, AppContext]
   ): F[CheckResult] =
     for {
@@ -128,9 +131,11 @@ class GceRuntimeMonitor[F[_]: Parallel](
         zoneParam,
         InstanceName(runtimeAndRuntimeConfig.runtime.runtimeName.asString)
       )
+      _ <- logger.info("MEEP")
+      _ <- logger.info(timeoutMinutes.toString)
       result <- runtimeAndRuntimeConfig.runtime.status match {
         case RuntimeStatus.Creating =>
-          creatingRuntime(instance, monitorContext, runtimeAndRuntimeConfig)
+          creatingRuntime(instance, monitorContext, runtimeAndRuntimeConfig, timeoutMinutes)
         // This is needed because during boot time, we no longer have reference to the previous delete operation
         // But this path should only happen during boot and there's on-going delete
         case RuntimeStatus.Deleting =>
@@ -157,7 +162,8 @@ class GceRuntimeMonitor[F[_]: Parallel](
   private[monitor] def creatingRuntime(
     instance: Option[Instance],
     monitorContext: MonitorContext,
-    runtimeAndRuntimeConfig: RuntimeAndRuntimeConfig
+    runtimeAndRuntimeConfig: RuntimeAndRuntimeConfig,
+    timeoutMinutes: Option[FiniteDuration]
   )(implicit ev: Ask[F, AppContext]): F[CheckResult] = instance match {
     case None =>
       nowInstant
@@ -217,7 +223,13 @@ class GceRuntimeMonitor[F[_]: Parallel](
                     case Some(ip) =>
                       // It takes a bit for jupyter to startup, hence wait 5 seconds before we check jupyter
                       Temporal[F]
-                        .sleep(8 seconds) >> handleCheckTools(monitorContext, runtimeAndRuntimeConfig, ip, None, true)
+                        .sleep(8 seconds) >> handleCheckTools(monitorContext,
+                                                              runtimeAndRuntimeConfig,
+                                                              ip,
+                                                              None,
+                                                              true,
+                                                              timeoutMinutes
+                      )
                     case None =>
                       checkAgain(monitorContext, runtimeAndRuntimeConfig, None, Some("Could not retrieve instance IP"))
                   }
@@ -306,7 +318,13 @@ class GceRuntimeMonitor[F[_]: Parallel](
                     case Some(ip) =>
                       // It takes a bit for jupyter to startup, hence wait 5 seconds before we check jupyter
                       Temporal[F]
-                        .sleep(8 seconds) >> handleCheckTools(monitorContext, runtimeAndRuntimeConfig, ip, None, false)
+                        .sleep(8 seconds) >> handleCheckTools(monitorContext,
+                                                              runtimeAndRuntimeConfig,
+                                                              ip,
+                                                              None,
+                                                              false,
+                                                              None
+                      )
                     case None =>
                       checkAgain(monitorContext, runtimeAndRuntimeConfig, None, Some("Could not retrieve instance IP"))
                   }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/GceRuntimeMonitor.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/GceRuntimeMonitor.scala
@@ -131,8 +131,6 @@ class GceRuntimeMonitor[F[_]: Parallel](
         zoneParam,
         InstanceName(runtimeAndRuntimeConfig.runtime.runtimeName.asString)
       )
-      _ <- logger.info("MEEP")
-      _ <- logger.info(timeoutMinutes.toString)
       result <- runtimeAndRuntimeConfig.runtime.status match {
         case RuntimeStatus.Creating =>
           creatingRuntime(instance, monitorContext, runtimeAndRuntimeConfig, timeoutMinutes)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
@@ -233,7 +233,10 @@ class LeoPubsubMessageSubscriber[F[_]](
         )).transaction
       }
       taskToRun = for {
-        _ <- msg.runtimeConfig.cloudService.process(msg.runtimeId, RuntimeStatus.Creating).compile.drain
+        _ <- msg.runtimeConfig.cloudService
+          .process(msg.runtimeId, RuntimeStatus.Creating, msg.timeoutMinutes)
+          .compile
+          .drain
       } yield ()
       _ <- asyncTasks.offer(
         Task(
@@ -293,7 +296,7 @@ class LeoPubsubMessageSubscriber[F[_]](
               .handlePollCheckCompletion(monitorContext, RuntimeAndRuntimeConfig(runtime, runtimeConfig))
           } yield ()
         case None =>
-          runtimeConfig.cloudService.process(runtime.id, RuntimeStatus.Deleting).compile.drain
+          runtimeConfig.cloudService.process(runtime.id, RuntimeStatus.Deleting, None).compile.drain
       }
       fa = msg.persistentDiskToDelete.fold(poll) { id =>
         val deleteDisk = for {
@@ -363,7 +366,7 @@ class LeoPubsubMessageSubscriber[F[_]](
                   )
                 } yield ()
               case None =>
-                runtimeConfig.cloudService.process(runtime.id, RuntimeStatus.Stopping).compile.drain
+                runtimeConfig.cloudService.process(runtime.id, RuntimeStatus.Stopping, None).compile.drain
             }
             _ <- asyncTasks.offer(
               Task(
@@ -425,7 +428,7 @@ class LeoPubsubMessageSubscriber[F[_]](
             _ <- asyncTasks.offer(
               Task(
                 ctx.traceId,
-                runtimeConfig.cloudService.process(msg.runtimeId, RuntimeStatus.Starting).compile.drain,
+                runtimeConfig.cloudService.process(msg.runtimeId, RuntimeStatus.Starting, None).compile.drain,
                 Some(
                   handleRuntimeMessageError(msg.runtimeId,
                                             ctx.now,
@@ -556,7 +559,7 @@ class LeoPubsubMessageSubscriber[F[_]](
                     )
                   } yield ()
                 case None =>
-                  runtimeConfig.cloudService.process(runtime.id, RuntimeStatus.Stopping).compile.drain
+                  runtimeConfig.cloudService.process(runtime.id, RuntimeStatus.Stopping, None).compile.drain
               }
               now <- nowInstant
               ctxStarting = Ask.const[F, AppContext](
@@ -590,7 +593,7 @@ class LeoPubsubMessageSubscriber[F[_]](
                 asyncTasks.offer(
                   Task(
                     ctx.traceId,
-                    runtimeConfig.cloudService.process(runtime.id, RuntimeStatus.Updating).compile.drain,
+                    runtimeConfig.cloudService.process(runtime.id, RuntimeStatus.Updating, None).compile.drain,
                     Some(handleRuntimeMessageError(runtime.id, ctx.now, "updating runtime")),
                     ctx.now,
                     "updateRuntime"
@@ -627,7 +630,7 @@ class LeoPubsubMessageSubscriber[F[_]](
         )
       }
       _ <- patchQuery.updatePatchAsComplete(runtime.id).transaction.void
-      _ <- updatedRuntimeConfig.cloudService.process(runtime.id, RuntimeStatus.Starting).compile.drain
+      _ <- updatedRuntimeConfig.cloudService.process(runtime.id, RuntimeStatus.Starting, None).compile.drain
     } yield ()
 
   private[monitor] def handleCreateDiskMessage(msg: CreateDiskMessage)(implicit

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/MonitorAtBoot.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/MonitorAtBoot.scala
@@ -289,7 +289,8 @@ class MonitorAtBoot[F[_]](publisherQueue: Queue[F, LeoPubsubMessage],
           runtime.welderEnabled,
           runtime.customEnvironmentVariables,
           rtConfigInMessage,
-          Some(traceId)
+          Some(traceId),
+          timeoutMinutes = None // TODO N8 what
         )
       case x => F.raiseError(MonitorAtBootException(s"Unexpected status for runtime ${runtime.id}: ${x}", traceId))
     }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/MonitorAtBoot.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/MonitorAtBoot.scala
@@ -259,7 +259,8 @@ class MonitorAtBoot[F[_]](publisherQueue: Queue[F, LeoPubsubMessage],
               diskId,
               x.bootDiskSize,
               x.zone,
-              x.gpuConfig
+              x.gpuConfig,
+              x.timeoutMinutes
             ): RuntimeConfigInCreateRuntimeMessage
           case _: RuntimeConfig.DataprocConfig =>
             Right(

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/MonitorAtBoot.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/MonitorAtBoot.scala
@@ -246,7 +246,8 @@ class MonitorAtBoot[F[_]](publisherQueue: Queue[F, LeoPubsubMessage],
               x.diskSize,
               bootDiskSize,
               x.zone,
-              x.gpuConfig
+              x.gpuConfig,
+              x.timeoutMinutes
             ): RuntimeConfigInCreateRuntimeMessage
           case x: RuntimeConfig.GceWithPdConfig =>
             for {

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/RuntimeMonitor.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/RuntimeMonitor.scala
@@ -22,7 +22,9 @@ import scala.jdk.CollectionConverters._
  * It doesn't trigger any of the action but only responsible for monitoring the progress and make necessary cleanup when the transition is done
  */
 trait RuntimeMonitor[F[_], A] {
-  def process(a: A)(runtimeId: Long, action: RuntimeStatus)(implicit ev: Ask[F, TraceId]): Stream[F, Unit]
+  def process(a: A)(runtimeId: Long, action: RuntimeStatus, timeoutMinutes: Option[FiniteDuration])(implicit
+    ev: Ask[F, TraceId]
+  ): Stream[F, Unit]
 
   def handlePollCheckCompletion(
     a: A

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/leoPubsubMessageSubscriberModels.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/leoPubsubMessageSubscriberModels.scala
@@ -38,7 +38,8 @@ object RuntimeConfigInCreateRuntimeMessage {
     diskSize: DiskSize,
     bootDiskSize: DiskSize,
     zone: ZoneName,
-    gpuConfig: Option[GpuConfig]
+    gpuConfig: Option[GpuConfig],
+    timeoutMinutes: Option[Int]
   ) extends RuntimeConfigInCreateRuntimeMessage {
     val cloudService: CloudService = CloudService.GCE
   }
@@ -659,12 +660,13 @@ object LeoPubsubCodec {
   }
 
   implicit val gceConfigInCreateRuntimeMessageDecoder: Decoder[RuntimeConfigInCreateRuntimeMessage.GceConfig] =
-    Decoder.forProduct5(
+    Decoder.forProduct6(
       "machineType",
       "diskSize",
       "bootDiskSize",
       "zone",
-      "gpuConfig"
+      "gpuConfig",
+      "timeoutMinutes"
     )(RuntimeConfigInCreateRuntimeMessage.GceConfig.apply)
 
   implicit val gceWithPdConfigInCreateRuntimeMessageDecoder

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/leoPubsubMessageSubscriberModels.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/leoPubsubMessageSubscriberModels.scala
@@ -39,7 +39,7 @@ object RuntimeConfigInCreateRuntimeMessage {
     bootDiskSize: DiskSize,
     zone: ZoneName,
     gpuConfig: Option[GpuConfig],
-    timeoutMinutes: Option[Int]
+    timeoutMinutes: Option[FiniteDuration]
   ) extends RuntimeConfigInCreateRuntimeMessage {
     val cloudService: CloudService = CloudService.GCE
   }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/leoPubsubMessageSubscriberModels.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/leoPubsubMessageSubscriberModels.scala
@@ -48,7 +48,8 @@ object RuntimeConfigInCreateRuntimeMessage {
                                    persistentDiskId: DiskId,
                                    bootDiskSize: DiskSize,
                                    zone: ZoneName,
-                                   gpuConfig: Option[GpuConfig]
+                                   gpuConfig: Option[GpuConfig],
+                                   timeoutMinutes: Option[FiniteDuration]
   ) extends RuntimeConfigInCreateRuntimeMessage {
     val cloudService: CloudService = CloudService.GCE
   }
@@ -670,12 +671,13 @@ object LeoPubsubCodec {
     )(RuntimeConfigInCreateRuntimeMessage.GceConfig.apply)
 
   implicit val gceWithPdConfigInCreateRuntimeMessageDecoder
-    : Decoder[RuntimeConfigInCreateRuntimeMessage.GceWithPdConfig] = Decoder.forProduct5(
+    : Decoder[RuntimeConfigInCreateRuntimeMessage.GceWithPdConfig] = Decoder.forProduct6(
     "machineType",
     "persistentDiskId",
     "bootDiskSize",
     "zone",
-    "gpuConfig"
+    "gpuConfig",
+    "timeoutMinutes"
   )(RuntimeConfigInCreateRuntimeMessage.GceWithPdConfig.apply)
 
   implicit val runtimeConfigInCreateRuntimeMessageDecoder: Decoder[RuntimeConfigInCreateRuntimeMessage] =


### PR DESCRIPTION
Note:
There is extra code in here. 
My initial approach had me thinking I had to add to runtimeConfig to get the timeout minutes through to LeoPubSubMessageSubscriber, but it seems like I didn't have the proper encoders/decoders?

My current issue was trying to figure out why I couldn't get my timeoutMinutes field into createRuntimeMessage



---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
