### PR TITLE
QA-2057: Changes for fork repo workflow permission.

### DIFF
--- a/.github/workflows/consumer_contract_tests.yml
+++ b/.github/workflows/consumer_contract_tests.yml
@@ -27,9 +27,12 @@ name: Consumer contract tests
 # NOTE: The publish-contracts workflow will use the latest commit of the branch that triggers this workflow to publish the unique consumer contract version to Pact Broker.
 
 on:
-  pull_request:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
     branches:
-      - develop
+      - QA-2057
     paths-ignore:
       - 'README.md'
   push:
@@ -57,6 +60,9 @@ jobs:
           if [[ "$GITHUB_EVENT_NAME" == "push" ]]; then
             GITHUB_REF=${{ github.ref }}
           elif [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
+            GITHUB_REF=refs/heads/${{ github.head_ref }}
+          elif [[ "$GITHUB_EVENT_NAME" == "pull_request_target" ]]; then
+            echo "$GITHUB_REF"
             GITHUB_REF=refs/heads/${{ github.head_ref }}
           elif [[ "$GITHUB_EVENT_NAME" == "merge_group" ]]; then
             GITHUB_REF=refs/heads/${{ github.head_ref }}

--- a/.github/workflows/consumer_contract_tests.yml
+++ b/.github/workflows/consumer_contract_tests.yml
@@ -48,6 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       repo-branch: ${{ steps.extract-branch.outputs.repo-branch }}
+      fork: ${{ steps.extract-branch.outputs.fork }}
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/consumer_contract_tests.yml
+++ b/.github/workflows/consumer_contract_tests.yml
@@ -27,12 +27,9 @@ name: Consumer contract tests
 # NOTE: The publish-contracts workflow will use the latest commit of the branch that triggers this workflow to publish the unique consumer contract version to Pact Broker.
 
 on:
-  pull_request_target:
-    types:
-      - opened
-      - reopened
+  pull_request:
     branches:
-      - QA-2057
+      - develop
     paths-ignore:
       - 'README.md'
   push:
@@ -54,15 +51,16 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - id: extract-branch
+
+      - name: Obtain branch properties
+        id: extract-branch
         run: |
+          FORK=false
           GITHUB_EVENT_NAME=${{ github.event_name }}
           if [[ "$GITHUB_EVENT_NAME" == "push" ]]; then
             GITHUB_REF=${{ github.ref }}
           elif [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
-            GITHUB_REF=refs/heads/${{ github.head_ref }}
-          elif [[ "$GITHUB_EVENT_NAME" == "pull_request_target" ]]; then
-            echo "$GITHUB_REF"
+            FORK=${{ github.event.pull_request.head.repo.fork }}
             GITHUB_REF=refs/heads/${{ github.head_ref }}
           elif [[ "$GITHUB_EVENT_NAME" == "merge_group" ]]; then
             GITHUB_REF=refs/heads/${{ github.head_ref }}
@@ -71,6 +69,12 @@ jobs:
             exit 1
           fi
           echo "repo-branch=${GITHUB_REF/refs\/heads\//""}" >> $GITHUB_OUTPUT
+          echo "fork=${FORK}" >> $GITHUB_OUTPUT
+
+      - name: Is PR triggered by forked repo?
+        if: ${{ steps.extract-branch.outputs.fork == 'true' }}
+        run: |
+          echo "PR was triggered by forked repo"
 
       - name: Echo repo and branch information
         run: |
@@ -102,12 +106,15 @@ jobs:
           NON_BREAKING_B64=$(cat target/pacts/leo-consumer-sam-provider.json | base64 -w 0)
           echo "pact-b64=${NON_BREAKING_B64}" >> $GITHUB_OUTPUT
 
+  # Prevent untrusted sources from using PRs to publish contracts
+  # since access to secrets is not allowed.
   publish-contracts:
     runs-on: ubuntu-latest
+    if: ${{ needs.init-github-context.outputs.fork == 'false' }}
     needs: [init-github-context, leo-consumer-contract-tests]
     steps:
       - name: Dispatch to terra-github-workflows
-        uses: aurelien-baudet/workflow-dispatch@93e95b157d791ae7f42aef8f8a0d3d723eba1c31 #commit sha for v2.1.1
+        uses: broadinstitute/workflow-dispatch@v3
         with:
           workflow: publish-contracts
           repo: broadinstitute/terra-github-workflows


### PR DESCRIPTION
Jira Ticket: [QA-2057](https://broadworkbench.atlassian.net/browse/QA-2057)

Since the `pull_request_target` is designed to run GitHub workflows in the base branch to prevent potential untrusted code to adversely impact live environments (see following article). 

[https://securitylab.github.com/research/github-actions-preventing-pwn-requests/](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Any PR triggered by forked repository is deemed untrusted code. Checking out forked code in a `pull_request_target` is not a good idea since it gives untrusted code access to sensitive secrets.

For this reason, this ticket address security in following way

- prevent `publish-contracts` to run if the PR is triggered by a forked repo
- allow contract tests to run so IA team can view test status


---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment


[QA-2057]: https://broadworkbench.atlassian.net/browse/QA-2057?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