### PR TITLE
IA-4286: listApps returning empty list

### DIFF
--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/AppServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/AppServiceInterp.scala
@@ -270,7 +270,7 @@ final class LeoAppServiceInterp[F[_]: Parallel](config: AppServiceConfig,
       allClusters <- KubernetesServiceDbQueries
         .listFullApps(cloudContext, paramMap._1, paramMap._2, creatorOnly)
         .transaction
-      res <- filterAppsBySamPermission(allClusters, userInfo, paramMap._3, "v1")
+      res <- filterAppsBySamPermission(allClusters, userInfo, paramMap._3)
     } yield res
 
   override def deleteApp(userInfo: UserInfo, cloudContext: CloudContext.Gcp, appName: AppName, deleteDisk: Boolean)(
@@ -435,7 +435,7 @@ final class LeoAppServiceInterp[F[_]: Parallel](config: AppServiceConfig,
       .listFullAppsByWorkspaceId(Some(workspaceId), paramMap._1, paramMap._2)
       .transaction
 
-    res <- filterAppsBySamPermission(allClusters, userInfo, paramMap._3, "v2")
+    res <- filterAppsBySamPermission(allClusters, userInfo, paramMap._3)
   } yield res
 
   override def getAppV2(userInfo: UserInfo, workspaceId: WorkspaceId, appName: AppName)(implicit
@@ -1144,19 +1144,17 @@ final class LeoAppServiceInterp[F[_]: Parallel](config: AppServiceConfig,
     )
   }
 
-  private def filterAppsBySamPermission(allClusters: List[KubernetesCluster],
-                                        userInfo: UserInfo,
-                                        labels: List[String],
-                                        apiVersion: String
-  )(implicit
-    as: Ask[F, AppContext]
+  private def filterAppsBySamPermission(allClusters: List[KubernetesCluster], userInfo: UserInfo, labels: List[String])(
+    implicit as: Ask[F, AppContext]
   ): F[Vector[ListAppResponse]] = for {
     _ <- as.ask
     samResources = allClusters.flatMap(_.nodepools.flatMap(_.apps.map(_.samResourceId)))
     // Partition apps by shared vs. private access scope and make a separate Sam call for each, then re-combine them.
     // The reason we do this shared vs. private app access scope is represented by different Sam resource types/actions,
-    // and therefore needs different decoders to process the result list..
-    partition = samResources.partition(_.accessScope.exists(_ == AppAccessScope.WorkspaceShared))
+    // and therefore needs different decoders to process the result list.
+    partition = samResources
+      .map(sr => sr.copy(accessScope = sr.accessScope.orElse(Some(AppAccessScope.UserPrivate))))
+      .partition(_.accessScope.exists(_ == AppAccessScope.WorkspaceShared))
     samVisibleSharedAppsOpt <- NonEmptyList.fromList(partition._1).traverse { apps =>
       authProvider.filterUserVisible(apps, userInfo)(implicitly, sharedAppSamIdDecoder, implicitly)
     }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/AppServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/AppServiceInterp.scala
@@ -1154,7 +1154,7 @@ final class LeoAppServiceInterp[F[_]: Parallel](config: AppServiceConfig,
     // and therefore needs different decoders to process the result list.
     partition = samResources
       .map(sr => sr.copy(accessScope = sr.accessScope.orElse(Some(AppAccessScope.UserPrivate))))
-      .partition(_.accessScope.exists(_ == AppAccessScope.WorkspaceShared))
+      .partition(_.accessScope == Some(AppAccessScope.WorkspaceShared))
     samVisibleSharedAppsOpt <- NonEmptyList.fromList(partition._1).traverse { apps =>
       authProvider.filterUserVisible(apps, userInfo)(implicitly, sharedAppSamIdDecoder, implicitly)
     }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/AppServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/AppServiceInterp.scala
@@ -1181,8 +1181,9 @@ final class LeoAppServiceInterp[F[_]: Parallel](config: AppServiceConfig,
                   n.copy(apps = n.apps.filter { a =>
                     // Making the assumption that users will always be able to access apps that they create
                     // Fix for https://github.com/DataBiosphere/leonardo/issues/821
-                    samVisibleAppsSet
-                      .contains(a.samResourceId) || a.auditInfo.creator == userInfo.userEmail
+                    val sr =
+                      a.samResourceId.copy(accessScope = a.appAccessScope.orElse(Some(AppAccessScope.UserPrivate)))
+                    samVisibleAppsSet.contains(sr) || a.auditInfo.creator == userInfo.userEmail
                   })
                 }
                 .filterNot(_.apps.isEmpty)


### PR DESCRIPTION
<!-- Welcome to your Leonardo pull request! -->
<!-- Contributor guidelines: https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md -->

__Jira ticket__: https://broadworkbench.atlassian.net/browse/IA-4286

<!-- ## Dependencies -->
<!-- Include any dependent tickets and describe the relationship. Include any other relevant Jira tickets. -->

I think this regressed in https://github.com/DataBiosphere/leonardo/pull/3255. That PR attempted to fix an issue with listing apps with `WorkspaceShared` accessScope; but inadvertently broke things for apps with `accessScope = None`.

<!-- Please give an abridged version of the ticket description here and/or fill out the following fields. -->

### What

- Fix logic bug with listApps filtering out results.

### Why

- AoU raised the issue.

## Testing these changes

### What to test

- Create an app; list the app as the user and the pet.
- Unit test now covers this

<!-- ### Test data -->

### Who tested and where

- [x] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [x] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [x] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
