### PR TITLE
IA-3879 use more recent toolbox image to help stabilize tests hopefully

### DIFF
--- a/http/src/main/resources/init-resources/gce-init.sh
+++ b/http/src/main/resources/init-resources/gce-init.sh
@@ -139,8 +139,8 @@ INIT_BUCKET_NAME=$(initBucketName)
 CERT_DIRECTORY='/var/certs'
 DOCKER_COMPOSE_FILES_DIRECTORY='/var/docker-compose-files'
 WORK_DIRECTORY='/mnt/disks/work'
-GSUTIL_CMD='docker run --rm -v /var:/var gcr.io/google-containers/toolbox:20200603-00 gsutil'
-GCLOUD_CMD='docker run --rm -v /var:/var gcr.io/google-containers/toolbox:20200603-00 gcloud'
+GSUTIL_CMD='docker run --rm -v /var:/var us.gcr.io/cos-cloud/toolbox:v20220722 gsutil'
+GCLOUD_CMD='docker run --rm -v /var:/var us.gcr.io/cos-cloud/toolbox:v20220722 gcloud'
 
 if [ ! -z "$RSTUDIO_DOCKER_IMAGE" ] ; then
   export SHOULD_BACKGROUND_SYNC="true"

--- a/http/src/main/resources/init-resources/startup.sh
+++ b/http/src/main/resources/init-resources/startup.sh
@@ -102,8 +102,8 @@ if [ -f "$FILE" ]
 then
     CERT_DIRECTORY='/var/certs'
     DOCKER_COMPOSE_FILES_DIRECTORY='/var/docker-compose-files'
-    GSUTIL_CMD='docker run --rm -v /var:/var gcr.io/google-containers/toolbox:20201104-00 gsutil'
-    GCLOUD_CMD='docker run --rm -v /var:/var gcr.io/google-containers/toolbox:20201104-00 gcloud'
+    GSUTIL_CMD='docker run --rm -v /var:/var us.gcr.io/cos-cloud/toolbox:v20220722 gsutil'
+    GCLOUD_CMD='docker run --rm -v /var:/var us.gcr.io/cos-cloud/toolbox:v20220722 gcloud'
     DOCKER_COMPOSE='docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v /var:/var docker/compose:1.29.2'
     WELDER_DOCKER_COMPOSE=$(ls ${DOCKER_COMPOSE_FILES_DIRECTORY}/welder*)
     JUPYTER_DOCKER_COMPOSE=$(ls ${DOCKER_COMPOSE_FILES_DIRECTORY}/jupyter-docker*)

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -101,7 +101,7 @@ dataproc {
 }
 
 gce {
-  customGceImage = "projects/broad-dsp-gcr-public/global/images/custom-leo-gce-cos-image-8886335"
+  customGceImage = "projects/broad-dsp-gcr-public/global/images/custom-leo-gce-cos-image-92e9e92"
   userDiskDeviceName = "user-disk"
   defaultScopes = [
     "https://www.googleapis.com/auth/userinfo.email",

--- a/jenkins/gce-custom-images/prepare_gce_image.sh
+++ b/jenkins/gce-custom-images/prepare_gce_image.sh
@@ -31,7 +31,7 @@ terra_jupyter_aou_old="us.gcr.io/broad-dsp-gcr-public/terra-jupyter-aou:2.1.10"
 
 # Not replaced by Jenkins
 cos_gpu_installer="gcr.io/cos-cloud/cos-gpu-installer:v2.0.20"
-google_cloud_toolbox="gcr.io/google-containers/toolbox:20201104-00"
+google_cloud_toolbox="us.gcr.io/cos-cloud/toolbox:v20220722"
 docker_composer="docker/compose:1.29.2"
 docker_composer_with_auth="cryptopants/docker-compose-gcr"
 


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-3879

```
qi@saturn-91bd4d25-b594-4624-bd81-b02ca571249e ~ $ cat /etc/default/toolbox
# Copyright 2016 The Chromium OS Authors. All rights reserved.
# Use of this source code is governed by a BSD-style license that can be
# found in the LICENSE file.

TOOLBOX_DOCKER_IMAGE="gcr.io/cos-cloud/toolbox"
TOOLBOX_DOCKER_TAG="v20220722"
TOOLBOX_BIND="--bind=/:/media/root/ --bind=/mnt/disks/:/media/root/mnt/disks/ --bind=/var/:/media/root/var/ --bind=/home:/media/root/home/"
: ${USER:=root}
```

Checked on VM that the default toolbox image has been updated. So update it in init script as well to see if this improves test stability


---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
