### PR TITLE
Fix dev issue: explicitly set array values

### DIFF
--- a/http/src/main/resources/leo.conf
+++ b/http/src/main/resources/leo.conf
@@ -65,53 +65,57 @@ azure.coa-app-config.dockstore-base-url = ${?DOCKSTORE_BASE_URL}
 azure.wds-app-config.instrumentation-enabled = ${?WDS_INSTRUMENTATION_ENABLED}
 
 contentSecurityPolicy {
-  frameAncestors.0 = ${?FRAME_ANCESTORS_0}
-  frameAncestors.1 = ${?FRAME_ANCESTORS_1}
-  frameAncestors.2 = ${?FRAME_ANCESTORS_2}
-  frameAncestors.3 = ${?FRAME_ANCESTORS_3}
-  frameAncestors.4 = ${?FRAME_ANCESTORS_4}
-  frameAncestors.5 = ${?FRAME_ANCESTORS_5}
-  frameAncestors.6 = ${?FRAME_ANCESTORS_6}
-  frameAncestors.7 = ${?FRAME_ANCESTORS_7}
-  frameAncestors.8 = ${?FRAME_ANCESTORS_8}
-  frameAncestors.9 = ${?FRAME_ANCESTORS_9}
-  frameAncestors.10 = ${?FRAME_ANCESTORS_10}
-  frameAncestors.11 = ${?FRAME_ANCESTORS_11}
-  frameAncestors.12 = ${?FRAME_ANCESTORS_12}
-  frameAncestors.13 = ${?FRAME_ANCESTORS_13}
-  frameAncestors.14 = ${?FRAME_ANCESTORS_14}
-  frameAncestors.15 = ${?FRAME_ANCESTORS_15}
-  frameAncestors.16 = ${?FRAME_ANCESTORS_16}
-  frameAncestors.17 = ${?FRAME_ANCESTORS_17}
-  frameAncestors.18 = ${?FRAME_ANCESTORS_18}
-  frameAncestors.19 = ${?FRAME_ANCESTORS_19}
-  frameAncestors.20 = ${?FRAME_ANCESTORS_20}
+  frameAncestors = [
+    ${?FRAME_ANCESTORS_0},
+    ${?FRAME_ANCESTORS_1},
+    ${?FRAME_ANCESTORS_2},
+    ${?FRAME_ANCESTORS_3},
+    ${?FRAME_ANCESTORS_4},
+    ${?FRAME_ANCESTORS_5},
+    ${?FRAME_ANCESTORS_6},
+    ${?FRAME_ANCESTORS_7},
+    ${?FRAME_ANCESTORS_8},
+    ${?FRAME_ANCESTORS_9},
+    ${?FRAME_ANCESTORS_10},
+    ${?FRAME_ANCESTORS_11},
+    ${?FRAME_ANCESTORS_12},
+    ${?FRAME_ANCESTORS_13},
+    ${?FRAME_ANCESTORS_14},
+    ${?FRAME_ANCESTORS_15},
+    ${?FRAME_ANCESTORS_16},
+    ${?FRAME_ANCESTORS_17},
+    ${?FRAME_ANCESTORS_18},
+    ${?FRAME_ANCESTORS_19},
+    ${?FRAME_ANCESTORS_20}
+  ]
 }
 
 refererConfig {
   # Note automation tests pass a Referer but the host:port is not predictable from Jenkins.
   # Hence we include '*' for fiab and alpha environments.
-  validHosts.0 = ${?VALID_HOSTS_0}
-  validHosts.1 = ${?VALID_HOSTS_1}
-  validHosts.2 = ${?VALID_HOSTS_2}
-  validHosts.3 = ${?VALID_HOSTS_3}
-  validHosts.4 = ${?VALID_HOSTS_4}
-  validHosts.5 = ${?VALID_HOSTS_5}
-  validHosts.6 = ${?VALID_HOSTS_6}
-  validHosts.7 = ${?VALID_HOSTS_7}
-  validHosts.8 = ${?VALID_HOSTS_8}
-  validHosts.9 = ${?VALID_HOSTS_9}
-  validHosts.10 = ${?VALID_HOSTS_10}
-  validHosts.11 = ${?VALID_HOSTS_11}
-  validHosts.12 = ${?VALID_HOSTS_12}
-  validHosts.13 = ${?VALID_HOSTS_13}
-  validHosts.14 = ${?VALID_HOSTS_14}
-  validHosts.15 = ${?VALID_HOSTS_15}
-  validHosts.16 = ${?VALID_HOSTS_16}
-  validHosts.17 = ${?VALID_HOSTS_17}
-  validHosts.18 = ${?VALID_HOSTS_18}
-  validHosts.19 = ${?VALID_HOSTS_19}
-  validHosts.20 = ${?VALID_HOSTS_20}
+  validHosts = [
+    ${?VALID_HOSTS_0},
+    ${?VALID_HOSTS_1},
+    ${?VALID_HOSTS_2},
+    ${?VALID_HOSTS_3},
+    ${?VALID_HOSTS_4},
+    ${?VALID_HOSTS_5},
+    ${?VALID_HOSTS_6},
+    ${?VALID_HOSTS_7},
+    ${?VALID_HOSTS_8},
+    ${?VALID_HOSTS_9},
+    ${?VALID_HOSTS_10},
+    ${?VALID_HOSTS_11},
+    ${?VALID_HOSTS_12},
+    ${?VALID_HOSTS_13},
+    ${?VALID_HOSTS_14},
+    ${?VALID_HOSTS_15},
+    ${?VALID_HOSTS_16},
+    ${?VALID_HOSTS_17},
+    ${?VALID_HOSTS_18},
+    ${?VALID_HOSTS_19},
+    ${?VALID_HOSTS_20}
+  ]
   enabled = ${?IS_REFERER_CONFIG_ENABLED}
   originStrict = ${?IS_ORIGIN_STRICT}
 }

