### PR TITLE
[PROD-848] Change all 5 second timeouts to unique durations

### DIFF
--- a/http/src/main/resources/leo.conf
+++ b/http/src/main/resources/leo.conf
@@ -48,7 +48,7 @@ mysql {
     url = ${?SQL_URL}
     user = ${?DB_USER}
     password = ${?DB_PASSWORD}
-    connectionTimeout = 5000
+    connectionTimeout = 5003
     numThreads = ${?NUM_DB_THREADS}
   }
 }

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -717,7 +717,7 @@ clusterFiles {
 # The expiration is low because the IP changes when a runtime is pause/resumed,
 # so we need to ensure we don't use stale cache entries.
 runtimeDnsCache {
-  cacheExpiryTime = 5001 milliseconds
+  cacheExpiryTime = 5001 milliseconds # [PROD-848] unique duration for debugging TimeoutException
   cacheMaxSize = 100
 }
 
@@ -736,7 +736,7 @@ mysql {
     #url = "jdbc:mysql://mysql/leonardo
     #user = "dbUser"
     #password = "pass"
-    connectionTimeout = 5002
+    connectionTimeout = 5002 # [PROD-848] unique duration for debugging TimeoutException
     numThreads = 200
   }
   concurrency = 120

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -717,7 +717,7 @@ clusterFiles {
 # The expiration is low because the IP changes when a runtime is pause/resumed,
 # so we need to ensure we don't use stale cache entries.
 runtimeDnsCache {
-  cacheExpiryTime = 5 seconds
+  cacheExpiryTime = 5001 milliseconds
   cacheMaxSize = 100
 }
 
@@ -736,7 +736,7 @@ mysql {
     #url = "jdbc:mysql://mysql/leonardo
     #user = "dbUser"
     #password = "pass"
-    connectionTimeout = 5000
+    connectionTimeout = 5002
     numThreads = 200
   }
   concurrency = 120

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/ProxyDAO.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/ProxyDAO.scala
@@ -42,11 +42,15 @@ object Proxy {
   ): F[HostStatus] =
     runtimeDnsCache
       .getHostStatus(RuntimeDnsCacheKey(cloudContext, runtimeName))
-      .timeout(5 seconds)
+      // TODO PROD-848 determine if frequency of runtime startup failures decreases after this change, and if the error message shows this unique duration
+      .timeout(5999 milliseconds)
 
   def getAppTargetHost[F[_]: Async](kubernetesDnsCache: KubernetesDnsCache[F],
                                     cloudContext: CloudContext,
                                     appName: AppName
   ): F[HostStatus] =
-    kubernetesDnsCache.getHostStatus(KubernetesDnsCacheKey(cloudContext, appName)).timeout(5 seconds)
+    kubernetesDnsCache
+      .getHostStatus(KubernetesDnsCacheKey(cloudContext, appName))
+      // TODO PROD-848 determine if frequency of app startup failures decreases after this change, and if the error message shows this unique duration
+      .timeout(5998 milliseconds)
 }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/StatusService.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/StatusService.scala
@@ -27,7 +27,7 @@ class StatusService(
   initialDelay: FiniteDuration = Duration.Zero,
   pollInterval: FiniteDuration = 1 minute
 )(implicit system: ActorSystem, executionContext: ExecutionContext, logger: Logger[IO]) {
-  implicit val askTimeout = Timeout(5.seconds)
+  implicit val askTimeout = Timeout(5004.milliseconds)
   import dbRef._
 
   private val healthMonitor =

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/StatusService.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/StatusService.scala
@@ -27,6 +27,7 @@ class StatusService(
   initialDelay: FiniteDuration = Duration.Zero,
   pollInterval: FiniteDuration = 1 minute
 )(implicit system: ActorSystem, executionContext: ExecutionContext, logger: Logger[IO]) {
+  // [PROD-848] unique duration for debugging TimeoutException
   implicit val askTimeout = Timeout(5004.milliseconds)
   import dbRef._
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/BaseCloudServiceRuntimeMonitor.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/BaseCloudServiceRuntimeMonitor.scala
@@ -596,7 +596,7 @@ abstract class BaseCloudServiceRuntimeMonitor[F[_]] {
 
     openTelemetry.time(
       "tools_start_up_time",
-      List(5 seconds, 20 seconds, 30 seconds, 1 minutes, 2 minutes),
+      List(5005 milliseconds, 20 seconds, 30 seconds, 1 minutes, 2 minutes),
       Map("cloud_service" -> runtimeAndRuntimeConfig.runtimeConfig.cloudService.asString)
     )(res)
   }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/BaseCloudServiceRuntimeMonitor.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/BaseCloudServiceRuntimeMonitor.scala
@@ -596,6 +596,7 @@ abstract class BaseCloudServiceRuntimeMonitor[F[_]] {
 
     openTelemetry.time(
       "tools_start_up_time",
+      // [PROD-848] unique duration for debugging TimeoutException
       List(5005 milliseconds, 20 seconds, 30 seconds, 1 minutes, 2 minutes),
       Map("cloud_service" -> runtimeAndRuntimeConfig.runtimeConfig.cloudService.asString)
     )(res)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/DataprocRuntimeMonitor.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/DataprocRuntimeMonitor.scala
@@ -168,7 +168,7 @@ class DataprocRuntimeMonitor[F[_]: Parallel](
                       case Some(dataprocInstance) =>
                         dataprocInstance.ip match {
                           case Some(ip) =>
-                            // It takes a bit for jupyter to startup, hence wait 5 seconds before we check jupyter
+                            // It takes a bit for jupyter to startup, hence wait some seconds before we check jupyter
                             F.sleep(8 seconds) >> handleCheckTools(monitorContext,
                                                                    runtimeAndRuntimeConfig,
                                                                    ip,
@@ -321,7 +321,7 @@ class DataprocRuntimeMonitor[F[_]: Parallel](
                 case UserScriptsValidationResult.Success =>
                   main.flatMap(_._1.ip) match {
                     case Some(ip) =>
-                      // It takes a bit for jupyter to startup, hence wait 5 seconds before we check jupyter
+                      // It takes a bit for jupyter to startup, hence wait some seconds before we check jupyter
                       F.sleep(8 seconds) >> handleCheckTools(monitorContext,
                                                              runtimeAndRuntimeConfig,
                                                              ip,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/GceRuntimeMonitor.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/GceRuntimeMonitor.scala
@@ -221,7 +221,7 @@ class GceRuntimeMonitor[F[_]: Parallel](
                 case UserScriptsValidationResult.Success =>
                   getInstanceIP(i) match {
                     case Some(ip) =>
-                      // It takes a bit for jupyter to startup, hence wait 5 seconds before we check jupyter
+                      // It takes a bit for jupyter to startup, hence wait some seconds before we check jupyter
                       Temporal[F]
                         .sleep(8 seconds) >> handleCheckTools(monitorContext,
                                                               runtimeAndRuntimeConfig,
@@ -316,7 +316,7 @@ class GceRuntimeMonitor[F[_]: Parallel](
                 case UserScriptsValidationResult.Success =>
                   getInstanceIP(i) match {
                     case Some(ip) =>
-                      // It takes a bit for jupyter to startup, hence wait 5 seconds before we check jupyter
+                      // It takes a bit for jupyter to startup, hence wait some seconds before we check jupyter
                       Temporal[F]
                         .sleep(8 seconds) >> handleCheckTools(monitorContext,
                                                               runtimeAndRuntimeConfig,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
@@ -1141,14 +1141,14 @@ class LeoPubsubMessageSubscriber[F[_]](
                   streamUntilDoneOrTimeout(
                     getDiskDetachStatus(postgresOriginalDetachTimestampOpt, getPostgresDisk),
                     50,
-                    5 seconds,
+                    5006 milliseconds,
                     "The postgres disk failed to detach within the time limit, cannot proceed with delete disk"
                   )
                 else F.unit
               _ <- streamUntilDoneOrTimeout(
                 getDiskDetachStatus(dataDiskOriginalDetachTimestampOpt, getDataDisk),
                 50,
-                5 seconds,
+                5007 milliseconds,
                 "The data disk failed to detach within the time limit, cannot proceed with delete disk"
               )
             } yield ()).adaptError { case e =>

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
@@ -1141,6 +1141,7 @@ class LeoPubsubMessageSubscriber[F[_]](
                   streamUntilDoneOrTimeout(
                     getDiskDetachStatus(postgresOriginalDetachTimestampOpt, getPostgresDisk),
                     50,
+                    // [PROD-848] unique duration for debugging TimeoutException
                     5006 milliseconds,
                     "The postgres disk failed to detach within the time limit, cannot proceed with delete disk"
                   )
@@ -1148,6 +1149,7 @@ class LeoPubsubMessageSubscriber[F[_]](
               _ <- streamUntilDoneOrTimeout(
                 getDiskDetachStatus(dataDiskOriginalDetachTimestampOpt, getDataDisk),
                 50,
+                // [PROD-848] unique duration for debugging TimeoutException
                 5007 milliseconds,
                 "The data disk failed to detach within the time limit, cannot proceed with delete disk"
               )

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
@@ -700,6 +700,7 @@ class GKEInterpreter[F[_]](
         .namespaceExists(dbApp.cluster.getClusterId, KubernetesNamespace(dbApp.app.appResources.namespace.name))
         .map(!_) // mapping to inverse because booleanDoneCheckable defines `Done` when it becomes `true`...In this case, the namespace will exists for a while, and eventually becomes non-existent
 
+      // [PROD-848] unique duration for debugging TimeoutException
       _ <- streamUntilDoneOrTimeout(fa, 30, 5008 milliseconds, "delete namespace timed out")
       _ <- logger.info(ctx.loggingCtx)(
         s"Delete app operation has finished for app ${app.appName.value} in cluster ${gkeClusterId.toString}"

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
@@ -700,7 +700,7 @@ class GKEInterpreter[F[_]](
         .namespaceExists(dbApp.cluster.getClusterId, KubernetesNamespace(dbApp.app.appResources.namespace.name))
         .map(!_) // mapping to inverse because booleanDoneCheckable defines `Done` when it becomes `true`...In this case, the namespace will exists for a while, and eventually becomes non-existent
 
-      _ <- streamUntilDoneOrTimeout(fa, 30, 5 seconds, "delete namespace timed out")
+      _ <- streamUntilDoneOrTimeout(fa, 30, 5008 milliseconds, "delete namespace timed out")
       _ <- logger.info(ctx.loggingCtx)(
         s"Delete app operation has finished for app ${app.appName.value} in cluster ${gkeClusterId.toString}"
       )


### PR DESCRIPTION
Jira ticket: [https://broadworkbench.atlassian.net/browse/[ticket_number]](https://broadworkbench.atlassian.net/browse/PROD-848)

Timeouts and timeoutlike durations to unique millisecond counts per Jack's advice.

ProxyDAO is bumped to ~6s in hopes of actually reducing the occurrence of the issue (if ProxyDAO is the culprit - I was sadly unable to reproduce in my BEE).

Something is occasionally timing out on create/start of GCP runtimes and apps, with the mysterious alert "failed due to 5 seconds." This is a TimeoutException; it's thrown by the `timeout()` method and possibly elsewhere. I changed occurrences of 5-second durations to unique values to see if this can help us pinpoint the behavior. https://console.cloud.google.com/monitoring/alerting/policies/1601022952764179214?project=broad-dsde-dev is an example of an alert which will help us notice these when they occur and use them to debug.

### Who tested and where

- [ ] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [ ] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
