### PR TITLE
[IA-4154] Changed flaky test to be run in serial rather than in parallel

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoSuite.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoSuite.scala
@@ -245,15 +245,15 @@ trait NewBillingProjectAndWorkspaceBeforeAndAfterAll extends BillingProjectUtils
 
 final class LeonardoSuite
     extends Suites(
-      new RuntimeCreationDiskSpec,
-      new LabSpec,
-      new RuntimeAutopauseSpec,
-      new RuntimePatchSpec,
-      new RuntimeStatusTransitionsSpec,
-      new NotebookGCECustomizationSpec,
-      new NotebookGCEDataSyncingSpec,
-      new RuntimeDataprocSpec,
-      new RuntimeGceSpec
+//      new RuntimeCreationDiskSpec,
+//      new LabSpec,
+//      new RuntimeAutopauseSpec,
+//      new RuntimePatchSpec,
+//      new RuntimeStatusTransitionsSpec,
+//      new NotebookGCECustomizationSpec,
+//      new NotebookGCEDataSyncingSpec,
+//      new RuntimeDataprocSpec,
+//      new RuntimeGceSpec
     )
     with TestSuite
     with NewBillingProjectAndWorkspaceBeforeAndAfterAll
@@ -261,12 +261,12 @@ final class LeonardoSuite
 
 final class LeonardoTerraDockerSuite
     extends Suites(
-      new NotebookAouSpec,
-      new NotebookGATKSpec,
-      new NotebookHailSpec,
-      new NotebookPyKernelSpec,
-      new NotebookRKernelSpec,
-      new RStudioSpec
+//      new NotebookAouSpec,
+//      new NotebookGATKSpec,
+//      new NotebookHailSpec,
+//      new NotebookPyKernelSpec,
+//      new NotebookRKernelSpec,
+//      new RStudioSpec
     )
     with TestSuite
     with NewBillingProjectAndWorkspaceBeforeAndAfterAll

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoSuite.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoSuite.scala
@@ -245,15 +245,15 @@ trait NewBillingProjectAndWorkspaceBeforeAndAfterAll extends BillingProjectUtils
 
 final class LeonardoSuite
     extends Suites(
-//      new RuntimeCreationDiskSpec,
-//      new LabSpec,
-//      new RuntimeAutopauseSpec,
-//      new RuntimePatchSpec,
-//      new RuntimeStatusTransitionsSpec,
-//      new NotebookGCECustomizationSpec,
-//      new NotebookGCEDataSyncingSpec,
-//      new RuntimeDataprocSpec,
-//      new RuntimeGceSpec
+      new RuntimeCreationDiskSpec,
+      new LabSpec,
+      new RuntimeAutopauseSpec,
+      new RuntimePatchSpec,
+      new RuntimeStatusTransitionsSpec,
+      new NotebookGCECustomizationSpec,
+      new NotebookGCEDataSyncingSpec,
+      new RuntimeDataprocSpec,
+      new RuntimeGceSpec
     )
     with TestSuite
     with NewBillingProjectAndWorkspaceBeforeAndAfterAll
@@ -261,12 +261,12 @@ final class LeonardoSuite
 
 final class LeonardoTerraDockerSuite
     extends Suites(
-//      new NotebookAouSpec,
-//      new NotebookGATKSpec,
-//      new NotebookHailSpec,
-//      new NotebookPyKernelSpec,
-//      new NotebookRKernelSpec,
-//      new RStudioSpec
+      new NotebookAouSpec,
+      new NotebookGATKSpec,
+      new NotebookHailSpec,
+      new NotebookPyKernelSpec,
+      new NotebookRKernelSpec,
+      new RStudioSpec
     )
     with TestSuite
     with NewBillingProjectAndWorkspaceBeforeAndAfterAll

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/AppLifecycleSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/AppLifecycleSpec.scala
@@ -13,7 +13,7 @@ import org.http4s.headers.Authorization
 import org.http4s.{AuthScheme, Credentials}
 import org.scalatest.prop.TableDrivenPropertyChecks
 import org.scalatest.tagobjects.Retryable
-import org.scalatest.Assertion
+import org.scalatest.{Assertion, DoNotDiscover}
 
 import scala.concurrent.duration._
 