--- a/http/src/main/resources/leo.conf
+++ b/http/src/main/resources/leo.conf
@@ -65,13 +65,53 @@ azure.coa-app-config.dockstore-base-url = ${?DOCKSTORE_BASE_URL}
 azure.wds-app-config.instrumentation-enabled = ${?WDS_INSTRUMENTATION_ENABLED}
 
 contentSecurityPolicy {
-  frameAncestors = ${?FRAME_ANCESTORS}
+  frameAncestors.0 = ${?FRAME_ANCESTORS_0}
+  frameAncestors.1 = ${?FRAME_ANCESTORS_1}
+  frameAncestors.2 = ${?FRAME_ANCESTORS_2}
+  frameAncestors.3 = ${?FRAME_ANCESTORS_3}
+  frameAncestors.4 = ${?FRAME_ANCESTORS_4}
+  frameAncestors.5 = ${?FRAME_ANCESTORS_5}
+  frameAncestors.6 = ${?FRAME_ANCESTORS_6}
+  frameAncestors.7 = ${?FRAME_ANCESTORS_7}
+  frameAncestors.8 = ${?FRAME_ANCESTORS_8}
+  frameAncestors.9 = ${?FRAME_ANCESTORS_9}
+  frameAncestors.10 = ${?FRAME_ANCESTORS_10}
+  frameAncestors.11 = ${?FRAME_ANCESTORS_11}
+  frameAncestors.12 = ${?FRAME_ANCESTORS_12}
+  frameAncestors.13 = ${?FRAME_ANCESTORS_13}
+  frameAncestors.14 = ${?FRAME_ANCESTORS_14}
+  frameAncestors.15 = ${?FRAME_ANCESTORS_15}
+  frameAncestors.16 = ${?FRAME_ANCESTORS_16}
+  frameAncestors.17 = ${?FRAME_ANCESTORS_17}
+  frameAncestors.18 = ${?FRAME_ANCESTORS_18}
+  frameAncestors.19 = ${?FRAME_ANCESTORS_19}
+  frameAncestors.20 = ${?FRAME_ANCESTORS_20}
 }
 
 refererConfig {
   # Note automation tests pass a Referer but the host:port is not predictable from Jenkins.
   # Hence we include '*' for fiab and alpha environments.
-  validHosts = ${?VALID_HOSTS}
+  validHosts.0 = ${?VALID_HOSTS_0}
+  validHosts.1 = ${?VALID_HOSTS_1}
+  validHosts.2 = ${?VALID_HOSTS_2}
+  validHosts.3 = ${?VALID_HOSTS_3}
+  validHosts.4 = ${?VALID_HOSTS_4}
+  validHosts.5 = ${?VALID_HOSTS_5}
+  validHosts.6 = ${?VALID_HOSTS_6}
+  validHosts.7 = ${?VALID_HOSTS_7}
+  validHosts.8 = ${?VALID_HOSTS_8}
+  validHosts.9 = ${?VALID_HOSTS_9}
+  validHosts.10 = ${?VALID_HOSTS_10}
+  validHosts.11 = ${?VALID_HOSTS_11}
+  validHosts.12 = ${?VALID_HOSTS_12}
+  validHosts.13 = ${?VALID_HOSTS_13}
+  validHosts.14 = ${?VALID_HOSTS_14}
+  validHosts.15 = ${?VALID_HOSTS_15}
+  validHosts.16 = ${?VALID_HOSTS_16}
+  validHosts.17 = ${?VALID_HOSTS_17}
+  validHosts.18 = ${?VALID_HOSTS_18}
+  validHosts.19 = ${?VALID_HOSTS_19}
+  validHosts.20 = ${?VALID_HOSTS_20}
   enabled = ${?IS_REFERER_CONFIG_ENABLED}
   originStrict = ${?IS_ORIGIN_STRICT}
 }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/CommonTestData.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/CommonTestData.scala
