### PR TITLE
QA-2056: Add can-i-deploy job to gate promotion of code to develop branch.

### DIFF
--- a/.github/workflows/consumer_contract_tests.yml
+++ b/.github/workflows/consumer_contract_tests.yml
@@ -46,6 +46,10 @@ jobs:
         run: |
           GITHUB_EVENT_NAME=${{ github.event_name }}
           if [[ "$GITHUB_EVENT_NAME" == "push" ]]; then
+            echo "${{ github.ref }}"
+            echo "$GITHUB_REF"
+            echo "${{ github.sha }}"
+            echo "$GITHUB_SHA"
             GITHUB_REF=${{ github.ref }}
             GITHUB_SHA=${{ github.sha }}
           elif [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then

--- a/.github/workflows/consumer_contract_tests.yml
+++ b/.github/workflows/consumer_contract_tests.yml
@@ -1,40 +1,32 @@
 name: Consumer contract tests
-# The purpose of this workflow is to validate the service level contract using Pact framework.
+# The purpose of this workflow is to run a suite of Leo contract tests against mock service provider(s) using Pact framework.
 #
-# More details on Contract Testing can be found in our handbook
+# More details about Contract Testing can be found in our handbook
 #
 # https://broadworkbench.atlassian.net/wiki/spaces/IRT/pages/2660368406/Getting+Started+with+Pact+Contract+Testing
 #
-# The workflow involves two parties: Leo as a consumer. Any provider (e.g. Sam) Leo consumes.
+# This workflow involves Leo as a consumer, and ANY provider (e.g. Sam) Leo consumes.
 # Each party owns a set of tests (aka contract tests).
 #
-#   The consumer contract tests (aka consumer tests) are completely independent of
-#   the provider contract tests (aka provider verification tests), and vice versa.
+#   Consumer contract tests (aka consumer tests) runs on a mock provider service and does not require a real provider service.
+#   Provider contract tests (aka provider verification tests) runs independently of any consumer.
 #
-# Specifically
-#   Leo runs consumer tests against mock Sam service. Upon success, publish a consumer pact to
+# Specifically:
+#   Leo runs consumer tests against mock Sam service. Upon success, publish consumer pacts to
 #   Pact Broker https://pact-broker.dsp-eng-tools.broadinstitute.org/.
 #
-#   Pact Broker is the source of truth
-#   to forge contractual obligations between consumer and provider.
+#   Pact Broker is the source of truth to forge contractual obligations between consumer and provider.
 #
-#   Provider downloads relevant versions of consumer pacts from Pact Broker
-#   and verify rhe provider tests against the pacts.
+#   This workflow meets the criteria of Pact Broker *Platinum* as described in https://docs.pact.io/pact_nirvana/step_6.
+#   The can-i-deploy job has been added to this workflow to support *Platinum* and gate the code for promotion to default branch.
 #
-#   This workflow meets Pact Broker *Platinum* as described in https://docs.pact.io/pact_nirvana/step_6.
-#   The can-i-deploy job has been added to this workflow to gate the merge of PRs into default branch.
+#   This is how it works.
 #
-#   This workflow is triggered when
-#
-#     Consumer makes a change that results in a new pact published to Pact Broker (will verify ONLY the changed pact and publish the verification results back to the broker)
-#
-# The Pact Broker is a 2-way street.
-#   It can trigger provider verification upon changes in the content of consumer pacts
-#
-#   The provider can run verification tests against any consumers in deployed environments and publish statues to Pact Broker
-#
-#   Both consumer and the provider can gate deployment on availability/honoring of the published pact
-#   (contract expectations) between the two parties.
+#     Consumer makes a change that results in a new pact published to Pact Broker.
+#     Pact Broker notifies provider(s) of the changed pact and trigger corresponding verification workflows.
+#     Provider downloads relevant versions of consumer pacts from Pact Broker and kicks off verification tests against the consumer pacts.
+#     Provider updates Pact Broker with verification status.
+#     Consumer kicks off can-i-deploy on process to determine if changes can be promoted and used for deployment.
 #
 # NOTE: The publish-contracts workflow will use the latest commit of the branch that triggers this workflow to publish the unique consumer contract version to Pact Broker.
 

--- a/.github/workflows/consumer_contract_tests.yml
+++ b/.github/workflows/consumer_contract_tests.yml
@@ -96,7 +96,7 @@ jobs:
     needs: [init-github-context, leo-consumer-contract-tests]
     steps:
       - name: Dispatch to terra-github-workflows
-        uses: aurelien-baudet/workflow-dispatch@93e95b157d791ae7f42aef8f8a0d3d723eba1c31 #commit sha for v2.1.1
+        uses: broadinstitute/workflow-dispatch@v3
         with:
           workflow: publish-contracts
           repo: broadinstitute/terra-github-workflows
@@ -109,9 +109,22 @@ jobs:
     needs: [ init-github-context, publish-contracts ]
     steps:
       - name: Dispatch to terra-github-workflows
-        uses: aurelien-baudet/workflow-dispatch@93e95b157d791ae7f42aef8f8a0d3d723eba1c31 #commit sha for v2.1.1
+        uses: broadinstitute/workflow-dispatch@v3
         with:
           workflow: can-i-deploy.yaml
+          repo: broadinstitute/terra-github-workflows
+          ref: refs/heads/QA-2056
+          token: ${{ secrets.BROADBOT_TOKEN }} # github token for access to kick off a job in the private repo
+          inputs: '{ "pacticipant": "leo-consumer", "version": "${{ needs.init-github-context.outputs.repo-version }}", "environment": "alpha" }'
+
+  try-deploy:
+    runs-on: ubuntu-latest
+    needs: [ publish-contracts ]
+    steps:
+      - name: Dispatch to terra-github-workflows
+        uses: broadinstitute/workflow-dispatch@v3
+        with:
+          workflow: record-deployment.yaml
           repo: broadinstitute/terra-github-workflows
           ref: refs/heads/QA-2056
           token: ${{ secrets.BROADBOT_TOKEN }} # github token for access to kick off a job in the private repo

--- a/.github/workflows/consumer_contract_tests.yml
+++ b/.github/workflows/consumer_contract_tests.yml
@@ -115,4 +115,17 @@ jobs:
           repo: broadinstitute/terra-github-workflows
           ref: refs/heads/QA-2056
           token: ${{ secrets.BROADBOT_TOKEN }} # github token for access to kick off a job in the private repo
-          inputs: '{ "pacticipant": "leo-consumer", "version": "${{ needs.init-github-context.outputs.repo-version }}", "environment": "" }'
+          inputs: '{ "pacticipant": "leo-consumer", "version": "${{ needs.init-github-context.outputs.repo-version }}", "environment": "alpha" }'
+
+  try-deploy:
+    runs-on: ubuntu-latest
+    needs: [ init-github-context, can-i-deploy ]
+    steps:
+      - name: Dispatch to terra-github-workflows
+        uses: broadinstitute/workflow-dispatch@v3
+        with:
+          workflow: record-deployment.yaml
+          repo: broadinstitute/terra-github-workflows
+          ref: refs/heads/QA-2056
+          token: ${{ secrets.BROADBOT_TOKEN }} # github token for access to kick off a job in the private repo
+          inputs: '{ "pacticipant": "leo-consumer", "version": "${{ needs.init-github-context.outputs.repo-version }}", "environment": "alpha" }'

--- a/.github/workflows/consumer_contract_tests.yml
+++ b/.github/workflows/consumer_contract_tests.yml
@@ -116,16 +116,3 @@ jobs:
           ref: refs/heads/QA-2056
           token: ${{ secrets.BROADBOT_TOKEN }} # github token for access to kick off a job in the private repo
           inputs: '{ "pacticipant": "leo-consumer", "version": "${{ needs.init-github-context.outputs.repo-version }}", "environment": "" }'
-
-  try-deploy:
-    runs-on: ubuntu-latest
-    needs: [ init-github-context, can-i-deploy ]
-    steps:
-      - name: Dispatch to terra-github-workflows
-        uses: broadinstitute/workflow-dispatch@v3
-        with:
-          workflow: record-deployment.yaml
-          repo: broadinstitute/terra-github-workflows
-          ref: refs/heads/QA-2056
-          token: ${{ secrets.BROADBOT_TOKEN }} # github token for access to kick off a job in the private repo
-          inputs: '{ "pacticipant": "leo-consumer", "version": "${{ needs.init-github-context.outputs.repo-version }}", "environment": "alpha" }'

--- a/.github/workflows/consumer_contract_tests.yml
+++ b/.github/workflows/consumer_contract_tests.yml
@@ -115,7 +115,7 @@ jobs:
           repo: broadinstitute/terra-github-workflows
           ref: refs/heads/QA-2056
           token: ${{ secrets.BROADBOT_TOKEN }} # github token for access to kick off a job in the private repo
-          inputs: '{ "pacticipant": "leo-consumer", "version": "${{ needs.init-github-context.outputs.repo-version }}", "environment": "alpha" }'
+          inputs: '{ "pacticipant": "leo-consumer", "version": "${{ needs.init-github-context.outputs.repo-version }}", "environment": "" }'
 
   try-deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/consumer_contract_tests.yml
+++ b/.github/workflows/consumer_contract_tests.yml
@@ -38,6 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       repo-branch: ${{ steps.extract-branch.outputs.repo-branch }}
+      repo-version: ${{ steps.extract-branch.outputs.repo-version }}
 
     steps:
       - uses: actions/checkout@v3
@@ -46,8 +47,10 @@ jobs:
           GITHUB_EVENT_NAME=${{ github.event_name }}
           if [[ "$GITHUB_EVENT_NAME" == "push" ]]; then
             GITHUB_REF=${{ github.ref }}
+            GITHUB_SHA=${{ github.sha }}
           elif [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
             GITHUB_REF=refs/heads/${{ github.head_ref }}
+            GITHUB_SHA=${{ github.event.pull_request.head.sha }}
           elif [[ "$GITHUB_EVENT_NAME" == "merge_group" ]]; then
             GITHUB_REF=refs/heads/${{ github.head_ref }}
           else
@@ -55,6 +58,7 @@ jobs:
             exit 1
           fi
           echo "repo-branch=${GITHUB_REF/refs\/heads\//""}" >> $GITHUB_OUTPUT
+          echo "repo-version=${GITHUB_SHA}" >> $GITHUB_OUTPUT
 
       - name: Echo repo and branch information
         run: |
@@ -98,3 +102,16 @@ jobs:
           ref: refs/heads/main
           token: ${{ secrets.BROADBOT_TOKEN }} # github token for access to kick off a job in the private repo
           inputs: '{ "pact-b64": "${{ needs.leo-consumer-contract-tests.outputs.pact-b64 }}", "repo-owner": "${{ github.repository_owner }}", "repo-name": "${{ github.event.repository.name }}", "repo-branch": "${{ needs.init-github-context.outputs.repo-branch }}" }'
+
+  can-i-deploy:
+    runs-on: ubuntu-latest
+    needs: [ init-github-context, publish-contracts ]
+    steps:
+      - name: Dispatch to terra-github-workflows
+        uses: aurelien-baudet/workflow-dispatch@93e95b157d791ae7f42aef8f8a0d3d723eba1c31 #commit sha for v2.1.1
+        with:
+          workflow: can-i-deploy.yaml
+          repo: broadinstitute/terra-github-workflows
+          ref: refs/heads/QA-2056
+          token: ${{ secrets.BROADBOT_TOKEN }} # github token for access to kick off a job in the private repo
+          inputs: '{ "pacticipant": "leo-consumer", "version": "${{ needs.init-github-context.outputs.repo-version }}", "environment": "alpha" }'

--- a/.github/workflows/consumer_contract_tests.yml
+++ b/.github/workflows/consumer_contract_tests.yml
@@ -46,10 +46,6 @@ jobs:
         run: |
           GITHUB_EVENT_NAME=${{ github.event_name }}
           if [[ "$GITHUB_EVENT_NAME" == "push" ]]; then
-            echo "${{ github.ref }}"
-            echo "$GITHUB_REF"
-            echo "${{ github.sha }}"
-            echo "$GITHUB_SHA"
             GITHUB_REF=${{ github.ref }}
             GITHUB_SHA=${{ github.sha }}
           elif [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then

--- a/.github/workflows/consumer_contract_tests.yml
+++ b/.github/workflows/consumer_contract_tests.yml
@@ -119,7 +119,7 @@ jobs:
 
   try-deploy:
     runs-on: ubuntu-latest
-    needs: [ publish-contracts ]
+    needs: [ init-github-context, publish-contracts ]
     steps:
       - name: Dispatch to terra-github-workflows
         uses: broadinstitute/workflow-dispatch@v3

--- a/.github/workflows/consumer_contract_tests.yml
+++ b/.github/workflows/consumer_contract_tests.yml
@@ -1,28 +1,40 @@
 name: Consumer contract tests
-# The purpose of this workflow is to validate the service level contract
-# using the Pact framework.
+# The purpose of this workflow is to validate the service level contract using Pact framework.
 #
 # More details on Contract Testing can be found in our handbook
 #
 # https://broadworkbench.atlassian.net/wiki/spaces/IRT/pages/2660368406/Getting+Started+with+Pact+Contract+Testing
 #
-# The workflow involves two parties: Leo as a consumer. Sam as a provider.
+# The workflow involves two parties: Leo as a consumer. Any provider (e.g. Sam) Leo consumes.
 # Each party owns a set of tests (aka contract tests).
 #
 #   The consumer contract tests (aka consumer tests) are completely independent of
-#   the provider contract tests (aka provider tests), and vice versa.
+#   the provider contract tests (aka provider verification tests), and vice versa.
 #
 # Specifically
-#   Leo runs consumer tests against mock Sam service. Upon success, publish a consumer-provider pact to
-#   Pact Broker https://pact-broker.dsp-eng-tools.broadinstitute.org/. Pact Broker is the source of truth
+#   Leo runs consumer tests against mock Sam service. Upon success, publish a consumer pact to
+#   Pact Broker https://pact-broker.dsp-eng-tools.broadinstitute.org/.
+#
+#   Pact Broker is the source of truth
 #   to forge contractual obligations between consumer and provider.
 #
-#   Sam obtains contract from Pact Broker and runs provider tests to validate its obligations to consumers.
+#   Provider downloads relevant versions of consumer pacts from Pact Broker
+#   and verify rhe provider tests against the pacts.
 #
-# The Pact Broker is a 2-way street. The consumer can see in the dashboard if the service is able to honor their consumer expectations
-# (which is also true when those expectations are updated).  The provider can validate that a desired deployment would not break any
-# of the consumers' published expectations.  Both the consumer and the provider can gate deployment on availability/honoring of the published pact
-# (contract expectations) between the two.
+#   This workflow meets Pact Broker *Platinum* as described in https://docs.pact.io/pact_nirvana/step_6.
+#   The can-i-deploy job has been added to this workflow to gate the merge of PRs into default branch.
+#
+#   This workflow is triggered when
+#
+#     Consumer makes a change that results in a new pact published to Pact Broker (will verify ONLY the changed pact and publish the verification results back to the broker)
+#
+# The Pact Broker is a 2-way street.
+#   It can trigger provider verification upon changes in the content of consumer pacts
+#
+#   The provider can run verification tests against any consumers in deployed environments and publish statues to Pact Broker
+#
+#   Both consumer and the provider can gate deployment on availability/honoring of the published pact
+#   (contract expectations) between the two parties.
 #
 # NOTE: The publish-contracts workflow will use the latest commit of the branch that triggers this workflow to publish the unique consumer contract version to Pact Broker.
 
@@ -120,6 +132,7 @@ jobs:
 
   can-i-deploy:
     runs-on: ubuntu-latest
+    if: ${{ needs.init-github-context.outputs.fork == 'false' }}
     needs: [ init-github-context, publish-contracts ]
     steps:
       - name: Dispatch to terra-github-workflows
@@ -133,6 +146,7 @@ jobs:
 
   try-deploy:
     runs-on: ubuntu-latest
+    if: ${{ needs.init-github-context.outputs.fork == 'false' }}
     needs: [ init-github-context, can-i-deploy ]
     steps:
       - name: Dispatch to terra-github-workflows

--- a/.github/workflows/consumer_contract_tests.yml
+++ b/.github/workflows/consumer_contract_tests.yml
@@ -119,7 +119,7 @@ jobs:
 
   try-deploy:
     runs-on: ubuntu-latest
-    needs: [ init-github-context, publish-contracts ]
+    needs: [ init-github-context, can-i-deploy ]
     steps:
       - name: Dispatch to terra-github-workflows
         uses: broadinstitute/workflow-dispatch@v3

--- a/.github/workflows/consumer_contract_tests.yml
+++ b/.github/workflows/consumer_contract_tests.yml
@@ -27,19 +27,9 @@ name: Consumer contract tests
 # NOTE: The publish-contracts workflow will use the latest commit of the branch that triggers this workflow to publish the unique consumer contract version to Pact Broker.
 
 on:
-  pull_request:
-    branches:
-      - develop
-    paths-ignore:
-      - 'README.md'
   push:
     branches:
-      - develop
-    paths-ignore:
-      - 'README.md'
-  merge_group:
-    branches:
-      - develop
+      - QA-2056
     paths-ignore:
       - 'README.md'
 

--- a/.github/workflows/consumer_contract_tests.yml
+++ b/.github/workflows/consumer_contract_tests.yml
@@ -142,4 +142,4 @@ jobs:
           repo: broadinstitute/terra-github-workflows
           ref: refs/heads/main
           token: ${{ secrets.BROADBOT_TOKEN }} # github token for access to kick off a job in the private repo
-          inputs: '{ "pacticipant": "leo-consumer", "version": "${{ needs.init-github-context.outputs.repo-version }}", "environment": "alpha" }'
+          inputs: '{ "pacticipant": "leo-consumer", "version": "${{ needs.init-github-context.outputs.repo-version }}" }'

--- a/.github/workflows/consumer_contract_tests.yml
+++ b/.github/workflows/consumer_contract_tests.yml
@@ -39,11 +39,19 @@ name: Consumer contract tests
 # NOTE: The publish-contracts workflow will use the latest commit of the branch that triggers this workflow to publish the unique consumer contract version to Pact Broker.
 
 on:
-  push:
+  pull_request:
     branches:
-      - QA-2056
+      - develop
     paths-ignore:
       - 'README.md'
+  push:
+    branches:
+      - develop
+    paths-ignore:
+      - 'README.md'
+  merge_group:
+    branches:
+      - develop
 
 jobs:
   init-github-context:

--- a/.github/workflows/consumer_contract_tests.yml
+++ b/.github/workflows/consumer_contract_tests.yml
@@ -124,7 +124,7 @@ jobs:
       - name: Dispatch to terra-github-workflows
         uses: broadinstitute/workflow-dispatch@v3
         with:
-          workflow: publish-contracts
+          workflow: .github/workflows/publish-contracts.yaml
           repo: broadinstitute/terra-github-workflows
           ref: refs/heads/main
           token: ${{ secrets.BROADBOT_TOKEN }} # github token for access to kick off a job in the private repo
@@ -138,9 +138,9 @@ jobs:
       - name: Dispatch to terra-github-workflows
         uses: broadinstitute/workflow-dispatch@v3
         with:
-          workflow: can-i-deploy.yaml
+          workflow: .github/workflows/can-i-deploy.yaml
           repo: broadinstitute/terra-github-workflows
-          ref: refs/heads/QA-2056
+          ref: refs/heads/main
           token: ${{ secrets.BROADBOT_TOKEN }} # github token for access to kick off a job in the private repo
           inputs: '{ "pacticipant": "leo-consumer", "version": "${{ needs.init-github-context.outputs.repo-version }}", "environment": "alpha" }'
 
@@ -152,8 +152,8 @@ jobs:
       - name: Dispatch to terra-github-workflows
         uses: broadinstitute/workflow-dispatch@v3
         with:
-          workflow: record-deployment.yaml
+          workflow: .github/workflows/record-deployment.yaml
           repo: broadinstitute/terra-github-workflows
-          ref: refs/heads/QA-2056
+          ref: refs/heads/main
           token: ${{ secrets.BROADBOT_TOKEN }} # github token for access to kick off a job in the private repo
           inputs: '{ "pacticipant": "leo-consumer", "version": "${{ needs.init-github-context.outputs.repo-version }}", "environment": "alpha" }'

--- a/.github/workflows/consumer_contract_tests.yml
+++ b/.github/workflows/consumer_contract_tests.yml
@@ -69,6 +69,7 @@ jobs:
           echo "repo-owner=${{ github.repository_owner }}"
           echo "repo-name=${{ github.event.repository.name }}"
           echo "repo-branch=${{ steps.extract-branch.outputs.repo-branch }}"
+          echo "repo-version=${{ steps.extract-branch.outputs.repo-version }}"
 
   leo-consumer-contract-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/consumer_contract_tests.yml
+++ b/.github/workflows/consumer_contract_tests.yml
@@ -143,17 +143,3 @@ jobs:
           ref: refs/heads/main
           token: ${{ secrets.BROADBOT_TOKEN }} # github token for access to kick off a job in the private repo
           inputs: '{ "pacticipant": "leo-consumer", "version": "${{ needs.init-github-context.outputs.repo-version }}", "environment": "alpha" }'
-
-  try-deploy:
-    runs-on: ubuntu-latest
-    if: ${{ needs.init-github-context.outputs.fork == 'false' }}
-    needs: [ init-github-context, can-i-deploy ]
-    steps:
-      - name: Dispatch to terra-github-workflows
-        uses: broadinstitute/workflow-dispatch@v3
-        with:
-          workflow: .github/workflows/record-deployment.yaml
-          repo: broadinstitute/terra-github-workflows
-          ref: refs/heads/main
-          token: ${{ secrets.BROADBOT_TOKEN }} # github token for access to kick off a job in the private repo
-          inputs: '{ "pacticipant": "leo-consumer", "version": "${{ needs.init-github-context.outputs.repo-version }}", "environment": "alpha" }'

--- a/pact4s/src/test/scala/org/broadinstitute/dede/workbench/leonardo/consumer/SamClientSpec.scala
+++ b/pact4s/src/test/scala/org/broadinstitute/dede/workbench/leonardo/consumer/SamClientSpec.scala
@@ -155,7 +155,7 @@ class SamClientSpec extends AnyFlatSpec with Matchers with RequestResponsePactFo
   // for Sam provider to generate the expected response
   var pactDslResponse: PactDslResponse = buildInteraction(
     pactProvider,
-    state = "Sam is ok revision 7",
+    state = "Sam is ok revision 8",
     stateParams = subsystems.map(s => s.toString() -> "ok").toMap,
     uponReceiving = "Request to get Sam ok status",
     method = "GET",

--- a/pact4s/src/test/scala/org/broadinstitute/dede/workbench/leonardo/consumer/SamClientSpec.scala
+++ b/pact4s/src/test/scala/org/broadinstitute/dede/workbench/leonardo/consumer/SamClientSpec.scala
@@ -155,7 +155,7 @@ class SamClientSpec extends AnyFlatSpec with Matchers with RequestResponsePactFo
   // for Sam provider to generate the expected response
   var pactDslResponse: PactDslResponse = buildInteraction(
     pactProvider,
-    state = "Sam subsystems changes are ok to run in the Pact Broker pipeline",
+    state = "Sam subsystems changes are ok to run in the Pact Broker CI/CD pipeline",
     stateParams = subsystems.map(s => s.toString() -> "ok").toMap,
     uponReceiving = "Request to get Sam ok status",
     method = "GET",

--- a/pact4s/src/test/scala/org/broadinstitute/dede/workbench/leonardo/consumer/SamClientSpec.scala
+++ b/pact4s/src/test/scala/org/broadinstitute/dede/workbench/leonardo/consumer/SamClientSpec.scala
@@ -155,7 +155,7 @@ class SamClientSpec extends AnyFlatSpec with Matchers with RequestResponsePactFo
   // for Sam provider to generate the expected response
   var pactDslResponse: PactDslResponse = buildInteraction(
     pactProvider,
-    state = "Sam subsystems changes are still alright and ok and ok and ok ok",
+    state = "Sam subsystems changes are still alright and ok and ok and ok ok ok",
     stateParams = subsystems.map(s => s.toString() -> "ok").toMap,
     uponReceiving = "Request to get Sam ok status",
     method = "GET",

--- a/pact4s/src/test/scala/org/broadinstitute/dede/workbench/leonardo/consumer/SamClientSpec.scala
+++ b/pact4s/src/test/scala/org/broadinstitute/dede/workbench/leonardo/consumer/SamClientSpec.scala
@@ -155,7 +155,7 @@ class SamClientSpec extends AnyFlatSpec with Matchers with RequestResponsePactFo
   // for Sam provider to generate the expected response
   var pactDslResponse: PactDslResponse = buildInteraction(
     pactProvider,
-    state = "Sam subsystems changes are ok to run in the PB pipeline",
+    state = "Sam subsystems changes are ok to run in the Pact Broker pipeline",
     stateParams = subsystems.map(s => s.toString() -> "ok").toMap,
     uponReceiving = "Request to get Sam ok status",
     method = "GET",

--- a/pact4s/src/test/scala/org/broadinstitute/dede/workbench/leonardo/consumer/SamClientSpec.scala
+++ b/pact4s/src/test/scala/org/broadinstitute/dede/workbench/leonardo/consumer/SamClientSpec.scala
@@ -155,7 +155,7 @@ class SamClientSpec extends AnyFlatSpec with Matchers with RequestResponsePactFo
   // for Sam provider to generate the expected response
   var pactDslResponse: PactDslResponse = buildInteraction(
     pactProvider,
-    state = "Sam subsystems changes are still alright and ok and ok and ok",
+    state = "Sam subsystems changes are still alright and ok and ok and ok ok",
     stateParams = subsystems.map(s => s.toString() -> "ok").toMap,
     uponReceiving = "Request to get Sam ok status",
     method = "GET",

--- a/pact4s/src/test/scala/org/broadinstitute/dede/workbench/leonardo/consumer/SamClientSpec.scala
+++ b/pact4s/src/test/scala/org/broadinstitute/dede/workbench/leonardo/consumer/SamClientSpec.scala
@@ -155,7 +155,7 @@ class SamClientSpec extends AnyFlatSpec with Matchers with RequestResponsePactFo
   // for Sam provider to generate the expected response
   var pactDslResponse: PactDslResponse = buildInteraction(
     pactProvider,
-    state = "Sam subsystems changes are ok to run in our new pipeline",
+    state = "Sam subsystems changes are ok to run in our new CI/CD pipeline",
     stateParams = subsystems.map(s => s.toString() -> "ok").toMap,
     uponReceiving = "Request to get Sam ok status",
     method = "GET",

--- a/pact4s/src/test/scala/org/broadinstitute/dede/workbench/leonardo/consumer/SamClientSpec.scala
+++ b/pact4s/src/test/scala/org/broadinstitute/dede/workbench/leonardo/consumer/SamClientSpec.scala
@@ -155,7 +155,7 @@ class SamClientSpec extends AnyFlatSpec with Matchers with RequestResponsePactFo
   // for Sam provider to generate the expected response
   var pactDslResponse: PactDslResponse = buildInteraction(
     pactProvider,
-    state = "Sam subsystems changes are ok to run in the brand new Pact Broker CI/CD pipeline",
+    state = "Sam subsystems changes are ok to run in the ready Pact Broker CI/CD pipeline",
     stateParams = subsystems.map(s => s.toString() -> "ok").toMap,
     uponReceiving = "Request to get Sam ok status",
     method = "GET",

--- a/pact4s/src/test/scala/org/broadinstitute/dede/workbench/leonardo/consumer/SamClientSpec.scala
+++ b/pact4s/src/test/scala/org/broadinstitute/dede/workbench/leonardo/consumer/SamClientSpec.scala
@@ -155,7 +155,7 @@ class SamClientSpec extends AnyFlatSpec with Matchers with RequestResponsePactFo
   // for Sam provider to generate the expected response
   var pactDslResponse: PactDslResponse = buildInteraction(
     pactProvider,
-    state = "Sam subsystems changes are still alright and ok or ok",
+    state = "Sam subsystems changes are still alright and ok or or ok",
     stateParams = subsystems.map(s => s.toString() -> "ok").toMap,
     uponReceiving = "Request to get Sam ok status",
     method = "GET",

--- a/pact4s/src/test/scala/org/broadinstitute/dede/workbench/leonardo/consumer/SamClientSpec.scala
+++ b/pact4s/src/test/scala/org/broadinstitute/dede/workbench/leonardo/consumer/SamClientSpec.scala
@@ -155,7 +155,7 @@ class SamClientSpec extends AnyFlatSpec with Matchers with RequestResponsePactFo
   // for Sam provider to generate the expected response
   var pactDslResponse: PactDslResponse = buildInteraction(
     pactProvider,
-    state = "Sam subsystems changes are still alright and ok  ok",
+    state = "Sam subsystems changes are still alright and ok or ok",
     stateParams = subsystems.map(s => s.toString() -> "ok").toMap,
     uponReceiving = "Request to get Sam ok status",
     method = "GET",

--- a/pact4s/src/test/scala/org/broadinstitute/dede/workbench/leonardo/consumer/SamClientSpec.scala
+++ b/pact4s/src/test/scala/org/broadinstitute/dede/workbench/leonardo/consumer/SamClientSpec.scala
@@ -155,7 +155,7 @@ class SamClientSpec extends AnyFlatSpec with Matchers with RequestResponsePactFo
   // for Sam provider to generate the expected response
   var pactDslResponse: PactDslResponse = buildInteraction(
     pactProvider,
-    state = "Sam subsystems changes are ok to run in our new Pact Broker pipeline",
+    state = "Sam subsystems changes are ok to run in our Pact Broker pipeline",
     stateParams = subsystems.map(s => s.toString() -> "ok").toMap,
     uponReceiving = "Request to get Sam ok status",
     method = "GET",

--- a/pact4s/src/test/scala/org/broadinstitute/dede/workbench/leonardo/consumer/SamClientSpec.scala
+++ b/pact4s/src/test/scala/org/broadinstitute/dede/workbench/leonardo/consumer/SamClientSpec.scala
@@ -155,7 +155,7 @@ class SamClientSpec extends AnyFlatSpec with Matchers with RequestResponsePactFo
   // for Sam provider to generate the expected response
   var pactDslResponse: PactDslResponse = buildInteraction(
     pactProvider,
-    state = "Sam subsystems are ok",
+    state = "Sam subsystems changes are ok",
     stateParams = subsystems.map(s => s.toString() -> "ok").toMap,
     uponReceiving = "Request to get Sam ok status",
     method = "GET",

--- a/pact4s/src/test/scala/org/broadinstitute/dede/workbench/leonardo/consumer/SamClientSpec.scala
+++ b/pact4s/src/test/scala/org/broadinstitute/dede/workbench/leonardo/consumer/SamClientSpec.scala
@@ -155,7 +155,7 @@ class SamClientSpec extends AnyFlatSpec with Matchers with RequestResponsePactFo
   // for Sam provider to generate the expected response
   var pactDslResponse: PactDslResponse = buildInteraction(
     pactProvider,
-    state = "Sam subsystems changes are ok to run in the ready Pact Broker CI/CD pipeline",
+    state = "Sam subsystems changes are ok to run readiness in Pact Broker CI/CD pipeline",
     stateParams = subsystems.map(s => s.toString() -> "ok").toMap,
     uponReceiving = "Request to get Sam ok status",
     method = "GET",

--- a/pact4s/src/test/scala/org/broadinstitute/dede/workbench/leonardo/consumer/SamClientSpec.scala
+++ b/pact4s/src/test/scala/org/broadinstitute/dede/workbench/leonardo/consumer/SamClientSpec.scala
@@ -155,7 +155,7 @@ class SamClientSpec extends AnyFlatSpec with Matchers with RequestResponsePactFo
   // for Sam provider to generate the expected response
   var pactDslResponse: PactDslResponse = buildInteraction(
     pactProvider,
-    state = "Sam subsystems changes are still alright and ok and ok and ok ok ok",
+    state = "Sam subsystems changes are still alright and ok and ok and ok ok ok ok",
     stateParams = subsystems.map(s => s.toString() -> "ok").toMap,
     uponReceiving = "Request to get Sam ok status",
     method = "GET",

--- a/pact4s/src/test/scala/org/broadinstitute/dede/workbench/leonardo/consumer/SamClientSpec.scala
+++ b/pact4s/src/test/scala/org/broadinstitute/dede/workbench/leonardo/consumer/SamClientSpec.scala
@@ -155,7 +155,7 @@ class SamClientSpec extends AnyFlatSpec with Matchers with RequestResponsePactFo
   // for Sam provider to generate the expected response
   var pactDslResponse: PactDslResponse = buildInteraction(
     pactProvider,
-    state = "Sam is ok revision 8",
+    state = "Sam is ok",
     stateParams = subsystems.map(s => s.toString() -> "ok").toMap,
     uponReceiving = "Request to get Sam ok status",
     method = "GET",

--- a/pact4s/src/test/scala/org/broadinstitute/dede/workbench/leonardo/consumer/SamClientSpec.scala
+++ b/pact4s/src/test/scala/org/broadinstitute/dede/workbench/leonardo/consumer/SamClientSpec.scala
@@ -155,7 +155,7 @@ class SamClientSpec extends AnyFlatSpec with Matchers with RequestResponsePactFo
   // for Sam provider to generate the expected response
   var pactDslResponse: PactDslResponse = buildInteraction(
     pactProvider,
-    state = "Sam is ok revision 4",
+    state = "Sam is ok revision 5",
     stateParams = subsystems.map(s => s.toString() -> "ok").toMap,
     uponReceiving = "Request to get Sam ok status",
     method = "GET",

--- a/pact4s/src/test/scala/org/broadinstitute/dede/workbench/leonardo/consumer/SamClientSpec.scala
+++ b/pact4s/src/test/scala/org/broadinstitute/dede/workbench/leonardo/consumer/SamClientSpec.scala
@@ -155,7 +155,7 @@ class SamClientSpec extends AnyFlatSpec with Matchers with RequestResponsePactFo
   // for Sam provider to generate the expected response
   var pactDslResponse: PactDslResponse = buildInteraction(
     pactProvider,
-    state = "Sam is ok revision 5",
+    state = "Sam is ok revision 6",
     stateParams = subsystems.map(s => s.toString() -> "ok").toMap,
     uponReceiving = "Request to get Sam ok status",
     method = "GET",

--- a/pact4s/src/test/scala/org/broadinstitute/dede/workbench/leonardo/consumer/SamClientSpec.scala
+++ b/pact4s/src/test/scala/org/broadinstitute/dede/workbench/leonardo/consumer/SamClientSpec.scala
@@ -155,7 +155,7 @@ class SamClientSpec extends AnyFlatSpec with Matchers with RequestResponsePactFo
   // for Sam provider to generate the expected response
   var pactDslResponse: PactDslResponse = buildInteraction(
     pactProvider,
-    state = "Sam is ok",
+    state = "Sam subsystems are ok",
     stateParams = subsystems.map(s => s.toString() -> "ok").toMap,
     uponReceiving = "Request to get Sam ok status",
     method = "GET",

--- a/pact4s/src/test/scala/org/broadinstitute/dede/workbench/leonardo/consumer/SamClientSpec.scala
+++ b/pact4s/src/test/scala/org/broadinstitute/dede/workbench/leonardo/consumer/SamClientSpec.scala
@@ -155,7 +155,7 @@ class SamClientSpec extends AnyFlatSpec with Matchers with RequestResponsePactFo
   // for Sam provider to generate the expected response
   var pactDslResponse: PactDslResponse = buildInteraction(
     pactProvider,
-    state = "Sam subsystems changes are still alright and ok",
+    state = "Sam subsystems changes are still alright and ok and ok",
     stateParams = subsystems.map(s => s.toString() -> "ok").toMap,
     uponReceiving = "Request to get Sam ok status",
     method = "GET",

--- a/pact4s/src/test/scala/org/broadinstitute/dede/workbench/leonardo/consumer/SamClientSpec.scala
+++ b/pact4s/src/test/scala/org/broadinstitute/dede/workbench/leonardo/consumer/SamClientSpec.scala
@@ -155,7 +155,7 @@ class SamClientSpec extends AnyFlatSpec with Matchers with RequestResponsePactFo
   // for Sam provider to generate the expected response
   var pactDslResponse: PactDslResponse = buildInteraction(
     pactProvider,
-    state = "Sam subsystems changes are all ok",
+    state = "Sam subsystems changes are all good",
     stateParams = subsystems.map(s => s.toString() -> "ok").toMap,
     uponReceiving = "Request to get Sam ok status",
     method = "GET",

--- a/pact4s/src/test/scala/org/broadinstitute/dede/workbench/leonardo/consumer/SamClientSpec.scala
+++ b/pact4s/src/test/scala/org/broadinstitute/dede/workbench/leonardo/consumer/SamClientSpec.scala
@@ -155,7 +155,7 @@ class SamClientSpec extends AnyFlatSpec with Matchers with RequestResponsePactFo
   // for Sam provider to generate the expected response
   var pactDslResponse: PactDslResponse = buildInteraction(
     pactProvider,
-    state = "Sam subsystems changes are still alright and ok and ok and ok ok ok ok",
+    state = "Sam subsystems changes are still alright and ok  ok",
     stateParams = subsystems.map(s => s.toString() -> "ok").toMap,
     uponReceiving = "Request to get Sam ok status",
     method = "GET",

--- a/pact4s/src/test/scala/org/broadinstitute/dede/workbench/leonardo/consumer/SamClientSpec.scala
+++ b/pact4s/src/test/scala/org/broadinstitute/dede/workbench/leonardo/consumer/SamClientSpec.scala
@@ -155,7 +155,7 @@ class SamClientSpec extends AnyFlatSpec with Matchers with RequestResponsePactFo
   // for Sam provider to generate the expected response
   var pactDslResponse: PactDslResponse = buildInteraction(
     pactProvider,
-    state = "Sam subsystems changes are still alright",
+    state = "Sam subsystems changes are still alright and ok",
     stateParams = subsystems.map(s => s.toString() -> "ok").toMap,
     uponReceiving = "Request to get Sam ok status",
     method = "GET",

--- a/pact4s/src/test/scala/org/broadinstitute/dede/workbench/leonardo/consumer/SamClientSpec.scala
+++ b/pact4s/src/test/scala/org/broadinstitute/dede/workbench/leonardo/consumer/SamClientSpec.scala
@@ -155,7 +155,7 @@ class SamClientSpec extends AnyFlatSpec with Matchers with RequestResponsePactFo
   // for Sam provider to generate the expected response
   var pactDslResponse: PactDslResponse = buildInteraction(
     pactProvider,
-    state = "Sam subsystems changes are ok to run readiness in Pact Broker CI/CD pipeline",
+    state = "Sam is ok",
     stateParams = subsystems.map(s => s.toString() -> "ok").toMap,
     uponReceiving = "Request to get Sam ok status",
     method = "GET",

--- a/pact4s/src/test/scala/org/broadinstitute/dede/workbench/leonardo/consumer/SamClientSpec.scala
+++ b/pact4s/src/test/scala/org/broadinstitute/dede/workbench/leonardo/consumer/SamClientSpec.scala
@@ -155,7 +155,7 @@ class SamClientSpec extends AnyFlatSpec with Matchers with RequestResponsePactFo
   // for Sam provider to generate the expected response
   var pactDslResponse: PactDslResponse = buildInteraction(
     pactProvider,
-    state = "Sam subsystems are all ok",
+    state = "Sam subsystems are ok",
     stateParams = subsystems.map(s => s.toString() -> "ok").toMap,
     uponReceiving = "Request to get Sam ok status",
     method = "GET",

--- a/pact4s/src/test/scala/org/broadinstitute/dede/workbench/leonardo/consumer/SamClientSpec.scala
+++ b/pact4s/src/test/scala/org/broadinstitute/dede/workbench/leonardo/consumer/SamClientSpec.scala
@@ -155,7 +155,7 @@ class SamClientSpec extends AnyFlatSpec with Matchers with RequestResponsePactFo
   // for Sam provider to generate the expected response
   var pactDslResponse: PactDslResponse = buildInteraction(
     pactProvider,
-    state = "Sam subsystems changes are ok to run in pipeline",
+    state = "Sam subsystems changes are ok to run in the new pipeline",
     stateParams = subsystems.map(s => s.toString() -> "ok").toMap,
     uponReceiving = "Request to get Sam ok status",
     method = "GET",

--- a/pact4s/src/test/scala/org/broadinstitute/dede/workbench/leonardo/consumer/SamClientSpec.scala
+++ b/pact4s/src/test/scala/org/broadinstitute/dede/workbench/leonardo/consumer/SamClientSpec.scala
@@ -155,7 +155,7 @@ class SamClientSpec extends AnyFlatSpec with Matchers with RequestResponsePactFo
   // for Sam provider to generate the expected response
   var pactDslResponse: PactDslResponse = buildInteraction(
     pactProvider,
-    state = "Sam - subsystems are ok",
+    state = "Sam subsystems are ok",
     stateParams = subsystems.map(s => s.toString() -> "ok").toMap,
     uponReceiving = "Request to get Sam ok status",
     method = "GET",

--- a/pact4s/src/test/scala/org/broadinstitute/dede/workbench/leonardo/consumer/SamClientSpec.scala
+++ b/pact4s/src/test/scala/org/broadinstitute/dede/workbench/leonardo/consumer/SamClientSpec.scala
@@ -155,7 +155,7 @@ class SamClientSpec extends AnyFlatSpec with Matchers with RequestResponsePactFo
   // for Sam provider to generate the expected response
   var pactDslResponse: PactDslResponse = buildInteraction(
     pactProvider,
-    state = "Sam is ok check 2",
+    state = "Sam is ok check 3",
     stateParams = subsystems.map(s => s.toString() -> "ok").toMap,
     uponReceiving = "Request to get Sam ok status",
     method = "GET",

--- a/pact4s/src/test/scala/org/broadinstitute/dede/workbench/leonardo/consumer/SamClientSpec.scala
+++ b/pact4s/src/test/scala/org/broadinstitute/dede/workbench/leonardo/consumer/SamClientSpec.scala
@@ -155,7 +155,7 @@ class SamClientSpec extends AnyFlatSpec with Matchers with RequestResponsePactFo
   // for Sam provider to generate the expected response
   var pactDslResponse: PactDslResponse = buildInteraction(
     pactProvider,
-    state = "Sam subsystems changes are ok",
+    state = "Sam subsystems changes are all ok",
     stateParams = subsystems.map(s => s.toString() -> "ok").toMap,
     uponReceiving = "Request to get Sam ok status",
     method = "GET",

--- a/pact4s/src/test/scala/org/broadinstitute/dede/workbench/leonardo/consumer/SamClientSpec.scala
+++ b/pact4s/src/test/scala/org/broadinstitute/dede/workbench/leonardo/consumer/SamClientSpec.scala
@@ -155,7 +155,7 @@ class SamClientSpec extends AnyFlatSpec with Matchers with RequestResponsePactFo
   // for Sam provider to generate the expected response
   var pactDslResponse: PactDslResponse = buildInteraction(
     pactProvider,
-    state = "Sam subsystems are ok",
+    state = "Sam subsystems are all ok",
     stateParams = subsystems.map(s => s.toString() -> "ok").toMap,
     uponReceiving = "Request to get Sam ok status",
     method = "GET",

--- a/pact4s/src/test/scala/org/broadinstitute/dede/workbench/leonardo/consumer/SamClientSpec.scala
+++ b/pact4s/src/test/scala/org/broadinstitute/dede/workbench/leonardo/consumer/SamClientSpec.scala
@@ -155,7 +155,7 @@ class SamClientSpec extends AnyFlatSpec with Matchers with RequestResponsePactFo
   // for Sam provider to generate the expected response
   var pactDslResponse: PactDslResponse = buildInteraction(
     pactProvider,
-    state = "Sam subsystems changes are all good and ok",
+    state = "Sam subsystems changes are still ok",
     stateParams = subsystems.map(s => s.toString() -> "ok").toMap,
     uponReceiving = "Request to get Sam ok status",
     method = "GET",

--- a/pact4s/src/test/scala/org/broadinstitute/dede/workbench/leonardo/consumer/SamClientSpec.scala
+++ b/pact4s/src/test/scala/org/broadinstitute/dede/workbench/leonardo/consumer/SamClientSpec.scala
@@ -155,7 +155,7 @@ class SamClientSpec extends AnyFlatSpec with Matchers with RequestResponsePactFo
   // for Sam provider to generate the expected response
   var pactDslResponse: PactDslResponse = buildInteraction(
     pactProvider,
-    state = "Sam is ok",
+    state = "Sam is ok check",
     stateParams = subsystems.map(s => s.toString() -> "ok").toMap,
     uponReceiving = "Request to get Sam ok status",
     method = "GET",

--- a/pact4s/src/test/scala/org/broadinstitute/dede/workbench/leonardo/consumer/SamClientSpec.scala
+++ b/pact4s/src/test/scala/org/broadinstitute/dede/workbench/leonardo/consumer/SamClientSpec.scala
@@ -155,7 +155,7 @@ class SamClientSpec extends AnyFlatSpec with Matchers with RequestResponsePactFo
   // for Sam provider to generate the expected response
   var pactDslResponse: PactDslResponse = buildInteraction(
     pactProvider,
-    state = "Sam subsystems changes are still alright and ok or and ok",
+    state = "Sam subsystems changes are ok to run in CICD",
     stateParams = subsystems.map(s => s.toString() -> "ok").toMap,
     uponReceiving = "Request to get Sam ok status",
     method = "GET",

--- a/pact4s/src/test/scala/org/broadinstitute/dede/workbench/leonardo/consumer/SamClientSpec.scala
+++ b/pact4s/src/test/scala/org/broadinstitute/dede/workbench/leonardo/consumer/SamClientSpec.scala
@@ -155,7 +155,7 @@ class SamClientSpec extends AnyFlatSpec with Matchers with RequestResponsePactFo
   // for Sam provider to generate the expected response
   var pactDslResponse: PactDslResponse = buildInteraction(
     pactProvider,
-    state = "Sam subsystems changes are ok to run in our PB pipeline",
+    state = "Sam subsystems changes are ok to run in the PB pipeline",
     stateParams = subsystems.map(s => s.toString() -> "ok").toMap,
     uponReceiving = "Request to get Sam ok status",
     method = "GET",

--- a/pact4s/src/test/scala/org/broadinstitute/dede/workbench/leonardo/consumer/SamClientSpec.scala
+++ b/pact4s/src/test/scala/org/broadinstitute/dede/workbench/leonardo/consumer/SamClientSpec.scala
@@ -155,7 +155,7 @@ class SamClientSpec extends AnyFlatSpec with Matchers with RequestResponsePactFo
   // for Sam provider to generate the expected response
   var pactDslResponse: PactDslResponse = buildInteraction(
     pactProvider,
-    state = "Sam subsystems changes are ok to run in the Pact Broker CI/CD pipeline",
+    state = "Sam subsystems changes are ok to run in the new Pact Broker CI/CD pipeline",
     stateParams = subsystems.map(s => s.toString() -> "ok").toMap,
     uponReceiving = "Request to get Sam ok status",
     method = "GET",

--- a/pact4s/src/test/scala/org/broadinstitute/dede/workbench/leonardo/consumer/SamClientSpec.scala
+++ b/pact4s/src/test/scala/org/broadinstitute/dede/workbench/leonardo/consumer/SamClientSpec.scala
@@ -155,7 +155,7 @@ class SamClientSpec extends AnyFlatSpec with Matchers with RequestResponsePactFo
   // for Sam provider to generate the expected response
   var pactDslResponse: PactDslResponse = buildInteraction(
     pactProvider,
-    state = "Sam subsystems changes are ok to run in our Pact Broker pipeline",
+    state = "Sam subsystems changes are ok to run in our PB pipeline",
     stateParams = subsystems.map(s => s.toString() -> "ok").toMap,
     uponReceiving = "Request to get Sam ok status",
     method = "GET",

--- a/pact4s/src/test/scala/org/broadinstitute/dede/workbench/leonardo/consumer/SamClientSpec.scala
+++ b/pact4s/src/test/scala/org/broadinstitute/dede/workbench/leonardo/consumer/SamClientSpec.scala
@@ -155,7 +155,7 @@ class SamClientSpec extends AnyFlatSpec with Matchers with RequestResponsePactFo
   // for Sam provider to generate the expected response
   var pactDslResponse: PactDslResponse = buildInteraction(
     pactProvider,
-    state = "Sam subsystems changes are ok to run in CICD",
+    state = "Sam subsystems changes are ok to run in pipeline",
     stateParams = subsystems.map(s => s.toString() -> "ok").toMap,
     uponReceiving = "Request to get Sam ok status",
     method = "GET",

--- a/pact4s/src/test/scala/org/broadinstitute/dede/workbench/leonardo/consumer/SamClientSpec.scala
+++ b/pact4s/src/test/scala/org/broadinstitute/dede/workbench/leonardo/consumer/SamClientSpec.scala
@@ -155,7 +155,7 @@ class SamClientSpec extends AnyFlatSpec with Matchers with RequestResponsePactFo
   // for Sam provider to generate the expected response
   var pactDslResponse: PactDslResponse = buildInteraction(
     pactProvider,
-    state = "Sam is ok revision 6",
+    state = "Sam is ok revision 7",
     stateParams = subsystems.map(s => s.toString() -> "ok").toMap,
     uponReceiving = "Request to get Sam ok status",
     method = "GET",

--- a/pact4s/src/test/scala/org/broadinstitute/dede/workbench/leonardo/consumer/SamClientSpec.scala
+++ b/pact4s/src/test/scala/org/broadinstitute/dede/workbench/leonardo/consumer/SamClientSpec.scala
@@ -155,7 +155,7 @@ class SamClientSpec extends AnyFlatSpec with Matchers with RequestResponsePactFo
   // for Sam provider to generate the expected response
   var pactDslResponse: PactDslResponse = buildInteraction(
     pactProvider,
-    state = "Sam is ok check",
+    state = "Sam is ok check 2",
     stateParams = subsystems.map(s => s.toString() -> "ok").toMap,
     uponReceiving = "Request to get Sam ok status",
     method = "GET",

--- a/pact4s/src/test/scala/org/broadinstitute/dede/workbench/leonardo/consumer/SamClientSpec.scala
+++ b/pact4s/src/test/scala/org/broadinstitute/dede/workbench/leonardo/consumer/SamClientSpec.scala
@@ -155,7 +155,7 @@ class SamClientSpec extends AnyFlatSpec with Matchers with RequestResponsePactFo
   // for Sam provider to generate the expected response
   var pactDslResponse: PactDslResponse = buildInteraction(
     pactProvider,
-    state = "Sam subsystems changes are still alright and ok or or ok",
+    state = "Sam subsystems changes are still alright and ok or and ok",
     stateParams = subsystems.map(s => s.toString() -> "ok").toMap,
     uponReceiving = "Request to get Sam ok status",
     method = "GET",

--- a/pact4s/src/test/scala/org/broadinstitute/dede/workbench/leonardo/consumer/SamClientSpec.scala
+++ b/pact4s/src/test/scala/org/broadinstitute/dede/workbench/leonardo/consumer/SamClientSpec.scala
@@ -155,7 +155,7 @@ class SamClientSpec extends AnyFlatSpec with Matchers with RequestResponsePactFo
   // for Sam provider to generate the expected response
   var pactDslResponse: PactDslResponse = buildInteraction(
     pactProvider,
-    state = "Sam subsystems changes are all good",
+    state = "Sam subsystems changes are all good and ok",
     stateParams = subsystems.map(s => s.toString() -> "ok").toMap,
     uponReceiving = "Request to get Sam ok status",
     method = "GET",

--- a/pact4s/src/test/scala/org/broadinstitute/dede/workbench/leonardo/consumer/SamClientSpec.scala
+++ b/pact4s/src/test/scala/org/broadinstitute/dede/workbench/leonardo/consumer/SamClientSpec.scala
@@ -155,7 +155,7 @@ class SamClientSpec extends AnyFlatSpec with Matchers with RequestResponsePactFo
   // for Sam provider to generate the expected response
   var pactDslResponse: PactDslResponse = buildInteraction(
     pactProvider,
-    state = "Sam is ok check 3",
+    state = "Sam is ok revision 4",
     stateParams = subsystems.map(s => s.toString() -> "ok").toMap,
     uponReceiving = "Request to get Sam ok status",
     method = "GET",

--- a/pact4s/src/test/scala/org/broadinstitute/dede/workbench/leonardo/consumer/SamClientSpec.scala
+++ b/pact4s/src/test/scala/org/broadinstitute/dede/workbench/leonardo/consumer/SamClientSpec.scala
@@ -155,7 +155,7 @@ class SamClientSpec extends AnyFlatSpec with Matchers with RequestResponsePactFo
   // for Sam provider to generate the expected response
   var pactDslResponse: PactDslResponse = buildInteraction(
     pactProvider,
-    state = "Sam subsystems are ok",
+    state = "Sam - subsystems are ok",
     stateParams = subsystems.map(s => s.toString() -> "ok").toMap,
     uponReceiving = "Request to get Sam ok status",
     method = "GET",

--- a/pact4s/src/test/scala/org/broadinstitute/dede/workbench/leonardo/consumer/SamClientSpec.scala
+++ b/pact4s/src/test/scala/org/broadinstitute/dede/workbench/leonardo/consumer/SamClientSpec.scala
@@ -155,7 +155,7 @@ class SamClientSpec extends AnyFlatSpec with Matchers with RequestResponsePactFo
   // for Sam provider to generate the expected response
   var pactDslResponse: PactDslResponse = buildInteraction(
     pactProvider,
-    state = "Sam subsystems changes are ok to run in the new Pact Broker CI/CD pipeline",
+    state = "Sam subsystems changes are ok to run in the brand new Pact Broker CI/CD pipeline",
     stateParams = subsystems.map(s => s.toString() -> "ok").toMap,
     uponReceiving = "Request to get Sam ok status",
     method = "GET",

--- a/pact4s/src/test/scala/org/broadinstitute/dede/workbench/leonardo/consumer/SamClientSpec.scala
+++ b/pact4s/src/test/scala/org/broadinstitute/dede/workbench/leonardo/consumer/SamClientSpec.scala
@@ -155,7 +155,7 @@ class SamClientSpec extends AnyFlatSpec with Matchers with RequestResponsePactFo
   // for Sam provider to generate the expected response
   var pactDslResponse: PactDslResponse = buildInteraction(
     pactProvider,
-    state = "Sam subsystems changes are still alright and ok and ok",
+    state = "Sam subsystems changes are still alright and ok and ok and ok",
     stateParams = subsystems.map(s => s.toString() -> "ok").toMap,
     uponReceiving = "Request to get Sam ok status",
     method = "GET",

--- a/pact4s/src/test/scala/org/broadinstitute/dede/workbench/leonardo/consumer/SamClientSpec.scala
+++ b/pact4s/src/test/scala/org/broadinstitute/dede/workbench/leonardo/consumer/SamClientSpec.scala
@@ -155,7 +155,7 @@ class SamClientSpec extends AnyFlatSpec with Matchers with RequestResponsePactFo
   // for Sam provider to generate the expected response
   var pactDslResponse: PactDslResponse = buildInteraction(
     pactProvider,
-    state = "Sam subsystems changes are ok to run in the new pipeline",
+    state = "Sam subsystems changes are ok to run in our new pipeline",
     stateParams = subsystems.map(s => s.toString() -> "ok").toMap,
     uponReceiving = "Request to get Sam ok status",
     method = "GET",

--- a/pact4s/src/test/scala/org/broadinstitute/dede/workbench/leonardo/consumer/SamClientSpec.scala
+++ b/pact4s/src/test/scala/org/broadinstitute/dede/workbench/leonardo/consumer/SamClientSpec.scala
@@ -155,7 +155,7 @@ class SamClientSpec extends AnyFlatSpec with Matchers with RequestResponsePactFo
   // for Sam provider to generate the expected response
   var pactDslResponse: PactDslResponse = buildInteraction(
     pactProvider,
-    state = "Sam subsystems changes are still ok",
+    state = "Sam subsystems changes are still alright",
     stateParams = subsystems.map(s => s.toString() -> "ok").toMap,
     uponReceiving = "Request to get Sam ok status",
     method = "GET",

--- a/pact4s/src/test/scala/org/broadinstitute/dede/workbench/leonardo/consumer/SamClientSpec.scala
+++ b/pact4s/src/test/scala/org/broadinstitute/dede/workbench/leonardo/consumer/SamClientSpec.scala
@@ -155,7 +155,7 @@ class SamClientSpec extends AnyFlatSpec with Matchers with RequestResponsePactFo
   // for Sam provider to generate the expected response
   var pactDslResponse: PactDslResponse = buildInteraction(
     pactProvider,
-    state = "Sam subsystems changes are ok to run in our new PB pipeline",
+    state = "Sam subsystems changes are ok to run in our new Pact Broker pipeline",
     stateParams = subsystems.map(s => s.toString() -> "ok").toMap,
     uponReceiving = "Request to get Sam ok status",
     method = "GET",

--- a/pact4s/src/test/scala/org/broadinstitute/dede/workbench/leonardo/consumer/SamClientSpec.scala
+++ b/pact4s/src/test/scala/org/broadinstitute/dede/workbench/leonardo/consumer/SamClientSpec.scala
@@ -155,7 +155,7 @@ class SamClientSpec extends AnyFlatSpec with Matchers with RequestResponsePactFo
   // for Sam provider to generate the expected response
   var pactDslResponse: PactDslResponse = buildInteraction(
     pactProvider,
-    state = "Sam subsystems changes are ok to run in our new CI/CD pipeline",
+    state = "Sam subsystems changes are ok to run in our new PB pipeline",
     stateParams = subsystems.map(s => s.toString() -> "ok").toMap,
     uponReceiving = "Request to get Sam ok status",
     method = "GET",


### PR DESCRIPTION
Ticket: [QA-2056](https://broadworkbench.atlassian.net/browse/QA-2056)

What:

This PR enhances the Consumer CI required to meet the definition of *Platinum* as described in [https://docs.pact.io/pact_nirvana/step_6](https://docs.pact.io/pact_nirvana/step_6)

Why:

Meeting the Platinum standard means that `Leonardo` can now use contract tests as part of an automated, end-to-end Independent Release process.

The following steps will become an integral part of the process.

1. automated verification of Leonardo pact changes against all providers
2. automated verification of Sam (as a provider) changes against Leonardo pacts on all deployed environments

How:

The magic that enables 1) is configured as `webhook` in the Pact Broker.
Logic has been added to `SamProviderSpec` in Sam repo to support 1) and 2).

---
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get a thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green (you can re-run automation tests with a comment saying `jenkins retest`
- [ ] Run the automation tests multiple times in parallel to weed out instability if applicable via a comment saying `multi-test`
- [ ] Squash and merge; Delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment


[QA-2056]: https://broadworkbench.atlassian.net/browse/QA-2056?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