### PR TITLE
IA-3823 List disks allows filtering by creator

### DIFF
--- a/http/src/main/resources/swagger/api-docs.yaml
+++ b/http/src/main/resources/swagger/api-docs.yaml
@@ -861,14 +861,6 @@ paths:
           schema:
             type: string
         - in: query
-          name: creator
-          description: >
-            Optional filter that includes only persistent disks created by the given user. Accepts an email.
-            Note: currently only the requesting user's email is supported (making this a duplicate of "role=creator").
-          required: false
-          schema:
-            type: string
-        - in: query
           name: includeDeleted
           description: Optional filter that includes any persistent disks with a Deleted status.
           required: false
@@ -935,14 +927,6 @@ paths:
             Note: this string format is a workaround because Swagger doesn't support free-form
             query string parameters. The recommended way to use this endpoint is to specify the
             labels as top-level query string parameters. For instance: GET /api/google/v1/disks?key1=val1&key2=val2.
-          required: false
-          schema:
-            type: string
-        - in: query
-          name: creator
-          description: >
-            Optional filter that includes only persistent disks created by the given user. Accepts an email.
-            Note: currently only the requesting user's email is supported (making this a duplicate of "role=creator").
           required: false
           schema:
             type: string

--- a/http/src/main/resources/swagger/api-docs.yaml
+++ b/http/src/main/resources/swagger/api-docs.yaml
@@ -861,6 +861,14 @@ paths:
           schema:
             type: string
         - in: query
+          name: creator
+          description: >
+            Optional filter that includes only persistent disks created by the given user. Accepts an email.
+            Note: currently only the requesting user's email is supported (making this a duplicate of "role=creator").
+          required: false
+          schema:
+            type: string
+        - in: query
           name: includeDeleted
           description: Optional filter that includes any persistent disks with a Deleted status.
           required: false
@@ -873,6 +881,12 @@ paths:
             Optional label keys of the labels returned in response. Example:
             Querying by key1,key2,key3
             returns all labels key1/val1 key2/val2 and key3 and val3 for each persistent disk in response
+          required: false
+          schema:
+            type: string
+        - in: query
+          name: role
+          description: Optional filter that excludes persistent disks you did not create. Accepts "creator" or nothing.
           required: false
           schema:
             type: string
@@ -925,6 +939,14 @@ paths:
           schema:
             type: string
         - in: query
+          name: creator
+          description: >
+            Optional filter that includes only persistent disks created by the given user. Accepts an email.
+            Note: currently only the requesting user's email is supported (making this a duplicate of "role=creator").
+          required: false
+          schema:
+            type: string
+        - in: query
           name: includeDeleted
           description: Optional filter that includes any persistent disks with a Deleted status.
           required: false
@@ -937,6 +959,12 @@ paths:
             Optional label keys of the labels returned in response. Example:
             Querying by key1,key2,key3
             returns all labels key1/val1 key2/val2 and key3 and val3 for each persistent disk in response
