### PR TITLE
Reverting IA-3961: hybrid connection name includes workspaceId

### DIFF
--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/AppServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/AppServiceInterp.scala
@@ -1057,14 +1057,6 @@ final class LeoAppServiceInterp[F[_]: Parallel](config: AppServiceConfig,
         case _ => Right(())
       }
 
-      // adding the relayHybridConnection name to custom env vars
-      // necessary for backwards compatibility before workspace was added to name
-      customEnvironmentVariables = (cloudContext.cloudProvider, workspaceId) match {
-        case (CloudProvider.Azure, Some(workspaceId)) =>
-          req.customEnvironmentVariables + ("RELAY_HYBRID_CONNECTION_NAME" -> s"${appName.value}-${workspaceId.value}")
-        case _ => req.customEnvironmentVariables
-      }
-
       // Generate namespace and app release names using a random 6-character string prefix.
       //
       // Theoretically release names should only need to be unique within a namespace, but the Galaxy
@@ -1132,7 +1124,7 @@ final class LeoAppServiceInterp[F[_]: Parallel](config: AppServiceConfig,
           Option(gkeAppConfig.serviceAccountName)
         ),
         List.empty,
-        customEnvironmentVariables,
+        req.customEnvironmentVariables,
         req.descriptorPath,
         req.extraArgs,
         req.sourceWorkspaceId

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/AppServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/AppServiceInterpSpec.scala
@@ -1507,9 +1507,7 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
 
   it should "V2 Azure - create an app V2" in isolatedDbTest {
     val appName = AppName("app1")
-    val customEnvVars = Map("WORKSPACE_NAME" -> "testWorkspace",
-                            "RELAY_HYBRID_CONNECTION_NAME" -> s"${appName.value}-${workspaceId.value}"
-    )
+    val customEnvVars = Map("WORKSPACE_NAME" -> "testWorkspace")
     val appReq = createAppRequest.copy(kubernetesRuntimeConfig = None,
                                        appType = AppType.Cromwell,
                                        diskConfig = None,

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/AKSInterpreterSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/AKSInterpreterSpec.scala
@@ -15,7 +15,7 @@ import com.azure.resourcemanager.msi.models.{Identities, Identity}
 import io.kubernetes.client.openapi.apis.CoreV1Api
 import io.kubernetes.client.openapi.models._
 import org.broadinstitute.dsde.workbench.azure._
-import org.mockito.ArgumentMatchers
+import org.broadinstitute.dsde.workbench.azure.mock.FakeAzureRelayService
 import org.broadinstitute.dsde.workbench.google2.KubernetesSerializableName.{NamespaceName, ServiceAccountName}
 import org.broadinstitute.dsde.workbench.google2.{NetworkName, SubnetworkName}
 import org.broadinstitute.dsde.workbench.leonardo.CommonTestData.{
@@ -35,7 +35,7 @@ import org.broadinstitute.dsp.Release
 import org.broadinstitute.dsp.mocks.MockHelm
 import org.http4s.Uri
 import org.mockito.ArgumentMatchers.{any, anyString}
-import org.mockito.Mockito.{verify, when}
+import org.mockito.Mockito.when
 import org.scalatest.flatspec.AnyFlatSpecLike
 import org.scalatestplus.mockito.MockitoSugar
 
@@ -67,7 +67,6 @@ class AKSInterpreterSpec extends AnyFlatSpecLike with TestComponent with Leonard
   val mockAzureContainerService = setUpMockAzureContainerService
   val mockAzureApplicationInsightsService = setUpMockAzureApplicationInsightsService
   val mockAzureBatchService = setUpMockAzureBatchService
-  val mockAzureRelayService = setUpMockAzureRelayService
 
   val aksInterp = new AKSInterpreter[IO](
     config,
@@ -75,7 +74,7 @@ class AKSInterpreterSpec extends AnyFlatSpecLike with TestComponent with Leonard
     mockAzureBatchService,
     mockAzureContainerService,
     mockAzureApplicationInsightsService,
-    mockAzureRelayService,
+    FakeAzureRelayService,
     mockSamDAO,
     mockCromwellDAO,
     mockCbasDAO,
@@ -352,37 +351,10 @@ class AKSInterpreterSpec extends AnyFlatSpecLike with TestComponent with Leonard
 
   for (appType <- List(AppType.Wds, AppType.Cromwell))
     it should s"create and poll a shared ${appType} app, then successfully delete it" in isolatedDbTest {
-      val mockAzureRelayService = setUpMockAzureRelayService
-
-      val aksInterp = new AKSInterpreter[IO](
-        config,
-        MockHelm,
-        mockAzureBatchService,
-        mockAzureContainerService,
-        mockAzureApplicationInsightsService,
-        mockAzureRelayService,
-        mockSamDAO,
-        mockCromwellDAO,
-        mockCbasDAO,
-        mockCbasUiDAO,
-        mockWdsDAO
-      ) {
-        override private[util] def buildMsiManager(cloudContext: AzureCloudContext) = IO.pure(setUpMockMsiManager)
-
-        override private[util] def buildComputeManager(cloudContext: AzureCloudContext) =
-          IO.pure(setUpMockComputeManager)
-
-        override private[util] def buildCoreV1Client(cloudContext: AzureCloudContext,
-                                                     clusterName: AKSClusterName
-        ): IO[CoreV1Api] = IO.pure(setUpMockKubeAPI)
-      }
       val res = for {
         cluster <- IO(makeKubeCluster(1).copy(cloudContext = CloudContext.Azure(cloudContext)).save())
         nodepool <- IO(makeNodepool(1, cluster.id).save())
-        customEnvVars = Map("WORKSPACE_NAME" -> "testWorkspace",
-                            "RELAY_HYBRID_CONNECTION_NAME" -> s"app1-${workspaceId.value}"
-        )
-        app = makeApp(1, nodepool.id, customEnvironmentVariables = customEnvVars).copy(
+        app = makeApp(1, nodepool.id).copy(
           appType = appType,
           appResources = AppResources(
             namespace = Namespace(
@@ -429,102 +401,10 @@ class AKSInterpreterSpec extends AnyFlatSpecLike with TestComponent with Leonard
         deletedApp <- KubernetesServiceDbQueries
           .getActiveFullAppByName(CloudContext.Azure(cloudContext), app.appName)
           .transaction
-      } yield {
-        deletedApp shouldBe None
-        verify(mockAzureRelayService).deleteRelayHybridConnection(
-          RelayNamespace(ArgumentMatchers.eq(landingZoneResources.relayNamespace.value)),
-          RelayHybridConnectionName(ArgumentMatchers.eq(s"${app.appName.value}-${workspaceId.value}")),
-          ArgumentMatchers.eq(cloudContext)
-        )(any())
-      }
+      } yield deletedApp shouldBe None
 
       deletion.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
     }
-
-  it should "successfully delete an app with old relayHybridConnection naming convention" in isolatedDbTest {
-    val mockAzureRelayService = setUpMockAzureRelayService
-
-    val aksInterp = new AKSInterpreter[IO](
-      config,
-      MockHelm,
-      mockAzureBatchService,
-      mockAzureContainerService,
-      mockAzureApplicationInsightsService,
-      mockAzureRelayService,
-      mockSamDAO,
-      mockCromwellDAO,
-      mockCbasDAO,
-      mockCbasUiDAO,
-      mockWdsDAO
-    ) {
-      override private[util] def buildMsiManager(cloudContext: AzureCloudContext) = IO.pure(setUpMockMsiManager)
-
-      override private[util] def buildComputeManager(cloudContext: AzureCloudContext) = IO.pure(setUpMockComputeManager)
-
-      override private[util] def buildCoreV1Client(cloudContext: AzureCloudContext,
-                                                   clusterName: AKSClusterName
-      ): IO[CoreV1Api] = IO.pure(setUpMockKubeAPI)
-    }
-
-    val res = for {
-      cluster <- IO(makeKubeCluster(1).copy(cloudContext = CloudContext.Azure(cloudContext)).save())
-      nodepool <- IO(makeNodepool(1, cluster.id).save())
-      customEnvVars = Map("WORKSPACE_NAME" -> "testWorkspace")
-      app = makeApp(1, nodepool.id, customEnvironmentVariables = customEnvVars).copy(
-        appType = AppType.Cromwell,
-        appResources = AppResources(
-          namespace = Namespace(
-            NamespaceId(-1),
-            NamespaceName("ns-1")
-          ),
-          disk = None,
-          services = List.empty,
-          kubernetesServiceAccountName = Some(ServiceAccountName("ksa-1"))
-        ),
-        appAccessScope = Some(AppAccessScope.WorkspaceShared)
-      )
-      saveApp <- IO(app.save())
-      appId = saveApp.id
-      appName = saveApp.appName
-
-      params = CreateAKSAppParams(appId,
-                                  appName,
-                                  workspaceId,
-                                  cloudContext,
-                                  landingZoneResources,
-                                  Some(storageContainer)
-      )
-      _ <- aksInterp.createAndPollApp(params)
-
-      app <- KubernetesServiceDbQueries
-        .getActiveFullAppByName(CloudContext.Azure(params.cloudContext), appName)
-        .transaction
-    } yield {
-      app shouldBe defined
-      app.get.app.status shouldBe AppStatus.Running
-      app.get.app.customEnvironmentVariables shouldBe customEnvVars
-      app
-    }
-
-    val dbApp = res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
-    dbApp shouldBe defined
-    val app = dbApp.get.app
-    val deletion = for {
-      _ <- aksInterp.deleteApp(DeleteAKSAppParams(app.appName, workspaceId, landingZoneResources, cloudContext))
-      deletedApp <- KubernetesServiceDbQueries
-        .getActiveFullAppByName(CloudContext.Azure(cloudContext), app.appName)
-        .transaction
-    } yield {
-      deletedApp shouldBe None
-      verify(mockAzureRelayService).deleteRelayHybridConnection(
-        RelayNamespace(ArgumentMatchers.eq(landingZoneResources.relayNamespace.value)),
-        RelayHybridConnectionName(ArgumentMatchers.eq(app.appName.value)),
-        ArgumentMatchers.eq(cloudContext)
-      )(any())
-    }
-
-    deletion.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
-  }
 
   private def setUpMockIdentity: Identity = {
     val identity = mock[Identity]
@@ -614,25 +494,6 @@ class AKSInterpreterSpec extends AnyFlatSpecLike with TestComponent with Leonard
       batchAccount.getKeys()
     } thenReturn batchAccountKeys
     container
-  }
-
-  private def setUpMockAzureRelayService: AzureRelayService[IO] = {
-    val mockAzureRelayService = mock[AzureRelayService[IO]]
-    val primaryKey = PrimaryKey("testKey")
-
-    when {
-      mockAzureRelayService.createRelayHybridConnection(any[String].asInstanceOf[RelayNamespace],
-                                                        any[String].asInstanceOf[RelayHybridConnectionName],
-                                                        any[String].asInstanceOf[AzureCloudContext]
-      )(any())
-    } thenReturn IO.pure(primaryKey)
-    when {
-      mockAzureRelayService.deleteRelayHybridConnection(any[String].asInstanceOf[RelayNamespace],
-                                                        any[String].asInstanceOf[RelayHybridConnectionName],
-                                                        any[String].asInstanceOf[AzureCloudContext]
-      )(any())
-    } thenReturn IO.unit
-    mockAzureRelayService
   }
 
   private def setUpMockAzureApplicationInsightsService: AzureApplicationInsightsService[IO] = {


### PR DESCRIPTION
<!-- Welcome to your Leonardo pull request! -->
<!-- Contributor guidelines: https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md -->

__Jira ticket__: https://broadworkbench.atlassian.net/browse/[IA-39161]

## Dependencies
Reverts [https://github.com/DataBiosphere/leonardo/pull/3280/files](https://github.com/DataBiosphere/leonardo/pull/3280/files) 

## Summary of changes

<!-- Please give an abridged version of the ticket description here and/or fill out the following fields. -->

### What

-

### Why

-

## Testing these changes

### What to test

- <!-- Test case 1 -->

<!-- ### Test data -->

### Who tested and where

- [ ] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [ ] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
