### PR TITLE
WOR-1218: Update wb-libs, fix compilation errors and warnings

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoSuite.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoSuite.scala
@@ -22,6 +22,7 @@ import org.scalatest._
 import org.scalatest.freespec.FixtureAnyFreeSpecLike
 import org.broadinstitute.dsde.rawls.model.AzureManagedAppCoordinates
 import org.broadinstitute.dsde.workbench.fixture.BillingFixtures.withTemporaryAzureBillingProject
+import org.http4s.headers.Authorization
 
 import java.util.UUID
 
@@ -142,7 +143,7 @@ trait BillingProjectUtils extends LeonardoTestUtils {
 trait NewBillingProjectAndWorkspaceBeforeAndAfterAll extends BillingProjectUtils with BeforeAndAfterAll {
   this: TestSuite =>
 
-  implicit val ronTestersonAuthorization = Ron.authorization()
+  implicit val ronTestersonAuthorization: IO[Authorization] = Ron.authorization()
 
   override def beforeAll(): Unit = {
     val res = for {
@@ -260,7 +261,7 @@ trait AzureBillingBeforeAndAfter extends FixtureAnyFreeSpecLike with BeforeAndAf
   // Note that the final 'optional' field for a pre-created landing zone is not technically optional
   // If you fail to include a landing zone, the wb-libs call to create the billing project will fail, timing out due to landing zone creation not being an expected part of creation
   // Contact the workspaces team if this fails to work
-  implicit val azureManagedAppCoordinates = AzureManagedAppCoordinates(
+  implicit val azureManagedAppCoordinates: AzureManagedAppCoordinates = AzureManagedAppCoordinates(
     UUID.fromString("fad90753-2022-4456-9b0a-c7e5b934e408"),
     UUID.fromString("f557c728-871d-408c-a28b-eb6b2141a087"),
     "staticTestingMrg",

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
@@ -728,7 +728,8 @@ sealed trait TestUser extends Product with Serializable {
 }
 
 object TestUser {
-  def getAuthTokenAndAuthorization(user: TestUser) = (user.authToken(), user.authorization())
+  def getAuthTokenAndAuthorization(user: TestUser): (IO[AuthToken], IO[Authorization]) =
+    (user.authToken(), user.authorization())
 
   final case object Ron extends TestUser { override val name: String = "ron" }
   final case object Hermione extends TestUser { override val name: String = "hermione" }

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/RuntimeFixtureSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/RuntimeFixtureSpec.scala
@@ -1,17 +1,18 @@
 package org.broadinstitute.dsde.workbench.leonardo
 
-import cats.syntax.all._
-import org.broadinstitute.dsde.workbench.leonardo.BillingProjectFixtureSpec._
-import org.broadinstitute.dsde.workbench.model.google.GoogleProject
-import org.scalatest.{BeforeAndAfterAll, Outcome, Retries}
-import RuntimeFixtureSpec._
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global
+import org.broadinstitute.dsde.workbench.auth.AuthToken
 import org.broadinstitute.dsde.workbench.google2.{MachineTypeName, ZoneName}
+import org.broadinstitute.dsde.workbench.leonardo.BillingProjectFixtureSpec._
+import org.broadinstitute.dsde.workbench.leonardo.RuntimeFixtureSpec._
 import org.broadinstitute.dsde.workbench.leonardo.TestUser.{getAuthTokenAndAuthorization, Ron}
 import org.broadinstitute.dsde.workbench.leonardo.http.{CreateRuntimeRequest, RuntimeConfigRequest}
+import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.http4s.client.Client
+import org.http4s.headers.Authorization
 import org.scalatest.freespec.FixtureAnyFreeSpec
+import org.scalatest.{BeforeAndAfterAll, Outcome, Retries}
 
 /**
  * trait BeforeAndAfterAll - One cluster per Scalatest Spec.
@@ -22,7 +23,7 @@ abstract class RuntimeFixtureSpec
     with LeonardoTestUtils
     with Retries {
 
-  implicit val (ronAuthToken, ronAuthorization) = getAuthTokenAndAuthorization(Ron)
+  implicit val (ronAuthToken: IO[AuthToken], ronAuthorization: IO[Authorization]) = getAuthTokenAndAuthorization(Ron)
 
   def toolDockerImage: Option[String] = None
   def welderRegistry: Option[ContainerRegistry] = None

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/AppLifecycleSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/AppLifecycleSpec.scala
@@ -3,6 +3,7 @@ package apps
 
 import cats.effect.IO
 import org.broadinstitute.dsde.workbench.DoneCheckable
+import org.broadinstitute.dsde.workbench.auth.AuthToken
 import org.broadinstitute.dsde.workbench.google2.{streamFUntilDone, streamUntilDoneOrTimeout, Generators}
 import org.broadinstitute.dsde.workbench.leonardo.LeonardoApiClient._
 import org.broadinstitute.dsde.workbench.leonardo.TestUser.{getAuthTokenAndAuthorization, Ron}
@@ -23,7 +24,7 @@ class AppLifecycleSpec
     with BillingProjectUtils
     with TableDrivenPropertyChecks
     with NewBillingProjectAndWorkspaceBeforeAndAfterAll {
-  implicit val (ronAuthToken, ronAuthorization) = getAuthTokenAndAuthorization(Ron)
+  implicit val (ronAuthToken: IO[AuthToken], ronAuthorization: IO[Authorization]) = getAuthTokenAndAuthorization(Ron)
 
   override def withFixture(test: NoArgTest) =
     if (isRetryable(test))

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/azure/AzureRuntimeSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/azure/AzureRuntimeSpec.scala
@@ -3,6 +3,7 @@ package org.broadinstitute.dsde.workbench.leonardo.azure
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global
 import org.broadinstitute.dsde.workbench.GeneratedLeonardoClient
+import org.broadinstitute.dsde.workbench.auth.AuthToken
 import org.broadinstitute.dsde.workbench.client.leonardo.model.{
   AzureDiskConfig,
   ClusterStatus,
@@ -26,7 +27,7 @@ class AzureRuntimeSpec
     with Retries
     with CleanUp {
 
-  implicit val accessToken = Hermione.authToken()
+  implicit val accessToken: IO[AuthToken] = Hermione.authToken()
 
   "create, get, delete azure runtime" taggedAs ExcludeFromJenkins in { workspaceDetails =>
     val workspaceId = workspaceDetails.workspace.workspaceId

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookGCECustomizationSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookGCECustomizationSpec.scala
@@ -1,5 +1,6 @@
 package org.broadinstitute.dsde.workbench.leonardo.notebooks
 
+import cats.effect.IO
 import cats.effect.unsafe.implicits.global
 import org.broadinstitute.dsde.workbench.ResourceFile
 import org.broadinstitute.dsde.workbench.auth.AuthToken
@@ -9,6 +10,7 @@ import org.broadinstitute.dsde.workbench.leonardo.{
   LeonardoApiClient,
   UserJupyterExtensionConfig
 }
+import org.http4s.headers.Authorization
 import org.scalatest.{DoNotDiscover, ParallelTestExecution}
 
 /**
@@ -21,7 +23,7 @@ final class NotebookGCECustomizationSpec
     extends BillingProjectFixtureSpec
     with ParallelTestExecution
     with NotebookTestUtils {
-  implicit val (ronAuthToken, ronAuthorization) = getAuthTokenAndAuthorization(Ron)
+  implicit val (ronAuthToken: IO[AuthToken], ronAuthorization: IO[Authorization]) = getAuthTokenAndAuthorization(Ron)
   implicit def ronToken: AuthToken = ronAuthToken.unsafeRunSync()
 
   "NotebookGCECustomizationSpec" - {

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeAutopauseSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeAutopauseSpec.scala
@@ -1,6 +1,8 @@
 package org.broadinstitute.dsde.workbench.leonardo.runtimes
 
+import cats.effect.IO
 import cats.effect.unsafe.implicits.global
+import org.broadinstitute.dsde.workbench.auth.AuthToken
 import org.broadinstitute.dsde.workbench.leonardo.TestUser.{getAuthTokenAndAuthorization, Ron}
 import org.broadinstitute.dsde.workbench.leonardo.{
   BillingProjectFixtureSpec,
@@ -9,15 +11,17 @@ import org.broadinstitute.dsde.workbench.leonardo.{
   LeonardoApiClient,
   LeonardoTestUtils
 }
+import org.http4s.headers.Authorization
 import org.scalatest.time.{Minutes, Seconds, Span}
+
 import scala.concurrent.duration._
 import org.scalatest.{DoNotDiscover, ParallelTestExecution}
 
 @DoNotDiscover
 class RuntimeAutopauseSpec extends BillingProjectFixtureSpec with ParallelTestExecution with LeonardoTestUtils {
-  implicit val (ronAuthToken, ronAuthorization) = getAuthTokenAndAuthorization(Ron)
-  implicit val rat = ronAuthToken.unsafeRunSync()
-  implicit val ra = ronAuthorization.unsafeRunSync()
+  implicit val (ronAuthToken: IO[AuthToken], ronAuthorization: IO[Authorization]) = getAuthTokenAndAuthorization(Ron)
+  implicit val rat: AuthToken = ronAuthToken.unsafeRunSync()
+  implicit val ra: Authorization = ronAuthorization.unsafeRunSync()
 
   "autopause should work" in { billingProject =>
     val runtimeName = randomClusterName

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeCreationDiskSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeCreationDiskSpec.scala
@@ -20,6 +20,7 @@ import org.broadinstitute.dsde.workbench.leonardo.http.{
 import org.broadinstitute.dsde.workbench.leonardo.notebooks.{NotebookTestUtils, Python3}
 import org.http4s.client.Client
 import org.http4s.Status
+import org.http4s.headers.Authorization
 import org.scalatest.tagobjects.Retryable
 import org.scalatest.{DoNotDiscover, ParallelTestExecution}
 
@@ -32,7 +33,7 @@ class RuntimeCreationDiskSpec
     with ParallelTestExecution
     with LeonardoTestUtils
     with NotebookTestUtils {
-  implicit val (authTokenForOldApiClient, auth) = getAuthTokenAndAuthorization(Ron)
+  implicit val (authTokenForOldApiClient: IO[AuthToken], auth: IO[Authorization]) = getAuthTokenAndAuthorization(Ron)
 
   override def withFixture(test: NoArgTest) =
     if (isRetryable(test))

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeDataprocSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeDataprocSpec.scala
@@ -27,6 +27,7 @@ import org.broadinstitute.dsde.workbench.model.TraceId
 import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GcsObjectName, GcsPath, GoogleProject}
 import org.broadinstitute.dsde.workbench.service.Sam
 import org.http4s.client.Client
+import org.http4s.headers.Authorization
 import org.scalatest.tagobjects.Retryable
 import org.scalatest.{DoNotDiscover, ParallelTestExecution}
 
@@ -40,8 +41,8 @@ class RuntimeDataprocSpec
     with ParallelTestExecution
     with LeonardoTestUtils
     with NotebookTestUtils {
-  implicit val (authTokenForOldApiClient, auth) = getAuthTokenAndAuthorization(Ron)
-  implicit val traceId = Ask.const[IO, TraceId](TraceId(UUID.randomUUID()))
+  implicit val (authTokenForOldApiClient: IO[AuthToken], auth: IO[Authorization]) = getAuthTokenAndAuthorization(Ron)
+  implicit val traceId: Ask[IO, TraceId] = Ask.const[IO, TraceId](TraceId(UUID.randomUUID()))
 
   override def withFixture(test: NoArgTest) =
     if (isRetryable(test))

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeGceSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeGceSpec.scala
@@ -23,6 +23,7 @@ import org.broadinstitute.dsde.workbench.model.TraceId
 import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GcsObjectName, GcsPath, GoogleProject}
 import org.broadinstitute.dsde.workbench.service.Sam
 import org.http4s.client.Client
+import org.http4s.headers.Authorization
 import org.scalatest.tagobjects.Retryable
 import org.scalatest.{DoNotDiscover, ParallelTestExecution}
 
@@ -35,8 +36,8 @@ class RuntimeGceSpec
     with ParallelTestExecution
     with LeonardoTestUtils
     with NotebookTestUtils {
-  implicit val (authTokenForOldApiClient, auth) = getAuthTokenAndAuthorization(Ron)
-  implicit val traceId = Ask.const[IO, TraceId](TraceId(UUID.randomUUID()))
+  implicit val (authTokenForOldApiClient: IO[AuthToken], auth: IO[Authorization]) = getAuthTokenAndAuthorization(Ron)
+  implicit val traceId: Ask[IO, TraceId] = Ask.const[IO, TraceId](TraceId(UUID.randomUUID()))
 
   val dependencies = for {
     storage <- google2StorageResource

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimePatchSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimePatchSpec.scala
@@ -15,6 +15,7 @@ import org.broadinstitute.dsde.workbench.leonardo.http.{
 }
 import org.broadinstitute.dsde.workbench.leonardo.notebooks.{NotebookTestUtils, Python3}
 import org.broadinstitute.dsde.workbench.service.util.Tags
+import org.http4s.headers.Authorization
 import org.scalatest.tagobjects.Retryable
 import org.scalatest.{DoNotDiscover, ParallelTestExecution}
 
@@ -26,7 +27,7 @@ class RuntimePatchSpec
     with ParallelTestExecution
     with LeonardoTestUtils
     with NotebookTestUtils {
-  implicit val (ronAuthToken, ronAuthorization) = getAuthTokenAndAuthorization(Ron)
+  implicit val (ronAuthToken: IO[AuthToken], ronAuthorization: IO[Authorization]) = getAuthTokenAndAuthorization(Ron)
 
   override def withFixture(test: NoArgTest) =
     if (isRetryable(test))

--- a/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestSuite.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestSuite.scala
@@ -5,7 +5,7 @@ import cats.effect.{Deferred, IO}
 import com.github.benmanes.caffeine.cache.Caffeine
 import fs2.Stream
 import org.broadinstitute.dsde.workbench.google2.GKEModels.KubernetesClusterId
-import org.broadinstitute.dsde.workbench.openTelemetry.FakeOpenTelemetryMetricsInterpreter
+import org.broadinstitute.dsde.workbench.openTelemetry.{FakeOpenTelemetryMetricsInterpreter, OpenTelemetryMetrics}
 import org.http4s.{AuthScheme, Credentials}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.prop.Configuration
@@ -19,7 +19,7 @@ import java.util.concurrent.TimeUnit
 import scala.concurrent.duration._
 
 trait LeonardoTestSuite extends Matchers {
-  implicit val metrics = FakeOpenTelemetryMetricsInterpreter
+  implicit val metrics: OpenTelemetryMetrics[IO] = FakeOpenTelemetryMetricsInterpreter
   implicit val loggerIO: StructuredLogger[IO] = Slf4jLogger.getLogger[IO]
 
   def ioAssertion(test: => IO[Assertion]): Assertion = test.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/Boot.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/Boot.scala
@@ -13,6 +13,7 @@ import com.google.api.gax.longrunning.OperationFuture
 import com.google.api.services.container.ContainerScopes
 import com.google.auth.oauth2.GoogleCredentials
 import com.google.cloud.compute.v1.Operation
+import fs2.io.file.Files
 import fs2.Stream
 import io.circe.syntax._
 import io.kubernetes.client.openapi.ApiClient
@@ -345,7 +346,8 @@ object Boot extends IOApp {
     logger: StructuredLogger[F],
     ec: ExecutionContext,
     as: ActorSystem,
-    F: Async[F]
+    F: Async[F],
+    files: Files[F]
   ): Resource[F, AppDependencies[F]] =
     for {
       semaphore <- Resource.eval(Semaphore[F](applicationConfig.concurrency))

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/AKSInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/AKSInterpreter.scala
@@ -22,6 +22,7 @@ import com.azure.resourcemanager.compute.models.{
 }
 import com.azure.resourcemanager.msi.MsiManager
 import com.azure.resourcemanager.msi.models.Identity
+import fs2.io.file.Files
 import org.broadinstitute.dsde.workbench.DoneCheckableSyntax._
 import org.broadinstitute.dsde.workbench.azure._
 import org.broadinstitute.dsde.workbench.google2.KubernetesModels.{KubernetesNamespace, PodStatus}
@@ -66,7 +67,8 @@ class AKSInterpreter[F[_]](config: AKSInterpreterConfig,
   executionContext: ExecutionContext,
   logger: StructuredLogger[F],
   dbRef: DbReference[F],
-  F: Async[F]
+  F: Async[F],
+  files: Files[F]
 ) extends AKSAlgebra[F] {
   implicit private def booleanDoneCheckable: DoneCheckable[Boolean] = identity[Boolean]
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/BucketHelper.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/BucketHelper.scala
@@ -8,6 +8,7 @@ import cats.mtl.Ask
 import cats.syntax.all._
 import com.google.cloud.Identity
 import fs2._
+import fs2.io.file.Files
 import org.broadinstitute.dsde.workbench.google2.{GcsBlobName, GoogleStorageService, StorageRole}
 import org.broadinstitute.dsde.workbench.leonardo.config._
 import org.broadinstitute.dsde.workbench.leonardo.model.{LeoInternalServerError, ServiceAccountProvider}
@@ -21,7 +22,7 @@ class BucketHelper[F[_]](
   config: BucketHelperConfig,
   google2StorageDAO: GoogleStorageService[F],
   serviceAccountProvider: ServiceAccountProvider[F]
-)(implicit val logger: Logger[F], F: Async[F]) {
+)(implicit val logger: Logger[F], F: Async[F], files: Files[F]) {
 
   val leoEntity = serviceAccountIdentity(Config.serviceAccountProviderConfig.leoServiceAccountEmail)
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
@@ -8,6 +8,7 @@ import cats.syntax.all._
 import com.google.auth.oauth2.GoogleCredentials
 import com.google.cloud.compute.v1.Disk
 import com.google.container.v1._
+import fs2.io.file.Files
 import org.broadinstitute.dsde.workbench.DoneCheckable
 import org.broadinstitute.dsde.workbench.DoneCheckableInstances._
 import org.broadinstitute.dsde.workbench.DoneCheckableSyntax._
@@ -72,8 +73,13 @@ class GKEInterpreter[F[_]](
   nodepoolLock: KeyLock[F, KubernetesClusterId],
   googleResourceService: GoogleResourceService[F],
   computeService: GoogleComputeService[F]
-)(implicit val executionContext: ExecutionContext, logger: StructuredLogger[F], dbRef: DbReference[F], F: Async[F])
-    extends GKEAlgebra[F] {
+)(implicit
+  val executionContext: ExecutionContext,
+  logger: StructuredLogger[F],
+  dbRef: DbReference[F],
+  F: Async[F],
+  files: Files[F]
+) extends GKEAlgebra[F] {
   // DoneCheckable instances
   implicit private def optionDoneCheckable[A]: DoneCheckable[Option[A]] = (a: Option[A]) => a.isDefined
   implicit private def booleanDoneCheckable: DoneCheckable[Boolean] = identity[Boolean]

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/TestExecutionContext.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/TestExecutionContext.scala
@@ -8,7 +8,7 @@ import scala.concurrent.ExecutionContextExecutor
  * Created by dvoet on 10/9/15.
  */
 object TestExecutionContext {
-  implicit val testExecutionContext = new TestExecutionContext()
+  implicit val testExecutionContext: TestExecutionContext = new TestExecutionContext()
 }
 
 class TestExecutionContext() extends ExecutionContextExecutor {

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/TestUtils.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/TestUtils.scala
@@ -126,24 +126,19 @@ object TestUtils extends Matchers {
   private def fixIdsForServices(services: List[KubernetesService]): List[KubernetesService] =
     services.map(fixIdForService).sortBy(_.config.name.value)
 
-  implicit val serviceEq =
-    new Equality[KubernetesService] {
+  implicit val serviceEq: Equality[KubernetesService] =
+    (a: KubernetesService, b: Any) =>
+      b match {
+        case c: KubernetesService => fixIdForService(a) === fixIdForService(c)
+        case _                    => false
+      }
 
-      def areEqual(a: KubernetesService, b: Any): Boolean =
-        b match {
-          case c: KubernetesService => fixIdForService(a) === fixIdForService(c)
-          case _                    => false
-        }
-    }
-
-  implicit val namespaceListEq =
-    new Equality[List[Namespace]] {
-      def areEqual(as: List[Namespace], bs: Any): Boolean =
-        bs match {
-          case cs: List[_] => isNamespaceListEquivalent(as, cs)
-          case _           => false
-        }
-    }
+  implicit val namespaceListEq: Equality[List[Namespace]] =
+    (as: List[Namespace], bs: Any) =>
+      bs match {
+        case cs: List[_] => isNamespaceListEquivalent(as, cs)
+        case _           => false
+      }
 
   private def isNamespaceListEquivalent(cs1: Traversable[_], cs2: Traversable[_]): Boolean = {
     val dummyId = NamespaceId(0)
@@ -154,25 +149,21 @@ object TestUtils extends Matchers {
     fcs1 == fcs2
   }
 
-  implicit val clusterSeqEq =
-    new Equality[Seq[Runtime]] {
-      def areEqual(as: Seq[Runtime], bs: Any): Boolean =
-        bs match {
-          case cs: Seq[_] => isEquivalent(as, cs)
-          case _          => false
-        }
-    }
+  implicit val clusterSeqEq: Equality[Seq[Runtime]] =
+    (as: Seq[Runtime], bs: Any) =>
+      bs match {
+        case cs: Seq[_] => isEquivalent(as, cs)
+        case _          => false
+      }
 
-  implicit val clusterSetEq =
-    new Equality[Set[Runtime]] {
-      def areEqual(as: Set[Runtime], bs: Any): Boolean =
-        bs match {
-          case cs: Set[_] => isEquivalent(as, cs)
-          case _          => false
-        }
-    }
+  implicit val clusterSetEq: Equality[Set[Runtime]] =
+    (as: Set[Runtime], bs: Any) =>
+      bs match {
+        case cs: Set[_] => isEquivalent(as, cs)
+        case _          => false
+      }
 
-  implicit val diskEq =
+  implicit val diskEq: Equality[PersistentDisk] =
     new Equality[PersistentDisk] {
       private val FixedId = DiskId(0)
 

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/TestUtils.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/TestUtils.scala
@@ -56,9 +56,7 @@ object TestUtils extends Matchers {
       def areEqual(a: KubernetesCluster, b: Any): Boolean =
         b match {
           case c: KubernetesCluster =>
-            a.copy(id = FixedId,
-                   nodepools = a.nodepools.map(n => n.copy(id = FixedNodepoolId, clusterId = FixedId))
-            ) ===
+            a.copy(id = FixedId, nodepools = a.nodepools.map(n => n.copy(id = FixedNodepoolId, clusterId = FixedId))) ==
               c.copy(id = FixedId, nodepools = c.nodepools.map(n => n.copy(id = FixedNodepoolId, clusterId = FixedId)))
           case _ => false
         }
@@ -102,7 +100,7 @@ object TestUtils extends Matchers {
                 services = fixIdsForServices(a.appResources.services),
                 disk = a.appResources.disk.map(d => d.copy(id = FixedDiskId))
               )
-            ) ===
+            ) ==
               c.copy(
                 id = FixedId,
                 appResources = c.appResources.copy(
@@ -129,7 +127,7 @@ object TestUtils extends Matchers {
   implicit val serviceEq: Equality[KubernetesService] =
     (a: KubernetesService, b: Any) =>
       b match {
-        case c: KubernetesService => fixIdForService(a) === fixIdForService(c)
+        case c: KubernetesService => fixIdForService(a) == fixIdForService(c)
         case _                    => false
       }
 

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpSamDAOSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpSamDAOSpec.scala
@@ -22,6 +22,7 @@ import org.http4s.client.Client
 import org.http4s.client.middleware.{Retry, RetryPolicy}
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.flatspec.AnyFlatSpec
+import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 import scalacache.caffeine.CaffeineCache
 
@@ -37,7 +38,7 @@ class HttpSamDAOSpec extends AnyFlatSpec with LeonardoTestSuite with BeforeAndAf
                                 10,
                                 ServiceAccountProviderConfig(Paths.get("test"), WorkbenchEmail("test"))
   )
-  implicit def unsafeLogger = Slf4jLogger.getLogger[IO]
+  implicit def unsafeLogger: Logger[IO] = Slf4jLogger.getLogger[IO]
   val underlyingPetTokenCache = Caffeine
     .newBuilder()
     .maximumSize(httpSamDaoConfig.petCacheMaxSize)

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/MockSamDAO.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/MockSamDAO.scala
@@ -42,7 +42,7 @@ class MockSamDAO extends SamDAO[IO] {
   var workspaceCreators: Map[Authorization, Set[(AppSamResourceId, SamPolicyName)]] = Map.empty
 
   // we don't care much about traceId in unit tests, hence providing a constant UUID here
-  implicit val traceId = Ask.const[IO, TraceId](TraceId(UUID.randomUUID()))
+  implicit val traceId: Ask[IO, TraceId] = Ask.const[IO, TraceId](TraceId(UUID.randomUUID()))
 
   override def registerLeo(implicit ev: Ask[IO, TraceId]): IO[Unit] = IO.unit
   override def hasResourcePermissionUnchecked(resourceType: SamResourceType,
@@ -390,9 +390,7 @@ class MockSamDAO extends SamDAO[IO] {
     ev: Ask[IO, TraceId]
   ): IO[Option[UserSubjectId]] = IO.pure(None)
 
-  def addUserToProject(creatorEmail: WorkbenchEmail, googleProject: GoogleProject)(implicit
-    ev: Ask[IO, TraceId]
-  ): IO[Unit] = {
+  def addUserToProject(creatorEmail: WorkbenchEmail, googleProject: GoogleProject): IO[Unit] = {
     val authHeader = userEmailToAuthorization(creatorEmail)
     val project = ProjectSamResourceId(googleProject)
     IO {

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/TestComponent.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/TestComponent.scala
@@ -35,7 +35,7 @@ import scala.concurrent.duration._
 trait TestComponent extends LeonardoTestSuite with ScalaFutures with GcsPathUtils with BeforeAndAfterAll {
 
   this: TestSuite =>
-  implicit override val patienceConfig = PatienceConfig(timeout = scaled(Span(30, Seconds)))
+  implicit override val patienceConfig: PatienceConfig = PatienceConfig(timeout = scaled(Span(30, Seconds)))
 
   val defaultServiceAccountKeyId = ServiceAccountKeyId("123")
 

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/ProxyRoutesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/ProxyRoutesSpec.scala
@@ -51,7 +51,7 @@ class ProxyRoutesSpec
     with GcsPathUtils
     with TestLeoRoutes
     with MockitoSugar {
-  implicit val patience = PatienceConfig(timeout = scaled(Span(30, Seconds)))
+  implicit val patience: PatienceConfig = PatienceConfig(timeout = scaled(Span(30, Seconds)))
   override def proxyConfig: ProxyConfig = CommonTestData.proxyConfig
 
   val clusterName = "test"

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/StatusRoutesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/StatusRoutesSpec.scala
@@ -33,7 +33,7 @@ class StatusRoutesSpec
     with TestComponent
     with TestLeoRoutes
     with MockitoSugar {
-  implicit override val patienceConfig = PatienceConfig(timeout = 1.second)
+  implicit override val patienceConfig: PatienceConfig = PatienceConfig(timeout = 1.second)
 
   "GET /version" should "give 200 for ok" in {
     eventually {

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/TestLeoRoutes.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/TestLeoRoutes.scala
@@ -44,7 +44,7 @@ trait TestLeoRoutes {
     with LeonardoTestSuite
     with TestComponent
     with MockitoSugar =>
-  implicit val timeout = RouteTestTimeout(20 seconds)
+  implicit val timeout: RouteTestTimeout = RouteTestTimeout(20 seconds)
 
   // Set up the mock directoryDAO to have the Google group used to grant permission to users
   // to pull the custom dataproc image

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoMetricsMonitorSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoMetricsMonitorSpec.scala
@@ -35,6 +35,7 @@ import org.broadinstitute.dsde.workbench.leonardo.{
   KubernetesServiceKindName,
   LeonardoTestSuite,
   NetworkFields,
+  RuntimeContainerServiceType,
   RuntimeImage,
   RuntimeImageType,
   RuntimeMetrics,
@@ -54,6 +55,7 @@ import org.scalatestplus.mockito.MockitoSugar
 
 import java.time.Instant
 import java.util.UUID
+import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 import scala.jdk.CollectionConverters._
 
@@ -85,9 +87,9 @@ class LeoMetricsMonitorSpec extends AnyFlatSpec with LeonardoTestSuite with Test
   val containerService = setUpMockAzureContainerService
 
   // Test object
-  implicit val clusterToolToToolDao =
+  implicit val clusterToolToToolDao: RuntimeContainerServiceType => ToolDAO[IO, RuntimeContainerServiceType] =
     ToolDAO.clusterToolToToolDao(jupyterDAO, welderDAO, rstudioDAO)
-  implicit val ec = cats.effect.unsafe.IORuntime.global.compute
+  implicit val ec: ExecutionContext = cats.effect.unsafe.IORuntime.global.compute
   val config = LeoMetricsMonitorConfig(true, 1 minute, true)
   val leoMetricsMonitor = new LeoMetricsMonitor[IO](
     config,

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/AKSManualTest.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/AKSManualTest.scala
@@ -42,10 +42,11 @@ import org.broadinstitute.dsde.workbench.leonardo.{
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
 import org.broadinstitute.dsp.{ChartName, HelmInterpreter, Release}
 import org.scalatestplus.mockito.MockitoSugar.mock
+import org.typelevel.log4cats.StructuredLogger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 
 import java.util.UUID
-import scala.concurrent.ExecutionContext
+import scala.concurrent.{ExecutionContext, ExecutionContextExecutor}
 
 /**
  * Manual test for deploying CoA helm chart against an AKS cluster. Usage:
@@ -82,8 +83,8 @@ object AKSManualTest {
   val appSamResourceId = AppSamResourceId("sam-id", None)
 
   // Implicit dependencies
-  implicit val logger = Slf4jLogger.getLogger[IO]
-  implicit val executionContext = ExecutionContext.global
+  implicit val logger: StructuredLogger[IO] = Slf4jLogger.getLogger[IO]
+  implicit val executionContext: ExecutionContextExecutor = ExecutionContext.global
 
   /** Initializes DbReference */
   def getDbRef: Resource[IO, DbReference[IO]] = for {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,16 +17,16 @@ object Dependencies {
   val munitCatsEffectV = "1.0.7"
   val pact4sV = "0.9.0"
 
-  private val workbenchLibsHash = "128901e"
+  private val workbenchLibsHash = "f87cad5"
   val serviceTestV = s"4.0-$workbenchLibsHash"
   val workbenchModelV = s"0.19-$workbenchLibsHash"
 
   // TODO update to 0.26 - DataprocInterpreter relies on deprecated class MemberType
   val workbenchGoogleV = s"0.23-4b46aac"
-  val workbenchGoogle2V = s"0.32-$workbenchLibsHash"
-  val workbenchOpenTelemetryV = s"0.6-$workbenchLibsHash"
+  val workbenchGoogle2V = s"0.33-$workbenchLibsHash"
+  val workbenchOpenTelemetryV = s"0.7-$workbenchLibsHash"
   val workbenchOauth2V = s"0.5-$workbenchLibsHash"
-  val workbenchAzureV = s"0.5-$workbenchLibsHash"
+  val workbenchAzureV = s"0.6-$workbenchLibsHash"
 
   val helmScalaSdkV = "0.0.20"
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,16 +17,16 @@ object Dependencies {
   val munitCatsEffectV = "1.0.7"
   val pact4sV = "0.9.0"
 
-  private val workbenchLibsHash = "63d2d78"
-  val serviceTestV = s"3.1-$workbenchLibsHash"
-  val workbenchModelV = s"0.18-$workbenchLibsHash"
+  private val workbenchLibsHash = "128901e"
+  val serviceTestV = s"4.0-$workbenchLibsHash"
+  val workbenchModelV = s"0.19-$workbenchLibsHash"
 
   // TODO update to 0.26 - DataprocInterpreter relies on deprecated class MemberType
   val workbenchGoogleV = s"0.23-4b46aac"
-  val workbenchGoogle2V = s"0.30-$workbenchLibsHash"
-  val workbenchOpenTelemetryV = s"0.5-$workbenchLibsHash"
-  val workbenchOauth2V = s"0.4-$workbenchLibsHash"
-  val workbenchAzureV = s"0.4-$workbenchLibsHash"
+  val workbenchGoogle2V = s"0.32-$workbenchLibsHash"
+  val workbenchOpenTelemetryV = s"0.6-$workbenchLibsHash"
+  val workbenchOauth2V = s"0.5-$workbenchLibsHash"
+  val workbenchAzureV = s"0.5-$workbenchLibsHash"
 
   val helmScalaSdkV = "0.0.20"
 


### PR DESCRIPTION
<!-- Welcome to your Leonardo pull request! -->
<!-- Contributor guidelines: https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md -->

https://broadworkbench.atlassian.net/browse/WOR-1218

<!-- ## Dependencies -->
<!-- Include any dependent tickets and describe the relationship. Include any other relevant Jira tickets. -->

## Summary of changes

@jsaun was trying to update wb-libs/workbench-azure dependency for https://github.com/broadinstitute/workbench-libs/pull/1494. However several of the wb-libs libraries were out of date, and updating them was causing breaking changes.

This is my attempt to update wb-libs to the latest and fix breaking changes. :) I also fixed a bunch of compiler warnings in tests, mostly related to implicits declared without a type.

### What

- Update each wb-libs module to the latest
- Fixed breaking changes related to fs2 `Files`
- Fixed compiler warnings, mostly in tests related to implicits not declaring types

### Why

- The impetus for this was to switch to using [admin credentials for AKS](https://github.com/broadinstitute/workbench-libs/pull/1494) due to a MSFT policy

## Testing these changes

### What to test

- Will rely on unit/automation tests

<!-- ### Test data -->

### Who tested and where

- [x] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [x] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
