### PR TITLE
IA-4402 enableIntranodeVisibility for AoU apps

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/package.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/package.scala
@@ -17,6 +17,8 @@ package object leonardo {
   val SECURITY_GROUP = "security-group"
   val SECURITY_GROUP_HIGH = "high"
 
+  val AOU_UI_LABEL = "all-of-us"
+
   implicit def http4sBody[F[_], A](body: A)(implicit encoder: EntityEncoder[F, A]): Entity[F] =
     encoder.toEntity(body)
 
@@ -53,8 +55,6 @@ package object leonardo {
       retryOnPermissionDenied
     )
   }
-
-  def isAoUProject(labels: Map[String, String]): Boolean = labels.get(SECURITY_GROUP).isDefined
 
   val allSupportedRegions = List(
     RegionName("us-central1"),

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/package.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/package.scala
@@ -14,6 +14,9 @@ package object leonardo {
   val autoPauseOffValue = 0
   val traceIdHeaderString = ci"X-Cloud-Trace-Context"
 
+  val SECURITY_GROUP = "security-group"
+  val SECURITY_GROUP_HIGH = "high"
+
   implicit def http4sBody[F[_], A](body: A)(implicit encoder: EntityEncoder[F, A]): Entity[F] =
     encoder.toEntity(body)
 
@@ -50,6 +53,8 @@ package object leonardo {
       retryOnPermissionDenied
     )
   }
+
+  def isAoUProject(labels: Map[String, String]): Boolean = labels.get(SECURITY_GROUP).isDefined
 
   val allSupportedRegions = List(
     RegionName("us-central1"),

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/Boot.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/Boot.scala
@@ -250,10 +250,12 @@ object Boot extends IOApp {
 
         val backLeoOnlyProcesses = {
           val monitorAtBoot =
-            new MonitorAtBoot[IO](appDependencies.publisherQueue,
-                                  googleDependencies.googleComputeService,
-                                  appDependencies.samDAO,
-                                  appDependencies.wsmDAO
+            new MonitorAtBoot[IO](
+              appDependencies.publisherQueue,
+              googleDependencies.googleComputeService,
+              googleDependencies.googleResourceService,
+              appDependencies.samDAO,
+              appDependencies.wsmDAO
             )
 
           val autopauseMonitor = AutopauseMonitor(

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/Boot.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/Boot.scala
@@ -253,7 +253,6 @@ object Boot extends IOApp {
             new MonitorAtBoot[IO](
               appDependencies.publisherQueue,
               googleDependencies.googleComputeService,
-              googleDependencies.googleResourceService,
               appDependencies.samDAO,
               appDependencies.wsmDAO
             )

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/LeoAppServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/LeoAppServiceInterp.scala
@@ -813,13 +813,11 @@ final class LeoAppServiceInterp[F[_]: Parallel](config: AppServiceConfig,
   /**
    * Short-cuit if app creation isn't allowed, and return whether or not the user's project is AoU project
    *
-   * If custom app check isn't enabled, we'll just turn on intranode visibility; otherwise, we only turn it on for AoU projects
-   *
    * @param userEmail
    * @param googleProject
    * @param descriptorPath
    * @param ev
-   * @return true if intranode visibility should be enabled; false otherwise
+   * @return 
    */
   private[service] def checkIfAppCreationIsAllowed(userEmail: WorkbenchEmail,
                                                    googleProject: GoogleProject,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/LeoAppServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/LeoAppServiceInterp.scala
@@ -834,7 +834,6 @@ final class LeoAppServiceInterp[F[_]: Parallel](config: AppServiceConfig,
             projectLabels <- googleResourceService.getLabels(googleProject)
             isAppAllowed <- projectLabels match {
               case Some(labels) =>
-                // as long as the project has SECURITY_GROUP label, it is an AoU project
                 labels.get(SECURITY_GROUP) match {
                   case Some(securityGroupValue) =>
                     val appAllowList =

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/LeoAppServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/LeoAppServiceInterp.scala
@@ -849,7 +849,7 @@ final class LeoAppServiceInterp[F[_]: Parallel](config: AppServiceConfig,
                         else Left("No labels found for this project. User is not in CUSTOM_APP_USERS group")
                       }
                     else
-                      F.pure(s"${descriptorPath.toString()} is not in app allow list.".asLeft[Boolean])
+                      F.pure(s"${descriptorPath.toString()} is not in app allow list.".asLeft[Unit])
                   case None =>
                     authProvider.isCustomAppAllowed(userEmail) map { res =>
                       if (res) Right(())

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
@@ -921,7 +921,11 @@ class LeoPubsubMessageSubscriber[F[_]](
             // initial the createCluster call synchronously
             createClusterResultOpt <- gkeAlg
               .createCluster(
-                CreateClusterParams(clusterId, msg.project, List(defaultNodepoolId, nodepoolId))
+                CreateClusterParams(clusterId,
+                                    msg.project,
+                                    List(defaultNodepoolId, nodepoolId),
+                                    msg.enableIntraNodeVisibility
+                )
               )
               .onError { case _ => cleanUpAfterCreateClusterError(clusterId, msg.project) }
               .adaptError { case e =>

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/MonitorAtBoot.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/MonitorAtBoot.scala
@@ -6,7 +6,7 @@ import cats.effect.std.Queue
 import cats.mtl.Ask
 import cats.syntax.all._
 import fs2.Stream
-import org.broadinstitute.dsde.workbench.google2.{GoogleComputeService, ZoneName}
+import org.broadinstitute.dsde.workbench.google2.{GoogleComputeService, GoogleResourceService, ZoneName}
 import org.broadinstitute.dsde.workbench.leonardo.dao.{SamDAO, WsmDao}
 import org.broadinstitute.dsde.workbench.leonardo.db._
 import org.broadinstitute.dsde.workbench.leonardo.http._
@@ -29,6 +29,7 @@ import scala.concurrent.ExecutionContext
 
 class MonitorAtBoot[F[_]](publisherQueue: Queue[F, LeoPubsubMessage],
                           computeService: GoogleComputeService[F],
+                          googleResourceService: GoogleResourceService[F],
                           samDAO: SamDAO[F],
                           wsmDao: WsmDao[F]
 )(implicit
@@ -193,6 +194,7 @@ class MonitorAtBoot[F[_]](publisherQueue: Queue[F, LeoPubsubMessage],
                         )
                       )
                     )
+                  projectLabels <- googleResourceService.getLabels(googleProject)
 
                   diskIdOpt = app.appResources.disk.flatMap(d =>
                     if (d.status == DiskStatus.Creating) Some(d.id) else None
@@ -207,7 +209,10 @@ class MonitorAtBoot[F[_]](publisherQueue: Queue[F, LeoPubsubMessage],
                     app.appType,
                     app.appResources.namespace.name,
                     Some(AppMachineType(machineType.getMemoryMb / 1024, machineType.getGuestCpus)),
-                    Some(appContext.traceId)
+                    Some(appContext.traceId),
+                    isAoUProject(
+                      projectLabels.getOrElse(Map.empty)
+                    )
                   )
                 } yield msg
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/leoPubsubMessageSubscriberModels.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/leoPubsubMessageSubscriberModels.scala
@@ -271,7 +271,8 @@ object LeoPubsubMessage {
     machineType: Option[
       AppMachineType
     ], // Currently only galaxy is using this info, but potentially other apps might take advantage of this info too
-    traceId: Option[TraceId]
+    traceId: Option[TraceId],
+    enableIntraNodeVisibility: Boolean
   ) extends LeoPubsubMessage {
     val messageType: LeoPubsubMessageType = LeoPubsubMessageType.CreateApp
   }
@@ -521,16 +522,18 @@ object LeoPubsubCodec {
   }
 
   implicit val createAppMessageDecoder: Decoder[CreateAppMessage] =
-    Decoder.forProduct10("project",
-                         "clusterNodepoolAction",
-                         "appId",
-                         "appName",
-                         "createDisk",
-                         "customEnvironmentVariables",
-                         "appType",
-                         "namespaceName",
-                         "machineType",
-                         "traceId"
+    Decoder.forProduct11(
+      "project",
+      "clusterNodepoolAction",
+      "appId",
+      "appName",
+      "createDisk",
+      "customEnvironmentVariables",
+      "appType",
+      "namespaceName",
+      "machineType",
+      "traceId",
+      "enableIntraNodeVisibility"
     )(CreateAppMessage.apply)
 
   implicit val deleteAppDecoder: Decoder[DeleteAppMessage] =
@@ -887,7 +890,7 @@ object LeoPubsubCodec {
     }
 
   implicit val createAppMessageEncoder: Encoder[CreateAppMessage] =
-    Encoder.forProduct11(
+    Encoder.forProduct12(
       "messageType",
       "project",
       "clusterNodepoolAction",
@@ -898,7 +901,8 @@ object LeoPubsubCodec {
       "appType",
       "namespaceName",
       "machineType",
-      "traceId"
+      "traceId",
+      "enableIntraNodeVisibility"
     )(x =>
       (x.messageType,
        x.project,
@@ -910,7 +914,8 @@ object LeoPubsubCodec {
        x.appType,
        x.namespaceName,
        x.machineType,
-       x.traceId
+       x.traceId,
+       x.enableIntraNodeVisibility
       )
     )
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEAlgebra.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEAlgebra.scala
@@ -78,7 +78,8 @@ object GKEAlgebra {
 
 final case class CreateClusterParams(clusterId: KubernetesClusterLeoId,
                                      googleProject: GoogleProject,
-                                     nodepoolsToCreate: List[NodepoolLeoId]
+                                     nodepoolsToCreate: List[NodepoolLeoId],
+                                     enableIntraNodeVisibility: Boolean
 )
 
 final case class CreateClusterResult(op: KubernetesOperationId,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
@@ -6,6 +6,7 @@ import _root_.org.typelevel.log4cats.StructuredLogger
 import cats.effect.Async
 import cats.mtl.Ask
 import cats.syntax.all._
+import com.google.api.services.container.model
 import com.google.auth.oauth2.GoogleCredentials
 import com.google.cloud.compute.v1.Disk
 import com.google.container.v1._
@@ -121,6 +122,7 @@ class GKEInterpreter[F[_]](
       kubeNetwork = KubernetesNetwork(googleProject, network)
       kubeSubNetwork = KubernetesSubNetwork(googleProject, dbCluster.region, subnetwork)
 
+      networkConfig = new model.NetworkConfig().setEnableIntraNodeVisibility(params.enableIntraNodeVisibility)
       legacyCreateClusterRec = new com.google.api.services.container.model.Cluster()
         .setName(dbCluster.clusterName.value)
         .setInitialClusterVersion(config.clusterConfig.version.value)
@@ -129,6 +131,7 @@ class GKEInterpreter[F[_]](
         .setNetwork(kubeNetwork.idString)
         .setSubnetwork(kubeSubNetwork.idString)
         .setResourceLabels(Map("leonardo" -> "true").asJava)
+        .setNetworkConfig(networkConfig)
         .setNetworkPolicy(
           new com.google.api.services.container.model.NetworkPolicy().setEnabled(true)
         )

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/auth/AllowlistAuthProvider.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/auth/AllowlistAuthProvider.scala
@@ -131,7 +131,7 @@ class AllowlistAuthProvider(config: Config, saProvider: ServiceAccountProvider[I
     }
   } yield ()
 
-  override def isCustomAppAllowed(userEmail: WorkbenchEmail)(implicit ev: Ask[IO, TraceId]): IO[Boolean] = ???
+  override def isCustomAppAllowed(userEmail: WorkbenchEmail)(implicit ev: Ask[IO, TraceId]): IO[Boolean] = IO.pure(true)
 
   override def notifyResourceCreatedV2[R](samResource: R,
                                           creatorEmail: WorkbenchEmail,

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/AppServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/AppServiceInterpSpec.scala
@@ -12,7 +12,7 @@ import org.broadinstitute.dsde.workbench.google2.mock.{
   FakeGooglePublisher,
   FakeGoogleResourceService
 }
-import org.broadinstitute.dsde.workbench.google2.{DiskName, MachineTypeName, ZoneName}
+import org.broadinstitute.dsde.workbench.google2.{DiskName, GoogleResourceService, MachineTypeName, ZoneName}
 import org.broadinstitute.dsde.workbench.leonardo.AppRestore.{CromwellRestore, GalaxyRestore}
 import org.broadinstitute.dsde.workbench.leonardo.CommonTestData._
 import org.broadinstitute.dsde.workbench.leonardo.KubernetesTestData._
@@ -69,23 +69,6 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
         )
       )
   }
-
-  // used when we care about queue state
-  def makeInterp(queue: Queue[IO, LeoPubsubMessage],
-                 allowlistAuthProvider: AllowlistAuthProvider = allowListAuthProvider,
-                 wsmDao: WsmDao[IO] = wsmDao
-  ) =
-    new LeoAppServiceInterp[IO](
-      appServiceConfig,
-      allowlistAuthProvider,
-      serviceAccountProvider,
-      queue,
-      FakeGoogleComputeService,
-      FakeGoogleResourceService,
-      gkeCustomAppConfig,
-      wsmDao,
-      samDao
-    )
 
   val appServiceInterp = makeInterp(QueueFactory.makePublisherQueue())
   val gcpWorkspaceAppServiceInterp = makeInterp(QueueFactory.makePublisherQueue(), wsmDao = gcpWsmDao)
@@ -2223,10 +2206,119 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
     thrown.appType shouldBe AppType.HailBatch
   }
 
+  "checkIfAppCreationIsAllowedAndIsAoU" should "enable IntraNodeVisibility if customApp check is disabled" in {
+    val interp = makeInterp(QueueFactory.makePublisherQueue(), enableCustomAppCheckFlag = false)
+    val res =
+      interp.isCreationAllowedAndEnableIntranodeVisilibity(userEmail, project, Uri.unsafeFromString("https://dummy"))
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global) shouldBe true
+  }
+
+  it should "should fail if app is not in allowed list for non high security projects" in {
+    val resourceService = new FakeGoogleResourceService {
+      override def getLabels(project: GoogleProject)(implicit ev: Ask[IO, TraceId]): IO[Option[Map[String, String]]] =
+        IO.pure(Some(Map(SECURITY_GROUP -> "other")))
+    }
+    val userEmail = WorkbenchEmail("allowlist")
+    val interp = makeInterp(
+      QueueFactory.makePublisherQueue(),
+      enableCustomAppCheckFlag = true,
+      googleResourceService = resourceService,
+      customAppConfig = gkeCustomAppConfig.copy(customApplicationAllowList =
+        CustomApplicationAllowListConfig(List(), List("https://dummy"))
+      )
+    )
+    val res =
+      interp.isCreationAllowedAndEnableIntranodeVisilibity(userEmail, project, Uri.unsafeFromString("https://dummy"))
+    res.attempt
+      .unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
+      .swap
+      .toOption
+      .get
+      .isInstanceOf[ForbiddenError] shouldBe true
+  }
+
+  it should "should fail if app is not in allowed list for high security projects" in {
+    val resourceService = new FakeGoogleResourceService {
+      override def getLabels(project: GoogleProject)(implicit ev: Ask[IO, TraceId]): IO[Option[Map[String, String]]] =
+        IO.pure(Some(Map(SECURITY_GROUP -> "high")))
+    }
+    val userEmail = WorkbenchEmail("allowlist")
+    val interp = makeInterp(
+      QueueFactory.makePublisherQueue(),
+      enableCustomAppCheckFlag = true,
+      googleResourceService = resourceService,
+      customAppConfig = gkeCustomAppConfig.copy(customApplicationAllowList =
+        CustomApplicationAllowListConfig(List("https://dummy"), List())
+      )
+    )
+    val res =
+      interp.isCreationAllowedAndEnableIntranodeVisilibity(userEmail, project, Uri.unsafeFromString("https://dummy"))
+    res.attempt
+      .unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
+      .swap
+      .toOption
+      .get
+      .isInstanceOf[ForbiddenError] shouldBe true
+  }
+
+  it should "enable IntraNodeVisibility only for AoU projects if customApp check is enabled" in {
+    val resourceService = new FakeGoogleResourceService {
+      override def getLabels(project: GoogleProject)(implicit ev: Ask[IO, TraceId]): IO[Option[Map[String, String]]] =
+        IO.pure(Some(Map(SECURITY_GROUP -> "other")))
+    }
+    val userEmail = WorkbenchEmail("allowlist")
+    val interp = makeInterp(
+      QueueFactory.makePublisherQueue(),
+      enableCustomAppCheckFlag = true,
+      googleResourceService = resourceService,
+      customAppConfig = gkeCustomAppConfig.copy(customApplicationAllowList =
+        CustomApplicationAllowListConfig(List("https://dummy"), List())
+      )
+    )
+    val res1 =
+      interp.isCreationAllowedAndEnableIntranodeVisilibity(userEmail, project, Uri.unsafeFromString("https://dummy"))
+    res1.unsafeRunSync()(cats.effect.unsafe.IORuntime.global) shouldBe true
+
+    val resourceService2 = new FakeGoogleResourceService {
+      override def getLabels(project: GoogleProject)(implicit ev: Ask[IO, TraceId]): IO[Option[Map[String, String]]] =
+        IO.pure(Some(Map.empty))
+    }
+    val interp2 = makeInterp(QueueFactory.makePublisherQueue(),
+                             enableCustomAppCheckFlag = true,
+                             googleResourceService = resourceService2
+    )
+    val res2 =
+      interp2.isCreationAllowedAndEnableIntranodeVisilibity(userEmail, project, Uri.unsafeFromString("https://dummy"))
+    res2.unsafeRunSync()(cats.effect.unsafe.IORuntime.global) shouldBe false
+  }
+
   private def withLeoPublisher(
     publisherQueue: Queue[IO, LeoPubsubMessage]
   )(validations: IO[Assertion]): IO[Assertion] = {
     val leoPublisher = new LeoPublisher[IO](publisherQueue, new FakeGooglePublisher)
     withInfiniteStream(leoPublisher.process, validations)
+  }
+
+  // used when we care about queue state
+  private def makeInterp(queue: Queue[IO, LeoPubsubMessage],
+                         allowlistAuthProvider: AllowlistAuthProvider = allowListAuthProvider,
+                         wsmDao: WsmDao[IO] = wsmDao,
+                         enableCustomAppCheckFlag: Boolean = true,
+                         googleResourceService: GoogleResourceService[IO] = FakeGoogleResourceService,
+                         customAppConfig: CustomAppConfig = gkeCustomAppConfig
+  ) = {
+    val appConfig = appServiceConfig.copy(enableCustomAppCheck = enableCustomAppCheckFlag)
+
+    new LeoAppServiceInterp[IO](
+      appConfig,
+      allowlistAuthProvider,
+      serviceAccountProvider,
+      queue,
+      FakeGoogleComputeService,
+      googleResourceService,
+      customAppConfig,
+      wsmDao,
+      samDao
+    )
   }
 }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/AppServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/AppServiceInterpSpec.scala
@@ -2209,7 +2209,7 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
   "checkIfAppCreationIsAllowedAndIsAoU" should "enable IntraNodeVisibility if customApp check is disabled" in {
     val interp = makeInterp(QueueFactory.makePublisherQueue(), enableCustomAppCheckFlag = false)
     val res =
-      interp.isCreationAllowedAndEnableIntranodeVisilibity(userEmail, project, Uri.unsafeFromString("https://dummy"))
+      interp.checkIfAppCreationIsAllowed(userEmail, project, Uri.unsafeFromString("https://dummy"))
     res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global) shouldBe true
   }
 
@@ -2228,7 +2228,7 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
       )
     )
     val res =
-      interp.isCreationAllowedAndEnableIntranodeVisilibity(userEmail, project, Uri.unsafeFromString("https://dummy"))
+      interp.checkIfAppCreationIsAllowed(userEmail, project, Uri.unsafeFromString("https://dummy"))
     res.attempt
       .unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
       .swap
@@ -2252,7 +2252,7 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
       )
     )
     val res =
-      interp.isCreationAllowedAndEnableIntranodeVisilibity(userEmail, project, Uri.unsafeFromString("https://dummy"))
+      interp.checkIfAppCreationIsAllowed(userEmail, project, Uri.unsafeFromString("https://dummy"))
     res.attempt
       .unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
       .swap
@@ -2276,7 +2276,7 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
       )
     )
     val res1 =
-      interp.isCreationAllowedAndEnableIntranodeVisilibity(userEmail, project, Uri.unsafeFromString("https://dummy"))
+      interp.checkIfAppCreationIsAllowed(userEmail, project, Uri.unsafeFromString("https://dummy"))
     res1.unsafeRunSync()(cats.effect.unsafe.IORuntime.global) shouldBe true
 
     val resourceService2 = new FakeGoogleResourceService {
@@ -2288,7 +2288,7 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
                              googleResourceService = resourceService2
     )
     val res2 =
-      interp2.isCreationAllowedAndEnableIntranodeVisilibity(userEmail, project, Uri.unsafeFromString("https://dummy"))
+      interp2.checkIfAppCreationIsAllowed(userEmail, project, Uri.unsafeFromString("https://dummy"))
     res2.unsafeRunSync()(cats.effect.unsafe.IORuntime.global) shouldBe false
   }
 

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubCodecSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubCodecSpec.scala
@@ -127,7 +127,8 @@ class LeoPubsubCodecSpec extends AnyFlatSpec with Matchers {
       Galaxy,
       NamespaceName("ns"),
       None,
-      Some(traceId)
+      Some(traceId),
+      false
     )
 
     val res = decode[CreateAppMessage](originalMessage.asJson.printWith(Printer.noSpaces))

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriberSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriberSpec.scala
@@ -899,7 +899,8 @@ class LeoPubsubMessageSubscriberSpec
           AppType.Galaxy,
           savedApp1.appResources.namespace.name,
           Some(AppMachineType(5, 4)),
-          Some(tr)
+          Some(tr),
+          false
         )
 
         asyncTaskProcessor = AsyncTaskProcessor(AsyncTaskProcessor.Config(10, 10), queue)
@@ -952,7 +953,8 @@ class LeoPubsubMessageSubscriberSpec
           AppType.Galaxy,
           savedApp1.appResources.namespace.name,
           None,
-          Some(tr)
+          Some(tr),
+          false
         )
 
         asyncTaskProcessor = AsyncTaskProcessor(AsyncTaskProcessor.Config(10, 10), queue)
@@ -1048,7 +1050,8 @@ class LeoPubsubMessageSubscriberSpec
           AppType.Galaxy,
           savedApp1.appResources.namespace.name,
           Some(AppMachineType(5, 4)),
-          Some(tr)
+          Some(tr),
+          false
         )
         msg2 = CreateAppMessage(
           savedCluster1.cloudContext.asInstanceOf[CloudContext.Gcp].value,
@@ -1060,7 +1063,8 @@ class LeoPubsubMessageSubscriberSpec
           AppType.Galaxy,
           savedApp2.appResources.namespace.name,
           Some(AppMachineType(5, 4)),
-          Some(tr)
+          Some(tr),
+          false
         )
         asyncTaskProcessor = AsyncTaskProcessor(AsyncTaskProcessor.Config(10, 10), queue)
         _ <- leoSubscriber.handleCreateAppMessage(msg1)
@@ -1102,7 +1106,8 @@ class LeoPubsubMessageSubscriberSpec
           AppType.Galaxy,
           savedApp1.appResources.namespace.name,
           None,
-          Some(tr)
+          Some(tr),
+          false
         )
         asyncTaskProcessor = AsyncTaskProcessor(AsyncTaskProcessor.Config(10, 10), queue)
         _ <- leoSubscriber.messageHandler(Event(msg, None, timestamp, mockAckConsumer))
@@ -1324,7 +1329,8 @@ class LeoPubsubMessageSubscriberSpec
           AppType.Galaxy,
           savedApp1.appResources.namespace.name,
           Some(AppMachineType(5, 4)),
-          Some(tr)
+          Some(tr),
+          false
         )
         asyncTaskProcessor = AsyncTaskProcessor(AsyncTaskProcessor.Config(10, 10), queue)
         _ <- leoSubscriber.handleCreateAppMessage(msg)
@@ -1430,7 +1436,8 @@ class LeoPubsubMessageSubscriberSpec
           AppType.Galaxy,
           savedApp1.appResources.namespace.name,
           None,
-          Some(tr)
+          Some(tr),
+          false
         )
         asyncTaskProcessor = AsyncTaskProcessor(AsyncTaskProcessor.Config(10, 10), queue)
         _ <- leoSubscriber.handleCreateAppMessage(msg)
@@ -1495,7 +1502,8 @@ class LeoPubsubMessageSubscriberSpec
           AppType.Galaxy,
           savedApp1.appResources.namespace.name,
           None,
-          Some(tr)
+          Some(tr),
+          false
         )
         asyncTaskProcessor = AsyncTaskProcessor(AsyncTaskProcessor.Config(10, 10), queue)
         _ <- leoSubscriber.handleCreateAppMessage(msg)
@@ -1574,7 +1582,8 @@ class LeoPubsubMessageSubscriberSpec
           AppType.Galaxy,
           savedApp1.appResources.namespace.name,
           None,
-          Some(tr)
+          Some(tr),
+          false
         )
         _ <- leoSubscriber.messageHandler(Event(msg, None, timestamp, mockAckConsumer))
       } yield ()
