### PR TITLE
[IA-3993] Bump workbench-libs azure version; pause runtimes with deallocate

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ ERROR 2003 (HY000): Can't connect to MySQL server on 'mysql' (113)
 Warning: Using a password on the command line interface can be insecure.
 ERROR 2003 (HY000): Can't connect to MySQL server on 'mysql' (113)
 ```
-Run `docker system prune -a`. If the error persists, try restart your laptop.
+Run `docker system prune -a`. If the error persists, try restarting your laptop.
 
 Build Leonardo and run all unit tests.
 ```

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/AppLifecycleSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/AppLifecycleSpec.scala
@@ -8,7 +8,7 @@ import org.broadinstitute.dsde.workbench.leonardo.LeonardoApiClient._
 import org.broadinstitute.dsde.workbench.leonardo.TestUser.{getAuthTokenAndAuthorization, Ron}
 import org.broadinstitute.dsde.workbench.leonardo.http.{CreateAppRequest, ListAppResponse, PersistentDiskRequest}
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
-import org.broadinstitute.dsde.workbench.service.util.Tags
+// import org.broadinstitute.dsde.workbench.service.util.Tags
 import org.http4s.headers.Authorization
 import org.http4s.{AuthScheme, Credentials}
 import org.scalatest.prop.TableDrivenPropertyChecks

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeAutopauseSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeAutopauseSpec.scala
@@ -4,9 +4,9 @@ import cats.effect.unsafe.implicits.global
 import org.broadinstitute.dsde.workbench.leonardo.TestUser.{getAuthTokenAndAuthorization, Ron}
 import org.broadinstitute.dsde.workbench.leonardo.{
   BillingProjectFixtureSpec,
-  // ClusterStatus,
-  // Leonardo,
-  // LeonardoApiClient,
+// ClusterStatus,
+// Leonardo,
+// LeonardoApiClient,
   LeonardoTestUtils
 }
 // import org.scalatest.time.{Minutes, Seconds, Span}
@@ -19,7 +19,7 @@ class RuntimeAutopauseSpec extends BillingProjectFixtureSpec with ParallelTestEx
   implicit val rat = ronAuthToken.unsafeRunSync()
   implicit val ra = ronAuthorization.unsafeRunSync()
 
-/* TODO [IA-4111] fix and reenable this test. It was timing out and stalling automation runs.
+  /* TODO [IA-4111] fix and reenable this test. It was timing out and stalling automation runs.
 
   "autopause should work" in { billingProject =>
     val runtimeName = randomClusterName
@@ -38,5 +38,5 @@ class RuntimeAutopauseSpec extends BillingProjectFixtureSpec with ParallelTestEx
       }
     }
   }
-  */
+   */
 }

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeAutopauseSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeAutopauseSpec.scala
@@ -10,9 +10,8 @@ import org.broadinstitute.dsde.workbench.leonardo.{
   LeonardoTestUtils
 }
 // import org.scalatest.time.{Minutes, Seconds, Span}
-import org.scalatest.{DoNotDiscover, ParallelTestExecution}
-
 // import scala.concurrent.duration._
+import org.scalatest.{DoNotDiscover, ParallelTestExecution}
 
 @DoNotDiscover
 class RuntimeAutopauseSpec extends BillingProjectFixtureSpec with ParallelTestExecution with LeonardoTestUtils {

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeAutopauseSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeAutopauseSpec.scala
@@ -20,6 +20,8 @@ class RuntimeAutopauseSpec extends BillingProjectFixtureSpec with ParallelTestEx
   implicit val rat = ronAuthToken.unsafeRunSync()
   implicit val ra = ronAuthorization.unsafeRunSync()
 
+/* TODO [IA-4111] fix and reenable this test. It was timing out and stalling automation runs.
+
   "autopause should work" in { billingProject =>
     val runtimeName = randomClusterName
     val runtimeRequest =
@@ -36,6 +38,6 @@ class RuntimeAutopauseSpec extends BillingProjectFixtureSpec with ParallelTestEx
         dbCluster.status shouldBe ClusterStatus.Stopping
       }
     }
-
   }
+  */
 }

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeAutopauseSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeAutopauseSpec.scala
@@ -4,15 +4,15 @@ import cats.effect.unsafe.implicits.global
 import org.broadinstitute.dsde.workbench.leonardo.TestUser.{getAuthTokenAndAuthorization, Ron}
 import org.broadinstitute.dsde.workbench.leonardo.{
   BillingProjectFixtureSpec,
-  ClusterStatus,
-  Leonardo,
-  LeonardoApiClient,
+  // ClusterStatus,
+  // Leonardo,
+  // LeonardoApiClient,
   LeonardoTestUtils
 }
-import org.scalatest.time.{Minutes, Seconds, Span}
+// import org.scalatest.time.{Minutes, Seconds, Span}
 import org.scalatest.{DoNotDiscover, ParallelTestExecution}
 
