### PR TITLE
[IA-4160] Add app/runtime version to metrics

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/runtimeModels.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/runtimeModels.scala
@@ -545,7 +545,7 @@ final case class RuntimeMetrics(cloudContext: CloudContext,
                                 runtimeName: RuntimeName,
                                 status: RuntimeStatus,
                                 workspaceId: Option[WorkspaceId],
-                                containers: Set[RuntimeContainerServiceType],
+                                images: Set[RuntimeImage],
                                 labels: LabelMap
 )
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponent.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponent.scala
@@ -776,7 +776,7 @@ object clusterQuery extends TableQuery(new ClusterTable(_)) {
   private def unmarshalRuntimeForMetrics(
     runtimeRecords: Seq[(ClusterRecord, ClusterImageRecord, Option[LabelRecord])]
   ): Seq[RuntimeMetrics] = {
-    val clusterContainerMap: Map[RuntimeMetrics, (Chain[RuntimeImage], Map[String, Chain[String]])] =
+    val runtimeMap: Map[RuntimeMetrics, (Chain[RuntimeImage], Map[String, Chain[String]])] =
       runtimeRecords.toList.foldMap { case (clusterRec, runtimeImageRec, labelRecordOpt) =>
         val images = Chain(clusterImageQuery.unmarshalClusterImage(runtimeImageRec))
         val labelMap = labelRecordOpt.map(labelRecordOpt => labelRecordOpt.key -> Chain(labelRecordOpt.value)).toMap
@@ -791,8 +791,8 @@ object clusterQuery extends TableQuery(new ClusterTable(_)) {
         )
       }
 
-    clusterContainerMap.toSeq.map { case (runtimeContainers, (images, labels)) =>
-      runtimeContainers.copy(images = images.toList.toSet, labels = labels.view.mapValues(_.toList.toSet.head).toMap)
+    runtimeMap.toSeq.map { case (runtime, (images, labels)) =>
+      runtime.copy(images = images.toList.toSet, labels = labels.view.mapValues(_.toList.toSet.head).toMap)
     }
   }
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponent.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponent.scala
@@ -776,11 +776,9 @@ object clusterQuery extends TableQuery(new ClusterTable(_)) {
   private def unmarshalRuntimeForMetrics(
     runtimeRecords: Seq[(ClusterRecord, ClusterImageRecord, Option[LabelRecord])]
   ): Seq[RuntimeMetrics] = {
-    val clusterContainerMap: Map[RuntimeMetrics, (Chain[RuntimeContainerServiceType], Map[String, Chain[String]])] =
-      runtimeRecords.toList.foldMap { case (clusterRec, clusterImageRec, labelRecordOpt) =>
-        val containers = Chain.fromSeq(
-          RuntimeContainerServiceType.imageTypeToRuntimeContainerServiceType.get(clusterImageRec.imageType).toSeq
-        )
+    val clusterContainerMap: Map[RuntimeMetrics, (Chain[RuntimeImage], Map[String, Chain[String]])] =
+      runtimeRecords.toList.foldMap { case (clusterRec, runtimeImageRec, labelRecordOpt) =>
+        val images = Chain(clusterImageQuery.unmarshalClusterImage(runtimeImageRec))
         val labelMap = labelRecordOpt.map(labelRecordOpt => labelRecordOpt.key -> Chain(labelRecordOpt.value)).toMap
         Map(
           RuntimeMetrics(clusterRec.cloudContext,
@@ -789,14 +787,12 @@ object clusterQuery extends TableQuery(new ClusterTable(_)) {
                          clusterRec.workspaceId,
                          Set.empty,
                          Map.empty
-          ) -> (containers, labelMap)
+          ) -> (images, labelMap)
         )
       }
 
-    clusterContainerMap.toSeq.map { case (runtimeContainers, (containers, labels)) =>
-      runtimeContainers.copy(containers = containers.toList.toSet,
-                             labels = labels.view.mapValues(_.toList.toSet.head).toMap
-      )
+    clusterContainerMap.toSeq.map { case (runtimeContainers, (images, labels)) =>
+      runtimeContainers.copy(images = images.toList.toSet, labels = labels.view.mapValues(_.toList.toSet.head).toMap)
     }
   }
 

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreterSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreterSpec.scala
@@ -16,8 +16,7 @@ import org.broadinstitute.dsde.workbench.leonardo.KubernetesTestData.{
   makeApp,
   makeCustomAppService,
   makeKubeCluster,
-  makeNodepool,
-  makeService
+  makeNodepool
 }
 import org.broadinstitute.dsde.workbench.leonardo.TestUtils.appContext
 import org.broadinstitute.dsde.workbench.leonardo.config.Config
@@ -30,8 +29,8 @@ import org.broadinstitute.dsde.workbench.leonardo.db.{
 }
 import org.broadinstitute.dsde.workbench.leonardo.http.dbioToIO
 import org.broadinstitute.dsde.workbench.leonardo.http.service.AppNotFoundException
-import org.broadinstitute.dsde.workbench.model.{TraceId, WorkbenchEmail}
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
+import org.broadinstitute.dsde.workbench.model.{TraceId, WorkbenchEmail}
 import org.broadinstitute.dsp.Release
 import org.broadinstitute.dsp.mocks._
 import org.scalatest.flatspec.AnyFlatSpecLike


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-4160

Small metrics-only change -- add tag to specify _version_ of runtime/apps. For apps this is the chart version; for runtimes this is the imageUrl. This will be useful for seeing what versions are running in the wild; and monitoring that app upgrades are working (in the future).

See also design doc about app upgrades: https://docs.google.com/document/d/1T-QzAgFGEmWJEhoUMQ0wzFAFrdC-gSWqLrEgcqEKAuI/edit#

Demo of this working (from my BEE).

Apps:
<img width="1176" alt="image" src="https://user-images.githubusercontent.com/5368863/226935146-5087348e-d21e-4e62-a01a-7ab1ae0ae918.png">

Runtimes:
<img width="1171" alt="image" src="https://user-images.githubusercontent.com/5368863/226935760-fd6cb8af-5baa-42c1-a65d-1aa2cca0a063.png">



---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
