### PR TITLE
[IA-4343] Set dateAccessed to current time on runtime create

### DIFF
--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandler.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandler.scala
@@ -414,7 +414,6 @@ class AzurePubsubHandlerInterp[F[_]: Parallel](
       v.jobReport.status.equals(WsmJobStatus.Succeeded) || v.jobReport.status == WsmJobStatus.Failed
     for {
       ctx <- ev.ask
-
       auth <- samDAO.getLeoAuthToken
       getWsmJobResult = wsmDao.getCreateVmJobResult(GetJobResultRequest(params.workspaceId, params.jobId), auth)
 
@@ -463,7 +462,7 @@ class AzurePubsubHandlerInterp[F[_]: Parallel](
             val hostIp = s"${params.relayNamespace.value}.servicebus.windows.net"
 
             for {
-              _ <- clusterQuery.updateClusterHostIp(params.runtime.id, Some(IP(hostIp)), ctx.now).transaction
+              _ <- clusterQuery.updateClusterHostIp(params.runtime.id, Some(IP(hostIp)), Instant.now).transaction
               // then poll the azure VM for Running status, retrieving the final azure representation
               _ <- streamUntilDoneOrTimeout(
                 isJupyterUp,
@@ -477,7 +476,7 @@ class AzurePubsubHandlerInterp[F[_]: Parallel](
                 config.createVmPollConfig.interval,
                 s"Welder was not running within ${config.createVmPollConfig.maxAttempts} attempts with ${config.createVmPollConfig.interval} delay"
               )
-              _ <- clusterQuery.setToRunning(params.runtime.id, IP(hostIp), ctx.now).transaction
+              _ <- clusterQuery.setToRunning(params.runtime.id, IP(hostIp), Instant.now).transaction
               _ <- logger.info(ctx.loggingCtx)("runtime is ready")
             } yield ()
         }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandler.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandler.scala
@@ -460,9 +460,9 @@ class AzurePubsubHandlerInterp[F[_]: Parallel](
             )
           case WsmJobStatus.Succeeded =>
             val hostIp = s"${params.relayNamespace.value}.servicebus.windows.net"
-
             for {
-              _ <- clusterQuery.updateClusterHostIp(params.runtime.id, Some(IP(hostIp)), Instant.now).transaction
+              now <- nowInstant
+              _ <- clusterQuery.updateClusterHostIp(params.runtime.id, Some(IP(hostIp)), now).transaction
               // then poll the azure VM for Running status, retrieving the final azure representation
               _ <- streamUntilDoneOrTimeout(
                 isJupyterUp,
@@ -476,7 +476,7 @@ class AzurePubsubHandlerInterp[F[_]: Parallel](
                 config.createVmPollConfig.interval,
                 s"Welder was not running within ${config.createVmPollConfig.maxAttempts} attempts with ${config.createVmPollConfig.interval} delay"
               )
-              _ <- clusterQuery.setToRunning(params.runtime.id, IP(hostIp), Instant.now).transaction
+              _ <- clusterQuery.setToRunning(params.runtime.id, IP(hostIp), now).transaction
               _ <- logger.info(ctx.loggingCtx)("runtime is ready")
             } yield ()
         }


### PR DESCRIPTION
<!-- Welcome to your Leonardo pull request! -->
<!-- Contributor guidelines: https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md -->

Subtask of
__Jira ticket__: https://broadworkbench.atlassian.net/browse/IA-4283

<!-- ## Dependencies -->
<!-- Include any dependent tickets and describe the relationship. Include any other relevant Jira tickets. -->

## Summary of changes

<!-- Please give an abridged version of the ticket description here and/or fill out the following fields. -->

### What

Use Instant.now instead of ctx.now for dateAccessed when setting runtime status to Running.

### Why

`AzurePubsubHandler#monitorCreateRuntime` has an `implicit ev: Ask[F, AppContext]` param, and sets `ctx <- ev.ask` as its first step. `ctx` thus is an instance of `AppContext`, whose `generate` method initializes `now` as the current `java.time.Instant` as of the initial HTTP create request. So `ctx.now` is always equal to the request time.

`monitorCreateRuntime` polls WorkspaceManager until the create action succeeds, at which point it sets the runtime’s `status`, `hostIp`, and `dateAccessed`. `dateAccessed` is set to `ctx.now` - which is the request time, not the time that the runtime status changes to "Running".

## Testing these changes

### What to test

- Create an Azure runtime through the UI with an `autopauseThreshold` = X minutes; note the time (t0)
- When runtime starts (moves from Creating -> Running status), note the time (t1)
- X minutes after creation request (t0 + X) runtime is running, not paused
- X minutes after start (t1 + X) runtime is paused

<!-- ### Test data -->

### Who tested and where

- [ ] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [ ] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
