### PR TITLE
[IA-4089] Disable custom AppLifeCycle automation test

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/AppLifecycleSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/AppLifecycleSpec.scala
@@ -62,23 +62,24 @@ class AppLifecycleSpec
     )
   )
 
-  // Test custom app first so that there will be a GKE cluster created already for the next two tests
-  "create CUSTOM app, start/stop, delete it" in { googleProject =>
-    test(
-      googleProject,
-      createAppRequest(
-        AppType.Custom,
-        "custom-test-workspace",
-        Some(
-          org.http4s.Uri.unsafeFromString(
-            "https://raw.githubusercontent.com/DataBiosphere/terra-app/acb66d96045e199d2cae6876723e028296794292/apps/ucsc_genome_browser/app.yaml"
-          )
-        )
-      ),
-      false,
-      false
-    )
-  }
+  // Disabling custom app integration tests as none are used, and the underlying image got deleted anyways
+  // See more details in https://broadworkbench.atlassian.net/browse/IA-4089
+//  "create CUSTOM app, start/stop, delete it" in { googleProject =>
+//    test(
+//      googleProject,
+//      createAppRequest(
+//        AppType.Custom,
+//        "custom-test-workspace",
+//        Some(
+//          org.http4s.Uri.unsafeFromString(
+//            "https://raw.githubusercontent.com/DataBiosphere/terra-app/acb66d96045e199d2cae6876723e028296794292/apps/ucsc_genome_browser/app.yaml"
+//          )
+//        )
+//      ),
+//      false,
+//      false
+//    )
+//  }
 
   // Use forAll so that tests are run in parallel
   forAll(appTestCases) { (description, createAppRequest, testStartStop, testPD) =>


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-4089

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
