### PR TITLE
Use slightly newer Broad cloudsqlproxy image

### DIFF
--- a/local/proxies.sh
+++ b/local/proxies.sh
@@ -13,7 +13,7 @@ start() {
     --restart "always" \
     -p 3306:3306 \
     --env-file="${SECRETS_DIR}/sqlproxy.env" \
-    broadinstitute/cloudsqlproxy:1.11_20180808
+    us-central1-docker.pkg.dev/dsp-artifact-registry/cloudsqlproxy/cloudsqlproxy:0.0.1
 
     echo "Copying files to CloudSQL proxy container..."
     docker cp ${SECRETS_DIR}/leonardo-account.json sqlproxy:/etc/sqlproxy-service-account.json


### PR DESCRIPTION
Fixes dbconnect by using a slightly newer version of the old cloudsqlproxy (v1).