@@ -76,6 +76,7 @@ import org.broadinstitute.dsde.workbench.azure.{
   SubscriptionId,
   TenantId
 }
+import org.broadinstitute.dsde.workbench.leonardo.config.ContentSecurityPolicyComponent.FrameAncestors
 import org.broadinstitute.dsde.workbench.leonardo.http.service.AzureServiceConfig
 import org.broadinstitute.dsde.workbench.oauth2.mock.FakeOpenIDConnectConfiguration
 import org.broadinstitute.dsde.workbench.util2.InstanceName
@@ -161,8 +162,8 @@ object CommonTestData {
   val clusterToolConfig = Config.clusterToolMonitorConfig
   val proxyUrlBase = proxyConfig.proxyUrlBase
   val clusterBucketConfig = Config.clusterBucketConfig
-  val contentSecurityPolicy = Config.contentSecurityPolicy
-  val refererConfig = Config.refererConfig
+  val contentSecurityPolicy = Config.contentSecurityPolicy.copy(frameAncestors = FrameAncestors(List("'none'")))
+  val refererConfig = Config.refererConfig.copy(validHosts = Set("example.com", "localhost:3000"))
   val leoKubernetesConfig = Config.leoKubernetesConfig
   val openIdConnectionConfiguration = FakeOpenIDConnectConfiguration
   val azureServiceConfig = AzureServiceConfig(

--- a/local/overrides.env
+++ b/local/overrides.env
@@ -31,7 +31,7 @@ SHOULD_INIT_WITH_LIQUIBASE=false
 JAVA_OPTS=-DXmx4G -DXms4G -DXss2M -Dsun.net.spi.nameservice.provider.1=default -Dsun.net.spi.nameservice.provider.2=dns,Jupyter -Djna.library.path=${HELM_BUILD_DIR} -Duser.timezone=UTC -Dapp-service.enable-custom-app-check=false -Dconfig.resource=leo.conf
 
 # SBT
-SBT_OPTS=-Xmx4G -Xms4G -Xss2M -XX:+UseG1GC -DVALID_HOSTS.0=local.dsde-dev.broadinstitute.org
+SBT_OPTS=-Xmx4G -Xms4G -Xss2M -XX:+UseG1GC -DVALID_HOSTS_0=local.dsde-dev.broadinstitute.org
 
 # SSL certs and SA key
 ROOT_CA_PEM_PATH=${RENDER_DIR}/rootCA.pem


### PR DESCRIPTION
This fixes the Leo issue currently on dev. Testing in a BEE. See related helmfile PR: https://github.com/broadinstitute/terra-helmfile/pull/4436

Not the most elegant fix, but I can't see anything better right now.

Before, terra-helmfile would set EVs like this (with dots in the name):
```
VALID_HOSTS.2=bvdp-saturn-dev.appspot.com
VALID_HOSTS.1=*
VALID_HOSTS.0=localhost:3000
```
which let us define list-valued HOCON configs like this in Leo (this behavior is mostly undocumented):
```
validHosts = ${?VALID_HOSTS}
```

Unfortunately, dots in EV names aren't really supported in many Unix shells like bash, and it broke in a recent Debian base image upgrade. Here's a quick [repro](https://gist.github.com/rtitle/c2022672a6f0007b73517717682a08b9).

So instead, we now just pass each array element as a string, as suggested in https://stackoverflow.com/questions/50133291/how-to-provide-an-array-of-values-as-an-env-variable-to-typesafe-lightbend-confi. So we have EVs like:
```
VALID_HOSTS_2=bvdp-saturn-dev.appspot.com
VALID_HOSTS_1=*
VALID_HOSTS_0=localhost:3000
```
and read them in Leo like:
```
validHosts = [
  ${?VALID_HOSTS_0},
  ${?VALID_HOSTS_1},
  ${?VALID_HOSTS_2},
  …
]
...
```
I made "space" for 20 but the config library will only read the ones defined by EVs.
