### PR TITLE
[IA-4169] Fix improperly configured dataproc machines.

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/runtimeModels.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/runtimeModels.scala
@@ -529,9 +529,13 @@ final case class MemorySize(bytes: Long) extends AnyVal {
   override def toString: String = bytes.toString + "b"
 }
 object MemorySize {
-  def fromKb(kb: Double): MemorySize = MemorySize((kb * 1024).toLong)
-  def fromMb(mb: Double): MemorySize = MemorySize((mb * 1048576).toLong)
-  def fromGb(gb: Double): MemorySize = MemorySize((gb * 1073741824).toLong)
+  val kbInBytes = 1024
+  val mbInBytes = 1048576
+  val gbInBytes = 1073741824
+
+  def fromKb(kb: Double): MemorySize = MemorySize((kb * kbInBytes).toLong)
+  def fromMb(mb: Double): MemorySize = MemorySize((mb * mbInBytes).toLong)
+  def fromGb(gb: Double): MemorySize = MemorySize((gb * gbInBytes).toLong)
 }
 
 /**
@@ -539,7 +543,7 @@ object MemorySize {
  * See https://docs.docker.com/compose/compose-file/compose-file-v2/#cpu-and-other-resources
  * for other types of resources we may want to add here.
  */
-final case class RuntimeResourceConstraints(memoryLimit: MemorySize)
+final case class RuntimeResourceConstraints(memoryLimit: MemorySize, totalMachineMemory: MemorySize)
 
 final case class RuntimeMetrics(cloudContext: CloudContext,
                                 runtimeName: RuntimeName,

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -71,7 +71,13 @@ dataproc {
 
   customDataprocImage = "projects/broad-dsp-gcr-public/global/images/leo-dataproc-image-2-0-51-debian10-2023-04-12-19-18-34"
 
-  dataprocReservedMemory = 6g
+  # The ratio of memory allocated to spark. 0.8 = 80%.
+  # Hail/Spark users generally allocate 80% of the ram to the JVM.
+  sparkMemoryConfigRatio = 0.8
+  # This allows at minimmum 4gb to be reserved away from Hail/Spark for Jupyter/system processes
+  # Jupyter has a suggested a minimum of 1.5gb, welder has a minimum of 0.5g, and we want some space for system processes.
+  # This limit is used to define the max memory available to Jupyter.
+  minimumRuntimeMemoryInGb = 4
 
   monitor {
     initialDelay = 30 seconds

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
@@ -124,7 +124,8 @@ object Config {
     DataprocConfig(
       config.getStringList("defaultScopes").asScala.toSet,
       config.as[DataprocCustomImage]("customDataprocImage"),
-      config.getAs[MemorySize]("dataprocReservedMemory"),
+      config.getAs[Double]("sparkMemoryConfigRatio"),
+      config.getAs[Double]("minimumRuntimeMemoryInGb"),
       config.as[RuntimeConfig.DataprocConfig]("runtimeDefaults"),
       config.as[Set[RegionName]]("supportedRegions")
     )

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/DataprocConfig.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/DataprocConfig.scala
@@ -7,7 +7,8 @@ import org.broadinstitute.dsde.workbench.leonardo.CustomImage.DataprocCustomImag
 final case class DataprocConfig(
   defaultScopes: Set[String],
   customDataprocImage: DataprocCustomImage,
-  dataprocReservedMemory: Option[MemorySize],
+  sparkMemoryConfigRatio: Option[Double],
+  minimumRuntimeMemoryInGb: Option[Double],
   runtimeConfigDefaults: RuntimeConfig.DataprocConfig,
   supportedRegions: Set[RegionName]
 )

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GceInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GceInterpreter.scala
@@ -527,7 +527,7 @@ class GceInterpreter[F[_]](
       gceAllocated = config.gceConfig.gceReservedMemory.map(_.bytes).getOrElse(0L)
       welderAllocated = config.welderConfig.welderReservedMemory.map(_.bytes).getOrElse(0L)
       result = MemorySize(total.bytes - gceAllocated - welderAllocated)
-    } yield RuntimeResourceConstraints(result)
+    } yield RuntimeResourceConstraints(result, total)
 
   private def buildNetworkInterfaces(runtimeProjectAndName: RuntimeProjectAndName,
                                      subnetwork: SubnetworkName,

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/CommonTestData.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/CommonTestData.scala
@@ -233,7 +233,7 @@ object CommonTestData {
   val cryptoDetectorImage =
     RuntimeImage(CryptoDetector, "crypto/crypto:0.0.1", None, Instant.now.truncatedTo(ChronoUnit.MICROS))
 
-  val clusterResourceConstraints = RuntimeResourceConstraints(MemorySize.fromMb(3584))
+  val clusterResourceConstraints = RuntimeResourceConstraints(MemorySize.fromMb(3584), MemorySize.fromMb(7680))
   val hostToIpMapping = Ref.unsafe[IO, Map[Host, IP]](Map.empty)
 
   def makeAsyncRuntimeFields(index: Int): AsyncRuntimeFields =


### PR DESCRIPTION
<!-- Welcome to your Leonardo pull request! -->
<!-- Contributor guidelines: https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md -->

__Jira ticket__: https://broadworkbench.atlassian.net/browse/IA-4169

<!-- ## Dependencies -->
<!-- Include any dependent tickets and describe the relationship. Include any other relevant Jira tickets. -->

## Summary of changes

Hail/Dataproc users are finding their machine's memory isn't being configured correctly.
<!-- Please give an abridged version of the ticket description here and/or fill out the following fields. -->

### What

- Add spark.driver.memory to the Software Config builder
- Add a DataProcMachineSpecification type for mapping MachineTypeName to / from CPU and Memory.

### Why

- dataproc users are unable to properly run their data analyses.

## Testing these changes

## How to test
Create a spark node OR cluster. **With the HAIL image!** 
Take note of the "non-worker" memory allocation.

![Screenshot 2023-05-04 at 3 16 26 PM](https://user-images.githubusercontent.com/11773357/236306337-0dfdc833-e1b6-4412-b366-82199e874f91.png)
Once it's running, view output from `!cat /etc/spark/conf/spark-defaults.conf`
Verify spark.driver.memory is set to a number approx 80% of the total available memory.
![Screenshot 2023-05-04 at 3 27 03 PM](https://user-images.githubusercontent.com/11773357/236309495-8aed2500-5251-4d89-a0a2-c1a243798fc3.png)

Additionally, verify Jupyter docker image is allowed up to 20% of total available memory.

![image](https://user-images.githubusercontent.com/11773357/236306593-4235a4e2-9319-4d9d-a96c-8a39aca682e3.png)

Note - you may need to find the resource in the GCC. dataproc machines are tagged with `-m` after the name seen in terra-ui.
gcloud compute ssh --zone "us-central1-a" "<runtimeName>" --project "<projectName>"

on the machine, run `docker stats`
Verify the jupyter-server image has a max limit set to ~20% available GB.
![Screenshot 2023-05-04 at 3 25 10 PM](https://user-images.githubusercontent.com/11773357/236309204-d39dba61-c8b5-40da-85bd-d79ab3e4c20e.png)





<!-- ### Test data -->

### Who tested and where



- [ ] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [x] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->

