### PR TITLE
[IA-4272] modify disk attachment logic for azure

### DIFF
--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponent.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponent.scala
@@ -528,7 +528,7 @@ object clusterQuery extends TableQuery(new ClusterTable(_)) {
       .result
       .headOption
 
-  def getLastClusterWithDiskId(diskId: DiskId)(implicit ec: ExecutionContext): DBIO[Option[ClusterRecord]] =
+  def getClusterWithDiskId(diskId: DiskId)(implicit ec: ExecutionContext): DBIO[Option[ClusterRecord]] =
     // get most recently created runtime with the specified persistent disk
     for {
       runtimeConfigId <- runtimeConfigs

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterp.scala
@@ -1204,7 +1204,7 @@ final case class DiskNotSupportedException(traceId: TraceId)
 
 final case class DiskAlreadyAttachedException(cloudContext: CloudContext, name: DiskName, traceId: TraceId)
     extends LeoException(
-      s"Persistent disk ${cloudContext.asStringWithProvider}/${name.value} is already attached to another runtime",
+      s"Your persistent disk ${cloudContext.asStringWithProvider}/${name.value} is already attached to another runtime. You might need to wait a few minutes if you just deleted a runtime.",
       StatusCodes.Conflict,
       traceId = Some(traceId)
     )

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeV2ServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeV2ServiceInterp.scala
@@ -174,7 +174,6 @@ class RuntimeV2ServiceInterp[F[_]: Parallel](config: RuntimeServiceConfig,
                   _ <- F
                     .raiseError(PersistentDiskNotReadyException(disk.id, disk.status))
                     .whenA(disk.status != DiskStatus.Ready)
-                  // TODO: TEST
                   isAttached <- persistentDiskQuery.isDiskAttached(disk.id).transaction
                   _ <- F
                     .raiseError(DiskAlreadyAttachedException(disk.cloudContext, disk.name, ctx.traceId))

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeV2ServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeV2ServiceInterp.scala
@@ -174,6 +174,11 @@ class RuntimeV2ServiceInterp[F[_]: Parallel](config: RuntimeServiceConfig,
                   _ <- F
                     .raiseError(PersistentDiskNotReadyException(disk.id, disk.status))
                     .whenA(disk.status != DiskStatus.Ready)
+                  // TODO: TEST
+                  isAttached <- persistentDiskQuery.isDiskAttached(disk.id).transaction
+                  _ <- F
+                    .raiseError(DiskAlreadyAttachedException(disk.cloudContext, disk.name, ctx.traceId))
+                    .whenA(isAttached)
                 } yield disk.id
 
               // if not using existing disk, create a new one

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandler.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandler.scala
@@ -618,7 +618,7 @@ class AzurePubsubHandlerInterp[F[_]: Parallel](
               case WsmJobStatus.Succeeded =>
                 for {
                   _ <- deleteDiskAction
-                  _ <- dbRef.inTransaction(clusterQuery.updateClusterStatus(runtime.id, RuntimeStatus.Deleted, ctx.now))
+                  _ <- dbRef.inTransaction(clusterQuery.completeDeletion(runtime.id, ctx.now))
                   _ <- logger.info(ctx.loggingCtx)(s"runtime ${msg.runtimeId} is deleted successfully")
                 } yield ()
               case WsmJobStatus.Failed =>

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponentSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponentSpec.scala
@@ -360,7 +360,6 @@ class ClusterComponentSpec extends AnyFlatSpecLike with TestComponent with GcsPa
     res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
-  // TODO: why doesn't this error out on save?
   it should "get cluster from diskId" in isolatedDbTest {
     val res = for {
       savedDisk <- makePersistentDisk(None).save()

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponentSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponentSpec.scala
@@ -360,6 +360,7 @@ class ClusterComponentSpec extends AnyFlatSpecLike with TestComponent with GcsPa
     res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
+  // TODO: why doesn't this error out on save?
   it should "get cluster from diskId" in isolatedDbTest {
     val res = for {
       savedDisk <- makePersistentDisk(None).save()
@@ -379,7 +380,7 @@ class ClusterComponentSpec extends AnyFlatSpecLike with TestComponent with GcsPa
           )
         )
       )
-      retrievedRuntime <- clusterQuery.getLastClusterWithDiskId(savedDisk.id).transaction
+      retrievedRuntime <- clusterQuery.getClusterWithDiskId(savedDisk.id).transaction
     } yield retrievedRuntime shouldBe savedRuntime2
   }
 }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceV2InterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceV2InterpSpec.scala
@@ -294,7 +294,8 @@ class RuntimeServiceV2InterpSpec extends AnyFlatSpec with LeonardoTestSuite with
           status = DiskStatus.Ready,
           auditInfo = auditInfo.copy(creator = userInfo.userEmail),
           cloudContext = CloudContext.Azure(azureCloudContext)
-        ).save()
+        )
+        .save()
       azureRuntimeConfig = RuntimeConfig.AzureConfig(MachineTypeName(VirtualMachineSizeTypes.STANDARD_A1.toString),
                                                      disk.id,
                                                      azureRegion

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceV2InterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceV2InterpSpec.scala
@@ -263,7 +263,14 @@ class RuntimeServiceV2InterpSpec extends AnyFlatSpec with LeonardoTestSuite with
   it should "fail to create a runtime with existing disk if disk isn't ready" in isolatedDbTest {
     val saveDisk = for {
       now <- IO.realTimeInstant
-      _ <- makePersistentDisk(Some(diskName)).copy(workspaceId = Some(workspaceId), status = DiskStatus.Creating).save()
+      _ <- makePersistentDisk(Some(diskName))
+        .copy(
+          workspaceId = Some(workspaceId),
+          status = DiskStatus.Ready,
+          auditInfo = auditInfo.copy(creator = userInfo.userEmail),
+          cloudContext = CloudContext.Azure(azureCloudContext)
+        )
+        .save()
     } yield ()
 
     saveDisk.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceV2InterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceV2InterpSpec.scala
@@ -261,63 +261,84 @@ class RuntimeServiceV2InterpSpec extends AnyFlatSpec with LeonardoTestSuite with
   }
 
   it should "fail to create a runtime with existing disk if disk isn't ready" in isolatedDbTest {
-    val saveDisk = for {
-      _ <- makePersistentDisk(Some(diskName))
-        .copy(
-          workspaceId = Some(workspaceId),
-          status = DiskStatus.Creating,
-          auditInfo = auditInfo.copy(creator = userInfo.userEmail),
-          cloudContext = CloudContext.Azure(azureCloudContext)
-        )
-        .save()
-    } yield ()
+    val res = for {
+      _ <- runtimeV2Service
+        .createRuntime(userInfo, name0, workspaceId, false, defaultCreateAzureRuntimeReq)
 
-    saveDisk.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
+      disks <- DiskServiceDbQueries
+        .listDisks(Map.empty, includeDeleted = false, Some(userInfo.userEmail), None, Some(workspaceId))
+        .transaction
+      disk = disks.head
+      now <- IO.realTimeInstant
+      _ <- persistentDiskQuery.updateStatus(disk.id, DiskStatus.Creating, now)
 
-    val exc = runtimeV2Service
-      .createRuntime(userInfo, name2, workspaceId, true, defaultCreateAzureRuntimeReq)
-      .attempt
-      .unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
-      .swap
-      .toOption
-      .get
+      // set runtime to deleted so they dont get hit by `OnlyOneRuntimePerWorkspacePerCreator`
+      runtime <- clusterQuery.getClusterWithDiskId(disk.id).transaction
+      _ <- clusterQuery.updateClusterStatus(runtime.get.id, RuntimeStatus.Deleted, now).transaction
 
-    exc shouldBe a[PersistentDiskNotReadyException]
+      err <- runtimeV2Service
+        .createRuntime(userInfo, name1, workspaceId, true, defaultCreateAzureRuntimeReq)
+        .attempt
+
+    } yield err shouldBe a[PersistentDiskNotReadyException]
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
+
   }
 
   it should "fail to create a runtime with existing disk if disk is attached" in isolatedDbTest {
-    val runtimeIO = for {
-      now <- IO.realTimeInstant
-      disk <- makePersistentDisk(Some(diskName))
-        .copy(
-          workspaceId = Some(workspaceId),
-          status = DiskStatus.Ready,
-          auditInfo = auditInfo.copy(creator = userInfo.userEmail),
-          cloudContext = CloudContext.Azure(azureCloudContext)
-        )
-        .save()
-      azureRuntimeConfig = RuntimeConfig.AzureConfig(MachineTypeName(VirtualMachineSizeTypes.STANDARD_A1.toString),
-                                                     disk.id,
-                                                     azureRegion
-      )
-      runtime = makeCluster(1).saveWithRuntimeConfig(runtimeConfig = azureRuntimeConfig)
-    } yield runtime
-
-    val runtime = runtimeIO.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
-
-//    runtimeV2Service
-//      .createRuntime(userInfo, name0, workspaceId, false, defaultCreateAzureRuntimeReq)
+//    val runtimeIO = for {
+//      now <- IO.realTimeInstant
+//      disk <- makePersistentDisk()
+//        .copy(
+//          workspaceId = Some(workspaceId),
+//          status = DiskStatus.Ready,
+//          auditInfo = auditInfo.copy(creator = userInfo.userEmail),
+//          cloudContext = CloudContext.Azure(azureCloudContext)
+//        )
+//        .save()
+//      azureRuntimeConfig = RuntimeConfig.AzureConfig(MachineTypeName(VirtualMachineSizeTypes.STANDARD_A1.toString),
+//                                                     disk.id,
+//                                                     azureRegion
+//      )
+//      runtime = makeCluster(1).saveWithRuntimeConfig(runtimeConfig = azureRuntimeConfig)
+//    } yield runtime
+//
+//    val runtime = runtimeIO.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
+//
+////    runtimeV2Service
+////      .createRuntime(userInfo, name0, workspaceId, false, defaultCreateAzureRuntimeReq)
+////      .unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
+//
+//    val exc = runtimeV2Service
+//      .createRuntime(userInfo, name2, workspaceId, true, defaultCreateAzureRuntimeReq)
+//      .attempt
 //      .unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
+//      .swap
+//      .toOption
+//      .get
+//
+//    exc shouldBe a[DiskAlreadyAttachedException]
 
-    val exc = runtimeV2Service
-      .createRuntime(userInfo, name2, workspaceId, true, defaultCreateAzureRuntimeReq)
-      .attempt
-      .unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
-      .swap
-      .toOption
-      .get
+    val res = for {
+      _ <- runtimeV2Service
+        .createRuntime(userInfo, name0, workspaceId, false, defaultCreateAzureRuntimeReq)
 
-    exc shouldBe a[DiskAlreadyAttachedException]
+      disks <- DiskServiceDbQueries
+        .listDisks(Map.empty, includeDeleted = false, Some(userInfo.userEmail), None, Some(workspaceId))
+        .transaction
+      disk = disks.head
+      now <- IO.realTimeInstant
+
+      // set runtime to deleted so they dont get hit by `OnlyOneRuntimePerWorkspacePerCreator`
+      runtime <- clusterQuery.getClusterWithDiskId(disk.id).transaction
+      _ <- clusterQuery.updateClusterStatus(runtime.get.id, RuntimeStatus.Deleted, now).transaction
+
+      err <- runtimeV2Service
+        .createRuntime(userInfo, name1, workspaceId, true, defaultCreateAzureRuntimeReq)
+        .attempt
+
+    } yield err shouldBe a[DiskAlreadyAttachedException]
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   it should "fail to create a runtime with existing disk if disk is attached to non-deleted runtime" in isolatedDbTest {

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceV2InterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceV2InterpSpec.scala
@@ -332,6 +332,7 @@ class RuntimeServiceV2InterpSpec extends AnyFlatSpec with LeonardoTestSuite with
         .transaction
       disk = disks.head
       now <- IO.realTimeInstant
+      _ <- persistentDiskQuery.updateStatus(disk.id, DiskStatus.Ready, now).transaction
 
       // set runtime to deleted so they dont get hit by `OnlyOneRuntimePerWorkspacePerCreator`
       runtime <- clusterQuery.getClusterWithDiskId(disk.id).transaction

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceV2InterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceV2InterpSpec.scala
@@ -278,11 +278,15 @@ class RuntimeServiceV2InterpSpec extends AnyFlatSpec with LeonardoTestSuite with
 
       err <- runtimeV2Service
         .createRuntime(userInfo, name1, workspaceId, true, defaultCreateAzureRuntimeReq)
-        .attempt
+    } yield ()
 
-    } yield err shouldBe a[PersistentDiskNotReadyException]
-    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
+    val exc = res.attempt
+      .unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
+      .swap
+      .toOption
+      .get
 
+    exc shouldBe a[PersistentDiskNotReadyException]
   }
 
   it should "fail to create a runtime with existing disk if disk is attached" in isolatedDbTest {
@@ -335,10 +339,16 @@ class RuntimeServiceV2InterpSpec extends AnyFlatSpec with LeonardoTestSuite with
 
       err <- runtimeV2Service
         .createRuntime(userInfo, name1, workspaceId, true, defaultCreateAzureRuntimeReq)
-        .attempt
 
-    } yield err shouldBe a[DiskAlreadyAttachedException]
-    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
+    } yield ()
+
+    val exc = res.attempt
+      .unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
+      .swap
+      .toOption
+      .get
+
+    exc shouldBe a[DiskAlreadyAttachedException]
   }
 
   it should "fail to create a runtime with existing disk if disk is attached to non-deleted runtime" in isolatedDbTest {

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceV2InterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceV2InterpSpec.scala
@@ -290,39 +290,6 @@ class RuntimeServiceV2InterpSpec extends AnyFlatSpec with LeonardoTestSuite with
   }
 
   it should "fail to create a runtime with existing disk if disk is attached" in isolatedDbTest {
-//    val runtimeIO = for {
-//      now <- IO.realTimeInstant
-//      disk <- makePersistentDisk()
-//        .copy(
-//          workspaceId = Some(workspaceId),
-//          status = DiskStatus.Ready,
-//          auditInfo = auditInfo.copy(creator = userInfo.userEmail),
-//          cloudContext = CloudContext.Azure(azureCloudContext)
-//        )
-//        .save()
-//      azureRuntimeConfig = RuntimeConfig.AzureConfig(MachineTypeName(VirtualMachineSizeTypes.STANDARD_A1.toString),
-//                                                     disk.id,
-//                                                     azureRegion
-//      )
-//      runtime = makeCluster(1).saveWithRuntimeConfig(runtimeConfig = azureRuntimeConfig)
-//    } yield runtime
-//
-//    val runtime = runtimeIO.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
-//
-////    runtimeV2Service
-////      .createRuntime(userInfo, name0, workspaceId, false, defaultCreateAzureRuntimeReq)
-////      .unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
-//
-//    val exc = runtimeV2Service
-//      .createRuntime(userInfo, name2, workspaceId, true, defaultCreateAzureRuntimeReq)
-//      .attempt
-//      .unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
-//      .swap
-//      .toOption
-//      .get
-//
-//    exc shouldBe a[DiskAlreadyAttachedException]
-
     val res = for {
       _ <- runtimeV2Service
         .createRuntime(userInfo, name0, workspaceId, false, defaultCreateAzureRuntimeReq)

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceV2InterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceV2InterpSpec.scala
@@ -270,7 +270,7 @@ class RuntimeServiceV2InterpSpec extends AnyFlatSpec with LeonardoTestSuite with
         .transaction
       disk = disks.head
       now <- IO.realTimeInstant
-      _ <- persistentDiskQuery.updateStatus(disk.id, DiskStatus.Creating, now)
+      _ <- persistentDiskQuery.updateStatus(disk.id, DiskStatus.Creating, now).transaction
 
       // set runtime to deleted so they dont get hit by `OnlyOneRuntimePerWorkspacePerCreator`
       runtime <- clusterQuery.getClusterWithDiskId(disk.id).transaction

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceV2InterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceV2InterpSpec.scala
@@ -290,7 +290,7 @@ class RuntimeServiceV2InterpSpec extends AnyFlatSpec with LeonardoTestSuite with
       now <- IO.realTimeInstant
       _ <- persistentDiskQuery.updateStatus(disk.id, DiskStatus.Ready, now).transaction
 
-      runtime <- clusterQuery.getLastClusterWithDiskId(disk.id).transaction
+      runtime <- clusterQuery.getClusterWithDiskId(disk.id).transaction
 
       err <- runtimeV2Service
         .createRuntime(userInfo, name1, workspaceId, true, defaultCreateAzureRuntimeReq)
@@ -312,7 +312,7 @@ class RuntimeServiceV2InterpSpec extends AnyFlatSpec with LeonardoTestSuite with
         .transaction
       disk = disks.head
       now <- IO.realTimeInstant
-      runtime <- clusterQuery.getLastClusterWithDiskId(disk.id).transaction
+      runtime <- clusterQuery.getClusterWithDiskId(disk.id).transaction
       _ <- persistentDiskQuery.updateStatus(disk.id, DiskStatus.Ready, now).transaction
       _ <- clusterQuery.updateClusterStatus(runtime.get.id, RuntimeStatus.Deleted, now).transaction
 

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandlerSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandlerSpec.scala
@@ -487,6 +487,7 @@ class AzurePubsubHandlerSpec
           controlledResources <- controlledResourceQuery.getAllForRuntime(runtime.id).transaction
           diskStatusOpt <- persistentDiskQuery.getStatus(disk.id).transaction
           diskStatus = diskStatusOpt.get
+          isAttached <- persistentDiskQuery.isDiskAttached(disk.id).transaction
         } yield {
           verify(mockWsmDao, times(1)).deleteStorageContainer(any[DeleteWsmResourceRequest], any[Authorization])(
             any[Ask[IO, AppContext]]
@@ -496,6 +497,7 @@ class AzurePubsubHandlerSpec
           val resourceTypes = controlledResources.map(_.resourceType)
           resourceTypes.contains(WsmResourceType.AzureDisk) shouldBe true
           diskStatus shouldBe DiskStatus.Ready
+          isAttached shouldBe false
         }
 
         _ <- controlledResourceQuery

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandlerSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandlerSpec.scala
@@ -509,6 +509,9 @@ class AzurePubsubHandlerSpec
         msg = DeleteAzureRuntimeMessage(runtime.id, None, workspaceId, Some(wsmResourceId), landingZoneResources, None)
 
         asyncTaskProcessor = AsyncTaskProcessor(AsyncTaskProcessor.Config(10, 10), queue)
+
+        isAttachedBeforeInterp <- persistentDiskQuery.isDiskAttached(disk.id).transaction
+        _ = isAttachedBeforeInterp shouldBe true 
         _ <- azureInterp.deleteAndPollRuntime(msg)
 
         _ <- withInfiniteStream(asyncTaskProcessor.process, assertions)

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandlerSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandlerSpec.scala
@@ -511,7 +511,7 @@ class AzurePubsubHandlerSpec
         asyncTaskProcessor = AsyncTaskProcessor(AsyncTaskProcessor.Config(10, 10), queue)
 
         isAttachedBeforeInterp <- persistentDiskQuery.isDiskAttached(disk.id).transaction
-        _ = isAttachedBeforeInterp shouldBe true 
+        _ = isAttachedBeforeInterp shouldBe true
         _ <- azureInterp.deleteAndPollRuntime(msg)
 
         _ <- withInfiniteStream(asyncTaskProcessor.process, assertions)


### PR DESCRIPTION
Main problem is we didn't correctly handle the concept of 'attached' for azure.

This is not heavily tested in a bee since it was a bit hard to reproduce consistently, but this field wasn't being used properly as is. Honestly, not super sure what is happening. The RUNTIME_CONFIG table uses `persistentDiskId` as a FOREIGN KEY referencing the PERSISTENT_DISK tables primary key `id`, but the RUNTIME_CONFIG table does not enforce this constraint. Indeed, this was not an issue for GCP as we enforce it in the app. However, the logic for azure disks violated this constraint and now there are multiple instances of the same `persistentDiskId` for multiple runtimes (because we viewed those attached to deleted runtimes as valid). This isn't that big of a problem moving forward, the logic handles it, but its impossible to enforce this constraint now that it is violated in prod without messy manual database manipulation risking user disks.  

Still need to do BEE testing, but unit tests exercise all logic introduced, so ready for some eyes.