### PR TITLE
[IA-4067] Bump GKM to 2.4.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ ENV HELM_DEBUG 1
 ENV TERRA_APP_SETUP_VERSION 0.0.7
 ENV TERRA_APP_VERSION 0.5.0
 # This is galaxykubeman, which references Galaxy
-ENV GALAXY_VERSION 2.4.7
+ENV GALAXY_VERSION 2.4.8
 ENV NGINX_VERSION 4.3.0
 # If you update this here, make sure to also update reference.conf:
 ENV CROMWELL_CHART_VERSION 0.2.201

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -504,7 +504,7 @@ gke {
     chartName = "/leonardo/galaxykubeman"
     # If you change this here, be sure to update it in the dockerfile
     # This is galaxykubeman, which references Galaxy
-    chartVersion = "2.4.7"
+    chartVersion = "2.4.8"
     namespaceNameSuffix = "gxy-ns"
     serviceAccountName = "gxy-ksa"
     # Setting uninstallKeepHistory will cause the `helm uninstall` command to keep a record of

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/KubernetesTestData.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/KubernetesTestData.scala
@@ -40,7 +40,7 @@ object KubernetesTestData {
   val galaxyApp = AppType.Galaxy
 
   val galaxyChartName = ChartName("/leonardo/galaxykubeman")
-  val galaxyChartVersion = ChartVersion("2.4.7")
+  val galaxyChartVersion = ChartVersion("2.4.8")
   val galaxyChart = Chart(galaxyChartName, galaxyChartVersion)
 
   val galaxyReleasePrefix = "gxy-release"


### PR DESCRIPTION
Add back wrongfully removed job destinations. 
---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
