### PR TITLE
[IA-4580] Update Rstudio bioconductor image to 3.17.1

### DIFF
--- a/automation/src/test/resources/reference.conf
+++ b/automation/src/test/resources/reference.conf
@@ -6,7 +6,7 @@ leonardo.aouImageUrl = "us.gcr.io/broad-dsp-gcr-public/terra-jupyter-aou:2.2.1"
 leonardo.baseImageUrl = "us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:1.1.1"
 leonardo.gcrWelderUri = "us.gcr.io/broad-dsp-gcr-public/welder-server"
 leonardo.dockerHubWelderUri = "broadinstitute/welder-server"
-leonardo.rstudioBioconductorImageUrl = "us.gcr.io/broad-dsp-gcr-public/anvil-rstudio-bioconductor:3.17.0"
+leonardo.rstudioBioconductorImageUrl = "us.gcr.io/broad-dsp-gcr-public/anvil-rstudio-bioconductor:3.17.1"
 //each fiab will have a unique topic name sourced from leonardo.conf, this is never published to in automation tests to ensure pub/sub components can auth properly, but never read from to avoid conflicts.
 leonardo.topicName = "leonardo-pubsub-test"
 leonardo.location = "us-central1-a"

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -69,7 +69,7 @@ dataproc {
   }
 
   # Cached dataproc image used by Terra
-  customDataprocImage = "projects/broad-dsp-gcr-public/global/images/leo-dataproc-image-2-1-11-debian11-2023-07-28-21-05-58"
+  customDataprocImage = "projects/broad-dsp-gcr-public/global/images/leo-dataproc-image-2-1-11-debian11-2023-09-25-14-14-15"
   # Cached dataproc image used by AOU
   legacyAouCustomDataprocImage = "projects/broad-dsp-gcr-public/global/images/leo-dataproc-image-2-0-51-debian10-2023-08-09-18-50-48"
 
@@ -112,7 +112,7 @@ dataproc {
 }
 
 gce {
-  customGceImage = "projects/broad-dsp-gcr-public/global/images/leo-gce-image-2023-08-03-18-31-36"
+  customGceImage = "projects/broad-dsp-gcr-public/global/images/leo-gce-image-2023-09-25-14-14-30"
   userDiskDeviceName = "user-disk"
   defaultScopes = [
     "https://www.googleapis.com/auth/userinfo.email",

--- a/jenkins/dataproc-custom-images/prepare-custom-leonardo-jupyter-dataproc-image.sh
+++ b/jenkins/dataproc-custom-images/prepare-custom-leonardo-jupyter-dataproc-image.sh
@@ -24,7 +24,7 @@ terra_jupyter_gatk="us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:2.3.1"
 terra_jupyter_aou="us.gcr.io/broad-dsp-gcr-public/terra-jupyter-aou:2.2.1"
 welder_server="us.gcr.io/broad-dsp-gcr-public/welder-server:8667bfe"
 openidc_proxy="broadinstitute/openidc-proxy:2.3.1_2"
-anvil_rstudio_bioconductor="us.gcr.io/broad-dsp-gcr-public/anvil-rstudio-bioconductor:3.17.0"
+anvil_rstudio_bioconductor="us.gcr.io/broad-dsp-gcr-public/anvil-rstudio-bioconductor:3.17.1"
 
 # Note that this is the version used currently by AOU in production!
 terra_jupyter_aou_old="us.gcr.io/broad-dsp-gcr-public/terra-jupyter-aou:2.1.15"

--- a/jenkins/gce-custom-images/prepare_gce_image.sh
+++ b/jenkins/gce-custom-images/prepare_gce_image.sh
@@ -23,7 +23,7 @@ terra_jupyter_gatk="us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:2.3.1"
 terra_jupyter_aou="us.gcr.io/broad-dsp-gcr-public/terra-jupyter-aou:2.2.1"
 welder_server="us.gcr.io/broad-dsp-gcr-public/welder-server:8667bfe"
 openidc_proxy="broadinstitute/openidc-proxy:2.3.1_2"
-anvil_rstudio_bioconductor="us.gcr.io/broad-dsp-gcr-public/anvil-rstudio-bioconductor:3.17.0"
+anvil_rstudio_bioconductor="us.gcr.io/broad-dsp-gcr-public/anvil-rstudio-bioconductor:3.17.1"
 
 # Note that this is the version used currently by AOU in production!
 terra_jupyter_aou_old="us.gcr.io/broad-dsp-gcr-public/terra-jupyter-aou:2.1.15"


### PR DESCRIPTION
<!-- Welcome to your Leonardo pull request! -->
<!-- Contributor guidelines: https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md -->

__Jira ticket__: https://broadworkbench.atlassian.net/browse/IA-4580

<!-- ## Dependencies -->
<!-- Include any dependent tickets and describe the relationship. Include any other relevant Jira tickets. -->

## Summary of changes

Leo follow up from Bioconductor PR in terra-docker: https://github.com/DataBiosphere/terra-docker/pull/458/files

## Testing these changes

### What to test

Just tested on my BEE and created and RSTudio runtime with the following request:
```
{
  "runtimeConfig": {
    "cloudService": "gce",
    "machineType": "n1-standard-4",
    "diskSize": 100
  },
  "toolDockerImage": "us.gcr.io/broad-dsp-gcr-public/anvil-rstudio-bioconductor:3.17.1"
}
```

The runtime was running and i could access the RStudio URL fine 👍  So I am going to merge this to Dev ASAP and then will promote the UI change to prod on Thursday morning to sync with the monolith release

### Who tested and where

- [ ] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [ ] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
