### PR TITLE
[IA-4111] Peg okhttp at prior version to fix tests; re-enable RuntimeAutopauseSpec

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/AppLifecycleSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/AppLifecycleSpec.scala
@@ -8,7 +8,6 @@ import org.broadinstitute.dsde.workbench.leonardo.LeonardoApiClient._
 import org.broadinstitute.dsde.workbench.leonardo.TestUser.{getAuthTokenAndAuthorization, Ron}
 import org.broadinstitute.dsde.workbench.leonardo.http.{CreateAppRequest, ListAppResponse, PersistentDiskRequest}
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
-// import org.broadinstitute.dsde.workbench.service.util.Tags
 import org.http4s.headers.Authorization
 import org.http4s.{AuthScheme, Credentials}
 import org.scalatest.prop.TableDrivenPropertyChecks

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeAutopauseSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeAutopauseSpec.scala
@@ -4,13 +4,13 @@ import cats.effect.unsafe.implicits.global
 import org.broadinstitute.dsde.workbench.leonardo.TestUser.{getAuthTokenAndAuthorization, Ron}
 import org.broadinstitute.dsde.workbench.leonardo.{
   BillingProjectFixtureSpec,
-// ClusterStatus,
-// Leonardo,
-// LeonardoApiClient,
+  ClusterStatus,
+  Leonardo,
+  LeonardoApiClient,
   LeonardoTestUtils
 }
-// import org.scalatest.time.{Minutes, Seconds, Span}
-// import scala.concurrent.duration._
+import org.scalatest.time.{Minutes, Seconds, Span}
+import scala.concurrent.duration._
 import org.scalatest.{DoNotDiscover, ParallelTestExecution}
 
 @DoNotDiscover
@@ -18,8 +18,6 @@ class RuntimeAutopauseSpec extends BillingProjectFixtureSpec with ParallelTestEx
   implicit val (ronAuthToken, ronAuthorization) = getAuthTokenAndAuthorization(Ron)
   implicit val rat = ronAuthToken.unsafeRunSync()
   implicit val ra = ronAuthorization.unsafeRunSync()
-
-  /* TODO [IA-4111] fix and reenable this test. It was timing out and stalling automation runs.
 
   "autopause should work" in { billingProject =>
     val runtimeName = randomClusterName
@@ -38,5 +36,4 @@ class RuntimeAutopauseSpec extends BillingProjectFixtureSpec with ParallelTestEx
       }
     }
   }
-   */
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -137,6 +137,7 @@ object Dependencies {
   val guava: ModuleID =   "com.google.guava"  % "guava"                 % guavaV
   val pact4sScalaTest =   "io.github.jbwheatley"  %% "pact4s-scalatest" % pact4sV % Test
   val pact4sCirce =       "io.github.jbwheatley"  %% "pact4s-circe"     % pact4sV
+  val okHttp =            "com.squareup.okhttp3"  % "okhttp"            % "4.10.0"
 
   val coreDependencies = List(
     workbenchOauth2,
@@ -215,7 +216,8 @@ object Dependencies {
     scalaTest,
     scalaTestSelenium,
     scalaTestMockito,
-    http4sBlazeServer % Test//,
+    http4sBlazeServer % Test,
+    okHttp % Test
 //    wsmClient
   )
 


### PR DESCRIPTION
Was comparing sbt `dependencyTree` between now and prior to the wb-libs upgrade on 3/2 (when tests started failing). The `selenium-remote-driver` version is consistent but a different `okhttp` version is being pulled in now. That smells related to the current test failures; try putting `okhttp` back to the old version.

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
