### PR TITLE
IA-3933 add retry for createDataprocCluster

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/package.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/package.scala
@@ -36,10 +36,12 @@ package object leonardo {
     // Google permission update is getting slow. This is to address the issue when creating dataproc
     // we're getting the following error
     // com.google.api.gax.rpc.PermissionDeniedException: io.grpc.StatusRuntimeException: PERMISSION_DENIED: Required 'compute.images.get' permission for 'projects/broad-dsp-gcr-public/global/images/custom-leo-image-dataproc-2-0-51-debian10-a46b242'. This usually happens when Dataproc Control Plane Identity service account does not have permission to validate resources in another project. For additional details see https://cloud.google.com/dataproc/docs/concepts/iam/dataproc-principals#service_agent_control_plane_identity
-    val retryOnPermissionDenied: Throwable => Boolean = { case e: io.grpc.StatusRuntimeException =>
-      if (e.getCause.getMessage contains "compute.images.get")
-        true
-      else false
+    val retryOnPermissionDenied: Throwable => Boolean = {
+      case e: io.grpc.StatusRuntimeException =>
+        if (e.getCause.getMessage contains "compute.images.get")
+          true
+        else false
+      case _ => false
     }
 
     RetryPredicates.retryConfigWithPredicates(

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/package.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/package.scala
@@ -2,6 +2,7 @@ package org.broadinstitute.dsde.workbench
 
 import cats.effect.Sync
 import org.broadinstitute.dsde.workbench.google2.RegionName
+import org.broadinstitute.dsde.workbench.google2.util.RetryPredicates
 import org.http4s.{Entity, EntityEncoder}
 import org.typelevel.ci._
 
@@ -30,6 +31,23 @@ package object leonardo {
           s"Invalid name ${nameString}. Only lowercase alphanumeric characters, numbers and dashes are allowed in leo names"
         )
     }
+
+  val googleDataprocRetryPolicy = {
+    // Google permission update is getting slow. This is to address the issue when creating dataproc
+    // we're getting the following error
+    // com.google.api.gax.rpc.PermissionDeniedException: io.grpc.StatusRuntimeException: PERMISSION_DENIED: Required 'compute.images.get' permission for 'projects/broad-dsp-gcr-public/global/images/custom-leo-image-dataproc-2-0-51-debian10-a46b242'. This usually happens when Dataproc Control Plane Identity service account does not have permission to validate resources in another project. For additional details see https://cloud.google.com/dataproc/docs/concepts/iam/dataproc-principals#service_agent_control_plane_identity
+    val retryOnPermissionDenied: Throwable => Boolean = { case e: io.grpc.StatusRuntimeException =>
+      if (e.getCause.getMessage contains "compute.images.get")
+        true
+      else false
+    }
+
+    RetryPredicates.retryConfigWithPredicates(
+      RetryPredicates.standardGoogleRetryPredicate,
+      RetryPredicates.whenStatusCode(400),
+      retryOnPermissionDenied
+    )
+  }
 
   val allSupportedRegions = List(
     RegionName("us-central1"),

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/Boot.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/Boot.scala
@@ -426,11 +426,6 @@ object Boot extends IOApp {
         googleComputeRetryPolicy
       )
 
-      googleDataprocRetryPolicy = RetryPredicates.retryConfigWithPredicates(
-        RetryPredicates.standardGoogleRetryPredicate,
-        RetryPredicates.whenStatusCode(400)
-      )
-
       dataprocService <- GoogleDataprocService
         .resource(
           googleComputeService,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeV2ServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeV2ServiceInterp.scala
@@ -80,7 +80,6 @@ class RuntimeV2ServiceInterp[F[_]: Parallel](config: RuntimeServiceConfig,
       _ <- F
         .raiseUnless(hasPermission)(ForbiddenError(userInfo.userEmail))
 
-      leoAuth <- samDAO.getLeoAuthToken
       storageContainerOpt <- wsmDao.getWorkspaceStorageContainer(workspaceId, userToken)
       storageContainer <- F.fromOption(
         storageContainerOpt,


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-3933

The following error is still happening.
```
INFO  [.d.w.l.n.NotebookHailSpec:deleteRonRuntime] - Deleting cluster for cluster fixture tests: NotebookHailSpec
[info] org.broadinstitute.dsde.workbench.leonardo.notebooks.NotebookHailSpec *** ABORTED *** (1 minute, 30 seconds)
[info]   java.lang.RuntimeException: terra-quality-5c31f798/automation-test-ang8ehzoz errored due to List(RuntimeError(Failed to create cluster 30 due to io.grpc.StatusRuntimeException: PERMISSION_DENIED: Required 'compute.images.get' permission for 'projects/broad-dsp-gcr-public/global/images/custom-leo-image-dataproc-2-0-51-debian10-a46b242'. This usually happens when Dataproc Control Plane Identity service account does not have permission to validate resources in another project. For additional details see https://cloud.google.com/dataproc/docs/concepts/iam/dataproc-principals#service_agent_control_plane_identity,None,2023-01-09T06:36:59Z,Some(TraceId(d5fe7d7fa9664356ac9e44abd9886c0b/3939911508519804487))))
```

After adding some logging, we can confirm that the 2 SA's are added to the right group in time. But permission propagation is taking longer in GCP. Hence when we get to `createDataproc` call, we're still getting the permission denied error. 
```
INFO 2023-01-09T06:37:10.430510044Z [resource.labels.containerName: leonardo-backend-app] Adding 'service-334906986373@dataproc-accounts.iam.gserviceaccount.com' to group 'dataproc-image-project-group@quality.firecloud.org'...
INFO 2023-01-09T06:37:21.490064959Z [resource.labels.containerName: leonardo-backend-app] Is service-334906986373@dataproc-accounts.iam.gserviceaccount.com a member of dataproc-image-project-group@quality.firecloud.org? true
INFO 2023-01-09T06:37:21.663067658Z [resource.labels.containerName: leonardo-backend-app] Adding '334906986373@cloudservices.gserviceaccount.com' to group 'dataproc-image-project-group@quality.firecloud.org'...
INFO 2023-01-09T06:37:32.475242666Z [resource.labels.containerName: leonardo-backend-app] Is 334906986373@cloudservices.gserviceaccount.com a member of dataproc-image-project-group@quality.firecloud.org? true
```

This PR adds retry for this particular error

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
