### PR TITLE
[IA-4066] adding merge group to consumer contract test yaml

### DIFF
--- a/.github/workflows/consumer_contract_tests.yml
+++ b/.github/workflows/consumer_contract_tests.yml
@@ -62,9 +62,12 @@ jobs:
           if [[ "$GITHUB_EVENT_NAME" == "push"]]; then
             GITHUB_REF=${{ github.ref }}
             GITHUB_SHA=${{ github.sha }}
-          elif [[ "$GITHUB_EVENT_NAME" == "pull_request"] || ["$GITHUB_EVENT_NAME" == "merge_group"]]; then
+          elif [[ "$GITHUB_EVENT_NAME" == "pull_request"]]; then
             GITHUB_REF=refs/heads/${{ github.head_ref }}
             GITHUB_SHA=${{ github.event.pull_request.head.sha }}
+          elif [["$GITHUB_EVENT_NAME" == "merge_group"]]; then
+            GITHUB_REF=${{ github.head_ref }}
+            GITHUB_SHA=${{ github.head_sha }}
           else
             echo "Failed to extract branch information"
             exit 1

--- a/.github/workflows/consumer_contract_tests.yml
+++ b/.github/workflows/consumer_contract_tests.yml
@@ -59,7 +59,7 @@ jobs:
         id: extract-branch
         run: |
           GITHUB_EVENT_NAME=${{ github.event_name }}
-          if [[ "$GITHUB_EVENT_NAME" == "push" ]]; then
+          if [[ "$GITHUB_EVENT_NAME" == "push" || "$GITHUB_EVENT_NAME" == "merge_group" ]]; then
             GITHUB_REF=${{ github.ref }}
             GITHUB_SHA=${{ github.sha }}
           elif [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then

--- a/.github/workflows/consumer_contract_tests.yml
+++ b/.github/workflows/consumer_contract_tests.yml
@@ -62,7 +62,7 @@ jobs:
           if [[ "$GITHUB_EVENT_NAME" == "push"]]; then
             GITHUB_REF=${{ github.ref }}
             GITHUB_SHA=${{ github.sha }}
-          elif [[ "$GITHUB_EVENT_NAME" == "pull_request" || "$GITHUB_EVENT_NAME" == "merge_group"]]; then
+          elif [[ "$GITHUB_EVENT_NAME" == "pull_request"] || ["$GITHUB_EVENT_NAME" == "merge_group"]]; then
             GITHUB_REF=refs/heads/${{ github.head_ref }}
             GITHUB_SHA=${{ github.event.pull_request.head.sha }}
           else

--- a/.github/workflows/consumer_contract_tests.yml
+++ b/.github/workflows/consumer_contract_tests.yml
@@ -59,14 +59,14 @@ jobs:
         id: extract-branch
         run: |
           GITHUB_EVENT_NAME=${{ github.event_name }}
-          if [[ "$GITHUB_EVENT_NAME" == "push"]]; then
+          if [[ "$GITHUB_EVENT_NAME" == "push" ]]; then
             GITHUB_REF=${{ github.ref }}
             GITHUB_SHA=${{ github.sha }}
-          elif [[ "$GITHUB_EVENT_NAME" == "pull_request"]]; then
+          elif [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
             GITHUB_REF=refs/heads/${{ github.head_ref }}
             GITHUB_SHA=${{ github.event.pull_request.head.sha }}
-          elif [["$GITHUB_EVENT_NAME" == "merge_group"]]; then
-            GITHUB_REF=${{ github.head_ref }}
+          elif [[ "$GITHUB_EVENT_NAME" == "merge_group" ]]; then
+            GITHUB_REF=refs/heads/${{ github.head_ref }}
             GITHUB_SHA=${{ github.head_sha }}
           else
             echo "Failed to extract branch information"

--- a/.github/workflows/consumer_contract_tests.yml
+++ b/.github/workflows/consumer_contract_tests.yml
@@ -59,10 +59,10 @@ jobs:
         id: extract-branch
         run: |
           GITHUB_EVENT_NAME=${{ github.event_name }}
-          if [[ "$GITHUB_EVENT_NAME" == "push" || "$GITHUB_EVENT_NAME" == "merge_group" ]]; then
+          if [[ "$GITHUB_EVENT_NAME" == "push"]]; then
             GITHUB_REF=${{ github.ref }}
             GITHUB_SHA=${{ github.sha }}
-          elif [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
+          elif [[ "$GITHUB_EVENT_NAME" == "pull_request" || "$GITHUB_EVENT_NAME" == "merge_group"]]; then
             GITHUB_REF=refs/heads/${{ github.head_ref }}
             GITHUB_SHA=${{ github.event.pull_request.head.sha }}
           else


### PR DESCRIPTION
Test used to fail in the merge queue due to this:
```Run GITHUB_EVENT_NAME=merge_group
  GITHUB_EVENT_NAME=merge_group
  if [[ "$GITHUB_EVENT_NAME" == "push" ]]; then
    GITHUB_REF=refs/heads/gh-readonly-queue/develop/pr-3186-3031b98aa37c61e33904daab8b008c6559c[2](https://github.com/DataBiosphere/leonardo/actions/runs/4298067256/jobs/7491763871#step:3:2)ea9f
    GITHUB_SHA=dd7af64cf10a2[3](https://github.com/DataBiosphere/leonardo/actions/runs/4298067256/jobs/7491763871#step:3:3)56d9[4](https://github.com/DataBiosphere/leonardo/actions/runs/4298067256/jobs/7491763871#step:3:4)f[6](https://github.com/DataBiosphere/leonardo/actions/runs/4298067256/jobs/7491763871#step:3:6)79e1d9cd0827e9baeee
  elif [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
    GITHUB_REF=refs/heads/
    GITHUB_SHA=
  else
    echo "Failed to extract branch information"
    exit 1
  fi
  echo "ref=$GITHUB_REF" >> $GITHUB_OUTPUT
  echo "sha=$GITHUB_SHA" >> $GITHUB_OUTPUT
  echo "sha-short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
  echo "branch=${GITHUB_REF/refs\/heads\//""}" >> $GITHUB_OUTPUT
  shell: /usr/bin/bash -e {0}
Failed to extract branch information
Error: Process completed with exit code 1.
```

I think we want the behavior of the merge group to match the push one 