@@ -49,38 +49,32 @@ class AppLifecycleSpec
   )
 
   // Test galaxy app first so that there will be a GKE cluster created already for the next two tests
-  "create GALAXY app, start/stop, delete it and re-create it with same disk" in { googleProject =>
-    test(googleProject, createAppRequest(AppType.Galaxy, "Galaxy-Workshop-ASHG_2020_GWAS_Demo", None), true, true)
-  }
+  // TODO: IA-4162 Enable this test
+  //  "create GALAXY app, start/stop, delete it and re-create it with same disk" in { googleProject =>
+  //    test(googleProject, createAppRequest(AppType.Galaxy, "Galaxy-Workshop-ASHG_2020_GWAS_Demo", None), true, true)
+  //  }
 
   "create CROMWELL app, delete it and re-create it with same disk" taggedAs (Tags.SmokeTest, Retryable) in {
     googleProject =>
       test(googleProject, createAppRequest(AppType.Cromwell, "cromwell-test-workspace", None), false, true)
   }
 
-//  "create CUSTOM app, start/stop, delete it" in { googleProject =>
-//    test(
-//      googleProject,
-//      createAppRequest(
-//        AppType.Custom,
-//        "custom-test-workspace",
-//        Some(
-//          org.http4s.Uri.unsafeFromString(
-//            "https://raw.githubusercontent.com/DataBiosphere/terra-app/main/apps/ucsc_genome_browser/app.yaml"
-//          )
-//        )
-//      ),
-//      false,
-//      false
-//    )
-//  }
-
-// Use forAll so that tests are run in parallel
-//  forAll(appTestCases) { (description, createAppRequest, testStartStop, testPD) =>
-//    description taggedAs Retryable in { googleProject =>
-//      test(googleProject, createAppRequest, testStartStop, testPD)
-//    }
-//  }
+  "create CUSTOM app, start/stop, delete it" in { googleProject =>
+    test(
+      googleProject,
+      createAppRequest(
+        AppType.Custom,
+        "custom-test-workspace",
+        Some(
+          org.http4s.Uri.unsafeFromString(
+            "https://raw.githubusercontent.com/DataBiosphere/terra-app/main/apps/ucsc_genome_browser/app.yaml"
+          )
+        )
+      ),
+      false,
+      false
+    )
+  }
 
   def test(googleProject: GoogleProject,
            createAppRequest: CreateAppRequest,

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/AppLifecycleSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/AppLifecycleSpec.scala
@@ -47,9 +47,7 @@ class AppLifecycleSpec
     customEnvironmentVariables = Map("WORKSPACE_NAME" -> workspaceName),
     descriptorPath = descriptorPath
   )
-
   // Test galaxy app first so that there will be a GKE cluster created already for the next two tests
-  // TODO: IA-4162 Enable this test
   //  "create GALAXY app, start/stop, delete it and re-create it with same disk" in { googleProject =>
   //    test(googleProject, createAppRequest(AppType.Galaxy, "Galaxy-Workshop-ASHG_2020_GWAS_Demo", None), true, true)
   //  }
@@ -59,7 +57,7 @@ class AppLifecycleSpec
       test(googleProject, createAppRequest(AppType.Cromwell, "cromwell-test-workspace", None), false, true)
   }
 
-  "create CUSTOM app, start/stop, delete it" in { googleProject =>
+  "create CUSTOM app, start/stop, delete it" taggedAs Retryable in { googleProject =>
     test(
       googleProject,
       createAppRequest(

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/AppLifecycleSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/AppLifecycleSpec.scala
@@ -13,7 +13,7 @@ import org.http4s.headers.Authorization
 import org.http4s.{AuthScheme, Credentials}
 import org.scalatest.prop.TableDrivenPropertyChecks
 import org.scalatest.tagobjects.Retryable
-import org.scalatest.{Assertion, DoNotDiscover}
+import org.scalatest.Assertion
 
 import scala.concurrent.duration._
 


### PR DESCRIPTION
After brief investigation, it appeared that running these AppLifecycle tests in parallel and this was causing extra flakiness.

Additionally, it seems like there is work going on for Galaxy that is causing a bit of instability, outside of the control of the Broad. So, we're going to disable this test for the time being until Galaxy is stable. The follow up ticket is here:

https://broadworkbench.atlassian.net/browse/IA-4162


---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
