### PR TITLE
IA-3933 Add logging to see if wait is working as expected for real

### DIFF
--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -434,6 +434,11 @@ groups {
   #subEmail = "google@{{$appsSubdomain}}"
   #dataprocImageProjectGroupName = "dataproc-image-project-group"
   #dataprocImageProjectGroupEmail = ${groups.dataprocImageProjectGroupName}"@{{$appsSubdomain}}"
+  waitForMemberAddedPollConfig = {
+    initial-delay = 5 seconds
+    max-attempts = 120
+    interval = 5 seconds
+  }
 }
 
 gke {

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
@@ -130,7 +130,8 @@ object Config {
     GoogleGroupsConfig(
       config.as[WorkbenchEmail]("subEmail"),
       config.getString("dataprocImageProjectGroupName"),
-      config.as[WorkbenchEmail]("dataprocImageProjectGroupEmail")
+      config.as[WorkbenchEmail]("dataprocImageProjectGroupEmail"),
+      config.as[PollMonitorConfig]("waitForMemberAddedPollConfig")
     )
   }
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/GoogleGroupsConfig.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/GoogleGroupsConfig.scala
@@ -1,8 +1,10 @@
 package org.broadinstitute.dsde.workbench.leonardo
 package config
+import org.broadinstitute.dsde.workbench.leonardo.monitor.PollMonitorConfig
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
 
 case class GoogleGroupsConfig(googleAdminEmail: WorkbenchEmail,
                               dataprocImageProjectGroupName: String,
-                              dataprocImageProjectGroupEmail: WorkbenchEmail
+                              dataprocImageProjectGroupEmail: WorkbenchEmail,
+                              waitForMemberAddedPollConfig: PollMonitorConfig
 )

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/RuntimeAlgebra.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/RuntimeAlgebra.scala
@@ -1,7 +1,6 @@
 package org.broadinstitute.dsde.workbench.leonardo
 package util
 
-import java.time.Instant
 import cats.mtl.Ask
 import com.google.api.gax.longrunning.OperationFuture
 import com.google.cloud.compute.v1.Operation
@@ -13,6 +12,7 @@ import org.broadinstitute.dsde.workbench.leonardo.monitor.RuntimeConfigInCreateR
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
 import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GoogleProject}
 
+import java.time.Instant
 import scala.concurrent.duration.FiniteDuration
 
 /**

--- a/http/src/test/resources/reference.conf
+++ b/http/src/test/resources/reference.conf
@@ -17,6 +17,11 @@ groups {
   subEmail = "google@dev.test.firecloud.org"
   dataprocImageProjectGroupName = "dataproc-image-project-group"
   dataprocImageProjectGroupEmail = ${groups.dataprocImageProjectGroupName}"@test.firecloud.org"
+  waitForMemberAddedPollConfig = {
+    initial-delay = 0 seconds
+    max-attempts = 3
+    interval = 1 seconds
+  }
 }
 
 image {

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/mocks.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/mocks.scala
@@ -171,7 +171,7 @@ class FakeGoogleSubcriber[A] extends GoogleSubscriber[IO, A] {
   def stop: IO[Unit] = IO.unit
 }
 
-object MockRuntimeAlgebra extends RuntimeAlgebra[IO] {
+class BaseMockRuntimeAlgebra extends RuntimeAlgebra[IO] {
   override def createRuntime(params: CreateRuntimeParams)(implicit
     ev: Ask[IO, AppContext]
   ): IO[Option[CreateGoogleRuntimeResponse]] = ???
@@ -197,6 +197,8 @@ object MockRuntimeAlgebra extends RuntimeAlgebra[IO] {
 
   override def resizeCluster(params: ResizeClusterParams)(implicit ev: Ask[IO, AppContext]): IO[Unit] = ???
 }
+
+object MockRuntimeAlgebra extends BaseMockRuntimeAlgebra
 
 class MockKubernetesService(podStatus: PodStatus = PodStatus.Running, appRelease: List[Release] = List.empty)
     extends org.broadinstitute.dsde.workbench.google2.mock.MockKubernetesService {


### PR DESCRIPTION
1. Add addtional logging. Example log
```
{"@timestamp":"2023-01-05T22:26:03.531Z","@version":"1","logger_name":"org.broadinstitute.dsde.workbench.leonardo.LeonardoTestSuite","traceId":"72f91bd9-fecd-4fa7-a8db-4ff3cbeafbec","thread_name":"io-compute-13","severity":"INFO","serviceContext":null,"message":"Is member a member of dataproc-image-project-group@test.firecloud.org? false"}
{"@timestamp":"2023-01-05T22:26:04.537Z","@version":"1","logger_name":"org.broadinstitute.dsde.workbench.leonardo.LeonardoTestSuite","traceId":"72f91bd9-fecd-4fa7-a8db-4ff3cbeafbec","thread_name":"io-compute-12","severity":"INFO","serviceContext":null,"message":"Is member a member of dataproc-image-project-group@test.firecloud.org? false"}
```

2. Add a unit test to confirm timeout error happens properly

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
