### PR TITLE
IA-3903 PROD-761 A few bug fixes and remove duplicate Sam ID for Azure runtime

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/samModels.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/samModels.scala
@@ -6,26 +6,36 @@ import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 
 sealed trait SamResourceId {
   def resourceId: String
+  def resourceType: SamResourceType
   def asString: String = resourceId
 }
 
 object SamResourceId {
-  final case class RuntimeSamResourceId(resourceId: String) extends SamResourceId
+  final case class RuntimeSamResourceId(resourceId: String) extends SamResourceId {
+    override def resourceType: SamResourceType = SamResourceType.Runtime
+  }
 
-  final case class PersistentDiskSamResourceId(resourceId: String) extends SamResourceId
+  final case class PersistentDiskSamResourceId(resourceId: String) extends SamResourceId {
+    override def resourceType: SamResourceType = SamResourceType.PersistentDisk
+  }
 
   final case class ProjectSamResourceId(googleProject: GoogleProject) extends SamResourceId {
     override def resourceId: String = googleProject.value
+    override def resourceType: SamResourceType = SamResourceType.Project
   }
 
-  final case class AppSamResourceId(resourceId: String) extends SamResourceId
+  final case class AppSamResourceId(resourceId: String) extends SamResourceId {
+    override def resourceType: SamResourceType = SamResourceType.App
+  }
 
   final case class WorkspaceResourceSamResourceId(workspaceId: WorkspaceId) extends SamResourceId {
     override def resourceId: String = workspaceId.value.toString
+    override def resourceType: SamResourceType = SamResourceType.Workspace
   }
 
   final case class WsmResourceSamResourceId(controlledResourceId: WsmControlledResourceId) extends SamResourceId {
     override def resourceId: String = controlledResourceId.value.toString
+    override def resourceType: SamResourceType = SamResourceType.WsmResource
   }
 }
 
