### PR TITLE
[IA-4468] Adjust front Leo DNS cache settings

### DIFF
--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -718,7 +718,7 @@ clusterFiles {
 # The expiration is low because the IP changes when a runtime is pause/resumed,
 # so we need to ensure we don't use stale cache entries.
 runtimeDnsCache {
-  cacheExpiryTime = 5 seconds
+  cacheExpiryTime = 1 minute
   cacheMaxSize = 1000
 }
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dns/ProxyResolver.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dns/ProxyResolver.scala
@@ -1,6 +1,5 @@
 package org.broadinstitute.dsde.workbench.leonardo.dns
 
-import akka.http.scaladsl.model.Uri.Host
 import cats.effect.Async
 import cats.effect.Ref
 import cats.effect.std.Dispatcher
@@ -27,13 +26,13 @@ trait ProxyResolver[F[_]] {
 }
 
 object ProxyResolver {
-  def apply[F[_]: Async](hostToIpMapping: Ref[F, Map[Host, IP]], dispatcher: Dispatcher[F]): ProxyResolver[F] =
+  def apply[F[_]: Async](hostToIpMapping: Ref[F, Map[String, IP]], dispatcher: Dispatcher[F]): ProxyResolver[F] =
     new ProxyResolverInterp(hostToIpMapping, dispatcher)
 
   /**
-   * Implementation of ProxyResolver using a Map[Host, IP] stored in a Ref.
+   * Implementation of ProxyResolver using a Map[String, IP] stored in a Ref.
    */
-  private class ProxyResolverInterp[F[_]](hostToIpMapping: Ref[F, Map[Host, IP]], dispatcher: Dispatcher[F])(implicit
+  private class ProxyResolverInterp[F[_]](hostToIpMapping: Ref[F, Map[String, IP]], dispatcher: Dispatcher[F])(implicit
     F: Async[F]
   ) extends ProxyResolver[F] {
 
@@ -52,7 +51,7 @@ object ProxyResolver {
       for {
         mapping <- hostToIpMapping.get
         // Use the IP if we have a mapping for it; otherwise fall back to default host name resolution
-        h = mapping.get(Host(host)).map(_.asString).getOrElse(host)
+        h = mapping.get(host).map(_.asString).getOrElse(host)
         res <- F.delay(new InetSocketAddress(h, port))
       } yield res
   }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dns/RuntimeDnsCache.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dns/RuntimeDnsCache.scala
@@ -30,7 +30,7 @@ final case class RuntimeDnsCacheKey(cloudContext: CloudContext, runtimeName: Run
 class RuntimeDnsCache[F[_]: Logger: OpenTelemetryMetrics](
   proxyConfig: ProxyConfig,
   dbRef: DbReference[F],
-  hostToIpMapping: Ref[F, Map[Host, IP]],
+  hostToIpMapping: Ref[F, Map[String, IP]],
   runtimeDnsCache: Cache[F, RuntimeDnsCacheKey, HostStatus]
 )(implicit F: Async[F], ec: ExecutionContext) {
   def getHostStatus(key: RuntimeDnsCacheKey): F[HostStatus] =
@@ -81,7 +81,7 @@ class RuntimeDnsCache[F[_]: Logger: OpenTelemetryMetrics](
     hostAndIpOpt match {
       case Some((h, ip)) =>
         hostToIpMapping
-          .getAndUpdate(_ + (h -> ip))
+          .getAndUpdate(_ + (h.address -> ip))
           .as[HostStatus](
             HostReady(h, s"${cloudContext.asString}/${runtimeName.asString}", CloudProvider.Gcp)
           )

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/Boot.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/Boot.scala
@@ -3,7 +3,6 @@ package http
 
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
-import akka.http.scaladsl.model.Uri.Host
 import cats.effect._
 import cats.effect.std.{Dispatcher, Queue, Semaphore}
 import cats.mtl.Ask
@@ -353,7 +352,7 @@ object Boot extends IOApp {
       implicit0(dbRef: DbReference[F]) <- DbReference.init(liquibaseConfig, concurrentDbAccessPermits)
 
       // Set up DNS caches
-      hostToIpMapping <- Resource.eval(Ref.of(Map.empty[Host, IP]))
+      hostToIpMapping <- Resource.eval(Ref.of(Map.empty[String, IP]))
       proxyResolver <- Dispatcher.parallel[F].map(d => ProxyResolver(hostToIpMapping, d))
 
       underlyingRuntimeDnsCache = buildCache[RuntimeDnsCacheKey, scalacache.Entry[HostStatus]](

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/CommonTestData.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/CommonTestData.scala
@@ -1,6 +1,5 @@
 package org.broadinstitute.dsde.workbench.leonardo
 
-import akka.http.scaladsl.model.Uri.Host
 import akka.http.scaladsl.model.headers.{HttpCookiePair, OAuth2BearerToken}
 import cats.effect.IO
 import cats.effect.Ref
@@ -236,7 +235,7 @@ object CommonTestData {
     RuntimeImage(CryptoDetector, "crypto/crypto:0.0.1", None, Instant.now.truncatedTo(ChronoUnit.MICROS))
 
   val clusterResourceConstraints = RuntimeResourceConstraints(MemorySize.fromMb(3584), MemorySize.fromMb(7680))
-  val hostToIpMapping = Ref.unsafe[IO, Map[Host, IP]](Map.empty)
+  val hostToIpMapping = Ref.unsafe[IO, Map[String, IP]](Map.empty)
 
   def makeAsyncRuntimeFields(index: Int): AsyncRuntimeFields =
     AsyncRuntimeFields(

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dns/RuntimeDnsCacheSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dns/RuntimeDnsCacheSpec.scala
@@ -92,11 +92,13 @@ class RuntimeDnsCacheSpec
 
     hostToIpMapping.get
       .unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
-      .get(runningClusterHost) shouldBe runningCluster.asyncRuntimeFields.flatMap(_.hostIp)
+      .get(runningClusterHost.address) shouldBe runningCluster.asyncRuntimeFields.flatMap(_.hostIp)
     hostToIpMapping.get
       .unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
-      .get(clusterBeingCreatedHost) shouldBe None
-    hostToIpMapping.get.unsafeRunSync()(cats.effect.unsafe.IORuntime.global).get(stoppedClusterHost) shouldBe None
+      .get(clusterBeingCreatedHost.address) shouldBe None
+    hostToIpMapping.get
+      .unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
+      .get(stoppedClusterHost.address) shouldBe None
 
     val cacheKeys = Set(cacheKeyForClusterBeingCreated, cacheKeyForRunningCluster, cacheKeyForStoppedCluster)
 

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/AKSInterpreterSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/AKSInterpreterSpec.scala
@@ -33,7 +33,6 @@ import org.broadinstitute.dsde.workbench.leonardo.db.{
   appControlledResourceQuery,
   AppControlledResourceStatus,
   KubernetesServiceDbQueries,
-  RuntimeServiceDbQueries,
   TestComponent
 }
 import org.broadinstitute.dsde.workbench.leonardo.http.{dbioToIO, ConfigReader}


### PR DESCRIPTION
<!-- Welcome to your Leonardo pull request! -->
<!-- Contributor guidelines: https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md -->

__Jira ticket__: https://broadworkbench.atlassian.net/browse/IA-4468

<!-- ## Dependencies -->
<!-- Include any dependent tickets and describe the relationship. Include any other relevant Jira tickets. -->

## Summary of changes

<!-- Please give an abridged version of the ticket description here and/or fill out the following fields. -->

### What

Two changes here:

1. Increase RuntimeDnsCache expiry from 5 seconds to 1 minute. The expiry is low because runtime IPs change during pause/resume. But 1 minute should be safe to allow for a pause/resume cycle. With 5 seconds we were getting a lot of evictions + cache loads, resulting in a lot of DB queries.

2. In addition to the caffeine cache we have an unbouded `Map[Host, IP]` which plugs into ProxyResolver. I was looking at akka-http Host class and I'm not sure it's a good HashMap key -- it's not a case class and doesn't have equals or hashCode implemented. So it might have been relying on reference equality and thus the Map may have been growing quickly with all the cache loads we were doing. We just unwrap the String anyway in proxy resolver so I change the map key to a String.


### Why

Attempt to address the GC pressure + restarts we're seeing in prod starting on 8/1.

The changes here are a little speculative (but shouldn't hurt). Analyzing a heap dump might give more insight.

## Testing these changes

### What to test

- <!-- Test case 1 -->

<!-- ### Test data -->

### Who tested and where

- [ ] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [ ] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
