### PR TITLE
[WOR-1030] Bump relay to pull in added logging

### DIFF
--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -207,7 +207,7 @@ azure {
         minor-version-auto-upgrade = true,
         file-uris = ["https://raw.githubusercontent.com/DataBiosphere/leonardo/61f9ad246382ade9a5242e4c6f899633876767f7/http/src/main/resources/init-resources/azure_vm_init_script.sh"]
       }
-      listener-image = "terradevacrpublic.azurecr.io/terra-azure-relay-listeners:decc8b0"
+      listener-image = "terradevacrpublic.azurecr.io/terra-azure-relay-listeners:3b326be"
     }
   }
 

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/ConfigReaderSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/ConfigReaderSpec.scala
@@ -43,7 +43,7 @@ class ConfigReaderSpec extends AnyFlatSpec with Matchers {
           Uri.unsafeFromString("https://sam.test.org:443"),
           Uri.unsafeFromString("https://localhost:8000"),
           "terradevacrpublic.azurecr.io/welder-server",
-          "3b326be",
+          "6648f5c",
           PollMonitorConfig(1 seconds, 10, 1 seconds),
           PollMonitorConfig(1 seconds, 20, 1 seconds),
           PollMonitorConfig(1 seconds, 10, 1 seconds),
@@ -73,7 +73,7 @@ class ConfigReaderSpec extends AnyFlatSpec with Matchers {
                 "https://raw.githubusercontent.com/DataBiosphere/leonardo/61f9ad246382ade9a5242e4c6f899633876767f7/http/src/main/resources/init-resources/azure_vm_init_script.sh"
               )
             ),
-            "terradevacrpublic.azurecr.io/terra-azure-relay-listeners:decc8b0",
+            "terradevacrpublic.azurecr.io/terra-azure-relay-listeners:3b326be",
             VMCredential(username = "username", password = "password")
           )
         ),

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/ConfigReaderSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/ConfigReaderSpec.scala
@@ -43,7 +43,7 @@ class ConfigReaderSpec extends AnyFlatSpec with Matchers {
           Uri.unsafeFromString("https://sam.test.org:443"),
           Uri.unsafeFromString("https://localhost:8000"),
           "terradevacrpublic.azurecr.io/welder-server",
-          "6648f5c",
+          "3b326be",
           PollMonitorConfig(1 seconds, 10, 1 seconds),
           PollMonitorConfig(1 seconds, 20, 1 seconds),
           PollMonitorConfig(1 seconds, 10, 1 seconds),


### PR DESCRIPTION
<!-- Welcome to your Leonardo pull request! -->
<!-- Contributor guidelines: https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md -->

__Jira ticket__: https://broadworkbench.atlassian.net/browse/WOR-1030

<!-- ## Dependencies -->
<!-- Include any dependent tickets and describe the relationship. Include any other relevant Jira tickets. -->

## Summary of changes

This PR bumps the relay image sha to pull in an updated version with added request logging.

### What

- Bumps the relay image

### Why

- The additional logging is needed for better auditability for Azure data plan apps

## Testing these changes

### What to test

* Turn on a bee and point it's leo to an image from this branch
* Create a workspace in the BEE
* Verify that WDS and notebooks function as normal
* Verify that there log entries in the `ContainerLog` table contain the updated logging like so:
```
ContainerLog
| where TimeGenerated > ago (20m)
| where LogEntry contains "RELAY_REQUEST_RESPONSE"
| order by TimeGenerated desc
| project LogEntry
```
should result in entries like:
```
2023-05-30 14:34:36.447 INFO 1 --- [undedElastic-10] o.b.l.relay.inspectors.RequestLogger : RELAY_REQUEST_RESPONSE - 69.173.127.24 "f6c1f779-5b2f-4d08-b67c-428a5e5dc981" "-" "aherbst@broadinstitute.org" "-" [2023-05-30T14:34:36.445991137Z] "GET sb://lzce3f775f870d3d933aa08492f2abde039e80e947bb1df198.servicebus.windows.net/wds-2e737b78-2aa6-434f-9a6f-2ccbf8d51faa-2e737b78-2aa6-434f-9a6f-2ccbf8d51faa/2e737b78-2aa6-434f-9a6f-2ccbf8d51faa/types/v0.2" 200 "https://terra.aherbst-swatomation-werewolf.bee.envs-terra.bio/" "https://terra.aherbst-swatomation-werewolf.bee.envs-terra.bio" "Mozilla/5.0 (Macintosh Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Safari/537.36"
```

<!-- ### Test data -->

### Who tested and where

- [ ] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [ ] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
