### PR TITLE
IA-3844 update listener image

### DIFF
--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -194,7 +194,7 @@ azure {
         minor-version-auto-upgrade = true,
         file-uris = ["https://raw.githubusercontent.com/DataBiosphere/leonardo/d6f5eea1a9299f8ef95cf1dc3eaf40594af26782/http/src/main/resources/init-resources/azure_vm_init_script.sh"]
      }
-     listener-image = "terradevacrpublic.azurecr.io/terra-azure-relay-listeners:a9576c8"
+     listener-image = "terradevacrpublic.azurecr.io/terra-azure-relay-listeners:7d764b8"
     }
    }
 

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/ConfigReaderSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/ConfigReaderSpec.scala
@@ -66,7 +66,7 @@ class ConfigReaderSpec extends AnyFlatSpec with Matchers {
                 "https://raw.githubusercontent.com/DataBiosphere/leonardo/d6f5eea1a9299f8ef95cf1dc3eaf40594af26782/http/src/main/resources/init-resources/azure_vm_init_script.sh"
               )
             ),
-            "terradevacrpublic.azurecr.io/terra-azure-relay-listeners:a9576c8",
+            "terradevacrpublic.azurecr.io/terra-azure-relay-listeners:7d764b8",
             VMCredential(username = "username", password = "password")
           )
         ),


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-3844

New relay image is published properly https://github.com/DataBiosphere/terra-azure-relay-listeners/actions/runs/3695856533/jobs/6258769195

Related [PR](https://github.com/DataBiosphere/terra-azure-relay-listeners/pull/24) 


---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