+          required: false
+          schema:
+            type: string
+        - in: query
+          name: role
+          description: Optional filter that excludes persistent disks you did not create. Accepts "creator" or nothing.
           required: false
           schema:
             type: string

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/DiskServiceDbQueries.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/DiskServiceDbQueries.scala
@@ -17,13 +17,13 @@ object DiskServiceDbQueries {
 
   def listDisks(labelMap: LabelMap,
                 includeDeleted: Boolean,
-                createdBy: Option[WorkbenchEmail],
+                creatorOnly: Option[WorkbenchEmail],
                 cloudContextOpt: Option[CloudContext] = None
   )(implicit
     ec: ExecutionContext
   ): DBIO[List[PersistentDisk]] = {
     // filtered by creator first as it may have great impact
-    val diskQueryFilteredByCreator = createdBy match {
+    val diskQueryFilteredByCreator = creatorOnly match {
       case Some(email) => persistentDiskQuery.tableQuery.filter(_.creator === email)
       case None        => persistentDiskQuery.tableQuery
     }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/DiskServiceDbQueries.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/DiskServiceDbQueries.scala
@@ -9,18 +9,28 @@ import org.broadinstitute.dsde.workbench.leonardo.db.LeoProfile.unmarshalDestroy
 import org.broadinstitute.dsde.workbench.leonardo.db.persistentDiskQuery.unmarshalPersistentDisk
 import org.broadinstitute.dsde.workbench.leonardo.http.GetPersistentDiskResponse
 import org.broadinstitute.dsde.workbench.leonardo.http.service.DiskNotFoundException
-import org.broadinstitute.dsde.workbench.model.TraceId
+import org.broadinstitute.dsde.workbench.model.{TraceId, WorkbenchEmail}
 
 import scala.concurrent.ExecutionContext
 
 object DiskServiceDbQueries {
 
-  def listDisks(labelMap: LabelMap, includeDeleted: Boolean, cloudContextOpt: Option[CloudContext] = None)(implicit
+  def listDisks(labelMap: LabelMap,
+                includeDeleted: Boolean,
+                createdBy: Option[WorkbenchEmail],
+                cloudContextOpt: Option[CloudContext] = None
+  )(implicit
     ec: ExecutionContext
   ): DBIO[List[PersistentDisk]] = {
+    // filtered by creator first as it may have great impact
+    val diskQueryFilteredByCreator = createdBy match {
+      case Some(email) => persistentDiskQuery.tableQuery.filter(_.creator === email)
+      case None        => persistentDiskQuery.tableQuery
+    }
+
     val diskQueryFilteredByDeletion =
-      if (includeDeleted) persistentDiskQuery.tableQuery
-      else persistentDiskQuery.tableQuery.filterNot(_.status === (DiskStatus.Deleted: DiskStatus))
+      if (includeDeleted) diskQueryFilteredByCreator
+      else diskQueryFilteredByCreator.filterNot(_.status === (DiskStatus.Deleted: DiskStatus))
 
     val diskQueryFilteredByProject =
       cloudContextOpt.fold(diskQueryFilteredByDeletion)(p =>

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/package.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/package.scala
@@ -31,7 +31,7 @@ package object http {
   val includeDeletedKey = "includeDeleted"
   val includeLabelsKey = "includeLabels"
   val creatorOnlyKey = "role"
-  val creatorOnlyValue = "creator"
+  val creatorOnlyValue = SamRole.Creator.asString
   val bucketPathMaxLength = 1024
   val WORKSPACE_NAME_KEY = "WORKSPACE_NAME"
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/DiskServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/DiskServiceInterp.scala
@@ -193,7 +193,7 @@ class DiskServiceInterp[F[_]: Parallel](config: PersistentDiskConfig,
     for {
       ctx <- as.ask
       paramMap <- F.fromEither(processListParameters(params))
-      creatorOnly <- F.fromEither(processCreatorOnlyParameter(userInfo, params))
+      creatorOnly <- F.fromEither(processCreatorOnlyParameter(userInfo.userEmail, params, ctx.traceId))
       disks <- DiskServiceDbQueries.listDisks(paramMap._1, paramMap._2, creatorOnly, cloudContext).transaction
       _ <- ctx.span.traverse(s => F.delay(s.addAnnotation("Done DB call")))
       diskAndProjects = disks.map(d =>

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/package.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/package.scala
@@ -85,11 +85,17 @@ package object service {
         )
       )
 
+  /**
+   * Parses requested creator email from a query. Returns the calling user's WorkbenchEmail given param role=creator or
+   * creator=(caller's email). The creator=email syntax is provided to support legacy terra-ui usages.
+   * @param userInfo ID and credentials of the calling user
+   * @param params Map of query params
+   * @return Either a ParseCreatorOnlyException or an Option WorkbenchEmail
+   */
   private[service] def processCreatorOnlyParameter(
     userInfo: UserInfo,
     params: LabelMap
   ): Either[ParseCreatorOnlyException, Option[WorkbenchEmail]] =
-    // Support filtering by creator either by role=creator query string, or creator=<user email> label
     for {
       result <- params match {
         case map if map.isDefinedAt(creatorOnlyKey) =>

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/package.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/package.scala
@@ -51,10 +51,9 @@ package object service {
     // 2) includeDeleted - Boolean which determines if we include deleted resources in the response
     // 3) includeLabels - List of label keys which represent the labels (key, value pairs) that will be returned in response
     // Note that optional parameter `role` or `creator` (represented by creatorOnlyKey and creatorOnlyValue) is omitted
-    // from this logic; once it is generally supported it should likely be processed here rather than separately in
-    // the various services.
+    // from this logic; once it is generally supported it should likely be processed in this service rather than elsewhere.
     for {
-      labelMap <- processLabelMap(params - includeDeletedKey - includeLabelsKey - creatorOnlyKey)
+      labelMap <- processLabelMap(params - includeDeletedKey - includeLabelsKey - creatorOnlyKey - creatorOnlyValue)
       includeDeleted = params.get(includeDeletedKey) match {
         case Some(includeDeletedValue) =>
           if (includeDeletedValue.toLowerCase == "true")

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/package.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/package.scala
@@ -43,6 +43,7 @@ package object service {
       case None => Right(params)
     }
 
+  // TODO likely need to check for `includeRoleKey` and remove it before processing labels
   private[service] def processListParameters(
     params: LabelMap
   ): Either[ParseLabelsException, (LabelMap, Boolean, List[String])] =

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/package.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/package.scala
@@ -95,36 +95,30 @@ package object service {
     callerEmail: WorkbenchEmail,
     params: Map[String, String],
     traceId: TraceId
-  ): Either[BadRequestException, Option[WorkbenchEmail]] = {
-    val creatorOnlyFromRoleKey = params.get(creatorOnlyKey) match {
+  ): Either[BadRequestException, Option[WorkbenchEmail]] =
+    params.get(creatorOnlyKey) match {
       case Some(role) =>
-        Some(
-          Either.cond(
-            role == creatorOnlyValue,
-            Some(callerEmail),
-            BadRequestException(
-              s"Failed to process invalid value for ${creatorOnlyKey}. The only currently supported value is ${creatorOnlyValue}.",
-              Some(traceId)
-            )
+        Either.cond(
+          role == creatorOnlyValue,
+          Some(callerEmail),
+          BadRequestException(
+            s"Failed to process invalid value for ${creatorOnlyKey}. The only currently supported value is ${creatorOnlyValue}.",
+            Some(traceId)
           )
         )
-      case None => None
-    }
-    val creatorOnlyFromCreatorKey = params.get(creatorOnlyValue) match {
-      case Some(email) =>
-        Some(
-          Either.cond(
-            email == callerEmail.value,
-            Some(callerEmail),
-            BadRequestException(
-              s"Failed to process invalid value for ${creatorOnlyValue}. The only currently supported value is your own user email.",
-              Some(traceId)
+      case None =>
+        params.get(creatorOnlyValue) match {
+          case Some(email) =>
+            Either.cond(
+              email == callerEmail.value,
+              Some(callerEmail),
+              BadRequestException(
+                s"Failed to process invalid value for ${creatorOnlyValue}. The only currently supported value is your own user email.",
+                Some(traceId)
+              )
             )
-          )
-        )
-      case None => None
+          case None => none.asRight
+        }
     }
 
-    (creatorOnlyFromRoleKey orElse creatorOnlyFromCreatorKey).getOrElse(Either.right(None))
-  }
 }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/package.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/package.scala
@@ -117,7 +117,7 @@ package object service {
                 Some(traceId)
               )
             )
-          case None => none.asRight
+          case None => none.asRight[BadRequestException]
         }
     }
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/package.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/package.scala
@@ -43,7 +43,6 @@ package object service {
       case None => Right(params)
     }
 
-  // TODO likely need to check for `includeRoleKey` and remove it before processing labels
   private[service] def processListParameters(
     params: LabelMap
   ): Either[ParseLabelsException, (LabelMap, Boolean, List[String])] =
@@ -51,6 +50,9 @@ package object service {
     // 1) LabelMap - represents the labels to filter the request by
     // 2) includeDeleted - Boolean which determines if we include deleted resources in the response
     // 3) includeLabels - List of label keys which represent the labels (key, value pairs) that will be returned in response
+    // Note that optional parameter `role` or `creator` (represented by creatorOnlyKey and creatorOnlyValue) is omitted
+    // from this logic; once it is generally supported it should likely be processed here rather than separately in
+    // the various services.
     for {
       labelMap <- processLabelMap(params - includeDeletedKey - includeLabelsKey - creatorOnlyKey)
       includeDeleted = params.get(includeDeletedKey) match {

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/package.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/package.scala
@@ -51,8 +51,7 @@ package object service {
     // 1) LabelMap - represents the labels to filter the request by
     // 2) includeDeleted - Boolean which determines if we include deleted resources in the response
     // 3) includeLabels - List of label keys which represent the labels (key, value pairs) that will be returned in response
-    // Note that optional parameter `role` or `creator` (represented by creatorOnlyKey and creatorOnlyValue) is omitted
-    // from this logic; once it is generally supported it should likely be processed in this service rather than elsewhere.
+    // Note that optional parameter `role` or `creator` (represented by creatorOnlyKey and creatorOnlyValue) is omitted.
     for {
       labelMap <- processLabelMap(params - includeDeletedKey - includeLabelsKey - creatorOnlyKey - creatorOnlyValue)
       includeDeleted = params.get(includeDeletedKey) match {

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeoException.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeoException.scala
@@ -156,6 +156,8 @@ case class ParseLabelsException(msg: String) extends LeoException(msg, StatusCod
 case class IllegalLabelKeyException(labelKey: String)
     extends LeoException(s"Labels cannot have a key of '$labelKey'", StatusCodes.NotAcceptable, traceId = None)
 
+case class ParseCreatorOnlyException(msg: String) extends LeoException(msg, StatusCodes.BadRequest, traceId = None)
+
 case class InvalidDataprocMachineConfigException(errorMsg: String)
     extends LeoException(s"${errorMsg}", StatusCodes.BadRequest, traceId = None)
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeoException.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeoException.scala
@@ -156,8 +156,6 @@ case class ParseLabelsException(msg: String) extends LeoException(msg, StatusCod
 case class IllegalLabelKeyException(labelKey: String)
     extends LeoException(s"Labels cannot have a key of '$labelKey'", StatusCodes.NotAcceptable, traceId = None)
 
-case class ParseCreatorOnlyException(msg: String) extends LeoException(msg, StatusCodes.BadRequest, traceId = None)
-
 case class InvalidDataprocMachineConfigException(errorMsg: String)
     extends LeoException(s"${errorMsg}", StatusCodes.BadRequest, traceId = None)
 

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/DiskServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/DiskServiceInterpSpec.scala
@@ -368,6 +368,7 @@ class DiskServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with Test
     res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
+  // TODO this!
   it should "list disks" in isolatedDbTest {
     val (diskService, _) = makeDiskService()
     val userInfo = UserInfo(OAuth2BearerToken(""),

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/DiskServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/DiskServiceInterpSpec.scala
@@ -22,7 +22,6 @@ import org.broadinstitute.dsde.workbench.leonardo.model.{
   BadRequestException,
   ForbiddenError,
   LeoAuthProvider,
-  ParseCreatorOnlyException,
   SamResourceAction
 }
 import org.broadinstitute.dsde.workbench.leonardo.monitor.LeoPubsubMessage._
@@ -531,9 +530,9 @@ class DiskServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with Test
         .set(WorkbenchEmail("a_different_user@example.com"))(makePersistentDisk(Some(DiskName("d2"))))
         .save()
       listResponse <- diskService.listDisks(userInfo, None, Map("role" -> "manager"))
-    } yield ()
+    } yield listResponse
 
-    a[ParseCreatorOnlyException] should be thrownBy {
+    a[BadRequestException] should be thrownBy {
       res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
     }
   }
@@ -553,9 +552,9 @@ class DiskServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with Test
         .set(WorkbenchEmail("a_different_user@example.com"))(makePersistentDisk(Some(DiskName("d2"))))
         .save()
       listResponse <- diskService.listDisks(userInfo, None, Map("creator" -> "a_different_user@example.com"))
-    } yield ()
+    } yield listResponse
 
-    a[ParseCreatorOnlyException] should be thrownBy {
+    a[BadRequestException] should be thrownBy {
       res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
     }
   }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/DiskServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/DiskServiceInterpSpec.scala
@@ -93,7 +93,7 @@ class DiskServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with Test
                             WorkbenchUserId("userId"),
                             WorkbenchEmail("user1@example.com"),
                             0
-    ) // this email is white listed
+    ) // this email is allow-listed
     val cloudContext = CloudContext.Gcp(GoogleProject("project1"))
     val diskName = DiskName("diskName1")
 
@@ -168,7 +168,7 @@ class DiskServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with Test
                             WorkbenchUserId("userId"),
                             WorkbenchEmail("user1@example.com"),
                             0
-    ) // this email is white listed
+    ) // this email is allow-listed
     val diskName = DiskName("diskName1")
     val diskCloneName = DiskName("clone")
     val expectedFormattedBy = FormattedBy.GCE
@@ -218,7 +218,7 @@ class DiskServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with Test
                             WorkbenchUserId("userId"),
                             WorkbenchEmail("user1@example.com"),
                             0
-    ) // this email is white listed
+    ) // this email is allow-listed
     val googleProject = GoogleProject("project1")
     val diskName = DiskName("diskName1")
 
@@ -247,7 +247,7 @@ class DiskServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with Test
                             WorkbenchUserId("userId"),
                             WorkbenchEmail("user1@example.com"),
                             0
-    ) // this email is white listed
+    ) // this email is allow-listed
     val googleProject = GoogleProject("project1")
     val diskName = DiskName("diskName1")
 
@@ -353,7 +353,7 @@ class DiskServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with Test
                             WorkbenchUserId("userId"),
                             WorkbenchEmail("user1@example.com"),
                             0
-    ) // this email is white listed
+    ) // this email is allow-listed
 
     val res = for {
       samResource <- IO(PersistentDiskSamResourceId(UUID.randomUUID.toString))
@@ -375,7 +375,7 @@ class DiskServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with Test
                             WorkbenchUserId("userId"),
                             WorkbenchEmail("user1@example.com"),
                             0
-    ) // this email is white listed
+    ) // this email is allow-listed
 
     val res = for {
       disk1 <- makePersistentDisk(Some(DiskName("d1"))).save()
@@ -395,7 +395,7 @@ class DiskServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with Test
                             WorkbenchUserId("userId"),
                             WorkbenchEmail("user1@example.com"),
                             0
-    ) // this email is white listed
+    ) // this email is allow-listed
 
     val res = for {
       disk1 <- makePersistentDisk(Some(DiskName("d1")), cloudContextOpt = Some(cloudContextGcp)).save()
@@ -413,7 +413,7 @@ class DiskServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with Test
                             WorkbenchUserId("userId"),
                             WorkbenchEmail("user1@example.com"),
                             0
-    ) // this email is white listed
+    ) // this email is allow-listed
 
     val res = for {
       disk1 <- makePersistentDisk(Some(DiskName("d1"))).save()
@@ -431,7 +431,7 @@ class DiskServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with Test
                             WorkbenchUserId("userId"),
                             WorkbenchEmail("user1@example.com"),
                             0
-    ) // this email is white listed
+    ) // this email is allow-listed
 
     // Make disks belonging to different users than the calling user
     val res = for {
@@ -443,7 +443,7 @@ class DiskServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with Test
         .save()
       listResponse <- diskService.listDisks(userInfo, None, Map.empty)
     } yield
-    // Since the calling user is whitelisted in the auth provider, it should return
+    // Since the calling user is allow-listed in the auth provider, it should return
     // the disks belonging to other users.
     listResponse.map(_.id).toSet shouldBe Set(disk1.id, disk2.id)
 
@@ -456,7 +456,7 @@ class DiskServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with Test
                             WorkbenchUserId("userId"),
                             WorkbenchEmail("user1@example.com"),
                             0
-    ) // this email is white listed
+    ) // this email is allow-listed
 
     val res = for {
       disk1 <- makePersistentDisk(Some(DiskName("d1"))).save()
@@ -478,7 +478,7 @@ class DiskServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with Test
                             WorkbenchUserId("userId"),
                             WorkbenchEmail("user1@example.com"),
                             0
-    ) // this email is white listed
+    ) // this email is allow-listed
 
     val res = for {
       disk1 <- makePersistentDisk(Some(DiskName("d1"))).save()
@@ -500,7 +500,7 @@ class DiskServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with Test
                             WorkbenchUserId("userId"),
                             WorkbenchEmail("user1@example.com"),
                             0
-    ) // this email is white listed
+    ) // this email is allow-listed
 
     val res = for {
       disk1 <- makePersistentDisk(Some(DiskName("d1"))).save()
@@ -522,7 +522,7 @@ class DiskServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with Test
                             WorkbenchUserId("userId"),
                             WorkbenchEmail("user1@example.com"),
                             0
-    ) // this email is white listed
+    ) // this email is allow-listed
 
     val res = for {
       disk1 <- makePersistentDisk(Some(DiskName("d1"))).save()
@@ -544,7 +544,7 @@ class DiskServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with Test
                             WorkbenchUserId("userId"),
                             WorkbenchEmail("user1@example.com"),
                             0
-    ) // this email is white listed
+    ) // this email is allow-listed
 
     val res = for {
       disk1 <- makePersistentDisk(Some(DiskName("d1"))).save()
@@ -566,7 +566,7 @@ class DiskServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with Test
                             WorkbenchUserId("userId"),
                             WorkbenchEmail("user1@example.com"),
                             0
-    ) // this email is white listed
+    ) // this email is allow-listed
 
     val res = for {
       context <- ctx.ask[AppContext]
@@ -594,7 +594,7 @@ class DiskServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with Test
                             WorkbenchUserId("userId"),
                             WorkbenchEmail("user1@example.com"),
                             0
-    ) // this email is white listed
+    ) // this email is allow-listed
 
     val res = for {
       t <- ctx.ask[AppContext]
@@ -622,7 +622,7 @@ class DiskServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with Test
                               WorkbenchUserId("userId"),
                               WorkbenchEmail("user1@example.com"),
                               0
-      ) // this email is white listed
+      ) // this email is allow-listed
       it should s"fail to update a disk in $status status" in isolatedDbTest {
         val (diskService, _) = makeDiskService()
         val res = for {
@@ -646,7 +646,7 @@ class DiskServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with Test
                             WorkbenchUserId("userId"),
                             WorkbenchEmail("user1@example.com"),
                             0
-    ) // this email is white listed
+    ) // this email is allow-listed
 
     val res = for {
       context <- ctx.ask[AppContext]

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/DiskServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/DiskServiceInterpSpec.scala
@@ -432,6 +432,7 @@ class DiskServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with Test
                             0
     ) // this email is white listed
 
