### PR TITLE
IA-3961: hybrid connection name includes workspaceId (2nd try)

### DIFF
--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/AppServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/AppServiceInterp.scala
@@ -1057,6 +1057,14 @@ final class LeoAppServiceInterp[F[_]: Parallel](config: AppServiceConfig,
         case _ => Right(())
       }
 
+      // adding the relayHybridConnection name to custom env vars
+      // necessary for backwards compatibility before workspace was added to name
+      customEnvironmentVariables = (cloudContext.cloudProvider, workspaceId) match {
+        case (CloudProvider.Azure, Some(workspaceId)) =>
+          req.customEnvironmentVariables + ("RELAY_HYBRID_CONNECTION_NAME" -> s"${appName.value}-${workspaceId.value}")
+        case _ => req.customEnvironmentVariables
+      }
+
       // Generate namespace and app release names using a random 6-character string prefix.
       //
       // Theoretically release names should only need to be unique within a namespace, but the Galaxy
@@ -1124,7 +1132,7 @@ final class LeoAppServiceInterp[F[_]: Parallel](config: AppServiceConfig,
           Option(gkeAppConfig.serviceAccountName)
         ),
         List.empty,
-        req.customEnvironmentVariables,
+        customEnvironmentVariables,
         req.descriptorPath,
         req.extraArgs,
         req.sourceWorkspaceId

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/AKSInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/AKSInterpreter.scala
@@ -145,6 +145,10 @@ class AKSInterpreter[F[_]](config: AKSInterpreterConfig,
       relayEndpoint = s"https://${params.landingZoneResources.relayNamespace.value}.servicebus.windows.net/"
       relayPath = Uri.unsafeFromString(relayEndpoint) / hcName.value
 
+      _ <- logger.info(ctx.loggingCtx)(
+        s"HERE: relayPath ${relayPath.path} with render string ${relayPath.renderString}"
+      )
+
       // Deploy setup chart
       appChartPrefix = app.appType match {
         case AppType.Wds => "wds"

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/AKSInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/AKSInterpreter.scala
@@ -137,13 +137,13 @@ class AKSInterpreter[F[_]](config: AKSInterpreterConfig,
         .run(authContext.copy(namespace = config.aadPodIdentityConfig.namespace))
 
       // Create relay hybrid connection pool
-      hcName = RelayHybridConnectionName(params.appName.value)
+      hcName = RelayHybridConnectionName(s"${params.appName.value}-${params.workspaceId.value}")
       relayPrimaryKey <- azureRelayService.createRelayHybridConnection(params.landingZoneResources.relayNamespace,
                                                                        hcName,
                                                                        params.cloudContext
       )
       relayEndpoint = s"https://${params.landingZoneResources.relayNamespace.value}.servicebus.windows.net/"
-      relayPath = Uri.unsafeFromString(relayEndpoint) / params.appName.value
+      relayPath = Uri.unsafeFromString(relayEndpoint) / hcName.value
 
       // Deploy setup chart
       appChartPrefix = app.appType match {
@@ -326,11 +326,15 @@ class AKSInterpreter[F[_]](config: AKSInterpreterConfig,
       clusterName = landingZoneResources.clusterName // NOT the same as dbCluster.clusterName
 
       // Delete hybrid connection for this app
-      _ <- azureRelayService.deleteRelayHybridConnection(
-        landingZoneResources.relayNamespace,
-        RelayHybridConnectionName(app.appName.value),
-        cloudContext
-      )
+      // for backwards compatibility, name used to be just the appName
+      name = app.customEnvironmentVariables.getOrElse("RELAY_HYBRID_CONNECTION_NAME", app.appName.value)
+
+      _ <- azureRelayService
+        .deleteRelayHybridConnection(
+          landingZoneResources.relayNamespace,
+          RelayHybridConnectionName(name),
+          cloudContext
+        )
 
       // Authenticate helm client
       authContext <- getHelmAuthContext(landingZoneResources.clusterName, cloudContext, namespaceName)

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/KubernetesTestData.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/KubernetesTestData.scala
@@ -77,6 +77,9 @@ object KubernetesTestData {
     None
   )
 
+  val customEnvironmentVariables =
+    Map("WORKSPACE_NAME" -> "testWorkspace", "RELAY_HYBRID_CONNECTION_NAME" -> s"app1-${workspaceId.value}")
+
   val testCluster = makeKubeCluster(1)
   val testNodepool = makeNodepool(1, testCluster.id)
   val testApp = makeApp(1, testNodepool.id)
@@ -99,7 +102,9 @@ object KubernetesTestData {
       )
       .toVector
 
-  def cromwellAppCreateRequest(diskConfig: Option[PersistentDiskRequest], customEnvVars: Map[String, String]) =
+  def cromwellAppCreateRequest(diskConfig: Option[PersistentDiskRequest],
+                               customEnvVars: Map[String, String] = customEnvironmentVariables
+  ) =
     CreateAppRequest(
       kubernetesRuntimeConfig = None,
       appType = AppType.Cromwell,
@@ -188,7 +193,7 @@ object KubernetesTestData {
 
   def makeApp(index: Int,
               nodepoolId: NodepoolLeoId,
-              customEnvironmentVariables: Map[String, String] = Map.empty,
+              customEnvironmentVariables: Map[String, String] = customEnvironmentVariables,
               status: AppStatus = AppStatus.Unspecified,
               appType: AppType = galaxyApp,
               workspaceId: WorkspaceId = WorkspaceId(UUID.randomUUID()),

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/AppServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/AppServiceInterpSpec.scala
@@ -1507,7 +1507,9 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
 
   it should "V2 Azure - create an app V2" in isolatedDbTest {
     val appName = AppName("app1")
-    val customEnvVars = Map("WORKSPACE_NAME" -> "testWorkspace")
+    val customEnvVars = Map("WORKSPACE_NAME" -> "testWorkspace",
+                            "RELAY_HYBRID_CONNECTION_NAME" -> s"${appName.value}-${workspaceId.value}"
+    )
     val appReq = createAppRequest.copy(kubernetesRuntimeConfig = None,
                                        appType = AppType.Cromwell,
                                        diskConfig = None,

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/model/KubernetesModelSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/model/KubernetesModelSpec.scala
@@ -3,7 +3,7 @@ package org.broadinstitute.dsde.workbench.leonardo.model
 import org.broadinstitute.dsde.workbench.azure.{AzureCloudContext, ManagedResourceGroupName, SubscriptionId, TenantId}
 import org.broadinstitute.dsde.workbench.google2.KubernetesSerializableName.ServiceName
 import org.broadinstitute.dsde.workbench.google2.{NetworkName, SubnetworkName}
-import org.broadinstitute.dsde.workbench.leonardo.CommonTestData.proxyUrlBase
+import org.broadinstitute.dsde.workbench.leonardo.CommonTestData.{proxyUrlBase, workspaceId}
 import org.broadinstitute.dsde.workbench.leonardo.KubernetesTestData.{
   makeKubeCluster,
   makeService,
@@ -77,13 +77,13 @@ class KubernetesModelSpec extends LeonardoTestSuite with AnyFlatSpecLike {
     val app = LeoLenses.appToServices.modify(_ => services)(testApp)
     app.getProxyUrls(cluster, proxyUrlBase) shouldBe Map(
       ServiceName("service1") -> new URL(
-        s"https://relay.windows.net/${app.appName.value}/service1"
+        s"https://relay.windows.net/${app.appName.value}-${workspaceId.value}/service1"
       ),
       ServiceName("service2") -> new URL(
-        s"https://relay.windows.net/${app.appName.value}/service2"
+        s"https://relay.windows.net/${app.appName.value}-${workspaceId.value}/service2"
       ),
       ServiceName("service3") -> new URL(
-        s"https://relay.windows.net/${app.appName.value}/service3"
+        s"https://relay.windows.net/${app.appName.value}-${workspaceId.value}/service3"
       )
     )
   }
@@ -107,7 +107,7 @@ class KubernetesModelSpec extends LeonardoTestSuite with AnyFlatSpecLike {
     val app = LeoLenses.appToServices.modify(_ => List(service))(testApp)
     app.getProxyUrls(cluster, proxyUrlBase) shouldBe Map(
       ServiceName("service1") -> new URL(
-        s"https://relay.windows.net/${app.appName.value}/"
+        s"https://relay.windows.net/${app.appName.value}-${workspaceId.value}/"
       )
     )
   }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/MonitorAtBootSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/MonitorAtBootSpec.scala
@@ -6,12 +6,37 @@ import cats.effect.std.Queue
 import cats.syntax.all._
 import org.broadinstitute.dsde.workbench.google2.mock.FakeGoogleComputeService
 import org.broadinstitute.dsde.workbench.leonardo.CommonTestData._
-import org.broadinstitute.dsde.workbench.leonardo.KubernetesTestData.{customEnvironmentVariables, makeApp, makeAzureCluster, makeKubeCluster, makeNodepool}
+import org.broadinstitute.dsde.workbench.leonardo.KubernetesTestData.{
+  customEnvironmentVariables,
+  makeApp,
+  makeAzureCluster,
+  makeKubeCluster,
+  makeNodepool
+}
 import org.broadinstitute.dsde.workbench.leonardo.dao.{MockSamDAO, MockWsmDAO}
 import org.broadinstitute.dsde.workbench.leonardo.db.TestComponent
-import org.broadinstitute.dsde.workbench.leonardo.monitor.ClusterNodepoolAction.{CreateClusterAndNodepool, CreateNodepool}
-import org.broadinstitute.dsde.workbench.leonardo.monitor.LeoPubsubMessage.{CreateAppMessage, CreateAppV2Message, DeleteAppMessage, DeleteAppV2Message}
-import org.broadinstitute.dsde.workbench.leonardo.{AppMachineType, AppStatus, AppType, CloudContext, DiskStatus, KubernetesClusterStatus, LeoLenses, LeonardoTestSuite, NodepoolStatus, RuntimeStatus}
+import org.broadinstitute.dsde.workbench.leonardo.monitor.ClusterNodepoolAction.{
+  CreateClusterAndNodepool,
+  CreateNodepool
+}
+import org.broadinstitute.dsde.workbench.leonardo.monitor.LeoPubsubMessage.{
+  CreateAppMessage,
+  CreateAppV2Message,
+  DeleteAppMessage,
+  DeleteAppV2Message
+}
+import org.broadinstitute.dsde.workbench.leonardo.{
+  AppMachineType,
+  AppStatus,
+  AppType,
+  CloudContext,
+  DiskStatus,
+  KubernetesClusterStatus,
+  LeoLenses,
+  LeonardoTestSuite,
+  NodepoolStatus,
+  RuntimeStatus
+}
 import org.scalatest.Assertions
 import org.scalatest.flatspec.AnyFlatSpec
 

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/MonitorAtBootSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/MonitorAtBootSpec.scala
@@ -6,36 +6,12 @@ import cats.effect.std.Queue
 import cats.syntax.all._
 import org.broadinstitute.dsde.workbench.google2.mock.FakeGoogleComputeService
 import org.broadinstitute.dsde.workbench.leonardo.CommonTestData._
-import org.broadinstitute.dsde.workbench.leonardo.KubernetesTestData.{
-  makeApp,
-  makeAzureCluster,
-  makeKubeCluster,
-  makeNodepool
-}
+import org.broadinstitute.dsde.workbench.leonardo.KubernetesTestData.{customEnvironmentVariables, makeApp, makeAzureCluster, makeKubeCluster, makeNodepool}
 import org.broadinstitute.dsde.workbench.leonardo.dao.{MockSamDAO, MockWsmDAO}
 import org.broadinstitute.dsde.workbench.leonardo.db.TestComponent
-import org.broadinstitute.dsde.workbench.leonardo.monitor.ClusterNodepoolAction.{
-  CreateClusterAndNodepool,
-  CreateNodepool
-}
-import org.broadinstitute.dsde.workbench.leonardo.monitor.LeoPubsubMessage.{
-  CreateAppMessage,
-  CreateAppV2Message,
-  DeleteAppMessage,
-  DeleteAppV2Message
-}
-import org.broadinstitute.dsde.workbench.leonardo.{
-  AppMachineType,
-  AppStatus,
-  AppType,
-  CloudContext,
-  DiskStatus,
-  KubernetesClusterStatus,
-  LeoLenses,
-  LeonardoTestSuite,
-  NodepoolStatus,
-  RuntimeStatus
-}
+import org.broadinstitute.dsde.workbench.leonardo.monitor.ClusterNodepoolAction.{CreateClusterAndNodepool, CreateNodepool}
+import org.broadinstitute.dsde.workbench.leonardo.monitor.LeoPubsubMessage.{CreateAppMessage, CreateAppV2Message, DeleteAppMessage, DeleteAppV2Message}
+import org.broadinstitute.dsde.workbench.leonardo.{AppMachineType, AppStatus, AppType, CloudContext, DiskStatus, KubernetesClusterStatus, LeoLenses, LeonardoTestSuite, NodepoolStatus, RuntimeStatus}
 import org.scalatest.Assertions
 import org.scalatest.flatspec.AnyFlatSpec
 
@@ -139,7 +115,7 @@ class MonitorAtBootSpec extends AnyFlatSpec with TestComponent with LeonardoTest
         savedApp.id,
         savedApp.appName,
         Some(disk.id),
-        Map.empty,
+        customEnvironmentVariables,
         AppType.Galaxy,
         savedApp.appResources.namespace.name,
         Some(defaultFakeAppMachineType),
@@ -190,7 +166,7 @@ class MonitorAtBootSpec extends AnyFlatSpec with TestComponent with LeonardoTest
         savedApp.id,
         savedApp.appName,
         Some(disk.id),
-        Map.empty,
+        customEnvironmentVariables,
         AppType.Galaxy,
         savedApp.appResources.namespace.name,
         Some(defaultFakeAppMachineType),
@@ -241,7 +217,7 @@ class MonitorAtBootSpec extends AnyFlatSpec with TestComponent with LeonardoTest
         savedApp.id,
         savedApp.appName,
         Some(disk.id),
-        Map.empty,
+        customEnvironmentVariables,
         AppType.Galaxy,
         savedApp.appResources.namespace.name,
         Some(defaultFakeAppMachineType),

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/AKSInterpreterSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/AKSInterpreterSpec.scala
@@ -15,7 +15,7 @@ import com.azure.resourcemanager.msi.models.{Identities, Identity}
 import io.kubernetes.client.openapi.apis.CoreV1Api
 import io.kubernetes.client.openapi.models._
 import org.broadinstitute.dsde.workbench.azure._
-import org.broadinstitute.dsde.workbench.azure.mock.FakeAzureRelayService
+import org.mockito.ArgumentMatchers
 import org.broadinstitute.dsde.workbench.google2.KubernetesSerializableName.{NamespaceName, ServiceAccountName}
 import org.broadinstitute.dsde.workbench.google2.{NetworkName, SubnetworkName}
 import org.broadinstitute.dsde.workbench.leonardo.CommonTestData.{
@@ -35,7 +35,7 @@ import org.broadinstitute.dsp.Release
 import org.broadinstitute.dsp.mocks.MockHelm
 import org.http4s.Uri
 import org.mockito.ArgumentMatchers.{any, anyString}
-import org.mockito.Mockito.when
+import org.mockito.Mockito.{verify, when}
 import org.scalatest.flatspec.AnyFlatSpecLike
 import org.scalatestplus.mockito.MockitoSugar
 
@@ -67,6 +67,7 @@ class AKSInterpreterSpec extends AnyFlatSpecLike with TestComponent with Leonard
   val mockAzureContainerService = setUpMockAzureContainerService
   val mockAzureApplicationInsightsService = setUpMockAzureApplicationInsightsService
   val mockAzureBatchService = setUpMockAzureBatchService
+  val mockAzureRelayService = setUpMockAzureRelayService
 
   val aksInterp = new AKSInterpreter[IO](
     config,
@@ -74,7 +75,7 @@ class AKSInterpreterSpec extends AnyFlatSpecLike with TestComponent with Leonard
     mockAzureBatchService,
     mockAzureContainerService,
     mockAzureApplicationInsightsService,
-    FakeAzureRelayService,
+    mockAzureRelayService,
     mockSamDAO,
     mockCromwellDAO,
     mockCbasDAO,
@@ -351,10 +352,37 @@ class AKSInterpreterSpec extends AnyFlatSpecLike with TestComponent with Leonard
 
   for (appType <- List(AppType.Wds, AppType.Cromwell))
     it should s"create and poll a shared ${appType} app, then successfully delete it" in isolatedDbTest {
+      val mockAzureRelayService = setUpMockAzureRelayService
+
+      val aksInterp = new AKSInterpreter[IO](
+        config,
+        MockHelm,
+        mockAzureBatchService,
+        mockAzureContainerService,
+        mockAzureApplicationInsightsService,
+        mockAzureRelayService,
+        mockSamDAO,
+        mockCromwellDAO,
+        mockCbasDAO,
+        mockCbasUiDAO,
+        mockWdsDAO
+      ) {
+        override private[util] def buildMsiManager(cloudContext: AzureCloudContext) = IO.pure(setUpMockMsiManager)
+
+        override private[util] def buildComputeManager(cloudContext: AzureCloudContext) =
+          IO.pure(setUpMockComputeManager)
+
+        override private[util] def buildCoreV1Client(cloudContext: AzureCloudContext,
+                                                     clusterName: AKSClusterName
+        ): IO[CoreV1Api] = IO.pure(setUpMockKubeAPI)
+      }
       val res = for {
         cluster <- IO(makeKubeCluster(1).copy(cloudContext = CloudContext.Azure(cloudContext)).save())
         nodepool <- IO(makeNodepool(1, cluster.id).save())
-        app = makeApp(1, nodepool.id).copy(
+        customEnvVars = Map("WORKSPACE_NAME" -> "testWorkspace",
+                            "RELAY_HYBRID_CONNECTION_NAME" -> s"app1-${workspaceId.value}"
+        )
+        app = makeApp(1, nodepool.id, customEnvironmentVariables = customEnvVars).copy(
           appType = appType,
           appResources = AppResources(
             namespace = Namespace(
@@ -401,10 +429,102 @@ class AKSInterpreterSpec extends AnyFlatSpecLike with TestComponent with Leonard
         deletedApp <- KubernetesServiceDbQueries
           .getActiveFullAppByName(CloudContext.Azure(cloudContext), app.appName)
           .transaction
-      } yield deletedApp shouldBe None
+      } yield {
+        deletedApp shouldBe None
+        verify(mockAzureRelayService).deleteRelayHybridConnection(
+          RelayNamespace(ArgumentMatchers.eq(landingZoneResources.relayNamespace.value)),
+          RelayHybridConnectionName(ArgumentMatchers.eq(s"${app.appName.value}-${workspaceId.value}")),
+          ArgumentMatchers.eq(cloudContext)
+        )(any())
+      }
 
       deletion.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
     }
+
+  it should "successfully delete an app with old relayHybridConnection naming convention" in isolatedDbTest {
+    val mockAzureRelayService = setUpMockAzureRelayService
+
+    val aksInterp = new AKSInterpreter[IO](
+      config,
+      MockHelm,
+      mockAzureBatchService,
+      mockAzureContainerService,
+      mockAzureApplicationInsightsService,
+      mockAzureRelayService,
+      mockSamDAO,
+      mockCromwellDAO,
+      mockCbasDAO,
+      mockCbasUiDAO,
+      mockWdsDAO
+    ) {
+      override private[util] def buildMsiManager(cloudContext: AzureCloudContext) = IO.pure(setUpMockMsiManager)
+
+      override private[util] def buildComputeManager(cloudContext: AzureCloudContext) = IO.pure(setUpMockComputeManager)
+
+      override private[util] def buildCoreV1Client(cloudContext: AzureCloudContext,
+                                                   clusterName: AKSClusterName
+      ): IO[CoreV1Api] = IO.pure(setUpMockKubeAPI)
+    }
+
+    val res = for {
+      cluster <- IO(makeKubeCluster(1).copy(cloudContext = CloudContext.Azure(cloudContext)).save())
+      nodepool <- IO(makeNodepool(1, cluster.id).save())
+      customEnvVars = Map("WORKSPACE_NAME" -> "testWorkspace")
+      app = makeApp(1, nodepool.id, customEnvironmentVariables = customEnvVars).copy(
+        appType = AppType.Cromwell,
+        appResources = AppResources(
+          namespace = Namespace(
+            NamespaceId(-1),
+            NamespaceName("ns-1")
+          ),
+          disk = None,
+          services = List.empty,
+          kubernetesServiceAccountName = Some(ServiceAccountName("ksa-1"))
+        ),
+        appAccessScope = Some(AppAccessScope.WorkspaceShared)
+      )
+      saveApp <- IO(app.save())
+      appId = saveApp.id
+      appName = saveApp.appName
+
+      params = CreateAKSAppParams(appId,
+                                  appName,
+                                  workspaceId,
+                                  cloudContext,
+                                  landingZoneResources,
+                                  Some(storageContainer)
+      )
+      _ <- aksInterp.createAndPollApp(params)
+
+      app <- KubernetesServiceDbQueries
+        .getActiveFullAppByName(CloudContext.Azure(params.cloudContext), appName)
+        .transaction
+    } yield {
+      app shouldBe defined
+      app.get.app.status shouldBe AppStatus.Running
+      app.get.app.customEnvironmentVariables shouldBe customEnvVars
+      app
+    }
+
+    val dbApp = res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
+    dbApp shouldBe defined
+    val app = dbApp.get.app
+    val deletion = for {
+      _ <- aksInterp.deleteApp(DeleteAKSAppParams(app.appName, workspaceId, landingZoneResources, cloudContext))
+      deletedApp <- KubernetesServiceDbQueries
+        .getActiveFullAppByName(CloudContext.Azure(cloudContext), app.appName)
+        .transaction
+    } yield {
+      deletedApp shouldBe None
+      verify(mockAzureRelayService).deleteRelayHybridConnection(
+        RelayNamespace(ArgumentMatchers.eq(landingZoneResources.relayNamespace.value)),
+        RelayHybridConnectionName(ArgumentMatchers.eq(app.appName.value)),
+        ArgumentMatchers.eq(cloudContext)
+      )(any())
+    }
+
+    deletion.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
+  }
 
   private def setUpMockIdentity: Identity = {
     val identity = mock[Identity]
@@ -494,6 +614,25 @@ class AKSInterpreterSpec extends AnyFlatSpecLike with TestComponent with Leonard
       batchAccount.getKeys()
     } thenReturn batchAccountKeys
     container
+  }
+
+  private def setUpMockAzureRelayService: AzureRelayService[IO] = {
+    val mockAzureRelayService = mock[AzureRelayService[IO]]
+    val primaryKey = PrimaryKey("testKey")
+
+    when {
+      mockAzureRelayService.createRelayHybridConnection(any[String].asInstanceOf[RelayNamespace],
+                                                        any[String].asInstanceOf[RelayHybridConnectionName],
+                                                        any[String].asInstanceOf[AzureCloudContext]
+      )(any())
+    } thenReturn IO.pure(primaryKey)
+    when {
+      mockAzureRelayService.deleteRelayHybridConnection(any[String].asInstanceOf[RelayNamespace],
+                                                        any[String].asInstanceOf[RelayHybridConnectionName],
+                                                        any[String].asInstanceOf[AzureCloudContext]
+      )(any())
+    } thenReturn IO.unit
+    mockAzureRelayService
   }
 
   private def setUpMockAzureApplicationInsightsService: AzureApplicationInsightsService[IO] = {


### PR DESCRIPTION
My [original PR](https://github.com/DataBiosphere/leonardo/pull/3280) caused errors because the incorrect proxyURL was being generated, [thread here](https://broadinstitute.slack.com/archives/C02GJ782BAA/p1682356982603629)

This reverts the reverse commit c8f1292698db194169e69c0465670b6fde1355c1 and adds changes to the getProxyURLs function to make sure those are correct with the naming changes.

<!-- Welcome to your Leonardo pull request! -->
<!-- Contributor guidelines: https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md -->

__Jira ticket__: https://broadworkbench.atlassian.net/browse/[IA-3961]

## Dependencies 
[original PR](https://github.com/DataBiosphere/leonardo/pull/3280) 

## Summary of changes

This reverts the reverse commit c8f1292698db194169e69c0465670b6fde1355c1 and adds changes to the getProxyURLs function to make sure those are correct with the naming changes.

### What

Changes the relayHybridConnection name to have the workspaceId as well as the appId.
### Why

Because the appId is not unique across workspaces, users can get access to other apps data

## Testing these changes

### What to test

- create a new workspace, create an Azure VM and open a jupyter notebook

<!-- ### Test data -->

### Who tested and where

- [ ] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [ ] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->


[IA-3961]: https://broadworkbench.atlassian.net/browse/IA-3961?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