### PR TITLE
[SUP-802] Added logic to prevent a disk from being deleted when it's in a valid state

### DIFF
--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/BaseCloudServiceRuntimeMonitor.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/BaseCloudServiceRuntimeMonitor.scala
@@ -167,7 +167,7 @@ abstract class BaseCloudServiceRuntimeMonitor[F[_]] {
                 persistentDiskOpt <- rc.persistentDiskId.flatTraverse(did =>
                   persistentDiskQuery.getPersistentDiskRecord(did).transaction
                 )
-                _ = persistentDiskOpt match {
+                _ <- persistentDiskOpt match {
                   case Some(value) =>
                     if (value.status == DiskStatus.Creating || value.status == DiskStatus.Failed) {
                       persistentDiskOpt.traverse_(d =>
@@ -175,7 +175,7 @@ abstract class BaseCloudServiceRuntimeMonitor[F[_]] {
                           .updateStatus(d.id, DiskStatus.Deleted, ctx.now)
                           .transaction
                       )
-                    }
+                    } else F.unit
                   case None => F.unit
                 }
               } yield ()

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
@@ -1364,7 +1364,7 @@ class LeoPubsubMessageSubscriber[F[_]](
                       persistentDiskOpt <- rc.persistentDiskId.flatTraverse(did =>
                         persistentDiskQuery.getPersistentDiskRecord(did).transaction
                       )
-                      _ = persistentDiskOpt match {
+                      _ <- persistentDiskOpt match {
                         case Some(value) =>
                           if (value.status == DiskStatus.Creating || value.status == DiskStatus.Failed) {
                             persistentDiskOpt.traverse_(d =>
@@ -1372,7 +1372,7 @@ class LeoPubsubMessageSubscriber[F[_]](
                                 .updateStatus(d.id, DiskStatus.Deleted, now)
                                 .transaction
                             )
-                          }
+                          } else F.unit
                         case None => F.unit
                       }
                     } yield ()

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/BaseCloudServiceRuntimeMonitorSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/BaseCloudServiceRuntimeMonitorSpec.scala
@@ -261,6 +261,47 @@ class BaseCloudServiceRuntimeMonitorSpec extends AnyFlatSpec with Matchers with 
     res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
+  it should "delete creating disk on failed runtime start" in isolatedDbTest {
+    val runtimeMonitor = baseRuntimeMonitor(false)
+
+    val res = for {
+      start <- IO.realTimeInstant
+      tid <- traceId.ask[TraceId]
+      implicit0(ec: ExecutionContext) = scala.concurrent.ExecutionContext.Implicits.global
+      disk <- makePersistentDisk().save()
+      runtime <- IO(
+        makeCluster(0)
+          .copy(status = RuntimeStatus.Creating)
+          .saveWithRuntimeConfig(CommonTestData.defaultGceRuntimeWithPDConfig(Some(disk.id)))
+      )
+      runtimeConfig <- RuntimeConfigQueries.getRuntimeConfig(runtime.runtimeConfigId).transaction
+
+      runtimeAndRuntimeConfig = RuntimeAndRuntimeConfig(runtime, runtimeConfig)
+      monitorContext = MonitorContext(start, runtime.id, tid, RuntimeStatus.Creating)
+      _ <- persistentDiskQuery.updateStatus(disk.id, DiskStatus.Failed, Instant.now()).transaction
+      runCheckTools = Stream.eval(
+        runtimeMonitor.handleCheckTools(monitorContext, runtimeAndRuntimeConfig, IP("1.2.3.4"), None, true, None)
+      )
+      deleteRuntime = Stream.sleep[IO](2 seconds) ++ Stream.eval(
+        clusterQuery.completeDeletion(runtime.id, start).transaction
+      )
+      // run above tasks concurrently and wait for both to terminate
+      _ <- Stream(runCheckTools, deleteRuntime).parJoin(2).compile.drain.timeout(15 seconds)
+
+      end <- IO.realTimeInstant
+      elapsed = end.toEpochMilli - start.toEpochMilli
+      status <- clusterQuery.getClusterStatus(runtime.id).transaction
+      diskStatus <- persistentDiskQuery.getStatus(disk.id).transaction
+    } yield {
+      // handleCheckTools should have timed out after 10 seconds and the runtime should remain in Deleted status
+      elapsed should be >= 10000L
+      status shouldBe Some(RuntimeStatus.Deleted)
+      diskStatus shouldBe (Some(DiskStatus.Deleted))
+    }
+
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
+  }
+
   class MockRuntimeMonitor(isWelderReady: Boolean,
                            timeouts: Map[RuntimeStatus, FiniteDuration],
                            googleStorageService: GoogleStorageService[IO] = FakeGoogleStorageService

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/BaseCloudServiceRuntimeMonitorSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/BaseCloudServiceRuntimeMonitorSpec.scala
@@ -269,6 +269,7 @@ class BaseCloudServiceRuntimeMonitorSpec extends AnyFlatSpec with Matchers with 
       tid <- traceId.ask[TraceId]
       implicit0(ec: ExecutionContext) = scala.concurrent.ExecutionContext.Implicits.global
       disk <- makePersistentDisk().save()
+      _ <- persistentDiskQuery.updateStatus(disk.id, DiskStatus.Failed, Instant.now()).transaction
       runtime <- IO(
         makeCluster(0)
           .copy(status = RuntimeStatus.Creating)
@@ -278,7 +279,6 @@ class BaseCloudServiceRuntimeMonitorSpec extends AnyFlatSpec with Matchers with 
 
       runtimeAndRuntimeConfig = RuntimeAndRuntimeConfig(runtime, runtimeConfig)
       monitorContext = MonitorContext(start, runtime.id, tid, RuntimeStatus.Creating)
-      _ <- persistentDiskQuery.updateStatus(disk.id, DiskStatus.Failed, Instant.now()).transaction
       runCheckTools = Stream.eval(
         runtimeMonitor.handleCheckTools(monitorContext, runtimeAndRuntimeConfig, IP("1.2.3.4"), None, true, None)
       )

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/BaseCloudServiceRuntimeMonitorSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/BaseCloudServiceRuntimeMonitorSpec.scala
@@ -255,7 +255,7 @@ class BaseCloudServiceRuntimeMonitorSpec extends AnyFlatSpec with Matchers with 
       // handleCheckTools should have timed out after 10 seconds and the runtime should remain in Deleted status
       elapsed should be >= 10000L
       status shouldBe Some(RuntimeStatus.Deleted)
-      diskStatus shouldBe (Some(DiskStatus.Deleted))
+      diskStatus shouldBe (Some(DiskStatus.Ready))
     }
 
     res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriberSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriberSpec.scala
@@ -214,7 +214,7 @@ class LeoPubsubMessageSubscriberSpec
         } yield {
           error.nonEmpty shouldBe true
           runtimeConfig.asInstanceOf[RuntimeConfig.GceWithPdConfig].persistentDiskId shouldBe None
-          diskStatus shouldBe Some(DiskStatus.Deleted)
+          diskStatus shouldBe Some(DiskStatus.Ready)
         }
 
         _ <- withInfiniteStream(

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriberSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriberSpec.scala
@@ -225,6 +225,50 @@ class LeoPubsubMessageSubscriberSpec
     res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
+  "createRuntimeErrorHandler" should "delete creating disk on failed runtime start" in isolatedDbTest {
+    val runtimeMonitor = new MockRuntimeMonitor {
+      override def process(
+        a: CloudService
+      )(runtimeId: Long, action: RuntimeStatus, checkToolsInterruptAfter: Option[FiniteDuration])(implicit
+        ev: Ask[IO, TraceId]
+      ): Stream[IO, Unit] = Stream.raiseError[IO](new Exception("failed"))
+    }
+    val queue = Queue.bounded[IO, Task[IO]](10).unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
+    val leoSubscriber = makeLeoSubscriber(runtimeMonitor = runtimeMonitor, asyncTaskQueue = queue)
+    val res =
+      for {
+        disk <- makePersistentDisk().save()
+        _ <- persistentDiskQuery.updateStatus(disk.id, DiskStatus.Failed, Instant.now()).transaction
+        runtime <- IO(
+          makeCluster(1)
+            .copy(serviceAccount = serviceAccount, asyncRuntimeFields = None, status = RuntimeStatus.Creating)
+            .saveWithRuntimeConfig(CommonTestData.defaultGceRuntimeWithPDConfig(Some(disk.id)))
+        )
+        runtimeConfig <- RuntimeConfigQueries.getRuntimeConfig(runtime.runtimeConfigId).transaction
+        tr <- traceId.ask[TraceId]
+        gceRuntimeConfigRequest = LeoLenses.runtimeConfigPrism.getOption(gceRuntimeConfig).get
+        asyncTaskProcessor = AsyncTaskProcessor(AsyncTaskProcessor.Config(10, 10), queue)
+        _ <- leoSubscriber.messageResponder(
+          CreateRuntimeMessage.fromRuntime(runtime, gceRuntimeConfigRequest, Some(tr), None)
+        )
+        assertions = for {
+          error <- clusterErrorQuery.get(runtime.id).transaction
+          runtimeConfig <- RuntimeConfigQueries.getRuntimeConfig(runtime.runtimeConfigId).transaction
+          diskStatus <- persistentDiskQuery.getStatus(disk.id).transaction
+        } yield {
+          error.nonEmpty shouldBe true
+          runtimeConfig.asInstanceOf[RuntimeConfig.GceWithPdConfig].persistentDiskId shouldBe None
+          diskStatus shouldBe Some(DiskStatus.Deleted)
+        }
+
+        _ <- withInfiniteStream(
+          asyncTaskProcessor.process,
+          assertions
+        )
+      } yield ()
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
+  }
+
   it should "handle dataproc runtime creation failure properly" in isolatedDbTest {
     val queue = Queue.bounded[IO, Task[IO]](10).unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
     val dataprocAlg = new BaseMockRuntimeAlgebra {


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/SUP-802

This ticket fixes a bug where a runtime errors out and deletes the user's PD without request.

To recreate - make a jupyter runtime, delete the runtime, create a new runtime with a failing user script, and then the PD is set to deleted, however it still exists on the Google side.

For reviewers - is this added logic the outcome we want? Or do we want to just leave the PD alone? "Acceptance critera" isn't defined, so I made some assumptions about the outcome.

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
