### PR TITLE
[IA-4081] Allowlist origins for CORS - forbid wildcard. DO NOT MERGE

### DIFF
--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/CorsSupport.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/CorsSupport.scala
@@ -29,10 +29,14 @@ class CorsSupport(contentSecurityPolicy: ContentSecurityPolicyConfig, refererCon
 
   // Ensure the request Origin is included in our referrer allowlist.
   private def validateOrigin: Directive0 =
-    if (!refererConfig.enabled || refererConfig.validHosts.contains("*"))
+    // comment out wildcard pass to verify BEE origins are blocked
+    if (!refererConfig.enabled /*|| refererConfig.validHosts.contains("*")*/)
       pass
     else {
-      def validOrigins: Set[HttpOrigin] = refererConfig.validHosts.map(uri => HttpOrigin(uri))
+      def validOrigins: Set[HttpOrigin] = refererConfig.validHosts
+        // ignore wildcard (remove me)
+        .filter(_ != "*")
+        .map(uri => HttpOrigin(uri))
       checkSameOrigin(HttpOriginRange(validOrigins.toSeq: _*))
     }
 


### PR DESCRIPTION
<!-- Welcome to your Leonardo pull request! -->
<!-- Contributor guidelines: https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md -->

__Jira ticket__: https://broadworkbench.atlassian.net/browse/IA-4081

<!-- ## Dependencies -->
<!-- Include any dependent tickets and describe the relationship. Include any other relevant Jira tickets. -->

## Summary of changes

<!-- Please give an abridged version of the ticket description here and/or fill out the following fields. -->

### What

- Forbid "*" origins in CorsSupport. For testing only! DO NOT MERGE TO DEVELOP OR STORY BRANCH

### Why

- This should break a BEE, demonstrating the effectiveness of the new CORS code which checks the value of the caller's Origin header against an allowlist. BEE allowlists currently include the wildcard "*" as part of their basic architecture.

## Testing these changes

### What to test

- <!-- Test case 1 -->

<!-- ### Test data -->

### Who tested and where

- [ ] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [ ] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
