### PR TITLE
[IA-4551] Adding delay before calling helm install for Galaxy

### DIFF
--- a/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestSuite.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestSuite.scala
@@ -37,7 +37,7 @@ trait LeonardoTestSuite extends Matchers {
     CaffeineCache[IO, KubernetesClusterId, Semaphore[IO]](underlyingCache)
   val nodepoolLock = KeyLock[IO, KubernetesClusterId](cache)
 
-  def withInfiniteStream(stream: Stream[IO, Unit], validations: IO[Assertion], maxRetry: Int = 30): IO[Assertion] = {
+  def withInfiniteStream(stream: Stream[IO, Unit], validations: IO[Assertion], maxRetry: Int = 120): IO[Assertion] = {
     val process = Stream.eval(Deferred[IO, Assertion]).flatMap { signalToStop =>
       val accumulator = Accumulator(maxRetry, None)
       val signal = Stream.unfoldEval(accumulator) { acc =>

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
@@ -1418,7 +1418,7 @@ class GKEInterpreter[F[_]](
       // TODO potentially add other status checks for pod readiness, beyond just HTTP polling the galaxy-web service
       // Wait a bit before starting polling for the app status check as the certificates might not be quite ready yet
       // This seems to only impact galaxy, See https://broadworkbench.atlassian.net/browse/IA-4551
-      _ <- F.sleep(5 seconds)
+      _ <- F.sleep(10 seconds)
       isDone <- streamFUntilDone(
         appDao.isProxyAvailable(googleProject, appName, ServiceName("galaxy")),
         config.monitorConfig.createApp.maxAttempts,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
@@ -1418,7 +1418,7 @@ class GKEInterpreter[F[_]](
       // TODO potentially add other status checks for pod readiness, beyond just HTTP polling the galaxy-web service
       // Wait a bit before starting polling for the app status check as the certificates might not be quite ready yet
       // This seems to only impact galaxy, See https://broadworkbench.atlassian.net/browse/IA-4551
-      _ <- F.sleep(10 seconds)
+      _ <- F.sleep(30 seconds)
       isDone <- streamFUntilDone(
         appDao.isProxyAvailable(googleProject, appName, ServiceName("galaxy")),
         config.monitorConfig.createApp.maxAttempts,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
@@ -430,8 +430,6 @@ class GKEInterpreter[F[_]](
                 traceId = Some(ctx.traceId)
               )
             )
-            // TESTING ADDING DELAY BEFORE GALAXY CREATION AS CLUSTER MIGHT NOT BE READY
-            _ <- F.sleep(60 seconds)
             _ <- installGalaxy(
               helmAuthContext,
               app.appName,
@@ -1418,6 +1416,8 @@ class GKEInterpreter[F[_]](
       )
       // Poll galaxy until it starts up
       // TODO potentially add other status checks for pod readiness, beyond just HTTP polling the galaxy-web service
+      // TESTING ADDING DELAY BEFORE POLLING GALAXY AS CERTS MIGHT NOT BE READY YET?
+      _ <- F.sleep(60 seconds)
       isDone <- streamFUntilDone(
         appDao.isProxyAvailable(googleProject, appName, ServiceName("galaxy")),
         config.monitorConfig.createApp.maxAttempts,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
@@ -1418,7 +1418,7 @@ class GKEInterpreter[F[_]](
       // TODO potentially add other status checks for pod readiness, beyond just HTTP polling the galaxy-web service
       // Wait a bit before starting polling for the app status check as the certificates might not be quite ready yet
       // This seems to only impact galaxy, See https://broadworkbench.atlassian.net/browse/IA-4551
-      _ <- F.sleep(30 seconds)
+      _ <- F.sleep(60 seconds)
       isDone <- streamFUntilDone(
         appDao.isProxyAvailable(googleProject, appName, ServiceName("galaxy")),
         config.monitorConfig.createApp.maxAttempts,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
@@ -431,7 +431,7 @@ class GKEInterpreter[F[_]](
               )
             )
             // TESTING ADDING DELAY BEFORE GALAXY CREATION AS CLUSTER MIGHT NOT BE READY
-            _ <- F.delay(60 seconds)
+            _ <- F.sleep(60 seconds)
             _ <- installGalaxy(
               helmAuthContext,
               app.appName,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
@@ -430,6 +430,8 @@ class GKEInterpreter[F[_]](
                 traceId = Some(ctx.traceId)
               )
             )
+            // TESTING ADDING DELAY BEFORE GALAXY CREATION AS CLUSTER MIGHT NOT BE READY
+            _ <- F.delay(60 seconds)
             _ <- installGalaxy(
               helmAuthContext,
               app.appName,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
@@ -1416,8 +1416,9 @@ class GKEInterpreter[F[_]](
       )
       // Poll galaxy until it starts up
       // TODO potentially add other status checks for pod readiness, beyond just HTTP polling the galaxy-web service
-      // TESTING ADDING DELAY BEFORE POLLING GALAXY AS CERTS MIGHT NOT BE READY YET?
-      _ <- F.sleep(60 seconds)
+      // Wait a bit before starting polling for the app status check as the certificates might not be quite ready yet
+      // This seems to only impact galaxy, See https://broadworkbench.atlassian.net/browse/IA-4551
+      _ <- F.sleep(5 seconds)
       isDone <- streamFUntilDone(
         appDao.isProxyAvailable(googleProject, appName, ServiceName("galaxy")),
         config.monitorConfig.createApp.maxAttempts,

--- a/http/src/test/resources/reference.conf
+++ b/http/src/test/resources/reference.conf
@@ -99,7 +99,7 @@ pubsub {
     createApp {
       interval = 0 seconds
       max-attempts = 120
-      interruptAfter = 30 seconds
+      interruptAfter = 60 seconds
     }
     deleteApp {
       initial-delay = 0 seconds

--- a/http/src/test/resources/reference.conf
+++ b/http/src/test/resources/reference.conf
@@ -99,7 +99,7 @@ pubsub {
     createApp {
       interval = 0 seconds
       max-attempts = 120
-      interruptAfter = 120 seconds
+      interruptAfter = 30 seconds
     }
     deleteApp {
       initial-delay = 0 seconds

--- a/http/src/test/resources/reference.conf
+++ b/http/src/test/resources/reference.conf
@@ -99,7 +99,7 @@ pubsub {
     createApp {
       interval = 0 seconds
       max-attempts = 120
-      interruptAfter = 60 seconds
+      interruptAfter = 120 seconds
     }
     deleteApp {
       initial-delay = 0 seconds


### PR DESCRIPTION
<!-- Welcome to your Leonardo pull request! -->
<!-- Contributor guidelines: https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md -->

__Jira ticket__: https://broadworkbench.atlassian.net/browse/IA-4551

<!-- ## Dependencies -->
<!-- Include any dependent tickets and describe the relationship. Include any other relevant Jira tickets. -->

## Summary of changes

<!-- Please give an abridged version of the ticket description here and/or fill out the following fields. -->

### What

- Adds a small delay after the galaxy helm install step and before polling for the app liveliness

### Why

- it seems like the SSL certificates were not quite ready yet when we try to poll immediately after the helm install step

## Testing these changes

### What to test

I tested on my BEE, and galaxy apps successfully started in a brand new workspace 👍 
I am currently trying to use a smaller delay and will fix the unit tests accordingly but would appreciate a 👍 now so it can quickly get to Dev today and prod early next week :)

<!-- ### Test data -->

### Who tested and where

- [ ] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [ ] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
