### PR TITLE
[IA-4153] Bump to GKM 2.5.1 & adjust resource requests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ ENV HELM_DEBUG 1
 ENV TERRA_APP_SETUP_VERSION 0.0.8
 ENV TERRA_APP_VERSION 0.5.0
 # This is galaxykubeman, which references Galaxy
-ENV GALAXY_VERSION 2.5.0
+ENV GALAXY_VERSION 2.5.1
 ENV NGINX_VERSION 4.3.0
 # If you update this here, make sure to also update reference.conf:
 ENV CROMWELL_CHART_VERSION 0.2.213

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -509,7 +509,7 @@ gke {
     chartName = "/leonardo/galaxykubeman"
     # If you change this here, be sure to update it in the dockerfile
     # This is galaxykubeman, which references Galaxy
-    chartVersion = "2.5.0"
+    chartVersion = "2.5.1"
     namespaceNameSuffix = "gxy-ns"
     serviceAccountName = "gxy-ksa"
     # Setting uninstallKeepHistory will cause the `helm uninstall` command to keep a record of

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
@@ -1507,7 +1507,7 @@ class GKEInterpreter[F[_]](
     // Machine type info
     val maxLimitMemory = machineType.memorySizeInGb
     val maxLimitCpu = machineType.numOfCpus
-    val maxRequestMemory = maxLimitMemory - 20
+    val maxRequestMemory = maxLimitMemory - 22
     val maxRequestCpu = maxLimitCpu - 6
 
     // Custom EV configs
@@ -1568,8 +1568,8 @@ class GKEInterpreter[F[_]](
       raw"""galaxy.jobs.maxLimits.cpu=${maxLimitCpu}""",
       raw"""galaxy.jobs.maxRequests.memory=${maxRequestMemory}""",
       raw"""galaxy.jobs.maxRequests.cpu=${maxRequestCpu}""",
-      raw"""galaxy.jobs.rules.tpv_rules_local\.yml.destinations.k8s.max_mem=${maxLimitMemory}""",
-      raw"""galaxy.jobs.rules.tpv_rules_local\.yml.destinations.k8s.max_cores=${maxLimitCpu}""",
+      raw"""galaxy.jobs.rules.tpv_rules_local\.yml.destinations.k8s.max_mem=${maxRequestMemory}""",
+      raw"""galaxy.jobs.rules.tpv_rules_local\.yml.destinations.k8s.max_cores=${maxRequestCpu}""",
       // RBAC configs
       raw"""galaxy.serviceAccount.create=false""",
       raw"""galaxy.serviceAccount.name=${ksa.value}""",

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/KubernetesTestData.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/KubernetesTestData.scala
@@ -43,7 +43,7 @@ object KubernetesTestData {
   val galaxyApp = AppType.Galaxy
 
   val galaxyChartName = ChartName("/leonardo/galaxykubeman")
-  val galaxyChartVersion = ChartVersion("2.5.0")
+  val galaxyChartVersion = ChartVersion("2.5.1")
   val galaxyChart = Chart(galaxyChartName, galaxyChartVersion)
 
   val galaxyReleasePrefix = "gxy-release"

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreterSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreterSpec.scala
@@ -123,7 +123,7 @@ class GKEInterpreterSpec extends AnyFlatSpecLike with TestComponent with Leonard
       NamespaceName("ns"),
       savedDisk1,
       DiskName("disk1-gxy-postres-disk"),
-      AppMachineType(21, 7),
+      AppMachineType(23, 7),
       None
     )
 
@@ -155,12 +155,12 @@ class GKEInterpreterSpec extends AnyFlatSpecLike with TestComponent with Leonard
       """galaxy.tusd.ingress.tls[0].hosts[0]=1455694897.jupyter.firecloud.org,""" +
       """galaxy.tusd.ingress.tls[0].secretName=tls-secret,""" +
       """galaxy.rabbitmq.persistence.storageClassName=nfs-app1-galaxy-rls,""" +
-      """galaxy.jobs.maxLimits.memory=21,""" +
+      """galaxy.jobs.maxLimits.memory=23,""" +
       """galaxy.jobs.maxLimits.cpu=7,""" +
       """galaxy.jobs.maxRequests.memory=1,""" +
       """galaxy.jobs.maxRequests.cpu=1,""" +
-      """galaxy.jobs.rules.tpv_rules_local\.yml.destinations.k8s.max_mem=21,""" +
-      """galaxy.jobs.rules.tpv_rules_local\.yml.destinations.k8s.max_cores=7,""" +
+      """galaxy.jobs.rules.tpv_rules_local\.yml.destinations.k8s.max_mem=1,""" +
+      """galaxy.jobs.rules.tpv_rules_local\.yml.destinations.k8s.max_cores=1,""" +
       """galaxy.serviceAccount.create=false,""" +
       """galaxy.serviceAccount.name=app1-galaxy-ksa,""" +
       """rbac.serviceAccount=app1-galaxy-ksa,persistence.nfs.name=ns-nfs-disk,""" +
@@ -205,7 +205,7 @@ class GKEInterpreterSpec extends AnyFlatSpecLike with TestComponent with Leonard
         NamespaceName("ns"),
         savedDisk1,
         DiskName("disk1-gxy-postres"),
-        AppMachineType(21, 7),
+        AppMachineType(23, 7),
         Some(
           GalaxyRestore(PvcId("galaxy-pvc-id"), AppId(123))
         )
@@ -238,12 +238,12 @@ class GKEInterpreterSpec extends AnyFlatSpecLike with TestComponent with Leonard
       """galaxy.tusd.ingress.tls[0].hosts[0]=1455694897.jupyter.firecloud.org,""" +
       """galaxy.tusd.ingress.tls[0].secretName=tls-secret,""" +
       """galaxy.rabbitmq.persistence.storageClassName=nfs-app1-galaxy-rls,""" +
-      """galaxy.jobs.maxLimits.memory=21,""" +
+      """galaxy.jobs.maxLimits.memory=23,""" +
       """galaxy.jobs.maxLimits.cpu=7,""" +
       """galaxy.jobs.maxRequests.memory=1,""" +
       """galaxy.jobs.maxRequests.cpu=1,""" +
-      """galaxy.jobs.rules.tpv_rules_local\.yml.destinations.k8s.max_mem=21,""" +
-      """galaxy.jobs.rules.tpv_rules_local\.yml.destinations.k8s.max_cores=7,""" +
+      """galaxy.jobs.rules.tpv_rules_local\.yml.destinations.k8s.max_mem=1,""" +
+      """galaxy.jobs.rules.tpv_rules_local\.yml.destinations.k8s.max_cores=1,""" +
       """galaxy.serviceAccount.create=false,""" +
       """galaxy.serviceAccount.name=app1-galaxy-ksa,""" +
       """rbac.serviceAccount=app1-galaxy-ksa,""" +


### PR DESCRIPTION
This uses latest Galaxy 23.0 code and necessary settings.