### PR TITLE
[IA-4432] use only SamRole to model runtime access

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/samModels.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/samModels.scala
@@ -237,24 +237,34 @@ object WsmResourceAction {
 }
 
 // TODO [IA-4608] merge with SamPolicyName
+/** Represents a role in Sam, permitting a set of actions on a resource of a certain type. */
 sealed trait SamRole extends Product with Serializable {
   def asString: String
+  override def toString = asString
 }
 object SamRole {
+
   final case object Creator extends SamRole {
     val asString = "creator"
   }
   final case object Manager extends SamRole {
     val asString = "manager"
   }
+  final case object Writer extends SamRole {
+    val asString = "writer"
+  }
   final case object Owner extends SamRole {
     val asString = "owner"
+  }
+  final case object User extends SamRole {
+    val asString = "user"
   }
   final case class Other(asString: String) extends SamRole
   val stringToRole = sealerate.collect[SamRole].map(p => (p.asString, p)).toMap
 }
 
 // TODO [IA-4608] merge with SamRole
+/** Represents a role in Sam, permitting a set of actions on a resource of a certain type. */
 sealed trait SamPolicyName extends Serializable with Product
 object SamPolicyName {
   final case object Creator extends SamPolicyName {

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpSamDAO.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpSamDAO.scala
@@ -125,6 +125,27 @@ class HttpSamDAO[F[_]](httpClient: Client[F],
       )(onError)
   }
 
+  /** For every role the user is granted on a Sam resource, list it and the resource ID. */
+  override def listResourceIdsWithRole[R <: SamResourceId](
+    authHeader: Authorization
+  )(implicit
+    resourceDefinition: SamResource[R],
+    resourceIdDecoder: Decoder[R],
+    ev: Ask[F, TraceId]
+  ): F[List[(R, SamRole)]] =
+    for {
+      ctx <- ev.ask
+      resourceType = resourceDefinition.resourceType.asString
+      _ <- metrics.incrementCounter(s"sam/getResourcePolicies/${resourceType}")
+      response <- httpClient.expectOr[List[ListResourceRolesItem[R]]](
+        Request[F](
+          method = Method.GET,
+          uri = config.samUri.withPath(Uri.Path.unsafeFromString(s"/api/resources/v2/${resourceType}")),
+          headers = Headers(authHeader)
+        )
+      )(onError)
+    } yield response.flatMap(item => item.samRoles.map(role => (item.samResourceId, role)))
+
   override def getResourcePolicies[R](
     authHeader: Authorization,
     resourceType: SamResourceType
@@ -680,8 +701,13 @@ object HttpSamDAO {
     } yield SyncStatusResponse(lastSyncDate, email)
   }
 
+  /** Decodes the `roles` field to a SamRoleAction object. */
   implicit val samRoleActionDecoder: Decoder[SamRoleAction] = Decoder.forProduct1("roles")(SamRoleAction.apply)
 
+  /** Decodes the `roles` field to a SamResourceRoles object. */
+  implicit val samResourceRolesDecoder: Decoder[SamResourceRoles] = Decoder.forProduct1("roles")(SamResourceRoles.apply)
+
+  /** Decodes an item from Sam's resource list endpoint to a `ListResourceResponse`. */
   implicit def listResourceResponseDecoder[R: Decoder]: Decoder[ListResourceResponse[R]] = Decoder.instance { x =>
     for {
       resourceId <- x.downField("resourceId").as[R]
@@ -690,6 +716,17 @@ object HttpSamDAO {
       inherited <- x.downField("inherited").as[SamRoleAction]
       public <- x.downField("public").as[SamRoleAction]
     } yield ListResourceResponse(resourceId, (direct.roles ++ inherited.roles ++ public.roles).toSet)
+  }
+
+  /** Decodes an item from Sam's resource list endpoint to a `ListResourceRolesItem`. Ignores any extra-role actions. */
+  implicit def listResourceRolesItemDecoder[R: Decoder]: Decoder[ListResourceRolesItem[R]] = Decoder.instance { x =>
+    for {
+      resourceId <- x.downField("resourceId").as[R]
+      // these three places can have duplicated SamResourceRoles
+      direct <- x.downField("direct").as[SamResourceRoles]
+      inherited <- x.downField("inherited").as[SamResourceRoles]
+      public <- x.downField("public").as[SamResourceRoles]
+    } yield ListResourceRolesItem[R](resourceId, (direct.roles ++ inherited.roles ++ public.roles).toSet)
   }
 
   val subsystemStatusDecoder: Decoder[SubsystemStatus] = Decoder.instance { c =>
@@ -721,7 +758,11 @@ final case class CreateSamResourceRequest[R](samResourceId: R,
 
 final case class SyncStatusResponse(lastSyncDate: String, email: SamPolicyEmail)
 
+/** An item in the list returned by the list resources endpoint, with a resource ID and a set of SamPolicyNames. */
 final case class ListResourceResponse[R](samResourceId: R, samPolicyNames: Set[SamPolicyName])
+
+/** An item in the list returned by the list resources endpoint, with a resource ID and a set of SamRoles. */
+final case class ListResourceRolesItem[R](samResourceId: R, samRoles: Set[SamRole])
 
 final case class HttpSamDaoConfig(samUri: Uri,
                                   petCacheEnabled: Boolean,
@@ -735,6 +776,9 @@ final case class UserEmailAndProject(userEmail: WorkbenchEmail, googleProject: G
 final case class SerializableSamResource(resourceTypeName: SamResourceType, resourceId: SamResourceId)
 
 final case class SamRoleAction(roles: List[SamPolicyName])
+
+/** Holds a list of roles. Replicates `SamRoleAction` but uses SamRole, which is appropriate to model Sam resource roles. */
+final case class SamResourceRoles(roles: List[SamRole])
 
 final case class SamUserInfo(userSubjectId: UserSubjectId, userEmail: WorkbenchEmail, enabled: Boolean)
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/SamDAO.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/SamDAO.scala
@@ -44,6 +44,15 @@ trait SamDAO[F[_]] {
     ev: Ask[F, TraceId]
   ): F[List[A]]
 
+  /** For every role the user is granted on a Sam resource, list it and the resource ID. */
+  def listResourceIdsWithRole[R <: SamResourceId](
+    authHeader: Authorization
+  )(implicit
+    resourceDefinition: SamResource[R],
+    resourceIdDecoder: Decoder[R],
+    ev: Ask[F, TraceId]
+  ): F[List[(R, SamRole)]]
+
   /** Returns all resources and actions (policies) the calling user has permission to for a given resource type.*/
   def getResourcePolicies[R](authHeader: Authorization, resourceType: SamResourceType)(implicit
     sr: SamResource[R],

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeoAuthProvider.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeoAuthProvider.scala
@@ -223,12 +223,13 @@ trait LeoAuthProvider[F[_]] {
     ev: Ask[F, TraceId]
   ): F[(List[A], List[ProjectAction])]
 
-  def getAuthorizedIds[R <: SamResourceId](
-    isOwner: Boolean,
+  def listResourceIds[R <: SamResourceId](
+    hasOwnerRole: Boolean,
     userInfo: UserInfo
   )(implicit
-    samResource: SamResource[R],
-    decoder: Decoder[R],
+    resourceDefinition: SamResource[R],
+    appDefinition: SamResource[AppSamResourceId],
+    resourceIdDecoder: Decoder[R],
     ev: Ask[F, TraceId]
   ): F[Set[R]]
 

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/auth/AllowlistAuthProvider.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/auth/AllowlistAuthProvider.scala
@@ -10,7 +10,7 @@ import io.circe.{Decoder, Encoder}
 import net.ceedubs.ficus.Ficus._
 import org.broadinstitute.dsde.workbench.leonardo.dao.AuthProviderException
 import org.broadinstitute.dsde.workbench.leonardo.CommonTestData.{serviceAccountEmail, userEmail}
-import org.broadinstitute.dsde.workbench.leonardo.SamResourceId.WorkspaceResourceSamResourceId
+import org.broadinstitute.dsde.workbench.leonardo.SamResourceId.{AppSamResourceId, WorkspaceResourceSamResourceId}
 import org.broadinstitute.dsde.workbench.leonardo.{CloudContext, ProjectAction, SamResourceId, WorkspaceId}
 import org.broadinstitute.dsde.workbench.leonardo.model._
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
@@ -54,18 +54,16 @@ class AllowlistAuthProvider(config: Config, saProvider: ServiceAccountProvider[I
       case false => (List.empty, List.empty)
     }
 
-  def getAuthorizedIds[R <: SamResourceId](
-    isOwner: Boolean,
+  def listResourceIds[R <: SamResourceId](
+    hasOwnerRole: Boolean,
     userInfo: UserInfo
   )(implicit
-    samResource: SamResource[R],
-    decoder: Decoder[R],
+    resourceDefinition: SamResource[R],
+    appDefinition: SamResource[AppSamResourceId],
+    resourceIdDecoder: Decoder[R],
     ev: Ask[IO, TraceId]
   ): IO[Set[R]] =
-    checkAllowlist(userInfo).map {
-      case true  => Set.empty
-      case false => Set.empty
-    }
+    checkAllowlist(userInfo).map(_ => Set.empty)
 
   def filterUserVisible[R](resources: NonEmptyList[R], userInfo: UserInfo)(implicit
     sr: SamResource[R],

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/auth/SamAuthProviderSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/auth/SamAuthProviderSpec.scala
@@ -422,12 +422,12 @@ class SamAuthProviderSpec extends AnyFlatSpec with LeonardoTestSuite with Before
 
     // Visible owned runtime returned as reader or owner
     samAuthProvider
-      .getAuthorizedIds[RuntimeSamResourceId](isOwner = false, userInfo)
+      .listResourceIds[RuntimeSamResourceId](hasOwnerRole = false, userInfo)
       .unsafeRunSync() shouldBe Set(
       runtimeSamResource
     )
     samAuthProvider
-      .getAuthorizedIds[RuntimeSamResourceId](isOwner = true, userInfo)
+      .listResourceIds[RuntimeSamResourceId](hasOwnerRole = true, userInfo)
       .unsafeRunSync() shouldBe Set(
       runtimeSamResource
     )
@@ -446,22 +446,22 @@ class SamAuthProviderSpec extends AnyFlatSpec with LeonardoTestSuite with Before
 
     // => owned workspace is in owner IDs
     mockSamAuthProvider
-      .getAuthorizedIds[WorkspaceResourceSamResourceId](isOwner = true, userInfo)
+      .listResourceIds[WorkspaceResourceSamResourceId](hasOwnerRole = true, userInfo)
       .unsafeRunSync() shouldBe Set(mockWorkspaceId)
 
     // => owned workspace is in reader IDs
     mockSamAuthProvider
-      .getAuthorizedIds[WorkspaceResourceSamResourceId](isOwner = false, userInfo)
+      .listResourceIds[WorkspaceResourceSamResourceId](hasOwnerRole = false, userInfo)
       .unsafeRunSync() shouldBe Set(mockWorkspaceId)
 
     // => read workspace is NOT in owner IDs
     mockSamAuthProvider
-      .getAuthorizedIds[WorkspaceResourceSamResourceId](isOwner = true, userInfo)
+      .listResourceIds[WorkspaceResourceSamResourceId](hasOwnerRole = true, userInfo)
       .unsafeRunSync() shouldBe Set.empty
 
     // => read workspace is in reader IDs
     mockSamAuthProvider
-      .getAuthorizedIds[WorkspaceResourceSamResourceId](isOwner = false, userInfo)
+      .listResourceIds[WorkspaceResourceSamResourceId](hasOwnerRole = false, userInfo)
       .unsafeRunSync() shouldBe Set(mockWorkspaceId)
   }
 

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/auth/SamAuthProviderSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/auth/SamAuthProviderSpec.scala
@@ -435,11 +435,11 @@ class SamAuthProviderSpec extends AnyFlatSpec with LeonardoTestSuite with Before
     // Visible workspace is returned as owner, then as writer
     val mockWorkspaceId = WorkspaceResourceSamResourceId(WorkspaceId(UUID.randomUUID))
     val mockSamDao = mock[SamDAO[IO]](defaultMockitoAnswer[IO])
-    when(mockSamDao.getResourcePolicies[WorkspaceResourceSamResourceId](any, any)(any, any, any))
-      .thenReturn(IO.pure(List((mockWorkspaceId, SamPolicyName.Owner))))
-      .thenReturn(IO.pure(List((mockWorkspaceId, SamPolicyName.Owner))))
-      .thenReturn(IO.pure(List((mockWorkspaceId, SamPolicyName.Writer))))
-      .thenReturn(IO.pure(List((mockWorkspaceId, SamPolicyName.Writer))))
+    when(mockSamDao.listResourceIdsWithRole[WorkspaceResourceSamResourceId](any)(any, any, any))
+      .thenReturn(IO.pure(List((mockWorkspaceId, SamRole.Owner))))
+      .thenReturn(IO.pure(List((mockWorkspaceId, SamRole.Owner))))
+      .thenReturn(IO.pure(List((mockWorkspaceId, SamRole.Writer))))
+      .thenReturn(IO.pure(List((mockWorkspaceId, SamRole.Writer))))
 
     val mockSamAuthProvider =
       new SamAuthProvider(mockSamDao, samAuthProviderConfigWithoutCache, serviceAccountProvider, authCache)

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/MockSamDAO.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/MockSamDAO.scala
@@ -97,6 +97,14 @@ class MockSamDAO extends SamDAO[IO] {
         IO.pure(res)
     }
 
+  override def listResourceIdsWithRole[R <: SamResourceId](
+    authHeader: Authorization
+  )(implicit
+    resourceDefinition: SamResource[R],
+    resourceIdDecoder: Decoder[R],
+    ev: Ask[IO, TraceId]
+  ): IO[List[(R, SamRole)]] = ???
+
   override def getResourcePolicies[R](authHeader: Authorization, resourceType: SamResourceType)(implicit
     sr: SamResource[R],
     decoder: Decoder[R],

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/MockSamDAO.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/MockSamDAO.scala
@@ -103,7 +103,32 @@ class MockSamDAO extends SamDAO[IO] {
     resourceDefinition: SamResource[R],
     resourceIdDecoder: Decoder[R],
     ev: Ask[IO, TraceId]
-  ): IO[List[(R, SamRole)]] = ???
+  ): IO[List[(R, SamRole)]] = resourceDefinition.resourceType match {
+    case SamResourceType.Runtime =>
+      IO.pure(
+        runtimeCreators.get(authHeader).map(_.toList).getOrElse(List.empty).map { case (resource, pn) => (resource, SamRole.stringToRole(pn.toString))}.asInstanceOf[List[(R, SamRole)]]
+      )
+    case SamResourceType.Project =>
+      IO.pure(
+        (projectOwners ++ projectUsers)
+          .get(authHeader)
+          .map(_.toList)
+          .getOrElse(List.empty)
+          .map { case (resource, pn) => (resource, SamRole.stringToRole(pn.toString))}.asInstanceOf[List[(R, SamRole)]]
+      )
+    case SamResourceType.PersistentDisk =>
+      IO.pure(diskCreators.get(authHeader).map(_.toList).getOrElse(List.empty).map { case (resource, pn) => (resource, SamRole.stringToRole(pn.toString))}.asInstanceOf[List[(R, SamRole)]])
+    case SamResourceType.SharedApp => throw new Exception("SharedApp not supported")
+    case SamResourceType.App => throw new Exception("App not supported")
+    case SamResourceType.Workspace =>
+      IO.pure(
+        workspaceCreators.get(authHeader).map(_.toList).getOrElse(List.empty).map { case (resource, pn) => (resource, SamRole.stringToRole(pn.toString))}.asInstanceOf[List[(R, SamRole)]]
+      )
+    case SamResourceType.WsmResource =>
+      IO.pure(
+        wmsResourceCreators.get(authHeader).map(_.toList).getOrElse(List.empty).map { case (resource, pn) => (resource, SamRole.stringToRole(pn.toString))}.asInstanceOf[List[(R, SamRole)]]
+      )
+  }
 
   override def getResourcePolicies[R](authHeader: Authorization, resourceType: SamResourceType)(implicit
     sr: SamResource[R],

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeV2ServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeV2ServiceInterpSpec.scala
@@ -35,7 +35,8 @@ import org.broadinstitute.dsde.workbench.leonardo.model.SamResourceAction.{
   projectSamResourceAction,
   runtimeSamResourceAction,
   workspaceSamResourceAction,
-  wsmResourceSamResourceAction
+  wsmResourceSamResourceAction,
+  AppSamResourceAction
 }
 import org.broadinstitute.dsde.workbench.leonardo.model._
 import org.broadinstitute.dsde.workbench.leonardo.monitor.LeoPubsubMessage.{
@@ -113,7 +114,7 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
 
   /**
    * Generate a mocked AuthProvider which will permit action on the given resource IDs by the given user.
-   * TODO: cover actions beside `checkUserEnabled` and `getAuthorizedIds`
+   * TODO: cover actions beside `checkUserEnabled` and `listResourceIds`
    * @param userInfo
    * @param readerRuntimeSamIds
    * @param readerWorkspaceSamIds
@@ -134,45 +135,51 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
 
     when(mockAuthProvider.checkUserEnabled(isEq(userInfo))(any)).thenReturn(IO.unit)
     when(
-      mockAuthProvider.getAuthorizedIds[RuntimeSamResourceId](isEq(false), isEq(userInfo))(
+      mockAuthProvider.listResourceIds[RuntimeSamResourceId](isEq(false), isEq(userInfo))(
         any(runtimeSamResourceAction.getClass),
+        any(AppSamResourceAction.getClass),
         any(Decoder[RuntimeSamResourceId].getClass),
         any(Ask[IO, TraceId].getClass)
       )
     ).thenReturn(IO.pure(readerRuntimeSamIds))
     when(
-      mockAuthProvider.getAuthorizedIds[WsmResourceSamResourceId](isEq(false), isEq(userInfo))(
+      mockAuthProvider.listResourceIds[WsmResourceSamResourceId](isEq(false), isEq(userInfo))(
         any(wsmResourceSamResourceAction.getClass),
+        any(AppSamResourceAction.getClass),
         any(Decoder[WsmResourceSamResourceId].getClass),
         any(Ask[IO, TraceId].getClass)
       )
     ).thenReturn(IO.pure(readerWsmSamIds))
     when(
-      mockAuthProvider.getAuthorizedIds[WorkspaceResourceSamResourceId](isEq(false), isEq(userInfo))(
+      mockAuthProvider.listResourceIds[WorkspaceResourceSamResourceId](isEq(false), isEq(userInfo))(
         any(workspaceSamResourceAction.getClass),
+        any(AppSamResourceAction.getClass),
         any(Decoder[WorkspaceResourceSamResourceId].getClass),
         any(Ask[IO, TraceId].getClass)
       )
     ).thenReturn(IO.pure(readerWorkspaceSamIds))
     when(
-      mockAuthProvider.getAuthorizedIds[ProjectSamResourceId](isEq(false), isEq(userInfo))(
+      mockAuthProvider.listResourceIds[ProjectSamResourceId](isEq(false), isEq(userInfo))(
         any(projectSamResourceAction.getClass),
+        any(AppSamResourceAction.getClass),
         any(Decoder[ProjectSamResourceId].getClass),
         any(Ask[IO, TraceId].getClass)
       )
     )
       .thenReturn(IO.pure(readerProjectSamIds))
     when(
-      mockAuthProvider.getAuthorizedIds[WorkspaceResourceSamResourceId](isEq(true), isEq(userInfo))(
+      mockAuthProvider.listResourceIds[WorkspaceResourceSamResourceId](isEq(true), isEq(userInfo))(
         any(workspaceSamResourceAction.getClass),
+        any(AppSamResourceAction.getClass),
         any(Decoder[WorkspaceResourceSamResourceId].getClass),
         any(Ask[IO, TraceId].getClass)
       )
     )
       .thenReturn(IO.pure(ownerWorkspaceSamIds))
     when(
-      mockAuthProvider.getAuthorizedIds[ProjectSamResourceId](isEq(true), isEq(userInfo))(
+      mockAuthProvider.listResourceIds[ProjectSamResourceId](isEq(true), isEq(userInfo))(
         any(projectSamResourceAction.getClass),
+        any(AppSamResourceAction.getClass),
         any(Decoder[ProjectSamResourceId].getClass),
         any(Ask[IO, TraceId].getClass)
       )

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeV2ServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeV2ServiceInterpSpec.scala
@@ -135,7 +135,7 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
 
     when(mockAuthProvider.checkUserEnabled(isEq(userInfo))(any)).thenReturn(IO.unit)
     when(
-      mockAuthProvider.listResourceIds[RuntimeSamResourceId](isEq(false), isEq(userInfo))(
+      mockAuthProvider.listResourceIds[RuntimeSamResourceId](isEq(true), isEq(userInfo))(
         any(runtimeSamResourceAction.getClass),
         any(AppSamResourceAction.getClass),
         any(Decoder[RuntimeSamResourceId].getClass),

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/mocks.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/mocks.scala
@@ -111,7 +111,7 @@ class BaseMockAuthProvider extends LeoAuthProvider[IO] {
     ev: Ask[IO, TraceId]
   ): IO[(List[A], List[ProjectAction])] = ???
 
-  def listResourceIds[R <: SamResourceId](
+  override def listResourceIds[R <: SamResourceId](
     hasOwnerRole: Boolean,
     userInfo: UserInfo
   )(implicit

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/mocks.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/mocks.scala
@@ -26,7 +26,7 @@ import org.broadinstitute.dsde.workbench.google2.{
   KubernetesModels,
   PvName
 }
-import org.broadinstitute.dsde.workbench.leonardo.SamResourceId.WorkspaceResourceSamResourceId
+import org.broadinstitute.dsde.workbench.leonardo.SamResourceId.{AppSamResourceId, WorkspaceResourceSamResourceId}
 import org.broadinstitute.dsde.workbench.leonardo.model.{
   LeoAuthProvider,
   SamResource,
@@ -111,12 +111,13 @@ class BaseMockAuthProvider extends LeoAuthProvider[IO] {
     ev: Ask[IO, TraceId]
   ): IO[(List[A], List[ProjectAction])] = ???
 
-  override def getAuthorizedIds[R](
-    isOwner: Boolean,
+  def listResourceIds[R <: SamResourceId](
+    hasOwnerRole: Boolean,
     userInfo: UserInfo
   )(implicit
-    samResource: SamResource[R],
-    decoder: Decoder[R],
+    resourceDefinition: SamResource[R],
+    appDefinition: SamResource[AppSamResourceId],
+    resourceIdDecoder: Decoder[R],
     ev: Ask[IO, TraceId]
   ): IO[Set[R]] = ???
 


### PR DESCRIPTION
Here I sketch an approach which would avoid use of misleadingly named SamPolicyName.