### PR TITLE
Final phase of WOR-1250: pass resources by name to WSM

### DIFF
--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -254,7 +254,7 @@ azure {
      # All app versions excluded up until the switch to WSM-controlled KubernetesNamespace
      # https://github.com/DataBiosphere/leonardo/pull/3666
      chart-versions-to-exclude-from-updates = [
-       "0.2.345",
+       "0.2.341",
        "0.2.338",
        "0.2.334",
        "0.2.332",

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/WsmApiClientProvider.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/WsmApiClientProvider.scala
@@ -1,7 +1,7 @@
 package org.broadinstitute.dsde.workbench.leonardo.dao
 
 import bio.terra.common.tracing.JerseyTracingFilter
-import bio.terra.workspace.api.{ControlledAzureResourceApi, ResourceApi}
+import bio.terra.workspace.api.ControlledAzureResourceApi
 import bio.terra.workspace.client.ApiClient
 import cats.effect.Async
 import cats.mtl.Ask
@@ -21,7 +21,6 @@ import org.http4s.Uri
  */
 trait WsmApiClientProvider[F[_]] {
   def getControlledAzureResourceApi(token: String)(implicit ev: Ask[F, AppContext]): F[ControlledAzureResourceApi]
-  def getResourceApi(token: String)(implicit ev: Ask[F, AppContext]): F[ResourceApi]
 }
 
 class HttpWsmClientProvider[F[_]](baseWorkspaceManagerUrl: Uri)(implicit F: Async[F]) extends WsmApiClientProvider[F] {
@@ -45,7 +44,4 @@ class HttpWsmClientProvider[F[_]](baseWorkspaceManagerUrl: Uri)(implicit F: Asyn
     ev: Ask[F, AppContext]
   ): F[ControlledAzureResourceApi] =
     getApiClient(token).map(apiClient => new ControlledAzureResourceApi(apiClient))
-
-  override def getResourceApi(token: String)(implicit ev: Ask[F, AppContext]): F[ResourceApi] =
-    getApiClient(token).map(apiClient => new ResourceApi(apiClient))
 }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/MockWsmApiClientProvider.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/MockWsmApiClientProvider.scala
@@ -6,14 +6,11 @@ import cats.mtl.Ask
 import org.broadinstitute.dsde.workbench.leonardo.AppContext
 import org.scalatestplus.mockito.MockitoSugar.mock
 
-class MockWsmClientProvider(controlledAzureResourceApi: ControlledAzureResourceApi = mock[ControlledAzureResourceApi],
-                            resourceApi: ResourceApi = mock[ResourceApi]
-) extends WsmApiClientProvider[IO] {
+class MockWsmClientProvider(controlledAzureResourceApi: ControlledAzureResourceApi = mock[ControlledAzureResourceApi])
+    extends WsmApiClientProvider[IO] {
 
   override def getControlledAzureResourceApi(token: String)(implicit
     ev: Ask[IO, AppContext]
   ): IO[ControlledAzureResourceApi] =
     IO.pure(controlledAzureResourceApi)
-
-  override def getResourceApi(token: String)(implicit ev: Ask[IO, AppContext]): IO[ResourceApi] = IO.pure(resourceApi)
 }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/ConfigReaderSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/ConfigReaderSpec.scala
@@ -89,7 +89,7 @@ class ConfigReaderSpec extends AnyFlatSpec with Matchers {
           dockstoreBaseUrl = new URL("https://staging.dockstore.org/"),
           databaseEnabled = false,
           chartVersionsToExcludeFromUpdates = List(
-            ChartVersion("0.2.345"),
+            ChartVersion("0.2.341"),
             ChartVersion("0.2.338"),
             ChartVersion("0.2.334"),
             ChartVersion("0.2.332"),

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/AKSInterpreterSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/AKSInterpreterSpec.scala
@@ -662,16 +662,9 @@ class AKSInterpreterSpec extends AnyFlatSpecLike with TestComponent with Leonard
     } thenReturn {
       new DeleteControlledAzureResourceResult().jobReport(new JobReport().status(JobReport.StatusEnum.SUCCEEDED))
     }
-    // Enumerate resources
-    when {
-      resourceApi.enumerateResources(any, any, any, any, any)
-    } thenReturn new ResourceList()
     when {
       wsm.getControlledAzureResourceApi(any)(any)
     } thenReturn IO.pure(api)
-    when {
-      wsm.getResourceApi(any)(any)
-    } thenReturn IO.pure(resourceApi)
     (wsm, api)
   }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -144,7 +144,7 @@ object Dependencies {
   val pact4sCirce =       "io.github.jbwheatley"  %% "pact4s-circe"     % pact4sV
   val okHttp =            "com.squareup.okhttp3"  % "okhttp"            % "4.11.0"
 
-  val workSpaceManagerV = "0.254.913-SNAPSHOT"
+  val workSpaceManagerV = "0.254.916-SNAPSHOT"
   val terraCommonLibV = "0.0.94-SNAPSHOT"
 
   def excludeJakartaActivationApi = ExclusionRule("jakarta.activation", "jakarta.activation-api")


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/WOR-1250

<!-- ## Dependencies -->
<!-- Include any dependent tickets and describe the relationship. Include any other relevant Jira tickets. -->

## Summary of changes

Final phase of WOR-1250. Now that the client is updated and https://github.com/DataBiosphere/terra-workspace-manager/pull/1467 is merged, simplify some Leo code by passing resources by-name.

### What

-

### Why

- This was a multi-phase effort to simplify some WSM/Leo interaction, and make WSM resource deletion more robust and less interdependent.

## Testing these changes

### What to test

- <!-- Test case 1 -->

<!-- ### Test data -->

### Who tested and where

- [ ] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [ ] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
