### PR TITLE
[WIP] [IA-4057] require user enabled directive on each direct Leo API route

### DIFF
--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/Boot.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/Boot.scala
@@ -55,7 +55,7 @@ import org.broadinstitute.dsde.workbench.leonardo.db.DbReference
 import org.broadinstitute.dsde.workbench.leonardo.dns._
 import org.broadinstitute.dsde.workbench.leonardo.http.api.{
   BuildTimeVersion,
-  EnabledUserDirectives,
+  StandardEnabledUserDirectives,
   HttpRoutes,
   LivenessRoutes,
   StandardUserInfoDirectives
@@ -205,7 +205,7 @@ object Boot extends IOApp {
         leoKubernetesService,
         azureService,
         StandardUserInfoDirectives,
-        EnabledUserDirectives,
+        StandardEnabledUserDirectives,
         contentSecurityPolicy,
         refererConfig
       )

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/Boot.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/Boot.scala
@@ -55,6 +55,7 @@ import org.broadinstitute.dsde.workbench.leonardo.db.DbReference
 import org.broadinstitute.dsde.workbench.leonardo.dns._
 import org.broadinstitute.dsde.workbench.leonardo.http.api.{
   BuildTimeVersion,
+  EnabledUserDirectives,
   HttpRoutes,
   LivenessRoutes,
   StandardUserInfoDirectives
@@ -204,6 +205,7 @@ object Boot extends IOApp {
         leoKubernetesService,
         azureService,
         StandardUserInfoDirectives,
+        EnabledUserDirectives,
         contentSecurityPolicy,
         refererConfig
       )

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/AppRoutes.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/AppRoutes.scala
@@ -103,6 +103,7 @@ class AppRoutes(kubernetesService: AppService[IO], userInfoDirectives: UserInfoD
                 }
             }
           }
+        }
       }
     }
   }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/EnabledUserDirectives.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/EnabledUserDirectives.scala
