### PR TITLE
RW-9838 Refactor existing RStudio app support to be more generic

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoApiClient.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoApiClient.scala
@@ -120,6 +120,7 @@ object LeonardoApiClient {
     AppType.Galaxy,
     None,
     None,
+    None,
     Map.empty,
     Map.empty,
     None,

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoSuite.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoSuite.scala
@@ -20,9 +20,7 @@ import org.broadinstitute.dsde.workbench.service.BillingProject.BillingProjectRo
 import org.broadinstitute.dsde.workbench.service.{Orchestration, Rawls}
 import org.scalatest._
 import org.scalatest.freespec.FixtureAnyFreeSpecLike
-import org.broadinstitute.dsde.workbench.leonardo.TestUser.getAuthTokenAndAuthorization
 import org.broadinstitute.dsde.rawls.model.AzureManagedAppCoordinates
-import org.broadinstitute.dsde.workbench.auth.AuthToken
 import org.broadinstitute.dsde.workbench.fixture.BillingFixtures.withTemporaryAzureBillingProject
 
 import java.util.UUID

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/AppLifecycleSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/AppLifecycleSpec.scala
@@ -33,7 +33,8 @@ class AppLifecycleSpec
 
   def createAppRequest(appType: AppType,
                        workspaceName: String,
-                       descriptorPath: Option[org.http4s.Uri]
+                       descriptorPath: Option[org.http4s.Uri],
+                       allowedChartName: Option[AllowedChartName] = None
   ): CreateAppRequest = defaultCreateAppRequest.copy(
     diskConfig = Some(
       PersistentDiskRequest(
@@ -43,6 +44,7 @@ class AppLifecycleSpec
         Map.empty
       )
     ),
+    allowedChartName = allowedChartName,
     appType = appType,
     customEnvironmentVariables = Map("WORKSPACE_NAME" -> workspaceName),
     descriptorPath = descriptorPath,
@@ -60,7 +62,11 @@ class AppLifecycleSpec
 
   "create RSTUDIO app, delete it and re-create it with same disk" taggedAs (Tags.SmokeTest, Retryable) in {
     googleProject =>
-      test(googleProject, createAppRequest(AppType.Allowed, "rstudio-test-workspace", None), false, true)
+      test(googleProject,
+           createAppRequest(AppType.Allowed, "rstudio-test-workspace", None, Some(AllowedChartName.RStudio)),
+           false,
+           true
+      )
   }
 
   "create CUSTOM app, start/stop, delete it" taggedAs Retryable in { googleProject =>

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/AppLifecycleSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/AppLifecycleSpec.scala
@@ -60,7 +60,7 @@ class AppLifecycleSpec
 
   "create RSTUDIO app, delete it and re-create it with same disk" taggedAs (Tags.SmokeTest, Retryable) in {
     googleProject =>
-      test(googleProject, createAppRequest(AppType.RStudio, "rstudio-test-workspace", None), false, true)
+      test(googleProject, createAppRequest(AppType.Allowed, "rstudio-test-workspace", None), false, true)
   }
 
   "create CUSTOM app, start/stop, delete it" taggedAs Retryable in { googleProject =>

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/ConfigImplicits.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/ConfigImplicits.scala
@@ -30,6 +30,11 @@ object ConfigImplicits {
   implicit val cidrIpConfigReader: ConfigReader[CidrIP] =
     ConfigReader.stringConfigReader.map(s => CidrIP(s))
 
+  implicit val appTypeConfigReader: ConfigReader[AppType] =
+    ConfigReader.stringConfigReader.emap(s =>
+      Either.fromOption(AppType.stringToObject.get(s), ExceptionThrown.apply(new Exception("invalid appType")))
+    )
+
   implicit val clientIdConfigReader: ConfigReader[ClientId] =
     ConfigReader.stringConfigReader.map(s => ClientId(s))
   implicit val clientSecretConfigReader: ConfigReader[ClientSecret] =

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/JsonCodec.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/JsonCodec.scala
@@ -44,6 +44,7 @@ import org.broadinstitute.dsde.workbench.model.google.{
 }
 import org.broadinstitute.dsde.workbench.model.{IP, WorkbenchEmail, WorkbenchUserId}
 import org.broadinstitute.dsde.workbench.util2.InstanceName
+import org.broadinstitute.dsp.ChartName
 import org.http4s.Uri
 
 import java.net.URL
@@ -253,6 +254,8 @@ object JsonCodec {
     "traceId"
   )(x => RuntimeError.unapply(x).get)
   implicit val errorSourceEncoder: Encoder[ErrorSource] = Encoder.encodeString.contramap(_.toString)
+  implicit val allowedChartNameEncoder: Encoder[AllowedChartName] = Encoder.encodeString.contramap(_.asString)
+  implicit val chartNameEncoder: Encoder[ChartName] = Encoder.encodeString.contramap(_.asString)
   implicit val errorActionEncoder: Encoder[ErrorAction] = Encoder.encodeString.contramap(_.toString)
   implicit val appErrorEncoder: Encoder[AppError] =
     Encoder.forProduct6("errorMessage", "timestamp", "action", "source", "googleErrorCode", "traceId")(x =>
@@ -679,6 +682,9 @@ object JsonCodec {
   implicit val appTypeDecoder: Decoder[AppType] =
     Decoder.decodeString.emap(s => AppType.stringToObject.get(s).toRight(s"Invalid app type ${s}"))
   implicit val relayNamespaceDecoder: Decoder[RelayNamespace] = Decoder.decodeString.map(RelayNamespace)
+  implicit val chartNameDecoder: Decoder[ChartName] = Decoder.decodeString.map(ChartName)
+  implicit val allowedChartNameDecoder: Decoder[AllowedChartName] =
+    Decoder.decodeString.emap(x => AllowedChartName.stringToObject.get(x).toRight("chart name not allowed"))
   implicit val aksClusterNameDecoder: Decoder[AKSClusterName] = Decoder.decodeString.map(AKSClusterName)
   implicit val postgresNameDecoder: Decoder[PostgresName] = Decoder.decodeString.map(PostgresName)
 

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/diskModels.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/diskModels.scala
@@ -106,6 +106,8 @@ object DiskType extends Enum[DiskType] {
   }
 }
 
+// We introduced this type to differentiate whether a disk is formatted by Galaxy or not because
+// Galaxy formats disk in unique ways. We might be able to simplify this to be Galaxy vs non-Galaxy
 sealed trait FormattedBy extends EnumEntry with Product with Serializable {
   def asString: String
 }
@@ -127,8 +129,8 @@ object FormattedBy extends Enum[FormattedBy] {
     override def asString: String = "CROMWELL"
   }
 
-  final case object RStudio extends FormattedBy {
-    override def asString: String = "RSTUDIO"
+  final case object Allowed extends FormattedBy {
+    override def asString: String = "ALLOWED"
   }
 }
 
@@ -143,10 +145,7 @@ object AppRestore {
   final case class GalaxyRestore(galaxyPvcId: PvcId, lastUsedBy: AppId) extends AppRestore
 
   // information needed for reconnecting a disk used previously by Cromwell app to another Cromwell app
-  final case class CromwellRestore(lastUsedBy: AppId) extends AppRestore
-
-  // information needed for reconnecting a disk used previously by RStudio app to another RStudio app
-  final case class RStudioRestore(lastUsedBy: AppId) extends AppRestore
+  final case class Other(lastUsedBy: AppId) extends AppRestore
 }
 
 final case class DiskLink(asString: String) extends AnyVal

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/appRoutesModels.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/appRoutesModels.scala
@@ -3,6 +3,7 @@ package org.broadinstitute.dsde.workbench.leonardo.http
 import org.broadinstitute.dsde.workbench.google2.DiskName
 import org.broadinstitute.dsde.workbench.google2.KubernetesSerializableName.ServiceName
 import org.broadinstitute.dsde.workbench.leonardo.{
+  AllowedChartName,
   App,
   AppAccessScope,
   AppError,
@@ -17,12 +18,14 @@ import org.broadinstitute.dsde.workbench.leonardo.{
   Nodepool,
   WorkspaceId
 }
+import org.broadinstitute.dsp.ChartName
 import org.http4s.Uri
 
 import java.net.URL
 
 final case class CreateAppRequest(kubernetesRuntimeConfig: Option[KubernetesRuntimeConfig],
                                   appType: AppType,
+                                  allowedChartName: Option[AllowedChartName],
                                   accessScope: Option[AppAccessScope],
                                   diskConfig: Option[PersistentDiskRequest],
                                   labels: LabelMap = Map.empty,
@@ -42,6 +45,7 @@ final case class GetAppResponse(appName: AppName,
                                 customEnvironmentVariables: Map[String, String],
                                 auditInfo: AuditInfo,
                                 appType: AppType,
+                                chartName: ChartName,
                                 accessScope: Option[AppAccessScope],
                                 labels: LabelMap
 )
@@ -54,6 +58,7 @@ final case class ListAppResponse(workspaceId: Option[WorkspaceId],
                                  proxyUrls: Map[ServiceName, URL],
                                  appName: AppName,
                                  appType: AppType,
+                                 chartName: ChartName,
                                  diskName: Option[DiskName],
                                  auditInfo: AuditInfo,
                                  accessScope: Option[AppAccessScope],
@@ -79,6 +84,7 @@ object ListAppResponse {
           a.getProxyUrls(c, proxyUrlBase),
           a.appName,
           a.appType,
+          a.chart.name,
           a.appResources.disk.map(_.name),
           a.auditInfo,
           a.appAccessScope,
@@ -105,6 +111,7 @@ object GetAppResponse {
       appResult.app.customEnvironmentVariables,
       appResult.app.auditInfo,
       appResult.app.appType,
+      appResult.app.chart.name,
       appResult.app.appAccessScope,
       appResult.app.labels
     )

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/kubernetesModels.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/kubernetesModels.scala
@@ -329,8 +329,7 @@ object AllowedChartName {
   def fromChartName(chartName: ChartName): Option[AllowedChartName] = {
     val splittedString = chartName.asString.split("/")
     if (splittedString.size == 3) {
-      val splitChartNameAndVersion = splittedString(2).split("-")
-      stringToObject.get(splitChartNameAndVersion.dropRight(1).mkString("-"))
+      stringToObject.get(splittedString(2))
     } else None
   }
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/kubernetesModels.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/kubernetesModels.scala
@@ -324,6 +324,15 @@ object AllowedChartName {
     def asString: String = "aou-sas-chart"
   }
   def stringToObject: Map[String, AllowedChartName] = sealerate.values[AllowedChartName].map(v => v.asString -> v).toMap
+
+  // Chartname from DB has the following format: /leonardo/cromwell-0.2.291
+  def fromChartName(chartName: ChartName): Option[AllowedChartName] = {
+    val splittedString = chartName.asString.split("/")
+    if (splittedString.size == 3) {
+      val splitChartNameAndVersion = splittedString(2).split("-")
+      stringToObject.get(splitChartNameAndVersion.dropRight(1).mkString("-"))
+    } else None
+  }
 }
 
 sealed abstract class AppType

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/kubernetesModels.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/kubernetesModels.scala
@@ -313,6 +313,19 @@ object ErrorSource {
   def stringToObject: Map[String, ErrorSource] = values.map(v => v.toString -> v).toMap
 }
 
+sealed abstract class AllowedChartName extends Product with Serializable {
+  def asString: String
+}
+object AllowedChartName {
+  final case object RStudio extends AllowedChartName {
+    def asString: String = "aou-rstudio-chart"
+  }
+  final case object Sas extends AllowedChartName {
+    def asString: String = "aou-sas-chart"
+  }
+  def stringToObject: Map[String, AllowedChartName] = sealerate.values[AllowedChartName].map(v => v.asString -> v).toMap
+}
+
 sealed abstract class AppType
 object AppType {
   case object Galaxy extends AppType {
@@ -330,8 +343,9 @@ object AppType {
     override def toString: String = "HAIL_BATCH"
   }
 
-  case object RStudio extends AppType {
-    override def toString: String = "RSTUDIO"
+  // See more context in https://docs.google.com/document/d/1RaQRMqAx7ymoygP6f7QVdBbZC-iD9oY_XLNMe_oz_cs/edit
+  case object Allowed extends AppType {
+    override def toString: String = "ALLOWED"
   }
 
   case object Custom extends AppType {
@@ -350,7 +364,7 @@ object AppType {
     appType match {
       case Galaxy                     => FormattedBy.Galaxy
       case Custom                     => FormattedBy.Custom
-      case RStudio                    => FormattedBy.RStudio
+      case Allowed                    => FormattedBy.Allowed
       case Cromwell | Wds | HailBatch => FormattedBy.Cromwell
     }
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/AppRoutesTestJsonCodec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/AppRoutesTestJsonCodec.scala
@@ -11,9 +11,10 @@ import org.http4s.Uri
 object AppRoutesTestJsonCodec {
   implicit val descriptorEncoder: Encoder[Uri] = Encoder.encodeString.contramap(_.toString)
 
-  implicit val createAppEncoder: Encoder[CreateAppRequest] = Encoder.forProduct8(
+  implicit val createAppEncoder: Encoder[CreateAppRequest] = Encoder.forProduct9(
     "kubernetesRuntimeConfig",
     "appType",
+    "allowedChartName",
     "accessScope",
     "diskConfig",
     "labels",
@@ -24,6 +25,7 @@ object AppRoutesTestJsonCodec {
     (
       x.kubernetesRuntimeConfig,
       x.appType,
+      x.allowedChartName,
       x.accessScope,
       x.diskConfig,
       x.labels,

--- a/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/AppRoutesTestJsonCodec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/AppRoutesTestJsonCodec.scala
@@ -38,7 +38,7 @@ object AppRoutesTestJsonCodec {
     Decoder.decodeMap[ServiceName, URL](KeyDecoder.decodeKeyString.map(ServiceName), urlDecoder)
 
   implicit val getAppResponseDecoder: Decoder[GetAppResponse] =
-    Decoder.forProduct12(
+    Decoder.forProduct13(
       "appName",
       "cloudContext",
       "kubernetesRuntimeConfig",
@@ -49,12 +49,13 @@ object AppRoutesTestJsonCodec {
       "customEnvironmentVariables",
       "auditInfo",
       "appType",
+      "chartName",
       "accessScope",
       "labels"
     )(GetAppResponse.apply)
 
   implicit val listAppResponseDecoder: Decoder[ListAppResponse] =
-    Decoder.forProduct12(
+    Decoder.forProduct13(
       "workspaceId",
       "cloudContext",
       "kubernetesRuntimeConfig",
@@ -63,6 +64,7 @@ object AppRoutesTestJsonCodec {
       "proxyUrls",
       "appName",
       "appType",
+      "chartName",
       "diskName",
       "auditInfo",
       "accessScope",

--- a/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/kubernetesModelsSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/kubernetesModelsSpec.scala
@@ -6,9 +6,9 @@ import org.broadinstitute.dsp.ChartName
 
 class kubernetesModelsSpec extends LeonardoTestSuite with Matchers with AnyFlatSpecLike {
   it should "convert chartName to AllowedChartName correctly" in {
-    AllowedChartName.fromChartName(ChartName("/leonardo/cromwell-0.2.291")) shouldBe None
-    AllowedChartName.fromChartName(ChartName("/leonardo/aou-sas-chart-0.1.0")) shouldBe Some(AllowedChartName.Sas)
-    AllowedChartName.fromChartName(ChartName("/leonardo/aou-rstudio-chart-0.2.0")) shouldBe Some(
+    AllowedChartName.fromChartName(ChartName("/leonardo/cromwell")) shouldBe None
+    AllowedChartName.fromChartName(ChartName("/leonardo/aou-sas-chart")) shouldBe Some(AllowedChartName.Sas)
+    AllowedChartName.fromChartName(ChartName("/leonardo/aou-rstudio-chart")) shouldBe Some(
       AllowedChartName.RStudio
     )
   }

--- a/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/kubernetesModelsSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/kubernetesModelsSpec.scala
@@ -1,0 +1,15 @@
+package org.broadinstitute.dsde.workbench.leonardo
+
+import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.matchers.should.Matchers
+import org.broadinstitute.dsp.ChartName
+
+class kubernetesModelsSpec extends LeonardoTestSuite with Matchers with AnyFlatSpecLike {
+  it should "convert chartName to AllowedChartName correctly" in {
+    AllowedChartName.fromChartName(ChartName("/leonardo/cromwell-0.2.291")) shouldBe None
+    AllowedChartName.fromChartName(ChartName("/leonardo/aou-sas-chart-0.1.0")) shouldBe Some(AllowedChartName.Sas)
+    AllowedChartName.fromChartName(ChartName("/leonardo/aou-rstudio-chart-0.2.0")) shouldBe Some(
+      AllowedChartName.RStudio
+    )
+  }
+}

--- a/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changelog.xml
+++ b/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changelog.xml
@@ -104,4 +104,5 @@
     <include file="changesets/20230614_add_app_controlled_resource.xml" relativeToChangelogFile="true" />
     <include file="changesets/20230621_update_app_status_enum.xml" relativeToChangelogFile="true" />
     <include file="changesets/20230713_app_controlled_resource_constraints.xml" relativeToChangelogFile="true" />
+    <include file="changesets/20230728_app_type_rename.xml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/20230728_app_type_rename.xml
+++ b/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/20230728_app_type_rename.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog logicalFilePath="leonardo" xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+    <changeSet logicalFilePath="leonardo" author="qi" id="qi_app_type_rename">
+        <update tableName="APP">
+            <column name="appType" value="ALLOWED"/>
+            <where>appType='RSTUDIO'</where>
+        </update>
+
+        <modifyDataType tableName="PERSISTENT_DISK" columnName="formattedBy" newDataType="ENUM('GALAXY', 'GCE', 'CROMWELL', 'CUSTOM', 'RSTUDIO', 'ALLOWED')"/>
+
+        <update tableName="PERSISTENT_DISK">
+            <column name="formattedBy" value="ALLOWED"/>
+            <where>formattedBy='RSTUDIO'</where>
+        </update>
+
+        <modifyDataType tableName="PERSISTENT_DISK" columnName="formattedBy" newDataType="ENUM('GALAXY', 'GCE', 'CROMWELL', 'CUSTOM', 'ALLOWED')"/>
+    </changeSet>
+</databaseChangeLog>

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -678,13 +678,17 @@ gke {
     # App developers - Please keep the list of non-backward compatible versions in the list below
     chartVersionsToExcludeFromUpdates = []
   }
-  rstudioApp {
+  allowedApp {
     # If you update this here, be sure to update in the dockerfile
-    chartName = "/leonardo/aou-rstudio-chart"
-    chartVersion = "0.2.0"
+    # This is really just a prefix of the chart name. Full chart name for AOU app will be
+    # this chartName in config file appended with allowedChartName from createAppRequest
+    chartName = "/leonardo/"
+    rstudioChartVersion = "0.2.0"
+    sasChartVersion = "0.1.0"
+
     services = [
           {
-            name = "rstudio-service"
+            name = "app"
             kind = "ClusterIP"
           },
           {
@@ -699,6 +703,7 @@ gke {
     # App developers - Please keep the list of non-backward compatible versions in the list below
     chartVersionsToExcludeFromUpdates = []
   }
+
   customApp {
     chartName = "/leonardo/terra-app"
     # If you update this here, be sure to update in the dockerfile

--- a/http/src/main/resources/swagger/api-docs.yaml
+++ b/http/src/main/resources/swagger/api-docs.yaml
@@ -15,7 +15,7 @@ tags:
   - name: disks
     description: Persistent Disks API.
   - name: apps
-    description: Experimental App API, Support for Google Kubernetes Engine and Azure Kubernetes Service. Under active Development.
+    description: Apps API. Support Google Kubernetes Engine and Azure Kubernetes Service.
   - name: proxy
     description: Proxy API
   - name: admin

--- a/http/src/main/resources/swagger/api-docs.yaml
+++ b/http/src/main/resources/swagger/api-docs.yaml
@@ -15,9 +15,7 @@ tags:
   - name: disks
     description: Persistent Disks API.
   - name: apps
-    description: Experimental App API
-  - name: appsV2
-    description: Apps API v2. Support for Google Kubernetes Engine and Azure Kubernetes Service. Under active Development.
+    description: Experimental App API, Support for Google Kubernetes Engine and Azure Kubernetes Service. Under active Development.
   - name: proxy
     description: Proxy API
   - name: admin
@@ -1663,7 +1661,7 @@ paths:
         Default labels appName, googleProject, serviceAccount, and creator cannot be overridden.
       operationId: createAppV2
       tags:
-        - appsV2
+        - apps
       parameters:
         - in: path
           name: workspaceId
@@ -1709,7 +1707,7 @@ paths:
         Poll this to find out when your app has finished starting up.
       operationId: getAppV2
       tags:
-        - appsV2
+        - apps
       parameters:
         - in: path
           name: workspaceId
@@ -1750,7 +1748,7 @@ paths:
       description: deletes an App
       operationId: deleteAppV2
       tags:
-        - appsV2
+        - apps
       parameters:
         - in: path
           name: workspaceId
@@ -1795,7 +1793,7 @@ paths:
       description: List all apps for a given workspaceId.
       operationId: listAppsV2
       tags:
-        - appsV2
+        - apps
       parameters:
         - in: path
           name: workspaceId
@@ -1847,7 +1845,7 @@ paths:
       description: deletes all Apps in a workspace
       operationId: deleteAllAppsV2
       tags:
-        - appsV2
+        - apps
       parameters:
         - in: path
           name: workspaceId
@@ -2866,6 +2864,10 @@ components:
         - WDS
         - HAIL_BATCH
         - RSTUDIO
+    AllowedChartName:
+      type: string
+      enum:
+        - aou-rstudio-chart
     AppStatus:
       type: string
       enum:
@@ -3938,6 +3940,8 @@ components:
           $ref: '#/components/schemas/PersistentDiskRequest'
         appType:
           $ref: '#/components/schemas/AppType'
+        allowedChartName:
+          $ref: '#/components/schemas/AllowedChartName'
         accessScope:
           $ref: '#/components/schemas/AppAccessScope'
         kubernetesRuntimeConfig:

--- a/http/src/main/resources/swagger/api-docs.yaml
+++ b/http/src/main/resources/swagger/api-docs.yaml
@@ -2863,7 +2863,7 @@ components:
         - GALAXY
         - WDS
         - HAIL_BATCH
-        - RSTUDIO
+        - ALLOWED
     AllowedChartName:
       type: string
       enum:
@@ -3227,7 +3227,7 @@ components:
             - GCE
             - CROMWELL
             - CUSTOM
-            - RSTUDIO
+            - ALLOWED
           description: App that formatted disk, missing if unformatted
 
     GetPersistentDiskV2Response:
@@ -3288,7 +3288,7 @@ components:
             - GCE
             - CROMWELL
             - CUSTOM
-            - RSTUDIO
+            - ALLOWED
           description: App that formatted disk, missing if unformatted
 
     InstanceKey:

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
@@ -690,8 +690,8 @@ object Config {
     )
   }
 
-  implicit private val aouAppConfigReader: ValueReader[AoUAppConfig] = ValueReader.relative { config =>
-    AoUAppConfig(
+  implicit private val aouAppConfigReader: ValueReader[AllowedAppConfig] = ValueReader.relative { config =>
+    AllowedAppConfig(
       config.as[ChartName]("chartName"),
       config.as[ChartVersion]("rstudioChartVersion"),
       config.as[ChartVersion]("sasChartVersion"),
@@ -742,7 +742,7 @@ object Config {
   val gkeGalaxyAppConfig = config.as[GalaxyAppConfig]("gke.galaxyApp")
   val gkeCromwellAppConfig = config.as[CromwellAppConfig]("gke.cromwellApp")
   val gkeCustomAppConfig = config.as[CustomAppConfig]("gke.customApp")
-  val gkeAllowedAppConfig = config.as[AoUAppConfig]("gke.allowedApp")
+  val gkeAllowedAppConfig = config.as[AllowedAppConfig]("gke.allowedApp")
   val gkeNodepoolConfig = NodepoolConfig(gkeDefaultNodepoolConfig, gkeGalaxyNodepoolConfig)
   val gkeGalaxyDiskConfig = config.as[GalaxyDiskConfig]("gke.galaxyDisk")
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
@@ -698,7 +698,6 @@ object Config {
       config.as[NamespaceNameSuffix]("namespaceNameSuffix"),
       config.as[ReleaseNameSuffix]("releaseNameSuffix"),
       config.as[List[ServiceConfig]]("services"),
-      config.as[ServiceAccountName]("serviceAccountName")
       config.as[ServiceAccountName]("serviceAccountName"),
       config.as[List[ChartVersion]]("chartVersionsToExcludeFromUpdates")
     )

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
@@ -690,15 +690,16 @@ object Config {
     )
   }
 
-  implicit private val rstudioAppConfigReader: ValueReader[RStudioAppConfig] = ValueReader.relative { config =>
-    RStudioAppConfig(
+  implicit private val aouAppConfigReader: ValueReader[AoUAppConfig] = ValueReader.relative { config =>
+    AoUAppConfig(
       config.as[ChartName]("chartName"),
-      config.as[ChartVersion]("chartVersion"),
+      config.as[ChartVersion]("rstudioChartVersion"),
+      config.as[ChartVersion]("sasChartVersion"),
       config.as[NamespaceNameSuffix]("namespaceNameSuffix"),
       config.as[ReleaseNameSuffix]("releaseNameSuffix"),
       config.as[List[ServiceConfig]]("services"),
+      config.as[ServiceAccountName]("serviceAccountName")
       config.as[ServiceAccountName]("serviceAccountName"),
-      config.as[Boolean]("enabled"),
       config.as[List[ChartVersion]]("chartVersionsToExcludeFromUpdates")
     )
   }
@@ -742,7 +743,7 @@ object Config {
   val gkeGalaxyAppConfig = config.as[GalaxyAppConfig]("gke.galaxyApp")
   val gkeCromwellAppConfig = config.as[CromwellAppConfig]("gke.cromwellApp")
   val gkeCustomAppConfig = config.as[CustomAppConfig]("gke.customApp")
-  val gkeRStudioAppConfig = config.as[RStudioAppConfig]("gke.rstudioApp")
+  val gkeAllowedAppConfig = config.as[AoUAppConfig]("gke.allowedApp")
   val gkeNodepoolConfig = NodepoolConfig(gkeDefaultNodepoolConfig, gkeGalaxyNodepoolConfig)
   val gkeGalaxyDiskConfig = config.as[GalaxyDiskConfig]("gke.galaxyDisk")
 
@@ -766,7 +767,7 @@ object Config {
     ConfigReader.appConfig.persistentDisk,
     gkeCromwellAppConfig,
     gkeCustomAppConfig,
-    gkeRStudioAppConfig
+    gkeAllowedAppConfig
   )
 
   val appServiceConfig = AppServiceConfig(
@@ -875,7 +876,7 @@ object Config {
       gkeGalaxyAppConfig,
       gkeCromwellAppConfig,
       gkeCustomAppConfig,
-      gkeRStudioAppConfig,
+      gkeAllowedAppConfig,
       appMonitorConfig,
       gkeClusterConfig,
       proxyConfig,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/KubernetesAppConfig.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/KubernetesAppConfig.scala
@@ -165,13 +165,14 @@ final case class HailBatchAppConfig(chartName: ChartName,
   val appType: AppType = AppType.HailBatch
 }
 
-final case class AoUAppConfig(chartName: ChartName,
-                              rstudioChartVersion: ChartVersion,
-                              sasChartVersion: ChartVersion,
-                              namespaceNameSuffix: NamespaceNameSuffix,
-                              releaseNameSuffix: ReleaseNameSuffix,
-                              services: List[ServiceConfig],
-                              serviceAccountName: ServiceAccountName
+final case class AllowedAppConfig(chartName: ChartName,
+                                  rstudioChartVersion: ChartVersion,
+                                  sasChartVersion: ChartVersion,
+                                  namespaceNameSuffix: NamespaceNameSuffix,
+                                  releaseNameSuffix: ReleaseNameSuffix,
+                                  services: List[ServiceConfig],
+                                  serviceAccountName: ServiceAccountName,
+                                  chartVersionsToExcludeFromUpdates: List[ChartVersion]
 ) extends KubernetesAppConfig {
   val cloudProvider: CloudProvider = CloudProvider.Gcp
   val appType: AppType = AppType.Allowed
@@ -182,8 +183,6 @@ final case class AoUAppConfig(chartName: ChartName,
   def chartVersion: ChartVersion = ChartVersion(
     "dummy"
   ) // For AoU apps, chart version will vary, and will be populated from user request
-
-  override def chartVersionsToExcludeFromUpdates: List[ChartVersion] = ???
 }
 
 sealed trait CoaService

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/KubernetesAppConfig.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/KubernetesAppConfig.scala
@@ -3,7 +3,9 @@ package org.broadinstitute.dsde.workbench.leonardo.config
 import org.broadinstitute.dsde.workbench.google2.KubernetesSerializableName.{ServiceAccountName, ServiceName}
 import org.broadinstitute.dsde.workbench.leonardo.config.CoaService.{Cbas, CbasUI, Cromwell}
 import org.broadinstitute.dsde.workbench.leonardo.{
+  AppType,
   Chart,
+  CloudProvider,
   DbPassword,
   GalaxyDrsUrl,
   GalaxyOrchUrl,
@@ -171,8 +173,6 @@ final case class AoUAppConfig(chartName: ChartName,
                               services: List[ServiceConfig],
                               serviceAccountName: ServiceAccountName
 ) extends KubernetesAppConfig {
-  override lazy val kubernetesServices: List[KubernetesService] = services.map(s => KubernetesService(ServiceId(-1), s))
-
   val cloudProvider: CloudProvider = CloudProvider.Gcp
   val appType: AppType = AppType.Allowed
 
@@ -182,6 +182,8 @@ final case class AoUAppConfig(chartName: ChartName,
   def chartVersion: ChartVersion = ChartVersion(
     "dummy"
   ) // For AoU apps, chart version will vary, and will be populated from user request
+
+  override def chartVersionsToExcludeFromUpdates: List[ChartVersion] = ???
 }
 
 sealed trait CoaService

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/ConfigReader.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/ConfigReader.scala
@@ -3,9 +3,15 @@ package http
 
 import org.broadinstitute.dsde.workbench.azure.AzureAppRegistrationConfig
 import org.broadinstitute.dsde.workbench.leonardo.config.{
+  AllowedAppConfig,
   CoaAppConfig,
+  Config,
+  CromwellAppConfig,
+  CustomAppConfig,
+  GalaxyAppConfig,
   HailBatchAppConfig,
   HttpWsmDaoConfig,
+  KubernetesAppConfig,
   PersistentDiskConfig,
   WdsAppConfig
 }
@@ -31,7 +37,7 @@ object ConfigReader {
       Config.gkeCustomAppConfig,
       Config.gkeGalaxyAppConfig,
       appConfig.azure.hailBatchAppConfig,
-      Config.gkeRStudioAppConfig,
+      Config.gkeAllowedAppConfig,
       appConfig.azure.wdsAppConfig
     )
 }
@@ -82,7 +88,7 @@ final case class AdminAppConfig(coaAppConfig: CoaAppConfig,
                                 customAppConfig: CustomAppConfig,
                                 galaxyAppConfig: GalaxyAppConfig,
                                 hailBatchAppConfig: HailBatchAppConfig,
-                                rstudioAppConfig: RStudioAppConfig,
+                                allowedAppConfig: AllowedAppConfig,
                                 wdsAppConfig: WdsAppConfig
 ) {
 
@@ -95,7 +101,7 @@ final case class AdminAppConfig(coaAppConfig: CoaAppConfig,
     customAppConfig,
     galaxyAppConfig,
     hailBatchAppConfig,
-    rstudioAppConfig,
+    allowedAppConfig,
     wdsAppConfig
   )
 }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/ConfigReader.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/ConfigReader.scala
@@ -2,7 +2,13 @@ package org.broadinstitute.dsde.workbench.leonardo
 package http
 
 import org.broadinstitute.dsde.workbench.azure.AzureAppRegistrationConfig
-import org.broadinstitute.dsde.workbench.leonardo.config._
+import org.broadinstitute.dsde.workbench.leonardo.config.{
+  CoaAppConfig,
+  HailBatchAppConfig,
+  HttpWsmDaoConfig,
+  PersistentDiskConfig,
+  WdsAppConfig
+}
 import org.broadinstitute.dsde.workbench.leonardo.util.{AzurePubsubHandlerConfig, TerraAppSetupChartConfig}
 import org.broadinstitute.dsp.{ChartName, ChartVersion, Namespace, Release, Values}
 import org.http4s.Uri
@@ -30,15 +36,16 @@ object ConfigReader {
     )
 }
 
-final case class AzureConfig(pubsubHandler: AzurePubsubHandlerConfig,
-                             wsm: HttpWsmDaoConfig,
-                             appRegistration: AzureAppRegistrationConfig,
-                             coaAppConfig: CoaAppConfig,
-                             wdsAppConfig: WdsAppConfig,
-                             hailBatchAppConfig: HailBatchAppConfig,
-                             aadPodIdentityConfig: AadPodIdentityConfig,
-                             allowedSharedApps: List[String],
-                             tdr: TdrConfig
+final case class AzureConfig(
+  pubsubHandler: AzurePubsubHandlerConfig,
+  wsm: HttpWsmDaoConfig,
+  appRegistration: AzureAppRegistrationConfig,
+  coaAppConfig: CoaAppConfig,
+  wdsAppConfig: WdsAppConfig,
+  hailBatchAppConfig: HailBatchAppConfig,
+  aadPodIdentityConfig: AadPodIdentityConfig,
+  allowedSharedApps: List[AppType],
+  tdr: TdrConfig
 )
 
 final case class OidcAuthConfig(
@@ -61,12 +68,13 @@ final case class TdrConfig(url: String)
 
 // Note: pureconfig supports reading kebab case into camel case in code by default
 // More docs see https://pureconfig.github.io/docs/index.html
-final case class AppConfig(terraAppSetupChart: TerraAppSetupChartConfig,
-                           persistentDisk: PersistentDiskConfig,
-                           azure: AzureConfig,
-                           oidc: OidcAuthConfig,
-                           drs: DrsConfig,
-                           metrics: LeoMetricsMonitorConfig
+final case class AppConfig(
+  terraAppSetupChart: TerraAppSetupChartConfig,
+  persistentDisk: PersistentDiskConfig,
+  azure: AzureConfig,
+  oidc: OidcAuthConfig,
+  drs: DrsConfig,
+  metrics: LeoMetricsMonitorConfig
 )
 
 final case class AdminAppConfig(coaAppConfig: CoaAppConfig,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/AppRoutes.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/AppRoutes.scala
@@ -124,7 +124,7 @@ class AppRoutes(kubernetesService: AppService[IO], userInfoDirectives: UserInfoD
       )
       _ <- req.allowedChartName match {
         case Some(cn) =>
-          val tags = Map("appType" -> req.appType.toString) ++ ("chartName" -> cn.asString)
+          val tags = Map("appType" -> req.appType.toString) + ("chartName" -> cn.asString)
           metrics.incrementCounter("createAllowedApp",
                                    1,
                                    tags

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/AppRoutes.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/AppRoutes.scala
@@ -9,16 +9,17 @@ import akka.http.scaladsl.server.Directives.{pathEndOrSingleSlash, _}
 import cats.effect.IO
 import cats.mtl.Ask
 import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
-import io.circe.{Decoder, Encoder, KeyEncoder}
+import io.circe.Decoder
 import io.opencensus.scala.akka.http.TracingDirective.traceRequestForService
-import org.broadinstitute.dsde.workbench.google2.KubernetesSerializableName.ServiceName
-import org.broadinstitute.dsde.workbench.leonardo.JsonCodec._
-import org.broadinstitute.dsde.workbench.leonardo.http.api.AppRoutes._
+import org.broadinstitute.dsde.workbench.leonardo.http.api.AppV2Routes.{
+  createAppDecoder,
+  getAppResponseEncoder,
+  listAppResponseEncoder
+}
 import org.broadinstitute.dsde.workbench.leonardo.http.service.AppService
 import org.broadinstitute.dsde.workbench.model.UserInfo
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.broadinstitute.dsde.workbench.openTelemetry.OpenTelemetryMetrics
-import org.http4s.Uri
 
 class AppRoutes(kubernetesService: AppService[IO], userInfoDirectives: UserInfoDirectives)(implicit
   metrics: OpenTelemetryMetrics[IO]
@@ -121,7 +122,8 @@ class AppRoutes(kubernetesService: AppService[IO], userInfoDirectives: UserInfoD
         appName,
         req
       )
-      tags = Map("appType" -> req.appType.toString)
+      chartName = req.allowedChartName.map(cn => "chartName" -> cn.asString)
+      tags = Map("appType" -> req.appType.toString) ++ chartName
       _ <- metrics.incrementCounter("createApp", 1, tags)
       _ <- ctx.span.fold(apiCall)(span => spanResource[IO](span, "createApp").use(_ => apiCall))
     } yield StatusCodes.Accepted
@@ -197,30 +199,6 @@ class AppRoutes(kubernetesService: AppService[IO], userInfoDirectives: UserInfoD
 }
 
 object AppRoutes {
-  implicit val createAppDecoder: Decoder[CreateAppRequest] =
-    Decoder.instance { x =>
-      for {
-        c <- x.downField("kubernetesRuntimeConfig").as[Option[KubernetesRuntimeConfig]]
-        a <- x.downField("appType").as[Option[AppType]]
-        s <- x.downField("accessScope").as[Option[AppAccessScope]]
-        d <- x.downField("diskConfig").as[Option[PersistentDiskRequest]]
-        l <- x.downField("labels").as[Option[LabelMap]]
-        cv <- x.downField("customEnvironmentVariables").as[Option[LabelMap]]
-        dp <- x.downField("descriptorPath").as[Option[Uri]]
-        ea <- x.downField("extraArgs").as[Option[List[String]]]
-        swi <- x.downField("sourceWorkspaceId").as[Option[WorkspaceId]]
-      } yield CreateAppRequest(c,
-                               a.getOrElse(AppType.Galaxy),
-                               s,
-                               d,
-                               l.getOrElse(Map.empty),
-                               cv.getOrElse(Map.empty),
-                               dp,
-                               ea.getOrElse(List.empty),
-                               swi
-      )
-    }
-
   implicit val numNodepoolsDecoder: Decoder[NumNodepools] = Decoder.decodeInt.emap(n =>
     n match {
       case n if n < 1   => Left("Minimum number of nodepools is 1")
@@ -228,51 +206,4 @@ object AppRoutes {
       case _            => Right(NumNodepools.apply(n))
     }
   )
-
-  implicit val nameKeyEncoder: KeyEncoder[ServiceName] = KeyEncoder.encodeKeyString.contramap(_.value)
-  implicit val listAppResponseEncoder: Encoder[ListAppResponse] =
-    Encoder.forProduct12(
-      "workspaceId",
-      "cloudContext",
-      "kubernetesRuntimeConfig",
-      "errors",
-      "status",
-      "proxyUrls",
-      "appName",
-      "appType",
-      "diskName",
-      "auditInfo",
-      "accessScope",
-      "labels"
-    )(x =>
-      (x.workspaceId,
-       x.cloudContext,
-       x.kubernetesRuntimeConfig,
-       x.errors,
-       x.status,
-       x.proxyUrls,
-       x.appName,
-       x.appType,
-       x.diskName,
-       x.auditInfo,
-       x.accessScope,
-       x.labels
-      )
-    )
-
-  implicit val getAppResponseEncoder: Encoder[GetAppResponse] =
-    Encoder.forProduct12(
-      "appName",
-      "cloudContext",
-      "kubernetesRuntimeConfig",
-      "errors",
-      "status",
-      "proxyUrls",
-      "diskName",
-      "customEnvironmentVariables",
-      "auditInfo",
-      "appType",
-      "accessScope",
-      "labels"
-    )(x => GetAppResponse.unapply(x).get)
 }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/AppV2Routes.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/AppV2Routes.scala
@@ -2,6 +2,7 @@ package org.broadinstitute.dsde.workbench.leonardo
 package http
 package api
 
+import cats.syntax.all._
 import akka.http.scaladsl.marshalling.ToResponseMarshallable
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.server
@@ -9,7 +10,7 @@ import akka.http.scaladsl.server.Directives.{pathEndOrSingleSlash, _}
 import cats.effect.IO
 import cats.mtl.Ask
 import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
-import io.circe.{Decoder, Encoder, KeyEncoder}
+import io.circe.{Decoder, DecodingFailure, Encoder, KeyEncoder}
 import io.opencensus.scala.akka.http.TracingDirective.traceRequestForService
 import org.broadinstitute.dsde.workbench.google2.KubernetesSerializableName.ServiceName
 import org.broadinstitute.dsde.workbench.leonardo.JsonCodec._
@@ -168,7 +169,6 @@ object AppV2Routes {
     Decoder.instance { x =>
       for {
         c <- x.downField("kubernetesRuntimeConfig").as[Option[KubernetesRuntimeConfig]]
-        a <- x.downField("appType").as[Option[AppType]]
         s <- x.downField("accessScope").as[Option[AppAccessScope]]
         d <- x.downField("diskConfig").as[Option[PersistentDiskRequest]]
         l <- x.downField("labels").as[Option[LabelMap]]
@@ -176,8 +176,26 @@ object AppV2Routes {
         dp <- x.downField("descriptorPath").as[Option[Uri]]
         ea <- x.downField("extraArgs").as[Option[List[String]]]
         swi <- x.downField("sourceWorkspaceId").as[Option[WorkspaceId]]
+
+        optStr <- x.downField("appType").as[Option[String]]
+        cn <- x.downField("allowedChartName").as[Option[AllowedChartName]]
+        // TODO: once AOU has migrated to use the new app type, we can use much simpler version instead of this workaround for backwards compatibility
+        (appType, allowedChartName) <- optStr match {
+          case Some(value) =>
+            AppType.stringToObject
+              .get(value) match {
+              case Some(v) => (v, cn).asRight[DecodingFailure]
+              case None =>
+                if (value == "RSTUDIO")
+                  (AppType.Allowed, Some(AllowedChartName.RStudio)).asRight[DecodingFailure]
+                else
+                  DecodingFailure(s"Invalid app type ${value}", List.empty).asLeft[(AppType, Option[AllowedChartName])]
+            }
+          case None => (AppType.Galaxy, cn).asRight[DecodingFailure]
+        }
       } yield CreateAppRequest(c,
-                               a.getOrElse(AppType.Galaxy),
+                               appType,
+                               allowedChartName,
                                s,
                                d,
                                l.getOrElse(Map.empty),
@@ -190,7 +208,7 @@ object AppV2Routes {
 
   implicit val nameKeyEncoder: KeyEncoder[ServiceName] = KeyEncoder.encodeKeyString.contramap(_.value)
   implicit val listAppResponseEncoder: Encoder[ListAppResponse] =
-    Encoder.forProduct12(
+    Encoder.forProduct13(
       "workspaceId",
       "cloudContext",
       "kubernetesRuntimeConfig",
@@ -199,6 +217,7 @@ object AppV2Routes {
       "proxyUrls",
       "appName",
       "appType",
+      "chartName",
       "diskName",
       "auditInfo",
       "accessScope",
@@ -212,6 +231,7 @@ object AppV2Routes {
        x.proxyUrls,
        x.appName,
        x.appType,
+       x.chartName,
        x.diskName,
        x.auditInfo,
        x.accessScope,
@@ -220,7 +240,7 @@ object AppV2Routes {
     )
 
   implicit val getAppResponseEncoder: Encoder[GetAppResponse] =
-    Encoder.forProduct12(
+    Encoder.forProduct13(
       "appName",
       "cloudContext",
       "kubernetesRuntimeConfig",
@@ -231,6 +251,7 @@ object AppV2Routes {
       "customEnvironmentVariables",
       "auditInfo",
       "appType",
+      "chartName",
       "accessScope",
       "labels"
     )(x => GetAppResponse.unapply(x).get)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/LeoAppServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/LeoAppServiceInterp.scala
@@ -21,12 +21,13 @@ import org.broadinstitute.dsde.workbench.google2.{
   MachineTypeName,
   ZoneName
 }
-import org.broadinstitute.dsde.workbench.leonardo.AppRestore.{CromwellRestore, GalaxyRestore, RStudioRestore}
+import org.broadinstitute.dsde.workbench.leonardo.AppRestore.GalaxyRestore
 import org.broadinstitute.dsde.workbench.leonardo.AppType._
 import org.broadinstitute.dsde.workbench.leonardo.JsonCodec._
 import org.broadinstitute.dsde.workbench.leonardo.SamResourceId._
 import org.broadinstitute.dsde.workbench.leonardo.config._
 import org.broadinstitute.dsde.workbench.leonardo.dao.{SamDAO, WsmDao}
+import org.broadinstitute.dsp.ChartName
 import org.broadinstitute.dsde.workbench.leonardo.db.KubernetesServiceDbQueries.getActiveFullAppByWorkspaceIdAndAppName
 import org.broadinstitute.dsde.workbench.leonardo.db._
 import org.broadinstitute.dsde.workbench.leonardo.http.service.LeoAppServiceInterp.isPatchVersionDifference
@@ -40,6 +41,7 @@ import org.broadinstitute.dsde.workbench.openTelemetry.OpenTelemetryMetrics
 import org.broadinstitute.dsp.{ChartVersion, Release}
 import org.http4s.{AuthScheme, Uri}
 import org.typelevel.log4cats.StructuredLogger
+import monocle.macros.syntax.lens._
 
 import java.time.Instant
 import java.util.UUID
@@ -82,7 +84,19 @@ final class LeoAppServiceInterp[F[_]: Parallel](config: AppServiceConfig,
 
       enableIntraNodeVisibility = req.labels.get(AOU_UI_LABEL).isDefined
       _ <- req.appType match {
-        case AppType.Galaxy | AppType.HailBatch | AppType.Wds | AppType.RStudio | AppType.Cromwell => F.unit
+        case AppType.Galaxy | AppType.HailBatch | AppType.Wds | AppType.Cromwell => F.unit
+        case AppType.Allowed =>
+          req.allowedChartName match {
+            case Some(cn) =>
+              cn match {
+                case AllowedChartName.RStudio => F.unit
+                case AllowedChartName.Sas     => F.unit // TODO: check group permission check here
+              }
+            case None =>
+              F.raiseError(
+                BadRequestException("when AppType is AoU, allowedChartName needs to be specified", Some(ctx.traceId))
+              )
+          }
         case AppType.Custom =>
           req.descriptorPath match {
             case Some(descriptorPath) =>
@@ -492,7 +506,7 @@ final class LeoAppServiceInterp[F[_]: Parallel](config: AppServiceConfig,
       // Validate shared access scope apps against an allow-list. No-op for private apps.
       _ <- req.accessScope match {
         case Some(AppAccessScope.WorkspaceShared) =>
-          F.raiseUnless(ConfigReader.appConfig.azure.allowedSharedApps.contains(req.appType.toString))(
+          F.raiseUnless(ConfigReader.appConfig.azure.allowedSharedApps.contains(req.appType))(
             SharedAppNotAllowedException(req.appType, ctx.traceId)
           )
         case _ => F.unit
@@ -873,8 +887,8 @@ final class LeoAppServiceInterp[F[_]: Parallel](config: AppServiceConfig,
         } else {
           (diskResult.disk.formattedBy, diskResult.disk.appRestore) match {
             case (Some(FormattedBy.Galaxy), Some(GalaxyRestore(_, _))) |
-                (Some(FormattedBy.Cromwell), Some(CromwellRestore(_))) |
-                (Some(FormattedBy.RStudio), Some(RStudioRestore(_))) =>
+                (Some(FormattedBy.Cromwell), Some(AppRestore.Other(_))) |
+                (Some(FormattedBy.Allowed), Some(AppRestore.Other(_))) =>
               val lastUsedBy = diskResult.disk.appRestore.get.lastUsedBy
               for {
                 lastUsedOpt <- appQuery.getLastUsedApp(lastUsedBy, Some(ctx.traceId)).transaction
@@ -894,7 +908,7 @@ final class LeoAppServiceInterp[F[_]: Parallel](config: AppServiceConfig,
                 }
               } yield lastUsed.some
             case (Some(FormattedBy.Galaxy), None) | (Some(FormattedBy.Cromwell), None) |
-                (Some(FormattedBy.RStudio), None) =>
+                (Some(FormattedBy.Allowed), None) =>
               F.raiseError[Option[LastUsedApp]](
                 new LeoException("Existing disk found, but no restore info found in DB", traceId = Some(ctx.traceId))
               )
@@ -916,7 +930,7 @@ final class LeoAppServiceInterp[F[_]: Parallel](config: AppServiceConfig,
               F.raiseError[Option[LastUsedApp]](
                 DiskAlreadyFormattedError(
                   diskResult.disk.formattedBy.get,
-                  s"${FormattedBy.Cromwell.asString} or ${FormattedBy.Galaxy.asString} or ${FormattedBy.RStudio.asString}",
+                  s"${FormattedBy.Cromwell.asString} or ${FormattedBy.Galaxy.asString} or ${FormattedBy.Allowed.asString}",
                   ctx.traceId
                 )
               )
@@ -1062,14 +1076,16 @@ final class LeoAppServiceInterp[F[_]: Parallel](config: AppServiceConfig,
     for {
       // Validate app type
       gkeAppConfig <- (req.appType, cloudContext.cloudProvider) match {
-        case (Galaxy, CloudProvider.Gcp)      => Right(config.leoKubernetesConfig.galaxyAppConfig)
-        case (Custom, CloudProvider.Gcp)      => Right(config.leoKubernetesConfig.customAppConfig)
-        case (Cromwell, CloudProvider.Gcp)    => Right(config.leoKubernetesConfig.cromwellAppConfig)
-        case (RStudio, CloudProvider.Gcp)     => Right(config.leoKubernetesConfig.rstudioAppConfig)
-        case (Cromwell, CloudProvider.Azure)  => Right(ConfigReader.appConfig.azure.coaAppConfig)
-        case (Wds, CloudProvider.Azure)       => Right(ConfigReader.appConfig.azure.wdsAppConfig)
-        case (HailBatch, CloudProvider.Azure) => Right(ConfigReader.appConfig.azure.hailBatchAppConfig)
-        case _ => Left(AppTypeNotSupportedOnCloudException(cloudContext.cloudProvider, req.appType, ctx.traceId))
+        case (Galaxy, CloudProvider.Gcp)          => Right(config.leoKubernetesConfig.galaxyAppConfig)
+        case (Custom, CloudProvider.Gcp)          => Right(config.leoKubernetesConfig.customAppConfig)
+        case (Cromwell, CloudProvider.Gcp)        => Right(config.leoKubernetesConfig.cromwellAppConfig)
+        case (AppType.Allowed, CloudProvider.Gcp) => Right(config.leoKubernetesConfig.aoUAppConfig)
+        case (Cromwell, CloudProvider.Azure)      => Right(ConfigReader.appConfig.azure.coaAppConfig)
+        case (Wds, CloudProvider.Azure)           => Right(ConfigReader.appConfig.azure.wdsAppConfig)
+        case (HailBatch, CloudProvider.Azure)     => Right(ConfigReader.appConfig.azure.hailBatchAppConfig)
+        case _ =>
+          AppTypeNotSupportedOnCloudException(cloudContext.cloudProvider, req.appType, ctx.traceId)
+            .asLeft[KubernetesAppConfig]
       }
 
       // Check if app type is enabled
@@ -1125,18 +1141,32 @@ final class LeoAppServiceInterp[F[_]: Parallel](config: AppServiceConfig,
         )
       )(app => app.namespaceName.asRight[Throwable])
 
+      potentialNewChart =
+        if (req.appType == AppType.Allowed) {
+          val chartVersion = req.allowedChartName.get match {
+            case AllowedChartName.RStudio => config.leoKubernetesConfig.aoUAppConfig.rstudioChartVersion
+            case AllowedChartName.Sas     => config.leoKubernetesConfig.aoUAppConfig.sasChartVersion
+          }
+          gkeAppConfig.chart
+            .lens(_.name)
+            .modify(cn => ChartName(cn.asString + req.allowedChartName.map(_.asString).get))
+            .lens(_.version)
+            .modify(_ => chartVersion)
+        } else gkeAppConfig.chart
+
       chart = lastUsedApp
         .map { lastUsed =>
           // if there's a patch version bump, then we use the later version defined in leo config; otherwise, we use lastUsed chart definition
           if (
-            lastUsed.chart.name == gkeAppConfig.chartName && isPatchVersionDifference(lastUsed.chart.version,
+            lastUsed.chart.name == potentialNewChart.name && isPatchVersionDifference(lastUsed.chart.version,
                                                                                       gkeAppConfig.chartVersion
             )
           )
-            gkeAppConfig.chart
+            potentialNewChart
           else lastUsed.chart
         }
-        .getOrElse(gkeAppConfig.chart)
+        .getOrElse(potentialNewChart)
+
       release <- lastUsedApp.fold(
         KubernetesName.withValidation(
           s"${uid}-${gkeAppConfig.releaseNameSuffix.value}",
@@ -1242,7 +1272,7 @@ object LeoAppServiceInterp {
                                  diskConfig: PersistentDiskConfig,
                                  cromwellAppConfig: CromwellAppConfig,
                                  customAppConfig: CustomAppConfig,
-                                 rstudioAppConfig: RStudioAppConfig
+                                 aoUAppConfig: AoUAppConfig
   )
 
   private[http] def isPatchVersionDifference(a: ChartVersion, b: ChartVersion): Boolean = {

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/LeoAppServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/LeoAppServiceInterp.scala
@@ -1079,7 +1079,7 @@ final class LeoAppServiceInterp[F[_]: Parallel](config: AppServiceConfig,
         case (Galaxy, CloudProvider.Gcp)          => Right(config.leoKubernetesConfig.galaxyAppConfig)
         case (Custom, CloudProvider.Gcp)          => Right(config.leoKubernetesConfig.customAppConfig)
         case (Cromwell, CloudProvider.Gcp)        => Right(config.leoKubernetesConfig.cromwellAppConfig)
-        case (AppType.Allowed, CloudProvider.Gcp) => Right(config.leoKubernetesConfig.aoUAppConfig)
+        case (AppType.Allowed, CloudProvider.Gcp) => Right(config.leoKubernetesConfig.allowedAppConfig)
         case (Cromwell, CloudProvider.Azure)      => Right(ConfigReader.appConfig.azure.coaAppConfig)
         case (Wds, CloudProvider.Azure)           => Right(ConfigReader.appConfig.azure.wdsAppConfig)
         case (HailBatch, CloudProvider.Azure)     => Right(ConfigReader.appConfig.azure.hailBatchAppConfig)
@@ -1144,8 +1144,8 @@ final class LeoAppServiceInterp[F[_]: Parallel](config: AppServiceConfig,
       potentialNewChart =
         if (req.appType == AppType.Allowed) {
           val chartVersion = req.allowedChartName.get match {
-            case AllowedChartName.RStudio => config.leoKubernetesConfig.aoUAppConfig.rstudioChartVersion
-            case AllowedChartName.Sas     => config.leoKubernetesConfig.aoUAppConfig.sasChartVersion
+            case AllowedChartName.RStudio => config.leoKubernetesConfig.allowedAppConfig.rstudioChartVersion
+            case AllowedChartName.Sas     => config.leoKubernetesConfig.allowedAppConfig.sasChartVersion
           }
           gkeAppConfig.chart
             .lens(_.name)
@@ -1272,7 +1272,7 @@ object LeoAppServiceInterp {
                                  diskConfig: PersistentDiskConfig,
                                  cromwellAppConfig: CromwellAppConfig,
                                  customAppConfig: CustomAppConfig,
-                                 aoUAppConfig: AoUAppConfig
+                                 allowedAppConfig: AllowedAppConfig
   )
 
   private[http] def isPatchVersionDifference(a: ChartVersion, b: ChartVersion): Boolean = {

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/LeoAppServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/LeoAppServiceInterp.scala
@@ -94,7 +94,9 @@ final class LeoAppServiceInterp[F[_]: Parallel](config: AppServiceConfig,
               }
             case None =>
               F.raiseError(
-                BadRequestException("when AppType is AoU, allowedChartName needs to be specified", Some(ctx.traceId))
+                BadRequestException("when AppType is ALLOWED, allowedChartName needs to be specified",
+                                    Some(ctx.traceId)
+                )
               )
           }
         case AppType.Custom =>

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterp.scala
@@ -990,7 +990,7 @@ object RuntimeServiceInterp {
               case Some(formattedBy) =>
                 if (willBeUsedBy == formattedBy) {
                   formattedBy match {
-                    case FormattedBy.Galaxy | FormattedBy.Cromwell | FormattedBy.Custom | FormattedBy.RStudio =>
+                    case FormattedBy.Galaxy | FormattedBy.Cromwell | FormattedBy.Custom | FormattedBy.Allowed =>
                       appQuery.isDiskAttached(pd.id).transaction
                     case FormattedBy.GCE => RuntimeConfigQueries.isDiskAttached(pd.id).transaction
                   }
@@ -1093,7 +1093,7 @@ object RuntimeServiceInterp {
               case Some(formattedBy) =>
                 if (willBeUsedBy == formattedBy) {
                   formattedBy match {
-                    case FormattedBy.Galaxy | FormattedBy.Cromwell | FormattedBy.Custom | FormattedBy.RStudio =>
+                    case FormattedBy.Galaxy | FormattedBy.Cromwell | FormattedBy.Custom | FormattedBy.Allowed =>
                       appQuery.isDiskAttached(pd.id).transaction
                     case FormattedBy.GCE => RuntimeConfigQueries.isDiskAttached(pd.id).transaction
                   }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
@@ -22,15 +22,7 @@ import org.broadinstitute.dsde.workbench.google2.{
   MachineTypeName,
   ZoneName
 }
-import org.broadinstitute.dsde.workbench.leonardo.AppType.{
-  appTypeToFormattedByType,
-  Cromwell,
-  Custom,
-  Galaxy,
-  HailBatch,
-  RStudio,
-  Wds
-}
+import org.broadinstitute.dsde.workbench.leonardo.AppType.appTypeToFormattedByType
 import org.broadinstitute.dsde.workbench.leonardo.AsyncTaskProcessor.Task
 import org.broadinstitute.dsde.workbench.leonardo.config.Config.appServiceConfig
 import org.broadinstitute.dsde.workbench.leonardo.db._
@@ -1020,7 +1012,7 @@ class LeoPubsubMessageSubscriber[F[_]](
 
       // create second Galaxy disk asynchronously
       createSecondDiskOp =
-        if (msg.appType == Galaxy && disk.isDefined) {
+        if (msg.appType == AppType.Galaxy && disk.isDefined) {
           val d = disk.get // it's safe to do `.get` here because we've verified
           for {
             res <- createGalaxyPostgresDiskOnlyInGoogle(msg.project, ZoneName("us-central1-a"), msg.appName, d.name)
@@ -1346,17 +1338,31 @@ class LeoPubsubMessageSubscriber[F[_]](
       )(F.pure)
 
       latestAppChartVersion <- (appResult.app.appType, msg.cloudContext.cloudProvider) match {
-        case (Galaxy, CloudProvider.Gcp) => F.pure(appServiceConfig.leoKubernetesConfig.galaxyAppConfig.chartVersion)
-        case (Custom, CloudProvider.Gcp) => F.pure(appServiceConfig.leoKubernetesConfig.customAppConfig.chartVersion)
-        case (Cromwell, CloudProvider.Gcp) =>
+        case (AppType.Galaxy, CloudProvider.Gcp) =>
+          F.pure(appServiceConfig.leoKubernetesConfig.galaxyAppConfig.chartVersion)
+        case (AppType.Custom, CloudProvider.Gcp) =>
+          F.pure(appServiceConfig.leoKubernetesConfig.customAppConfig.chartVersion)
+        case (AppType.Cromwell, CloudProvider.Gcp) =>
           F.pure(appServiceConfig.leoKubernetesConfig.cromwellAppConfig.chartVersion)
-        case (RStudio, CloudProvider.Gcp) => F.pure(appServiceConfig.leoKubernetesConfig.rstudioAppConfig.chartVersion)
-        case (Cromwell, CloudProvider.Azure)  => F.pure(ConfigReader.appConfig.azure.coaAppConfig.chartVersion)
-        case (Wds, CloudProvider.Azure)       => F.pure(ConfigReader.appConfig.azure.wdsAppConfig.chartVersion)
-        case (HailBatch, CloudProvider.Azure) => F.pure(ConfigReader.appConfig.azure.hailBatchAppConfig.chartVersion)
-        case _ =>
+        case (AppType.Allowed, CloudProvider.Gcp) =>
+          // TODO: fix this
+          AllowedChartName.fromChartName(appResult.app.chart.name) match {
+            case Some(AllowedChartName.RStudio) =>
+              F.pure(appServiceConfig.leoKubernetesConfig.allowedAppConfig.rstudioChartVersion)
+            case Some(AllowedChartName.Sas) =>
+              F.pure(appServiceConfig.leoKubernetesConfig.allowedAppConfig.sasChartVersion)
+            case None =>
+              F.raiseError[ChartVersion](
+                AppTypeNotSupportedOnCloudException(msg.cloudContext.cloudProvider, appResult.app.appType, ctx.traceId)
+              )
+          }
+        case (AppType.Cromwell, CloudProvider.Azure) => F.pure(ConfigReader.appConfig.azure.coaAppConfig.chartVersion)
+        case (AppType.Wds, CloudProvider.Azure)      => F.pure(ConfigReader.appConfig.azure.wdsAppConfig.chartVersion)
+        case (AppType.HailBatch, CloudProvider.Azure) =>
+          F.pure(ConfigReader.appConfig.azure.hailBatchAppConfig.chartVersion)
+        case (appType, cloud) =>
           F.raiseError[ChartVersion](
-            AppTypeNotSupportedOnCloudException(msg.cloudContext.cloudProvider, appResult.app.appType, ctx.traceId)
+            AppTypeNotSupportedOnCloudException(cloud, appType, ctx.traceId)
           )
       }
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
@@ -1345,7 +1345,6 @@ class LeoPubsubMessageSubscriber[F[_]](
         case (AppType.Cromwell, CloudProvider.Gcp) =>
           F.pure(appServiceConfig.leoKubernetesConfig.cromwellAppConfig.chartVersion)
         case (AppType.Allowed, CloudProvider.Gcp) =>
-          // TODO: fix this
           AllowedChartName.fromChartName(appResult.app.chart.name) match {
             case Some(AllowedChartName.RStudio) =>
               F.pure(appServiceConfig.leoKubernetesConfig.allowedAppConfig.rstudioChartVersion)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/AKSInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/AKSInterpreter.scala
@@ -747,7 +747,7 @@ class AKSInterpreter[F[_]](config: AKSInterpreterConfig,
       case AppType.Cromwell  => s"http://coa-${release.asString}-reverse-proxy-service:8000/"
       case AppType.Wds       => s"http://wds-${release.asString}-wds-svc:8080"
       case AppType.HailBatch => "http://batch:8080"
-      case AppType.Galaxy | AppType.Custom | AppType.RStudio =>
+      case AppType.Galaxy | AppType.Custom | AppType.Allowed =>
         F.raiseError(AppCreationException(s"App type $appType not supported on Azure"))
     }
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/BuildHelmChartValues.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/BuildHelmChartValues.scala
@@ -245,7 +245,7 @@ private[leonardo] object BuildHelmChartValues {
                                                stagingBucket: GcsBucketName,
                                                customEnvironmentVariables: Map[String, String]
   ): List[String] = {
-    val rstudioIngressPath = s"/proxy/google/v1/apps/${cluster.cloudContext.asString}/${appName.value}/rstudio-service"
+    val rstudioIngressPath = s"/proxy/google/v1/apps/${cluster.cloudContext.asString}/${appName.value}/app"
     val welderIngressPath = s"/proxy/google/v1/apps/${cluster.cloudContext.asString}/${appName.value}/welder-service"
     val k8sProxyHost = kubernetesProxyHost(cluster, config.proxyConfig.proxyDomain).address
     val leoProxyhost = config.proxyConfig.getProxyServerHostName

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GceInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GceInterpreter.scala
@@ -155,7 +155,7 @@ class GceInterpreter[F[_]](
             )
             isFormatted <- persistentDisk.formattedBy match {
               case Some(FormattedBy.Galaxy) | Some(FormattedBy.Custom) | Some(FormattedBy.Cromwell) | Some(
-                    FormattedBy.RStudio
+                    FormattedBy.Allowed
                   ) =>
                 F.raiseError[Boolean](
                   new RuntimeException(

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/KubernetesTestData.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/KubernetesTestData.scala
@@ -70,6 +70,7 @@ object KubernetesTestData {
     AppType.Galaxy,
     None,
     None,
+    None,
     Map.empty,
     Map.empty,
     None,
@@ -108,6 +109,7 @@ object KubernetesTestData {
     CreateAppRequest(
       kubernetesRuntimeConfig = None,
       appType = AppType.Cromwell,
+      None,
       None,
       diskConfig = diskConfig,
       labels = Map.empty,

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/ConfigReaderSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/ConfigReaderSpec.scala
@@ -168,7 +168,7 @@ class ConfigReaderSpec extends AnyFlatSpec with Matchers {
           ChartVersion("4.1.14"),
           Values("operationMode=managed")
         ),
-        List("WDS"),
+        List(AppType.Wds),
         TdrConfig("https://jade.datarepo-dev.broadinstitute.org")
       ),
       OidcAuthConfig(

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/AppServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/AppServiceInterpSpec.scala
@@ -13,7 +13,7 @@ import org.broadinstitute.dsde.workbench.google2.mock.{
   FakeGoogleResourceService
 }
 import org.broadinstitute.dsde.workbench.google2.{DiskName, GoogleResourceService, MachineTypeName, ZoneName}
-import org.broadinstitute.dsde.workbench.leonardo.AppRestore.{CromwellRestore, GalaxyRestore}
+import org.broadinstitute.dsde.workbench.leonardo.AppRestore.{GalaxyRestore, Other}
 import org.broadinstitute.dsde.workbench.leonardo.CommonTestData._
 import org.broadinstitute.dsde.workbench.leonardo.KubernetesTestData._
 import org.broadinstitute.dsde.workbench.leonardo.TestUtils.appContext
@@ -650,13 +650,11 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
     val cluster = makeKubeCluster(0).save()
     val nodepool = makeNodepool(1, cluster.id).save()
     val cromwellApp = makeApp(1, nodepool.id).save()
-    val disk = makePersistentDisk(None,
-                                  formattedBy = Some(FormattedBy.Cromwell),
-                                  appRestore = Some(CromwellRestore(cromwellApp.id))
-    )
-      .copy(cloudContext = cloudContextGcp)
-      .save()
-      .unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
+    val disk =
+      makePersistentDisk(None, formattedBy = Some(FormattedBy.Cromwell), appRestore = Some(Other(cromwellApp.id)))
+        .copy(cloudContext = cloudContextGcp)
+        .save()
+        .unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
 
     val galaxyAppName = AppName("galaxy-app1")
     val createDiskConfig = PersistentDiskRequest(disk.name, None, None, Map.empty)
@@ -1973,13 +1971,11 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
     val cluster = makeKubeCluster(0).save()
     val nodepool = makeNodepool(1, cluster.id).save()
     val cromwellApp = makeApp(1, nodepool.id).save()
-    val disk = makePersistentDisk(None,
-                                  formattedBy = Some(FormattedBy.Cromwell),
-                                  appRestore = Some(CromwellRestore(cromwellApp.id))
-    )
-      .copy(cloudContext = CloudContext.Gcp(GoogleProject(workspaceId.toString)))
-      .save()
-      .unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
+    val disk =
+      makePersistentDisk(None, formattedBy = Some(FormattedBy.Cromwell), appRestore = Some(Other(cromwellApp.id)))
+        .copy(cloudContext = CloudContext.Gcp(GoogleProject(workspaceId.toString)))
+        .save()
+        .unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
 
     val galaxyAppName = AppName("galaxy-app1")
     val createDiskConfig = PersistentDiskRequest(disk.name, None, None, Map.empty)

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoMetricsMonitorSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoMetricsMonitorSpec.scala
@@ -133,7 +133,7 @@ class LeoMetricsMonitorSpec extends AnyFlatSpec with LeonardoTestSuite with Test
     ) shouldBe Some(1)
     // RStudio on GCP on AoU
     test.get(
-      AppStatusMetric(CloudProvider.Gcp, AppType.RStudio, AppStatus.Running, RuntimeUI.AoU, None, rstudioChart)
+      AppStatusMetric(CloudProvider.Gcp, AppType.Allowed, AppStatus.Running, RuntimeUI.AoU, None, rstudioChart)
     ) shouldBe Some(1)
     // Hail Batch on Azure
     test.get(
@@ -440,7 +440,7 @@ class LeoMetricsMonitorSpec extends AnyFlatSpec with LeonardoTestSuite with Test
   private def cromwellAppGcpAou: KubernetesCluster =
     genApp(false, AppType.Cromwell, cromwellChart, true, true)
   private def rstudioAppGcpAou: KubernetesCluster =
-    genApp(false, AppType.RStudio, rstudioChart, true, false)
+    genApp(false, AppType.Allowed, rstudioChart, true, false)
   private def hailBatchAppAzure: KubernetesCluster =
     genApp(true, AppType.HailBatch, hailBatchChart, false, false)
       .copy(cloudContext = CloudContext.Azure(azureContext))

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/BuildHelmChartValuesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/BuildHelmChartValuesSpec.scala
@@ -301,11 +301,11 @@ class BuildHelmChartValuesSpec extends AnyFlatSpecLike with LeonardoTestSuite {
       """ingress.enabled=true,""" +
       """ingress.annotations.nginx\.ingress\.kubernetes\.io/auth-tls-secret=ns/ca-secret,""" +
       """ingress.annotations.nginx\.ingress\.kubernetes\.io/proxy-redirect-from=https://1455694897.jupyter.firecloud.org,""" +
-      """ingress.annotations.nginx\.ingress\.kubernetes\.io/proxy-redirect-to=https://leo/proxy/google/v1/apps/dsp-leo-test1/app1/rstudio-service,""" +
+      """ingress.annotations.nginx\.ingress\.kubernetes\.io/proxy-redirect-to=https://leo/proxy/google/v1/apps/dsp-leo-test1/app1/app,""" +
       """ingress.annotations.nginx\.ingress\.kubernetes\.io/rewrite-target=/$2,""" +
       """ingress.annotations.nginx\.ingress\.kubernetes\.io/proxy-cookie-path=/ "/; Secure; SameSite=None",""" +
       """ingress.host=1455694897.jupyter.firecloud.org,""" +
-      """ingress.rstudio.path=/proxy/google/v1/apps/dsp-leo-test1/app1/rstudio-service(/|$)(.*),""" +
+      """ingress.rstudio.path=/proxy/google/v1/apps/dsp-leo-test1/app1/app(/|$)(.*),""" +
       """ingress.welder.path=/proxy/google/v1/apps/dsp-leo-test1/app1/welder-service(/|$)(.*),""" +
       """ingress.tls[0].secretName=tls-secret,""" +
       """ingress.tls[0].hosts[0]=1455694897.jupyter.firecloud.org,""" +


### PR DESCRIPTION
https://precisionmedicineinitiative.atlassian.net/browse/RW-9838

https://github.com/all-of-us/workbench/pull/7851 needs to be merged shortly after this

[This doc](https://docs.google.com/document/d/1RaQRMqAx7ymoygP6f7QVdBbZC-iD9oY_XLNMe_oz_cs/edit) has more context for this PR

1. Update to createApp API should be backwards compatible createApp API for the most part. One thing that's different is that the proxy path for RStudio will be `/app` instead of `/rstudio`
2. Change to createApp api includes adding `ALLOWED` app type and `allowedChartName` as described in [the doc](https://docs.google.com/document/d/1RaQRMqAx7ymoygP6f7QVdBbZC-iD9oY_XLNMe_oz_cs/edit)


TODOs:
- [x] Update swagger yaml
- [x] Test start/stop
- [x] Check metrics categorized by `AppType`
- [x] Test App upgrade

**Tests**
1. Tested in BEE with this req:
```
POST https://{{leoUrl}}/api/google/v1/apps/{{project}}/{{appName}}
accept: */*
Authorization: Bearer {{token}}
Content-Type: application/json

{
  "diskConfig": {
    "name": "{{appName}}"
  },
  "appType": "RSTUDIO",
  "labels": {"all-of-us": "true"}
}
```

<img width="1051" alt="Screenshot 2023-07-25 at 1 47 43 PM" src="https://github.com/DataBiosphere/leonardo/assets/32771737/64578995-498f-48fb-b6e8-90f5a3948e02">

2. Tested in BEE with new contract:
```
{
  "diskConfig": {
    "name": "qi-rstudio-1-new"
  },
  "appType": "ALLOWED",
  "allowedChartName": "aou-rstudio-chart",
  "customEnvironmentVariables": {
    "WORKSPACE_NAME": "qi-ws"
  }
}
```

3. Tested start/stop/delete
4. Tested reusing the same disk with a second app
5. Tested creating multiple apps as same user on the same cluster, and found a bug as mentioned in [here](https://broadinstitute.slack.com/archives/C05HS98C0V8/p1690570413087969)
6. Tested ALLOWED app upgrade path
```
2023/08/07 18:12:57 preparing upgrade for xyrvde-rstudio-rls
2023/08/07 18:12:57 resetting values to the chart's original version
2023/08/07 18:13:02 performing update for xyrvde-rstudio-rls
2023/08/07 18:13:02 creating upgraded release for xyrvde-rstudio-rls
2023/08/07 18:13:02 checking 6 resources for changes
2023/08/07 18:13:02 Looks like there are no changes for PersistentVolume "xyrvde-rstudio-rls-aou-rstudio-chart-pv"
2023/08/07 18:13:02 Looks like there are no changes for PersistentVolumeClaim "xyrvde-rstudio-rls-aou-rstudio-chart-pvc"
2023/08/07 18:13:02 Looks like there are no changes for Service "xyrvde-rstudio-rls-aou-rstudio-chart"
2023/08/07 18:13:02 Looks like there are no changes for Service "xyrvde-rstudio-rls-aou-rstudio-chart-welder"
2023/08/07 18:13:02 Patch Deployment "xyrvde-rstudio-rls-aou-rstudio-chart" in namespace xyrvde-rstudio-ns
2023/08/07 18:13:02 Looks like there are no changes for Ingress "xyrvde-rstudio-rls-aou-rstudio-chart"
2023/08/07 18:13:02 updating status for upgraded release for xyrvde-rstudio-rls
2023/08/07 18:13:02 Finished upgrading to release xyrvde-rstudio-rls
```

- [ ] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [ ] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
