### PR TITLE
[IA-4066] Run CI checks for merge group

### DIFF
--- a/.github/workflows/consumer_contract_tests.yml
+++ b/.github/workflows/consumer_contract_tests.yml
@@ -35,6 +35,11 @@ on:
       - develop
     paths-ignore:
       - 'README.md'
+  merge_group:
+    branches:
+      - develop
+    paths-ignore:
+      - 'README.md'
 
 jobs:
   leo-consumer-contract-tests:

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -6,6 +6,8 @@ on:
     branches: [ develop ]
   pull_request:
     branches: [ develop ]
+  merge_group:
+    branches: [ develop ]
 
 jobs:
   build:


### PR DESCRIPTION
Merge groups timed out because the CI checks were not triggered for that new action, this should fix it 🤞 
https://broadworkbench.atlassian.net/browse/IA-4066

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
