### PR TITLE
[IA-4081] DO NOT MERGE forbid cors wildcard

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 #   1. Build the Helm client Go lib
 #   2. Deploy Leonardo pointing to the Go lib
 
-FROM golang:1.14.6-stretch AS helm-go-lib-builder
+FROM golang:1.20 AS helm-go-lib-builder
 
 # TODO Consider moving repo set-up to the build script to make CI versioning easier
 RUN mkdir /helm-go-lib-build && \

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/CorsSupport.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/CorsSupport.scala
@@ -32,7 +32,8 @@ class CorsSupport(contentSecurityPolicy: ContentSecurityPolicyConfig, refererCon
     if (!refererConfig.enabled || refererConfig.validHosts.contains("*"))
       pass
     else {
-      def validOrigins: Set[HttpOrigin] = refererConfig.validHosts.map(uri => HttpOrigin(uri))
+      def validOrigins: Set[HttpOrigin] = refererConfig.validHosts
+        .map(uri => HttpOrigin("http", Host(uri)))
       checkSameOrigin(HttpOriginRange(validOrigins.toSeq: _*))
     }
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/CorsSupport.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/CorsSupport.scala
@@ -29,10 +29,13 @@ class CorsSupport(contentSecurityPolicy: ContentSecurityPolicyConfig, refererCon
 
   // Ensure the request Origin is included in our referrer allowlist.
   private def validateOrigin: Directive0 =
-    if (!refererConfig.enabled || refererConfig.validHosts.contains("*"))
+    // comment out wildcard pass to verify BEE origins are blocked
+    if (!refererConfig.enabled /*|| refererConfig.validHosts.contains("*")*/)
       pass
     else {
       def validOrigins: Set[HttpOrigin] = refererConfig.validHosts
+        // ignore wildcard (remove me)
+        .filter(_ != "*")
         .map(uri => HttpOrigin("http", Host(uri)))
       checkSameOrigin(HttpOriginRange(validOrigins.toSeq: _*))
     }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/HttpRoutes.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/HttpRoutes.scala
@@ -40,7 +40,7 @@ class HttpRoutes(
   refererConfig: RefererConfig
 )(implicit ec: ExecutionContext, ac: ActorSystem, metrics: OpenTelemetryMetrics[IO], logger: StructuredLogger[IO]) {
   private val statusRoutes = new StatusRoutes(statusService)
-  private val corsSupport = new CorsSupport(contentSecurityPolicy)
+  private val corsSupport = new CorsSupport(contentSecurityPolicy, refererConfig)
   private val proxyRoutes = new ProxyRoutes(proxyService, corsSupport, refererConfig)
   private val runtimeRoutes = new RuntimeRoutes(refererConfig, runtimeService, userInfoDirectives)
   private val diskRoutes = new DiskRoutes(diskService, userInfoDirectives)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/ProxyService.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/ProxyService.scala
@@ -552,6 +552,7 @@ class ProxyService(
 
   private val HeadersToFilter = Set(
     "Host",
+    "Origin",
     "Timeout-Access",
     "Sec-WebSocket-Accept",
     "Sec-WebSocket-Version",

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/ProxyRoutesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/ProxyRoutesSpec.scala
@@ -679,11 +679,11 @@ class ProxyRoutesSpec
     }
   }
 
-  it should "403 when Origin is not an allowlisted URI" in {
+  it should "401 when Origin is not an allowlisted URI" in {
     Get(s"/proxy/$googleProject/$clusterName")
       .addHeader(Origin(invalidOrigin))
       .addHeader(Referer(Uri(validRefererUri))) ~> httpRoutes.route ~> check {
-      status shouldEqual StatusCodes.Forbidden
+      status shouldEqual StatusCodes.Unauthorized
     }
   }
 

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/TestLeoRoutes.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/TestLeoRoutes.scala
@@ -168,7 +168,7 @@ trait TestLeoRoutes {
   val statusService =
     new StatusService(mockSamDAO, testDbRef, pollInterval = 1.second)
   val timedUserInfo = defaultUserInfo.copy(tokenExpiresIn = tokenAge)
-  val corsSupport = new CorsSupport(contentSecurityPolicy)
+  val corsSupport = new CorsSupport(contentSecurityPolicy, refererConfig)
   val statusRoutes = new StatusRoutes(statusService)
   val userInfoDirectives = new MockUserInfoDirectives {
     override val userInfo: UserInfo = defaultUserInfo


### PR DESCRIPTION
<!-- Welcome to your Leonardo pull request! -->
<!-- Contributor guidelines: https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md -->

__Jira ticket__: https://broadworkbench.atlassian.net/browse/IA-4081

<!-- ## Dependencies -->
<!-- Include any dependent tickets and describe the relationship. Include any other relevant Jira tickets. -->

## Summary of changes

<!-- Please give an abridged version of the ticket description here and/or fill out the following fields. -->

### What

- Forbid "*" origins in CorsSupport. For testing only! DO NOT MERGE TO DEVELOP OR STORY BRANCH

### Why

- This should break a BEE, demonstrating the effectiveness of the new CORS code which checks the value of the caller's Origin header against an allowlist. BEE allowlists currently include the wildcard "*" as part of their basic architecture.

## Testing these changes

### What to test

- <!-- Test case 1 -->

<!-- ### Test data -->

### Who tested and where

- [ ] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [ ] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
