### PR TITLE
IA-3888 Optimize listRuntimeV2 performance

### DIFF
--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -47,8 +47,6 @@ jobs:
         JAVA_OPTS: -Xmx4G -Xms4G -Xss2M -Duser.timezone=UTC -Denv.type=test -Dmysql.host=localhost -Dmysql.port=3307
         JVM_OPTS:  -Xmx4G -Xms4G -Xss2M
       run: |
-#         sbt "project core" coverage test coverageReport
-#         sbt "project http" coverage test coverageReport
          sbt "project http" "testOnly org.broadinstitute.dsde.workbench.leonardo.http.db.RuntimeServiceDbQueriesSpec -- -z 'list runtimes'"
 
     - name: Upload coverage to Codecov

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -36,11 +36,11 @@ jobs:
         java-version: 17
         distribution: 'temurin'
 
-#    - name: Compile and check scalafmt
-#      env:
-#        JAVA_OPTS: -Xmx4G -Xms4G -Xss2M
-#        JVM_OPTS:  -Xmx4G -Xms4G -Xss2M
-#      run: sbt -Denv.type=test clean "test:compile" scalafmtCheckAll
+    - name: Compile and check scalafmt
+      env:
+        JAVA_OPTS: -Xmx4G -Xms4G -Xss2M
+        JVM_OPTS:  -Xmx4G -Xms4G -Xss2M
+      run: sbt -Denv.type=test clean "test:compile" scalafmtCheckAll
 
     - name: Run tests
       env:

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -49,9 +49,9 @@ jobs:
         JAVA_OPTS: -Xmx4G -Xms4G -Xss2M -Duser.timezone=UTC -Denv.type=test -Dmysql.host=localhost -Dmysql.port=3307
         JVM_OPTS:  -Xmx4G -Xms4G -Xss2M
       run: |
+        sbt "project http" coverage "testOnly -- -n SlickPlainQueryTest" coverageReport
         sbt "project core" coverage test coverageReport
         sbt "project http" coverage "testOnly -- -l SlickPlainQueryTest" coverageReport
-        sbt "project http" coverage "testOnly -- -n SlickPlainQueryTest" coverageReport
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -47,13 +47,13 @@ jobs:
         JAVA_OPTS: -Xmx4G -Xms4G -Xss2M -Duser.timezone=UTC -Denv.type=test -Dmysql.host=localhost -Dmysql.port=3307
         JVM_OPTS:  -Xmx4G -Xms4G -Xss2M
       run: |
-        sbt "project http" "testOnly org.broadinstitute.dsde.workbench.leonardo.http.db.RuntimeServiceDbQueriesSpec -- -z \"list runtimes\""
+        sbt "project http" "testOnly org.broadinstitute.dsde.workbench.leonardo.http.db.RuntimeServiceDbQueriesSpec org.broadinstitute.dsde.workbench.leonardo.http.service.RuntimeServiceV2InterpSpec org.broadinstitute.dsde.workbench.leonardo.http.db.RuntimeServiceDbQueriesSpec"
 
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v1
-      with:
-        fail_ci_if_error: true
-        token: ${{ secrets.CODECOV_TOKEN }}
+#    - name: Upload coverage to Codecov
+#      uses: codecov/codecov-action@v1
+#      with:
+#        fail_ci_if_error: true
+#        token: ${{ secrets.CODECOV_TOKEN }}
 
     - name: Setup Cache
       uses: coursier/cache-action@v5

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -42,18 +42,22 @@ jobs:
         JVM_OPTS:  -Xmx4G -Xms4G -Xss2M
       run: sbt -Denv.type=test clean "test:compile" scalafmtCheckAll
 
+    # Run SlickPlainQueryTest separately from the rest of the unit tests because for some reason, when run together, these
+    # tests will always fail
     - name: Run tests
       env:
         JAVA_OPTS: -Xmx4G -Xms4G -Xss2M -Duser.timezone=UTC -Denv.type=test -Dmysql.host=localhost -Dmysql.port=3307
         JVM_OPTS:  -Xmx4G -Xms4G -Xss2M
       run: |
-        sbt "project http" "testOnly org.broadinstitute.dsde.workbench.leonardo.http.db.RuntimeServiceDbQueriesSpec org.broadinstitute.dsde.workbench.leonardo.http.service.RuntimeServiceV2InterpSpec org.broadinstitute.dsde.workbench.leonardo.http.db.RuntimeServiceDbQueriesSpec"
+        sbt "project core" coverage test coverageReport
+        sbt "project http" coverage "testOnly -- -l SlickPlainQueryTest" coverageReport
+        sbt "project http" coverage "testOnly -- -n SlickPlainQueryTest" coverageReport
 
-#    - name: Upload coverage to Codecov
-#      uses: codecov/codecov-action@v1
-#      with:
-#        fail_ci_if_error: true
-#        token: ${{ secrets.CODECOV_TOKEN }}
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v1
+      with:
+        fail_ci_if_error: true
+        token: ${{ secrets.CODECOV_TOKEN }}
 
     - name: Setup Cache
       uses: coursier/cache-action@v5

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -47,7 +47,7 @@ jobs:
         JAVA_OPTS: -Xmx4G -Xms4G -Xss2M -Duser.timezone=UTC -Denv.type=test -Dmysql.host=localhost -Dmysql.port=3307
         JVM_OPTS:  -Xmx4G -Xms4G -Xss2M
       run: |
