### PR TITLE
[WOR-1043] Bump relay version to pull in fix

### DIFF
--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -207,7 +207,7 @@ azure {
         minor-version-auto-upgrade = true,
         file-uris = ["https://raw.githubusercontent.com/DataBiosphere/leonardo/61f9ad246382ade9a5242e4c6f899633876767f7/http/src/main/resources/init-resources/azure_vm_init_script.sh"]
       }
-      listener-image = "terradevacrpublic.azurecr.io/terra-azure-relay-listeners:decc8b0"
+      listener-image = "terradevacrpublic.azurecr.io/terra-azure-relay-listeners:04fb3fe"
     }
   }
 

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/ConfigReaderSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/ConfigReaderSpec.scala
@@ -73,7 +73,7 @@ class ConfigReaderSpec extends AnyFlatSpec with Matchers {
                 "https://raw.githubusercontent.com/DataBiosphere/leonardo/61f9ad246382ade9a5242e4c6f899633876767f7/http/src/main/resources/init-resources/azure_vm_init_script.sh"
               )
             ),
-            "terradevacrpublic.azurecr.io/terra-azure-relay-listeners:decc8b0",
+            "terradevacrpublic.azurecr.io/terra-azure-relay-listeners:04fb3fe",
             VMCredential(username = "username", password = "password")
           )
         ),


### PR DESCRIPTION
<!-- Welcome to your Leonardo pull request! -->
<!-- Contributor guidelines: https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md -->

__Jira ticket__: https://broadworkbench.atlassian.net/browse/WOR-1043

<!-- ## Dependencies -->
<!-- Include any dependent tickets and describe the relationship. Include any other relevant Jira tickets. -->

## Summary of changes

Pulls in a fix for the azure relay listener that was breaking logging (related [PR](https://github.com/DataBiosphere/terra-azure-relay-listeners/pull/34)).

### What

- We need updated logging in the relay listener. The previous attempt was reverted due to an error introduced on relay listener bootstrap. 

### Why

- This logging [PR](https://github.com/DataBiosphere/terra-azure-relay-listeners/commits/main) in the relay listener had an errant @ cacheable notation that was causing the relay to fail on startup. 

## Testing these changes
Tested in a BEE:

Spun up WDS, imported data to a table successfully
Spun up a VM, turned on a Jupyter notebook and did a print("Hello world") successfully.
Spun up Cromwell, ran a workflow (errored out with config issues unrelated to the listener)

### What to test

- <!-- Test case 1 -->

<!-- ### Test data -->

### Who tested and where

- [ ] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [ ] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
