### PR TITLE
IA-3875 Update disk status to `Deleted` if Azure VM creation fails

### DIFF
--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponent.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponent.scala
@@ -7,6 +7,7 @@ import org.broadinstitute.dsde.workbench.azure.{AzureCloudContext, ContainerName
 import org.broadinstitute.dsde.workbench.google2.OperationName
 import org.broadinstitute.dsde.workbench.leonardo.SamResourceId.{RuntimeSamResourceId, WsmResourceSamResourceId}
 import org.broadinstitute.dsde.workbench.leonardo.config.Config
+import org.broadinstitute.dsde.workbench.leonardo.db.DBIOInstances._
 import org.broadinstitute.dsde.workbench.leonardo.db.LeoProfile.api._
 import org.broadinstitute.dsde.workbench.leonardo.db.LeoProfile.dummyDate
 import org.broadinstitute.dsde.workbench.leonardo.db.LeoProfile.mappedColumnImplicits._
@@ -666,6 +667,18 @@ object clusterQuery extends TableQuery(new ClusterTable(_)) {
     for {
       _ <- findByIdQuery(id).map(c => (c.welderEnabled, c.dateAccessed)).update((true, dateAccessed))
       _ <- clusterImageQuery.upsert(id, welderImage)
+    } yield ()
+
+  def updateDiskStatus(runtimeId: Long, dateAccessed: Instant)(implicit
+    ec: ExecutionContext
+  ): DBIO[Unit] =
+    for {
+      runtimeConfigId <- findByIdQuery(runtimeId)
+        .map(_.runtimeConfigId)
+        .result
+        .headOption
+      diskIdOpt <- runtimeConfigId.flatTraverse(rid => RuntimeConfigQueries.getDiskId(rid))
+      _ <- diskIdOpt.traverse(diskId => persistentDiskQuery.updateStatus(diskId, DiskStatus.Deleted, dateAccessed))
     } yield ()
 
   def setToRunning(id: Long, hostIp: IP, dateAccessed: Instant): DBIO[Int] =

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/PersistentDiskComponent.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/PersistentDiskComponent.scala
@@ -221,7 +221,7 @@ object persistentDiskQuery {
   ): DBIO[Option[PersistentDisk]] =
     joinLabelQuery(findActiveByNameQuery(cloudContext, name)).result.map(aggregateLabels).map(_.headOption)
 
-  def updateStatus(id: DiskId, newStatus: DiskStatus, dateAccessed: Instant) =
+  def updateStatus(id: DiskId, newStatus: DiskStatus, dateAccessed: Instant): DBIO[Int] =
     findByIdQuery(id).map(d => (d.status, d.dateAccessed)).update((newStatus, dateAccessed))
 
   def updateStatusAndIsFormatted(id: DiskId, newStatus: DiskStatus, formattedBy: FormattedBy, dateAccessed: Instant) =

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
@@ -1334,28 +1334,17 @@ class LeoPubsubMessageSubscriber[F[_]](
     for {
       ctx <- ev.ask
       _ <- logger.error(ctx.loggingCtx, e)(s"Failed to create runtime ${runtimeId}")
-      errorMessage = e match {
-        case leoEx: LeoException =>
-          Some(ErrorReport.loggableString(leoEx.toErrorReport))
-        case ee: com.google.api.gax.rpc.AbortedException
-            if ee.getStatusCode.getCode.getHttpStatusCode == 409 && ee.getMessage.contains("already exists") =>
-          None // this could happen when pubsub redelivers an event unexpectedly
-        case _ =>
-          Some(s"Failed to create cluster ${runtimeId} due to ${e.getMessage}")
-      }
-      _ <- errorMessage.traverse(m =>
-        (clusterErrorQuery.save(runtimeId, RuntimeError(m.take(1024), None, now, Some(ctx.traceId))) >>
-          clusterQuery.updateClusterStatus(runtimeId, RuntimeStatus.Error, now)).transaction[F]
-      )
       // want to detach persistent disk for runtime
       _ <- cloudService match {
         case CloudService.GCE =>
           for {
-            _ <- clusterQuery.detachPersistentDisk(runtimeId, now).transaction
             runtimeOpt <- clusterQuery.getClusterById(runtimeId).transaction
-            _ <- runtimeOpt.traverse { runtime =>
+
+            _ <- runtimeOpt.traverse_ { runtime =>
+              // If the disk is in Creating status, then it means it hasn't been used previously. Hence delete the disk
+              // if the runtime fails to create.
+              // Otherwise, the disk is most likely used previously by an old runtime, and we don't want to delete it
               if (runtime.status == RuntimeStatus.Creating) {
-                // TODO: delete disk
                 for {
                   googleProject <- runtime.cloudContext match {
                     case CloudContext.Gcp(value) => F.pure(value)
@@ -1363,15 +1352,16 @@ class LeoPubsubMessageSubscriber[F[_]](
                   }
                   runtimeConfig <- RuntimeConfigQueries.getRuntimeConfig(runtime.runtimeConfigId).transaction
                   gceRuntimeConfig <- runtimeConfig match {
-                    case x: RuntimeConfig.GceWithPdConfig => F.pure(Some(x))
+                    case x: RuntimeConfig.GceWithPdConfig => F.pure(x.some)
                     case _                                => F.pure(none[RuntimeConfig.GceWithPdConfig])
                   }
-                  _ <- gceRuntimeConfig.traverse { rc =>
+
+                  _ <- gceRuntimeConfig.traverse_ { rc =>
                     for {
                       persistentDiskOpt <- rc.persistentDiskId.flatTraverse(did =>
                         persistentDiskQuery.getPersistentDiskRecord(did).transaction
                       )
-                      _ <- persistentDiskOpt.traverse(d =>
+                      _ <- persistentDiskOpt.traverse_(d =>
                         googleDiskService.deleteDisk(googleProject, rc.zone, d.name) >> persistentDiskQuery
                           .updateStatus(d.id, DiskStatus.Deleted, now)
                           .transaction
@@ -1381,7 +1371,20 @@ class LeoPubsubMessageSubscriber[F[_]](
                 } yield ()
               } else F.unit
             }
-
+            errorMessage = e match {
+              case leoEx: LeoException =>
+                Some(ErrorReport.loggableString(leoEx.toErrorReport))
+              case ee: com.google.api.gax.rpc.AbortedException
+                  if ee.getStatusCode.getCode.getHttpStatusCode == 409 && ee.getMessage.contains("already exists") =>
+                None // this could happen when pubsub redelivers an event unexpectedly
+              case _ =>
+                Some(s"Failed to create cluster ${runtimeId} due to ${e.getMessage}")
+            }
+            _ <- errorMessage.traverse(m =>
+              (clusterErrorQuery.save(runtimeId, RuntimeError(m.take(1024), None, now, Some(ctx.traceId))) >>
+                clusterQuery.updateClusterStatus(runtimeId, RuntimeStatus.Error, now)).transaction[F]
+            )
+            _ <- clusterQuery.detachPersistentDisk(runtimeId, now).transaction
           } yield ()
         case CloudService.Dataproc => F.unit
         case CloudService.AzureVm  => F.unit

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandler.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandler.scala
@@ -730,6 +730,7 @@ class AzurePubsubHandlerInterp[F[_]: Parallel](
           auth
         )
       }.void
+      _ <- clusterQuery.updateDiskStatus(e.runtimeId, now).transaction
 
       networkResourceOpt <- controlledResourceQuery
         .getWsmRecordForRuntime(e.runtimeId, WsmResourceType.AzureNetwork)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandler.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandler.scala
@@ -719,6 +719,7 @@ class AzurePubsubHandlerInterp[F[_]: Parallel](
         .getWsmRecordForRuntime(e.runtimeId, WsmResourceType.AzureDisk)
         .transaction
       _ <- diskResourceOpt.traverse { disk =>
+        // TODO: once we start supporting persistent disk, we should not delete disk anymore
         wsmDao.deleteDisk(
           DeleteWsmResourceRequest(
             e.workspaceId,

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/CommonTestData.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/CommonTestData.scala
@@ -277,10 +277,11 @@ object CommonTestData {
   def defaultGceRuntimeWithPDConfig(persistentDiskId: Option[DiskId]) =
     RuntimeConfig.GceWithPdConfig(MachineTypeName("n1-standard-4"),
                                   bootDiskSize = DiskSize(50),
-                                  persistentDiskId = None,
+                                  persistentDiskId = persistentDiskId,
                                   zone = ZoneName("us-west2-b"),
                                   gpuConfig = None
     )
+
   val defaultRuntimeConfigRequest =
     RuntimeConfigRequest.DataprocConfig(
       Some(0),


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-3875
https://broadworkbench.atlassian.net/browse/IA-3835

* We're currently deleting disk upon Azure VM creation failure, which is intended. But we're not updating disk status in Leo DB properly after that. This PR updates disk status properly if failure happens. Also added unit test to cover this case.
* In the case of GCP, this PR adds the deleting logic if disk is in `Creating` status, and update its status to be `Deleted` if runtime creation fails

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