-         sbt "project http" "testOnly org.broadinstitute.dsde.workbench.leonardo.http.db.RuntimeServiceDbQueriesSpec -- -z 'list runtimes'"
+        sbt "project http" "testOnly org.broadinstitute.dsde.workbench.leonardo.http.db.RuntimeServiceDbQueriesSpec -- -z \"list runtimes\""
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -49,7 +49,7 @@ jobs:
         JAVA_OPTS: -Xmx4G -Xms4G -Xss2M -Duser.timezone=UTC -Denv.type=test -Dmysql.host=localhost -Dmysql.port=3307
         JVM_OPTS:  -Xmx4G -Xms4G -Xss2M
       run: |
-        sbt "project http" coverage "testOnly -- -n SlickPlainQueryTest" coverageReport
+        sbt "project http" coverage "testOnly org.broadinstitute.dsde.workbench.leonardo.http.db.RuntimeServiceDbQueriesSpec org.broadinstitute.dsde.workbench.leonardo.http.service.RuntimeServiceV2InterpSpec org.broadinstitute.dsde.workbench.leonardo.http.db.RuntimeServiceDbQueriesSpec" coverageReport
         sbt "project core" coverage test coverageReport
         sbt "project http" coverage "testOnly -- -l SlickPlainQueryTest" coverageReport
 

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -36,19 +36,20 @@ jobs:
         java-version: 17
         distribution: 'temurin'
 
-    - name: Compile and check scalafmt
-      env:
-        JAVA_OPTS: -Xmx4G -Xms4G -Xss2M
-        JVM_OPTS:  -Xmx4G -Xms4G -Xss2M
-      run: sbt -Denv.type=test clean "test:compile" scalafmtCheckAll
+#    - name: Compile and check scalafmt
+#      env:
+#        JAVA_OPTS: -Xmx4G -Xms4G -Xss2M
+#        JVM_OPTS:  -Xmx4G -Xms4G -Xss2M
+#      run: sbt -Denv.type=test clean "test:compile" scalafmtCheckAll
 
     - name: Run tests
       env:
         JAVA_OPTS: -Xmx4G -Xms4G -Xss2M -Duser.timezone=UTC -Denv.type=test -Dmysql.host=localhost -Dmysql.port=3307
         JVM_OPTS:  -Xmx4G -Xms4G -Xss2M
       run: |
-         sbt "project core" coverage test coverageReport
-         sbt "project http" coverage test coverageReport
+#         sbt "project core" coverage test coverageReport
+#         sbt "project http" coverage test coverageReport
+         sbt "project http" "testOnly org.broadinstitute.dsde.workbench.leonardo.http.db.RuntimeServiceDbQueriesSpec -- -z 'list runtimes'"
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1

--- a/Dockerfile-tests
+++ b/Dockerfile-tests
@@ -1,4 +1,4 @@
-FROM sbtscala/scala-sbt:openjdk-17.0.2_1.7.2_2.13.10
+FROM sbtscala/scala-sbt:openjdk-17.0.2_1.8.0_2.13.10
 
 # This is only to make `sbt` work because `Version.scala` depends on `git` if this environment is not set
 ENV GIT_HASH="0.0.1"

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -144,7 +144,7 @@ function make_jar()
                           -v $PWD:/working \
                           -v jar-cache:/root/.ivy \
                           -v jar-cache:/root/.ivy2 \
-                          sbtscala/scala-sbt:openjdk-17.0.2_1.7.2_2.13.10 \
+                          sbtscala/scala-sbt:openjdk-17.0.2_1.8.0_2.13.10 \
                           /working/docker/install.sh /working || EXIT_CODE=$?
 
     # stop test db

--- a/http/src/main/resources/logback.xml
+++ b/http/src/main/resources/logback.xml
@@ -55,10 +55,10 @@
 
     <!-- see https://github.com/slick/slick/blob/master/common-test-resources/logback.xml for more Slick logging -->
 
-<!--    <logger name="slick.jdbc.JdbcBackend.statement" level="DEBUG" additivity="false">-->
-<!--        <appender-ref ref="file"/>-->
-<!--        <appender-ref ref="console"/>-->
-<!--    </logger>-->
+    <logger name="slick.jdbc.JdbcBackend.statement" level="DEBUG" additivity="false">
+        <appender-ref ref="file"/>
+        <appender-ref ref="console"/>
+    </logger>
 
 <!--    <logger name="slick.jdbc.JdbcBackend.benchmark" level="DEBUG" additivity="false">-->
 <!--        <appender-ref ref="file"/>-->

--- a/http/src/main/resources/logback.xml
+++ b/http/src/main/resources/logback.xml
@@ -55,10 +55,10 @@
 
     <!-- see https://github.com/slick/slick/blob/master/common-test-resources/logback.xml for more Slick logging -->
 
-    <logger name="slick.jdbc.JdbcBackend.statement" level="DEBUG" additivity="false">
-        <appender-ref ref="file"/>
-        <appender-ref ref="console"/>
-    </logger>
+<!--    <logger name="slick.jdbc.JdbcBackend.statement" level="DEBUG" additivity="false">-->
+<!--        <appender-ref ref="file"/>-->
+<!--        <appender-ref ref="console"/>-->
+<!--    </logger>-->
 
 <!--    <logger name="slick.jdbc.JdbcBackend.benchmark" level="DEBUG" additivity="false">-->
 <!--        <appender-ref ref="file"/>-->

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/auth/SamAuthProvider.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/auth/SamAuthProvider.scala
@@ -150,28 +150,6 @@ class SamAuthProvider[F[_]: OpenTelemetryMetrics](
     }
   }
 
