### PR TITLE
AJ-1147: no direct Sam policies for kubernetes-app-shared only

### DIFF
--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -211,7 +211,7 @@ azure {
         minor-version-auto-upgrade = true,
         file-uris = ["https://raw.githubusercontent.com/DataBiosphere/leonardo/270bd6aad916344fadc06d1a51629c432da663a8/http/src/main/resources/init-resources/azure_vm_init_script.sh"]
       }
-      listener-image = "terradevacrpublic.azurecr.io/terra-azure-relay-listeners:7c9a542"
+      listener-image = "terradevacrpublic.azurecr.io/terra-azure-relay-listeners:21a30dc"
     }
   }
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpSamDAO.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpSamDAO.scala
@@ -285,7 +285,7 @@ class HttpSamDAO[F[_]](httpClient: Client[F],
           Map.empty[SamPolicyName, SamPolicyData]
         case _ =>
           // Other types set an explicit ownerRoleName() policy. As of this writing, the only other resource type
-          // handled by this case clause is SamResourceType.App ("kubernetes-app"); his is controlled by
+          // handled by this case clause is SamResourceType.App ("kubernetes-app"); this is controlled by
           // SamAuthProvider.notifyResourceCreatedV2().
           Map[SamPolicyName, SamPolicyData](
             SamPolicyName.Creator -> SamPolicyData(List(creatorEmail), List(sr.ownerRoleName(resource)))

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpSamDAO.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpSamDAO.scala
@@ -278,8 +278,9 @@ class HttpSamDAO[F[_]](httpClient: Client[F],
         s"Creating ${sr.resourceType(resource).asString} resource in sam v2 for ${workspaceId}/${sr.resourceIdAsString(resource)}"
       )
       _ <- metrics.incrementCounter(s"sam/createResource/${sr.resourceType(resource).asString}")
-      // all app policies inherit from the workspace parent; there are no direct policies
-      policies = Map.empty[SamPolicyName, SamPolicyData]
+      policies = Map[SamPolicyName, SamPolicyData](
+        SamPolicyName.Creator -> SamPolicyData(List(creatorEmail), List(sr.ownerRoleName(resource)))
+      )
       parent = SerializableSamResource(SamResourceType.Workspace, WorkspaceResourceSamResourceId(workspaceId))
       _ <- httpClient
         .run(

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpSamDAO.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpSamDAO.scala
@@ -278,9 +278,19 @@ class HttpSamDAO[F[_]](httpClient: Client[F],
         s"Creating ${sr.resourceType(resource).asString} resource in sam v2 for ${workspaceId}/${sr.resourceIdAsString(resource)}"
       )
       _ <- metrics.incrementCounter(s"sam/createResource/${sr.resourceType(resource).asString}")
-      policies = Map[SamPolicyName, SamPolicyData](
-        SamPolicyName.Creator -> SamPolicyData(List(creatorEmail), List(sr.ownerRoleName(resource)))
-      )
+      policies = sr.resourceType(resource) match {
+        case SamResourceType.SharedApp =>
+          // SamResourceType.SharedApp (kubernetes-app-shared") inherits all its policies from the parent workspace,
+          // so should have no direct roles.
+          Map.empty[SamPolicyName, SamPolicyData]
+        case _ =>
+          // Other types set an explicit ownerRoleName() policy. As of this writing, the only other resource type
+          // handled by this case clause is SamResourceType.App ("kubernetes-app"); his is controlled by
+          // SamAuthProvider.notifyResourceCreatedV2().
+          Map[SamPolicyName, SamPolicyData](
+            SamPolicyName.Creator -> SamPolicyData(List(creatorEmail), List(sr.ownerRoleName(resource)))
+          )
+      }
       parent = SerializableSamResource(SamResourceType.Workspace, WorkspaceResourceSamResourceId(workspaceId))
       _ <- httpClient
         .run(

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/ConfigReaderSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/ConfigReaderSpec.scala
@@ -68,7 +68,7 @@ class ConfigReaderSpec extends AnyFlatSpec with Matchers {
                 "https://raw.githubusercontent.com/DataBiosphere/leonardo/270bd6aad916344fadc06d1a51629c432da663a8/http/src/main/resources/init-resources/azure_vm_init_script.sh"
               )
             ),
-            "terradevacrpublic.azurecr.io/terra-azure-relay-listeners:7c9a542",
+            "terradevacrpublic.azurecr.io/terra-azure-relay-listeners:21a30dc",
             VMCredential(username = "username", password = "password")
           )
         ),


### PR DESCRIPTION
<!-- Welcome to your Leonardo pull request! -->
<!-- Contributor guidelines: https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md -->

__Jira ticket__: https://broadworkbench.atlassian.net/browse/AJ-1147

<!-- ## Dependencies -->
<!-- Include any dependent tickets and describe the relationship. Include any other relevant Jira tickets. -->

## Summary of changes

Two changes:
1. A revision of #3488. This revision changes `kubernetes-app-shared` Sam resources only, instead of both `kubernetes-app-shared` and `kubernetes-app`.
2. Update to latest listener image, which enforces a 90-second TTL on the Sam cache.

<!-- Please give an abridged version of the ticket description here and/or fill out the following fields. -->

### What

See #3488 for discussion of the Sam policy changes. However, that PR broke CBAS/Cromwell apps (which use `kubernetes-app`), so this PR leaves those apps alone but still fixes the issue for WDS (which uses `kubernetes-app-shared`).

See https://github.com/DataBiosphere/terra-azure-relay-listeners/pull/43 for a discussion of the listener changes.

### Why

-

## Testing these changes

### What to test

- <!-- Test case 1 -->

<!-- ### Test data -->

### Who tested and where

- [ ] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [ ] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
