### PR TITLE
[IA-4295] Stub SAM client

### DIFF
--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/SamClient.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/SamClient.scala
@@ -1,0 +1,49 @@
+package org.broadinstitute.dsde.workbench.leonardo
+package dao
+
+import org.broadinstitute.dsde.workbench.client.sam.ApiClient
+import org.broadinstitute.dsde.workbench.client.sam.api.ResourcesApi
+import org.broadinstitute.dsde.workbench.client.sam.api.ConfigApi
+import org.broadinstitute.dsde.workbench.client.sam.model.{ResourceType, UserResourcesResponse}
+
+// Implicit for .asScala
+import scala.jdk.CollectionConverters.ListHasAsScala
+
+class SamClient(config: HttpSamDaoConfig) {
+  private def getResourcesApi(accessToken: String): ResourcesApi = {
+    val apiClient = new ApiClient()
+    apiClient.setAccessToken(accessToken)
+    apiClient.setBasePath(config.samUri.toString)
+    new ResourcesApi(apiClient)
+  }
+
+  private def getConfigApi(accessToken: String): ConfigApi = {
+    val apiClient = new ApiClient()
+    apiClient.setAccessToken(accessToken)
+    apiClient.setBasePath(config.samUri.toString)
+    new ConfigApi(apiClient)
+  }
+
+  /** Can the user perform the given action on the given resource? */
+  def hasResourceAction(token: String,
+                        resourceType: String,
+                        resourceId: String,
+                        action: String,
+                        userEmail: String
+  ): Boolean = {
+    val samResourceApi = getResourcesApi(token)
+    samResourceApi.resourceActionV2(resourceType, resourceId, action, userEmail)
+  }
+
+  /** List all policies granted to the caller on resources of the given type. */
+  def listResourcesAndPolicies(token: String, resourceType: String): List[UserResourcesResponse] = {
+    val samResourceApi = getResourcesApi(token)
+    samResourceApi.listResourcesAndPoliciesV2(resourceType).asScala.toList
+  }
+
+  /** List the configuration for all resource types. */
+  def listResourceTypes(token: String): List[ResourceType] = {
+    val samConfigApi = getConfigApi(token)
+    samConfigApi.listResourceTypes.asScala.toList
+  }
+}

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/SamClient.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/SamClient.scala
@@ -10,6 +10,13 @@ import org.broadinstitute.dsde.workbench.client.sam.model.{ResourceType, UserRes
 import scala.jdk.CollectionConverters.ListHasAsScala
 
 class SamClient(config: HttpSamDaoConfig) {
+  private def getConfigApi(accessToken: String): ConfigApi = {
+    val apiClient = new ApiClient()
+    apiClient.setAccessToken(accessToken)
+    apiClient.setBasePath(config.samUri.toString)
+    new ConfigApi(apiClient)
+  }
+
   private def getResourcesApi(accessToken: String): ResourcesApi = {
     val apiClient = new ApiClient()
     apiClient.setAccessToken(accessToken)
@@ -17,11 +24,10 @@ class SamClient(config: HttpSamDaoConfig) {
     new ResourcesApi(apiClient)
   }
 
-  private def getConfigApi(accessToken: String): ConfigApi = {
-    val apiClient = new ApiClient()
-    apiClient.setAccessToken(accessToken)
-    apiClient.setBasePath(config.samUri.toString)
-    new ConfigApi(apiClient)
+  /** List the configuration for all resource types. */
+  def listResourceTypes(token: String): List[ResourceType] = {
+    val samConfigApi = getConfigApi(token)
+    samConfigApi.listResourceTypes.asScala.toList
   }
 
   /** Can the user perform the given action on the given resource? */
@@ -39,11 +45,5 @@ class SamClient(config: HttpSamDaoConfig) {
   def listResourcesAndPolicies(token: String, resourceType: String): List[UserResourcesResponse] = {
     val samResourceApi = getResourcesApi(token)
     samResourceApi.listResourcesAndPoliciesV2(resourceType).asScala.toList
-  }
-
-  /** List the configuration for all resource types. */
-  def listResourceTypes(token: String): List[ResourceType] = {
-    val samConfigApi = getConfigApi(token)
-    samConfigApi.listResourceTypes.asScala.toList
   }
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -142,7 +142,8 @@ object Dependencies {
   val pact4sCirce =       "io.github.jbwheatley"  %% "pact4s-circe"     % pact4sV
   val okHttp =            "com.squareup.okhttp3"  % "okhttp"            % "4.11.0"
 
-  val workSpaceManagerV = "0.254.916-SNAPSHOT"
+  val samV = "0.1-fd8ee25"
+  val workspaceManagerV = "0.254.916-SNAPSHOT"
   val terraCommonLibV = "0.0.94-SNAPSHOT"
 
   def excludeJakartaActivationApi = ExclusionRule("jakarta.activation", "jakarta.activation-api")
@@ -159,7 +160,8 @@ object Dependencies {
   def excludeSnakeyaml = ExclusionRule("org.yaml", "snakeyaml")
   def tclExclusions(m: ModuleID): ModuleID = m.excludeAll(excludeSpringBoot, excludeSpringAop, excludeSpringData, excludeSpringFramework, excludeOpenCensus, excludeGoogleFindBugs, excludeBroadWorkbench, excludePostgresql, excludeSnakeyaml, excludeSlf4j)
 
-  val workspaceManager = excludeJakarta("bio.terra" % "workspace-manager-client" % workSpaceManagerV)
+  val sam = "org.broadinstitute.dsde.workbench" %% "sam-client" % samV
+  val workspaceManager = excludeJakarta("bio.terra" % "workspace-manager-client" % workspaceManagerV)
   val terraCommonLib = tclExclusions(excludeJakarta("bio.terra" % "terra-common-lib" % terraCommonLibV classifier "plain"))
 
   val coreDependencies = List(
@@ -190,6 +192,7 @@ object Dependencies {
     workbenchAzure,
     workbenchAzureTest,
     logbackClassic,
+    sam,
     workspaceManager,
     terraCommonLib
   )


### PR DESCRIPTION
<!-- Welcome to your Leonardo pull request! -->
<!-- Contributor guidelines: https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md -->

__Jira ticket__: https://broadworkbench.atlassian.net/browse/IA-4295

<!-- ## Dependencies -->
<!-- Include any dependent tickets and describe the relationship. Include any other relevant Jira tickets. -->

## Summary of changes

<!-- Please give an abridged version of the ticket description here and/or fill out the following fields. -->

### What

- A `sam` client for `leonardo`! At long last. Not yet actually used, just initialized with a couple of methods that seem useful for my current work.

### Why

- Leo rolls its own Sam client, and it's hard to read for Scala newbies. The published API client for Sam is robust, so why not use it? Also, `listResourceTypes` would allow Leonardo to stop modeling Sam permissions itself (in `samModels` and `LeoAuthProvider`).

## Testing these changes

### What to test

- <!-- Test case 1 -->

<!-- ### Test data -->

### Who tested and where

- [ ] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [ ] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
