### PR TITLE
IA-3926 add wait in updateDataprocImageGroupMembership

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookRKernelSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookRKernelSpec.scala
@@ -66,31 +66,6 @@ class NotebookRKernelSpec extends RuntimeFixtureSpec with NotebookTestUtils {
       }
     }
 
-    "should be able to install new R packages" in { runtimeFixture =>
-      withWebDriver { implicit driver =>
-        withNewNotebook(runtimeFixture.runtime, RKernel) { notebookPage =>
-          // httr is a simple http library for R
-          // http://httr.r-lib.org//index.html
-
-          // it may take a little while to install
-          val installTimeout = 2.minutes
-
-          val output = notebookPage.executeCell("""install.packages("httr")""", installTimeout)
-          output shouldBe defined
-          output.get should include("Installing package into")
-          output.get should include("/home/jupyter/packages")
-
-          val httpGetTest =
-            """library(httr)
-              |r <- GET("http://www.example.com")
-              |status_code(r)
-            """.stripMargin
-
-          notebookPage.executeCell(httpGetTest) shouldBe Some("200")
-        }
-      }
-    }
-
     // See https://github.com/DataBiosphere/leonardo/issues/398
     "should be able to install mlr" in { runtimeFixture =>
       withWebDriver { implicit driver =>

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/DataprocInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/DataprocInterpreter.scala
@@ -13,7 +13,6 @@ import com.google.api.services.directory.model.Group
 import com.google.cloud.compute.v1.{Operation, Tags}
 import com.google.cloud.dataproc.v1.{RuntimeConfig => _, _}
 import com.typesafe.scalalogging.LazyLogging
-import org.broadinstitute.dsde.workbench.{google2, DoneCheckable, DoneCheckableInstances}
 import org.broadinstitute.dsde.workbench.google.GoogleIamDAO.MemberType
 import org.broadinstitute.dsde.workbench.google.GoogleUtilities.RetryPredicates._
 import org.broadinstitute.dsde.workbench.google._
@@ -43,6 +42,7 @@ import org.broadinstitute.dsde.workbench.model.google._
 import org.broadinstitute.dsde.workbench.model.{TraceId, WorkbenchEmail}
 import org.broadinstitute.dsde.workbench.openTelemetry.OpenTelemetryMetrics
 import org.broadinstitute.dsde.workbench.util2.InstanceName
+import org.broadinstitute.dsde.workbench.{google2, DoneCheckable}
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/DataprocInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/DataprocInterpreter.scala
@@ -647,6 +647,8 @@ class DataprocInterpreter[F[_]: Parallel](
             // Note we add both service-[project-number]@dataproc-accounts.iam.gserviceaccount.com and
             // [project-number]@cloudservices.gserviceaccount.com to the group because both seem to be
             // used in different circumstances (the latter seems to be used for adding preemptibles, for example).
+            // See https://cloud.google.com/dataproc/docs/concepts/configuring-clusters/service-accounts#dataproc_service_accounts_2
+            // for more information
             dataprocServiceAccountEmail = WorkbenchEmail(
               s"service-${projectNumber}@dataproc-accounts.iam.gserviceaccount.com"
             )

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/DataprocInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/DataprocInterpreter.scala
@@ -105,7 +105,7 @@ class DataprocInterpreter[F[_]: Parallel](
     with LazyLogging {
 
   import dbRef._
-  val isMemberofGroupDonecheckable = new DoneCheckable[Boolean] {
+  val isMemberofGroupDoneCheckable = new DoneCheckable[Boolean] {
     override def isDone(a: Boolean): Boolean = a
   }
 
@@ -678,7 +678,7 @@ class DataprocInterpreter[F[_]: Parallel](
     } yield ()
 
   private def waitUntilMemberAdded(memberEmail: WorkbenchEmail): F[Boolean] = {
-    implicit val doneCheckable = isMemberofGroupDonecheckable
+    implicit val doneCheckable = isMemberofGroupDoneCheckable
     streamUntilDoneOrTimeout(
       F.fromFuture(
         F.blocking(

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/DataprocInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/DataprocInterpreter.scala
@@ -656,6 +656,8 @@ class DataprocInterpreter[F[_]: Parallel](
                                        dataprocServiceAccountEmail,
                                        createCluster
             )
+            // Sometimes adding member to a group can take longer than when it gets to the point when we create dataproc cluster.
+            // Hence add polling here to make sure the 2 service accounts are added to the image user group properly before proceeding
             _ <-
               if (createCluster)
                 waitUntilMemberAdded(dataprocServiceAccountEmail)


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-3926

* This is the error when the issue happens.
```
com.google.api.gax.rpc.PermissionDeniedException: io.grpc.StatusRuntimeException: PERMISSION_DENIED: Required 'compute.images.get' permission for 'projects/broad-dsp-gcr-public/global/images/aou-leo-image-dataproc-2-0-51-debian10-215b822'
	at com.google.api.gax.rpc.ApiExceptionFactory.createException(ApiExceptionFactory.java:98)
	at com.google.api.gax.rpc.ApiExceptionFactory.createException(ApiExceptionFactory.java:41)
```
From the 4 sample clusters I've looked at, the 2 that failed creation had the following log, indicating there was group addition happened during cluster creation, while the 2 successful creation didn't go through that becuz members were previously added already.
<img width="994" alt="Screen Shot 2022-12-21 at 5 51 41 PM" src="https://user-images.githubusercontent.com/32771737/209159136-d3796e27-ec4a-4d97-9dd5-0cb948b4d49a.png">


Think what happened for some automation tests and users in prod is adding member to the dataproc image user group is taking extra long lately…
This PR adds some polling in leo to make sure the adding member has finished before we proceed dataproc cluster creation


* Remove a spec that's already covered

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