@@ -1749,7 +1758,8 @@ class LeoPubsubMessageSubscriberSpec
           savedApp1.appType,
           savedApp1.appResources.namespace.name,
           Some(AppMachineType(5, 4)),
-          Some(tr)
+          Some(tr),
+          false
         )
         asyncTaskProcessor = AsyncTaskProcessor(AsyncTaskProcessor.Config(10, 10), queue)
         // send message twice

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/MonitorAtBootSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/MonitorAtBootSpec.scala
@@ -4,7 +4,7 @@ import cats.Eq
 import cats.effect.IO
 import cats.effect.std.Queue
 import cats.syntax.all._
-import org.broadinstitute.dsde.workbench.google2.mock.FakeGoogleComputeService
+import org.broadinstitute.dsde.workbench.google2.mock.{FakeGoogleComputeService, FakeGoogleResourceService}
 import org.broadinstitute.dsde.workbench.leonardo.CommonTestData._
 import org.broadinstitute.dsde.workbench.leonardo.KubernetesTestData.{
   customEnvironmentVariables,
@@ -144,7 +144,8 @@ class MonitorAtBootSpec extends AnyFlatSpec with TestComponent with LeonardoTest
         AppType.Galaxy,
         savedApp.appResources.namespace.name,
         Some(defaultFakeAppMachineType),
-        None
+        None,
+        false
       )
       (msg eqv Some(expected)) shouldBe true
     }
