### PR TITLE
[PROD-869] Bumping the subscriber timeout + adding logging

### DIFF
--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -1028,7 +1028,7 @@ pubsub {
   #pubsubGoogleProject = "broad-dsde-dev"
   #topicName = "leonardo-pubsub"
   queueSize = 100
-  ackDeadLine = 5 minutes
+  ackDeadLine = 10 minutes // TODO change back to 5 minutes when PROD-869 is resolved
 
   kubernetes-monitor {
     createNodepool {
@@ -1090,7 +1090,8 @@ pubsub {
 
   subscriber {
     concurrency = 100
-    timeout = 295 seconds // slightly less than ackDeadline
+    // TODO change back to 5 minutes when PROD-869 is resolved
+    timeout = 595 seconds // slightly less than ackDeadline
 
     persistent-disk-monitor {
       create {

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/LeoPublisher.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/LeoPublisher.scala
@@ -51,7 +51,7 @@ final class LeoPublisher[F[_]](
             .handleErrorWith { t =>
               val loggingCtx = event.traceId.map(t => Map("traceId" -> t.asString)).getOrElse(Map.empty)
               Stream
-                .eval(logger.error(loggingCtx, t)(s"Failed to publish message of type ${event.messageType.asString}"))
+                .eval(logger.error(loggingCtx, t)(s"Failed to publish message of type ${event.messageType.asString}, message: $event"))
             }
       }
     Stream(publishingStream, recordMetrics).covary[F].parJoin(2)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/LeoPublisher.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/LeoPublisher.scala
@@ -51,7 +51,11 @@ final class LeoPublisher[F[_]](
             .handleErrorWith { t =>
               val loggingCtx = event.traceId.map(t => Map("traceId" -> t.asString)).getOrElse(Map.empty)
               Stream
-                .eval(logger.error(loggingCtx, t)(s"Failed to publish message of type ${event.messageType.asString}, message: $event"))
+                .eval(
+                  logger.error(loggingCtx, t)(
+                    s"Failed to publish message of type ${event.messageType.asString}, message: $event"
+                  )
+                )
             }
       }
     Stream(publishingStream, recordMetrics).covary[F].parJoin(2)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
@@ -357,14 +357,14 @@ class LeoPubsubMessageSubscriber[F[_]](
     for {
       ctx <- ev.ask
       _ <- logger.info(
-        s"StopRuntimeMessage timing: About to get the cluster by id, [runtimeId = ${msg.runtimeId}, traceId = ${ctx.traceId}, time = ${nowInstant.toString}]"
+        s"StopRuntimeMessage timing: About to get the cluster by id, [runtimeId = ${msg.runtimeId}, traceId = ${ctx.traceId.asString}, time = ${ctx.now.toString}]"
       )
       runtimeOpt <- clusterQuery.getClusterById(msg.runtimeId).transaction
       runtime <- runtimeOpt.fold(
         F.raiseError[Runtime](PubsubHandleMessageError.ClusterNotFound(msg.runtimeId, msg))
       )(F.pure)
       _ <- logger.info(
-        s"StopRuntimeMessage timing: Got the cluster, [runtime = ${runtime.runtimeName} traceId = ${ctx.traceId}, time = ${nowInstant.toString}]"
+        s"StopRuntimeMessage timing: Got the cluster, [runtime = ${runtime.runtimeName}, traceId = ${ctx.traceId.asString}, time = ${ctx.now.toString}]"
       )
 
       _ <-
@@ -374,11 +374,11 @@ class LeoPubsubMessageSubscriber[F[_]](
           )
         else F.unit
       _ <- logger.info(
-        s"StopRuntimeMessage timing: About to get the runtimeConfig, [runtime = ${runtime.runtimeName}, traceId = ${ctx.traceId}, time = ${nowInstant.toString}]"
+        s"StopRuntimeMessage timing: About to get the runtimeConfig, [runtime = ${runtime.runtimeName}, traceId = ${ctx.traceId.asString}, time = ${ctx.now.toString}]"
       )
       runtimeConfig <- RuntimeConfigQueries.getRuntimeConfig(runtime.runtimeConfigId).transaction
       _ <- logger.info(
-        s"StopRuntimeMessage timing: Got the runtimeConfig, [runtime = ${runtime.runtimeName}, traceId = ${ctx.traceId}, time = ${nowInstant.toString}]"
+        s"StopRuntimeMessage timing: Got the runtimeConfig, [runtime = ${runtime.runtimeName}, traceId = ${ctx.traceId.asString}, time = ${ctx.now.toString}]"
       )
       _ <- runtime.cloudContext match {
         case CloudContext.Gcp(_) =>
@@ -401,7 +401,7 @@ class LeoPubsubMessageSubscriber[F[_]](
                 runtimeConfig.cloudService.process(runtime.id, RuntimeStatus.Stopping, None).compile.drain
             }
             _ <- logger.info(
-              s"StopRuntimeMessage timing: Polling the stopRuntime, [runtime = ${runtime.runtimeName}, traceId = ${ctx.traceId}, time = ${nowInstant.toString}]"
+              s"StopRuntimeMessage timing: Polling the stopRuntime, [runtime = ${runtime.runtimeName}, traceId = ${ctx.traceId.asString}, time = ${ctx.now.toString}]"
             )
             _ <- asyncTasks.offer(
               Task(

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
@@ -356,15 +356,17 @@ class LeoPubsubMessageSubscriber[F[_]](
   ): F[Unit] =
     for {
       ctx <- ev.ask
+      now <- F.realTimeInstant
       _ <- logger.info(
-        s"StopRuntimeMessage timing: About to get the cluster by id, [runtimeId = ${msg.runtimeId}, traceId = ${ctx.traceId.asString}, time = ${ctx.now.toString}]"
+        s"StopRuntimeMessage timing: About to get the cluster by id, [runtimeId = ${msg.runtimeId}, traceId = ${ctx.traceId.asString},time = ${(now.toEpochMilli - ctx.now.toEpochMilli).toString}]"
       )
       runtimeOpt <- clusterQuery.getClusterById(msg.runtimeId).transaction
       runtime <- runtimeOpt.fold(
         F.raiseError[Runtime](PubsubHandleMessageError.ClusterNotFound(msg.runtimeId, msg))
       )(F.pure)
+      now <- F.realTimeInstant
       _ <- logger.info(
-        s"StopRuntimeMessage timing: Got the cluster, [runtime = ${runtime.runtimeName}, traceId = ${ctx.traceId.asString}, time = ${ctx.now.toString}]"
+        s"StopRuntimeMessage timing: Got the cluster, [runtime = ${runtime.runtimeName.asString}, traceId = ${ctx.traceId.asString},time = ${(now.toEpochMilli - ctx.now.toEpochMilli).toString}]"
       )
 
       _ <-
@@ -373,12 +375,14 @@ class LeoPubsubMessageSubscriber[F[_]](
             PubsubHandleMessageError.ClusterInvalidState(msg.runtimeId, runtime.projectNameString, runtime, msg)
           )
         else F.unit
+      now <- F.realTimeInstant
       _ <- logger.info(
-        s"StopRuntimeMessage timing: About to get the runtimeConfig, [runtime = ${runtime.runtimeName}, traceId = ${ctx.traceId.asString}, time = ${ctx.now.toString}]"
+        s"StopRuntimeMessage timing: About to get the runtimeConfig, [runtime = ${runtime.runtimeName.asString}, traceId = ${ctx.traceId.asString},time = ${(now.toEpochMilli - ctx.now.toEpochMilli).toString}]"
       )
       runtimeConfig <- RuntimeConfigQueries.getRuntimeConfig(runtime.runtimeConfigId).transaction
+      now <- F.realTimeInstant
       _ <- logger.info(
-        s"StopRuntimeMessage timing: Got the runtimeConfig, [runtime = ${runtime.runtimeName}, traceId = ${ctx.traceId.asString}, time = ${ctx.now.toString}]"
+        s"StopRuntimeMessage timing: Got the runtimeConfig, [runtime = ${runtime.runtimeName.asString}, traceId = ${ctx.traceId.asString},time = ${(now.toEpochMilli - ctx.now.toEpochMilli).toString}]"
       )
       _ <- runtime.cloudContext match {
         case CloudContext.Gcp(_) =>
@@ -400,8 +404,9 @@ class LeoPubsubMessageSubscriber[F[_]](
               case None =>
                 runtimeConfig.cloudService.process(runtime.id, RuntimeStatus.Stopping, None).compile.drain
             }
+            now <- F.realTimeInstant
             _ <- logger.info(
-              s"StopRuntimeMessage timing: Polling the stopRuntime, [runtime = ${runtime.runtimeName}, traceId = ${ctx.traceId.asString}, time = ${ctx.now.toString}]"
+              s"StopRuntimeMessage timing: Polling the stopRuntime, [runtime = ${runtime.runtimeName}, traceId = ${ctx.traceId.asString}, time = ${(now.toEpochMilli - ctx.now.toEpochMilli).toString}]"
             )
             _ <- asyncTasks.offer(
               Task(

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/BaseRuntimeInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/BaseRuntimeInterpreter.scala
@@ -50,7 +50,7 @@ abstract private[util] class BaseRuntimeInterpreter[F[_]](
   )(implicit ev: Ask[F, AppContext]): F[Option[OperationFuture[Operation, Operation]]] =
     for {
       ctx <- ev.ask
-      runtimeName = params.runtimeAndRuntimeConfig.runtime.runtimeName
+      runtimeName = params.runtimeAndRuntimeConfig.runtime.runtimeName.asString
       // Flush the welder cache to disk
       _ <- logger.info(
         s"StopRuntimeMessage timing: Flushing the welder cache, [runtime = ${runtimeName}, traceId = ${ctx.traceId}, time = ${nowInstant.toString}]"

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/BaseRuntimeInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/BaseRuntimeInterpreter.scala
@@ -52,8 +52,9 @@ abstract private[util] class BaseRuntimeInterpreter[F[_]](
       ctx <- ev.ask
       runtimeName = params.runtimeAndRuntimeConfig.runtime.runtimeName.asString
       // Flush the welder cache to disk
+      now <- F.realTimeInstant
       _ <- logger.info(
-        s"StopRuntimeMessage timing: Flushing the welder cache, [runtime = ${runtimeName}, traceId = ${ctx.traceId.asString}, time = ${ctx.now.toString}]"
+        s"StopRuntimeMessage timing: Flushing the welder cache, [runtime = ${runtimeName}, traceId = ${ctx.traceId.asString},time = ${(now.toEpochMilli - ctx.now.toEpochMilli).toString}]"
       )
       _ <-
         welderDao
@@ -68,13 +69,14 @@ abstract private[util] class BaseRuntimeInterpreter[F[_]](
           .whenA(params.runtimeAndRuntimeConfig.runtime.welderEnabled)
 
       _ <- logger.info(
-        s"StopRuntimeMessage timing: Updating the hostIp, [runtime = ${runtimeName}, traceId = ${ctx.traceId.asString}, time = ${ctx.now.toString}]"
+        s"StopRuntimeMessage timing: Updating the hostIp, [runtime = ${runtimeName}, traceId = ${ctx.traceId.asString},time = ${(now.toEpochMilli - ctx.now.toEpochMilli).toString}]"
       )
       _ <- clusterQuery.updateClusterHostIp(params.runtimeAndRuntimeConfig.runtime.id, None, ctx.now).transaction
 
       // Stop the cluster in Google
+      now <- F.realTimeInstant
       _ <- logger.info(
-        s"StopRuntimeMessage timing: Calling stopGoogleRuntime, [runtime = ${runtimeName}, traceId = ${ctx.traceId.asString}, time = ${ctx.now.toString}]"
+        s"StopRuntimeMessage timing: Calling stopGoogleRuntime, [runtime = ${runtimeName}, traceId = ${ctx.traceId.asString},time = ${(now.toEpochMilli - ctx.now.toEpochMilli).toString}]"
       )
       r <- stopGoogleRuntime(
         StopGoogleRuntime(params.runtimeAndRuntimeConfig, params.isDataprocFullStop)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/BaseRuntimeInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/BaseRuntimeInterpreter.scala
@@ -53,7 +53,7 @@ abstract private[util] class BaseRuntimeInterpreter[F[_]](
       runtimeName = params.runtimeAndRuntimeConfig.runtime.runtimeName.asString
       // Flush the welder cache to disk
       _ <- logger.info(
-        s"StopRuntimeMessage timing: Flushing the welder cache, [runtime = ${runtimeName}, traceId = ${ctx.traceId}, time = ${nowInstant.toString}]"
+        s"StopRuntimeMessage timing: Flushing the welder cache, [runtime = ${runtimeName}, traceId = ${ctx.traceId.asString}, time = ${ctx.now.toString}]"
       )
       _ <-
         welderDao
@@ -68,13 +68,13 @@ abstract private[util] class BaseRuntimeInterpreter[F[_]](
           .whenA(params.runtimeAndRuntimeConfig.runtime.welderEnabled)
 
       _ <- logger.info(
-        s"StopRuntimeMessage timing: Updating the hostIp, [runtime = ${runtimeName}, traceId = ${ctx.traceId}, time = ${nowInstant.toString}]"
+        s"StopRuntimeMessage timing: Updating the hostIp, [runtime = ${runtimeName}, traceId = ${ctx.traceId.asString}, time = ${ctx.now.toString}]"
       )
       _ <- clusterQuery.updateClusterHostIp(params.runtimeAndRuntimeConfig.runtime.id, None, ctx.now).transaction
 
       // Stop the cluster in Google
       _ <- logger.info(
-        s"StopRuntimeMessage timing: Calling stopGoogleRuntime, [runtime = ${runtimeName}, traceId = ${ctx.traceId}, time = ${nowInstant.toString}]"
+        s"StopRuntimeMessage timing: Calling stopGoogleRuntime, [runtime = ${runtimeName}, traceId = ${ctx.traceId.asString}, time = ${ctx.now.toString}]"
       )
       r <- stopGoogleRuntime(
         StopGoogleRuntime(params.runtimeAndRuntimeConfig, params.isDataprocFullStop)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GceInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GceInterpreter.scala
@@ -339,7 +339,7 @@ class GceInterpreter[F[_]](
   ): F[Option[OperationFuture[Operation, Operation]]] =
     for {
       ctx <- ev.ask
-      runtimeName = params.runtimeAndRuntimeConfig.runtime.runtimeName
+      runtimeName = params.runtimeAndRuntimeConfig.runtime.runtimeName.asString
       zoneParam <- F.fromOption(
         LeoLenses.gceZone.getOption(params.runtimeAndRuntimeConfig.runtimeConfig),
         new RuntimeException(

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GceInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GceInterpreter.scala
@@ -350,12 +350,14 @@ class GceInterpreter[F[_]](
         LeoLenses.cloudContextToGoogleProject.get(params.runtimeAndRuntimeConfig.runtime.cloudContext),
         new RuntimeException("this should never happen. GCE runtime's cloud context should be a google project")
       )
+      now <- F.realTimeInstant
       _ <- logger.info(
-        s"StopRuntimeMessage timing: Getting shutdown script, [runtime = ${runtimeName}, traceId = ${ctx.traceId.asString}, time = ${ctx.now.toString}]"
+        s"StopRuntimeMessage timing: Getting shutdown script, [runtime = ${runtimeName}, traceId = ${ctx.traceId.asString},time = ${(now.toEpochMilli - ctx.now.toEpochMilli).toString}]"
       )
       metadata <- getShutdownScript(params.runtimeAndRuntimeConfig, false)
+      now <- F.realTimeInstant
       _ <- logger.info(
-        s"StopRuntimeMessage timing: Adding instance metadata, [runtime = ${runtimeName}, traceId = ${ctx.traceId.asString}, time = ${ctx.now.toString}]"
+        s"StopRuntimeMessage timing: Adding instance metadata, [runtime = ${runtimeName}, traceId = ${ctx.traceId.asString},time = ${(now.toEpochMilli - ctx.now.toEpochMilli).toString}]"
       )
       _ <- googleComputeService.addInstanceMetadata(
         googleProject,
@@ -363,8 +365,9 @@ class GceInterpreter[F[_]](
         InstanceName(params.runtimeAndRuntimeConfig.runtime.runtimeName.asString),
         metadata
       )
+      now <- F.realTimeInstant
       _ <- logger.info(
-        s"StopRuntimeMessage timing: Sending stop message to google, [runtime = ${runtimeName}, traceId = ${ctx.traceId.asString}, time = ${ctx.now.toString}]"
+        s"StopRuntimeMessage timing: Sending stop message to google, [runtime = ${runtimeName}, traceId = ${ctx.traceId.asString},time = ${(now.toEpochMilli - ctx.now.toEpochMilli).toString}]"
       )
       opFuture <- googleComputeService.stopInstance(
         googleProject,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GceInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GceInterpreter.scala
@@ -351,11 +351,11 @@ class GceInterpreter[F[_]](
         new RuntimeException("this should never happen. GCE runtime's cloud context should be a google project")
       )
       _ <- logger.info(
-        s"StopRuntimeMessage timing: Getting shutdown script, [runtime = ${runtimeName}, traceId = ${ctx.traceId}, time = ${nowInstant.toString}]"
+        s"StopRuntimeMessage timing: Getting shutdown script, [runtime = ${runtimeName}, traceId = ${ctx.traceId.asString}, time = ${ctx.now.toString}]"
       )
       metadata <- getShutdownScript(params.runtimeAndRuntimeConfig, false)
       _ <- logger.info(
-        s"StopRuntimeMessage timing: Adding instance metadata, [runtime = ${runtimeName}, traceId = ${ctx.traceId}, time = ${nowInstant.toString}]"
+        s"StopRuntimeMessage timing: Adding instance metadata, [runtime = ${runtimeName}, traceId = ${ctx.traceId.asString}, time = ${ctx.now.toString}]"
       )
       _ <- googleComputeService.addInstanceMetadata(
         googleProject,
@@ -364,7 +364,7 @@ class GceInterpreter[F[_]](
         metadata
       )
       _ <- logger.info(
-        s"StopRuntimeMessage timing: Sending stop message to google, [runtime = ${runtimeName}, traceId = ${ctx.traceId}, time = ${nowInstant.toString}]"
+        s"StopRuntimeMessage timing: Sending stop message to google, [runtime = ${runtimeName}, traceId = ${ctx.traceId.asString}, time = ${ctx.now.toString}]"
       )
       opFuture <- googleComputeService.stopInstance(
         googleProject,

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/config/ConfigSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/config/ConfigSpec.scala
@@ -22,7 +22,7 @@ final class ConfigSpec extends AnyFlatSpec with Matchers {
   it should "read LeoPubsubMessageSubscriberConfig properly" in {
     val expectedResult = LeoPubsubMessageSubscriberConfig(
       100,
-      295 seconds,
+      595 seconds,
       PersistentDiskMonitorConfig(
         CreateDiskTimeout(5, 20),
         PollMonitorConfig(2 seconds, 5, 3 seconds),


### PR DESCRIPTION


<!-- Welcome to your Leonardo pull request! -->
<!-- Contributor guidelines: https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md -->

__Jira ticket__: https://broadworkbench.atlassian.net/browse/[ticket_number]

<!-- ## Dependencies -->
<!-- Include any dependent tickets and describe the relationship. Include any other relevant Jira tickets. -->

## Summary of changes

<!-- Please give an abridged version of the ticket description here and/or fill out the following fields. -->

GCP runtimes stuck in stopping, stop message never sent to google, timing out

### What

- Bumping up the subscriber timeout from 5 to 10 minutes
- Adding timing logging around GCP stopRuntime messages

### Why

- GCP runtimes stuck in stopping, stop message never sent to google, timing out
- Trying to diagnose where they're getting stuck in the backend

## Testing these changes

### What to test

- <!-- Test case 1 -->

<!-- ### Test data -->

### Who tested and where

- [ ] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [ ] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
