### PR TITLE
[IA-4010] Delete All Apps associated with a workspaceId

### DIFF
--- a/http/src/main/resources/swagger/api-docs.yaml
+++ b/http/src/main/resources/swagger/api-docs.yaml
@@ -1732,7 +1732,7 @@ paths:
     post:
       summary: Deletes ALL apps associated with the given workspace Id
       description: deletes all Apps in a workspace
-      operationId: deleteAllAppV2
+      operationId: deleteAllAppsV2
       tags:
         - appsV2
       parameters:
@@ -1751,11 +1751,11 @@ paths:
             default: false
       responses:
         "202":
-          description: App deletion request accepted
+          description: App(s) deletion request accepted
         "403":
           description: User does not have permission to perform action on App(s)
         "404":
-          description: App not found
+          description: App(s) not found
           content:
             application/json:
               schema:

--- a/http/src/main/resources/swagger/api-docs.yaml
+++ b/http/src/main/resources/swagger/api-docs.yaml
@@ -1728,6 +1728,45 @@ paths:
                 items:
                   $ref: "#/components/schemas/ListAppResponse"
 
+  "/api/apps/v2/{workspaceId}/deleteAll":
+    post:
+      summary: Deletes ALL apps associated with the given workspace Id
+      description: deletes all Apps in a workspace
+      operationId: deleteAllAppV2
+      tags:
+        - appsV2
+      parameters:
+        - in: path
+          name: workspaceId
+          description: workspaceId
+          required: true
+          schema:
+            type: string
+        - in: query
+          name: deleteDisk
+          description: Whether or not the disk associated with the apps should be deleted. Default to false if not specified.
+          required: false
+          schema:
+            type: boolean
+            default: false
+      responses:
+        "202":
+          description: App deletion request accepted
+        "403":
+          description: User does not have permission to perform action on App(s)
+        "404":
+          description: App not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorReport"
+        "500":
+          description: Internal Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorReport"
+
   ## Deprecated Notebook API ##
 
   "/notebooks/{googleProject}/{clusterName}":

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/AppV2Routes.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/AppV2Routes.scala
@@ -150,7 +150,7 @@ class AppV2Routes(kubernetesService: AppService[IO], userInfoDirectives: UserInf
     for {
       ctx <- ev.ask[AppContext]
       deleteDisk = params.get("deleteDisk").exists(_ == "true")
-      apiCall = kubernetesService.deleteAllAppV2(
+      apiCall = kubernetesService.deleteAllAppsV2(
         userInfo,
         workspaceId,
         deleteDisk

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/AppV2Routes.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/AppV2Routes.scala
@@ -22,6 +22,7 @@ import org.http4s.Uri
 class AppV2Routes(kubernetesService: AppService[IO], userInfoDirectives: UserInfoDirectives)(implicit
   metrics: OpenTelemetryMetrics[IO]
 ) {
+
   val routes: server.Route = traceRequestForService(serviceData) { span =>
     extractAppContext(Some(span)) { implicit ctx =>
       userInfoDirectives.requireUserInfo { userInfo =>
@@ -56,6 +57,14 @@ class AppV2Routes(kubernetesService: AppService[IO], userInfoDirectives: UserInf
                       )
                     }
                   }
+              }
+            } ~ pathPrefix("deleteAll") {
+              post {
+                parameterMap { params =>
+                  complete(
+                    deleteAllAppsForWorkspaceHandler(userInfo, workspaceId, params)
+                  )
+                }
               }
             }
           }
@@ -130,6 +139,25 @@ class AppV2Routes(kubernetesService: AppService[IO], userInfoDirectives: UserInf
       tags = Map("deleteDisk" -> deleteDisk.toString)
       _ <- metrics.incrementCounter("deleteAppV2", 1, tags)
       _ <- ctx.span.fold(apiCall)(span => spanResource[IO](span, "deleteAppV2").use(_ => apiCall))
+    } yield StatusCodes.Accepted
+
+  private[api] def deleteAllAppsForWorkspaceHandler(userInfo: UserInfo,
+                                                    workspaceId: WorkspaceId,
+                                                    params: Map[String, String]
+  )(implicit
+    ev: Ask[IO, AppContext]
+  ): IO[ToResponseMarshallable] =
+    for {
+      ctx <- ev.ask[AppContext]
+      deleteDisk = params.get("deleteDisk").exists(_ == "true")
+      apiCall = kubernetesService.deleteAllAppV2(
+        userInfo,
+        workspaceId,
+        deleteDisk
+      )
+      tags = Map("deleteDisk" -> deleteDisk.toString)
+      _ <- metrics.incrementCounter("deleteAllAppV2", 1, tags)
+      _ <- ctx.span.fold(apiCall)(span => spanResource[IO](span, "deleteAllAppV2").use(_ => apiCall))
     } yield StatusCodes.Accepted
 
 }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/AppService.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/AppService.scala
@@ -66,7 +66,7 @@ trait AppService[F[_]] {
     deleteDisk: Boolean
   )(implicit as: Ask[F, AppContext]): F[Unit]
 
-  def deleteAllAppV2(userInfo: UserInfo, workspaceId: WorkspaceId, deleteDisk: Boolean)(implicit
+  def deleteAllAppsV2(userInfo: UserInfo, workspaceId: WorkspaceId, deleteDisk: Boolean)(implicit
     as: Ask[F, AppContext]
   ): F[Unit]
 }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/AppService.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/AppService.scala
@@ -7,6 +7,7 @@ import org.broadinstitute.dsde.workbench.leonardo.{AppContext, AppName, CloudCon
 import org.broadinstitute.dsde.workbench.model.UserInfo
 
 trait AppService[F[_]] {
+
   def createApp(
     userInfo: UserInfo,
     cloudContext: CloudContext.Gcp,
@@ -64,6 +65,10 @@ trait AppService[F[_]] {
     appName: AppName,
     deleteDisk: Boolean
   )(implicit as: Ask[F, AppContext]): F[Unit]
+
+  def deleteAllAppV2(userInfo: UserInfo, workspaceId: WorkspaceId, deleteDisk: Boolean)(implicit
+    as: Ask[F, AppContext]
+  ): F[Unit]
 }
 
 final case class AppServiceConfig(enableCustomAppCheck: Boolean, leoKubernetesConfig: LeoKubernetesConfig)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/AppServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/AppServiceInterp.scala
@@ -645,9 +645,11 @@ final class LeoAppServiceInterp[F[_]: Parallel](config: AppServiceConfig,
       .flatMap(_.nodepools)
       .flatMap(n => n.apps)
 
-    _ <- apps.traverse { app =>
-      deleteAppV2Base(app, userInfo, workspaceId, deleteDisk)
-    }
+    _ <- apps
+      .filter(app => AppStatus.deletableStatuses.contains(app.status))
+      .traverse { app =>
+        deleteAppV2Base(app, userInfo, workspaceId, deleteDisk)
+      }
   } yield ()
 
   private def deleteAppV2Base(app: App, userInfo: UserInfo, workspaceId: WorkspaceId, deleteDisk: Boolean)(implicit

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/AppServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/AppServiceInterp.scala
@@ -637,7 +637,7 @@ final class LeoAppServiceInterp[F[_]: Parallel](config: AppServiceConfig,
     _ <- deleteAppV2Base(appResult.app, userInfo, workspaceId, deleteDisk)
   } yield ()
 
-  override def deleteAllAppV2(userInfo: UserInfo, workspaceId: WorkspaceId, deleteDisk: Boolean)(implicit
+  override def deleteAllAppsV2(userInfo: UserInfo, workspaceId: WorkspaceId, deleteDisk: Boolean)(implicit
     as: Ask[F, AppContext]
   ): F[Unit] = for {
     allClusters <- KubernetesServiceDbQueries.listFullAppsByWorkspaceId(Some(workspaceId), Map.empty).transaction

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/AppServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/AppServiceInterp.scala
@@ -634,7 +634,27 @@ final class LeoAppServiceInterp[F[_]: Parallel](config: AppServiceConfig,
       appOpt,
       AppNotFoundByWorkspaceIdException(workspaceId, appName, ctx.traceId, "No active app found in DB")
     )
-    listOfPermissions <- authProvider.getActions(appResult.app.samResourceId, userInfo)
+    _ <- deleteAppV2Base(appResult.app, userInfo, workspaceId, deleteDisk)
+  } yield ()
+
+  override def deleteAllAppV2(userInfo: UserInfo, workspaceId: WorkspaceId, deleteDisk: Boolean)(implicit
+    as: Ask[F, AppContext]
+  ): F[Unit] = for {
+    allClusters <- KubernetesServiceDbQueries.listFullAppsByWorkspaceId(Some(workspaceId), Map.empty).transaction
+    apps = allClusters
+      .flatMap(_.nodepools)
+      .flatMap(n => n.apps)
+
+    _ <- apps.traverse { app =>
+      deleteAppV2Base(app, userInfo, workspaceId, deleteDisk)
+    }
+  } yield ()
+
+  private def deleteAppV2Base(app: App, userInfo: UserInfo, workspaceId: WorkspaceId, deleteDisk: Boolean)(implicit
+    as: Ask[F, AppContext]
+  ): F[Unit] = for {
+    ctx <- as.ask
+    listOfPermissions <- authProvider.getActions(app.samResourceId, userInfo)
 
     // throw 404 if no GetAppStatus permission
     hasReadPermission = listOfPermissions.toSet.contains(AppAction.GetAppStatus)
@@ -642,23 +662,23 @@ final class LeoAppServiceInterp[F[_]: Parallel](config: AppServiceConfig,
       if (hasReadPermission) F.unit
       else
         F.raiseError[Unit](
-          AppNotFoundByWorkspaceIdException(workspaceId, appName, ctx.traceId, "no read permission")
+          AppNotFoundByWorkspaceIdException(workspaceId, app.appName, ctx.traceId, "no read permission")
         )
 
     // throw 403 if no DeleteApp permission
     hasDeletePermission = listOfPermissions.toSet.contains(AppAction.DeleteApp)
     _ <- if (hasDeletePermission) F.unit else F.raiseError[Unit](ForbiddenError(userInfo.userEmail))
 
-    canDelete = AppStatus.deletableStatuses.contains(appResult.app.status)
+    canDelete = AppStatus.deletableStatuses.contains(app.status)
     _ <-
       if (canDelete) F.unit
       else
         F.raiseError[Unit](
-          AppCannotBeDeletedByWorkspaceIdException(workspaceId, appName, appResult.app.status, ctx.traceId)
+          AppCannotBeDeletedByWorkspaceIdException(workspaceId, app.appName, app.status, ctx.traceId)
         )
 
     // Get the disk to delete if specified
-    diskOpt = if (deleteDisk) appResult.app.appResources.disk.map(_.id) else None
+    diskOpt = if (deleteDisk) app.appResources.disk.map(_.id) else None
 
     // Resolve the workspace in WSM to get the cloud context
     userToken = org.http4s.headers.Authorization(
@@ -683,18 +703,18 @@ final class LeoAppServiceInterp[F[_]: Parallel](config: AppServiceConfig,
     }
 
     _ <-
-      if (appResult.app.status == AppStatus.Error) {
+      if (app.status == AppStatus.Error) {
         for {
-          _ <- appQuery.markAsDeleted(appResult.app.id, ctx.now).transaction >> authProvider
-            .notifyResourceDeletedV2(appResult.app.samResourceId, userInfo)
+          _ <- appQuery.markAsDeleted(app.id, ctx.now).transaction >> authProvider
+            .notifyResourceDeletedV2(app.samResourceId, userInfo)
             .void
         } yield ()
       } else {
         for {
-          _ <- KubernetesServiceDbQueries.markPreDeleting(appResult.app.id).transaction
+          _ <- KubernetesServiceDbQueries.markPreDeleting(app.id).transaction
           deleteMessage = DeleteAppV2Message(
-            appResult.app.id,
-            appResult.app.appName,
+            app.id,
+            app.appName,
             workspaceId,
             cloudContext,
             diskOpt,
@@ -1231,13 +1251,6 @@ case class AppDiskNotSupportedException(cloudContext: CloudContext,
       s"App ${cloudContext.asStringWithProvider}/${appName.value} of type ${appType} does not support persistent disk. Trace ID: ${traceId.toString}",
       StatusCodes.BadRequest,
       traceId = Some(traceId)
-    )
-
-case class ClusterExistsException(googleProject: GoogleProject)
-    extends LeoException(
-      s"Cannot pre-create nodepools for project $googleProject because a cluster already exists",
-      StatusCodes.Conflict,
-      traceId = None
     )
 
 case class AppCannotBeStoppedException(cloudContext: CloudContext,

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/AppServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/AppServiceInterpSpec.scala
@@ -1907,6 +1907,75 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
     res.swap.toOption.get.getMessage shouldBe s"Persistent disk Gcp/${workspaceId}/disk is already formatted by CROMWELL"
   }
 
+  it should "V2 Azure - deleteAllApp, update all status appropriately, and queue multiple messages" in isolatedDbTest {
+    val publisherQueue = QueueFactory.makePublisherQueue()
+    val kubeServiceInterp = makeInterp(publisherQueue)
+    val appName = AppName("app1")
+    val appReq =
+      createAppRequest.copy(kubernetesRuntimeConfig = None, appType = AppType.Cromwell, diskConfig = None)
+    val appName2 = AppName("app2")
+    val appReq2 =
+      createAppRequest.copy(kubernetesRuntimeConfig = None, appType = AppType.Cromwell, diskConfig = None)
+
+    kubeServiceInterp
+      .createAppV2(userInfo, workspaceId, appName, appReq)
+      .unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
+
+    kubeServiceInterp
+      .createAppV2(userInfo, workspaceId, appName2, appReq2)
+      .unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
+
+    val appResultPreStatusUpdate = dbFutureValue {
+      KubernetesServiceDbQueries.getActiveFullAppByWorkspaceIdAndAppName(workspaceId, appName)
+    }
+    val appResultPreStatusUpdate2 = dbFutureValue {
+      KubernetesServiceDbQueries.getActiveFullAppByWorkspaceIdAndAppName(workspaceId, appName2)
+    }
+
+    // we can't delete while its creating, so set it to Running
+    dbFutureValue(appQuery.updateStatus(appResultPreStatusUpdate.get.app.id, AppStatus.Running))
+    dbFutureValue(nodepoolQuery.updateStatus(appResultPreStatusUpdate.get.nodepool.id, NodepoolStatus.Running))
+
+    dbFutureValue(appQuery.updateStatus(appResultPreStatusUpdate2.get.app.id, AppStatus.Running))
+    dbFutureValue(nodepoolQuery.updateStatus(appResultPreStatusUpdate2.get.nodepool.id, NodepoolStatus.Running))
+
+    val appResultPreDelete = dbFutureValue {
+      KubernetesServiceDbQueries.getActiveFullAppByWorkspaceIdAndAppName(workspaceId, appName)
+    }
+    appResultPreDelete.get.app.status shouldEqual AppStatus.Running
+    appResultPreDelete.get.app.auditInfo.destroyedDate shouldBe None
+
+    val appResultPreDelete2 = dbFutureValue {
+      KubernetesServiceDbQueries.getActiveFullAppByWorkspaceIdAndAppName(workspaceId, appName2)
+    }
+    appResultPreDelete2.get.app.status shouldEqual AppStatus.Running
+    appResultPreDelete2.get.app.auditInfo.destroyedDate shouldBe None
+
+    kubeServiceInterp
+      .deleteAllAppV2(userInfo, workspaceId, false)
+      .unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
+    val clusterPostDelete = dbFutureValue {
+      KubernetesServiceDbQueries.listFullAppsByWorkspaceId(Some(workspaceId), includeDeleted = true)
+    }
+
+    clusterPostDelete.length shouldEqual 1
+    val nodepools = clusterPostDelete.flatMap(_.nodepools)
+    val apps = clusterPostDelete.flatMap(_.nodepools).flatMap(_.apps)
+    nodepools.map(_.status) shouldEqual List(NodepoolStatus.Running)
+    apps.map(_.status) shouldEqual List(AppStatus.Predeleting, AppStatus.Predeleting)
+
+    // throw away create messages
+    publisherQueue.take.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
+    publisherQueue.take.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
+
+    val messages = publisherQueue.tryTakeN(Some(2)).unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
+    messages.map(_.messageType) shouldBe List(LeoPubsubMessageType.DeleteAppV2, LeoPubsubMessageType.DeleteAppV2)
+    val deleteAppMessages = messages.map(_.asInstanceOf[DeleteAppV2Message])
+    deleteAppMessages.map(_.appId) shouldBe apps.map(_.id)
+    deleteAppMessages.map(_.workspaceId) shouldBe List(workspaceId, workspaceId)
+    deleteAppMessages.map(_.diskId) shouldBe List(None, None)
+  }
+
   private def withLeoPublisher(
     publisherQueue: Queue[IO, LeoPubsubMessage]
   )(validations: IO[Assertion]): IO[Assertion] = {

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/AppServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/AppServiceInterpSpec.scala
@@ -1952,7 +1952,86 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
     appResultPreDelete2.get.app.auditInfo.destroyedDate shouldBe None
 
     kubeServiceInterp
-      .deleteAllAppV2(userInfo, workspaceId, false)
+      .deleteAllAppsV2(userInfo, workspaceId, false)
+      .unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
+    val clusterPostDelete = dbFutureValue {
+      KubernetesServiceDbQueries.listFullAppsByWorkspaceId(Some(workspaceId), includeDeleted = true)
+    }
+
+    clusterPostDelete.length shouldEqual 1
+    val nodepools = clusterPostDelete.flatMap(_.nodepools)
+    val apps = clusterPostDelete.flatMap(_.nodepools).flatMap(_.apps)
+    nodepools.map(_.status) shouldEqual List(NodepoolStatus.Running)
+    apps.map(_.status) shouldEqual List(AppStatus.Predeleting, AppStatus.Predeleting)
+
+    // throw away create messages
+    publisherQueue.take.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
+    publisherQueue.take.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
+
+    val messages = publisherQueue.tryTakeN(Some(2)).unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
+    messages.map(_.messageType) shouldBe List(LeoPubsubMessageType.DeleteAppV2, LeoPubsubMessageType.DeleteAppV2)
+    val deleteAppMessages = messages.map(_.asInstanceOf[DeleteAppV2Message])
+    deleteAppMessages.map(_.appId) shouldBe apps.map(_.id)
+    deleteAppMessages.map(_.workspaceId) shouldBe List(workspaceId, workspaceId)
+    deleteAppMessages.map(_.diskId) shouldBe List(None, None)
+  }
+
+  it should "V2 GCP - deleteAllApp, update all status appropriately, and queue multiple messages" in isolatedDbTest {
+    val publisherQueue = QueueFactory.makePublisherQueue()
+    val kubeServiceInterp = makeGcpWorkspaceInterp(publisherQueue)
+
+    val appName = AppName("app1")
+    val appName2 = AppName("app2")
+    val diskConfig1 = PersistentDiskRequest(DiskName("disk1"), None, None, Map.empty)
+    val diskConfig2 = PersistentDiskRequest(DiskName("disk2"), None, None, Map.empty)
+
+    val appReq =
+      createAppRequest.copy(kubernetesRuntimeConfig = None, appType = AppType.Galaxy, diskConfig = Some(diskConfig1))
+    val appReq2 =
+      createAppRequest.copy(kubernetesRuntimeConfig = None, appType = AppType.Galaxy, diskConfig = Some(diskConfig2))
+
+    kubeServiceInterp
+      .createAppV2(userInfo, workspaceId, appName, appReq)
+      .unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
+
+    val appResultPreStatusUpdate = dbFutureValue {
+      KubernetesServiceDbQueries.getActiveFullAppByWorkspaceIdAndAppName(workspaceId, appName)
+    }
+    // we can't delete/create another while its creating, so set it to Running
+    dbFutureValue(appQuery.updateStatus(appResultPreStatusUpdate.get.app.id, AppStatus.Running))
+    dbFutureValue(nodepoolQuery.updateStatus(appResultPreStatusUpdate.get.nodepool.id, NodepoolStatus.Running))
+    dbFutureValue(
+      kubernetesClusterQuery.updateStatus(appResultPreStatusUpdate.get.cluster.id, KubernetesClusterStatus.Running)
+    )
+
+    kubeServiceInterp
+      .createAppV2(userInfo, workspaceId, appName2, appReq2)
+      .unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
+
+    val appResultPreStatusUpdate2 = dbFutureValue {
+      KubernetesServiceDbQueries.getActiveFullAppByWorkspaceIdAndAppName(workspaceId, appName2)
+    }
+
+    dbFutureValue(appQuery.updateStatus(appResultPreStatusUpdate2.get.app.id, AppStatus.Running))
+    dbFutureValue(nodepoolQuery.updateStatus(appResultPreStatusUpdate2.get.nodepool.id, NodepoolStatus.Running))
+    dbFutureValue(
+      kubernetesClusterQuery.updateStatus(appResultPreStatusUpdate2.get.cluster.id, KubernetesClusterStatus.Running)
+    )
+
+    val appResultPreDelete = dbFutureValue {
+      KubernetesServiceDbQueries.getActiveFullAppByWorkspaceIdAndAppName(workspaceId, appName)
+    }
+    appResultPreDelete.get.app.status shouldEqual AppStatus.Running
+    appResultPreDelete.get.app.auditInfo.destroyedDate shouldBe None
+
+    val appResultPreDelete2 = dbFutureValue {
+      KubernetesServiceDbQueries.getActiveFullAppByWorkspaceIdAndAppName(workspaceId, appName2)
+    }
+    appResultPreDelete2.get.app.status shouldEqual AppStatus.Running
+    appResultPreDelete2.get.app.auditInfo.destroyedDate shouldBe None
+
+    kubeServiceInterp
+      .deleteAllAppsV2(userInfo, workspaceId, false)
       .unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
     val clusterPostDelete = dbFutureValue {
       KubernetesServiceDbQueries.listFullAppsByWorkspaceId(Some(workspaceId), includeDeleted = true)

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/MockAppService.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/MockAppService.scala
@@ -58,7 +58,7 @@ class MockAppService extends AppService[IO] {
   ): IO[Unit] =
     IO.unit
 
-  override def deleteAllAppV2(userInfo: UserInfo, workspaceId: WorkspaceId, deleteDisk: Boolean)(implicit
+  override def deleteAllAppsV2(userInfo: UserInfo, workspaceId: WorkspaceId, deleteDisk: Boolean)(implicit
     as: Ask[IO, AppContext]
   ): IO[Unit] =
     IO.unit

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/MockAppService.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/MockAppService.scala
@@ -58,6 +58,11 @@ class MockAppService extends AppService[IO] {
   ): IO[Unit] =
     IO.unit
 
+  override def deleteAllAppV2(userInfo: UserInfo, workspaceId: WorkspaceId, deleteDisk: Boolean)(implicit
+    as: Ask[IO, AppContext]
+  ): IO[Unit] =
+    IO.unit
+
 }
 
 object MockAppService extends MockAppService


### PR DESCRIPTION
This is tested in live Leo. It works in the base case present in the public preview, where a the workspace owner has an app created by default and no additional users in the workspace will have an app.

However, it **does not** work for workspaces with apps not owned by the workspace owner, due to a sam permission model issue. More details can be found [here](https://broadinstitute.slack.com/archives/C02GJ782BAA/p16751965562040890) with the ticket for this fix found [here](https://broadworkbench.atlassian.net/browse/IA-4012) 