@@ -195,7 +196,8 @@ class MonitorAtBootSpec extends AnyFlatSpec with TestComponent with LeonardoTest
         AppType.Galaxy,
         savedApp.appResources.namespace.name,
         Some(defaultFakeAppMachineType),
-        None
+        None,
+        false
       )
       (msg eqv Some(expected)) shouldBe true
     }
@@ -246,7 +248,8 @@ class MonitorAtBootSpec extends AnyFlatSpec with TestComponent with LeonardoTest
         AppType.Galaxy,
         savedApp.appResources.namespace.name,
         Some(defaultFakeAppMachineType),
-        None
+        None,
+        false
       )
       (msg eqv Some(expected)) shouldBe true
     }
@@ -356,5 +359,10 @@ class MonitorAtBootSpec extends AnyFlatSpec with TestComponent with LeonardoTest
     queue: Queue[IO, LeoPubsubMessage] =
       Queue.bounded[IO, LeoPubsubMessage](10).unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   ): MonitorAtBoot[IO] =
-    new MonitorAtBoot[IO](queue, FakeGoogleComputeService, new MockSamDAO(), new MockWsmDAO())
+    new MonitorAtBoot[IO](queue,
+                          FakeGoogleComputeService,
+                          FakeGoogleResourceService,
+                          new MockSamDAO(),
+                          new MockWsmDAO()
+    )
 }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/MonitorAtBootSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/MonitorAtBootSpec.scala