@@ -1,0 +1,9 @@
+package org.broadinstitute.dsde.workbench.leonardo.http
+package api
+
+import akka.http.scaladsl.server.Directive
+import org.broadinstitute.dsde.workbench.model.UserInfo
+
+trait EnabledUserDirectives {
+  def requireEnabledUser: Directive[UserInfo]
+}

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/HttpRoutes.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/HttpRoutes.scala
@@ -35,17 +35,18 @@ class HttpRoutes(
   kubernetesService: AppService[IO],
   azureService: RuntimeV2Service[IO],
   userInfoDirectives: UserInfoDirectives,
+  enabledUserDirectives: EnabledUserDirectives,
   contentSecurityPolicy: ContentSecurityPolicyConfig,
   refererConfig: RefererConfig
 )(implicit ec: ExecutionContext, ac: ActorSystem, metrics: OpenTelemetryMetrics[IO], logger: StructuredLogger[IO]) {
   private val statusRoutes = new StatusRoutes(statusService)
   private val corsSupport = new CorsSupport(contentSecurityPolicy)
   private val proxyRoutes = new ProxyRoutes(proxyService, corsSupport, refererConfig)
-  private val runtimeRoutes = new RuntimeRoutes(refererConfig, runtimeService, userInfoDirectives)
-  private val diskRoutes = new DiskRoutes(diskService, userInfoDirectives)
-  private val kubernetesRoutes = new AppRoutes(kubernetesService, userInfoDirectives)
-  private val appV2Routes = new AppV2Routes(kubernetesService, userInfoDirectives)
-  private val runtimeV2Routes = new RuntimeV2Routes(refererConfig, azureService, userInfoDirectives)
+  private val runtimeRoutes = new RuntimeRoutes(refererConfig, runtimeService, userInfoDirectives, enabledUserDirectives)
+  private val diskRoutes = new DiskRoutes(diskService, userInfoDirectives, enabledUserDirectives)
+  private val kubernetesRoutes = new AppRoutes(kubernetesService, userInfoDirectives, enabledUserDirectives)
+  private val appV2Routes = new AppV2Routes(kubernetesService, userInfoDirectives, enabledUserDirectives)
+  private val runtimeV2Routes = new RuntimeV2Routes(refererConfig, azureService, userInfoDirectives, enabledUserDirectives)
 
   // basis for logRequestResult lifted from http://stackoverflow.com/questions/32475471/how-does-one-log-akka-http-client-requests
   private val logRequestResult: Directive0 = {

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/StandardEnabledUserDirectives.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/StandardEnabledUserDirectives.scala
@@ -1,0 +1,33 @@
+package org.broadinstitute.dsde.workbench.leonardo.http
+package api
+
+import akka.http.scaladsl.server.{Directive, Directive1}
+import akka.http.scaladsl.server.Directives.{require, reject}
+import org.broadinstitute.dsde.workbench.model.UserInfo
+import org.broadinstitute.dsde.workbench.leonardo.dao.{AuthProviderException, SamDAO}
+import org.broadinstitute.dsde.workbench.leonardo.model.AuthenticationError
+
+object StandardEnabledUserDirectives extends EnabledUserDirectives {
+
+  /** Directive requiring the given user is enabled in Sam. */
+  override def requireEnabledUser(userInfo: UserInfo): Directive = require(isUserEnabled(userInfo))
+
+  private[leonardo] def isUserEnabled(userInfo: UserInfo)(implicit
+    ev: Ask[IO, TraceId]
+  ): IO[Boolean] =
+    for {
+      ctx <- ev.ask[TraceId]
+      samUserInfoOpt <- samDAO.getSamUserInfo(userInfo.accessToken.token)
+      samUserInfo <- IO.fromOption(samUserInfo)(AuthenticationError(Some(userInfo.userEmail)))
+      _ <-
+        if (samUserInfo.enabled) IO.unit
+        else
+          IO.raiseError(
+            AuthProviderException(
+              ctx.traceId,
+              s"[] User ${samUserInfo.userEmail.value} is disabled.",
+              StatusCodes.Forbidden
+            )
+          )
+    } yield IO.pure(true)
+}

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/StandardEnabledUserDirectives.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/StandardEnabledUserDirectives.scala
@@ -1,24 +1,32 @@
 package org.broadinstitute.dsde.workbench.leonardo.http
 package api
 
-import akka.http.scaladsl.server.{Directive, Directive1}
-import akka.http.scaladsl.server.Directives.{require, reject}
-import org.broadinstitute.dsde.workbench.model.UserInfo
+import akka.http.scaladsl.server.Directive
+// TODO akka require isn't in this package - where is it? see https://doc.akka.io/docs/akka-http/current/routing-dsl/directives/custom-directives.html#require-trequire
+import akka.http.scaladsl.server.Directives.require
+import akka.http.scaladsl.model.StatusCodes
+import org.broadinstitute.dsde.workbench.model.{TraceId, UserInfo}
 import org.broadinstitute.dsde.workbench.leonardo.dao.{AuthProviderException, SamDAO}
 import org.broadinstitute.dsde.workbench.leonardo.model.AuthenticationError
+import cats.effect.IO
+import cats.mtl.Ask
 
 object StandardEnabledUserDirectives extends EnabledUserDirectives {
 
   /** Directive requiring the given user is enabled in Sam. */
+  // TODO how do I properly define this to accept userInfo as a param, and produce a Directive which itself accepts no params?
+  // TODO do I need an Ask here to get TraceId?
   override def requireEnabledUser(userInfo: UserInfo): Directive = require(isUserEnabled(userInfo))
 
+  // TODO how do I correctly preserve and promote errors that occur in the various stages of this req. an Either?
   private[leonardo] def isUserEnabled(userInfo: UserInfo)(implicit
     ev: Ask[IO, TraceId]
   ): IO[Boolean] =
     for {
       ctx <- ev.ask[TraceId]
+      // TODO how to get access to the samDAO instance from this scope (StandardEnabledUserDirectives passed whole into the *Routes)
       samUserInfoOpt <- samDAO.getSamUserInfo(userInfo.accessToken.token)
-      samUserInfo <- IO.fromOption(samUserInfo)(AuthenticationError(Some(userInfo.userEmail)))
+      samUserInfo <- IO.fromOption(samUserInfoOpt)(AuthenticationError(Some(userInfo.userEmail)))
       _ <-
         if (samUserInfo.enabled) IO.unit
         else

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/ProxyService.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/ProxyService.scala
@@ -115,6 +115,11 @@ class ProxyService(
           userInfo <- googleOauth2Service.getUserInfoFromToken(token)
           _ <-
             if (checkUserEnabled) for {
+              // TODO [] this code seems to assume a non-enabled user will return an error or an empty response. However,
+              // HttpSamDAO::getSamUserInfo calls /register/user/v2/self/info which
+              // (per https://sam.mnolting.bee.envs-terra.bio/#/Users/getUserStatusInfo)
+              // returns a JSON body with an isEnabled flag.
+              // See also SamAuthProvider::lookupOriginatingUserEmail which the same endpoint differently, actually looking for isEnabled on the response.
               samUserInfo <- samDAO.getSamUserInfo(token)
               _ <- IO.fromOption(samUserInfo)(AuthenticationError(Some(userInfo.userEmail)))
             } yield ()


### PR DESCRIPTION
Add an explicit check to Sam for user isEnabled, to all direct Leo resource routes. Fix ProxyService's non-check of enabled.

Consider this more of a sketch of an intention than an attempt at working code - my StandardEnabledUserDirectives class is the loadbearing element and I'm not sure it's the correct approach (can it actually get access to SamDAO's instance, `samDAO`?).

I'd deeply appreciate any eyes with notions of how to write an Akka Directive or properly surface errors during execution.

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
