### PR TITLE
[IA-3769] add `configType` to runtimeConfig encoding

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/JsonCodec.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/JsonCodec.scala
@@ -89,6 +89,7 @@ object JsonCodec {
   implicit val diskLinkEncoder: Encoder[DiskLink] = Encoder.encodeString.contramap(_.asString)
   implicit val formattedByEncoder: Encoder[FormattedBy] = Encoder.encodeString.contramap(_.asString)
   implicit val toolEncoder: Encoder[Tool] = Encoder.encodeString.contramap(_.asString)
+  implicit val runtimeConfigTypeEncoder: Encoder[RuntimeConfigType] = Encoder.encodeString.contramap(_.asString)
 
   implicit val cloudContextEncoder: Encoder[CloudContext] = Encoder.forProduct2(
     "cloudProvider",
@@ -105,7 +106,7 @@ object JsonCodec {
     "numOfCpus"
   )(x => AppMachineType.unapply(x).get)
 
-  implicit val dataprocConfigEncoder: Encoder[RuntimeConfig.DataprocConfig] = Encoder.forProduct11(
+  implicit val dataprocConfigEncoder: Encoder[RuntimeConfig.DataprocConfig] = Encoder.forProduct12(
     "numberOfWorkers",
     "masterMachineType",
     "masterDiskSize",
@@ -117,7 +118,8 @@ object JsonCodec {
     "cloudService",
     "region",
     "componentGatewayEnabled",
-    "workerPrivateAccess"
+    "workerPrivateAccess",
+    "configType"
   )(x =>
     (x.numberOfWorkers,
      x.machineType,
@@ -129,25 +131,28 @@ object JsonCodec {
      x.cloudService,
      x.region,
      x.componentGatewayEnabled,
-     x.workerPrivateAccess
+     x.workerPrivateAccess,
+     x.configType
     )
   )
-  implicit val gceRuntimeConfigEncoder: Encoder[RuntimeConfig.GceConfig] = Encoder.forProduct6(
+  implicit val gceRuntimeConfigEncoder: Encoder[RuntimeConfig.GceConfig] = Encoder.forProduct7(
     "machineType",
     "diskSize",
     "cloudService",
     "bootDiskSize",
     "zone",
-    "gpuConfig"
-  )(x => (x.machineType, x.diskSize, x.cloudService, x.bootDiskSize, x.zone, x.gpuConfig))
+    "gpuConfig",
+    "configType"
+  )(x => (x.machineType, x.diskSize, x.cloudService, x.bootDiskSize, x.zone, x.gpuConfig, x.configType))
 
   implicit val azureRegionEncoder: Encoder[Region] = Encoder.encodeString.contramap(_.toString)
-  implicit val azureRuntimeConfigEncoder: Encoder[RuntimeConfig.AzureConfig] = Encoder.forProduct4(
+  implicit val azureRuntimeConfigEncoder: Encoder[RuntimeConfig.AzureConfig] = Encoder.forProduct5(
     "cloudService",
     "machineType",
     "persistentDiskId",
-    "region"
-  )(x => (x.cloudService, x.machineType, x.persistentDiskId, x.region))
+    "region",
+    "configType"
+  )(x => (x.cloudService, x.machineType, x.persistentDiskId, x.region, x.configType))
 
   implicit val azureMachineTypeDecoder: Decoder[VirtualMachineSizeTypes] = Decoder.decodeString.emap { s =>
     val machineSizeOpt: Option[VirtualMachineSizeTypes] =
@@ -191,14 +196,15 @@ object JsonCodec {
     "homeDirectory",
     "timestamp"
   )(x => RuntimeImage.unapply(x).get)
-  implicit val gceWithPdConfigEncoder: Encoder[RuntimeConfig.GceWithPdConfig] = Encoder.forProduct6(
+  implicit val gceWithPdConfigEncoder: Encoder[RuntimeConfig.GceWithPdConfig] = Encoder.forProduct7(
     "machineType",
     "persistentDiskId",
     "cloudService",
     "bootDiskSize",
     "zone",
-    "gpuConfig"
-  )(x => (x.machineType, x.persistentDiskId, x.cloudService, x.bootDiskSize, x.zone, x.gpuConfig))
+    "gpuConfig",
+    "configType"
+  )(x => (x.machineType, x.persistentDiskId, x.cloudService, x.bootDiskSize, x.zone, x.gpuConfig, x.configType))
 
   implicit val runtimeConfigEncoder: Encoder[RuntimeConfig] = Encoder.instance(x =>
     x match {

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/runtimeModels.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/runtimeModels.scala
@@ -238,10 +238,36 @@ object CustomImage {
 }
 
 /** Configuration of the runtime such as machine types, disk size, etc */
+sealed trait RuntimeConfigType extends EnumEntry with Product with Serializable {
+  def asString: String
+
+  override def toString: String = asString // Enumeratum's withName function uses `toString` as key for lookup
+}
+object RuntimeConfigType extends Enum[RuntimeConfigType] {
+  case object Dataproc extends RuntimeConfigType {
+    val asString = "Dataproc"
+  }
+
+  case object GceConfig extends RuntimeConfigType {
+    val asString = "GceConfig"
+  }
+
+  case object GceWithPdConfig extends RuntimeConfigType {
+    val asString = "GceWithPdConfig"
+  }
+
+  case object AzureVmConfig extends RuntimeConfigType {
+    val asString = "AzureVmConfig"
+  }
+
+  override def values: immutable.IndexedSeq[RuntimeConfigType] = findValues
+}
 final case class RuntimeConfigId(id: Long) extends AnyVal
 sealed trait RuntimeConfig extends Product with Serializable {
   def cloudService: CloudService
   def machineType: MachineTypeName
+
+  def configType: RuntimeConfigType
 }
 object RuntimeConfig {
   final case class GceConfig(
@@ -254,6 +280,7 @@ object RuntimeConfig {
     gpuConfig: Option[GpuConfig] // This is optional since not all runtimes use gpus
   ) extends RuntimeConfig {
     val cloudService: CloudService = CloudService.GCE
+    val configType: RuntimeConfigType = RuntimeConfigType.GceConfig
   }
 
   // When persistentDiskId is None, then we don't have any disk attached to the runtime
@@ -264,6 +291,7 @@ object RuntimeConfig {
                                    gpuConfig: Option[GpuConfig]
   ) extends RuntimeConfig {
     val cloudService: CloudService = CloudService.GCE
+    val configType: RuntimeConfigType = RuntimeConfigType.GceWithPdConfig
   }
 
   final case class DataprocConfig(numberOfWorkers: Int,
@@ -282,6 +310,7 @@ object RuntimeConfig {
     val cloudService: CloudService = CloudService.Dataproc
     val machineType: MachineTypeName = masterMachineType
     val diskSize: DiskSize = masterDiskSize
+    val configType: RuntimeConfigType = RuntimeConfigType.Dataproc
   }
 
   // Azure machineType maps to `com.azure.resourcemanager.compute.models.VirtualMachineSizeTypes`
@@ -290,6 +319,7 @@ object RuntimeConfig {
                                region: com.azure.core.management.Region
   ) extends RuntimeConfig {
     val cloudService: CloudService = CloudService.AzureVm
+    val configType: RuntimeConfigType = RuntimeConfigType.AzureVmConfig
   }
 }
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/CookieSupport.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/CookieSupport.scala
@@ -35,7 +35,7 @@ object CookieSupport {
       domain = None, // Do not specify domain, making it default to Leo's domain
       maxAge = Option(userInfo.tokenExpiresIn), // cookie expiry is tied to the token expiry
       path = Some("/") // needed so it works for AJAX requests
-    )
+    )l
 
   private def buildRawCookie(userInfo: UserInfo) =
     RawHeader(

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/CookieSupport.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/CookieSupport.scala
@@ -35,7 +35,7 @@ object CookieSupport {
       domain = None, // Do not specify domain, making it default to Leo's domain
       maxAge = Option(userInfo.tokenExpiresIn), // cookie expiry is tied to the token expiry
       path = Some("/") // needed so it works for AJAX requests
-    )l
+    )
 
   private def buildRawCookie(userInfo: UserInfo) =
     RawHeader(

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/RuntimeRoutesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/RuntimeRoutesSpec.scala
@@ -369,7 +369,8 @@ class RuntimeRoutesSpec extends AnyFlatSpec with Matchers with LeonardoTestSuite
          |    "gpuConfig" : {
          |      "gpuType" : "nvidia-tesla-t4",
          |      "numOfGpus" : 2
-         |    }
+         |    },
+         |    "configType": "GceConfig"
          |  },
          |  "proxyUrl" : "https://leo.org/proxy",
          |  "status" : "Running",
@@ -437,7 +438,8 @@ class RuntimeRoutesSpec extends AnyFlatSpec with Matchers with LeonardoTestSuite
         |    "diskSize" : 500,
         |    "cloudService" : "GCE",
         |    "bootDiskSize" : 50,
-        |    "zone" : "us-west2-b"
+        |    "zone" : "us-west2-b",
+        |    "configType": "GceConfig"
         |  },
         |  "proxyUrl" : "https://leo.org/proxy",
         |  "status" : "Running",

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/RuntimeRoutesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/RuntimeRoutesSpec.scala
@@ -370,7 +370,7 @@ class RuntimeRoutesSpec extends AnyFlatSpec with Matchers with LeonardoTestSuite
          |      "gpuType" : "nvidia-tesla-t4",
          |      "numOfGpus" : 2
          |    },
-         |    "configType": "GceConfig"
+         |    "configType" : "GceConfig"
          |  },
          |  "proxyUrl" : "https://leo.org/proxy",
          |  "status" : "Running",
@@ -439,7 +439,7 @@ class RuntimeRoutesSpec extends AnyFlatSpec with Matchers with LeonardoTestSuite
         |    "cloudService" : "GCE",
         |    "bootDiskSize" : 50,
         |    "zone" : "us-west2-b",
-        |    "configType": "GceConfig"
+        |    "configType" : "GceConfig"
         |  },
         |  "proxyUrl" : "https://leo.org/proxy",
         |  "status" : "Running",


### PR DESCRIPTION
This PR is to support front-end typing.

There is not solid way to inspect a serialized `RuntimeConfig` as  to what type of runtime config it is. This PR adds a field for each subclass of runtimeconfig, so it can be  easily typed in the UI without inspecting differences between the models themselves. See discussion of the smell introduced into UI code without this here: https://github.com/DataBiosphere/terra-ui/pull/3811/files#r1114922516