@@ -228,6 +238,9 @@ object SamRole {
   }
   final case object Manager extends SamRole {
     val asString = "manager"
+  }
+  final case object Owner extends SamRole {
+    val asString = "owner"
   }
   final case class Other(asString: String) extends SamRole
   val stringToRole = sealerate.collect[SamRole].map(p => (p.asString, p)).toMap

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/samModels.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/samModels.scala
@@ -238,6 +238,9 @@ object SamPolicyName {
   final case object Creator extends SamPolicyName {
     override def toString = "creator"
   }
+  final case object Writer extends SamPolicyName {
+    override def toString = "writer"
+  }
   final case object Owner extends SamPolicyName {
     override def toString = "owner"
   }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/SamDAO.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/SamDAO.scala
@@ -51,6 +51,11 @@ trait SamDAO[F[_]] {
     ev: Ask[F, TraceId]
   ): F[List[(R, SamPolicyName)]]
 
+  /** Returns all roles for the user for a given resource.*/
+  def getResourceRoles(authHeader: Authorization, resourceId: SamResourceId)(implicit
+    ev: Ask[F, TraceId]
+  ): F[Set[SamRole]]
+
   /** Creates a Sam resource R using a GCP pet credential for the given email/project. */
   def createResourceAsGcpPet[R](resource: R, creatorEmail: WorkbenchEmail, googleProject: GoogleProject)(implicit
     sr: SamResource[R],

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponent.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponent.scala
@@ -392,6 +392,7 @@ object clusterQuery extends TableQuery(new ClusterTable(_)) {
           rec._1._1.cloudContext,
           rec._1._1.runtimeName,
           rec._1._1.status,
+          rec._1._1.internalId,
           rec._2.map(_.inProgress).getOrElse(false),
           rec._1._2.runtimeConfig,
           rec._1._1.serviceAccountInfo,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/RuntimeServiceDbQueries.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/RuntimeServiceDbQueries.scala
@@ -262,11 +262,11 @@ object RuntimeServiceDbQueries {
     listRuntimesHelper(labelMap, includeDeleted, creatorOnly, workspaceId, cp)
   }
 
-  def listRuntimesHelper(labelMap: LabelMap,
-                         includeDeleted: Boolean,
-                         creatorOnly: Option[WorkbenchEmail],
-                         workspaceId: Option[WorkspaceId],
-                         cloudContextOrCloudProvider: Option[Either[CloudContext, CloudProvider]]
+  private def listRuntimesHelper(labelMap: LabelMap,
+                                 includeDeleted: Boolean,
+                                 creatorOnly: Option[WorkbenchEmail],
+                                 workspaceId: Option[WorkspaceId],
+                                 cloudContextOrCloudProvider: Option[Either[CloudContext, CloudProvider]]
   ): DBIO[Vector[ListRuntimeResponse2]] = {
     val runtimeQueryFilteredByCreator = creatorOnly match {
       case Some(creator) => List(s"C.`creator` = '${creator.value}'")
@@ -403,7 +403,7 @@ object RuntimeServiceDbQueries {
               left join `LABEL` L on (L.`resourceId` = FILTERED_CLUSTER.id) and (L.`resourceType` = 'runtime') 
               #${labelMapFilters}
           ) AS LABEL_FILTERED 
-          inner join `RUNTIME_CONFIG` RG on LABEL_FILTERED.id = RG.`id` 
+          inner join `RUNTIME_CONFIG` RG on LABEL_FILTERED.runtimeConfigId = RG.`id` 
           left join `CLUSTER_PATCH` CP on LABEL_FILTERED.id = CP.`clusterId`
           GROUP BY LABEL_FILTERED.id""".stripMargin
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeV2ServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeV2ServiceInterp.scala
@@ -11,7 +11,6 @@ import cats.mtl.Ask
 import cats.syntax.all._
 import org.broadinstitute.dsde.workbench.google2.{DiskName, MachineTypeName, ZoneName}
 import org.broadinstitute.dsde.workbench.leonardo.JsonCodec._
-import org.broadinstitute.dsde.workbench.leonardo.model.SamResourceAction.runtimeSamResourceAction
 import org.broadinstitute.dsde.workbench.leonardo.SamResourceId.{
   PersistentDiskSamResourceId,
   RuntimeSamResourceId,
@@ -21,6 +20,7 @@ import org.broadinstitute.dsde.workbench.leonardo.SamResourceId.{
 import org.broadinstitute.dsde.workbench.leonardo.config.PersistentDiskConfig
 import org.broadinstitute.dsde.workbench.leonardo.dao._
 import org.broadinstitute.dsde.workbench.leonardo.db._
+import org.broadinstitute.dsde.workbench.leonardo.model.SamResourceAction.runtimeSamResourceAction
 import org.broadinstitute.dsde.workbench.leonardo.model._
 import org.broadinstitute.dsde.workbench.leonardo.monitor.LeoPubsubMessage
 import org.broadinstitute.dsde.workbench.leonardo.monitor.LeoPubsubMessage.{
@@ -31,7 +31,6 @@ import org.broadinstitute.dsde.workbench.leonardo.monitor.LeoPubsubMessage.{
 }
 import org.broadinstitute.dsde.workbench.model.{TraceId, UserInfo, WorkbenchEmail}
 import org.http4s.AuthScheme
-import org.typelevel.log4cats.StructuredLogger
 
 import java.time.Instant
 import java.util.UUID
@@ -45,8 +44,7 @@ class RuntimeV2ServiceInterp[F[_]: Parallel](config: RuntimeServiceConfig,
 )(implicit
   F: Async[F],
   dbReference: DbReference[F],
-  ec: ExecutionContext,
-  logger: StructuredLogger[F]
+  ec: ExecutionContext
 ) extends RuntimeV2Service[F] {
   override def createRuntime(userInfo: UserInfo,
                              runtimeName: RuntimeName,
@@ -97,7 +95,6 @@ class RuntimeV2ServiceInterp[F[_]: Parallel](config: RuntimeServiceConfig,
                             Some(ctx.traceId)
         )
       )
-      _ <- logger.info(ctx.loggingCtx)(s"found ${storageContainer} for ${userInfo.userEmail}")
       runtimeOpt <- RuntimeServiceDbQueries.getStatusByName(cloudContext, runtimeName).transaction
       _ <- ctx.span.traverse(s => F.delay(s.addAnnotation("Done DB query for azure runtime")))
 
@@ -119,6 +116,7 @@ class RuntimeV2ServiceInterp[F[_]: Parallel](config: RuntimeServiceConfig,
         None,
         ctx.now
       )
+      vmSamResourceId <- F.delay(UUID.randomUUID())
 
       _ <- runtimeOpt match {
         case Some(status) => F.raiseError[Unit](RuntimeAlreadyExistsException(cloudContext, runtimeName, status))
@@ -141,7 +139,7 @@ class RuntimeV2ServiceInterp[F[_]: Parallel](config: RuntimeServiceConfig,
               cloudContext,
               userInfo,
               req,
-              RuntimeSamResourceId(samResource.resourceId),
+              RuntimeSamResourceId(vmSamResourceId.toString),
               Set(runtimeImage, listenerImage, welderImage),
               Set.empty,
               ctx.now
@@ -180,17 +178,11 @@ class RuntimeV2ServiceInterp[F[_]: Parallel](config: RuntimeServiceConfig,
       hasPermission <-
         if (runtime.auditInfo.creator == userInfo.userEmail) F.pure(true)
         else {
-          for {
-            controlledResourceOpt <- controlledResourceQuery
-              .getWsmRecordForRuntime(runtime.id, WsmResourceType.AzureVm)
-              .transaction
-
-            azureRuntimeControlledResource <- F.fromOption(
-              controlledResourceOpt,
-              AzureRuntimeControlledResourceNotFoundException(runtime.cloudContext, runtimeName, ctx.traceId)
-            )
-            res <- checkSamPermission(azureRuntimeControlledResource, userInfo, WsmResourceAction.Read).map(_._1)
-          } yield res
+          checkSamPermission(
+            WsmResourceSamResourceId(WsmControlledResourceId(UUID.fromString(runtime.samResource.resourceId))),
+            userInfo,
+            WsmResourceAction.Read
+          ).map(_._1)
         }
 
       _ <- ctx.span.traverse(s => F.delay(s.addAnnotation("Done auth call for get azure runtime permission")))
@@ -230,27 +222,18 @@ class RuntimeV2ServiceInterp[F[_]: Parallel](config: RuntimeServiceConfig,
           )
       }
 
-      controlledResourceOpt <- controlledResourceQuery
-        .getWsmRecordForRuntime(runtime.id, WsmResourceType.AzureVm)
-        .transaction
-
+      // We only update IP to properly after the VM is created in WSM. Hence, if IP is not defined, we don't need to pass the VM resourceId
+      // to back leo, where it'll trigger a WSM call to delete the VM
+      wsmVMResourceSamId = runtime.hostIp.map(_ => WsmControlledResourceId(UUID.fromString(runtime.internalId)))
       // If there's no controlled resource record, that means we created the DB record in front leo but failed somewhere in back leo (possibly in polling WSM)
       // This is non-fatal, as we still want to allow users to clean up the db record if they have permission.
       // We must check if they have permission other ways if we did not get an ID back from WSM though
-      (hasPermission, wsmResourceIdOpt) <- controlledResourceOpt.fold(
+      hasPermission <-
         if (runtime.auditInfo.creator == userInfo.userEmail)
-          F.pure((true, none[WsmControlledResourceId]))
+          F.pure(true)
         else
           authProvider
             .isUserWorkspaceOwner(workspaceId, WorkspaceResourceSamResourceId(workspaceId), userInfo)
-            .map(isOwner => (isOwner, none[WsmControlledResourceId]))
-      ) { controlledResource =>
-        if (runtime.auditInfo.creator == userInfo.userEmail)
-          F.pure((true, Some(controlledResource.resourceId)))
-        else
-          checkSamPermission(controlledResource, userInfo, WsmResourceAction.Write)
-            .map(x => (x._1, Some(x._2)))
-      }
 
       _ <- ctx.span.traverse(s => F.delay(s.addAnnotation("Done auth call for delete azure runtime permission")))
       _ <- F
@@ -263,7 +246,7 @@ class RuntimeV2ServiceInterp[F[_]: Parallel](config: RuntimeServiceConfig,
       _ <- persistentDiskQuery.markPendingDeletion(diskId, ctx.now).transaction
 
       _ <- publisherQueue.offer(
-        DeleteAzureRuntimeMessage(runtime.id, Some(diskId), workspaceId, wsmResourceIdOpt, Some(ctx.traceId))
+        DeleteAzureRuntimeMessage(runtime.id, Some(diskId), workspaceId, wsmVMResourceSamId, Some(ctx.traceId))
       )
     } yield ()
 
@@ -274,11 +257,10 @@ class RuntimeV2ServiceInterp[F[_]: Parallel](config: RuntimeServiceConfig,
     runtime <- RuntimeServiceDbQueries.getActiveRuntimeRecord(workspaceId, runtimeName).transaction
 
     // If user is creator of the runtime, they should definitely be able to see the runtime.
-    hasPermission <- checkPermission(runtime.auditInfo.creator,
-                                     userInfo,
-                                     runtime.cloudContext,
-                                     runtime.runtimeName,
-                                     runtime.id
+    hasPermission <- checkPermission(
+      runtime.auditInfo.creator,
+      userInfo,
+      WsmResourceSamResourceId(WsmControlledResourceId(UUID.fromString(runtime.internalId)))
     )
     _ <- F
       .raiseError[Unit](
@@ -300,11 +282,10 @@ class RuntimeV2ServiceInterp[F[_]: Parallel](config: RuntimeServiceConfig,
     runtime <- RuntimeServiceDbQueries.getActiveRuntimeRecord(workspaceId, runtimeName).transaction
 
     // If user is creator of the runtime, they should definitely be able to see the runtime.
-    hasPermission <- checkPermission(runtime.auditInfo.creator,
-                                     userInfo,
-                                     runtime.cloudContext,
-                                     runtime.runtimeName,
-                                     runtime.id
+    hasPermission <- checkPermission(
+      runtime.auditInfo.creator,
+      userInfo,
+      WsmResourceSamResourceId(WsmControlledResourceId(UUID.fromString(runtime.internalId)))
     )
 
     _ <- F
@@ -327,6 +308,7 @@ class RuntimeV2ServiceInterp[F[_]: Parallel](config: RuntimeServiceConfig,
     params: Map[String, String]
   )(implicit as: Ask[F, AppContext]): F[Vector[ListRuntimeResponse2]] =
     for {
+      ctx <- as.ask
       (labelMap, includeDeleted, _) <- F.fromEither(processListParameters(params))
 
       creatorOnly =
@@ -378,11 +360,11 @@ class RuntimeV2ServiceInterp[F[_]: Parallel](config: RuntimeServiceConfig,
               .map(_.getOrElse(List.empty))
 
             samUserVisibleRuntimesUserIsNotCreatorWithWorkspace =
-              runtimesUserIsNotCreatorWithWorkspaceIdAndSamResourceId.mapFilter(runtimeAndSamId =>
-                if (samVisibleWsmControlledResourceSamIds.contains(runtimeAndSamId._2))
+              runtimesUserIsNotCreatorWithWorkspaceIdAndSamResourceId.mapFilter { runtimeAndSamId =>
+                if (samVisibleWsmControlledResourceSamIds.contains(runtimeAndSamId._2)) {
                   Some(runtimeAndSamId._1)
-                else None
-              )
+                } else None
+              }
 
             // -----------   Filter runtimes that's in runtimesUserIsNotCreatorWithoutWorkspaceId   -----------
             // We must also check the RuntimeSamResourceId in sam to support already existing and newly created google runtimes
@@ -472,29 +454,19 @@ class RuntimeV2ServiceInterp[F[_]: Parallel](config: RuntimeServiceConfig,
 
   private def checkPermission(creator: WorkbenchEmail,
                               userInfo: UserInfo,
-                              cloudContext: CloudContext,
-                              runtimeName: RuntimeName,
-                              runtimeId: Long
+                              wsmResourceSamResourceId: WsmResourceSamResourceId
   )(implicit
     ev: Ask[F, AppContext]
   ) = if (creator == userInfo.userEmail) F.pure(true)
   else {
     for {
       ctx <- ev.ask
-      controlledResourceOpt <- controlledResourceQuery
-        .getWsmRecordForRuntime(runtimeId, WsmResourceType.AzureVm)
-        .transaction
-
-      azureRuntimeControlledResource <- F.fromOption(
-        controlledResourceOpt,
-        AzureRuntimeControlledResourceNotFoundException(cloudContext, runtimeName, ctx.traceId)
-      )
-      res <- checkSamPermission(azureRuntimeControlledResource, userInfo, WsmResourceAction.Read).map(_._1)
+      res <- checkSamPermission(wsmResourceSamResourceId, userInfo, WsmResourceAction.Read).map(_._1)
       _ <- ctx.span.traverse(s => F.delay(s.addAnnotation("Done auth call for azure runtime permission check")))
     } yield res
   }
 
-  private def checkSamPermission(azureRuntimeControlledResource: RuntimeControlledResourceRecord,
+  private def checkSamPermission(wsmResourceSamResourceId: WsmResourceSamResourceId,
                                  userInfo: UserInfo,
                                  wsmResourceAction: WsmResourceAction
   )(implicit
@@ -503,11 +475,11 @@ class RuntimeV2ServiceInterp[F[_]: Parallel](config: RuntimeServiceConfig,
     for {
       // TODO: generalize for google
       res <- authProvider.hasPermission(
-        WsmResourceSamResourceId(azureRuntimeControlledResource.resourceId),
+        wsmResourceSamResourceId,
         wsmResourceAction,
         userInfo
       )
-    } yield (res, azureRuntimeControlledResource.resourceId)
+    } yield (res, wsmResourceSamResourceId.controlledResourceId)
 
   private def errorHandler(runtimeId: Long, ctx: AppContext): Throwable => F[Unit] =
     e =>

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeoAuthProvider.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeoAuthProvider.scala
@@ -51,7 +51,7 @@ object SamResource {
   }
   class WsmResource extends SamResource[WsmResourceSamResourceId] {
     val resourceType = SamResourceType.WsmResource
-    val policyNames = Set(SamPolicyName.Creator) // TODO: is this policy name correct?
+    val policyNames = Set(SamPolicyName.Writer)
     def resourceIdAsString(r: WsmResourceSamResourceId): String = r.resourceId
   }
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeoAuthProvider.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeoAuthProvider.scala
@@ -163,6 +163,12 @@ trait LeoAuthProvider[F[_]] {
     ev: Ask[F, TraceId]
   ): F[List[(GoogleProject, R)]]
 
+  def filterWorkspaceOwner(
+    resources: NonEmptyList[WorkspaceResourceSamResourceId],
+    userInfo: UserInfo
+  )(implicit
+    ev: Ask[F, TraceId]
+  ): F[Set[WorkspaceResourceSamResourceId]]
   // Creates a resource in Sam
   def notifyResourceCreated[R](samResource: R, creatorEmail: WorkbenchEmail, googleProject: GoogleProject)(implicit
     sr: SamResource[R],
@@ -193,11 +199,10 @@ trait LeoAuthProvider[F[_]] {
     userInfo: UserInfo
   )(implicit sr: SamResource[R], ev: Ask[F, TraceId]): F[Unit]
 
-  def isUserWorkspaceOwner[R](
-    workspaceId: WorkspaceId,
-    workspaceResource: R,
+  def isUserWorkspaceOwner(
+    workspaceResource: WorkspaceResourceSamResourceId,
     userInfo: UserInfo
-  )(implicit sr: SamResource[R], decoder: Decoder[R], ev: Ask[F, TraceId]): F[Boolean]
+  )(implicit ev: Ask[F, TraceId]): F[Boolean]
 
   // Get user info from Sam. If petOrUserInfo is a pet SA, Sam will return it's associated user account info
   def lookupOriginatingUserEmail[R](petOrUserInfo: UserInfo)(implicit ev: Ask[F, TraceId]): F[WorkbenchEmail]

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/MonitorAtBoot.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/MonitorAtBoot.scala
@@ -16,6 +16,7 @@ import org.broadinstitute.dsde.workbench.model.{TraceId, WorkbenchEmail}
 import org.broadinstitute.dsde.workbench.openTelemetry.OpenTelemetryMetrics
 import org.typelevel.log4cats.Logger
 
+import java.util.UUID
 import scala.concurrent.ExecutionContext
 
 class MonitorAtBoot[F[_]](publisherQueue: Queue[F, LeoPubsubMessage],
@@ -306,14 +307,12 @@ class MonitorAtBoot[F[_]](publisherQueue: Queue[F, LeoPubsubMessage],
           wid <- F.fromOption(runtime.workspaceId,
                               MonitorAtBootException(s"no workspaceId found for ${runtime.id.toString}", traceId)
           )
-          controlledResourceOpt <- controlledResourceQuery
-            .getWsmRecordForRuntime(runtime.id, WsmResourceType.AzureVm)
-            .transaction
+          controlledResourceOpt = WsmControlledResourceId(UUID.fromString(runtime.internalId))
         } yield LeoPubsubMessage.DeleteAzureRuntimeMessage(
           runtimeId = runtime.id,
           None,
           workspaceId = wid,
-          wsmResourceId = controlledResourceOpt.map(_.resourceId),
+          wsmResourceId = Some(controlledResourceOpt),
           traceId = Some(traceId)
         )
       case RuntimeStatus.Starting =>
@@ -359,6 +358,7 @@ final case class RuntimeToMonitor(
   cloudContext: CloudContext,
   runtimeName: RuntimeName,
   status: RuntimeStatus,
+  internalId: String,
   patchInProgress: Boolean,
   runtimeConfig: RuntimeConfig,
   serviceAccount: WorkbenchEmail,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandler.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandler.scala
@@ -11,7 +11,6 @@ import com.azure.resourcemanager.compute.models.{VirtualMachine, VirtualMachineS
 import org.broadinstitute.dsde.workbench.azure._
 import org.broadinstitute.dsde.workbench.google2.{streamFUntilDone, streamUntilDoneOrTimeout}
 import org.broadinstitute.dsde.workbench.leonardo.AsyncTaskProcessor.Task
-import org.broadinstitute.dsde.workbench.leonardo.SamResourceId.WsmResourceSamResourceId
 import org.broadinstitute.dsde.workbench.leonardo.config.ContentSecurityPolicyConfig
 import org.broadinstitute.dsde.workbench.leonardo.dao._
 import org.broadinstitute.dsde.workbench.leonardo.db._
@@ -111,7 +110,7 @@ class AzurePubsubHandlerInterp[F[_]: Parallel](
         auth
       )
 
-      samResourceId <- F.delay(WsmControlledResourceId(UUID.randomUUID()))
+      samResourceId = WsmControlledResourceId(UUID.fromString(params.runtime.samResource.resourceId))
       createVmRequest <- (createDiskAction, createNetworkAction).parMapN { (diskResp, networkResp) =>
         val vmCommon = getCommonFields(
           ControlledResourceName(params.runtime.runtimeName.asString),
@@ -421,19 +420,9 @@ class AzurePubsubHandlerInterp[F[_]: Parallel](
               )
             )
           case WsmJobStatus.Succeeded =>
+            val hostIp = s"${params.relayNamespace.value}.servicebus.windows.net"
+
             for {
-              _ <- resp.vm.traverse { x =>
-                dbRef.inTransaction(
-                  controlledResourceQuery.save(
-                    params.runtime.id,
-                    x.metadata.resourceId,
-                    WsmResourceType.AzureVm
-                  )
-                ) >> dbRef.inTransaction(
-                  clusterQuery.updateSamResourceId(params.runtime.id, WsmResourceSamResourceId(x.metadata.resourceId))
-                )
-              }
-              hostIp = s"${params.relayNamespace.value}.servicebus.windows.net"
               _ <- clusterQuery.updateClusterHostIp(params.runtime.id, Some(IP(hostIp)), ctx.now).transaction
               // then poll the azure VM for Running status, retrieving the final azure representation
               _ <- streamUntilDoneOrTimeout(

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/auth/WhitelistAuthProvider.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/auth/WhitelistAuthProvider.scala
@@ -8,6 +8,7 @@ import com.typesafe.config.Config
 import io.circe.{Decoder, Encoder}
 import net.ceedubs.ficus.Ficus._
 import org.broadinstitute.dsde.workbench.leonardo.CommonTestData.{serviceAccountEmail, userEmail}
+import org.broadinstitute.dsde.workbench.leonardo.SamResourceId.WorkspaceResourceSamResourceId
 import org.broadinstitute.dsde.workbench.leonardo.{CloudContext, ProjectAction, WorkspaceId}
 import org.broadinstitute.dsde.workbench.leonardo.model._
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
@@ -94,11 +95,10 @@ class WhitelistAuthProvider(config: Config, saProvider: ServiceAccountProvider[I
 
   override def serviceAccountProvider: ServiceAccountProvider[IO] = saProvider
 
-  override def isUserWorkspaceOwner[R](
-    workspaceId: WorkspaceId,
-    workspaceResource: R,
+  override def isUserWorkspaceOwner(
+    workspaceResource: WorkspaceResourceSamResourceId,
     userInfo: UserInfo
-  )(implicit sr: SamResource[R], decoder: Decoder[R], ev: Ask[IO, TraceId]): IO[Boolean] =
+  )(implicit ev: Ask[IO, TraceId]): IO[Boolean] =
     checkWhitelist(userInfo)
 
   override def lookupOriginatingUserEmail[R](petOrUserInfo: UserInfo)(implicit
@@ -121,4 +121,8 @@ class WhitelistAuthProvider(config: Config, saProvider: ServiceAccountProvider[I
     sr: SamResource[R],
     ev: Ask[IO, TraceId]
   ): IO[Unit] = IO.unit
+
+  override def filterWorkspaceOwner(resources: NonEmptyList[WorkspaceResourceSamResourceId], userInfo: UserInfo)(
+    implicit ev: Ask[IO, TraceId]
+  ): IO[Set[WorkspaceResourceSamResourceId]] = IO.pure(Set.empty)
 }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/auth/WhitelistAuthProvider.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/auth/WhitelistAuthProvider.scala
@@ -124,5 +124,5 @@ class WhitelistAuthProvider(config: Config, saProvider: ServiceAccountProvider[I
 
   override def filterWorkspaceOwner(resources: NonEmptyList[WorkspaceResourceSamResourceId], userInfo: UserInfo)(
     implicit ev: Ask[IO, TraceId]
-  ): IO[Set[WorkspaceResourceSamResourceId]] = IO.pure(Set.empty)
+  ): IO[Set[WorkspaceResourceSamResourceId]] = IO.pure(resources.toList.toSet)
 }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/MockSamDAO.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/MockSamDAO.scala
@@ -329,6 +329,11 @@ class MockSamDAO extends SamDAO[IO] {
     sr: SamResource[R],
     ev: Ask[IO, TraceId]
   ): IO[Unit] = ???
+
+  /** Returns all roles for the user for a given resource.  */
+  override def getResourceRoles(authHeader: Authorization, resourceId: SamResourceId)(implicit
+    ev: Ask[IO, TraceId]
+  ): IO[Set[SamRole]] = ???
 }
 
 object MockSamDAO {

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceV2InterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceV2InterpSpec.scala
@@ -24,7 +24,7 @@ import org.broadinstitute.dsde.workbench.leonardo.monitor.LeoPubsubMessage.{
   StopRuntimeMessage
 }
 import org.broadinstitute.dsde.workbench.leonardo.util.QueueFactory
-import org.broadinstitute.dsde.workbench.model.{IP, UserInfo, WorkbenchEmail, WorkbenchUserId}
+import org.broadinstitute.dsde.workbench.model.{UserInfo, WorkbenchEmail, WorkbenchUserId}
 import org.http4s.headers.Authorization
 import org.scalatest.flatspec.AnyFlatSpec
 

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceV2InterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceV2InterpSpec.scala
@@ -224,7 +224,6 @@ class RuntimeServiceV2InterpSpec extends AnyFlatSpec with LeonardoTestSuite with
         )
         .transaction
       cluster = clusterOpt.get
-      _ <- controlledResourceQuery.save(cluster.id, wsmResourceId, WsmResourceType.AzureVm).transaction
       getResponse <- azureService.getRuntime(userInfo, runtimeName, workspaceId)
     } yield {
       getResponse.clusterName shouldBe runtimeName
@@ -272,7 +271,6 @@ class RuntimeServiceV2InterpSpec extends AnyFlatSpec with LeonardoTestSuite with
           )
           .save()
       )
-      _ <- controlledResourceQuery.save(runtime.id, wsmResourceId, WsmResourceType.AzureVm).transaction
       r <- defaultAzureService
         .startRuntime(userInfo, runtime.runtimeName, runtime.workspaceId.get)
         .attempt
@@ -360,7 +358,6 @@ class RuntimeServiceV2InterpSpec extends AnyFlatSpec with LeonardoTestSuite with
           )
           .save()
       )
-      _ <- controlledResourceQuery.save(runtime.id, wsmResourceId, WsmResourceType.AzureVm).transaction
       r <- defaultAzureService
         .stopRuntime(userInfo, runtime.runtimeName, runtime.workspaceId.get)
         .attempt
@@ -477,7 +474,6 @@ class RuntimeServiceV2InterpSpec extends AnyFlatSpec with LeonardoTestSuite with
         )
         .transaction
       cluster = clusterOpt.get
-      _ <- controlledResourceQuery.save(cluster.id, wsmResourceId, WsmResourceType.AzureVm).transaction
       _ <- azureService.getRuntime(badUserInfo, runtimeName, workspaceId)
     } yield ()
 
@@ -516,7 +512,6 @@ class RuntimeServiceV2InterpSpec extends AnyFlatSpec with LeonardoTestSuite with
         )
         .transaction
       preDeleteCluster = preDeleteClusterOpt.get
-      _ <- controlledResourceQuery.save(preDeleteCluster.id, wsmResourceId, WsmResourceType.AzureVm).transaction
       _ <- clusterQuery.updateClusterStatus(preDeleteCluster.id, RuntimeStatus.Running, context.now).transaction
 
       _ <- azureService.deleteRuntime(userInfo, runtimeName, workspaceId)
@@ -576,7 +571,6 @@ class RuntimeServiceV2InterpSpec extends AnyFlatSpec with LeonardoTestSuite with
         )
         .transaction
       preDeleteCluster = preDeleteClusterOpt.get
-      _ <- controlledResourceQuery.save(preDeleteCluster.id, wsmResourceId, WsmResourceType.AzureVm).transaction
       _ <- azureService.deleteRuntime(userInfo, runtimeName, workspaceId)
     } yield ()
 
@@ -618,7 +612,6 @@ class RuntimeServiceV2InterpSpec extends AnyFlatSpec with LeonardoTestSuite with
       cluster = clusterOpt.get
       now <- IO.realTimeInstant
       _ <- clusterQuery.updateClusterStatus(cluster.id, RuntimeStatus.Running, now).transaction
-      _ <- controlledResourceQuery.save(cluster.id, wsmResourceId, WsmResourceType.AzureVm).transaction
       _ <- azureService.deleteRuntime(badUserInfo, runtimeName, workspaceId)
     } yield ()
 
@@ -782,7 +775,6 @@ class RuntimeServiceV2InterpSpec extends AnyFlatSpec with LeonardoTestSuite with
         .transaction
 
       cluster = clusterOpt.get
-      _ <- controlledResourceQuery.save(cluster.id, wsmResourceId, WsmResourceType.AzureVm).transaction
     } yield ()
     setupControlledResource1.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
 
@@ -822,11 +814,6 @@ class RuntimeServiceV2InterpSpec extends AnyFlatSpec with LeonardoTestSuite with
         .getActiveClusterByNameMinimal(CloudContext.Azure(azureCloudContext.get), clusterName2)(
           scala.concurrent.ExecutionContext.global
         )
-        .transaction
-
-      cluster = clusterOpt.get
-      _ <- controlledResourceQuery
-        .save(cluster.id, WsmControlledResourceId(UUID.randomUUID()), WsmResourceType.AzureVm)
         .transaction
     } yield ()
     setupControlledResource2.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/mocks.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/mocks.scala
@@ -26,6 +26,7 @@ import org.broadinstitute.dsde.workbench.google2.{
   KubernetesModels,
   PvName
 }
+import org.broadinstitute.dsde.workbench.leonardo.SamResourceId.WorkspaceResourceSamResourceId
 import org.broadinstitute.dsde.workbench.leonardo.model.{
   LeoAuthProvider,
   SamResource,
@@ -134,9 +135,7 @@ class BaseMockAuthProvider extends LeoAuthProvider[IO] {
     ev: Ask[IO, TraceId]
   ): IO[Unit] = IO.unit
 
-  override def isUserWorkspaceOwner[R](workspaceId: WorkspaceId, workspaceResource: R, userInfo: UserInfo)(implicit
-    sr: SamResource[R],
-    decoder: Decoder[R],
+  override def isUserWorkspaceOwner(workspaceResource: WorkspaceResourceSamResourceId, userInfo: UserInfo)(implicit
     ev: Ask[IO, TraceId]
   ): IO[Boolean] = ???
 
@@ -157,6 +156,10 @@ class BaseMockAuthProvider extends LeoAuthProvider[IO] {
     sr: SamResource[R],
     ev: Ask[IO, TraceId]
   ): IO[Unit] = ???
+
+  override def filterWorkspaceOwner(resources: NonEmptyList[WorkspaceResourceSamResourceId], userInfo: UserInfo)(
+    implicit ev: Ask[IO, TraceId]
+  ): IO[Set[WorkspaceResourceSamResourceId]] = ???
 }
 
 object MockAuthProvider extends BaseMockAuthProvider

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriberSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriberSpec.scala
@@ -1816,7 +1816,6 @@ class LeoPubsubMessageSubscriberSpec
           )
           .saveWithRuntimeConfig(azureRuntimeConfig)
         vmResourceId = WsmControlledResourceId(UUID.randomUUID())
-        _ <- controlledResourceQuery.save(runtime.id, vmResourceId, WsmResourceType.AzureVm).transaction
 
         msg = DeleteAzureRuntimeMessage(runtime.id, Some(disk.id), workspaceId, Some(vmResourceId), None)
 

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandlerSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandlerSpec.scala
@@ -114,7 +114,6 @@ class AzurePubsubHandlerSpec
       } yield {
         controlledResources.length shouldBe 3
         val resourceTypes = controlledResources.map(_.resourceType)
-        resourceTypes.contains(WsmResourceType.AzureVm) shouldBe true
         resourceTypes.contains(WsmResourceType.AzureNetwork) shouldBe true
         resourceTypes.contains(WsmResourceType.AzureDisk) shouldBe true
         resourceTypes.contains(WsmResourceType.AzureStorageContainer) shouldBe true

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandlerSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandlerSpec.scala
@@ -117,7 +117,6 @@ class AzurePubsubHandlerSpec
         resourceTypes.contains(WsmResourceType.AzureNetwork) shouldBe true
         resourceTypes.contains(WsmResourceType.AzureDisk) shouldBe true
         resourceTypes.contains(WsmResourceType.AzureStorageContainer) shouldBe true
-        controlledResources.map(_.resourceId).contains(resourceId) shouldBe true
       }
 
     res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandlerSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandlerSpec.scala
@@ -112,7 +112,7 @@ class AzurePubsubHandlerSpec
         _ <- withInfiniteStream(asyncTaskProcessor.process, assertions)
         controlledResources <- controlledResourceQuery.getAllForRuntime(runtime.id).transaction
       } yield {
-        controlledResources.length shouldBe 4
+        controlledResources.length shouldBe 3
         val resourceTypes = controlledResources.map(_.resourceType)
         resourceTypes.contains(WsmResourceType.AzureVm) shouldBe true
         resourceTypes.contains(WsmResourceType.AzureNetwork) shouldBe true


### PR DESCRIPTION
1. No longer save Azure Runtime's WSM resourceId in `RUNTIME_CONTROLLED_RESOURCE` because this resourceId is the same as runtime's Sam resource id, which already exists in `CLUSTER` table as`internalId`. This also simplifies things a bit in a few places where we can just use `internalId` as the runtime's Sam ID for checking permissions instead of having to read the value from DB separately.
2. Fix a bug where we're joining CLUSTER and RUNTIME_CONFIG table on the wrong key..Introduced in [this PR](https://github.com/DataBiosphere/leonardo/pull/3061)...It should've been caught by at least one unit test, but for some reason that test didn't fail in CI...I'll spend a bit more time looking into how to run `RuntimeServiceDbQueriesSpec` more reliably in CI
3. Fix a bug where we're checking `creator` role for Azure runtime when calling Sam API. But it should be `writer`.
4. Fix a bug where workspace owner can't see runtimes created other users in the worksapce

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
