### PR TITLE
[TOAZ-296] Send relayPath instead of relayEndpoint to cromwell chart

### DIFF
--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/AKSInterpreterSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/AKSInterpreterSpec.scala
@@ -25,6 +25,7 @@ import org.broadinstitute.dsde.workbench.leonardo.db.{KubernetesServiceDbQueries
 import org.broadinstitute.dsde.workbench.leonardo.http.ConfigReader
 import org.broadinstitute.dsp.Release
 import org.broadinstitute.dsp.mocks.MockHelm
+import org.http4s.Uri
 import org.mockito.ArgumentMatchers.{any, anyString}
 import org.mockito.Mockito.when
 import org.scalatest.flatspec.AnyFlatSpecLike
@@ -117,7 +118,7 @@ class AKSInterpreterSpec extends AnyFlatSpecLike with TestComponent with Leonard
       cloudContext,
       workspaceId,
       lzResources,
-      "https://relay.com/app",
+      Uri.unsafeFromString("https://relay.com/app"),
       setUpMockIdentity,
       storageContainer
     )


### PR DESCRIPTION
JIRA: https://broadworkbench.atlassian.net/browse/TOAZ-296

I suspect this was an oversight when we migrated the relay listener out of the cromwhelm chart.

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
