### PR TITLE
[PROD-860] Bump boot disk size

### DIFF
--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -123,7 +123,7 @@ gce {
   runtimeDefaults {
     machineType = "n1-standard-4"
     diskSize = 30 # This is default size for just user disk
-    bootDiskSize = 120
+    bootDiskSize = 250
     zone = "us-central1-a"
   }
   gceReservedMemory = 1g

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -123,7 +123,7 @@ gce {
   runtimeDefaults {
     machineType = "n1-standard-4"
     diskSize = 30 # This is default size for just user disk
-    bootDiskSize = 240
+    bootDiskSize = 120
     zone = "us-central1-a"
   }
   gceReservedMemory = 1g

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -123,7 +123,7 @@ gce {
   runtimeDefaults {
     machineType = "n1-standard-4"
     diskSize = 30 # This is default size for just user disk
-    bootDiskSize = 120
+    bootDiskSize = 240
     zone = "us-central1-a"
   }
   gceReservedMemory = 1g

--- a/http/src/main/resources/swagger/api-docs.yaml
+++ b/http/src/main/resources/swagger/api-docs.yaml
@@ -3705,7 +3705,7 @@ components:
                 Minimum size is 50GB. If unspecified, default size is 100GB.
             bootDiskSize:
               type: integer
-              description: size for boot disk. For old runtimes (prior 6/22/2020, gce runtimes don't have a separate boot disk)
+              description: UNUSED
             machineType:
               type: string
               description: >
@@ -3732,7 +3732,7 @@ components:
               $ref: "#/components/schemas/PersistentDiskRequest"
             bootDiskSize:
               type: integer
-              description: size for boot disk
+              description: UNUSED
             machineType:
               type: string
               description: >
@@ -3838,7 +3838,7 @@ components:
             machineType:
               type: string
               description: >
-                Azure machine type describing number of CPUs/Memory as , ex: Standard_DS1_v2. 
+                Azure machine type describing number of CPUs/Memory as , ex: Standard_DS1_v2.
                 See https://learn.microsoft.com/en-us/azure/virtual-machines/sizes
             persistentDiskId:
               type: number

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterpSpec.scala
@@ -641,7 +641,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
       runtimeConfig shouldBe RuntimeConfig.GceWithPdConfig(
         MachineTypeName("n1-standard-4"),
         Some(disk.id),
-        bootDiskSize = DiskSize(120),
+        bootDiskSize = DiskSize(120), // will be ignored
         zone = ZoneName("us-central1-a"),
         None
       ) // TODO: this is a problem in terms of inconsistency
@@ -665,7 +665,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
           scopes = Config.gceConfig.defaultScopes,
           runtimeConfig = RuntimeConfigInCreateRuntimeMessage.GceWithPdConfig(runtimeConfig.machineType,
                                                                               disk.id,
-                                                                              bootDiskSize = DiskSize(120),
+                                                                              bootDiskSize = DiskSize(250),
                                                                               zone = ZoneName("us-central1-a"),
                                                                               None
           )

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterpSpec.scala
@@ -641,7 +641,7 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
       runtimeConfig shouldBe RuntimeConfig.GceWithPdConfig(
         MachineTypeName("n1-standard-4"),
         Some(disk.id),
-        bootDiskSize = DiskSize(120), // will be ignored
+        bootDiskSize = DiskSize(250),
         zone = ZoneName("us-central1-a"),
         None
       ) // TODO: this is a problem in terms of inconsistency


### PR DESCRIPTION
## Increase GCP VM boot disk size to 250gb
### Jira Ticket: https://broadworkbench.atlassian.net/browse/PROD-860
See https://github.com/DataBiosphere/terra-ui/pull/4128 for the corresponding Terra client change.

Users are seeing timeouts when creating GCP VMs from custom images that once worked. GCP logs show boot disks filling up quickly. I've seen the specific message `Attempting next endpoint for pull after error: failed to register layer: Error processing tar file(exit status 1): write /opt/conda/lib/python3.7/site-packages/tensorflow_io/python/ops/libtensorflow_io.so: no space left on device` in multiple failed runs.

The boot disk is largest during initialization, when packages being pulled are unpacking temporary files. This is likely when custom images, which also include all the base images, hit the 120Gb limit.

Temporary solution is a bump to 250Gb for all GCP VMs. This is probably much more space than necessary, and is wasted extra space for users on base images, which are capped at 120Gb.

## Cost impact

Users will see more expensive maintenance costs, by $0.01-$0.02 per hour, because of the larger disk size. These costs are *not* reduced by pausing the VM.

## Testing

I tested on my BEE. I used custom image http://us.gcr.io/broad-dsde-methods/terra-jupyter-pcl:0.0.4 which also failed on prod.

* branch `develop` (120Gb boot disk) => timed out after 30m, with "no space left on device" in logs.
* branch `PROD-860-custom-image-timeout` (250Gb boot disk) => successfully created in under 10 minutes.

### Regression

* Default base image (GATK) => successfully created, 250Gb
<img width="1045" alt="Screenshot 2023-08-17 at 6 53 29 PM" src="https://github.com/DataBiosphere/leonardo/assets/117680805/1e987801-65aa-4780-a20d-cdad9d5afb3d">
* RStudio app => successfully created, 250Gb
<img width="1056" alt="Screenshot 2023-08-17 at 7 03 46 PM" src="https://github.com/DataBiosphere/leonardo/assets/117680805/6d4d5486-4208-4da1-8bd8-f1c4ff8973c3">
* Hail/Dataproc base image, Spark single node => successfully created, 150Gb
<img width="1041" alt="Screenshot 2023-08-17 at 7 25 01 PM" src="https://github.com/DataBiosphere/leonardo/assets/117680805/2cf4fe18-9392-44d3-8e2f-b032292f6357">
* GATK legacy image => successfully created
<img width="1057" alt="Screenshot 2023-08-17 at 7 44 39 PM" src="https://github.com/DataBiosphere/leonardo/assets/117680805/1f26c11e-887e-47df-8d5d-3346b5dd62ea">
