### PR TITLE
AJ-1147: no direct policies for apps with workspace parent

### DIFF
--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpSamDAO.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpSamDAO.scala
@@ -278,9 +278,8 @@ class HttpSamDAO[F[_]](httpClient: Client[F],
         s"Creating ${sr.resourceType(resource).asString} resource in sam v2 for ${workspaceId}/${sr.resourceIdAsString(resource)}"
       )
       _ <- metrics.incrementCounter(s"sam/createResource/${sr.resourceType(resource).asString}")
-      policies = Map[SamPolicyName, SamPolicyData](
-        SamPolicyName.Creator -> SamPolicyData(List(creatorEmail), List(sr.ownerRoleName(resource)))
-      )
+      // all app policies inherit from the workspace parent; there are no direct policies
+      policies = Map.empty[SamPolicyName, SamPolicyData]
       parent = SerializableSamResource(SamResourceType.Workspace, WorkspaceResourceSamResourceId(workspaceId))
       _ <- httpClient
         .run(


### PR DESCRIPTION
__Jira ticket__: https://broadworkbench.atlassian.net/browse/AJ-1147

<!-- ## Dependencies -->
<!-- Include any dependent tickets and describe the relationship. Include any other relevant Jira tickets. -->

## Summary of changes / What

When creating a `kubernetes-app` or `kubernetes-app-shared` Sam resource that uses a workspace parent, don't create any direct policies (e.g. creator, owner) on that resource. These child resources should inherit all of their policies from the parent workspace. If they don't inherit everything, it means that something must explicitly manage the direct policies if the creator/owner is removed from the workspace.

### Why

This prevents any problems with the`kubernetes-app` or `kubernetes-app-shared` direct policy being out of sync with the parent workspace's policy, if the parent workspace's membership changes.

## Testing these changes

<!-- ### Test data -->

### Who tested and where

- [ ] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [x] I validated this change _in a BEE, for both `kubernetes-app-shared` and `kubernetes-app` Sam resources_
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