-import scala.concurrent.duration._
+// import scala.concurrent.duration._
 
 @DoNotDiscover
 class RuntimeAutopauseSpec extends BillingProjectFixtureSpec with ParallelTestExecution with LeonardoTestUtils {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -25,7 +25,7 @@ object Dependencies {
   val workbenchOpenTelemetryV = s"0.3-$workbenchLibsHash1"
   val workbenchOauth2V = s"0.2-$workbenchLibsHash1"
   private val workbenchLibsHash2 = "d0369c0"
-  val workbenchAzureV = s"0.1-$workbenchLibsHash2"
+  val workbenchAzureV = s"0.2-$workbenchLibsHash2"
 
   val helmScalaSdkV = "0.0.4"
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,15 +17,14 @@ object Dependencies {
   val munitCatsEffectV = "1.0.7"
   val pact4sV = "0.7.0"
 
-  private val workbenchLibsHash1 = "1a6839f"
-  val serviceTestV = s"2.0-$workbenchLibsHash1"
-  val workbenchModelV = s"0.15-$workbenchLibsHash1"
-  val workbenchGoogleV = s"0.22-$workbenchLibsHash1"
-  val workbenchGoogle2V = s"0.25-$workbenchLibsHash1"
-  val workbenchOpenTelemetryV = s"0.3-$workbenchLibsHash1"
-  val workbenchOauth2V = s"0.2-$workbenchLibsHash1"
-  private val workbenchLibsHash2 = "d0369c0"
-  val workbenchAzureV = s"0.2-$workbenchLibsHash2"
+  private val workbenchLibsHash = "d0369c0"
+  val serviceTestV = s"2.0-$workbenchLibsHash"
+  val workbenchModelV = s"0.15-$workbenchLibsHash"
+  val workbenchGoogleV = s"0.22-$workbenchLibsHash"
+  val workbenchGoogle2V = s"0.25-$workbenchLibsHash"
+  val workbenchOpenTelemetryV = s"0.3-$workbenchLibsHash"
+  val workbenchOauth2V = s"0.2-$workbenchLibsHash"
+  val workbenchAzureV = s"0.2-$workbenchLibsHash"
 
   val helmScalaSdkV = "0.0.4"
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,14 +17,15 @@ object Dependencies {
   val munitCatsEffectV = "1.0.7"
   val pact4sV = "0.7.0"
 
-  private val workbenchLibsHash = "d0369c0"
-  val serviceTestV = s"2.0-$workbenchLibsHash"
-  val workbenchModelV = s"0.15-$workbenchLibsHash"
-  val workbenchGoogleV = s"0.22-$workbenchLibsHash"
-  val workbenchGoogle2V = s"0.25-$workbenchLibsHash"
-  val workbenchOpenTelemetryV = s"0.3-$workbenchLibsHash"
-  val workbenchOauth2V = s"0.2-$workbenchLibsHash"
-  val workbenchAzureV = s"0.2-$workbenchLibsHash"
+  private val workbenchLibsHash1 = "1a6839f"
+  val serviceTestV = s"2.0-$workbenchLibsHash1"
+  val workbenchModelV = s"0.15-$workbenchLibsHash1"
+  val workbenchGoogleV = s"0.22-$workbenchLibsHash1"
+  val workbenchGoogle2V = s"0.25-$workbenchLibsHash1"
+  val workbenchOpenTelemetryV = s"0.3-$workbenchLibsHash1"
+  val workbenchOauth2V = s"0.2-$workbenchLibsHash1"
+  private val workbenchLibsHash2 = "d0369c0"
+  val workbenchAzureV = s"0.1-$workbenchLibsHash2"
 
   val helmScalaSdkV = "0.0.4"
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -20,7 +20,7 @@ object Dependencies {
   private val workbenchLibsHash = "d0369c0"
   val serviceTestV = s"2.0-$workbenchLibsHash"
   val workbenchModelV = s"0.15-$workbenchLibsHash"
-  val workbenchGoogleV = s"0.22-$workbenchLibsHash"
+  val workbenchGoogleV = s"0.23-$workbenchLibsHash"
   val workbenchGoogle2V = s"0.25-$workbenchLibsHash"
   val workbenchOpenTelemetryV = s"0.3-$workbenchLibsHash"
   val workbenchOauth2V = s"0.2-$workbenchLibsHash"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,14 +17,14 @@ object Dependencies {
   val munitCatsEffectV = "1.0.7"
   val pact4sV = "0.7.0"
 
-  private val workbenchLibsHash = "1a6839f"
+  private val workbenchLibsHash = "d0369c0"
   val serviceTestV = s"2.0-$workbenchLibsHash"
   val workbenchModelV = s"0.15-$workbenchLibsHash"
   val workbenchGoogleV = s"0.22-$workbenchLibsHash"
   val workbenchGoogle2V = s"0.25-$workbenchLibsHash"
   val workbenchOpenTelemetryV = s"0.3-$workbenchLibsHash"
   val workbenchOauth2V = s"0.2-$workbenchLibsHash"
-  val workbenchAzureV = s"0.2-d0369c0"
+  val workbenchAzureV = s"0.2-$workbenchLibsHash"
 
   val helmScalaSdkV = "0.0.4"
 


### PR DESCRIPTION
Instead of stopping via powerOff, stop with deallocate! Bump to the version of workbench-azure which makes this change in behavior.

To test:
- Create an Azure runtime
- Submit an API request to /stop
- Verify the Azure VM's status in Azure Portal is Stopped (deallocated)

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
