### PR TITLE
[IA-4131] proxy endpoints actually check user enabled

### DIFF
--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/ProxyService.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/ProxyService.scala
@@ -113,9 +113,7 @@ class ProxyService(
       case Left(_: JWTDecodeException) =>
         for {
           userInfo <- googleOauth2Service.getUserInfoFromToken(token)
-          _ <-
-            if (checkUserEnabled) authProvider.checkUserEnabled(userInfo) >> IO.unit
-            else IO.unit
+          _ <- IO.whenA(checkUserEnabled)(authProvider.checkUserEnabled(userInfo))
         } yield (userInfo, now.plusSeconds(userInfo.tokenExpiresIn.toInt))
       case Left(e) =>
         IO.raiseError(e)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/ProxyService.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/ProxyService.scala
@@ -114,6 +114,7 @@ class ProxyService(
         for {
           userInfo <- googleOauth2Service.getUserInfoFromToken(token)
           _ <- IO.whenA(checkUserEnabled)(authProvider.checkUserEnabled(userInfo))
+          _ = println(s"inside getUserInfo - after checkUserEnabled (which is ${checkUserEnabled}")
         } yield (userInfo, now.plusSeconds(userInfo.tokenExpiresIn.toInt))
       case Left(e) =>
         IO.raiseError(e)
@@ -129,6 +130,7 @@ class ProxyService(
       ctx <- ev.ask[TraceId]
       now <- IO.realTimeInstant
 
+      _ = println(s"inside getCachedUserInfoFromToken - checkUserEnabled is ${checkUserEnabled}")
       cache <- googleTokenCache.cachingF(token)(None)(getUserInfo(token, now, checkUserEnabled)).handleErrorWith {
         case e: AuthenticationError =>
           loggerIO.error(Map("traceId" -> ctx.asString), e)(s"${e.message} due to ${e.extraMessage}") >> IO
@@ -144,6 +146,7 @@ class ProxyService(
           else
             IO.raiseError(AccessTokenExpiredException)
       }
+      _ = println(s"inside getCachedUserInfoFromToken - past all possible errors - userInfo is good :(")
     } yield res
 
   private[leonardo] def getSamResourceFromDb(

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/ProxyService.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/ProxyService.scala
@@ -114,7 +114,7 @@ class ProxyService(
     _ <- IO.whenA(checkUserEnabled)(authProvider.checkUserEnabled(userInfo))
     _ <- loggerIO.info(s"inside getUserInfo - after checkUserEnabled (which is ${checkUserEnabled}")
     decodedToken <- decodeB2cToken(token, now) match {
-      case Left(_: JWTDecodeException) => (userInfo, now.plusSeconds(userInfo.tokenExpiresIn.toInt))
+      case Left(_: JWTDecodeException) => IO.pure(userInfo, now.plusSeconds(userInfo.tokenExpiresIn.toInt))
       case Left(e) =>
         IO.raiseError(e)
       case Right(value) =>

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/ProxyService.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/ProxyService.scala
@@ -114,7 +114,7 @@ class ProxyService(
         for {
           userInfo <- googleOauth2Service.getUserInfoFromToken(token)
           _ <-
-            if (checkUserEnabled) authProvider.checkUserEnabled(userInfo)
+            if (checkUserEnabled) authProvider.checkUserEnabled(userInfo) >> IO.unit
             else IO.unit
         } yield (userInfo, now.plusSeconds(userInfo.tokenExpiresIn.toInt))
       case Left(e) =>

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/ProxyService.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/ProxyService.scala
@@ -114,15 +114,7 @@ class ProxyService(
         for {
           userInfo <- googleOauth2Service.getUserInfoFromToken(token)
           _ <-
-            if (checkUserEnabled) for {
-              // TODO [IA-4131] this code seems to assume a non-enabled user will return an error or an empty response. However,
-              // HttpSamDAO::getSamUserInfo calls /register/user/v2/self/info which
-              // (per https://sam.dsde-dev.broadinstitute.org/#/Users/getUserStatusInfo)
-              // returns a JSON body with Boolean property `enabled`.
-              // See also SamAuthProvider::lookupOriginatingUserEmail which looks for `enabled` on the response.
-              samUserInfo <- samDAO.getSamUserInfo(token)
-              _ <- IO.fromOption(samUserInfo)(AuthenticationError(Some(userInfo.userEmail)))
-            } yield ()
+            if (checkUserEnabled) authProvider.checkUserEnabled(userInfo)
             else IO.unit
         } yield (userInfo, now.plusSeconds(userInfo.tokenExpiresIn.toInt))
       case Left(e) =>

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/ProxyRoutesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/ProxyRoutesSpec.scala
@@ -501,8 +501,8 @@ class ProxyRoutesSpec
       .get(tokenCookie.value)
       .map(_.isDefined)
       .unsafeRunSync()(cats.effect.unsafe.IORuntime.global) shouldBe false
-    // login request with Authorization header should succeed and return a Set-Cookie header
-    Get(s"/proxy/$googleProject/$clusterName/setCookie")
+    // login request with Authorization header should fail with Unauthorized
+    Get(s"/proxy/setCookie")
       .addHeader(Authorization(OAuth2BearerToken(tokenCookie.value)))
       .addHeader(Origin("http://example.com"))
       .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {


### PR DESCRIPTION
The goal here is to have ProxyService always check the user's enabled status in Sam whenever it has to refresh its value in its cache of Google auth tokens. With the code as is I'm seeing 401 rejections for all users, however (even correctly authenticated ones). The issue is an AuthenticationException as the `googleOauth2Service` fails to parse the provided token.
```
{
  "insertId": "upd81t7y88844rw0",
  "jsonPayload": {
    "thread_name": "io-compute-blocker-3",
    "version": "72f9671",
    "serviceContext": {
      "service": "leonardo",
      "version": "72f9671"
    },
    "stack_trace": "com.google.api.client.googleapis.json.GoogleJsonResponseException: 400 Bad Request\nPOST https://www.googleapis.com/oauth2/v2/tokeninfo?access_token=eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6Inp4UnJ6aEw4OTBrYi1vVkZOWkdWUFlxSzYtSkI3RFRlTGVvMllTbzRtc1UifQ.eyJpc3MiOiJodHRwczovL3RlcnJhZGV2YjJjLmIyY2xvZ2luLmNvbS9mZDBiYzBlZi0xNzQ3LTRlZTYtYWIzZS1kNGQ2YmI4ODJkNDAvdjIuMC8iLCJleHAiOjE2Nzg5ODQ2NDksIm5iZiI6MTY3ODk4MTA0OSwiYXVkIjoiYmJkMDdkNDMtMDFjYi00YjY5LThmZDAtNTc0NmQ5YTVjOWZlIiwiZW1haWwiOiJtbmVtby5saXR0bGVAZ21haWwuY29tIiwiZ2l2ZW5fbmFtZSI6IkxJdHRsZSIsImZhbWlseV9uYW1lIjoiTW5lbW8iLCJuYW1lIjoiTEl0dGxlIE1uZW1vIiwiaWRwIjoiZ29vZ2xlLmNvbSIsImlkcF9hY2Nlc3NfdG9rZW4iOiJ5YTI5LmEwQVZ2WlZzb1BESUNiNUJ4ZGdMcXhscjJ6aFgxVjI5aTZVZmd3ZGhKLVV2Y2ZtMWdmZ1pBeTBOcmQ2V0VkcXpEcTd2N0FsQ0g1cHJFbnZBSzBxUHNpbHItOUJuZDI1eC1DN1pqcDVDSThDekNoYndTT185eEhVTk1aaWlBWWpGY1NfWEVXRmk5WjNRQ0w2ZUhyYzRpdDVXSDNBWjVTbWdhQ2dZS0FjVVNBUkVTRlFHYmR3YUl6SjdDel82T1hmaEhZelE1SXZ4Nml3MDE2NSIsImdvb2dsZV9pZCI6IjEwNjcxMTgzNzA1NDYyNzc0MzQ0NiIsInBpY3R1cmUiOiJodHRwczovL2xoMy5nb29nbGV1c2VyY29udGVudC5jb20vYS9BR05teXhicGtDUVVnbVVac01CbTZvM2RidTRPUzZVUExOajZ2dF9CTFJYQj1zOTYtYyIsInN1YiI6ImZlNDM3NmFmLWNlOTEtNDJhYy1iMzIzLWY2ZTc4Yzc2Y2ViYyIsInRpZCI6ImZkMGJjMGVmLTE3NDctNGVlNi1hYjNlLWQ0ZDZiYjg4MmQ0MCIsImF6cCI6ImJiZDA3ZDQzLTAxY2ItNGI2OS04ZmQwLTU3NDZkOWE1YzlmZSIsInZlciI6IjEuMCIsImlhdCI6MTY3ODk4MTA0OX0.LG440waOLFRPoEjGIU3Kx-fnmrttmC59jZry_GUY83Ox25eW6LguoVuACMlj24petFzQaKgrrPeLpsRHnx2-KZZ9CZqSAkB6-bKIw9R4lFZiCHrHvrhAULUR6nG5nZ6fY6BcPoDoCI8bnoK89FO7V-Meubi4SHq1NMeoeICjIlUzyzl31KMfwqFi9Oawnk9DS3kYLcuqgnYTkIPJHdSh58aUMeY_RkqIvOVunD03xG6IPgtx0g5vy4LObJx_pmzNiNJeqiq2xQiK-dHiWBSizCvVhXk2cKwMlwof2Nez-DXp4P32JOVguDRMIVgMyJEMz_vByucKcpsbdtcily14yg\n\tat com.google.api.client.googleapis.json.GoogleJsonResponseException.from(GoogleJsonResponseException.java:146)\n\tat com.google.api.client.googleapis.services.json.AbstractGoogleJsonClientRequest.newExceptionOnError(AbstractGoogleJsonClientRequest.java:118)\n\tat com.google.api.client.googleapis.services.json.AbstractGoogleJsonClientRequest.newExceptionOnError(AbstractGoogleJsonClientRequest.java:37)\n\tat com.google.api.client.googleapis.services.AbstractGoogleClientRequest$1.interceptResponse(AbstractGoogleClientRequest.java:439)\n\tat com.google.api.client.http.HttpRequest.execute(HttpRequest.java:1111)\n\tat com.google.api.client.googleapis.services.AbstractGoogleClientRequest.executeUnparsed(AbstractGoogleClientRequest.java:525)\n\tat com.google.api.client.googleapis.services.AbstractGoogleClientRequest.executeUnparsed(AbstractGoogleClientRequest.java:466)\n\tat com.google.api.client.googleapis.services.AbstractGoogleClientRequest.execute(AbstractGoogleClientRequest.java:576)\n\tat org.broadinstitute.dsde.workbench.leonardo.dao.google.GoogleOAuth2Interpreter.$anonfun$getUserInfoFromToken$2(GoogleOAuth2Interpreter.scala:25)\n\tat recoverWith$extension @ org.broadinstitute.dsde.workbench.google2.GooglePublisherInterpreter$.createTopic(GooglePublisherInterpreter.scala:114)\n\tat modify @ fs2.internal.Scope.close(Scope.scala:262)\n\tat main$ @ org.broadinstitute.dsde.workbench.leonardo.http.Boot$.main(Boot.scala:89)\n",
    "message": "Failed to get token info",
    "@timestamp": "2023-03-16T15:38:08.685Z",
    "@version": "1",
    "logger_name": "org.broadinstitute.dsde.workbench.leonardo.http.Boot",
    "traceId": "f59e32c6-3ca7-448c-9d0e-b108c75fe37b"
  },
  "resource": {
    "type": "k8s_container",
    "labels": {
      "namespace_name": "terra-mnolting",
      "project_id": "broad-dsde-qa",
      "pod_name": "leonardo-backend-deployment-675bd4567b-9cvwn",
      "container_name": "leonardo-backend-app",
      "location": "us-central1-a",
      "cluster_name": "terra-qa-bees"
    }
  },
  "timestamp": "2023-03-16T15:38:08.686250466Z",
  "severity": "ERROR",
  "labels": {
    "k8s-pod/app_kubernetes_io/managed-by": "Helm",
    "k8s-pod/pod-template-hash": "675bd4567b",
    "compute.googleapis.com/resource_name": "gke-terra-qa-bees-default-v3-34002118-dt8u",
    "k8s-pod/app_kubernetes_io/component": "leonardo",
    "k8s-pod/app_kubernetes_io/name": "leonardo",
    "k8s-pod/deployment": "leonardo-backend-deployment",
    "k8s-pod/app_kubernetes_io/instance": "leonardo",
    "k8s-pod/app_kubernetes_io/part-of": "terra",
    "k8s-pod/helm_sh/chart": "leonardo-0.143.0"
  },
  "logName": "projects/broad-dsde-qa/logs/stdout",
  "receiveTimestamp": "2023-03-16T15:38:13.142379711Z"
}
```
Pausing for now for higher-priority work.