+    // Make disks belonging to different users than the calling user
     val res = for {
       disk1 <- LeoLenses.diskToCreator
         .set(WorkbenchEmail("a_different_user@example.com"))(makePersistentDisk(Some(DiskName("d1"))))

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/PackageSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/PackageSpec.scala
@@ -47,14 +47,25 @@ class PackageSpec extends AnyFlatSpec with Matchers {
   it should "reject creatorOnly parameter when role=not_creator" in {
     val email = WorkbenchEmail("user1@example.com")
     val params = Map("role" -> "owner")
-    val res = processCreatorOnlyParameter(email, params, TraceId(UUID.randomUUID()))
-    res.isLeft
+    val traceId = TraceId(UUID.randomUUID())
+    val res = processCreatorOnlyParameter(email, params, traceId)
+    res shouldBe Left(
+      BadRequestException("Failed to process invalid value for role. The only currently supported value is creator.",
+                          Some(traceId)
+      )
+    )
   }
 
   it should "reject creatorOnly parameter when creator=another_email" in {
     val email = WorkbenchEmail("user1@example.com")
     val params = Map("creator" -> "another_user@example.com")
-    val res = processCreatorOnlyParameter(email, params, TraceId(UUID.randomUUID()))
-    res.isLeft
+    val traceId = TraceId(UUID.randomUUID())
+    val res = processCreatorOnlyParameter(email, params, traceId)
+    res shouldBe Left(
+      BadRequestException(
+        "Failed to process invalid value for creator. The only currently supported value is your own user email.",
+        Some(traceId)
+      )
+    )
   }
 }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/PackageSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/PackageSpec.scala
@@ -2,8 +2,12 @@ package org.broadinstitute.dsde.workbench.leonardo
 package http
 package service
 
+import org.broadinstitute.dsde.workbench.leonardo.model.BadRequestException
+import org.broadinstitute.dsde.workbench.model.{TraceId, WorkbenchEmail}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+
+import java.util.UUID
 
 class PackageSpec extends AnyFlatSpec with Matchers {
   it should "extract labels to filter by properly" in {
@@ -20,5 +24,37 @@ class PackageSpec extends AnyFlatSpec with Matchers {
   it should "process labels to return properly" in {
     val input1 = "foo,bar"
     processLabelsToReturn(input1) shouldBe Right(List("foo", "bar"))
+  }
+
+  it should "process creatorOnly parameter when role=creator" in {
+    val email = WorkbenchEmail("user1@example.com")
+    val params = Map("role" -> "creator")
+    processCreatorOnlyParameter(email, params, TraceId(UUID.randomUUID())) shouldBe Right(Some(email))
+  }
+
+  it should "process creatorOnly parameter when creator=caller_email" in {
+    val email = WorkbenchEmail("user1@example.com")
+    val params = Map("creator" -> email.value)
+    processCreatorOnlyParameter(email, params, TraceId(UUID.randomUUID())) shouldBe Right(Some(email))
+  }
+
+  it should "process creatorOnly parameter when no role specified" in {
+    val email = WorkbenchEmail("user1@example.com")
+    val params: Map[String, String] = Map.empty
+    processCreatorOnlyParameter(email, params, TraceId(UUID.randomUUID())) shouldBe Right(None)
+  }
+
+  it should "reject creatorOnly parameter when role=not_creator" in {
+    val email = WorkbenchEmail("user1@example.com")
+    val params = Map("role" -> "owner")
+    val res = processCreatorOnlyParameter(email, params, TraceId(UUID.randomUUID()))
+    res.isLeft
+  }
+
+  it should "reject creatorOnly parameter when creator=another_email" in {
+    val email = WorkbenchEmail("user1@example.com")
+    val params = Map("creator" -> "another_user@example.com")
+    val res = processCreatorOnlyParameter(email, params, TraceId(UUID.randomUUID()))
+    res.isLeft
   }
 }


### PR DESCRIPTION
Unit tests pass for DiskServiceInterp (there is no spec for DiskServiceDbQueries; it would be reasonable to create one for this work but I have left this undone), and I've verified the endpoints work via local Swagger.

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
