### PR TITLE
[IA-4486] Regenerate the legacy aou dataproc debian 10 image

### DIFF
--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -71,7 +71,7 @@ dataproc {
   # Cached dataproc image used by Terra
   customDataprocImage = "projects/broad-dsp-gcr-public/global/images/leo-dataproc-image-2-1-11-debian11-2023-07-28-21-05-58"
   # Cached dataproc image used by AOU
-  legacyAouCustomDataprocImage = "projects/broad-dsp-gcr-public/global/images/leo-dataproc-image-2-0-51-debian10-2023-06-09-19-40-21"
+  legacyAouCustomDataprocImage = "projects/broad-dsp-gcr-public/global/images/leo-dataproc-image-2-0-51-debian10-2023-08-09-18-50-48"
 
   # The ratio of memory allocated to spark. 0.8 = 80%.
   # Hail/Spark users generally allocate 80% of the ram to the JVM.

--- a/jenkins/dataproc-custom-images/create_dataproc_image.sh
+++ b/jenkins/dataproc-custom-images/create_dataproc_image.sh
@@ -27,7 +27,7 @@ TEST_BUCKET="gs://leo-dataproc-image-creation-logs"
 pushd $WORK_DIR
 
 DATAPROC_BASE_NAME="leo-dataproc-image"
-DP_VERSION_FORMATTED="2-1-11-debian11"
+DP_VERSION_FORMATTED="2-0-51-debian10"
 # This needs to be unique for each run
 IMAGE_ID=$(date +"%Y-%m-%d-%H-%M-%S")
 OUTPUT_IMAGE_NAME="$DATAPROC_BASE_NAME-$DP_VERSION_FORMATTED-$IMAGE_ID"
@@ -36,7 +36,7 @@ gcloud config set dataproc/region us-central1
 
 python generate_custom_image.py \
     --image-name "$OUTPUT_IMAGE_NAME" \
-    --dataproc-version "2.1.11-debian11" \
+    --dataproc-version "2.0.51-debian10" \
     --customization-script ../prepare-custom-leonardo-jupyter-dataproc-image.sh \
     --zone $ZONE \
     --gcs-bucket $DATAPROC_IMAGE_BUCKET \

--- a/jenkins/dataproc-custom-images/create_dataproc_image.sh
+++ b/jenkins/dataproc-custom-images/create_dataproc_image.sh
@@ -27,7 +27,7 @@ TEST_BUCKET="gs://leo-dataproc-image-creation-logs"
 pushd $WORK_DIR
 
 DATAPROC_BASE_NAME="leo-dataproc-image"
-DP_VERSION_FORMATTED="2-0-51-debian10"
+DP_VERSION_FORMATTED="2-1-11-debian11"
 # This needs to be unique for each run
 IMAGE_ID=$(date +"%Y-%m-%d-%H-%M-%S")
 OUTPUT_IMAGE_NAME="$DATAPROC_BASE_NAME-$DP_VERSION_FORMATTED-$IMAGE_ID"
@@ -36,7 +36,7 @@ gcloud config set dataproc/region us-central1
 
 python generate_custom_image.py \
     --image-name "$OUTPUT_IMAGE_NAME" \
-    --dataproc-version "2.0.51-debian10" \
+    --dataproc-version "2.1.11-debian11" \
     --customization-script ../prepare-custom-leonardo-jupyter-dataproc-image.sh \
     --zone $ZONE \
     --gcs-bucket $DATAPROC_IMAGE_BUCKET \


### PR DESCRIPTION
<!-- Welcome to your Leonardo pull request! -->
<!-- Contributor guidelines: https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md -->

__Jira ticket__: https://broadworkbench.atlassian.net/browse/IA-4486

<!-- ## Dependencies -->
<!-- Include any dependent tickets and describe the relationship. Include any other relevant Jira tickets. -->

## Summary of changes

<!-- Please give an abridged version of the ticket description here and/or fill out the following fields. -->

### What

-

### Why

-

## Testing these changes

### What to test

- <!-- Test case 1 -->

<!-- ### Test data -->

### Who tested and where

- [ ] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [ ] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
