### PR TITLE
[IA-4449] Improve proxy DNS cache performance

### DIFF
--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -719,14 +719,14 @@ clusterFiles {
 # so we need to ensure we don't use stale cache entries.
 runtimeDnsCache {
   cacheExpiryTime = 5 seconds
-  cacheMaxSize = 10000
+  cacheMaxSize = 1000
 }
 
 # Kubernetes expiration can be higher because the IP is at the cluster level, which is
 # consistent across app pause/resume. Clusters are garbage collected ~1 hour after app deletion.
 kubernetesDnsCache {
   cacheExpiryTime = 10 minutes
-  cacheMaxSize = 10000
+  cacheMaxSize = 100
 }
 
 mysql {

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -719,14 +719,14 @@ clusterFiles {
 # so we need to ensure we don't use stale cache entries.
 runtimeDnsCache {
   cacheExpiryTime = 10 seconds
-  cacheMaxSize = 1000
+  cacheMaxSize = 10000
 }
 
 # Kubernetes expiration can be higher because the IP is at the cluster level, which is
 # consistent across app pause/resume. Clusters are garbage collected ~1 hour after app deletion.
 kubernetesDnsCache {
   cacheExpiryTime = 10 minutes
-  cacheMaxSize = 1000
+  cacheMaxSize = 10000
 }
 
 mysql {

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -718,15 +718,15 @@ clusterFiles {
 # The expiration is low because the IP changes when a runtime is pause/resumed,
 # so we need to ensure we don't use stale cache entries.
 runtimeDnsCache {
-  cacheExpiryTime = 5 seconds
-  cacheMaxSize = 100
+  cacheExpiryTime = 10 seconds
+  cacheMaxSize = 1000
 }
 
 # Kubernetes expiration can be higher because the IP is at the cluster level, which is
 # consistent across app pause/resume. Clusters are garbage collected ~1 hour after app deletion.
 kubernetesDnsCache {
   cacheExpiryTime = 10 minutes
-  cacheMaxSize = 100
+  cacheMaxSize = 1000
 }
 
 mysql {

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -718,7 +718,7 @@ clusterFiles {
 # The expiration is low because the IP changes when a runtime is pause/resumed,
 # so we need to ensure we don't use stale cache entries.
 runtimeDnsCache {
-  cacheExpiryTime = 10 seconds
+  cacheExpiryTime = 5 seconds
   cacheMaxSize = 10000
 }
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/ProxyDAO.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/ProxyDAO.scala
@@ -7,8 +7,6 @@ import cats.effect.implicits._
 import org.broadinstitute.dsde.workbench.leonardo.dns._
 import org.http4s.Uri
 
-import scala.concurrent.duration._
-
 sealed trait HostStatus extends Product with Serializable
 object HostStatus {
   final case object HostNotFound extends HostStatus

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/ProxyDAO.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/ProxyDAO.scala
@@ -43,11 +43,10 @@ object Proxy {
   ): F[HostStatus] =
     runtimeDnsCache
       .getHostStatus(RuntimeDnsCacheKey(cloudContext, runtimeName))
-      .timeout(10 seconds)
 
   def getAppTargetHost[F[_]: Async](kubernetesDnsCache: KubernetesDnsCache[F],
                                     cloudContext: CloudContext,
                                     appName: AppName
   ): F[HostStatus] =
-    kubernetesDnsCache.getHostStatus(KubernetesDnsCacheKey(cloudContext, appName)).timeout(10 seconds)
+    kubernetesDnsCache.getHostStatus(KubernetesDnsCacheKey(cloudContext, appName))
 }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/ProxyDAO.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/ProxyDAO.scala
@@ -3,7 +3,6 @@ package dao
 
 import akka.http.scaladsl.model.Uri.Host
 import cats.effect.Async
-import cats.effect.implicits._
 import org.broadinstitute.dsde.workbench.leonardo.dns._
 import org.http4s.Uri
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponent.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponent.scala
@@ -268,6 +268,7 @@ object clusterQuery extends TableQuery(new ClusterTable(_)) {
   ) = {
     val destroyedDate = destroyedDateOpt.getOrElse(dummyDate)
     val baseQuery = clusterQuery
+      .filter(_.cloudProvider === cloudContext.cloudProvider)
       .filter(_.cloudContextDb === cloudContext.asCloudContextDb)
       .filter(_.runtimeName === clusterName)
       .filter(_.destroyedDate === destroyedDate)
@@ -310,6 +311,7 @@ object clusterQuery extends TableQuery(new ClusterTable(_)) {
   ) = {
     val destroyedDate = destroyedDateOpt.getOrElse(dummyDate)
     clusterQuery
+      .filter(_.cloudProvider === cloudContext.cloudProvider)
       .filter(_.cloudContextDb === cloudContext.asCloudContextDb)
       .filter(_.runtimeName === clusterName)
       .filter(_.destroyedDate === destroyedDate)
@@ -462,6 +464,7 @@ object clusterQuery extends TableQuery(new ClusterTable(_)) {
     ec: ExecutionContext
   ): DBIO[Option[ClusterRecord]] =
     clusterQuery
+      .filter(_.cloudProvider === cloudContext.cloudProvider)
       .filter(_.cloudContextDb === cloudContext.asCloudContextDb)
       .filter(_.runtimeName === name)
       .filter(_.destroyedDate === dummyDate)
@@ -475,6 +478,7 @@ object clusterQuery extends TableQuery(new ClusterTable(_)) {
     ec: ExecutionContext
   ): DBIO[Option[RuntimeSamResourceId]] =
     clusterQuery
+      .filter(_.cloudProvider === cloudContext.cloudProvider)
       .filter(_.cloudContextDb === cloudContext.asCloudContextDb)
       .filter(_.runtimeName === name)
       .filter(_.destroyedDate === dummyDate)
@@ -485,6 +489,7 @@ object clusterQuery extends TableQuery(new ClusterTable(_)) {
     ec: ExecutionContext
   ): DBIO[Option[GcsPath]] =
     clusterQuery
+      .filter(_.cloudProvider === cloudContext.cloudProvider)
       .filter(_.cloudContextDb === cloudContext.asCloudContextDb)
       .filter(_.runtimeName === name)
       .map(_.initBucket)
@@ -495,6 +500,7 @@ object clusterQuery extends TableQuery(new ClusterTable(_)) {
     ec: ExecutionContext
   ): DBIO[Option[StagingBucket]] =
     clusterQuery
+      .filter(_.cloudProvider === cloudContext.cloudProvider)
       .filter(_.cloudContextDb === cloudContext.asCloudContextDb)
       .filter(_.runtimeName === name)
       .map(x => (x.cloudProvider, x.stagingBucket))

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/DiskServiceDbQueries.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/DiskServiceDbQueries.scala
@@ -37,8 +37,8 @@ object DiskServiceDbQueries {
     val diskQueryFilteredByProject =
       cloudContextOpt.fold(diskQueryFilteredByDeletion)(p =>
         diskQueryFilteredByDeletion
-          .filter(_.cloudContext === p.asCloudContextDb)
           .filter(_.cloudProvider === p.cloudProvider)
+          .filter(_.cloudContext === p.asCloudContextDb)
       )
 
     val diskQueryFilteredByWorkspace =

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dns/RuntimeDnsCache.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dns/RuntimeDnsCache.scala
@@ -23,6 +23,9 @@ final case class RuntimeDnsCacheKey(cloudContext: CloudContext, runtimeName: Run
  * proxy request.
  * It also populates HostToIpMapping reference used by JupyterNameService to match a "fake" hostname to a
  * real IP address.
+ * TODO [IA-4460] watch this cache for "miss storms" where multiple threads miss the cache, starting a positive
+ * feedback loop where queries run slower, take longer, and extend the time the cache is cold, accruing more
+ * misses. Consider keyed blocking via a mutex, or increasing time-to-live ({@code CacheConfig::cacheExpiryTime}).
  */
 class RuntimeDnsCache[F[_]: Logger: OpenTelemetryMetrics](
   proxyConfig: ProxyConfig,


### PR DESCRIPTION
* Use index in Cluster queries
* Remove explicit timeouts on DNS host lookups
* Allocate more resources to DNS caches

__Jira ticket__: https://broadworkbench.atlassian.net/browse/IA-4449

This PR combines https://github.com/DataBiosphere/leonardo/pull/3516 and https://github.com/DataBiosphere/leonardo/pull/3514

## Dependencies
Follows PROD-848, PROD-852 - "due to 5 seconds" timeout bug preventing launch of apps/runtimes

## Summary of changes

1. Add `cloudProvider` to queries against the CLUSTER table. This table is configured with only one index: `IDX_KUBERNETES_CLUSTER_UNIQUE_V2  | 1. cloudProvider  | 2. cloudContext  |  3. destroyedDate`. This is a multiple-column index:

> If the table has a multiple-column index, _any leftmost prefix of the index_ can be used by the optimizer to look up rows. For example, if you have a three-column index on (col1, col2, col3), you have indexed search capabilities on (col1), (col1, col2), and (col1, col2, col3). (see https://dev.mysql.com/doc/refman/8.0/en/multiple-column-indexes.html)

Existing functions depend on methods like `getRuntimeQueryByUniqueKey` which use only `cloudContext` and `destroyedDate` - presumably an artifact of the GCP-only days.

```
  def getRuntimeQueryByUniqueKey(cloudContext: CloudContext,
                                 clusterName: RuntimeName,
                                 destroyedDateOpt: Option[Instant]
  ) = {
    val destroyedDate = destroyedDateOpt.getOrElse(dummyDate)
    val baseQuery = clusterQuery
	  // without a filter on cloudProvider here, the index cannot be leveraged
      .filter(_.cloudContextDb === cloudContext.asCloudContextDb)
      .filter(_.runtimeName === clusterName)
      .filter(_.destroyedDate === destroyedDate)
```

2. Increase cache expiry time and max size for the DNS host caches which the ProxyDAO uses to get the IP address associated with a given runtime/app. These methods are called everywhere Leo attempts to communicate with its runtimes or AKS apps, and the various settings - timeout 5 seconds, expiry time 5 seconds, max size 100 - have been in place for years. An increasing number of users report Jupyter startup failures which we traced to these timeouts.

3. Removing the timeout allows the DB lookup to take as long as it takes. This seems consistent with other DB lookups in Leonardo.

4. Bumping cache max sizes decreases the frequency of cache misses. Other caches in Leo are set to 1000 or greater sizes; no other cache is as small as 100. (safe)

## Next Steps/Not Doing

Timeouts are also observed on app start and create. However the DB queries which create app responses are highly complex and more planning is needed before these can be optimized.

## Testing these changes

### What to test

- Stop and start GCP and Azure runtimes
- Create, update, and delete GCP and Azure runtimes
- Stop and start GCP and Azure apps
- Create, update, and delete GCP and Azure apps

<!-- ### Test data -->

### Who tested and where

- [x] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [x] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
