### PR TITLE
IA-3887 update script reference

### DIFF
--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -192,7 +192,7 @@ azure {
         type = "CustomScript",
         version = "2.1",
         minor-version-auto-upgrade = true,
-        file-uris = ["https://raw.githubusercontent.com/DataBiosphere/leonardo/b9c7fc1ec10697f8d8e278188ebbf30f6d124d67/http/src/main/resources/init-resources/azure_vm_init_script.sh"]
+        file-uris = ["https://raw.githubusercontent.com/DataBiosphere/leonardo/d6f5eea1a9299f8ef95cf1dc3eaf40594af26782/http/src/main/resources/init-resources/azure_vm_init_script.sh"]
      }
      listener-image = "terradevacrpublic.azurecr.io/terra-azure-relay-listeners:a9576c8"
     }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/WsmCodecSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/WsmCodecSpec.scala
@@ -191,7 +191,7 @@ class WsmCodecSpec extends AnyFlatSpec with Matchers {
          |      "minorVersionAutoUpgrade": true,
          |      "protectedSettings": [{
          |          "key": "fileUris",
-         |          "value": ["https://raw.githubusercontent.com/DataBiosphere/leonardo/b9c7fc1ec10697f8d8e278188ebbf30f6d124d67/http/src/main/resources/init-resources/azure_vm_init_script.sh"]
+         |          "value": ["https://raw.githubusercontent.com/DataBiosphere/leonardo/d6f5eea1a9299f8ef95cf1dc3eaf40594af26782/http/src/main/resources/init-resources/azure_vm_init_script.sh"]
          |        },
          |        {
          |          "key": "commandToExecute",

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/ConfigReaderSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/ConfigReaderSpec.scala
@@ -63,7 +63,7 @@ class ConfigReaderSpec extends AnyFlatSpec with Matchers {
               "2.1",
               true,
               List(
-                "https://raw.githubusercontent.com/DataBiosphere/leonardo/b9c7fc1ec10697f8d8e278188ebbf30f6d124d67/http/src/main/resources/init-resources/azure_vm_init_script.sh"
+                "https://raw.githubusercontent.com/DataBiosphere/leonardo/d6f5eea1a9299f8ef95cf1dc3eaf40594af26782/http/src/main/resources/init-resources/azure_vm_init_script.sh"
               )
             ),
             "terradevacrpublic.azurecr.io/terra-azure-relay-listeners:a9576c8",


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-3887

https://github.com/DataBiosphere/leonardo/pull/2900 updated the azure script properly with the new env, but the script isn't being used by Leo yet since the reference.conf needs to be udpated to point to the new version of the script

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
