### PR TITLE
RW-10808 Don't fail deleteApp when failing to record stopTime

### DIFF
--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/AppUsageComponent.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/AppUsageComponent.scala
@@ -16,7 +16,7 @@ import java.time.Instant
 import scala.concurrent.ExecutionContext
 import scala.util.control.NoStackTrace
 
-class AppUasageTable(tag: Tag) extends Table[AppUsageRecord](tag, "APP_USAGE") {
+class AppUsageTable(tag: Tag) extends Table[AppUsageRecord](tag, "APP_USAGE") {
   def id = column[AppUsageId]("id", O.PrimaryKey, O.AutoInc)
   def appId = column[AppId]("appId")
 
@@ -26,7 +26,7 @@ class AppUasageTable(tag: Tag) extends Table[AppUsageRecord](tag, "APP_USAGE") {
   def * = (id, appId, startTime, stopTime) <> (AppUsageRecord.tupled, AppUsageRecord.unapply)
 }
 
-object appUsageQuery extends TableQuery(new AppUasageTable(_)) {
+object appUsageQuery extends TableQuery(new AppUsageTable(_)) {
   def recordStart[F[_]](appId: AppId, startTime: Instant)(implicit
     ec: ExecutionContext,
     dbReference: DbReference[F],
@@ -105,6 +105,6 @@ object appUsageQuery extends TableQuery(new AppUasageTable(_)) {
 final case class AppUsageId(id: Long) extends Product with Serializable
 final case class AppUsageRecord(id: AppUsageId, appId: AppId, startTime: Instant, stopTime: Instant)
 final case class FailToRecordStoptime(appId: AppId) extends NoStackTrace {
-  override def toString: String =
+  override def getMessage: String =
     s"Cannot record stopTime because there's no existing unresolved startTime for ${appId.id}"
 }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/AppUsageComponent.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/AppUsageComponent.scala
@@ -14,6 +14,7 @@ import org.typelevel.log4cats.Logger
 import java.sql.SQLDataException
 import java.time.Instant
 import scala.concurrent.ExecutionContext
+import scala.util.control.NoStackTrace
 
 class AppUasageTable(tag: Tag) extends Table[AppUsageRecord](tag, "APP_USAGE") {
   def id = column[AppUsageId]("id", O.PrimaryKey, O.AutoInc)
@@ -79,9 +80,7 @@ object appUsageQuery extends TableQuery(new AppUasageTable(_)) {
           DBIO.successful(())
         else
           DBIO.failed(
-            new RuntimeException(
-              s"Cannot record stopTime because there's no existing unresolved startTime for ${appId.id}"
-            )
+            FailToRecordStoptime(appId)
           )
       }
 
@@ -105,3 +104,7 @@ object appUsageQuery extends TableQuery(new AppUasageTable(_)) {
 
 final case class AppUsageId(id: Long) extends Product with Serializable
 final case class AppUsageRecord(id: AppUsageId, appId: AppId, startTime: Instant, stopTime: Instant)
+final case class FailToRecordStoptime(appId: AppId) extends NoStackTrace {
+  override def toString: String =
+    s"Cannot record stopTime because there's no existing unresolved startTime for ${appId.id}"
+}

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/DbReference.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/DbReference.scala
@@ -118,7 +118,7 @@ object DataAccess {
       persistentDiskQuery.nullifyDiskIds andThen
       TableQuery[ServiceTable].delete andThen
       TableQuery[AppErrorTable].delete andThen
-      TableQuery[AppUasageTable].delete andThen
+      TableQuery[AppUsageTable].delete andThen
       TableQuery[AppTable].delete andThen
       TableQuery[NamespaceTable].delete andThen
       TableQuery[NodepoolTable].delete andThen

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/LeoAppServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/LeoAppServiceInterp.scala
@@ -404,7 +404,7 @@ final class LeoAppServiceInterp[F[_]: Parallel](config: AppServiceConfig,
             )
             trackUsage = AllowedChartName.fromChartName(appResult.app.chart.name).exists(_.trackUsage)
             _ <- appUsageQuery.recordStop(appResult.app.id, ctx.now).whenA(trackUsage).recoverWith {
-              case e: FailToRecordStoptime => log.warn(ctx.loggingCtx)(e.getMessage)
+              case e: FailToRecordStoptime => log.error(ctx.loggingCtx)(e.getMessage)
             }
             _ <- publisherQueue.offer(deleteMessage)
           } yield ()

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/LeoAppServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/LeoAppServiceInterp.scala
@@ -403,7 +403,9 @@ final class LeoAppServiceInterp[F[_]: Parallel](config: AppServiceConfig,
               Some(ctx.traceId)
             )
             trackUsage = AllowedChartName.fromChartName(appResult.app.chart.name).exists(_.trackUsage)
-            _ <- appUsageQuery.recordStop(appResult.app.id, ctx.now).whenA(trackUsage)
+            _ <- appUsageQuery.recordStop(appResult.app.id, ctx.now).whenA(trackUsage).recoverWith {
+              case e: FailToRecordStoptime => log.warn(ctx.loggingCtx)(e.getMessage)
+            }
             _ <- publisherQueue.offer(deleteMessage)
           } yield ()
         }


### PR DESCRIPTION
https://precisionmedicineinitiative.atlassian.net/browse/RW-10808

Existing SAS apps before [this PR](https://github.com/DataBiosphere/leonardo/pull/3728) don't have usage `startTime` recorded, hence they'll fail to delete with the app usage PR introduced.

This PR changes the behavior in a way to only log as error but don't fail the whole deleteApp request. 

### Who tested and where

- [ ] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [ ] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
