### PR TITLE
[WOR-1250] Pass WSM resources by name

### DIFF
--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/WsmApiClientProvider.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/WsmApiClientProvider.scala
@@ -1,7 +1,13 @@
 package org.broadinstitute.dsde.workbench.leonardo.dao
 
-import bio.terra.workspace.api.{ControlledAzureResourceApi, ResourceApi}
+import bio.terra.workspace.api.ControlledAzureResourceApi
 import bio.terra.workspace.client.ApiClient
+import cats.effect.Async
+import cats.mtl.Ask
+import cats.syntax.all._
+import io.opencensus.trace.Tracing
+import org.broadinstitute.dsde.workbench.leonardo.AppContext
+import org.glassfish.jersey.client.ClientConfig
 import org.http4s.Uri
 
 /**
@@ -11,27 +17,26 @@ import org.http4s.Uri
  * Based on `org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/WorkspaceManagerApiClientProvider.scala`
  *
  */
-trait WsmApiClientProvider {
-  def getControlledAzureResourceApi(token: String): ControlledAzureResourceApi
-  def getResourceApi(token: String): ResourceApi
+trait WsmApiClientProvider[F[_]] {
+  def getControlledAzureResourceApi(token: String)(implicit ev: Ask[F, AppContext]): F[ControlledAzureResourceApi]
 }
 
-class HttpWsmClientProvider(baseWorkspaceManagerUrl: Uri) extends WsmApiClientProvider {
-  private def getApiClient: ApiClient = {
-    val client: ApiClient = new ApiClient()
-    client.setBasePath(baseWorkspaceManagerUrl.renderString)
-    client
-  }
+class HttpWsmClientProvider[F[_]](baseWorkspaceManagerUrl: Uri)(implicit F: Async[F]) extends WsmApiClientProvider[F] {
+  private def getApiClient(token: String)(implicit ev: Ask[F, AppContext]): F[ApiClient] =
+    for {
+      ctx <- ev.ask
+      client = new ApiClient() {
+        override def performAdditionalClientConfiguration(clientConfig: ClientConfig): Unit = {
+          super.performAdditionalClientConfiguration(clientConfig)
+          ctx.span.foreach { span =>
+            clientConfig.register(Tracing.getTracer.withSpan(span))
+          }
+        }
+      }
+      _ = client.setBasePath(baseWorkspaceManagerUrl.renderString)
+      _ = client.setAccessToken(token)
+    } yield client
 
-  def getControlledAzureResourceApi(token: String): ControlledAzureResourceApi = {
-    val apiClient = getApiClient
-    apiClient.setAccessToken(token)
-    new ControlledAzureResourceApi(apiClient)
-  }
-
-  def getResourceApi(token: String): ResourceApi = {
-    val apiClient = getApiClient
-    apiClient.setAccessToken(token)
-    new ResourceApi(apiClient)
-  }
+  def getControlledAzureResourceApi(token: String)(implicit ev: Ask[F, AppContext]): F[ControlledAzureResourceApi] =
+    getApiClient(token).map(apiClient => new ControlledAzureResourceApi(apiClient))
 }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/Boot.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/Boot.scala
@@ -947,7 +947,7 @@ final case class AppDependencies[F[_]](
   cromwellDAO: CromwellDAO[F],
   hailBatchDAO: HailBatchDAO[F],
   listenerDAO: ListenerDAO[F],
-  wsmClientProvider: HttpWsmClientProvider,
+  wsmClientProvider: HttpWsmClientProvider[F],
   kubeAlg: KubernetesAlgebra[F],
   azureContainerService: AzureContainerService[F]
 )

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeV2ServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeV2ServiceInterp.scala
@@ -42,7 +42,7 @@ class RuntimeV2ServiceInterp[F[_]: Parallel](config: RuntimeServiceConfig,
                                              samDAO: SamDAO[F],
                                              publisherQueue: Queue[F, LeoPubsubMessage],
                                              dateAccessUpdaterQueue: Queue[F, UpdateDateAccessMessage],
-                                             wsmClientProvider: WsmApiClientProvider
+                                             wsmClientProvider: WsmApiClientProvider[F]
 )(implicit
   F: Async[F],
   dbReference: DbReference[F],
@@ -317,7 +317,7 @@ class RuntimeV2ServiceInterp[F[_]: Parallel](config: RuntimeServiceConfig,
       }
 
       // get wsm api
-      wsmAzureResourceApi = wsmClientProvider.getControlledAzureResourceApi(userInfo.accessToken.token)
+      wsmAzureResourceApi <- wsmClientProvider.getControlledAzureResourceApi(userInfo.accessToken.token)
       wsmResourceId = WsmControlledResourceId(UUID.fromString(runtime.internalId))
 
       // if the vm is found in WSM and has a deletable state,

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/MockWsmApiClientProvider.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/MockWsmApiClientProvider.scala
@@ -1,14 +1,16 @@
 package org.broadinstitute.dsde.workbench.leonardo.dao
 
 import bio.terra.workspace.api._
+import cats.effect.IO
+import cats.mtl.Ask
+import org.broadinstitute.dsde.workbench.leonardo.AppContext
 import org.scalatestplus.mockito.MockitoSugar.mock
 
-class MockWsmClientProvider(controlledAzureResourceApi: ControlledAzureResourceApi = mock[ControlledAzureResourceApi],
-                            resourceApi: ResourceApi = mock[ResourceApi]
-) extends WsmApiClientProvider {
+class MockWsmClientProvider(controlledAzureResourceApi: ControlledAzureResourceApi = mock[ControlledAzureResourceApi])
+    extends WsmApiClientProvider[IO] {
 
-  override def getControlledAzureResourceApi(token: String): ControlledAzureResourceApi =
-    controlledAzureResourceApi
-
-  override def getResourceApi(token: String): ResourceApi = resourceApi
+  override def getControlledAzureResourceApi(token: String)(implicit
+    ev: Ask[IO, AppContext]
+  ): IO[ControlledAzureResourceApi] =
+    IO.pure(controlledAzureResourceApi)
 }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/TestLeoRoutes.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/TestLeoRoutes.scala
@@ -62,7 +62,7 @@ trait TestLeoRoutes {
 
   val mockGoogleIamDAO = new MockGoogleIamDAO
   val wsmDao = new MockWsmDAO
-  val wsmClientProvider = mock[HttpWsmClientProvider]
+  val wsmClientProvider = mock[HttpWsmClientProvider[IO]]
   val mockPetGoogleStorageDAO: String => GoogleStorageDAO = _ => {
     val petMock = new MockGoogleStorageDAO
     petMock.buckets += userScriptBucketName -> Set(

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeV2ServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeV2ServiceInterpSpec.scala
@@ -73,7 +73,7 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
                  allowlistAuthProvider: AllowlistAuthProvider = allowListAuthProvider,
                  wsmDao: WsmDao[IO] = wsmDao,
                  dateAccessedQueue: Queue[IO, UpdateDateAccessMessage] = QueueFactory.makeDateAccessedQueue(),
-                 wsmClientProvider: WsmApiClientProvider = wsmClientProvider
+                 wsmClientProvider: WsmApiClientProvider[IO] = wsmClientProvider
   ) =
     new RuntimeV2ServiceInterp[IO](serviceConfig,
                                    allowlistAuthProvider,

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/AKSInterpreterSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/AKSInterpreterSpec.scala
@@ -301,7 +301,7 @@ class AKSInterpreterSpec extends AnyFlatSpecLike with TestComponent with Leonard
       saveApp <- IO(app.save())
 
       appId = saveApp.id
-      owner = UUID.randomUUID()
+      owner = "id"
 
       createdDatabase <- aksInterp.createWsmDatabaseResource(saveApp,
                                                              workspaceId,
@@ -348,8 +348,8 @@ class AKSInterpreterSpec extends AnyFlatSpecLike with TestComponent with Leonard
       saveApp <- IO(app.save())
 
       appId = saveApp.id
-      databases = List(UUID.randomUUID(), UUID.randomUUID())
-      identity = UUID.randomUUID()
+      databases = List("db1", "db2")
+      identity = "id"
 
       createdNamespace <- aksInterp.createWsmKubernetesNamespaceResource(saveApp,
                                                                          workspaceId,
@@ -540,8 +540,8 @@ class AKSInterpreterSpec extends AnyFlatSpecLike with TestComponent with Leonard
     sam
   }
 
-  private def setUpMockWsmApiClientProvider: (WsmApiClientProvider, ControlledAzureResourceApi) = {
-    val wsm = mock[WsmApiClientProvider]
+  private def setUpMockWsmApiClientProvider: (WsmApiClientProvider[IO], ControlledAzureResourceApi) = {
+    val wsm = mock[WsmApiClientProvider[IO]]
     val api = mock[ControlledAzureResourceApi]
     val resourceApi = mock[ResourceApi]
     val dbsByJob = mutable.Map.empty[String, CreateControlledAzureDatabaseRequestBody]
@@ -642,8 +642,8 @@ class AKSInterpreterSpec extends AnyFlatSpecLike with TestComponent with Leonard
         .attributes(
           new AzureKubernetesNamespaceAttributes()
             .kubernetesNamespace("ns")
-            .databases(List(UUID.randomUUID()).asJava)
-            .managedIdentity(UUID.randomUUID())
+            .databases(List("db").asJava)
+            .managedIdentity("id")
             .kubernetesServiceAccount("ksa-1")
         )
     }
@@ -667,11 +667,8 @@ class AKSInterpreterSpec extends AnyFlatSpecLike with TestComponent with Leonard
       resourceApi.enumerateResources(any, any, any, any, any)
     } thenReturn new ResourceList()
     when {
-      wsm.getControlledAzureResourceApi(any)
-    } thenReturn api
-    when {
-      wsm.getResourceApi(any)
-    } thenReturn resourceApi
+      wsm.getControlledAzureResourceApi(any)(any)
+    } thenReturn IO.pure(api)
     (wsm, api)
   }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -144,7 +144,7 @@ object Dependencies {
   val pact4sCirce =       "io.github.jbwheatley"  %% "pact4s-circe"     % pact4sV
   val okHttp =            "com.squareup.okhttp3"  % "okhttp"            % "4.11.0"
 
-  val workSpaceManagerV = "0.254.903-SNAPSHOT"
+  val workSpaceManagerV = "0.254.906-rt-bump-SNAPSHOT"
 
   def excludeJakartaActivationApi = ExclusionRule("jakarta.activation", "jakarta.activation-api")
   def excludeJakartaXmlBindApi = ExclusionRule("jakarta.xml.bind", "jakarta.xml.bind-api")


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/WOR-1250

Bonus: pass optional `span` to WSM for tracing.

## Dependencies
Depends on https://github.com/DataBiosphere/terra-workspace-manager/pull/1467

## Summary of changes

WSM supports pass-by-name in addition to pass-by-id when linking databases, identities, and kubernetes namespaces. Switch Leo to pass-by-name, which is cleaner and involves fewer API calls.

### What

-

### Why

-

## Testing these changes

### What to test

- <!-- Test case 1 -->

<!-- ### Test data -->

### Who tested and where

- [ ] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [ ] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