@@ -4,15 +4,9 @@ import cats.Eq
 import cats.effect.IO
 import cats.effect.std.Queue
 import cats.syntax.all._
-import org.broadinstitute.dsde.workbench.google2.mock.{FakeGoogleComputeService, FakeGoogleResourceService}
+import org.broadinstitute.dsde.workbench.google2.mock.FakeGoogleComputeService
 import org.broadinstitute.dsde.workbench.leonardo.CommonTestData._
-import org.broadinstitute.dsde.workbench.leonardo.KubernetesTestData.{
-  customEnvironmentVariables,
-  makeApp,
-  makeAzureCluster,
-  makeKubeCluster,
-  makeNodepool
-}
+import org.broadinstitute.dsde.workbench.leonardo.KubernetesTestData._
 import org.broadinstitute.dsde.workbench.leonardo.dao.{MockSamDAO, MockWsmDAO}
 import org.broadinstitute.dsde.workbench.leonardo.db.TestComponent
 import org.broadinstitute.dsde.workbench.leonardo.monitor.ClusterNodepoolAction.{
@@ -359,10 +353,5 @@ class MonitorAtBootSpec extends AnyFlatSpec with TestComponent with LeonardoTest
     queue: Queue[IO, LeoPubsubMessage] =
       Queue.bounded[IO, LeoPubsubMessage](10).unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   ): MonitorAtBoot[IO] =
