### PR TITLE
[IA-4081] Allowlist origins for CORS

### DIFF
--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/CorsSupport.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/CorsSupport.scala
@@ -2,9 +2,7 @@ package org.broadinstitute.dsde.workbench.leonardo
 package http
 package api
 
-import akka.http.scaladsl.model.{HttpResponse, StatusCodes}
 import akka.http.scaladsl.model.headers._
-import akka.http.scaladsl.model.HttpMethods._
 import akka.http.scaladsl.server.{Directive0, Route}
 import akka.http.scaladsl.server.Directives._
 import org.broadinstitute.dsde.workbench.leonardo.config.ContentSecurityPolicyConfig
@@ -13,19 +11,11 @@ import com.typesafe.scalalogging.LazyLogging
 
 class CorsSupport(contentSecurityPolicy: ContentSecurityPolicyConfig, refererConfig: RefererConfig)
     extends LazyLogging {
-  def corsHandler(r: Route) =
-    validateOrigin {
-      addAccessControlHeaders {
-        preflightRequestHandler ~ r
-      }
+
+  def corsHandler(r: Route): Route = validateOrigin {
+    addAccessControlHeaders {
+      r
     }
-  // TODO proxy routes only?
-  // This handles preflight OPTIONS requests.
-  private def preflightRequestHandler: Route = options {
-    complete(
-      HttpResponse(StatusCodes.NoContent)
-        .withHeaders(`Access-Control-Allow-Methods`(OPTIONS, POST, PUT, GET, DELETE, HEAD, PATCH))
-    )
   }
 
   // Ensure the request Origin is included in our referrer allowlist.

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/CorsSupport.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/CorsSupport.scala
@@ -45,7 +45,6 @@ class CorsSupport(contentSecurityPolicy: ContentSecurityPolicyConfig, refererCon
           h.isNot(`Access-Control-Allow-Origin`.lowercaseName) && h.isNot("content-security-policy")
         } ++
           allowOrigin ++
-          // TODO do the rest of these apply to all routes or proxy only?
           Seq(
             `Access-Control-Allow-Credentials`(true),
             `Access-Control-Allow-Headers`("Authorization", "Content-Type", "Accept", "Origin", "X-App-Id"),

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/CorsSupport.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/CorsSupport.scala
@@ -23,8 +23,7 @@ class CorsSupport(contentSecurityPolicy: ContentSecurityPolicyConfig, refererCon
       pass
     } else {
       def validOrigins: Set[HttpOrigin] = refererConfig.validHosts
-        .map(uri => if (uri.last == '/') uri.slice(0, uri.length - 1) else uri)
-        .map(host => HttpOrigin("http", Host(host)))
+        .map(uriString => HttpOrigin(s"http://${uriString}"))
       checkSameOrigin(HttpOriginRange(validOrigins.toSeq: _*))
     }
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/CorsSupport.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/CorsSupport.scala
@@ -2,9 +2,7 @@ package org.broadinstitute.dsde.workbench.leonardo
 package http
 package api
 
-import akka.http.scaladsl.model.HttpMethods._
 import akka.http.scaladsl.model.headers._
-import akka.http.scaladsl.model.{HttpResponse, StatusCodes}
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.{Directive0, Route}
 import com.typesafe.scalalogging.LazyLogging
@@ -15,21 +13,9 @@ class CorsSupport(contentSecurityPolicy: ContentSecurityPolicyConfig, refererCon
 
   def corsHandler(r: Route): Route =
     addAccessControlHeaders {
-      concat (
-        preflightRequestHandler,
-        validateOrigin {
-          r
-        }
-      )
-    }
-
-  // This handles preflight OPTIONS requests.
-  private def preflightRequestHandler: Route =
-    options {
-      complete(
-        HttpResponse(StatusCodes.NoContent)
-          .withHeaders(`Access-Control-Allow-Methods`(OPTIONS, POST, PUT, GET, DELETE, HEAD, PATCH))
-      )
+      validateOrigin {
+        r
+      }
     }
 
   // Ensure the request Origin is included in our referrer allowlist.

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/CorsSupport.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/CorsSupport.scala
@@ -3,12 +3,10 @@ package http
 package api
 
 import akka.http.scaladsl.model.headers._
-import akka.http.scaladsl.server.Directive0
 import akka.http.scaladsl.server.Directives._
-import akka.http.scaladsl.server.Route
+import akka.http.scaladsl.server.{Directive0, Route}
 import com.typesafe.scalalogging.LazyLogging
-import org.broadinstitute.dsde.workbench.leonardo.config.ContentSecurityPolicyConfig
-import org.broadinstitute.dsde.workbench.leonardo.config.RefererConfig
+import org.broadinstitute.dsde.workbench.leonardo.config.{ContentSecurityPolicyConfig, RefererConfig}
 
 class CorsSupport(contentSecurityPolicy: ContentSecurityPolicyConfig, refererConfig: RefererConfig)
     extends LazyLogging {

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/CorsSupport.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/CorsSupport.scala
@@ -32,7 +32,8 @@ class CorsSupport(contentSecurityPolicy: ContentSecurityPolicyConfig, refererCon
     if (!refererConfig.enabled || refererConfig.validHosts.contains("*"))
       pass
     else {
-      def validOrigins: Set[HttpOrigin] = refererConfig.validHosts.map(uri => HttpOrigin(uri))
+      def validOrigins: Set[HttpOrigin] = refererConfig.validHosts
+        .map(uri => HttpOrigin("http", Host(uri)))
       checkSameOrigin(HttpOriginRange(validOrigins.toSeq: _*))
     }
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/CorsSupport.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/CorsSupport.scala
@@ -24,7 +24,10 @@ class CorsSupport(contentSecurityPolicy: ContentSecurityPolicyConfig, refererCon
       pass
     } else {
       def validOrigins: Set[HttpOrigin] = refererConfig.validHosts
-        .map(uriString => HttpOrigin(s"http://${uriString}"))
+        .flatMap { uriString =>
+          Set(HttpOrigin(s"http://${uriString}"), HttpOrigin(s"https://${uriString}"))
+        }
+
       checkSameOrigin(HttpOriginRange(validOrigins.toSeq: _*))
     }
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/CorsSupport.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/CorsSupport.scala
@@ -3,11 +3,12 @@ package http
 package api
 
 import akka.http.scaladsl.model.headers._
-import akka.http.scaladsl.server.{Directive0, Route}
+import akka.http.scaladsl.server.Directive0
 import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.server.Route
+import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.workbench.leonardo.config.ContentSecurityPolicyConfig
 import org.broadinstitute.dsde.workbench.leonardo.config.RefererConfig
-import com.typesafe.scalalogging.LazyLogging
 
 class CorsSupport(contentSecurityPolicy: ContentSecurityPolicyConfig, refererConfig: RefererConfig)
     extends LazyLogging {
@@ -20,9 +21,9 @@ class CorsSupport(contentSecurityPolicy: ContentSecurityPolicyConfig, refererCon
 
   // Ensure the request Origin is included in our referrer allowlist.
   private def validateOrigin: Directive0 =
-    if (!refererConfig.enabled || refererConfig.validHosts.contains("*"))
+    if (!refererConfig.enabled || refererConfig.validHosts.contains("*")) {
       pass
-    else {
+    } else {
       def validOrigins: Set[HttpOrigin] = refererConfig.validHosts
         .map(uri => if (uri.last == '/') uri.slice(0, uri.length - 1) else uri)
         .map(host => HttpOrigin("http", Host(host)))
@@ -32,7 +33,8 @@ class CorsSupport(contentSecurityPolicy: ContentSecurityPolicyConfig, refererCon
   // This directive adds access control headers to normal responses
   private def addAccessControlHeaders: Directive0 =
     optionalHeaderValueByType(Origin) map {
-      case Some(origin) => Seq(`Access-Control-Allow-Origin`(origin.value), RawHeader("Vary", Origin.name))
+      case Some(origin) =>
+        Seq(`Access-Control-Allow-Origin`(origin.value), RawHeader("Vary", Origin.name))
       case None =>
         Seq(`Access-Control-Allow-Origin`.*)
     } flatMap { allowOrigin =>

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/CorsSupport.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/CorsSupport.scala
@@ -14,15 +14,14 @@ class CorsSupport(contentSecurityPolicy: ContentSecurityPolicyConfig, refererCon
     extends LazyLogging {
 
   def corsHandler(r: Route): Route =
-      addAccessControlHeaders {
-        preflightRequestHandler ~ validateOrigin {
-          r
-        }
+    addAccessControlHeaders {
+      preflightRequestHandler ~ validateOrigin {
+        r
       }
     }
 
   // This handles preflight OPTIONS requests.
-  private val preflightRequestHandler: Route =
+  private def preflightRequestHandler: Route =
     options {
       complete(
         HttpResponse(StatusCodes.NoContent)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/CorsSupport.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/CorsSupport.scala
@@ -2,8 +2,10 @@ package org.broadinstitute.dsde.workbench.leonardo
 package http
 package api
 
+import akka.http.scaladsl.model.HttpRequest
 import akka.http.scaladsl.model.headers._
 import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.server.directives.DebuggingDirectives
 import akka.http.scaladsl.server.{Directive0, Route}
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.workbench.leonardo.config.{ContentSecurityPolicyConfig, RefererConfig}
@@ -31,22 +33,21 @@ class CorsSupport(contentSecurityPolicy: ContentSecurityPolicyConfig, refererCon
       checkSameOrigin(HttpOriginRange(validOrigins.toSeq: _*))
     }
 
+  private def requestPath(req: HttpRequest): String = req.uri.toString
+  private val logRequestPath = DebuggingDirectives.logRequest(requestPath _)
+
   // This directive adds access control headers to normal responses
   private def addAccessControlHeaders: Directive0 =
-    optionalHeaderValueByType(Origin) map {
-      case Some(origin) =>
-        Seq(`Access-Control-Allow-Origin`(origin.value), RawHeader("Vary", Origin.name))
-      case None =>
-        Seq(`Access-Control-Allow-Origin`.*)
-    } flatMap { allowOrigin =>
+    headerValueByType(Origin).flatMap { origin =>
       mapResponseHeaders { headers =>
         // Filter out the Access-Control-Allow-Origin set by Jupyter so we don't have duplicate headers
         // (causes issues on some browsers). See https://github.com/DataBiosphere/leonardo/issues/272
         headers.filter { h =>
           h.isNot(`Access-Control-Allow-Origin`.lowercaseName) && h.isNot("content-security-policy")
         } ++
-          allowOrigin ++
           Seq(
+            `Access-Control-Allow-Origin`(origin.value),
+            RawHeader("Vary", Origin.name),
             `Access-Control-Allow-Credentials`(true),
             `Access-Control-Allow-Headers`("Authorization", "Content-Type", "Accept", "Origin", "X-App-Id"),
             `Access-Control-Max-Age`(1728000),

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/CorsSupport.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/CorsSupport.scala
@@ -15,9 +15,12 @@ class CorsSupport(contentSecurityPolicy: ContentSecurityPolicyConfig, refererCon
 
   def corsHandler(r: Route): Route =
     addAccessControlHeaders {
-      preflightRequestHandler ~ validateOrigin {
-        r
-      }
+      concat (
+        preflightRequestHandler,
+        validateOrigin {
+          r
+        }
+      )
     }
 
   // This handles preflight OPTIONS requests.

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/HttpRoutes.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/HttpRoutes.scala
@@ -40,7 +40,7 @@ class HttpRoutes(
   refererConfig: RefererConfig
 )(implicit ec: ExecutionContext, ac: ActorSystem, metrics: OpenTelemetryMetrics[IO], logger: StructuredLogger[IO]) {
   private val statusRoutes = new StatusRoutes(statusService)
-  private val corsSupport = new CorsSupport(contentSecurityPolicy)
+  private val corsSupport = new CorsSupport(contentSecurityPolicy, refererConfig)
   private val proxyRoutes = new ProxyRoutes(proxyService, corsSupport, refererConfig)
   private val runtimeRoutes = new RuntimeRoutes(refererConfig, runtimeService, userInfoDirectives)
   private val diskRoutes = new DiskRoutes(diskService, userInfoDirectives)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/HttpRoutes.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/HttpRoutes.scala
@@ -112,13 +112,26 @@ class HttpRoutes(
   val route: Route =
     logRequestResult {
       Route.seal(
-        corsSupport.corsHandler {
-          oidcConfig
-            .swaggerRoutes("swagger/api-docs.yaml") ~ oidcConfig.oauth2Routes ~ proxyRoutes.route ~ statusRoutes.route ~
-            pathPrefix("api") {
-              runtimeRoutes.routes ~ runtimeV2Routes.routes ~ diskRoutes.routes ~ kubernetesRoutes.routes ~ appV2Routes.routes ~ diskV2Routes.routes
-            }
-        }
+        concat(
+          oidcConfig.swaggerRoutes("swagger/api-docs.yaml"),
+          oidcConfig.oauth2Routes,
+          corsSupport.corsHandler {
+            concat(
+              proxyRoutes.route,
+              statusRoutes.route,
+              pathPrefix("api") {
+                concat(
+                  runtimeRoutes.routes,
+                  runtimeV2Routes.routes,
+                  diskRoutes.routes,
+                  kubernetesRoutes.routes,
+                  appV2Routes.routes,
+                  diskV2Routes.routes
+                )
+              }
+            )
+          }
+        )
       )
     }
 }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/HttpRoutes.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/HttpRoutes.scala
@@ -115,10 +115,11 @@ class HttpRoutes(
         concat(
           oidcConfig.swaggerRoutes("swagger/api-docs.yaml"),
           oidcConfig.oauth2Routes,
+          statusRoutes.route,
           corsSupport.corsHandler {
+            // TODO handle cors rejections here
             concat(
               proxyRoutes.route,
-              statusRoutes.route,
               pathPrefix("api") {
                 concat(
                   runtimeRoutes.routes,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/HttpRoutes.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/HttpRoutes.scala
@@ -111,15 +111,15 @@ class HttpRoutes(
 
   val route: Route =
     logRequestResult {
-        Route.seal(
-          corsSupport.corsHandler {
-            oidcConfig
-              .swaggerRoutes("swagger/api-docs.yaml") ~ oidcConfig.oauth2Routes ~ proxyRoutes.route ~ statusRoutes.route ~
-                pathPrefix("api") {
-                  runtimeRoutes.routes ~ runtimeV2Routes.routes ~ diskRoutes.routes ~ kubernetesRoutes.routes ~ appV2Routes.routes ~ diskV2Routes.routes
-                }
-          }
-        )
+      Route.seal(
+        corsSupport.corsHandler {
+          oidcConfig
+            .swaggerRoutes("swagger/api-docs.yaml") ~ oidcConfig.oauth2Routes ~ proxyRoutes.route ~ statusRoutes.route ~
+            pathPrefix("api") {
+              runtimeRoutes.routes ~ runtimeV2Routes.routes ~ diskRoutes.routes ~ kubernetesRoutes.routes ~ appV2Routes.routes ~ diskV2Routes.routes
+            }
+        }
+      )
     }
 }
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/HttpRoutes.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/HttpRoutes.scala
@@ -113,12 +113,14 @@ class HttpRoutes(
     RejectionHandler
       .newBuilder()
       .handle {
+        // From checkSameOrigin failure
         case InvalidOriginRejection(allowedOrigins) =>
           complete(
             HttpResponse(StatusCodes.BadRequest,
                          entity = s"Invalid origin header; accepted origins are ${allowedOrigins.toString}"
             )
           )
+        // From checkSameOrigin failure
         case MissingHeaderRejection(headerName) =>
           complete(HttpResponse(StatusCodes.BadRequest, entity = s"Missing required HTTP header: ${headerName}"))
       }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/HttpRoutes.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/HttpRoutes.scala
@@ -111,13 +111,15 @@ class HttpRoutes(
 
   val route: Route =
     logRequestResult {
-      Route.seal(
-        oidcConfig
-          .swaggerRoutes("swagger/api-docs.yaml") ~ oidcConfig.oauth2Routes ~ proxyRoutes.route ~ statusRoutes.route ~
-          pathPrefix("api") {
-            runtimeRoutes.routes ~ runtimeV2Routes.routes ~ diskRoutes.routes ~ kubernetesRoutes.routes ~ appV2Routes.routes ~ diskV2Routes.routes
+        Route.seal(
+          corsSupport.corsHandler {
+            oidcConfig
+              .swaggerRoutes("swagger/api-docs.yaml") ~ oidcConfig.oauth2Routes ~ proxyRoutes.route ~ statusRoutes.route ~
+                pathPrefix("api") {
+                  runtimeRoutes.routes ~ runtimeV2Routes.routes ~ diskRoutes.routes ~ kubernetesRoutes.routes ~ appV2Routes.routes ~ diskV2Routes.routes
+                }
           }
-      )
+        )
     }
 }
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/ProxyRoutes.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/ProxyRoutes.scala
@@ -2,22 +2,15 @@ package org.broadinstitute.dsde.workbench.leonardo
 package http
 package api
 
-import akka.event.Logging
-import akka.event.LoggingAdapter
+import akka.event.{Logging, LoggingAdapter}
 import akka.http.scaladsl.marshalling.ToResponseMarshallable
 import akka.http.scaladsl.model.HttpMethods._
-import akka.http.scaladsl.model.HttpResponse
-import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.headers._
-import akka.http.scaladsl.server.Directive0
-import akka.http.scaladsl.server.Directive1
 import akka.http.scaladsl.server.Directives._
-import akka.http.scaladsl.server.Route
+import akka.http.scaladsl.server.{Directive0, Directive1, Route}
 import akka.http.scaladsl.server.RouteResult.Complete
-import akka.http.scaladsl.server.directives.DebuggingDirectives
-import akka.http.scaladsl.server.directives.LogEntry
-import akka.http.scaladsl.server.directives.LoggingMagnet
+import akka.http.scaladsl.server.directives.{DebuggingDirectives, LogEntry, LoggingMagnet}
 import akka.stream.Materializer
 import cats.effect.IO
 import cats.mtl.Ask
@@ -29,8 +22,7 @@ import org.broadinstitute.dsde.workbench.leonardo.config.RefererConfig
 import org.broadinstitute.dsde.workbench.leonardo.dao.TerminalName
 import org.broadinstitute.dsde.workbench.leonardo.http.service.ProxyService
 import org.broadinstitute.dsde.workbench.leonardo.model.AuthenticationError
-import org.broadinstitute.dsde.workbench.model.TraceId
-import org.broadinstitute.dsde.workbench.model.UserInfo
+import org.broadinstitute.dsde.workbench.model.{TraceId, UserInfo}
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.broadinstitute.dsde.workbench.openTelemetry.OpenTelemetryMetrics
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/ProxyRoutes.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/ProxyRoutes.scala
@@ -2,16 +2,22 @@ package org.broadinstitute.dsde.workbench.leonardo
 package http
 package api
 
-import akka.event.{Logging, LoggingAdapter}
+import akka.event.Logging
+import akka.event.LoggingAdapter
 import akka.http.scaladsl.marshalling.ToResponseMarshallable
 import akka.http.scaladsl.model.HttpMethods._
+import akka.http.scaladsl.model.HttpResponse
+import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.headers._
-import akka.http.scaladsl.model.{HttpResponse, StatusCodes}
+import akka.http.scaladsl.server.Directive0
+import akka.http.scaladsl.server.Directive1
 import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.server.Route
 import akka.http.scaladsl.server.RouteResult.Complete
-import akka.http.scaladsl.server.directives.{DebuggingDirectives, LogEntry, LoggingMagnet}
-import akka.http.scaladsl.server.{Directive0, Directive1, Route}
+import akka.http.scaladsl.server.directives.DebuggingDirectives
+import akka.http.scaladsl.server.directives.LogEntry
+import akka.http.scaladsl.server.directives.LoggingMagnet
 import akka.stream.Materializer
 import cats.effect.IO
 import cats.mtl.Ask
@@ -23,8 +29,9 @@ import org.broadinstitute.dsde.workbench.leonardo.config.RefererConfig
 import org.broadinstitute.dsde.workbench.leonardo.dao.TerminalName
 import org.broadinstitute.dsde.workbench.leonardo.http.service.ProxyService
 import org.broadinstitute.dsde.workbench.leonardo.model.AuthenticationError
+import org.broadinstitute.dsde.workbench.model.TraceId
+import org.broadinstitute.dsde.workbench.model.UserInfo
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
-import org.broadinstitute.dsde.workbench.model.{TraceId, UserInfo}
 import org.broadinstitute.dsde.workbench.openTelemetry.OpenTelemetryMetrics
 
 class ProxyRoutes(proxyService: ProxyService, corsSupport: CorsSupport, refererConfig: RefererConfig)(implicit
@@ -123,7 +130,7 @@ class ProxyRoutes(proxyService: ProxyService, corsSupport: CorsSupport, refererC
                     }
                   }
                 }
-           }
+            }
           }
         }
       }
@@ -163,7 +170,8 @@ class ProxyRoutes(proxyService: ProxyService, corsSupport: CorsSupport, refererC
         onSuccess(
           proxyService.getCachedUserInfoFromToken(token, false).unsafeToFuture()(cats.effect.unsafe.IORuntime.global)
         )
-      case None => failWith(AuthenticationError())
+      case None =>
+        failWith(AuthenticationError())
     }
 
   /**

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/RuntimeRoutes.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/RuntimeRoutes.scala
@@ -10,19 +10,15 @@ import cats.effect.IO
 import cats.mtl.Ask
 import cats.syntax.all._
 import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
-import io.circe.Decoder
-import io.circe.DecodingFailure
-import io.circe.Encoder
+import io.circe.{Decoder, DecodingFailure, Encoder}
 import io.opencensus.scala.akka.http.TracingDirective.traceRequestForService
 import org.broadinstitute.dsde.workbench.google2.JsonCodec.traceIdEncoder
-import org.broadinstitute.dsde.workbench.google2.MachineTypeName
-import org.broadinstitute.dsde.workbench.google2.RegionName
-import org.broadinstitute.dsde.workbench.google2.ZoneName
+import org.broadinstitute.dsde.workbench.google2.{MachineTypeName, RegionName, ZoneName}
 import org.broadinstitute.dsde.workbench.leonardo.JsonCodec._
 import org.broadinstitute.dsde.workbench.leonardo.config.RefererConfig
+import org.broadinstitute.dsde.workbench.leonardo.http.RuntimeRoutesCodec._
 import org.broadinstitute.dsde.workbench.leonardo.http.api.RuntimeRoutes._
-import org.broadinstitute.dsde.workbench.leonardo.http.service.DeleteRuntimeRequest
-import org.broadinstitute.dsde.workbench.leonardo.http.service.RuntimeService
+import org.broadinstitute.dsde.workbench.leonardo.http.service.{DeleteRuntimeRequest, RuntimeService}
 import org.broadinstitute.dsde.workbench.leonardo.model.BadRequestException
 import org.broadinstitute.dsde.workbench.model.UserInfo
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
@@ -30,8 +26,6 @@ import org.broadinstitute.dsde.workbench.openTelemetry.OpenTelemetryMetrics
 import org.typelevel.log4cats.StructuredLogger
 
 import scala.concurrent.duration._
-
-import RuntimeRoutesCodec._
 
 class RuntimeRoutes(saturnIframeExtentionHostConfig: RefererConfig,
                     runtimeService: RuntimeService[IO],

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/RuntimeRoutes.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/RuntimeRoutes.scala
@@ -10,22 +10,28 @@ import cats.effect.IO
 import cats.mtl.Ask
 import cats.syntax.all._
 import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
-import io.circe.{Decoder, DecodingFailure, Encoder}
+import io.circe.Decoder
+import io.circe.DecodingFailure
+import io.circe.Encoder
 import io.opencensus.scala.akka.http.TracingDirective.traceRequestForService
-import org.broadinstitute.dsde.workbench.google2.{MachineTypeName, RegionName, ZoneName}
+import org.broadinstitute.dsde.workbench.google2.JsonCodec.traceIdEncoder
+import org.broadinstitute.dsde.workbench.google2.MachineTypeName
+import org.broadinstitute.dsde.workbench.google2.RegionName
+import org.broadinstitute.dsde.workbench.google2.ZoneName
 import org.broadinstitute.dsde.workbench.leonardo.JsonCodec._
-import RuntimeRoutesCodec._
 import org.broadinstitute.dsde.workbench.leonardo.config.RefererConfig
 import org.broadinstitute.dsde.workbench.leonardo.http.api.RuntimeRoutes._
-import org.broadinstitute.dsde.workbench.leonardo.http.service.{DeleteRuntimeRequest, RuntimeService}
+import org.broadinstitute.dsde.workbench.leonardo.http.service.DeleteRuntimeRequest
+import org.broadinstitute.dsde.workbench.leonardo.http.service.RuntimeService
 import org.broadinstitute.dsde.workbench.leonardo.model.BadRequestException
 import org.broadinstitute.dsde.workbench.model.UserInfo
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.broadinstitute.dsde.workbench.openTelemetry.OpenTelemetryMetrics
-import org.broadinstitute.dsde.workbench.google2.JsonCodec.traceIdEncoder
 import org.typelevel.log4cats.StructuredLogger
 
 import scala.concurrent.duration._
+
+import RuntimeRoutesCodec._
 
 class RuntimeRoutes(saturnIframeExtentionHostConfig: RefererConfig,
                     runtimeService: RuntimeService[IO],

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/ProxyService.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/ProxyService.scala
@@ -552,6 +552,7 @@ class ProxyService(
 
   private val HeadersToFilter = Set(
     "Host",
+    "Origin",
     "Timeout-Access",
     "Sec-WebSocket-Accept",
     "Sec-WebSocket-Version",

--- a/http/src/test/resources/reference.conf
+++ b/http/src/test/resources/reference.conf
@@ -135,8 +135,7 @@ oidc {
 
 refererConfig {
   validHosts = [
-    "example.com",
-    "*"
+    "example.com"
   ]
   enabled = true
 }

--- a/http/src/test/resources/reference.conf
+++ b/http/src/test/resources/reference.conf
@@ -135,6 +135,7 @@ oidc {
 
 refererConfig {
   validHosts = [
+    "localhost:3000"
     "example.com"
   ]
   enabled = true

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/config/RefererConfigSpec/RefererConfigSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/config/RefererConfigSpec/RefererConfigSpec.scala
@@ -4,7 +4,7 @@ import org.scalatest.flatspec.AnyFlatSpecLike
 
 class RefererConfigSpec extends LeonardoTestSuite with AnyFlatSpecLike {
   it should "parse config values correctly" in {
-    CommonTestData.refererConfig.validHosts shouldBe Set("example.com")
+    CommonTestData.refererConfig.validHosts shouldBe Set("localhost:3000", "example.com")
     CommonTestData.refererConfig.enabled shouldBe true
   }
 }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/config/RefererConfigSpec/RefererConfigSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/config/RefererConfigSpec/RefererConfigSpec.scala
@@ -4,7 +4,7 @@ import org.scalatest.flatspec.AnyFlatSpecLike
 
 class RefererConfigSpec extends LeonardoTestSuite with AnyFlatSpecLike {
   it should "parse config values correctly" in {
-    CommonTestData.refererConfig.validHosts shouldBe Set("example.com", "*")
+    CommonTestData.refererConfig.validHosts shouldBe Set("example.com")
     CommonTestData.refererConfig.enabled shouldBe true
   }
 }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/HttpRoutesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/HttpRoutesSpec.scala
@@ -80,6 +80,7 @@ class HttpRoutesSpec
 
   "RuntimeRoutes" should "create runtime id1" in {
     Post("/api/google/v1/runtimes/googleProject1/runtime1")
+      .addHeader(Origin(validOrigin))
       .withEntity(ContentTypes.`application/json`,
                   defaultCreateRuntimeRequest.asJson.spaces2
       ) ~> routes.route ~> check {
@@ -100,6 +101,7 @@ class HttpRoutesSpec
     }
 
     Post("/api/google/v1/runtimes/googleProject1/runtime1")
+      .addHeader(Origin(validOrigin))
       .withEntity(ContentTypes.`application/json`, req.asJson.spaces2) ~> routes.route ~> check {
       status shouldEqual StatusCodes.Accepted
     }
@@ -107,6 +109,7 @@ class HttpRoutesSpec
 
   it should "create a runtime with default parameters" in {
     Post("/api/google/v1/runtimes/googleProject1/runtime1")
+      .addHeader(Origin(validOrigin))
       .withEntity(ContentTypes.`application/json`, "{}") ~> routes.route ~> check {
       status shouldEqual StatusCodes.Accepted
       validateRawCookie(header("Set-Cookie"))
@@ -115,9 +118,8 @@ class HttpRoutesSpec
 
   it should s"reject create a cluster if cluster name is invalid" in {
     val invalidClusterName = "MyCluster"
-    Post(s"/api/google/v1/runtimes/googleProject1/$invalidClusterName",
-         defaultCreateRuntimeRequest.asJson.spaces2
-    ) ~> httpRoutes.route ~> check {
+    Post(s"/api/google/v1/runtimes/googleProject1/$invalidClusterName", defaultCreateRuntimeRequest.asJson.spaces2)
+      .addHeader(Origin(validOrigin)) ~> httpRoutes.route ~> check {
       val expectedResponse =
         """Invalid name MyCluster. Only lowercase alphanumeric characters, numbers and dashes are allowed in leo names"""
       responseEntity.toStrict(5 seconds).futureValue.data.utf8String shouldBe expectedResponse
@@ -127,7 +129,8 @@ class HttpRoutesSpec
   }
 
   it should "get a runtime" in {
-    Get("/api/google/v1/runtimes/googleProject/runtime1") ~> routes.route ~> check {
+    Get("/api/google/v1/runtimes/googleProject/runtime1")
+      .addHeader(Origin(validOrigin)) ~> routes.route ~> check {
       status shouldEqual StatusCodes.OK
       responseAs[GetRuntimeResponse].id shouldBe CommonTestData.testCluster.id
       validateRawCookie(header("Set-Cookie"))
@@ -135,13 +138,15 @@ class HttpRoutesSpec
   }
 
   it should "return 404 when getting a non-existent runtime" in {
-    Get("/api/google/v1/runtimes/googleProject/runtime-non-existent") ~> httpRoutes.route ~> check {
+    Get("/api/google/v1/runtimes/googleProject/runtime-non-existent")
+      .addHeader(Origin(validOrigin)) ~> httpRoutes.route ~> check {
       status shouldEqual StatusCodes.NotFound
     }
   }
 
   it should "list runtimes with a project" in {
-    Get("/api/google/v1/runtimes/googleProject") ~> routes.route ~> check {
+    Get("/api/google/v1/runtimes/googleProject")
+      .addHeader(Origin(validOrigin)) ~> routes.route ~> check {
       status shouldEqual StatusCodes.OK
       responseAs[Vector[ListRuntimeResponse2]].map(_.id) shouldBe Vector(CommonTestData.testCluster.id)
       validateRawCookie(header("Set-Cookie"))
@@ -149,7 +154,8 @@ class HttpRoutesSpec
   }
 
   it should "list runtimes without a project" in {
-    Get("/api/google/v1/runtimes") ~> routes.route ~> check {
+    Get("/api/google/v1/runtimes")
+      .addHeader(Origin(validOrigin)) ~> routes.route ~> check {
       status shouldEqual StatusCodes.OK
       val response = responseAs[Vector[ListRuntimeResponse2]]
       response.map(_.id) shouldBe Vector(CommonTestData.testCluster.id)
@@ -178,13 +184,12 @@ class HttpRoutesSpec
       )
 
     for (i <- 1 to 10)
-      Post(s"/api/google/v1/runtimes/${googleProject}/${clusterName}-$i",
-           runtimesWithLabels(i).asJson
-      ) ~> httpRoutes.route ~> check {
+      Post(s"/api/google/v1/runtimes/${googleProject}/${clusterName}-$i", runtimesWithLabels(i).asJson)
+        .addHeader(Origin(validOrigin)) ~> httpRoutes.route ~> check {
         status shouldEqual StatusCodes.Accepted
       }
 
-    Get("/api/google/v1/runtimes?label6=value6") ~> httpRoutes.route ~> check {
+    Get("/api/google/v1/runtimes?label6=value6").addHeader(Origin(validOrigin)) ~> httpRoutes.route ~> check {
       status shouldEqual StatusCodes.OK
 
       val responseClusters = responseAs[List[ListRuntimeResponse2]]
@@ -207,7 +212,7 @@ class HttpRoutesSpec
       validateRawCookie(header("Set-Cookie"))
     }
 
-    Get("/api/google/v1/runtimes?_labels=label4%3Dvalue4") ~> httpRoutes.route ~> check {
+    Get("/api/google/v1/runtimes?_labels=label4%3Dvalue4").addHeader(Origin(validOrigin)) ~> httpRoutes.route ~> check {
       status shouldEqual StatusCodes.OK
 
       val responseClusters = responseAs[List[ListRuntimeResponse2]]
@@ -230,13 +235,13 @@ class HttpRoutesSpec
       validateRawCookie(header("Set-Cookie"))
     }
 
-    Get("/api/google/v1/runtimes?_labels=bad") ~> httpRoutes.route ~> check {
+    Get("/api/google/v1/runtimes?_labels=bad").addHeader(Origin(validOrigin)) ~> httpRoutes.route ~> check {
       status shouldEqual StatusCodes.BadRequest
     }
   }
 
   it should "list runtimes with parameters" in {
-    Get("/api/google/v1/runtimes?project=foo&creator=bar") ~> routes.route ~> check {
+    Get("/api/google/v1/runtimes?project=foo&creator=bar").addHeader(Origin(validOrigin)) ~> routes.route ~> check {
       status shouldEqual StatusCodes.OK
       responseAs[Vector[ListRuntimeResponse2]].map(_.id) shouldBe Vector(CommonTestData.testCluster.id)
       validateRawCookie(header("Set-Cookie"))
@@ -244,7 +249,7 @@ class HttpRoutesSpec
   }
 
   it should "delete a runtime" in {
-    Delete("/api/google/v1/runtimes/googleProject1/runtime1") ~> routes.route ~> check {
+    Delete("/api/google/v1/runtimes/googleProject1/runtime1").addHeader(Origin(validOrigin)) ~> routes.route ~> check {
       status shouldEqual StatusCodes.Accepted
       validateRawCookie(header("Set-Cookie"))
     }
@@ -260,7 +265,9 @@ class HttpRoutesSpec
         deleteRuntimeRequest shouldBe expectedDeleteRuntime
       }
     }
-    Delete("/api/google/v1/runtimes/googleProject1/runtime1?deleteDisk=true") ~> fakeRoutes(
+    Delete("/api/google/v1/runtimes/googleProject1/runtime1?deleteDisk=true").addHeader(
+      Origin(validOrigin)
+    ) ~> fakeRoutes(
       runtimeService
     ).route ~> check {
       status shouldEqual StatusCodes.Accepted
@@ -269,7 +276,9 @@ class HttpRoutesSpec
   }
 
   it should "return 404 when deleting a non-existent runtime" in {
-    Delete("/api/google/v1/runtimes/googleProject/runtime-non-existent") ~> httpRoutes.route ~> check {
+    Delete("/api/google/v1/runtimes/googleProject/runtime-non-existent").addHeader(
+      Origin(validOrigin)
+    ) ~> httpRoutes.route ~> check {
       status shouldEqual StatusCodes.NotFound
     }
   }
@@ -284,7 +293,9 @@ class HttpRoutesSpec
         deleteRuntimeRequest shouldBe expectedDeleteRuntime
       }
     }
-    Delete("/api/google/v1/runtimes/googleProject1/runtime1?deleteDisk=false") ~> fakeRoutes(
+    Delete("/api/google/v1/runtimes/googleProject1/runtime1?deleteDisk=false").addHeader(
+      Origin(validOrigin)
+    ) ~> fakeRoutes(
       runtimeService
     ).route ~> check {
       status shouldEqual StatusCodes.Accepted
@@ -303,7 +314,9 @@ class HttpRoutesSpec
         deleteRuntimeRequest shouldBe expectedDeleteRuntime
       }
     }
-    Delete("/api/google/v1/runtimes/googleProject1/runtime1") ~> fakeRoutes(runtimeService).route ~> check {
+    Delete("/api/google/v1/runtimes/googleProject1/runtime1").addHeader(Origin(validOrigin)) ~> fakeRoutes(
+      runtimeService
+    ).route ~> check {
       status shouldEqual StatusCodes.Accepted
       validateRawCookie(header("Set-Cookie"))
     }
@@ -319,34 +332,44 @@ class HttpRoutesSpec
         deleteDisk shouldBe false
       }
     }
-    Delete("/api/google/v1/apps/googleProject1/app1") ~> fakeRoutes(kubernetesService).route ~> check {
+    Delete("/api/google/v1/apps/googleProject1/app1").addHeader(Origin(validOrigin)) ~> fakeRoutes(
+      kubernetesService
+    ).route ~> check {
       status shouldEqual StatusCodes.Accepted
       validateRawCookie(header("Set-Cookie"))
     }
   }
 
   it should "stop a runtime" in {
-    Post("/api/google/v1/runtimes/googleProject1/runtime1/stop") ~> routes.route ~> check {
+    Post("/api/google/v1/runtimes/googleProject1/runtime1/stop").addHeader(
+      Origin(validOrigin)
+    ) ~> routes.route ~> check {
       status shouldEqual StatusCodes.Accepted
       validateRawCookie(header("Set-Cookie"))
     }
   }
 
   it should "return 404 when stopping a non-existent runtime" in {
-    Post("/api/google/v1/runtimes/googleProject1/runtime-non-existent/stop") ~> httpRoutes.route ~> check {
+    Post("/api/google/v1/runtimes/googleProject1/runtime-non-existent/stop").addHeader(
+      Origin(validOrigin)
+    ) ~> httpRoutes.route ~> check {
       status shouldEqual StatusCodes.NotFound
     }
   }
 
   it should "start a runtime" in {
-    Post("/api/google/v1/runtimes/googleProject1/runtime1/start") ~> routes.route ~> check {
+    Post("/api/google/v1/runtimes/googleProject1/runtime1/start").addHeader(
+      Origin(validOrigin)
+    ) ~> routes.route ~> check {
       status shouldEqual StatusCodes.Accepted
       validateRawCookie(header("Set-Cookie"))
     }
   }
 
   it should "return 404 when starting a non-existent runtime" in {
-    Post("/api/google/v1/runtimes/googleProject1/runtime-non-existent/start") ~> httpRoutes.route ~> check {
+    Post("/api/google/v1/runtimes/googleProject1/runtime-non-existent/start").addHeader(
+      Origin(validOrigin)
+    ) ~> httpRoutes.route ~> check {
       status shouldEqual StatusCodes.NotFound
     }
   }
@@ -361,6 +384,7 @@ class HttpRoutesSpec
       Set.empty
     )
     Patch("/api/google/v1/runtimes/googleProject1/runtime1")
+      .addHeader(Origin(validOrigin))
       .withEntity(ContentTypes.`application/json`, request.asJson.spaces2) ~> routes.route ~> check {
       status shouldEqual StatusCodes.Accepted
       validateRawCookie(header("Set-Cookie"))
@@ -369,6 +393,7 @@ class HttpRoutesSpec
 
   it should "update a runtime with default parameters" in {
     Patch("/api/google/v1/runtimes/googleProject1/runtime1")
+      .addHeader(Origin(validOrigin))
       .withEntity(ContentTypes.`application/json`, "{}") ~> routes.route ~> check {
       status shouldEqual StatusCodes.Accepted
       validateRawCookie(header("Set-Cookie"))
@@ -385,6 +410,7 @@ class HttpRoutesSpec
                            Set.empty
       )
     Patch("/api/google/v1/runtimes/googleProject1/runtime1")
+      .addHeader(Origin(validOrigin))
       .withEntity(ContentTypes.`application/json`, negative.asJson.spaces2) ~> routes.route ~> check {
       status shouldBe StatusCodes.BadRequest
       val resp = responseEntity.toStrict(5 seconds).futureValue.data.utf8String
@@ -399,6 +425,7 @@ class HttpRoutesSpec
                            Set.empty
       )
     Patch("/api/google/v1/runtimes/googleProject1/runtime1")
+      .addHeader(Origin(validOrigin))
       .withEntity(ContentTypes.`application/json`, oneWorker.asJson.spaces2) ~> routes.route ~> check {
       status shouldBe StatusCodes.BadRequest
       val resp = responseEntity.toStrict(5 seconds).futureValue.data.utf8String
@@ -408,6 +435,7 @@ class HttpRoutesSpec
 
   "RuntimeRoutesV2" should "create azure runtime" in {
     Post(s"/api/v2/runtimes/${workspaceId.value.toString}/azure/azureruntime1")
+      .addHeader(Origin(validOrigin))
       .withEntity(ContentTypes.`application/json`,
                   defaultCreateAzureRuntimeReq.asJson.spaces2
       ) ~> routes.route ~> check {
@@ -418,6 +446,7 @@ class HttpRoutesSpec
 
   it should "reject azure runtime with invalid workspaceId" in {
     Post(s"/api/v2/runtimes/invalidWorkspaceId/azure/azureruntime1")
+      .addHeader(Origin(validOrigin))
       .withEntity(ContentTypes.`application/json`,
                   defaultCreateAzureRuntimeReq.asJson.spaces2
       ) ~> routes.route ~> check {
@@ -430,6 +459,7 @@ class HttpRoutesSpec
 
   it should "reject azure runtime with invalid runtimeName" in {
     Post(s"/api/v2/runtimes/${workspaceId.value.toString}/azure/invalidRuntime")
+      .addHeader(Origin(validOrigin))
       .withEntity(ContentTypes.`application/json`,
                   defaultCreateAzureRuntimeReq.asJson.spaces2
       ) ~> routes.route ~> check {
@@ -441,7 +471,8 @@ class HttpRoutesSpec
   }
 
   it should "get an azure runtime" in {
-    Get(s"/api/v2/runtimes/${workspaceId.value.toString}/azure/azureruntime1") ~> routes.route ~> check {
+    Get(s"/api/v2/runtimes/${workspaceId.value.toString}/azure/azureruntime1")
+      .addHeader(Origin(validOrigin)) ~> routes.route ~> check {
       status shouldEqual StatusCodes.OK
       responseAs[GetRuntimeResponse].clusterName shouldBe RuntimeName("azureruntime1")
       validateRawCookie(header("Set-Cookie"))
@@ -449,25 +480,28 @@ class HttpRoutesSpec
   }
 
   it should "404 on get azure runtime when it does not exist" in {
-    Get(s"/api/v2/runtimes/${workspaceId.value.toString}/azure/fakeruntime") ~> httpRoutes.route ~> check {
+    Get(s"/api/v2/runtimes/${workspaceId.value.toString}/azure/fakeruntime")
+      .addHeader(Origin(validOrigin)) ~> httpRoutes.route ~> check {
       status shouldEqual StatusCodes.NotFound
     }
   }
 
   it should "delete an azure runtime" in {
-    Delete(s"/api/v2/runtimes/${workspaceId.value.toString}/azure/azureruntime1") ~> routes.route ~> check {
+    Delete(s"/api/v2/runtimes/${workspaceId.value.toString}/azure/azureruntime1")
+      .addHeader(Origin(validOrigin)) ~> routes.route ~> check {
       status shouldEqual StatusCodes.Accepted
     }
   }
 
   it should "404 on delete azure runtime when it does not exist" in {
-    Delete(s"/api/v2/runtimes/${workspaceId.value.toString}/azure/azureruntime1") ~> httpRoutes.route ~> check {
+    Delete(s"/api/v2/runtimes/${workspaceId.value.toString}/azure/azureruntime1")
+      .addHeader(Origin(validOrigin)) ~> httpRoutes.route ~> check {
       status shouldEqual StatusCodes.NotFound
     }
   }
 
   it should "list runtimes v2 with a workspace" in {
-    Get(s"/api/v2/runtimes/${workspaceId.value.toString}") ~> routes.route ~> check {
+    Get(s"/api/v2/runtimes/${workspaceId.value.toString}").addHeader(Origin(validOrigin)) ~> routes.route ~> check {
       status shouldEqual StatusCodes.OK
       responseAs[Vector[ListRuntimeResponse2]].map(_.clusterName) shouldBe Vector(RuntimeName("azureruntime1"))
       validateRawCookie(header("Set-Cookie"))
@@ -475,7 +509,7 @@ class HttpRoutesSpec
   }
 
   it should "list runtimes v2 without a workspace or cloudContext" in {
-    Get("/api/v2/runtimes") ~> routes.route ~> check {
+    Get("/api/v2/runtimes").addHeader(Origin(validOrigin)) ~> routes.route ~> check {
       status shouldEqual StatusCodes.OK
       val response = responseAs[Vector[ListRuntimeResponse2]]
       response.map(_.clusterName) shouldBe Vector(RuntimeName("azureruntime1"))
@@ -484,7 +518,8 @@ class HttpRoutesSpec
   }
 
   it should "list runtimes v2 with a workspace and cloud context" in {
-    Get(s"/api/v2/runtimes/${workspaceId.value.toString}/azure") ~> routes.route ~> check {
+    Get(s"/api/v2/runtimes/${workspaceId.value.toString}/azure")
+      .addHeader(Origin(validOrigin)) ~> routes.route ~> check {
       status shouldEqual StatusCodes.OK
       val response = responseAs[Vector[ListRuntimeResponse2]]
       response.map(_.clusterName) shouldBe Vector(RuntimeName("azureruntime1"))
@@ -506,9 +541,8 @@ class HttpRoutesSpec
           azureDiskConfig = defaultCreateAzureRuntimeReq.azureDiskConfig.copy(name = AzureDiskName(s"azureDisk-$i"))
         )
 
-    Post(s"/api/v2/runtimes/${workspaceId.value.toString}/azure/azureruntime-1",
-         runtimesWithLabels(1).asJson
-    ) ~> httpRoutes.route ~> check {
+    Post(s"/api/v2/runtimes/${workspaceId.value.toString}/azure/azureruntime-1", runtimesWithLabels(1).asJson)
+      .addHeader(Origin(validOrigin)) ~> httpRoutes.route ~> check {
       status shouldEqual StatusCodes.Accepted
     }
 
@@ -525,15 +559,14 @@ class HttpRoutesSpec
       .transaction
       .unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
 
-    Post(s"/api/v2/runtimes/${workspaceId.value.toString}/azure/azureruntime-2",
-         runtimesWithLabels(2).asJson
-    ) ~> httpRoutes.route ~> check {
+    Post(s"/api/v2/runtimes/${workspaceId.value.toString}/azure/azureruntime-2", runtimesWithLabels(2).asJson)
+      .addHeader(Origin(validOrigin)) ~> httpRoutes.route ~> check {
       status shouldEqual StatusCodes.Accepted
     }
 
     Get(
       s"/api/v2/runtimes/${workspaceId.value.toString}/azure?label1=value1&includeDeleted=true"
-    ) ~> httpRoutes.route ~> check {
+    ).addHeader(Origin(validOrigin)) ~> httpRoutes.route ~> check {
       status shouldEqual StatusCodes.OK
 
       val responseClusters = responseAs[List[ListRuntimeResponse2]]
@@ -554,7 +587,8 @@ class HttpRoutesSpec
       validateRawCookie(header("Set-Cookie"))
     }
 
-    Get(s"/api/v2/runtimes/${workspaceId.value.toString}/azure?_labels=label2%3Dvalue2") ~> httpRoutes.route ~> check {
+    Get(s"/api/v2/runtimes/${workspaceId.value.toString}/azure?_labels=label2%3Dvalue2")
+      .addHeader(Origin(validOrigin)) ~> httpRoutes.route ~> check {
       status shouldEqual StatusCodes.OK
 
       val responseClusters = responseAs[List[ListRuntimeResponse2]]
@@ -576,13 +610,15 @@ class HttpRoutesSpec
       validateRawCookie(header("Set-Cookie"))
     }
 
-    Get(s"/api/v2/runtimes/${workspaceId.value.toString}/azure?_labels=bad") ~> httpRoutes.route ~> check {
+    Get(s"/api/v2/runtimes/${workspaceId.value.toString}/azure?_labels=bad")
+      .addHeader(Origin(validOrigin)) ~> httpRoutes.route ~> check {
       status shouldEqual StatusCodes.BadRequest
     }
   }
 
   it should "list runtimes v2 with parameters" in {
-    Get(s"/api/v2/runtimes/${workspaceId.value.toString}/azure?project=foo&creator=bar") ~> routes.route ~> check {
+    Get(s"/api/v2/runtimes/${workspaceId.value.toString}/azure?project=foo&creator=bar")
+      .addHeader(Origin(validOrigin)) ~> routes.route ~> check {
       status shouldEqual StatusCodes.OK
       responseAs[Vector[ListRuntimeResponse2]].map(_.clusterName) shouldBe Vector(RuntimeName("azureruntime1"))
       validateRawCookie(header("Set-Cookie"))
@@ -599,6 +635,7 @@ class HttpRoutesSpec
       None
     )
     Post("/api/google/v1/disks/googleProject1/disk1")
+      .addHeader(Origin(validOrigin))
       .withEntity(ContentTypes.`application/json`, diskCreateRequest.asJson.spaces2) ~> routes.route ~> check {
       status shouldEqual StatusCodes.Accepted
       validateRawCookie(header("Set-Cookie"))
@@ -607,6 +644,7 @@ class HttpRoutesSpec
 
   it should "create a disk with default parameters" in {
     Post("/api/google/v1/disks/googleProject1/disk1")
+      .addHeader(Origin(validOrigin))
       .withEntity(ContentTypes.`application/json`, "{}") ~> routes.route ~> check {
       status shouldEqual StatusCodes.Accepted
       validateRawCookie(header("Set-Cookie"))
@@ -614,7 +652,7 @@ class HttpRoutesSpec
   }
 
   it should "get a disk" in {
-    Get("/api/google/v1/disks/googleProject/disk1") ~> routes.route ~> check {
+    Get("/api/google/v1/disks/googleProject/disk1").addHeader(Origin(validOrigin)) ~> routes.route ~> check {
       status shouldEqual StatusCodes.OK
       responseAs[GetPersistentDiskResponse].name shouldBe CommonTestData.diskName
       validateRawCookie(header("Set-Cookie"))
@@ -622,7 +660,7 @@ class HttpRoutesSpec
   }
 
   it should "list all disks" in {
-    Get("/api/google/v1/disks") ~> routes.route ~> check {
+    Get("/api/google/v1/disks").addHeader(Origin(validOrigin)) ~> routes.route ~> check {
       status shouldEqual StatusCodes.OK
       responseAs[Vector[ListPersistentDiskResponse]].map(_.name) shouldBe Vector(CommonTestData.diskName)
       validateRawCookie(header("Set-Cookie"))
@@ -630,7 +668,7 @@ class HttpRoutesSpec
   }
 
   it should "list all disks within a project" in {
-    Get("/api/google/v1/disks/googleProject") ~> routes.route ~> check {
+    Get("/api/google/v1/disks/googleProject").addHeader(Origin(validOrigin)) ~> routes.route ~> check {
       status shouldEqual StatusCodes.OK
       responseAs[Vector[ListPersistentDiskResponse]].map(_.name) shouldBe Vector(CommonTestData.diskName)
       validateRawCookie(header("Set-Cookie"))
@@ -638,7 +676,7 @@ class HttpRoutesSpec
   }
 
   it should "list disks with parameters" in {
-    Get("/api/google/v1/disks?project=foo&creator=bar") ~> routes.route ~> check {
+    Get("/api/google/v1/disks?project=foo&creator=bar").addHeader(Origin(validOrigin)) ~> routes.route ~> check {
       status shouldEqual StatusCodes.OK
       responseAs[Vector[ListPersistentDiskResponse]].map(_.name) shouldBe Vector(CommonTestData.diskName)
       validateRawCookie(header("Set-Cookie"))
@@ -646,7 +684,7 @@ class HttpRoutesSpec
   }
 
   it should "delete a disk" in {
-    Delete("/api/google/v1/disks/googleProject1/disk1") ~> routes.route ~> check {
+    Delete("/api/google/v1/disks/googleProject1/disk1").addHeader(Origin(validOrigin)) ~> routes.route ~> check {
       status shouldEqual StatusCodes.Accepted
       validateRawCookie(header("Set-Cookie"))
     }
@@ -657,14 +695,16 @@ class HttpRoutesSpec
       Map("foo" -> "bar"),
       DiskSize(1024)
     )
-    Patch("/api/google/v1/disks/googleProject1/disk1", request.asJson) ~> routes.route ~> check {
+    Patch("/api/google/v1/disks/googleProject1/disk1", request.asJson).addHeader(
+      Origin(validOrigin)
+    ) ~> routes.route ~> check {
       status shouldEqual StatusCodes.Accepted
       validateRawCookie(header("Set-Cookie"))
     }
   }
 
   it should "get a disk v2" in {
-    Get(s"/api/v2/disks/-1") ~> routes.route ~> check {
+    Get(s"/api/v2/disks/-1").addHeader(Origin(validOrigin)) ~> routes.route ~> check {
       status shouldEqual StatusCodes.OK
       responseAs[GetPersistentDiskV2Response].name shouldBe CommonTestData.diskName
       validateRawCookie(header("Set-Cookie"))
@@ -672,14 +712,14 @@ class HttpRoutesSpec
   }
 
   it should "delete a disk v2" in {
-    Delete(s"/api/v2/disks/-1") ~> routes.route ~> check {
+    Delete(s"/api/v2/disks/-1").addHeader(Origin(validOrigin)) ~> routes.route ~> check {
       status shouldEqual StatusCodes.Accepted
       validateRawCookie(header("Set-Cookie"))
     }
   }
 
   it should "reject get a disk if id is invalid" in {
-    Get(s"/api/v2/disks/diskid") ~> routes.route ~> check {
+    Get(s"/api/v2/disks/diskid").addHeader(Origin(validOrigin)) ~> routes.route ~> check {
       val expectedResponse =
         """Invalid workspace id workspaceId, workspace id must be a valid UUID"""
       responseEntity.toStrict(5 seconds).futureValue.data.utf8String.contains(expectedResponse)
@@ -688,37 +728,39 @@ class HttpRoutesSpec
   }
 
   "HttpRoutes" should "not handle unrecognized routes" in {
-    Post("/api/google/v1/runtime/googleProject1/runtime1/unhandled") ~> routes.route ~> check {
+    Post("/api/google/v1/runtime/googleProject1/runtime1/unhandled").addHeader(
+      Origin(validOrigin)
+    ) ~> routes.route ~> check {
       status shouldBe StatusCodes.NotFound
       val resp = responseEntity.toStrict(5 seconds).futureValue.data.utf8String
       resp shouldBe "\"API not found. Make sure you're calling the correct endpoint with correct method\""
     }
-    Get("/api/google/v1/badruntime/googleProject1/runtime1") ~> routes.route ~> check {
+    Get("/api/google/v1/badruntime/googleProject1/runtime1").addHeader(Origin(validOrigin)) ~> routes.route ~> check {
       status shouldBe StatusCodes.NotFound
       val resp = responseEntity.toStrict(5 seconds).futureValue.data.utf8String
       resp shouldBe "\"API not found. Make sure you're calling the correct endpoint with correct method\""
     }
-    Get("/api/google/v2/runtime/googleProject1/runtime1") ~> routes.route ~> check {
+    Get("/api/google/v2/runtime/googleProject1/runtime1").addHeader(Origin(validOrigin)) ~> routes.route ~> check {
       status shouldBe StatusCodes.NotFound
       val resp = responseEntity.toStrict(5 seconds).futureValue.data.utf8String
       resp shouldBe "\"API not found. Make sure you're calling the correct endpoint with correct method\""
     }
-    Post("/api/google/v1/runtime/googleProject1/runtime1") ~> routes.route ~> check {
+    Post("/api/google/v1/runtime/googleProject1/runtime1").addHeader(Origin(validOrigin)) ~> routes.route ~> check {
       status shouldBe StatusCodes.NotFound
       val resp = responseEntity.toStrict(5 seconds).futureValue.data.utf8String
       resp shouldBe "\"API not found. Make sure you're calling the correct endpoint with correct method\""
     }
-    Post("/api/google/v1/disk/googleProject1/disk1") ~> routes.route ~> check {
+    Post("/api/google/v1/disk/googleProject1/disk1").addHeader(Origin(validOrigin)) ~> routes.route ~> check {
       status shouldBe StatusCodes.NotFound
       val resp = responseEntity.toStrict(5 seconds).futureValue.data.utf8String
       resp shouldBe "\"API not found. Make sure you're calling the correct endpoint with correct method\""
     }
-    Get("/api/google/v1/disks/googleProject1/disk1/foo") ~> routes.route ~> check {
+    Get("/api/google/v1/disks/googleProject1/disk1/foo").addHeader(Origin(validOrigin)) ~> routes.route ~> check {
       status shouldBe StatusCodes.NotFound
       val resp = responseEntity.toStrict(5 seconds).futureValue.data.utf8String
       resp shouldBe "\"API not found. Make sure you're calling the correct endpoint with correct method\""
     }
-    Get(s"/api/disks/v2/${workspaceId.value.toString}/disk1") ~> routes.route ~> check {
+    Get(s"/api/disks/v2/${workspaceId.value.toString}/disk1").addHeader(Origin(validOrigin)) ~> routes.route ~> check {
       status shouldBe StatusCodes.NotFound
       val resp = responseEntity.toStrict(5 seconds).futureValue.data.utf8String
       resp shouldBe "\"API not found. Make sure you're calling the correct endpoint with correct method\""
@@ -727,6 +769,7 @@ class HttpRoutesSpec
 
   "Kubernetes Routes" should "create an app" in {
     Post("/api/google/v1/apps/googleProject1/app1")
+      .addHeader(Origin(validOrigin))
       .withEntity(ContentTypes.`application/json`, createAppRequest.asJson.spaces2) ~> routes.route ~> check {
       status shouldEqual StatusCodes.Accepted
       validateRawCookie(header("Set-Cookie"))
@@ -734,7 +777,7 @@ class HttpRoutesSpec
   }
 
   it should "list apps with project" in {
-    Get("/api/google/v1/apps/googleProject1") ~> routes.route ~> check {
+    Get("/api/google/v1/apps/googleProject1").addHeader(Origin(validOrigin)) ~> routes.route ~> check {
       status shouldEqual StatusCodes.OK
       validateRawCookie(header("Set-Cookie"))
       val response = responseAs[Vector[ListAppResponse]]
@@ -743,21 +786,23 @@ class HttpRoutesSpec
   }
 
   it should "list apps with no project" in {
-    Get("/api/google/v1/apps/") ~> routes.route ~> check {
+    Get("/api/google/v1/apps/").addHeader(Origin(validOrigin)) ~> routes.route ~> check {
       status shouldEqual StatusCodes.OK
       validateRawCookie(header("Set-Cookie"))
     }
   }
 
   it should "list apps with labels" in {
-    Get("/api/google/v1/apps?project=foo&creator=bar&includeDeleted=true") ~> routes.route ~> check {
+    Get("/api/google/v1/apps?project=foo&creator=bar&includeDeleted=true").addHeader(
+      Origin(validOrigin)
+    ) ~> routes.route ~> check {
       status shouldEqual StatusCodes.OK
       validateRawCookie(header("Set-Cookie"))
     }
   }
 
   it should "get app" in {
-    Get("/api/google/v1/apps/googleProject1/app1") ~> routes.route ~> check {
+    Get("/api/google/v1/apps/googleProject1/app1").addHeader(Origin(validOrigin)) ~> routes.route ~> check {
       status shouldEqual StatusCodes.OK
       validateRawCookie(header("Set-Cookie"))
       responseAs[GetAppResponse] shouldBe getAppResponse
@@ -765,20 +810,21 @@ class HttpRoutesSpec
   }
 
   it should "delete app" in {
-    Delete("/api/google/v1/apps/googleProject1/app1") ~> routes.route ~> check {
+    Delete("/api/google/v1/apps/googleProject1/app1").addHeader(Origin(validOrigin)) ~> routes.route ~> check {
       status shouldEqual StatusCodes.Accepted
       validateRawCookie(header("Set-Cookie"))
     }
   }
 
   it should "validate app name" in {
-    Get("/api/google/v1/apps/googleProject1/1badApp") ~> routes.route ~> check {
+    Get("/api/google/v1/apps/googleProject1/1badApp").addHeader(Origin(validOrigin)) ~> routes.route ~> check {
       status.intValue shouldBe 400
     }
   }
 
   it should "validate create app request" in {
     Post("/api/google/v1/apps/googleProject1/app1")
+      .addHeader(Origin(validOrigin))
       .withEntity(
         ContentTypes.`application/json`,
         createAppRequest
@@ -795,14 +841,14 @@ class HttpRoutesSpec
   }
 
   it should "stop an app" in {
-    Post("/api/google/v1/apps/googleProject1/app1/stop") ~> routes.route ~> check {
+    Post("/api/google/v1/apps/googleProject1/app1/stop").addHeader(Origin(validOrigin)) ~> routes.route ~> check {
       status shouldEqual StatusCodes.Accepted
       validateRawCookie(header("Set-Cookie"))
     }
   }
 
   it should "start an app" in {
-    Post("/api/google/v1/apps/googleProject1/app1/start") ~> routes.route ~> check {
+    Post("/api/google/v1/apps/googleProject1/app1/start").addHeader(Origin(validOrigin)) ~> routes.route ~> check {
       status shouldEqual StatusCodes.Accepted
       validateRawCookie(header("Set-Cookie"))
     }
@@ -810,6 +856,7 @@ class HttpRoutesSpec
 
   it should "create an app V2" in {
     Post(s"/api/apps/v2/${workspaceId.value.toString}/app1")
+      .addHeader(Origin(validOrigin))
       .withEntity(ContentTypes.`application/json`,
                   createAppRequest.copy(accessScope = Some(AppAccessScope.WorkspaceShared)).asJson.spaces2
       ) ~> routes.route ~> check {
@@ -819,7 +866,7 @@ class HttpRoutesSpec
   }
 
   it should "list apps v2 with project" in {
-    Get(s"/api/apps/v2/${workspaceId.value.toString}") ~> routes.route ~> check {
+    Get(s"/api/apps/v2/${workspaceId.value.toString}").addHeader(Origin(validOrigin)) ~> routes.route ~> check {
       status shouldEqual StatusCodes.OK
       validateRawCookie(header("Set-Cookie"))
       val response = responseAs[Vector[ListAppResponse]]
@@ -828,7 +875,7 @@ class HttpRoutesSpec
   }
 
   it should "get app V2" in {
-    Get(s"/api/apps/v2/${workspaceId.value.toString}/app1") ~> routes.route ~> check {
+    Get(s"/api/apps/v2/${workspaceId.value.toString}/app1").addHeader(Origin(validOrigin)) ~> routes.route ~> check {
       status shouldEqual StatusCodes.OK
       validateRawCookie(header("Set-Cookie"))
       responseAs[GetAppResponse] shouldBe getAppResponse
@@ -836,7 +883,7 @@ class HttpRoutesSpec
   }
 
   it should "delete app V2" in {
-    Delete(s"/api/apps/v2/${workspaceId.value.toString}/app1") ~> routes.route ~> check {
+    Delete(s"/api/apps/v2/${workspaceId.value.toString}/app1").addHeader(Origin(validOrigin)) ~> routes.route ~> check {
       status shouldEqual StatusCodes.Accepted
       validateRawCookie(header("Set-Cookie"))
     }
@@ -844,6 +891,7 @@ class HttpRoutesSpec
 
   it should "validate create appV2 request" in {
     Post(s"/api/apps/v2/${workspaceId.value.toString}/app1")
+      .addHeader(Origin(validOrigin))
       .withEntity(
         ContentTypes.`application/json`,
         createAppRequest

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/HttpRoutesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/HttpRoutesSpec.scala
@@ -67,7 +67,7 @@ class HttpRoutesSpec
       new MockRuntimeV2Interp,
       timedUserInfoDirectives,
       contentSecurityPolicy,
-      RefererConfig(Set("https://bvdp-saturn-dev.appspot.com/"), true)
+      RefererConfig(Set("bvdp-saturn-dev.appspot.com/"), true)
     )
 
   implicit val errorReportDecoder: Decoder[ErrorReport] = Decoder.instance { h =>

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/ProxyRoutesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/ProxyRoutesSpec.scala
@@ -679,11 +679,11 @@ class ProxyRoutesSpec
     }
   }
 
-  it should "403 when Origin is not an allowlisted URI" in {
+  it should "401 when Origin is not an allowlisted URI" in {
     Get(s"/proxy/$googleProject/$clusterName")
       .addHeader(Origin(invalidOrigin))
       .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
-      status shouldEqual StatusCodes.Forbidden
+      status shouldEqual StatusCodes.Unauthorized
     }
   }
 

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/ProxyRoutesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/ProxyRoutesSpec.scala
@@ -683,9 +683,9 @@ class ProxyRoutesSpec
     Get(s"/proxy/$googleProject/$clusterName")
       .addHeader(Origin(invalidOrigin))
       .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
-        handled shouldBe false
-        status shouldEqual StatusCodes.Forbidden
-      }
+      handled shouldBe false
+      status shouldEqual StatusCodes.Forbidden
+    }
   }
 
   it should "handle wildcards in referer allow list" in {

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/ProxyRoutesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/ProxyRoutesSpec.scala
@@ -136,7 +136,7 @@ class ProxyRoutesSpec
       .addHeader(Cookie(tokenCookie))
       .addHeader(Origin(validOrigin))
       .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
-      status shouldBe StatusCodes.NotFound
+      // status shouldBe StatusCodes.
       val resp = responseEntity.toStrict(5 seconds).futureValue.data.utf8String
       resp shouldBe "\"API not found. Make sure you're calling the correct endpoint with correct method\""
     }
@@ -679,12 +679,13 @@ class ProxyRoutesSpec
     }
   }
 
-  it should "401 when Origin is not an allowlisted URI" in {
+  it should "403 when Origin is not an allowlisted URI" in {
     Get(s"/proxy/$googleProject/$clusterName")
       .addHeader(Origin(invalidOrigin))
       .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
-      status shouldEqual StatusCodes.Unauthorized
-    }
+        handled shouldBe false
+        status shouldEqual StatusCodes.Forbidden
+      }
   }
 
   it should "handle wildcards in referer allow list" in {

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/TestLeoRoutes.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/TestLeoRoutes.scala
@@ -168,7 +168,7 @@ trait TestLeoRoutes {
   val statusService =
     new StatusService(mockSamDAO, testDbRef, pollInterval = 1.second)
   val timedUserInfo = defaultUserInfo.copy(tokenExpiresIn = tokenAge)
-  val corsSupport = new CorsSupport(contentSecurityPolicy)
+  val corsSupport = new CorsSupport(contentSecurityPolicy, refererConfig)
   val statusRoutes = new StatusRoutes(statusService)
   val userInfoDirectives = new MockUserInfoDirectives {
     override val userInfo: UserInfo = defaultUserInfo

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/TestLeoRoutes.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/TestLeoRoutes.scala
@@ -3,24 +3,27 @@ package http
 package api
 
 import akka.http.scaladsl.model.HttpHeader
-import akka.http.scaladsl.model.headers.{`Set-Cookie`, HttpCookiePair}
-import akka.http.scaladsl.testkit.{RouteTestTimeout, ScalatestRouteTest}
+import akka.http.scaladsl.model.headers.HttpCookiePair
+import akka.http.scaladsl.model.headers.`Set-Cookie`
+import akka.http.scaladsl.testkit.RouteTestTimeout
+import akka.http.scaladsl.testkit.ScalatestRouteTest
 import cats.effect.IO
 import com.github.benmanes.caffeine.cache.Caffeine
 import org.broadinstitute.dsde.workbench.google.GoogleStorageDAO
-import org.broadinstitute.dsde.workbench.google.mock.{MockGoogleDirectoryDAO, MockGoogleIamDAO, MockGoogleStorageDAO}
+import org.broadinstitute.dsde.workbench.google.mock.MockGoogleDirectoryDAO
+import org.broadinstitute.dsde.workbench.google.mock.MockGoogleIamDAO
+import org.broadinstitute.dsde.workbench.google.mock.MockGoogleStorageDAO
 import org.broadinstitute.dsde.workbench.google2.mock._
 import org.broadinstitute.dsde.workbench.leonardo.CommonTestData._
 import org.broadinstitute.dsde.workbench.leonardo.config.Config
-import org.broadinstitute.dsde.workbench.leonardo.dao.google.MockGoogleOAuth2Service
+import org.broadinstitute.dsde.workbench.leonardo.config.RefererConfig
 import org.broadinstitute.dsde.workbench.leonardo.dao._
+import org.broadinstitute.dsde.workbench.leonardo.dao.google.MockGoogleOAuth2Service
 import org.broadinstitute.dsde.workbench.leonardo.db.TestComponent
-import org.broadinstitute.dsde.workbench.leonardo.dns.{
-  KubernetesDnsCache,
-  KubernetesDnsCacheKey,
-  RuntimeDnsCache,
-  RuntimeDnsCacheKey
-}
+import org.broadinstitute.dsde.workbench.leonardo.dns.KubernetesDnsCache
+import org.broadinstitute.dsde.workbench.leonardo.dns.KubernetesDnsCacheKey
+import org.broadinstitute.dsde.workbench.leonardo.dns.RuntimeDnsCache
+import org.broadinstitute.dsde.workbench.leonardo.dns.RuntimeDnsCacheKey
 import org.broadinstitute.dsde.workbench.leonardo.http.service._
 import org.broadinstitute.dsde.workbench.leonardo.util._
 import org.broadinstitute.dsde.workbench.model.UserInfo
@@ -28,7 +31,8 @@ import org.scalactic.source.Position
 import org.scalatest.concurrent.PatienceConfiguration.Interval
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.matchers.should.Matchers
-import org.scalatest.time.{Seconds, Span}
+import org.scalatest.time.Seconds
+import org.scalatest.time.Span
 import scalacache.Cache
 import scalacache.caffeine.CaffeineCache
 
@@ -36,6 +40,7 @@ import java.io.ByteArrayInputStream
 import java.time.Instant
 import scala.concurrent.duration._
 import scala.util.matching.Regex
+
 trait TestLeoRoutes {
   this: ScalatestRouteTest with Matchers with ScalaFutures with LeonardoTestSuite with TestComponent =>
   implicit val timeout = RouteTestTimeout(20 seconds)
@@ -201,6 +206,21 @@ trait TestLeoRoutes {
       userInfoDirectives,
       contentSecurityPolicy,
       refererConfig
+    )
+
+  val httpRoutesWithWildcardReferer =
+    new HttpRoutes(
+      openIdConnectionConfiguration,
+      statusService,
+      proxyService,
+      runtimeService,
+      MockDiskServiceInterp,
+      MockDiskV2ServiceInterp,
+      leoKubernetesService,
+      runtimev2Service,
+      userInfoDirectives,
+      contentSecurityPolicy,
+      RefererConfig(Set("*", "bvdp-saturn-dev.appspot.com/"), true)
     )
 
   val timedHttpRoutes =


### PR DESCRIPTION
<!-- Welcome to your Leonardo pull request! -->
<!-- Contributor guidelines: https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md -->

__Jira ticket__: https://broadworkbench.atlassian.net/browse/IA-4081

<!-- ## Dependencies -->
<!-- Include any dependent tickets and describe the relationship. Include any other relevant Jira tickets. -->

## Summary of changes

### What

- Use the existing `refererConfig` as an allowlist for Origin in requests to leonardo - respond to requests that hold an Origin header with headers Access-Control-Allow-Origin (val) only if `val` is in the allowlist

### Why

- Requests from untrusted domains should not be honored for security reasons!

## Testing these changes

### What to test

(refererConfig enabled and validHosts does not contain *)
- Hit Leonardo endpoints with Origin (x: something in the configured allowlist) => pass, response headers Access-Control-Allow-Origin x and Vary: Origin
- Hit Leonardo endpoints with Origin (something NOT in the configured allowlist) => fail with 401
- Hit Leonardo endpoints with no Origin => fail with 400

(refererConfig enabled and validHosts contains *)
- Hit Leonardo endpoints with any Origin => pass, response header Access-Control-Allow-Origin *

(refererConfig NOT enabled)
- Hit Leonardo endpoints with any Origin => pass, response header Access-Control-Allow-Origin *

<!-- ### Test data -->

### Who tested and where

- [ ] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [ ] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