-  def filterUserVisibleWithWorkspaceFallback[R](
-    resources: NonEmptyList[(WorkspaceId, R)],
-    userInfo: UserInfo
-  )(implicit
-    sr: SamResource[R],
-    decoder: Decoder[R],
-    ev: Ask[F, TraceId]
-  ): F[List[(WorkspaceId, R)]] = {
-    val authHeader = Authorization(Credentials.Token(AuthScheme.Bearer, userInfo.accessToken.token))
-    for {
-      workspacePolicies <- samDao.getResourcePolicies[WorkspaceResourceSamResourceId](authHeader)
-      owningWorkspaces = workspacePolicies.collect { case (r, SamPolicyName.Owner) =>
-        r.workspaceId
-      }
-      resourcePolicies <- samDao
-        .getResourcePolicies[R](authHeader)
-      res = resourcePolicies.filter { case (_, pn) => sr.policyNames.contains(pn) }
-    } yield resources.filter { case (id, r) =>
-      owningWorkspaces.contains(id) || res.exists(_._1 == r)
-    }
-  }
-
   def isUserWorkspaceOwner[R](
     workspaceId: WorkspaceId,
     workspaceResource: R,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/GetResultInstances.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/GetResultInstances.scala
@@ -1,0 +1,175 @@
+package org.broadinstitute.dsde.workbench.leonardo.db
+
+import org.broadinstitute.dsde.workbench.azure.AzureCloudContext
+import org.broadinstitute.dsde.workbench.google2.{MachineTypeName, RegionName, ZoneName}
+import org.broadinstitute.dsde.workbench.leonardo.SamResourceId.RuntimeSamResourceId
+import org.broadinstitute.dsde.workbench.leonardo.{
+  AuditInfo,
+  CloudContext,
+  CloudService,
+  DiskId,
+  DiskSize,
+  GpuType,
+  LabelMap,
+  RuntimeConfig,
+  RuntimeName,
+  RuntimeStatus,
+  WorkspaceId
+}
+import org.broadinstitute.dsde.workbench.leonardo.db.LeoProfile.ColumnDecodingException
+import org.broadinstitute.dsde.workbench.model.{IP, WorkbenchEmail}
+import org.broadinstitute.dsde.workbench.model.google.GoogleProject
+import slick.jdbc.GetResult
+
+import java.sql.SQLDataException
+import java.time.Instant
+import java.util.UUID
+
+object GetResultInstances {
+  implicit val getResultWorkspaceId: GetResult[Option[WorkspaceId]] =
+    GetResult.GetStringOption.andThen(sOpt => sOpt.map(s => WorkspaceId(UUID.fromString(s))))
+  implicit val getResultRuntimeName: GetResult[RuntimeName] =
+    GetResult.GetString.andThen(s => RuntimeName(s))
+  implicit val getResultRuntimeSamResourceId: GetResult[RuntimeSamResourceId] =
+    GetResult.GetString.andThen(s => RuntimeSamResourceId(s))
+  implicit val getResultCloudService: GetResult[CloudService] =
+    GetResult.GetString.andThen(s => CloudService.withName(s))
+  implicit val getResultDiskSizeOpt: GetResult[Option[DiskSize]] =
+    GetResult.GetIntOption.andThen(size => size.map(s => DiskSize(s)))
+  implicit val getResultMachineTypeName: GetResult[MachineTypeName] =
+    GetResult.GetString.andThen(s => MachineTypeName(s))
+  implicit val getResultMachineTypeNameOpt: GetResult[Option[MachineTypeName]] =
+    GetResult.GetStringOption.andThen(s => s.map(MachineTypeName))
+  implicit val getResultRegionNameOpt: GetResult[Option[RegionName]] =
+    GetResult.GetStringOption.andThen(s => s.map(ss => RegionName(ss)))
+  implicit val getResultZoneNameOpt: GetResult[Option[ZoneName]] =
+    GetResult.GetStringOption.andThen(s => s.map(ss => ZoneName(ss)))
+  implicit val getResultIPOpt: GetResult[Option[IP]] =
+    GetResult.GetStringOption.andThen(s => s.map(ss => IP(ss)))
+  implicit val getResultGpuTypeOpt: GetResult[Option[GpuType]] =
+    GetResult.GetStringOption.andThen(s =>
+      s.map(ss => GpuType.stringToObject.getOrElse(ss, throw ColumnDecodingException(s"invalid gpuType $ss")))
+    )
+  implicit val getResultInstant: GetResult[Instant] =
+    GetResult.GetTimestamp.andThen(t => t.toInstant)
+  implicit val getResultInstantOpt: GetResult[Option[Instant]] =
+    GetResult.GetTimestampOption.andThen(t => t.map(_.toInstant))
+  implicit val getResultDiskIdOpt: GetResult[Option[DiskId]] =
+    GetResult.GetLongOption.andThen(t => t.map(DiskId))
+  implicit val getResultMap: GetResult[Option[Map[String, String]]] =
+    GetResult.GetStringOption.andThen { sOpt =>
+      sOpt match {
+        case Some(s) =>
+          val res = for {
+            s <- _root_.io.circe.parser.parse(s)
+            map <- s.as[Map[String, String]]
+          } yield map
+          res match {
+            case Left(e)      => throw e
+            case Right(value) => Some(value)
+          }
+        case None => None
+      }
+    }
+  implicit val getResultLabelMap: GetResult[LabelMap] =
+    GetResult.createGetTuple2[String, String].andThen { case (keys, values) =>
+      if (keys == null || values == null)
+        Map.empty
+      else {
+        val keysList = keys.split(",")
+        val valueList = values.split(",")
+
+        keysList.zip(valueList).toMap
+      }
+    }
+  implicit val getResultRuntimeStatus: GetResult[RuntimeStatus] =
+    GetResult.GetString.andThen(s =>
+      RuntimeStatus
+        .withNameInsensitiveOption(s)
+        .getOrElse(throw ColumnDecodingException(s"unexpected runtime status ${s} from database"))
+    )
+  implicit val getResultCloudContext: GetResult[CloudContext] =
+    GetResult.createGetTuple2[String, String].andThen { case (provider, context) =>
+      provider match {
+        case "GCP" =>
+          CloudContext.Gcp(GoogleProject(context)): CloudContext
+        case "AZURE" =>
+          val aContext =
+            AzureCloudContext.fromString(context) match {
+              case Left(e)      => throw new SQLDataException(e)
+              case Right(value) => value
+            }
+          CloudContext.Azure(aContext): CloudContext
+      }
+    }
+
+  implicit val getResultAuditInfo: GetResult[AuditInfo] =
+    GetResult.createGetTuple4[String, Instant, Option[Instant], Instant].andThen {
+      case (creator, createdDate, destroyedDate, dateAccessed) =>
+        AuditInfo(
+          WorkbenchEmail(creator),
+          createdDate,
+          destroyedDate.flatMap(LeoProfile.unmarshalDestroyedDate(_)),
+          dateAccessed
+        )
+    }
+
+  implicit val getResultRuntimeConfig: GetResult[RuntimeConfig] =
+    GetResult
+      .createGetTuple16[
+        CloudService,
+        Int,
+        MachineTypeName,
+        Option[DiskSize],
+        Option[DiskSize],
+        Option[MachineTypeName],
+        Option[DiskSize],
+        Option[Int],
+        Option[Int],
+        Option[Map[String, String]],
+        Option[DiskId],
+        Option[ZoneName],
+        Option[RegionName],
+        (Option[GpuType], Option[Int]),
+        Boolean,
+        Boolean
+      ]
+      .andThen {
+        case (
+              cloudService,
+              numberOfWorkers,
+              machineType,
+              diskSize,
+              bootDiskSize,
+              workerMachineType,
+              workerDiskSize,
+              numberOfWorkerLocalSSDs,
+              numberOfPreemptibleWorkers,
+              dataprocProperties,
+              persistentDiskId,
+              zone,
+              region,
+              gpuConfig,
+              componentGatewayEnabled,
+              workerPrivateAccess
+            ) =>
+          RuntimeConfigTable.toRuntimeConfig(
+            cloudService,
+            numberOfWorkers,
+            machineType,
+            diskSize,
+            bootDiskSize,
+            workerMachineType,
+            workerDiskSize,
+            numberOfWorkerLocalSSDs,
+            numberOfPreemptibleWorkers,
+            dataprocProperties,
+            persistentDiskId,
+            zone,
+            region,
+            gpuConfig,
+            componentGatewayEnabled,
+            workerPrivateAccess
+          )
+      }
+}

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/RuntimeConfigQueries.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/RuntimeConfigQueries.scala
@@ -2,13 +2,11 @@ package org.broadinstitute.dsde.workbench.leonardo
 package db
 
 import cats.implicits._
-
-import java.time.Instant
 import org.broadinstitute.dsde.workbench.google2.MachineTypeName
 import org.broadinstitute.dsde.workbench.leonardo.db.LeoProfile.api._
 import org.broadinstitute.dsde.workbench.leonardo.db.LeoProfile.mappedColumnImplicits._
-import org.broadinstitute.dsde.workbench.leonardo.db.RuntimeServiceDbQueries.RuntimeJoinLabel
 
+import java.time.Instant
 import scala.concurrent.ExecutionContext
 
 object RuntimeConfigQueries {
@@ -19,15 +17,6 @@ object RuntimeConfigQueries {
     ]
 
   val runtimeConfigs = TableQuery[RuntimeConfigTable]
-
-  def runtimeLabelRuntimeConfigQuery(baseQuery: RuntimeJoinLabel): RuntimeJoinLabelJoinRuntimeConfigJoinPatch =
-    for {
-      (((cluster, label), runtimeConfig), patch) <- baseQuery
-        .join(runtimeConfigs)
-        .on(_._1.runtimeConfigId === _.id)
-        .joinLeft(patchQuery)
-        .on(_._1._1.id === _.clusterId)
-    } yield (((cluster, label), runtimeConfig), patch)
 
   /**
    * return DB generated id

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/RuntimeServiceDbQueries.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/RuntimeServiceDbQueries.scala
@@ -236,16 +236,20 @@ object RuntimeServiceDbQueries {
     }.toSeq
   }
 
-  def listRuntimes(labelMap: LabelMap, includeDeleted: Boolean, cloudContext: Option[CloudContext] = None)(implicit
+  def listRuntimes(labelMap: LabelMap,
+                   includeDeleted: Boolean,
+                   creatorOnly: Option[WorkbenchEmail],
+                   cloudContext: Option[CloudContext] = None
+  )(implicit
     ec: ExecutionContext
   ): DBIO[List[ListRuntimeResponse2]] = {
     val cloudContextFilter = cloudContext match {
       case Some(cc) => Some(Left(cc))
       case None     => None
     }
-    listRuntimesHelper(labelMap, includeDeleted, None, None, cloudContextFilter).map(
+    listRuntimesHelper(labelMap, includeDeleted, creatorOnly, None, cloudContextFilter).map(
       _.toList
-    ) // TODO: we should take advantage of creatorOnly filter with Lily's ticket
+    )
   }
 
   def listRuntimesForWorkspace(labelMap: LabelMap,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/RuntimeServiceDbQueries.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/RuntimeServiceDbQueries.scala
@@ -396,13 +396,12 @@ object RuntimeServiceDbQueries {
                   `CLUSTER` AS C
                 #${clusterFiltersFinal}
               ) AS FILTERED_CLUSTER 
-              left join `LABEL` L on (L.`resourceId` = FILTERED_CLUSTER.id) 
-              and (L.`resourceType` = 'runtime') 
+              left join `LABEL` L on (L.`resourceId` = FILTERED_CLUSTER.id) and (L.`resourceType` = 'runtime') 
               #${labelMapFilters}
           ) AS LABEL_FILTERED 
           inner join `RUNTIME_CONFIG` RG on LABEL_FILTERED.id = RG.`id` 
           left join `CLUSTER_PATCH` CP on LABEL_FILTERED.id = CP.`clusterId`
-          GROUP BY LABEL_FILTERED.id"""
+          GROUP BY LABEL_FILTERED.id""".stripMargin
 
     sqlStatement.as[ListRuntimeResponse2]
   }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/RuntimeServiceDbQueries.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/RuntimeServiceDbQueries.scala
@@ -236,7 +236,7 @@ object RuntimeServiceDbQueries {
     ec: ExecutionContext
   ): DBIO[List[ListRuntimeResponse2]] = {
     val runtimeQueryFilteredByCreator = creatorOnly match {
-      case Some(creator) => clusterQuery.filterNot(_.creator === creator)
+      case Some(creator) => clusterQuery.filter(_.creator === creator)
       case None          => clusterQuery
     }
     val runtimeQueryFilteredByDeletion =

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/package.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/package.scala
@@ -29,6 +29,8 @@ import java.util.UUID
 package object http {
   val includeDeletedKey = "includeDeleted"
   val includeLabelsKey = "includeLabels"
+  val creatorOnlyKey = "role"
+  val creatorOnlyValue = "creator"
   val bucketPathMaxLength = 1024
   val WORKSPACE_NAME_KEY = "WORKSPACE_NAME"
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterp.scala
@@ -236,9 +236,17 @@ class RuntimeServiceInterp[F[_]: Parallel](config: RuntimeServiceConfig,
   ): F[Vector[ListRuntimeResponse2]] =
     for {
       ctx <- as.ask
-      paramMap <- F.fromEither(processListParameters(params))
+      (labelMap, includeDeleted, _) <- F.fromEither(processListParameters(params))
+      creatorOnly =
+        // Support filtering by creator either by role=creator query string, or creator=<user email> label
+        if (
+          params
+            .get(creatorOnlyKey)
+            .exists(_ == creatorOnlyValue) || labelMap.get(creatorOnlyValue).exists(_ == userInfo.userEmail)
+        ) Some(userInfo.userEmail)
+        else None
       runtimes <- RuntimeServiceDbQueries
-        .listRuntimes(paramMap._1, paramMap._2, cloudContext)
+        .listRuntimes(labelMap, includeDeleted, creatorOnly, cloudContext)
         .transaction
       _ <- ctx.span.traverse(s => F.delay(s.addAnnotation("DB | Done listRuntime db query")))
       runtimesAndProjects = runtimes.map(r => (GoogleProject(r.cloudContext.asString), r.samResource))

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeV2ServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeV2ServiceInterp.scala
@@ -339,17 +339,10 @@ class RuntimeV2ServiceInterp[F[_]: Parallel](config: RuntimeServiceConfig,
             .exists(_ == creatorOnlyValue) || labelMap.get("creator").exists(_ == userInfo.userEmail)
         ) Some(userInfo.userEmail)
         else None
-
-      _ <- logger.info(ctx.loggingCtx)(
-        s"1111 start DB lookup runtimes ${userInfo.userEmail}"
-      )
       runtimes <- RuntimeServiceDbQueries
         .listRuntimesForWorkspace(labelMap, includeDeleted, creatorOnly, workspaceId, cloudProvider)
         .map(_.toList)
         .transaction
-      _ <- logger.info(ctx.loggingCtx)(
-        s"1111 finish DB lookup runtimes"
-      )
       filteredRuntimes <-
         if (creatorOnly.isDefined) {
           F.pure(runtimes)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeV2ServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeV2ServiceInterp.scala
@@ -340,10 +340,16 @@ class RuntimeV2ServiceInterp[F[_]: Parallel](config: RuntimeServiceConfig,
         ) Some(userInfo.userEmail)
         else None
 
+      _ <- logger.info(ctx.loggingCtx)(
+        s"1111 start DB lookup runtimes ${userInfo.userEmail}"
+      )
       runtimes <- RuntimeServiceDbQueries
         .listRuntimesForWorkspace(labelMap, includeDeleted, creatorOnly, workspaceId, cloudProvider)
+        .map(_.toList)
         .transaction
-
+      _ <- logger.info(ctx.loggingCtx)(
+        s"1111 finish DB lookup runtimes"
+      )
       filteredRuntimes <-
         if (creatorOnly.isDefined) {
           F.pure(runtimes)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeV2ServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeV2ServiceInterp.scala
@@ -334,7 +334,7 @@ class RuntimeV2ServiceInterp[F[_]: Parallel](config: RuntimeServiceConfig,
         if (
           params
             .get(creatorOnlyKey)
-            .exists(_ == creatorOnlyValue) || labelMap.get("creator").exists(_ == userInfo.userEmail)
+            .exists(_ == creatorOnlyValue) || labelMap.get(creatorOnlyValue).exists(_ == userInfo.userEmail)
         ) Some(userInfo.userEmail)
         else None
       runtimes <- RuntimeServiceDbQueries

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeoAuthProvider.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeoAuthProvider.scala
@@ -163,15 +163,6 @@ trait LeoAuthProvider[F[_]] {
     ev: Ask[F, TraceId]
   ): F[List[(GoogleProject, R)]]
 
-  def filterUserVisibleWithWorkspaceFallback[R](
-    resources: NonEmptyList[(WorkspaceId, R)],
-    userInfo: UserInfo
-  )(implicit
-    sr: SamResource[R],
-    decoder: Decoder[R],
-    ev: Ask[F, TraceId]
-  ): F[List[(WorkspaceId, R)]]
-
   // Creates a resource in Sam
   def notifyResourceCreated[R](samResource: R, creatorEmail: WorkbenchEmail, googleProject: GoogleProject)(implicit
     sr: SamResource[R],

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/CommonTestData.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/CommonTestData.scala
@@ -315,8 +315,12 @@ object CommonTestData {
                                   None
     )
 
-  def makeCluster(index: Int): Runtime = {
+  def makeCluster(index: Int, creator: Option[WorkbenchEmail] = None): Runtime = {
     val clusterName = RuntimeName("clustername" + index.toString)
+    val auditInfoUpdated = creator match {
+      case Some(c) => auditInfo.copy(creator = c)
+      case None    => auditInfo
+    }
     Runtime(
       id = -1,
       workspaceId = Some(WorkspaceId(UUID.randomUUID())),
@@ -325,7 +329,7 @@ object CommonTestData {
       cloudContext = cloudContextGcp,
       serviceAccount = serviceAccount,
       asyncRuntimeFields = Some(makeAsyncRuntimeFields(index)),
-      auditInfo = auditInfo,
+      auditInfo = auditInfoUpdated,
       kernelFoundBusyDate = None,
       proxyUrl = Runtime.getProxyUrl(proxyUrlBase, cloudContextGcp, clusterName, Set(jupyterImage), None, Map.empty),
       status = RuntimeStatus.Unknown,

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/auth/WhitelistAuthProvider.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/auth/WhitelistAuthProvider.scala
@@ -94,17 +94,6 @@ class WhitelistAuthProvider(config: Config, saProvider: ServiceAccountProvider[I
 
   override def serviceAccountProvider: ServiceAccountProvider[IO] = saProvider
 
-  override def filterUserVisibleWithWorkspaceFallback[R](
-    resources: NonEmptyList[(WorkspaceId, R)],
-    userInfo: UserInfo
-  )(implicit sr: SamResource[R], decoder: Decoder[R], ev: Ask[IO, TraceId]): IO[List[(WorkspaceId, R)]] =
-    resources.toList.traverseFilter { a =>
-      checkWhitelist(userInfo).map {
-        case true  => Some(a)
-        case false => None
-      }
-    }
-
   override def isUserWorkspaceOwner[R](
     workspaceId: WorkspaceId,
     workspaceResource: R,

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/RuntimeServiceDbQueriesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/RuntimeServiceDbQueriesSpec.scala
@@ -13,6 +13,7 @@ import org.broadinstitute.dsde.workbench.leonardo.db.{
   labelQuery,
   LabelResourceType,
   RuntimeServiceDbQueries,
+  SlickPlainQueryTest,
   TestComponent
 }
 import org.broadinstitute.dsde.workbench.leonardo.db.RuntimeServiceDbQueries._
@@ -43,7 +44,7 @@ class RuntimeServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent wit
     res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
-  it should "list runtimes" in isolatedDbTest {
+  it should "list runtimes" taggedAs SlickPlainQueryTest in isolatedDbTest {
     val res = for {
       start <- IO.realTimeInstant
       list1 <- RuntimeServiceDbQueries.listRuntimes(Map.empty, false, None).transaction
@@ -84,7 +85,7 @@ class RuntimeServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent wit
     res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
-  it should "list runtimes by labels" in isolatedDbTest {
+  it should "list runtimes by labels" taggedAs SlickPlainQueryTest in isolatedDbTest {
     val res = for {
       start <- IO.realTimeInstant
       d1 <- makePersistentDisk(Some(DiskName("d1"))).save()
@@ -137,7 +138,7 @@ class RuntimeServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent wit
     res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
-  "listRuntimesForWorkspace" should "list runtimes by labels properly" in isolatedDbTest {
+  "listRuntimesForWorkspace" should "list runtimes by labels properly" taggedAs SlickPlainQueryTest in isolatedDbTest {
     val res = for {
       start <- IO.realTimeInstant
       d1 <- makePersistentDisk(Some(DiskName("d1"))).save()
@@ -190,7 +191,7 @@ class RuntimeServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent wit
     res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
-  it should "list runtimes by project" in isolatedDbTest {
+  it should "list runtimes by project" taggedAs SlickPlainQueryTest in isolatedDbTest {
     val res = for {
       start <- IO.realTimeInstant
       d1 <- makePersistentDisk(Some(DiskName("d1"))).save()
@@ -229,7 +230,7 @@ class RuntimeServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent wit
     res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
-  it should "list runtimes including deleted" in isolatedDbTest {
+  it should "list runtimes including deleted" taggedAs SlickPlainQueryTest in isolatedDbTest {
     val res = for {
       start <- IO.realTimeInstant
       d1 <- makePersistentDisk(Some(DiskName("d1"))).save()
@@ -290,7 +291,7 @@ class RuntimeServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent wit
     res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
-  it should "list runtimesV2 including deleted" in isolatedDbTest {
+  it should "list runtimesV2 including deleted" taggedAs SlickPlainQueryTest in isolatedDbTest {
     val res = for {
       start <- IO.realTimeInstant
       d1 <- makePersistentDisk(Some(DiskName("d1"))).save()
@@ -341,7 +342,7 @@ class RuntimeServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent wit
     res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
-  it should "list runtimesV2 by workspace" in isolatedDbTest {
+  it should "list runtimesV2 by workspace" taggedAs SlickPlainQueryTest in isolatedDbTest {
     val res = for {
       start <- IO.realTimeInstant
 
@@ -404,7 +405,7 @@ class RuntimeServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent wit
     res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
-  it should "list runtimesV2 by cloudProvider and workspace" in isolatedDbTest {
+  it should "list runtimesV2 by cloudProvider and workspace" taggedAs SlickPlainQueryTest in isolatedDbTest {
     val res = for {
       start <- IO.realTimeInstant
 

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/RuntimeServiceDbQueriesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/RuntimeServiceDbQueriesSpec.scala
@@ -214,8 +214,8 @@ class RuntimeServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent wit
       c2 <- IO(
         makeCluster(2).saveWithRuntimeConfig(c2RuntimeConfig)
       )
-      list1 <- RuntimeServiceDbQueries.listRuntimes(Map.empty, false, Some(cloudContextGcp)).transaction
-      list2 <- RuntimeServiceDbQueries.listRuntimes(Map.empty, false, Some(cloudContext2Gcp)).transaction
+      list1 <- RuntimeServiceDbQueries.listRuntimes(Map.empty, false, None, Some(cloudContextGcp)).transaction
+      list2 <- RuntimeServiceDbQueries.listRuntimes(Map.empty, false, None, Some(cloudContext2Gcp)).transaction
       end <- IO.realTimeInstant
       elapsed = (end.toEpochMilli - start.toEpochMilli).millis
       _ <- loggerIO.info(s"listClusters took $elapsed")

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/TestComponent.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/TestComponent.scala
@@ -73,6 +73,7 @@ trait TestComponent extends LeonardoTestSuite with ScalaFutures with GcsPathUtil
 
   def dbFutureValue[T](f: DBIO[T]): T =
     testDbRef.inTransaction(f).timeout(60 seconds).unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
+
   def dbFailure[T](f: DBIO[T]): Throwable =
     testDbRef
       .inTransaction(f)

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/scalaTestTags.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/scalaTestTags.scala
@@ -1,0 +1,5 @@
+package org.broadinstitute.dsde.workbench.leonardo.db
+
+import org.scalatest.Tag
+
+object SlickPlainQueryTest extends Tag("SlickPlainQueryTest")

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterpSpec.scala
@@ -771,7 +771,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
     exc shouldBe a[RuntimeNotFoundException]
   }
 
-  it should "list runtimes" in isolatedDbTest {
+  it should "list runtimes" taggedAs SlickPlainQueryTest in isolatedDbTest {
     val userInfo = UserInfo(OAuth2BearerToken(""),
                             WorkbenchUserId("userId"),
                             WorkbenchEmail("user1@example.com"),
@@ -789,7 +789,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
     res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
-  it should "list runtimes with a project" in isolatedDbTest {
+  it should "list runtimes with a project" taggedAs SlickPlainQueryTest in isolatedDbTest {
     val userInfo = UserInfo(OAuth2BearerToken(""),
                             WorkbenchUserId("userId"),
                             WorkbenchEmail("user1@example.com"),
@@ -807,7 +807,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
     res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
-  it should "list runtimes with parameters" in isolatedDbTest {
+  it should "list runtimes with parameters" taggedAs SlickPlainQueryTest in isolatedDbTest {
     val userInfo = UserInfo(OAuth2BearerToken(""),
                             WorkbenchUserId("userId"),
                             WorkbenchEmail("user1@example.com"),
@@ -828,7 +828,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
 
   // See https://broadworkbench.atlassian.net/browse/PROD-440
   // AoU relies on the ability for project owners to list other users' runtimes.
-  it should "list runtimes belonging to other users" in isolatedDbTest {
+  it should "list runtimes belonging to other users" taggedAs SlickPlainQueryTest in isolatedDbTest {
     val userInfo = UserInfo(OAuth2BearerToken(""),
                             WorkbenchUserId("userId"),
                             WorkbenchEmail("user1@example.com"),
@@ -856,7 +856,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
     res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
-  it should "list runtimes with labels" in isolatedDbTest {
+  it should "list runtimes with labels" taggedAs SlickPlainQueryTest in isolatedDbTest {
     // create a couple of clusters
     val clusterName1 = RuntimeName(s"cluster-${UUID.randomUUID.toString}")
     val req = emptyCreateRuntimeReq.copy(

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceV2InterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceV2InterpSpec.scala
@@ -627,7 +627,7 @@ class RuntimeServiceV2InterpSpec extends AnyFlatSpec with LeonardoTestSuite with
     }
   }
 
-  it should "list runtimes" in isolatedDbTest {
+  it should "list runtimes" taggedAs SlickPlainQueryTest in isolatedDbTest {
     val userInfo = UserInfo(OAuth2BearerToken(""),
                             WorkbenchUserId("userId"),
                             WorkbenchEmail("user1@example.com"),
@@ -649,7 +649,7 @@ class RuntimeServiceV2InterpSpec extends AnyFlatSpec with LeonardoTestSuite with
     res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
-  it should "list runtimes with a workspace" in isolatedDbTest {
+  it should "list runtimes with a workspace" taggedAs SlickPlainQueryTest in isolatedDbTest {
     val userInfo = UserInfo(OAuth2BearerToken(""),
                             WorkbenchUserId("userId"),
                             WorkbenchEmail("user1@example.com"),
@@ -668,7 +668,7 @@ class RuntimeServiceV2InterpSpec extends AnyFlatSpec with LeonardoTestSuite with
     res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
-  it should "list runtimes with a workspace and cloudContext" in isolatedDbTest {
+  it should "list runtimes with a workspace and cloudContext" taggedAs SlickPlainQueryTest in isolatedDbTest {
     val userInfo = UserInfo(OAuth2BearerToken(""),
                             WorkbenchUserId("userId"),
                             WorkbenchEmail("user1@example.com"),
@@ -713,7 +713,7 @@ class RuntimeServiceV2InterpSpec extends AnyFlatSpec with LeonardoTestSuite with
     res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
-  it should "list runtimes with parameters" in isolatedDbTest {
+  it should "list runtimes with parameters" taggedAs SlickPlainQueryTest in isolatedDbTest {
     val userInfo = UserInfo(OAuth2BearerToken(""),
                             WorkbenchUserId("userId"),
                             WorkbenchEmail("user1@example.com"),
@@ -734,7 +734,7 @@ class RuntimeServiceV2InterpSpec extends AnyFlatSpec with LeonardoTestSuite with
 
   // See https://broadworkbench.atlassian.net/browse/PROD-440
   // AoU relies on the ability for project owners to list other users' runtimes.
-  it should "list runtimes belonging to other users" in isolatedDbTest {
+  it should "list runtimes belonging to other users" taggedAs SlickPlainQueryTest in isolatedDbTest {
     val userInfo = UserInfo(OAuth2BearerToken(""),
                             WorkbenchUserId("userId"),
                             WorkbenchEmail("user1@example.com"),
@@ -762,7 +762,7 @@ class RuntimeServiceV2InterpSpec extends AnyFlatSpec with LeonardoTestSuite with
     res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
-  it should "list runtimes with labels" in isolatedDbTest {
+  it should "list runtimes with labels" taggedAs SlickPlainQueryTest in isolatedDbTest {
     // create a couple of clusters
     val clusterName1 = RuntimeName(s"cluster-${UUID.randomUUID.toString}")
     val wsmJobId1 = WsmJobId("job1")

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/mocks.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/mocks.scala
@@ -134,11 +134,6 @@ class BaseMockAuthProvider extends LeoAuthProvider[IO] {
     ev: Ask[IO, TraceId]
   ): IO[Unit] = IO.unit
 
-  override def filterUserVisibleWithWorkspaceFallback[R](
-    resources: NonEmptyList[(WorkspaceId, R)],
-    userInfo: UserInfo
-  )(implicit sr: SamResource[R], decoder: Decoder[R], ev: Ask[IO, TraceId]): IO[List[(WorkspaceId, R)]] = ???
-
   override def isUserWorkspaceOwner[R](workspaceId: WorkspaceId, workspaceResource: R, userInfo: UserInfo)(implicit
     sr: SamResource[R],
     decoder: Decoder[R],

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.7.2
+sbt.version=1.8.0


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-3888

* Support `creator=role` query string for listRuntimeV2 api
* Update DB query to filter based on an optional `creatorOnly` field for better DB query performance
* Update underlying query to [plain SQL](https://scala-slick.org/doc/3.0.0/sql.html#splicing-literal-values) for better performance (more than 1 min to a few seconds).
* Removed workspace permission check fallback. After talking to @rtitle , it turns out Sam model created by WSM is hierarchical, so by asking sam if a user can read a runtime is sufficient (Sam will take care of checking if the caller has permission at workspace level as well)

Test
1. Run Leo locally against dev DB
2. Run the following cmd as `hermione`
```
curl 'https://local.dsde-dev.broadinstitute.org:30443/api/v2/runtimes?saturnAutoCreated=true&includeLabels=saturnWorkspaceNamespace%2CsaturnWorkspaceName' \
  -H 'Accept: */*' \
  -H 'Accept-Language: en-US,en;q=0.9' \
  -H "Authorization: Bearer `gcloud auth print-access-token`" \
  -H 'Cache-Control: no-cache' \
  -H 'Connection: keep-alive' \
  -H 'Origin: http://localhost:3000' \
  -H 'Pragma: no-cache' \
  -H 'Referer: http://localhost:3000/' \
  -H 'Sec-Fetch-Dest: empty' \
  -H 'Sec-Fetch-Mode: cors' \
  -H 'Sec-Fetch-Site: cross-site' \
  -H 'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.0.0 Safari/537.36' \
  -H 'X-App-ID: Saturn' \
  -H 'sec-ch-ua: "Not?A_Brand";v="8", "Chromium";v="108", "Google Chrome";v="108"' \
  -H 'sec-ch-ua-mobile: ?0' \
  -H 'sec-ch-ua-platform: "macOS"' \
  --compressed
```
3. Before the optimization, the DB query will take more than 1 min to finish, and it'll cause curl to timeout. After the optimization, the DB query only takes about 2 seconds to finish. (I put log message before and after the DB query for debugging)

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