-    new MonitorAtBoot[IO](queue,
-                          FakeGoogleComputeService,
-                          FakeGoogleResourceService,
-                          new MockSamDAO(),
-                          new MockWsmDAO()
-    )
+    new MonitorAtBoot[IO](queue, FakeGoogleComputeService, new MockSamDAO(), new MockWsmDAO())
 }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreterSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreterSpec.scala
@@ -551,7 +551,8 @@ class GKEInterpreterSpec extends AnyFlatSpecLike with TestComponent with Leonard
         .createCluster(
           CreateClusterParams(KubernetesClusterLeoId(-1),
                               GoogleProject("fake"),
-                              List(NodepoolLeoId(-1), NodepoolLeoId(-1))
+                              List(NodepoolLeoId(-1), NodepoolLeoId(-1)),
+                              false
           )
         )
         .attempt
@@ -568,7 +569,11 @@ class GKEInterpreterSpec extends AnyFlatSpecLike with TestComponent with Leonard
     val res = for {
       createResult <- gkeInterp
         .createCluster(
-          CreateClusterParams(savedCluster1.id, savedCluster1.cloudContext.asInstanceOf[CloudContext.Gcp].value, List())
+          CreateClusterParams(savedCluster1.id,
+                              savedCluster1.cloudContext.asInstanceOf[CloudContext.Gcp].value,
+                              List(),
+                              false
+          )
         )
       r <- gkeInterp
         .pollCluster(
@@ -593,7 +598,8 @@ class GKEInterpreterSpec extends AnyFlatSpecLike with TestComponent with Leonard
         .createCluster(
           CreateClusterParams(savedCluster1.id,
                               savedCluster1.cloudContext.asInstanceOf[CloudContext.Gcp].value,
-                              List(NodepoolLeoId(-2))
+                              List(NodepoolLeoId(-2)),
+                              false
           )
         )
         .attempt


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-4402

With `enableIntraNodeVisibility`, we'll be able to see more inter node traffic logs, which will make it possible for us to trace back to a user if what they do triggers egress alert.

This PR turns on `enableIntraNodeVisibility` for GKE apps
1. For envs with `enable-custom-app-check` being false. This is mostly for dev envs.
2. For envs with `enable-custom-app-check` being true, it's only on for in AoU projects and AoU supported apps (RStudio, custom apps, cromwell).

We could potentially turn this flag on for all apps, but figured it's less risky to have it on only for AoU projects for now.

Tested things are working in BEE.
![Screenshot 2023-06-29 at 1 25 53 PM](https://github.com/DataBiosphere/leonardo/assets/32771737/46bd8587-3aac-4cc7-ad84-9f3d9672cbc8)


- [ ] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [ ] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
