### PR TITLE
[IA-4462] Address test instability

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeDataprocSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeDataprocSpec.scala
@@ -207,15 +207,7 @@ class RuntimeDataprocSpec
         // preemptibles should be added in Dataproc
         _ <- verifyDataproc(project, runtime.clusterName, dep.dataproc, 2, 5, RegionName("us-central1"))
 
-        // check output of yarn node -list command
-        _ <- IO(
-          withWebDriver { implicit driver =>
-            withNewNotebook(runtime, Python3) { notebookPage =>
-              val output = notebookPage.executeCell("""!yarn node -list""")
-              output.get should include("Total Nodes:")
-            }
-          }
-        )
+        // TODO PR comment: we probably dont want to use selenium to verify the cluster/node status
 
         // startup script should have run again
         startScriptOutputs <- dep.storage


### PR DESCRIPTION
This attempts to remediate 
```
Could not start a new session. Possible causes are invalid address of the remote server or browser start-up failure. Build info: version: '4.1.1', revision: 'e8fcc2cecf' System info: host: '3f2e1c7e8264', ip: '172.18.0.2', os.name: 'Linux', os.arch: 'amd64', os.version: '3.10.0-862.3.3.el7.x86_64', java.version: '17.0.2' Driver info: org.openqa.selenium.remote.RemoteWebDriver Command: [null, newSession {capabilities=[Capabilities {browserName: chrome, goog:chromeOptions: {args: [--incognito, --no-experiments, --no-sandbox, --dns-prefetch-disable, --lang=en-US, --disable-setuid-sandbox, --disable-extensions, --disable-dev-shm-usage, --window-size=2880,1800, --disable-background-timer-..., --disable-backgrounding-occ..., --disable-breakpad, --disable-component-extensi..., --disable-features=Translat..., --disable-ipc-flooding-prot..., --disable-renderer-backgrou..., --enable-features=NetworkSe..., --force-color-profile=srgb, --hide-scrollbars, --metrics-recording-only, --mute-audio], extensions: [], prefs: {download.default_directory: /app/Some(/tmp), download.prompt_for_download: false, profile.block_third_party_cookies: false, profile.default_content_settings.cookies: 1}, useAutomationExtension: false}, goog:loggingPrefs: org.openqa.selenium.logging...}], desiredCapabilities=Capabilities {browserName: chrome, goog:chromeOptions: {args: [--incognito, --no-experiments, --no-sandbox, --dns-prefetch-disable, --lang=en-US, --disable-setuid-sandbox, --disable-extensions, --disable-dev-shm-usage, --window-size=2880,1800, --disable-background-timer-..., --disable-backgrounding-occ..., --disable-breakpad, --disable-component-extensi..., --disable-features=Translat..., --disable-ipc-flooding-prot..., --disable-renderer-backgrou..., --enable-features=NetworkSe..., --force-color-profile=srgb, --hide-scrollbars, --metrics-recording-only, --mute-audio], extensions: [], prefs: {download.default_directory: /app/Some(/tmp), download.prompt_for_download: false, profile.block_third_party_cookies: false, profile.default_content_settings.cookies: 1}, useAutomationExtension: false}, loggingPrefs: org.openqa.selenium.logging...}}] Capabilities {}
```