### PR TITLE
IA-4607: Query LZ Service in Back Leo for runtime and app creation

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/JsonCodec.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/JsonCodec.scala
@@ -631,6 +631,9 @@ object JsonCodec {
         .leftMap(_.getMessage)
     }
 
+  implicit val billingProfileIdDecoder: Decoder[BillingProfileId] =
+    Decoder.decodeString.map(BillingProfileId)
+
   implicit val workspaceSamResourceIdDecoder: Decoder[WorkspaceResourceSamResourceId] =
     workspaceIdDecoder.map(WorkspaceResourceSamResourceId.apply)
 
@@ -740,6 +743,9 @@ object JsonCodec {
 
   implicit val workspaceIdEncoder: Encoder[WorkspaceId] =
     Encoder.encodeString.contramap(_.value.toString)
+
+  implicit val billingProfileIdEncoder: Encoder[BillingProfileId] =
+    Encoder.encodeString.contramap(_.value)
 
   implicit val wsmControlledResourceIdEncoder: Encoder[WsmControlledResourceId] =
     Encoder.encodeString.contramap(_.value.toString)

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/models.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/models.scala
@@ -8,6 +8,8 @@ import java.util.UUID
 
 final case class WorkspaceId(value: UUID) extends AnyVal
 
+final case class BillingProfileId(value: String) extends AnyVal
+
 final case class CloudContextDb(value: String) extends AnyVal
 
 sealed abstract class CloudContext extends Product with Serializable {

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/runtimeModels.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/runtimeModels.scala
@@ -316,7 +316,7 @@ object RuntimeConfig {
   // Azure machineType maps to `com.azure.resourcemanager.compute.models.VirtualMachineSizeTypes`
   final case class AzureConfig(machineType: MachineTypeName,
                                persistentDiskId: Option[DiskId],
-                               region: com.azure.core.management.Region
+                               region: Option[RegionName]
   ) extends RuntimeConfig {
     val cloudService: CloudService = CloudService.AzureVm
     val configType: RuntimeConfigType = RuntimeConfigType.AzureVmConfig

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpWsmDao.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpWsmDao.scala
@@ -33,14 +33,10 @@ import org.http4s.client.dsl.Http4sClientDsl
 import org.http4s.headers.{`Content-Type`, Authorization}
 import org.typelevel.ci.CIString
 import org.typelevel.log4cats.StructuredLogger
-import scalacache.Cache
 
 import java.util.UUID
 
-class HttpWsmDao[F[_]](httpClient: Client[F],
-                       config: HttpWsmDaoConfig,
-                       lzResourcesCache: Cache[F, BillingProfileId, LandingZoneResources]
-)(implicit
+class HttpWsmDao[F[_]](httpClient: Client[F], config: HttpWsmDaoConfig)(implicit
   logger: StructuredLogger[F],
   F: Async[F],
   metrics: OpenTelemetryMetrics[F]
@@ -130,11 +126,6 @@ class HttpWsmDao[F[_]](httpClient: Client[F],
     } yield res
 
   override def getLandingZoneResources(billingProfileId: BillingProfileId, userToken: Authorization)(implicit
-    ev: Ask[F, AppContext]
-  ): F[LandingZoneResources] =
-    lzResourcesCache.cachingF(billingProfileId)(None)(getLandingZoneResourcesInternal(billingProfileId, userToken))
-
-  private def getLandingZoneResourcesInternal(billingProfileId: BillingProfileId, userToken: Authorization)(implicit
     ev: Ask[F, AppContext]
   ): F[LandingZoneResources] =
     for {

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/WsmDao.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/WsmDao.scala
@@ -70,7 +70,7 @@ trait WsmDao[F[_]] {
     ev: Ask[F, AppContext]
   ): F[Option[WorkspaceDescription]]
 
-  def getLandingZoneResources(billingProfileId: String, userToken: Authorization)(implicit
+  def getLandingZoneResources(billingProfileId: BillingProfileId, userToken: Authorization)(implicit
     ev: Ask[F, AppContext]
   ): F[LandingZoneResources]
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/WsmDao.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/WsmDao.scala
@@ -7,10 +7,12 @@ import ca.mrvisser.sealerate
 import cats.mtl.Ask
 import com.azure.resourcemanager.compute.models.VirtualMachineSizeTypes
 import org.broadinstitute.dsde.workbench.azure._
+import org.broadinstitute.dsde.workbench.google2.RegionName
 import org.broadinstitute.dsde.workbench.leonardo.JsonCodec.{
   azureImageEncoder,
   azureMachineTypeEncoder,
   googleProjectDecoder,
+  regionDecoder,
   runtimeNameEncoder,
   storageContainerNameDecoder,
   storageContainerNameEncoder,
@@ -147,7 +149,8 @@ final case class CreateVmRequestData(name: RuntimeName,
 )
 
 final case class WsmVMMetadata(resourceId: WsmControlledResourceId)
-final case class WsmVm(metadata: WsmVMMetadata)
+final case class WsmVMAttributes(region: RegionName)
+final case class WsmVm(metadata: WsmVMMetadata, attributes: WsmVMAttributes)
 
 final case class DeleteWsmResourceRequest(workspaceId: WorkspaceId,
                                           resourceId: WsmControlledResourceId,
@@ -308,10 +311,17 @@ object WsmDecoders {
     } yield WsmVMMetadata(WsmControlledResourceId(id))
   }
 
+  implicit val vmAttributesDecoder: Decoder[WsmVMAttributes] = Decoder.instance { a =>
+    for {
+      region <- a.downField("region").as[RegionName]
+    } yield WsmVMAttributes(region)
+  }
+
   implicit val createVmResponseDecoder: Decoder[WsmVm] = Decoder.instance { c =>
     for {
       m <- c.downField("metadata").as[WsmVMMetadata]
-    } yield WsmVm(m)
+      a <- c.downField("attributes").as[WsmVMAttributes]
+    } yield WsmVm(m, a)
   }
 
   implicit val createStorageContainerResultDecoder: Decoder[CreateStorageContainerResult] =

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/KubernetesClusterComponent.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/KubernetesClusterComponent.scala
@@ -213,6 +213,11 @@ object kubernetesClusterQuery extends TableQuery(KubernetesClusterTable(_)) {
         .update((destroyedDate, KubernetesClusterStatus.Deleted))
     } yield nodepool + cluster
 
+  def updateRegion(id: KubernetesClusterLeoId, regionName: RegionName): DBIO[Int] =
+    findByIdQuery(id)
+      .map(c => c.region)
+      .update(regionName)
+
   private[db] def joinMinimalClusterAndUnmarshal(
     clusterQuery: Query[KubernetesClusterTable, KubernetesClusterRecord, Seq],
     nodepoolQuery: Query[NodepoolTable, NodepoolRecord, Seq]

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/KubernetesServiceDbQueries.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/KubernetesServiceDbQueries.scala
@@ -139,7 +139,7 @@ object KubernetesServiceDbQueries {
                   None
                 )
               )
-            case _ => DBIO.successful(ClusterExists(cluster))
+            case _ => DBIO.successful(ClusterExists(cluster, DefaultNodepool.fromNodepool(cluster.nodepools.head)))
           }
         case _ =>
           kubernetesClusterQuery
@@ -455,12 +455,14 @@ object KubernetesServiceDbQueries {
 //minimal cluster has the nodepools, but no namespaces or apps
 sealed trait SaveClusterResult {
   def minimalCluster: KubernetesCluster
+  def defaultNodepool: DefaultNodepool
 }
 
 final case class ClusterDoesNotExist(minimalCluster: KubernetesCluster, defaultNodepool: DefaultNodepool)
     extends SaveClusterResult
 
-final case class ClusterExists(minimalCluster: KubernetesCluster) extends SaveClusterResult
+final case class ClusterExists(minimalCluster: KubernetesCluster, defaultNodepool: DefaultNodepool)
+    extends SaveClusterResult
 
 final case class GetAppAssertion(msg: String) extends LeoException(msg, StatusCodes.InternalServerError, traceId = None)
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/RuntimeConfigQueries.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/RuntimeConfigQueries.scala
@@ -2,7 +2,7 @@ package org.broadinstitute.dsde.workbench.leonardo
 package db
 
 import cats.implicits._
-import org.broadinstitute.dsde.workbench.google2.MachineTypeName
+import org.broadinstitute.dsde.workbench.google2.{MachineTypeName, RegionName}
 import org.broadinstitute.dsde.workbench.leonardo.db.LeoProfile.api._
 import org.broadinstitute.dsde.workbench.leonardo.db.LeoProfile.mappedColumnImplicits._
 
@@ -93,4 +93,10 @@ object RuntimeConfigQueries {
       .length
       .result
       .map(_ > 0)
+
+  def updateRegion(id: RuntimeConfigId, region: Option[RegionName]): DBIO[Int] =
+    runtimeConfigs
+      .filter(x => x.id === id)
+      .map(c => c.region)
+      .update(region)
 }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/RuntimeConfigTable.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/RuntimeConfigTable.scala
@@ -1,13 +1,13 @@
 package org.broadinstitute.dsde.workbench.leonardo
 package db
 
-import java.sql.SQLDataException
-import java.time.Instant
-import com.azure.core.management.Region
 import org.broadinstitute.dsde.workbench.google2.{MachineTypeName, RegionName, ZoneName}
 import org.broadinstitute.dsde.workbench.leonardo.db.LeoProfile.api._
 import org.broadinstitute.dsde.workbench.leonardo.db.LeoProfile.mappedColumnImplicits._
 import org.broadinstitute.dsde.workbench.leonardo.db.RuntimeConfigTable.toRuntimeConfig
+
+import java.sql.SQLDataException
+import java.time.Instant
 
 class RuntimeConfigTable(tag: Tag) extends Table[RuntimeConfigRecord](tag, "RUNTIME_CONFIG") {
   def id = column[RuntimeConfigId]("id", O.PrimaryKey, O.AutoInc)
@@ -175,8 +175,7 @@ class RuntimeConfigTable(tag: Tag) extends Table[RuntimeConfigRecord](tag, "RUNT
              None,
              r.persistentDiskId,
              None,
-             // TODO: should this be generalized to a type above regionName?
-             Some(RegionName(r.region.toString)),
+             r.region,
              (None, None),
              false,
              false
@@ -260,9 +259,7 @@ object RuntimeConfigTable {
         RuntimeConfig.AzureConfig(
           machineType,
           persistentDiskId,
-          Region.fromName(
-            region.getOrElse(throw new SQLDataException("region field should not be null for Azure.")).value
-          )
+          region
         )
     }
 }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/Boot.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/Boot.scala
@@ -432,15 +432,8 @@ object Boot extends IOApp {
       appDescriptorDAO <- buildHttpClient(sslContext, proxyResolver.resolveHttp4s, None, true).map(client =>
         new HttpAppDescriptorDAO(client)
       )
-      underlyingLandingZoneCache = buildCache[BillingProfileId, scalacache.Entry[LandingZoneResources]](
-        500,
-        4 hours
-      )
-      landingZoneCaffeineCache <- Resource.make(
-        F.delay(CaffeineCache[F, BillingProfileId, LandingZoneResources](underlyingLandingZoneCache))
-      )(_.close)
       wsmDao <- buildHttpClient(sslContext, proxyResolver.resolveHttp4s, Some("leo_wsm_client"), true)
-        .map(client => new HttpWsmDao[F](client, ConfigReader.appConfig.azure.wsm, landingZoneCaffeineCache))
+        .map(client => new HttpWsmDao[F](client, ConfigReader.appConfig.azure.wsm))
       googleOauth2DAO <- GoogleOAuth2Service.resource(semaphore)
 
       wsmClientProvider = new HttpWsmClientProvider(ConfigReader.appConfig.azure.wsm.uri)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/Boot.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/Boot.scala
@@ -432,10 +432,9 @@ object Boot extends IOApp {
       appDescriptorDAO <- buildHttpClient(sslContext, proxyResolver.resolveHttp4s, None, true).map(client =>
         new HttpAppDescriptorDAO(client)
       )
-      // TODO configure
       underlyingLandingZoneCache = buildCache[BillingProfileId, scalacache.Entry[LandingZoneResources]](
-        1000,
-        1.day
+        500,
+        4 hours
       )
       landingZoneCaffeineCache <- Resource.make(
         F.delay(CaffeineCache[F, BillingProfileId, LandingZoneResources](underlyingLandingZoneCache))

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/Boot.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/Boot.scala
@@ -198,15 +198,13 @@ object Boot extends IOApp {
           appDependencies.googleDependencies.googleComputeService,
           googleDependencies.googleResourceService,
           gkeCustomAppConfig,
-          appDependencies.wsmDAO,
-          appDependencies.samDAO
+          appDependencies.wsmDAO
         )
 
       val azureService = new RuntimeV2ServiceInterp[IO](
         runtimeServiceConfig,
         appDependencies.authProvider,
         appDependencies.wsmDAO,
-        appDependencies.samDAO,
         appDependencies.publisherQueue,
         appDependencies.dateAccessedUpdaterQueue,
         appDependencies.wsmClientProvider
@@ -434,8 +432,16 @@ object Boot extends IOApp {
       appDescriptorDAO <- buildHttpClient(sslContext, proxyResolver.resolveHttp4s, None, true).map(client =>
         new HttpAppDescriptorDAO(client)
       )
+      // TODO configure
+      underlyingLandingZoneCache = buildCache[BillingProfileId, scalacache.Entry[LandingZoneResources]](
+        1000,
+        1.day
+      )
+      landingZoneCaffeineCache <- Resource.make(
+        F.delay(CaffeineCache[F, BillingProfileId, LandingZoneResources](underlyingLandingZoneCache))
+      )(_.close)
       wsmDao <- buildHttpClient(sslContext, proxyResolver.resolveHttp4s, Some("leo_wsm_client"), true)
-        .map(client => new HttpWsmDao[F](client, ConfigReader.appConfig.azure.wsm))
+        .map(client => new HttpWsmDao[F](client, ConfigReader.appConfig.azure.wsm, landingZoneCaffeineCache))
       googleOauth2DAO <- GoogleOAuth2Service.resource(semaphore)
 
       wsmClientProvider = new HttpWsmClientProvider(ConfigReader.appConfig.azure.wsm.uri)
@@ -734,7 +740,8 @@ object Boot extends IOApp {
         samDao,
         wsmDao,
         kubeAlg,
-        wsmClientProvider
+        wsmClientProvider,
+        wsmDao
       )
 
       val azureAlg = new AzurePubsubHandlerInterp[F](

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/LeoAppServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/LeoAppServiceInterp.scala
@@ -9,9 +9,8 @@ import cats.effect.Async
 import cats.effect.std.Queue
 import cats.mtl.Ask
 import cats.syntax.all._
+import monocle.macros.syntax.lens._
 import org.apache.commons.lang3.RandomStringUtils
-import com.azure.core.management.Region
-import org.broadinstitute.dsde.workbench.azure.AKSClusterName
 import org.broadinstitute.dsde.workbench.google2.GKEModels.{KubernetesClusterName, NodepoolName}
 import org.broadinstitute.dsde.workbench.google2.KubernetesSerializableName.NamespaceName
 import org.broadinstitute.dsde.workbench.google2.{
@@ -28,8 +27,7 @@ import org.broadinstitute.dsde.workbench.leonardo.AppType._
 import org.broadinstitute.dsde.workbench.leonardo.JsonCodec._
 import org.broadinstitute.dsde.workbench.leonardo.SamResourceId._
 import org.broadinstitute.dsde.workbench.leonardo.config._
-import org.broadinstitute.dsde.workbench.leonardo.dao.{SamDAO, WsmDao}
-import org.broadinstitute.dsp.ChartName
+import org.broadinstitute.dsde.workbench.leonardo.dao.WsmDao
 import org.broadinstitute.dsde.workbench.leonardo.db.KubernetesServiceDbQueries.getActiveFullAppByWorkspaceIdAndAppName
 import org.broadinstitute.dsde.workbench.leonardo.db._
 import org.broadinstitute.dsde.workbench.leonardo.http.service.LeoAppServiceInterp.isPatchVersionDifference
@@ -40,10 +38,9 @@ import org.broadinstitute.dsde.workbench.leonardo.monitor.{ClusterNodepoolAction
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.broadinstitute.dsde.workbench.model.{TraceId, UserInfo, WorkbenchEmail}
 import org.broadinstitute.dsde.workbench.openTelemetry.OpenTelemetryMetrics
-import org.broadinstitute.dsp.{ChartVersion, Release}
+import org.broadinstitute.dsp.{ChartName, ChartVersion, Release}
 import org.http4s.{AuthScheme, Uri}
 import org.typelevel.log4cats.StructuredLogger
-import monocle.macros.syntax.lens._
 
 import java.time.Instant
 import java.util.UUID
@@ -56,8 +53,7 @@ final class LeoAppServiceInterp[F[_]: Parallel](config: AppServiceConfig,
                                                 computeService: GoogleComputeService[F],
                                                 googleResourceService: GoogleResourceService[F],
                                                 customAppConfig: CustomAppConfig,
-                                                wsmDao: WsmDao[F],
-                                                samDAO: SamDAO[F]
+                                                wsmDao: WsmDao[F]
 )(implicit
   F: Async[F],
   log: StructuredLogger[F],
@@ -162,7 +158,7 @@ final class LeoAppServiceInterp[F[_]: Parallel](config: AppServiceConfig,
         }
 
       saveCluster <- F.fromEither(
-        getSavableCluster(originatingUserEmail, cloudContext, ctx.now, None, None)
+        getSavableCluster(originatingUserEmail, cloudContext, ctx.now)
       )
 
       saveClusterResult <- KubernetesServiceDbQueries.saveOrGetClusterForApp(saveCluster).transaction
@@ -613,28 +609,14 @@ final class LeoAppServiceInterp[F[_]: Parallel](config: AppServiceConfig,
         F.raiseError[Unit](AppAlreadyExistsInWorkspaceException(workspaceId, appName, c.app.status, ctx.traceId))
       )
 
-      // Get the Landing Zone Resources for the app for Azure
-      leoAuth <- samDAO.getLeoAuthToken
-      landingZoneResourcesOpt <- cloudContext.cloudProvider match {
-        case CloudProvider.Gcp => F.pure(None)
-        case CloudProvider.Azure =>
-          for {
-            landingZoneResources <- wsmDao.getLandingZoneResources(workspaceDesc.spendProfile, leoAuth)
-          } yield Some(landingZoneResources)
-      }
-
-      // Get the optional storage container for the workspace
-      storageContainer <- wsmDao.getWorkspaceStorageContainer(workspaceId, userToken)
-
       // Validate the machine config from the request
       // For Azure: we don't support setting a machine type in the request; we use the landing zone configuration instead.
       // For GCP: we support setting optionally a machine type in the request; and use a default value otherwise.
       machineConfig <- (cloudContext.cloudProvider, req.kubernetesRuntimeConfig) match {
         case (CloudProvider.Azure, Some(_)) =>
           F.raiseError(AppMachineConfigNotSupportedException(ctx.traceId))
-        // TODO: pull this from the landing zone instead of hardcoding once TOAZ-232 is implemented
         case (CloudProvider.Azure, None) =>
-          F.pure(KubernetesRuntimeConfig(NumNodes(1), MachineTypeName("Standard_A2_v2"), false))
+          F.pure(KubernetesRuntimeConfig(NumNodes(1), MachineTypeName("unset"), false))
         case (CloudProvider.Gcp, Some(mt)) => F.pure(mt)
         case (CloudProvider.Gcp, None) =>
           F.pure(
@@ -660,12 +642,7 @@ final class LeoAppServiceInterp[F[_]: Parallel](config: AppServiceConfig,
 
       // Save or retrieve a KubernetesCluster record for the app
       saveCluster <- F.fromEither(
-        getSavableCluster(userInfo.userEmail,
-                          cloudContext,
-                          ctx.now,
-                          landingZoneResourcesOpt.map(_.clusterName),
-                          landingZoneResourcesOpt.map(_.region)
-        )
+        getSavableCluster(userInfo.userEmail, cloudContext, ctx.now)
       )
       saveClusterResult <- KubernetesServiceDbQueries.saveOrGetClusterForApp(saveCluster).transaction
       _ <-
@@ -747,8 +724,7 @@ final class LeoAppServiceInterp[F[_]: Parallel](config: AppServiceConfig,
         app.appName,
         workspaceId,
         cloudContext,
-        landingZoneResourcesOpt,
-        storageContainer,
+        BillingProfileId(workspaceDesc.spendProfile),
         Some(ctx.traceId)
       )
       _ <- publisherQueue.offer(createAppV2Message)
@@ -837,16 +813,6 @@ final class LeoAppServiceInterp[F[_]: Parallel](config: AppServiceConfig,
       case (None, None) => F.raiseError[CloudContext](CloudContextNotFoundException(workspaceId, ctx.traceId))
     }
 
-    // Get the Landing Zone Resources for the app for Azure
-    leoAuth <- samDAO.getLeoAuthToken
-    landingZoneResourcesOpt <- cloudContext.cloudProvider match {
-      case CloudProvider.Gcp => F.pure(None)
-      case CloudProvider.Azure =>
-        for {
-          landingZoneResources <- wsmDao.getLandingZoneResources(workspaceDesc.spendProfile, leoAuth)
-        } yield Some(landingZoneResources)
-    }
-
     _ <-
       for {
         _ <- KubernetesServiceDbQueries.markPreDeleting(app.id).transaction
@@ -856,7 +822,7 @@ final class LeoAppServiceInterp[F[_]: Parallel](config: AppServiceConfig,
           workspaceId,
           cloudContext,
           diskOpt,
-          landingZoneResourcesOpt,
+          BillingProfileId(workspaceDesc.spendProfile),
           Some(ctx.traceId)
         )
         _ <- publisherQueue.offer(deleteMessage)
@@ -866,9 +832,7 @@ final class LeoAppServiceInterp[F[_]: Parallel](config: AppServiceConfig,
   private[service] def getSavableCluster(
     userEmail: WorkbenchEmail,
     cloudContext: CloudContext,
-    now: Instant,
-    aksClusterName: Option[AKSClusterName],
-    azureRegionOpt: Option[Region]
+    now: Instant
   ): Either[Throwable, SaveKubernetesCluster] = {
     val auditInfo = AuditInfo(userEmail, now, None, now)
 
@@ -887,18 +851,15 @@ final class LeoAppServiceInterp[F[_]: Parallel](config: AppServiceConfig,
       autoscalingConfig = None
     )
 
-    // regionName can be empty in some test configurations
-    val regionName = if (azureRegionOpt.isEmpty) "" else azureRegionOpt.map(_.name).getOrElse("")
     for {
       nodepool <- defaultNodepool
       defaultClusterName <- KubernetesNameUtils.getUniqueName(KubernetesClusterName.apply)
-      clusterName = aksClusterName.map(c => KubernetesClusterName(c.value)).getOrElse(defaultClusterName)
     } yield SaveKubernetesCluster(
       cloudContext = cloudContext,
-      clusterName = clusterName,
+      clusterName = defaultClusterName,
       location = config.leoKubernetesConfig.clusterConfig.location,
       region =
-        if (cloudContext.cloudProvider == CloudProvider.Azure) RegionName(regionName)
+        if (cloudContext.cloudProvider == CloudProvider.Azure) RegionName("unset")
         else config.leoKubernetesConfig.clusterConfig.region,
       status =
         if (cloudContext.cloudProvider == CloudProvider.Azure) KubernetesClusterStatus.Running

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/MonitorAtBoot.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/MonitorAtBoot.scala
@@ -11,7 +11,7 @@ import org.broadinstitute.dsde.workbench.leonardo.dao.{SamDAO, WsmDao}
 import org.broadinstitute.dsde.workbench.leonardo.db._
 import org.broadinstitute.dsde.workbench.leonardo.http._
 import org.broadinstitute.dsde.workbench.leonardo.http.service.WorkspaceNotFoundException
-import org.broadinstitute.dsde.workbench.leonardo.model.{BadRequestException, LeoException}
+import org.broadinstitute.dsde.workbench.leonardo.model.LeoException
 import org.broadinstitute.dsde.workbench.leonardo.monitor.LeoPubsubMessage.{
   CreateAppMessage,
   CreateAppV2Message,
@@ -239,16 +239,12 @@ class MonitorAtBoot[F[_]](publisherQueue: Queue[F, LeoPubsubMessage],
                                                 WorkspaceNotFoundException(workspaceId, appContext.traceId)
                   )
 
-                  landingZoneResources <- wsmDao.getLandingZoneResources(workspaceDesc.spendProfile, bearerAuth)
-                  storageContainer <- wsmDao.getWorkspaceStorageContainer(workspaceId, bearerAuth)
-
                   msg = CreateAppV2Message(
                     app.id,
                     app.appName,
                     workspaceId,
                     cluster.cloudContext,
-                    Some(landingZoneResources),
-                    storageContainer,
+                    BillingProfileId(workspaceDesc.spendProfile),
                     Some(appContext.traceId)
                   )
                 } yield msg
@@ -293,7 +289,6 @@ class MonitorAtBoot[F[_]](publisherQueue: Queue[F, LeoPubsubMessage],
                                               WorkspaceNotFoundException(workspaceId, appContext.traceId)
                 )
 
-                landingZoneResources <- wsmDao.getLandingZoneResources(workspaceDesc.spendProfile, bearerAuth)
                 diskOpt <- appQuery.getDiskId(app.id).transaction
                 workspaceId = app.workspaceId.getOrElse(
                   throw MonitorAtBootException(
@@ -307,7 +302,7 @@ class MonitorAtBoot[F[_]](publisherQueue: Queue[F, LeoPubsubMessage],
                   workspaceId,
                   cluster.cloudContext,
                   diskOpt,
-                  Some(landingZoneResources),
+                  BillingProfileId(workspaceDesc.spendProfile),
                   Some(appContext.traceId)
                 )
               } yield msg
@@ -416,16 +411,25 @@ class MonitorAtBoot[F[_]](publisherQueue: Queue[F, LeoPubsubMessage],
                               MonitorAtBootException(s"no workspaceId found for ${runtime.id.toString}", traceId)
           )
           controlledResourceOpt = WsmControlledResourceId(UUID.fromString(runtime.internalId))
-          leoAuth <- samDAO.getLeoAuthToken
-          workspaceDescOpt <- wsmDao.getWorkspace(wid, leoAuth)
+          tokenOpt <- samDAO.getCachedArbitraryPetAccessToken(runtime.auditInfo.creator)
+          userToken <- F.fromOption(
+            tokenOpt,
+            MonitorAtBootException(
+              s"Unable to get pet token for ${runtime.auditInfo.creator} for runtime ${runtime.id.toString}",
+              traceId
+            )
+          )
+          bearerAuth = org.http4s.headers.Authorization(
+            org.http4s.Credentials.Token(AuthScheme.Bearer, userToken)
+          )
+          workspaceDescOpt <- wsmDao.getWorkspace(wid, bearerAuth)
           workspaceDesc <- F.fromOption(workspaceDescOpt, WorkspaceNotFoundException(wid, traceId))
-          landingZoneResources <- wsmDao.getLandingZoneResources(workspaceDesc.spendProfile, leoAuth)
         } yield LeoPubsubMessage.DeleteAzureRuntimeMessage(
           runtimeId = runtime.id,
           None,
           workspaceId = wid,
           wsmResourceId = Some(controlledResourceOpt),
-          landingZoneResources,
+          BillingProfileId(workspaceDesc.spendProfile),
           traceId = Some(traceId)
         )
       case RuntimeStatus.Starting =>
@@ -433,43 +437,26 @@ class MonitorAtBoot[F[_]](publisherQueue: Queue[F, LeoPubsubMessage],
       case RuntimeStatus.Creating =>
         for {
           now <- F.realTimeInstant
+          implicit0(appContext: Ask[F, AppContext]) <- F.pure(Ask.const(AppContext(traceId, now)))
           wid <- F.fromOption(runtime.workspaceId,
                               MonitorAtBootException(s"no workspaceId found for ${runtime.id.toString}", traceId)
           )
-          leoAuth <- samDAO.getLeoAuthToken
-          azureRuntimeConfig <- runtime.runtimeConfig match {
-            case x: RuntimeConfig.AzureConfig => F.pure(x)
-            case _ =>
-              F.raiseError(MonitorAtBootException("Azure runtime shouldn't have non Azure runtime config", traceId))
-          }
           petTokenOpt <- samDAO.getCachedArbitraryPetAccessToken(runtime.auditInfo.creator)
           petToken <- F.fromOption(
             petTokenOpt,
             MonitorAtBootException(s"Failed to get pet access token for ${runtime.auditInfo.creator}", traceId)
           )
           petAuth = Authorization(Credentials.Token(AuthScheme.Bearer, petToken))
-          implicit0(appContext: Ask[F, AppContext]) <- F.pure(Ask.const(AppContext(traceId, now)))
-          storageContainerOpt <- wsmDao.getWorkspaceStorageContainer(wid, leoAuth)
-          storageContainer <- F.fromOption(
-            storageContainerOpt,
-            BadRequestException(s"Workspace ${wid} doesn't have storage container provisioned appropriately",
-                                Some(traceId)
-            )
-          )
-          workspaceDescOpt <- wsmDao.getWorkspace(wid, leoAuth)
-          workspaceDesc <- F.fromOption(workspaceDescOpt, WorkspaceNotFoundException(wid, traceId))
 
-          // Get the Landing Zone Resources for the app for Azure
-          landingZoneResources <- wsmDao.getLandingZoneResources(workspaceDesc.spendProfile, leoAuth)
+          workspaceDescOpt <- wsmDao.getWorkspace(wid, petAuth)
+          workspaceDesc <- F.fromOption(workspaceDescOpt, WorkspaceNotFoundException(wid, traceId))
         } yield LeoPubsubMessage.CreateAzureRuntimeMessage(
           runtime.id,
           wid,
-          storageContainer.resourceId,
-          landingZoneResources,
           false,
           Some(traceId),
           workspaceDesc.displayName,
-          storageContainer.name
+          BillingProfileId(workspaceDesc.spendProfile)
         )
       case x => F.raiseError(MonitorAtBootException(s"Unexpected status for runtime ${runtime.id}: ${x}", traceId))
     }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/AKSAlgebra.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/AKSAlgebra.scala
@@ -2,8 +2,7 @@ package org.broadinstitute.dsde.workbench.leonardo.util
 
 import cats.mtl.Ask
 import org.broadinstitute.dsde.workbench.azure.AzureCloudContext
-import org.broadinstitute.dsde.workbench.leonardo.dao.StorageContainerResponse
-import org.broadinstitute.dsde.workbench.leonardo.{AppContext, AppId, AppName, LandingZoneResources, WorkspaceId}
+import org.broadinstitute.dsde.workbench.leonardo.{AppContext, AppId, AppName, BillingProfileId, WorkspaceId}
 import org.broadinstitute.dsp.ChartVersion
 
 trait AKSAlgebra[F[_]] {
@@ -21,8 +20,7 @@ final case class CreateAKSAppParams(appId: AppId,
                                     appName: AppName,
                                     workspaceId: WorkspaceId,
                                     cloudContext: AzureCloudContext,
-                                    landingZoneResources: LandingZoneResources,
-                                    storageContainer: Option[StorageContainerResponse]
+                                    billingProfileId: BillingProfileId
 )
 
 final case class UpdateAKSAppParams(appId: AppId,
@@ -35,25 +33,6 @@ final case class UpdateAKSAppParams(appId: AppId,
 final case class DeleteAKSAppParams(
   appName: AppName,
   workspaceId: WorkspaceId,
-  landingZoneResourcesOpt: LandingZoneResources,
-  cloudContext: AzureCloudContext
+  cloudContext: AzureCloudContext,
+  billingProfileId: BillingProfileId
 )
-
-/** Enumerates the possible identity modes for an AKS app. */
-sealed trait IdentityType
-object IdentityType {
-  // Runs the app with aad-pod-identity.
-  // Currently this is only done for single-user applications who don't provision a database.
-  // The pet UAMI is linked to the app.
-  // See https://broadworkbench.atlassian.net/browse/IA-3804 for tracking migration to AKS Workload Identity.
-  case object PodIdentity extends IdentityType
-
-  // Runs the app with Workload Identity.
-  // Currently this is only done for apps who provision a database.
-  // The WSM-managed identity is linked to the app
-  case object WorkloadIdentity extends IdentityType
-
-  // Runs the app with no identity.
-  // This is done for multi-user applications who do _not_ provision a database.
-  case object NoIdentity extends IdentityType
-}

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/AKSInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/AKSInterpreter.scala
@@ -15,7 +15,7 @@ import org.broadinstitute.dsde.workbench.DoneCheckableSyntax._
 import org.broadinstitute.dsde.workbench.azure._
 import org.broadinstitute.dsde.workbench.google2.KubernetesModels.{KubernetesNamespace, PodStatus}
 import org.broadinstitute.dsde.workbench.google2.KubernetesSerializableName.{NamespaceName, ServiceAccountName}
-import org.broadinstitute.dsde.workbench.google2.{streamFUntilDone, streamUntilDoneOrTimeout}
+import org.broadinstitute.dsde.workbench.google2.{streamFUntilDone, streamUntilDoneOrTimeout, RegionName}
 import org.broadinstitute.dsde.workbench.leonardo.app.Database.{CreateDatabase, ReferenceDatabase}
 import org.broadinstitute.dsde.workbench.leonardo.app.{AppInstall, BuildHelmOverrideValuesParams}
 import org.broadinstitute.dsde.workbench.leonardo.config.Config.refererConfig
@@ -271,6 +271,10 @@ class AKSInterpreter[F[_]](config: AKSInterpreterConfig,
             )
           )
         )
+        .transaction
+
+      _ <- kubernetesClusterQuery
+        .updateRegion(dbApp.cluster.id, RegionName(landingZoneResources.region.name))
         .transaction
 
       // If we've got here, update the App status to Running.

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/AKSInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/AKSInterpreter.scala
@@ -23,7 +23,7 @@ import org.broadinstitute.dsde.workbench.leonardo.config._
 import org.broadinstitute.dsde.workbench.leonardo.dao._
 import org.broadinstitute.dsde.workbench.leonardo.db._
 import org.broadinstitute.dsde.workbench.leonardo.http._
-import org.broadinstitute.dsde.workbench.leonardo.http.service.{AppNotFoundException, WorkspaceNotFoundException}
+import org.broadinstitute.dsde.workbench.leonardo.http.service.AppNotFoundException
 import org.broadinstitute.dsde.workbench.model.{IP, WorkbenchEmail}
 import org.broadinstitute.dsp.{Release, _}
 import org.http4s.headers.Authorization
@@ -74,24 +74,6 @@ class AKSInterpreter[F[_]](config: AKSInterpreterConfig,
 
   private def getListenerReleaseName(appReleaseName: Release): Release =
     Release(s"${appReleaseName.asString}-listener-rls")
-
-  private def retrieveWsmReferenceDatabases(resourceApi: ResourceApi,
-                                            referenceDatabaseNames: Set[String],
-                                            workspaceId: UUID
-  ): F[List[String]] = {
-    val wsmResourceDatabases = F.delay(
-      resourceApi
-        .enumerateResources(workspaceId, 0, 100, ResourceType.AZURE_DATABASE, StewardshipType.CONTROLLED)
-        .getResources
-        .asScala
-        .toList
-    )
-    wsmResourceDatabases.map { dbs =>
-      dbs
-        .filter(r => referenceDatabaseNames.contains(r.getMetadata().getName()))
-        .map(r => r.getResourceAttributes().getAzureDatabase().getDatabaseName())
-    }
-  }
 
   /** Creates an app and polls it for completion */
   override def createAndPollApp(params: CreateAKSAppParams)(implicit ev: Ask[F, AppContext]): F[Unit] =

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandler.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandler.scala
@@ -14,7 +14,7 @@ import org.broadinstitute.dsde.workbench.leonardo.AsyncTaskProcessor.Task
 import org.broadinstitute.dsde.workbench.leonardo.config.{ApplicationConfig, ContentSecurityPolicyConfig, RefererConfig}
 import org.broadinstitute.dsde.workbench.leonardo.dao._
 import org.broadinstitute.dsde.workbench.leonardo.db._
-import org.broadinstitute.dsde.workbench.leonardo.http.{childSpan, ctxConversion, dbioToIO}
+import org.broadinstitute.dsde.workbench.leonardo.http.{ctxConversion, dbioToIO}
 import org.broadinstitute.dsde.workbench.leonardo.monitor.LeoPubsubMessage.{
   CreateAzureRuntimeMessage,
   DeleteAzureRuntimeMessage,
@@ -63,9 +63,7 @@ class AzurePubsubHandlerInterp[F[_]: Parallel](
       }
       // Query the Landing Zone service for the landing zone resources
       leoAuth <- samDAO.getLeoAuthToken
-      landingZoneResources <- childSpan("getLandingZoneResources").use { implicit ev =>
-        wsmDao.getLandingZoneResources(msg.billingProfileId, leoAuth)
-      }
+      landingZoneResources <- wsmDao.getLandingZoneResources(msg.billingProfileId, leoAuth)
 
       // Get the optional storage container for the workspace
       tokenOpt <- samDAO.getCachedArbitraryPetAccessToken(runtime.auditInfo.creator)
@@ -548,9 +546,7 @@ class AzurePubsubHandlerInterp[F[_]: Parallel](
       auth <- samDAO.getLeoAuthToken
 
       // Query the Landing Zone service for the landing zone resources
-      landingZoneResources <- childSpan("getLandingZoneResources").use { implicit ev =>
-        wsmDao.getLandingZoneResources(msg.billingProfileId, auth)
-      }
+      landingZoneResources <- wsmDao.getLandingZoneResources(msg.billingProfileId, auth)
 
       // Delete the staging storage container in WSM
       stagingBucketResourceOpt <- controlledResourceQuery

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandler.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandler.scala
@@ -513,6 +513,9 @@ class AzurePubsubHandlerInterp[F[_]: Parallel](
                 s"Welder was not running within ${config.createVmPollConfig.maxAttempts} attempts with ${config.createVmPollConfig.interval} delay"
               )
               _ <- clusterQuery.setToRunning(params.runtime.id, IP(hostIp), now).transaction
+              _ <- RuntimeConfigQueries
+                .updateRegion(params.runtime.runtimeConfigId, resp.vm.map(_.attributes.region))
+                .transaction
               _ <- logger.info(ctx.loggingCtx)("runtime is ready")
             } yield ()
         }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandler.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandler.scala
@@ -14,7 +14,7 @@ import org.broadinstitute.dsde.workbench.leonardo.AsyncTaskProcessor.Task
 import org.broadinstitute.dsde.workbench.leonardo.config.{ApplicationConfig, ContentSecurityPolicyConfig, RefererConfig}
 import org.broadinstitute.dsde.workbench.leonardo.dao._
 import org.broadinstitute.dsde.workbench.leonardo.db._
-import org.broadinstitute.dsde.workbench.leonardo.http.{ctxConversion, dbioToIO}
+import org.broadinstitute.dsde.workbench.leonardo.http.{childSpan, ctxConversion, dbioToIO}
 import org.broadinstitute.dsde.workbench.leonardo.monitor.LeoPubsubMessage.{
   CreateAzureRuntimeMessage,
   DeleteAzureRuntimeMessage,
@@ -25,6 +25,7 @@ import org.broadinstitute.dsde.workbench.leonardo.monitor.PubsubHandleMessageErr
 import org.broadinstitute.dsde.workbench.model.{IP, WorkbenchEmail}
 import org.broadinstitute.dsde.workbench.util2.InstanceName
 import org.broadinstitute.dsp.ChartVersion
+import org.http4s.AuthScheme
 import org.http4s.headers.Authorization
 import org.typelevel.log4cats.StructuredLogger
 
@@ -60,18 +61,41 @@ class AzurePubsubHandlerInterp[F[_]: Parallel](
         case x: RuntimeConfig.AzureConfig => F.pure(x)
         case x => F.raiseError(new RuntimeException(s"this runtime doesn't have proper azure config ${x}"))
       }
+      // Query the Landing Zone service for the landing zone resources
+      leoAuth <- samDAO.getLeoAuthToken
+      landingZoneResources <- childSpan("getLandingZoneResources").use { implicit ev =>
+        wsmDao.getLandingZoneResources(msg.billingProfileId, leoAuth)
+      }
+
+      // Get the optional storage container for the workspace
+      tokenOpt <- samDAO.getCachedArbitraryPetAccessToken(runtime.auditInfo.creator)
+      storageContainerOpt <- tokenOpt.flatTraverse { token =>
+        wsmDao.getWorkspaceStorageContainer(
+          msg.workspaceId,
+          org.http4s.headers.Authorization(org.http4s.Credentials.Token(AuthScheme.Bearer, token))
+        )
+      }
+      storageContainer <- F.fromOption(
+        storageContainerOpt,
+        AzureRuntimeCreationError(
+          runtime.id,
+          msg.workspaceId,
+          s"Storage container not found for runtime: ${runtime.id}",
+          msg.useExistingDisk
+        )
+      )
       createVmJobId = WsmJobId(s"create-vm-${runtime.id.toString.take(10)}")
       _ <- createRuntime(
         CreateAzureRuntimeParams(
           msg.workspaceId,
           runtime,
-          msg.storageContainerResourceId,
-          msg.landingZoneResources,
+          storageContainer.resourceId,
+          landingZoneResources,
           azureConfig,
           config.runtimeDefaults.image,
           msg.useExistingDisk,
           msg.workspaceName,
-          msg.containerName
+          storageContainer.name
         ),
         WsmJobControl(createVmJobId)
       )
@@ -79,7 +103,7 @@ class AzurePubsubHandlerInterp[F[_]: Parallel](
         PollRuntimeParams(msg.workspaceId,
                           runtime,
                           createVmJobId,
-                          msg.landingZoneResources.relayNamespace,
+                          landingZoneResources.relayNamespace,
                           msg.useExistingDisk
         )
       )
@@ -523,6 +547,11 @@ class AzurePubsubHandlerInterp[F[_]: Parallel](
       runtime <- F.fromOption(runtimeOpt, PubsubHandleMessageError.ClusterNotFound(msg.runtimeId, msg))
       auth <- samDAO.getLeoAuthToken
 
+      // Query the Landing Zone service for the landing zone resources
+      landingZoneResources <- childSpan("getLandingZoneResources").use { implicit ev =>
+        wsmDao.getLandingZoneResources(msg.billingProfileId, auth)
+      }
+
       // Delete the staging storage container in WSM
       stagingBucketResourceOpt <- controlledResourceQuery
         .getWsmRecordForRuntime(runtime.id, WsmResourceType.AzureStorageContainer)
@@ -561,7 +590,7 @@ class AzurePubsubHandlerInterp[F[_]: Parallel](
 
       // Delete hybrid connection for this VM
       _ <- azureRelay.deleteRelayHybridConnection(
-        msg.landingZoneResources.relayNamespace,
+        landingZoneResources.relayNamespace,
         RelayHybridConnectionName(runtime.runtimeName.asString),
         cloudContext
       )
@@ -740,14 +769,13 @@ class AzurePubsubHandlerInterp[F[_]: Parallel](
                                 appName: AppName,
                                 workspaceId: WorkspaceId,
                                 cloudContext: AzureCloudContext,
-                                landingZoneResources: LandingZoneResources,
-                                storageContainer: Option[StorageContainerResponse]
+                                billingProfileId: BillingProfileId
   )(implicit
     ev: Ask[F, AppContext]
   ): F[Unit] =
     for {
       ctx <- ev.ask
-      params = CreateAKSAppParams(appId, appName, workspaceId, cloudContext, landingZoneResources, storageContainer)
+      params = CreateAKSAppParams(appId, appName, workspaceId, cloudContext, billingProfileId)
       _ <- aksAlgebra.createAndPollApp(params).adaptError { case e =>
         PubsubKubernetesError(
           AppError(
@@ -801,14 +829,14 @@ class AzurePubsubHandlerInterp[F[_]: Parallel](
     appId: AppId,
     appName: AppName,
     workspaceId: WorkspaceId,
-    landingZoneResources: LandingZoneResources,
-    cloudContext: AzureCloudContext
+    cloudContext: AzureCloudContext,
+    billingProfileId: BillingProfileId
   )(implicit
     ev: Ask[F, AppContext]
   ): F[Unit] =
     for {
       ctx <- ev.ask
-      params = DeleteAKSAppParams(appName, workspaceId, landingZoneResources, cloudContext)
+      params = DeleteAKSAppParams(appName, workspaceId, cloudContext, billingProfileId)
       _ <- aksAlgebra.deleteApp(params).adaptError { case e =>
         PubsubKubernetesError(
           AppError(

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandlerAlgebra.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandlerAlgebra.scala
@@ -3,7 +3,6 @@ package util
 
 import cats.mtl.Ask
 import org.broadinstitute.dsde.workbench.azure.{AzureCloudContext, ContainerName, RelayNamespace}
-import org.broadinstitute.dsde.workbench.leonardo.dao.StorageContainerResponse
 import org.broadinstitute.dsde.workbench.leonardo.http.service.AzureRuntimeDefaults
 import org.broadinstitute.dsde.workbench.leonardo.monitor.LeoPubsubMessage.{
   CreateAzureRuntimeMessage,
@@ -45,8 +44,7 @@ trait AzurePubsubHandlerAlgebra[F[_]] {
                        appName: AppName,
                        workspaceId: WorkspaceId,
                        cloudContext: AzureCloudContext,
-                       landingZoneResources: LandingZoneResources,
-                       storageContainer: Option[StorageContainerResponse]
+                       billingProfileId: BillingProfileId
   )(implicit
     ev: Ask[F, AppContext]
   ): F[Unit]
@@ -63,8 +61,8 @@ trait AzurePubsubHandlerAlgebra[F[_]] {
   def deleteApp(appId: AppId,
                 appName: AppName,
                 workspaceId: WorkspaceId,
-                landingZoneResources: LandingZoneResources,
-                cloudContext: AzureCloudContext
+                cloudContext: AzureCloudContext,
+                billingProfileId: BillingProfileId
   )(implicit
     ev: Ask[F, AppContext]
   ): F[Unit]

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/CommonTestData.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/CommonTestData.scala
@@ -533,6 +533,7 @@ object CommonTestData {
   val workspaceId3 = WorkspaceId(UUID.randomUUID())
   val wsmResourceId = WsmControlledResourceId(UUID.randomUUID())
   val cloudContextAzure = CloudContext.Azure(azureCloudContext)
+  val billingProfileId = BillingProfileId("spend-profile")
 
   val testCommonControlledResourceFields = ControlledResourceCommonFields(
     ControlledResourceName("name"),

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpWsmDaoSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpWsmDaoSpec.scala
@@ -2,6 +2,7 @@ package org.broadinstitute.dsde.workbench.leonardo.dao
 
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global
+import com.github.benmanes.caffeine.cache.Caffeine
 import io.circe.syntax.EncoderOps
 import io.circe.{Encoder, Printer}
 import org.broadinstitute.dsde.workbench.azure.{
@@ -22,6 +23,7 @@ import org.broadinstitute.dsde.workbench.leonardo.dao.LandingZoneResourcePurpose
   WORKSPACE_COMPUTE_SUBNET
 }
 import org.broadinstitute.dsde.workbench.leonardo.{
+  BillingProfileId,
   LandingZoneResources,
   LeonardoTestSuite,
   PostgresServer,
@@ -35,17 +37,24 @@ import org.http4s.client.Client
 import org.http4s.headers.Authorization
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.flatspec.AnyFlatSpec
+import scalacache.caffeine.CaffeineCache
 
 import java.util.UUID
 
 class HttpWsmDaoSpec extends AnyFlatSpec with LeonardoTestSuite with BeforeAndAfterAll {
   val config = HttpWsmDaoConfig(Uri.unsafeFromString("127.0.0.1"))
+  val underlyingLzResourcesCache = Caffeine
+    .newBuilder()
+    .maximumSize(10)
+    .build[BillingProfileId, scalacache.Entry[LandingZoneResources]]()
+  val lzResourcesCache = CaffeineCache[IO, BillingProfileId, LandingZoneResources](underlyingLzResourcesCache)
+
   it should "not error when getting 404 during resource deletion" in {
     val wsmClient = Client.fromHttpApp[IO](
       HttpApp(_ => IO(Response(status = Status.NotFound)))
     )
 
-    val wsmDao = new HttpWsmDao[IO](wsmClient, config)
+    val wsmDao = new HttpWsmDao[IO](wsmClient, config, lzResourcesCache)
     val res = wsmDao
       .deleteVm(
         DeleteWsmResourceRequest(WorkspaceId(UUID.randomUUID()),
@@ -130,10 +139,10 @@ class HttpWsmDaoSpec extends AnyFlatSpec with LeonardoTestSuite with BeforeAndAf
         }
       )
 
-      val wsmDao = new HttpWsmDao[IO](wsmClient, config)
+      val wsmDao = new HttpWsmDao[IO](wsmClient, config, lzResourcesCache)
       val res = wsmDao
         .getLandingZoneResources(
-          billingId.toString,
+          BillingProfileId(billingId.toString),
           Authorization(Credentials.Token(AuthScheme.Bearer, "dummy"))
         )
         .attempt

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpWsmDaoSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpWsmDaoSpec.scala
@@ -79,8 +79,8 @@ class HttpWsmDaoSpec extends AnyFlatSpec with LeonardoTestSuite with BeforeAndAf
 
   testCases.foreach { case (tags, expectedPgBouncer) =>
     it should s"correctly get landing zone resources and detect PgBouncer for tags: $tags" in {
-      val billingId = UUID.fromString("78bacb57-2d47-4ac2-8710-5bd12edbc1bf")
-      val landingZoneId = UUID.fromString("910f1c68-425d-4060-94f2-cb57f08425fe")
+      val billingId = UUID.randomUUID()
+      val landingZoneId = UUID.randomUUID()
 
       val originalLandingZone = LandingZone(landingZoneId, billingId, "def", "v1", "2022-11-11")
       val landingZoneResponse = ListLandingZonesResult(List(originalLandingZone))
@@ -151,7 +151,7 @@ class HttpWsmDaoSpec extends AnyFlatSpec with LeonardoTestSuite with BeforeAndAf
       res.isRight shouldBe true
 
       val expectedLandingZoneResources = LandingZoneResources(
-        UUID.fromString("910f1c68-425d-4060-94f2-cb57f08425fe"),
+        landingZoneId,
         AKSClusterName("lzcluster"),
         BatchAccountName("lzbatch"),
         RelayNamespace("lznamespace"),

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/MockWsmDAO.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/MockWsmDAO.scala
@@ -110,7 +110,7 @@ class MockWsmDAO(jobStatus: WsmJobStatus = WsmJobStatus.Succeeded) extends WsmDa
         WorkspaceDescription(
           workspaceId,
           "workspaceName" + workspaceId,
-          "9f3434cb-8f18-4595-95a9-d9b1ec9731d4",
+          "spend-profile",
           Some(
             AzureCloudContext(TenantId(workspaceId.toString),
                               SubscriptionId(workspaceId.toString),
@@ -122,7 +122,7 @@ class MockWsmDAO(jobStatus: WsmJobStatus = WsmJobStatus.Succeeded) extends WsmDa
       )
     )
 
-  override def getLandingZoneResources(billingProfileId: String, userToken: Authorization)(implicit
+  override def getLandingZoneResources(billingProfileId: BillingProfileId, userToken: Authorization)(implicit
     ev: Ask[IO, AppContext]
   ): IO[LandingZoneResources] =
     IO.pure(

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/MockWsmDAO.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/MockWsmDAO.scala
@@ -4,6 +4,7 @@ package dao
 import cats.effect.IO
 import cats.mtl.Ask
 import org.broadinstitute.dsde.workbench.azure._
+import org.broadinstitute.dsde.workbench.google2.RegionName
 import org.http4s.headers.Authorization
 
 import java.time.ZonedDateTime
@@ -52,7 +53,11 @@ class MockWsmDAO(jobStatus: WsmJobStatus = WsmJobStatus.Succeeded) extends WsmDa
   )(implicit ev: Ask[IO, AppContext]): IO[GetCreateVmJobResult] =
     IO.pure(
       GetCreateVmJobResult(
-        Some(WsmVm(WsmVMMetadata(WsmControlledResourceId(UUID.randomUUID())))),
+        Some(
+          WsmVm(WsmVMMetadata(WsmControlledResourceId(UUID.randomUUID())),
+                WsmVMAttributes(RegionName("southcentralus"))
+          )
+        ),
         WsmJobReport(
           request.jobId,
           "desc",

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/WsmCodecSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/WsmCodecSpec.scala
@@ -4,6 +4,7 @@ package dao
 import _root_.io.circe.syntax._
 import com.azure.resourcemanager.compute.models.VirtualMachineSizeTypes
 import io.circe.parser._
+import org.broadinstitute.dsde.workbench.google2.RegionName
 import org.broadinstitute.dsde.workbench.leonardo.CommonTestData._
 import org.broadinstitute.dsde.workbench.leonardo.dao.WsmDecoders._
 import org.broadinstitute.dsde.workbench.leonardo.dao.WsmEncoders._
@@ -238,7 +239,8 @@ class WsmCodecSpec extends AnyFlatSpec with Matchers {
     val expected = GetCreateVmJobResult(
       Some(
         WsmVm(
-          WsmVMMetadata(WsmControlledResourceId(UUID.fromString("dcfa6fa4-ab46-465e-a8dd-76705cbdb4ec")))
+          WsmVMMetadata(WsmControlledResourceId(UUID.fromString("dcfa6fa4-ab46-465e-a8dd-76705cbdb4ec"))),
+          WsmVMAttributes(RegionName("westcentralus"))
         )
       ),
       WsmJobReport(

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponentSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponentSpec.scala
@@ -367,7 +367,7 @@ class ClusterComponentSpec extends AnyFlatSpecLike with TestComponent with GcsPa
         makeCluster(1).saveWithRuntimeConfig(
           RuntimeConfig.AzureConfig(MachineTypeName(VirtualMachineSizeTypes.STANDARD_A1.toString),
                                     Some(savedDisk.id),
-                                    azureRegion
+                                    None
           )
         )
       )
@@ -375,7 +375,7 @@ class ClusterComponentSpec extends AnyFlatSpecLike with TestComponent with GcsPa
         makeCluster(2).saveWithRuntimeConfig(
           RuntimeConfig.AzureConfig(MachineTypeName(VirtualMachineSizeTypes.STANDARD_A1.toString),
                                     Some(savedDisk.id),
-                                    azureRegion
+                                    None
           )
         )
       )

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/RuntimeControlledResourceComponentSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/RuntimeControlledResourceComponentSpec.scala
@@ -1,14 +1,13 @@
 package org.broadinstitute.dsde.workbench.leonardo
-package http
 package db
-
-import java.util.UUID
 
 import com.azure.resourcemanager.compute.models.VirtualMachineSizeTypes
 import org.broadinstitute.dsde.workbench.google2.MachineTypeName
 import org.broadinstitute.dsde.workbench.leonardo.CommonTestData._
-import org.broadinstitute.dsde.workbench.leonardo.db.{controlledResourceQuery, TestComponent, WsmResourceType}
+import org.broadinstitute.dsde.workbench.leonardo.http._
 import org.scalatest.flatspec.AnyFlatSpecLike
+
+import java.util.UUID
 import scala.concurrent.ExecutionContext.Implicits.global
 
 class RuntimeControlledResourceComponentSpec extends AnyFlatSpecLike with TestComponent {
@@ -18,7 +17,7 @@ class RuntimeControlledResourceComponentSpec extends AnyFlatSpecLike with TestCo
       disk <- makePersistentDisk().copy(status = DiskStatus.Ready).save()
       azureRuntimeConfig = RuntimeConfig.AzureConfig(MachineTypeName(VirtualMachineSizeTypes.STANDARD_A1.toString),
                                                      Some(disk.id),
-                                                     azureRegion
+                                                     None
       )
       runtime = makeCluster(1)
         .copy(
@@ -49,7 +48,7 @@ class RuntimeControlledResourceComponentSpec extends AnyFlatSpecLike with TestCo
       disk <- makePersistentDisk().copy(status = DiskStatus.Ready).save()
       azureRuntimeConfig = RuntimeConfig.AzureConfig(MachineTypeName(VirtualMachineSizeTypes.STANDARD_A1.toString),
                                                      Some(disk.id),
-                                                     azureRegion
+                                                     None
       )
       runtime = makeCluster(1)
         .copy(
@@ -76,7 +75,7 @@ class RuntimeControlledResourceComponentSpec extends AnyFlatSpecLike with TestCo
       disk <- makePersistentDisk().copy(status = DiskStatus.Ready).save()
       azureRuntimeConfig = RuntimeConfig.AzureConfig(MachineTypeName(VirtualMachineSizeTypes.STANDARD_A1.toString),
                                                      Some(disk.id),
-                                                     azureRegion
+                                                     None
       )
       runtime1 = makeCluster(1)
         .copy(

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/RuntimeServiceDbQueriesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/RuntimeServiceDbQueriesSpec.scala
@@ -1,30 +1,22 @@
 package org.broadinstitute.dsde.workbench.leonardo
-package http
 package db
 
-import java.time.Instant
-import java.util.UUID
 import cats.effect.IO
 import org.broadinstitute.dsde.workbench.google2.{DiskName, ZoneName}
 import org.broadinstitute.dsde.workbench.leonardo.CommonTestData.{makeCluster, _}
-import org.broadinstitute.dsde.workbench.leonardo.config.Config
-import org.broadinstitute.dsde.workbench.leonardo.db.{
-  clusterQuery,
-  labelQuery,
-  LabelResourceType,
-  RuntimeServiceDbQueries,
-  TestComponent
-}
-import org.broadinstitute.dsde.workbench.leonardo.db.RuntimeServiceDbQueries._
 import org.broadinstitute.dsde.workbench.leonardo.LeonardoTestTags.SlickPlainQueryTest
+import org.broadinstitute.dsde.workbench.leonardo.config.Config
+import org.broadinstitute.dsde.workbench.leonardo.db.RuntimeServiceDbQueries._
+import org.broadinstitute.dsde.workbench.leonardo.http._
 import org.broadinstitute.dsde.workbench.model.{IP, WorkbenchEmail}
 import org.scalatest.concurrent.ScalaFutures
-
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.duration._
 import org.scalatest.flatspec.AnyFlatSpecLike
 
+import java.time.Instant
+import java.util.UUID
 import scala.collection.immutable.List
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration._
 
 class RuntimeServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent with GcsPathUtils with ScalaFutures {
   val maxElapsed = 5.seconds
@@ -338,7 +330,7 @@ class RuntimeServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent wit
           .saveWithRuntimeConfig(c2RuntimeConfig)
       )
       d3 <- makePersistentDisk(Some(DiskName("d3"))).save()
-      c3RuntimeConfig = RuntimeConfig.AzureConfig(defaultMachineType, Some(d3.id), azureRegion)
+      c3RuntimeConfig = RuntimeConfig.AzureConfig(defaultMachineType, Some(d3.id), None)
       c3 <- IO(
         makeCluster(3).saveWithRuntimeConfig(
           c3RuntimeConfig
@@ -397,7 +389,7 @@ class RuntimeServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent wit
       )
 
       d3 <- makePersistentDisk(None).save()
-      c3RuntimeConfig = RuntimeConfig.AzureConfig(defaultMachineType, Some(d3.id), azureRegion)
+      c3RuntimeConfig = RuntimeConfig.AzureConfig(defaultMachineType, Some(d3.id), None)
       c3 <- IO(
         makeCluster(3)
           .copy(workspaceId = Some(workspaceId2))
@@ -447,7 +439,7 @@ class RuntimeServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent wit
       )
 
       d2 <- makePersistentDisk(Some(DiskName("d2"))).save()
-      c2RuntimeConfig = RuntimeConfig.AzureConfig(defaultMachineType, Some(d2.id), azureRegion)
+      c2RuntimeConfig = RuntimeConfig.AzureConfig(defaultMachineType, Some(d2.id), None)
       c2 <- IO(
         makeCluster(2)
           .copy(workspaceId = Some(workspaceId1), cloudContext = CloudContext.Azure(CommonTestData.azureCloudContext))
@@ -458,7 +450,7 @@ class RuntimeServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent wit
       c2ClusterRecord <- clusterQuery.getActiveClusterRecordByName(c2.cloudContext, c2.runtimeName).transaction
 
       d3 <- makePersistentDisk(None).save()
-      c3RuntimeConfig = RuntimeConfig.AzureConfig(defaultMachineType, Some(d3.id), azureRegion)
+      c3RuntimeConfig = RuntimeConfig.AzureConfig(defaultMachineType, Some(d3.id), None)
       c3 <- IO(
         makeCluster(3)
           .copy(workspaceId = Some(workspaceId2), cloudContext = CloudContext.Azure(CommonTestData.azureCloudContext))
@@ -469,7 +461,7 @@ class RuntimeServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent wit
       c3ClusterRecord <- clusterQuery.getActiveClusterRecordByName(c3.cloudContext, c3.runtimeName).transaction
 
       d4 <- makePersistentDisk(Some(DiskName("d4"))).save()
-      c4RuntimeConfig = RuntimeConfig.AzureConfig(defaultMachineType, Some(d4.id), azureRegion)
+      c4RuntimeConfig = RuntimeConfig.AzureConfig(defaultMachineType, Some(d4.id), None)
       c4 <- IO(
         makeCluster(4)
           .copy(workspaceId = Some(workspaceId1), cloudContext = CloudContext.Azure(CommonTestData.azureCloudContext))
@@ -480,7 +472,7 @@ class RuntimeServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent wit
       c4ClusterRecord <- clusterQuery.getActiveClusterRecordByName(c4.cloudContext, c4.runtimeName).transaction
 
       d5 <- makePersistentDisk(Some(DiskName("d5"))).save()
-      c5RuntimeConfig = RuntimeConfig.AzureConfig(defaultMachineType, Some(d5.id), azureRegion)
+      c5RuntimeConfig = RuntimeConfig.AzureConfig(defaultMachineType, Some(d5.id), None)
       c5 <- IO(
         makeCluster(5, Some(WorkbenchEmail("different@gmail.com")))
           .copy(workspaceId = Some(workspaceId2), cloudContext = CloudContext.Azure(CommonTestData.azureCloudContext))

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/TestLeoRoutes.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/TestLeoRoutes.scala
@@ -29,6 +29,7 @@ import org.scalatest.concurrent.PatienceConfiguration.Interval
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.time.{Seconds, Span}
+import org.scalatestplus.mockito.MockitoSugar
 import scalacache.Cache
 import scalacache.caffeine.CaffeineCache
 
@@ -36,7 +37,6 @@ import java.io.ByteArrayInputStream
 import java.time.Instant
 import scala.concurrent.duration._
 import scala.util.matching.Regex
-import org.scalatestplus.mockito.MockitoSugar
 trait TestLeoRoutes {
   this: ScalatestRouteTest
     with Matchers
@@ -114,8 +114,7 @@ trait TestLeoRoutes {
     FakeGoogleComputeService,
     FakeGoogleResourceService,
     Config.gkeCustomAppConfig,
-    wsmDao,
-    new MockSamDAO
+    wsmDao
   )
 
   val serviceConfig = RuntimeServiceConfig(
@@ -132,7 +131,6 @@ trait TestLeoRoutes {
       serviceConfig,
       allowListAuthProvider,
       new MockWsmDAO,
-      new MockSamDAO,
       QueueFactory.makePublisherQueue(),
       QueueFactory.makeDateAccessedQueue(),
       wsmClientProvider

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/AppServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/AppServiceInterpSpec.scala
@@ -1675,11 +1675,9 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
     val cluster = clusters.head
     cluster.auditInfo.creator shouldEqual userInfo.userEmail
 
+    clusters.flatMap(_.nodepools).size shouldBe 1
     val nodepool = clusters.flatMap(_.nodepools).head
-    nodepool.machineType shouldEqual appReq.kubernetesRuntimeConfig.get.machineType
-    nodepool.numNodes shouldEqual appReq.kubernetesRuntimeConfig.get.numNodes
-    nodepool.autoscalingEnabled shouldEqual appReq.kubernetesRuntimeConfig.get.autoscalingEnabled
-    nodepool.auditInfo.creator shouldEqual userInfo.userEmail
+    nodepool.isDefault shouldBe true
 
     clusters.flatMap(_.nodepools).flatMap(_.apps).length shouldEqual 1
     val app = clusters.flatMap(_.nodepools).flatMap(_.apps).head
@@ -1719,12 +1717,9 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
     cluster.auditInfo.creator shouldEqual userInfo.userEmail
     cluster.status shouldEqual KubernetesClusterStatus.Running
 
+    clusters.flatMap(_.nodepools).size shouldBe 1
     val nodepool = clusters.flatMap(_.nodepools).head
-    nodepool.machineType shouldEqual MachineTypeName("unset")
-    nodepool.numNodes shouldEqual NumNodes(1)
-    nodepool.autoscalingEnabled shouldEqual false
-    nodepool.auditInfo.creator shouldEqual userInfo.userEmail
-    nodepool.status shouldEqual NodepoolStatus.Running
+    nodepool.isDefault shouldBe true
 
     clusters.flatMap(_.nodepools).flatMap(_.apps).length shouldEqual 1
     val app = clusters.flatMap(_.nodepools).flatMap(_.apps).head

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/AppServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/AppServiceInterpSpec.scala
@@ -20,15 +20,9 @@ import org.broadinstitute.dsde.workbench.leonardo.TestUtils.appContext
 import org.broadinstitute.dsde.workbench.leonardo.auth.AllowlistAuthProvider
 import org.broadinstitute.dsde.workbench.leonardo.config.Config.leoKubernetesConfig
 import org.broadinstitute.dsde.workbench.leonardo.config.{Config, CustomAppConfig, CustomApplicationAllowListConfig}
-import org.broadinstitute.dsde.workbench.leonardo.dao.{MockSamDAO, MockWsmDAO, WorkspaceDescription, WsmDao}
+import org.broadinstitute.dsde.workbench.leonardo.dao.{MockWsmDAO, WorkspaceDescription, WsmDao}
 import org.broadinstitute.dsde.workbench.leonardo.db._
-import org.broadinstitute.dsde.workbench.leonardo.model.{
-  AuthenticationError,
-  BadRequestException,
-  ForbiddenError,
-  LeoAuthProvider,
-  LeoException
-}
+import org.broadinstitute.dsde.workbench.leonardo.model._
 import org.broadinstitute.dsde.workbench.leonardo.monitor.LeoPubsubMessage.{
   CreateAppMessage,
   CreateAppV2Message,

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/AppServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/AppServiceInterpSpec.scala
@@ -1720,7 +1720,7 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
     cluster.status shouldEqual KubernetesClusterStatus.Running
 
     val nodepool = clusters.flatMap(_.nodepools).head
-    nodepool.machineType shouldEqual MachineTypeName("Standard_A2_v2")
+    nodepool.machineType shouldEqual MachineTypeName("unset")
     nodepool.numNodes shouldEqual NumNodes(1)
     nodepool.autoscalingEnabled shouldEqual false
     nodepool.auditInfo.creator shouldEqual userInfo.userEmail

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/AppServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/AppServiceInterpSpec.scala
@@ -57,7 +57,6 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
   val gkeCustomAppConfig = Config.gkeCustomAppConfig
 
   val wsmDao = new MockWsmDAO
-  val samDao = new MockSamDAO
 
   val gcpWsmDao = new MockWsmDAO {
     override def getWorkspace(workspaceId: WorkspaceId, authorization: Authorization)(implicit
@@ -124,8 +123,7 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
       passComputeService,
       FakeGoogleResourceService,
       gkeCustomAppConfig,
-      wsmDao,
-      samDao
+      wsmDao
     )
     val notEnoughMemoryAppService = new LeoAppServiceInterp[IO](
       appServiceConfig,
@@ -135,8 +133,7 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
       notEnoughMemoryComputeService,
       FakeGoogleResourceService,
       gkeCustomAppConfig,
-      wsmDao,
-      samDao
+      wsmDao
     )
     val notEnoughCpuAppService = new LeoAppServiceInterp[IO](
       appServiceConfig,
@@ -146,8 +143,7 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
       notEnoughCpuComputeService,
       FakeGoogleResourceService,
       gkeCustomAppConfig,
-      wsmDao,
-      samDao
+      wsmDao
     )
 
     for {
@@ -178,8 +174,7 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
       FakeGoogleComputeService,
       noLabelsGoogleResourceService,
       gkeCustomAppConfig,
-      wsmDao,
-      samDao
+      wsmDao
     )
 
     an[ForbiddenError] should be thrownBy {
@@ -209,8 +204,7 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
       FakeGoogleComputeService,
       FakeGoogleResourceService,
       gkeCustomAppConfig,
-      wsmDao,
-      samDao
+      wsmDao
     )
     val res = interp
       .createApp(userInfo, cloudContextGcp, AppName("foo"), createAppRequest.copy(appType = AppType.Custom))
@@ -1285,8 +1279,7 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
         true,
         List()
       ),
-      wsmDao,
-      samDao
+      wsmDao
     )
     val appReq = createAppRequest.copy(
       diskConfig = Some(createDiskConfig),
@@ -1436,8 +1429,7 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
         true,
         List()
       ),
-      wsmDao,
-      samDao
+      wsmDao
     )
     val appReq = createAppRequest.copy(
       diskConfig = Some(createDiskConfig),
@@ -1480,8 +1472,7 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
         true,
         List()
       ),
-      wsmDao,
-      samDao
+      wsmDao
     )
     val appReq = createAppRequest.copy(
       diskConfig = Some(createDiskConfig),
@@ -1523,8 +1514,7 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
         true,
         List()
       ),
-      wsmDao,
-      samDao
+      wsmDao
     )
     val appReq = createAppRequest.copy(
       diskConfig = Some(createDiskConfig),
@@ -1563,8 +1553,7 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
         true,
         List()
       ),
-      wsmDao,
-      samDao
+      wsmDao
     )
     val appReq = createAppRequest.copy(
       diskConfig = Some(createDiskConfig),
@@ -1609,8 +1598,7 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
         true,
         List()
       ),
-      wsmDao,
-      samDao
+      wsmDao
     )
     val appReq = createAppRequest.copy(
       diskConfig = Some(createDiskConfig),
@@ -1655,8 +1643,7 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
         true,
         List()
       ),
-      wsmDao,
-      samDao
+      wsmDao
     )
     val appReq = createAppRequest.copy(
       diskConfig = Some(createDiskConfig),
@@ -2515,8 +2502,7 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
       FakeGoogleComputeService,
       googleResourceService,
       customAppConfig,
-      wsmDao,
-      samDao
+      wsmDao
     )
   }
 }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/DiskV2ServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/DiskV2ServiceInterpSpec.scala
@@ -13,14 +13,15 @@ import org.broadinstitute.dsde.workbench.leonardo.auth.AllowlistAuthProvider
 import org.broadinstitute.dsde.workbench.leonardo.dao.{MockWsmDAO, WsmDao}
 import org.broadinstitute.dsde.workbench.leonardo.db._
 import org.broadinstitute.dsde.workbench.leonardo.model.ForbiddenError
-import org.broadinstitute.dsde.workbench.leonardo.monitor.LeoPubsubMessage.DeleteDiskV2Message
 import org.broadinstitute.dsde.workbench.leonardo.monitor.LeoPubsubMessage
+import org.broadinstitute.dsde.workbench.leonardo.monitor.LeoPubsubMessage.DeleteDiskV2Message
 import org.broadinstitute.dsde.workbench.leonardo.util.QueueFactory
 import org.broadinstitute.dsde.workbench.model.{UserInfo, WorkbenchEmail, WorkbenchUserId}
 import org.scalatest.flatspec.AnyFlatSpec
 
 import java.util.UUID
 import scala.concurrent.ExecutionContext.Implicits.global
+
 class DiskV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with TestComponent {
   val wsmDao = new MockWsmDAO
 
@@ -178,7 +179,7 @@ class DiskV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with Te
       _ <- diskV2Service.deleteDisk(userInfo, disk.id)
       _ <- IO(
         makeCluster(1).saveWithRuntimeConfig(
-          RuntimeConfig.AzureConfig(MachineTypeName("n1-standard-4"), Some(disk.id), azureRegion)
+          RuntimeConfig.AzureConfig(MachineTypeName("n1-standard-4"), Some(disk.id), None)
         )
       )
       err <- diskV2Service.deleteDisk(userInfo, disk.id).attempt
@@ -235,7 +236,7 @@ class DiskV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with Te
 
       _ <- IO(
         makeCluster(1).saveWithRuntimeConfig(
-          RuntimeConfig.AzureConfig(MachineTypeName("n1-standard-4"), Some(disk.id), azureRegion)
+          RuntimeConfig.AzureConfig(MachineTypeName("n1-standard-4"), Some(disk.id), None)
         )
       )
       err <- diskV2Service.deleteDisk(userInfo, disk.id).attempt
@@ -260,7 +261,7 @@ class DiskV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with Te
 
       _ <- IO(
         makeCluster(1).saveWithRuntimeConfig(
-          RuntimeConfig.AzureConfig(MachineTypeName("n1-standard-4"), Some(disk.id), azureRegion)
+          RuntimeConfig.AzureConfig(MachineTypeName("n1-standard-4"), Some(disk.id), None)
         )
       )
       err <- diskV2service2.deleteDisk(userInfo, disk.id).attempt

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/MockRuntimeV2Interp.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/MockRuntimeV2Interp.scala
@@ -6,8 +6,8 @@ import cats.effect.IO
 import cats.mtl.Ask
 import com.azure.resourcemanager.compute.models.VirtualMachineSizeTypes
 import org.broadinstitute.dsde.workbench.google2.MachineTypeName
+import org.broadinstitute.dsde.workbench.leonardo.CommonTestData._
 import org.broadinstitute.dsde.workbench.model.UserInfo
-import CommonTestData._
 
 class MockRuntimeV2Interp extends RuntimeV2Service[IO] {
   override def createRuntime(userInfo: UserInfo,
@@ -27,7 +27,7 @@ class MockRuntimeV2Interp extends RuntimeV2Service[IO] {
         .fromRuntime(CommonTestData.testCluster,
                      RuntimeConfig.AzureConfig(MachineTypeName(VirtualMachineSizeTypes.STANDARD_A0.toString),
                                                Some(DiskId(-1)),
-                                               azureRegion
+                                               None
                      ),
                      None
         )
@@ -69,7 +69,7 @@ class MockRuntimeV2Interp extends RuntimeV2Service[IO] {
           CommonTestData.testCluster.auditInfo,
           RuntimeConfig.AzureConfig(MachineTypeName(VirtualMachineSizeTypes.STANDARD_A0.toString),
                                     Some(DiskId(-1)),
-                                    azureRegion
+                                    None
           ),
           CommonTestData.testCluster.proxyUrl,
           CommonTestData.testCluster.status,

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeV2ServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeV2ServiceInterpSpec.scala
@@ -90,13 +90,7 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
                  dateAccessedQueue: Queue[IO, UpdateDateAccessedMessage] = QueueFactory.makeDateAccessedQueue(),
                  wsmClientProvider: WsmApiClientProvider[IO] = wsmClientProvider
   ) =
-    new RuntimeV2ServiceInterp[IO](serviceConfig,
-                                   authProvider,
-                                   wsmDao,
-                                   queue,
-                                   dateAccessedQueue,
-                                   wsmClientProvider
-    )
+    new RuntimeV2ServiceInterp[IO](serviceConfig, authProvider, wsmDao, queue, dateAccessedQueue, wsmClientProvider)
 
   // need to set previous runtime to deleted status before creating next to avoid exception
   def setRuntimetoDeleted(workspaceId: WorkspaceId, name: RuntimeName): IO[Long] =

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeV2ServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeV2ServiceInterpSpec.scala
@@ -93,7 +93,6 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
     new RuntimeV2ServiceInterp[IO](serviceConfig,
                                    authProvider,
                                    wsmDao,
-                                   mockSamDAO,
                                    queue,
                                    dateAccessedQueue,
                                    wsmClientProvider
@@ -197,7 +196,6 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
       serviceConfig,
       allowListAuthProvider,
       new MockWsmDAO,
-      mockSamDAO,
       QueueFactory.makePublisherQueue(),
       QueueFactory.makeDateAccessedQueue(),
       wsmClientProvider
@@ -208,7 +206,6 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
       serviceConfig,
       allowListAuthProvider2,
       new MockWsmDAO,
-      mockSamDAO,
       QueueFactory.makePublisherQueue(),
       QueueFactory.makeDateAccessedQueue(),
       wsmClientProvider
@@ -233,7 +230,7 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
       ): IO[Option[StorageContainerResponse]] =
         IO.pure(Some(StorageContainerResponse(ContainerName("dummy"), storageContainerResourceId)))
 
-      override def getLandingZoneResources(billingProfileId: String, userToken: Authorization)(implicit
+      override def getLandingZoneResources(billingProfileId: BillingProfileId, userToken: Authorization)(implicit
         ev: Ask[IO, AppContext]
       ): IO[LandingZoneResources] =
         IO.pure(landingZoneResources)
@@ -306,12 +303,10 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
       val expectedMessage = CreateAzureRuntimeMessage(
         cluster.id,
         workspaceId,
-        storageContainerResourceId,
-        landingZoneResources,
         false,
         Some(context.traceId),
         workspaceDesc.get.displayName,
-        ContainerName("dummy")
+        BillingProfileId("spend-profile")
       )
       message shouldBe expectedMessage
     }
@@ -511,7 +506,7 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
       ): IO[Option[StorageContainerResponse]] =
         IO.pure(Some(StorageContainerResponse(ContainerName("dummy"), storageContainerResourceId)))
 
-      override def getLandingZoneResources(billingProfileId: String, userToken: Authorization)(implicit
+      override def getLandingZoneResources(billingProfileId: BillingProfileId, userToken: Authorization)(implicit
         ev: Ask[IO, AppContext]
       ): IO[LandingZoneResources] =
         IO.pure(landingZoneResources)
@@ -549,12 +544,10 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
       val expectedMessage = CreateAzureRuntimeMessage(
         cluster.id,
         workspaceId,
-        storageContainerResourceId,
-        landingZoneResources,
         false,
         Some(context.traceId),
         workspaceDesc.get.displayName,
-        ContainerName("dummy")
+        BillingProfileId("spend-profile")
       )
       message shouldBe expectedMessage
     }
@@ -571,7 +564,7 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
       ): IO[Option[StorageContainerResponse]] =
         IO.pure(Some(StorageContainerResponse(ContainerName("dummy"), storageContainerResourceId)))
 
-      override def getLandingZoneResources(billingProfileId: String, userToken: Authorization)(implicit
+      override def getLandingZoneResources(billingProfileId: BillingProfileId, userToken: Authorization)(implicit
         ev: Ask[IO, AppContext]
       ): IO[LandingZoneResources] =
         IO.pure(landingZoneResources)
@@ -621,12 +614,10 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
       val expectedMessage = CreateAzureRuntimeMessage(
         cluster.id,
         workspaceId,
-        storageContainerResourceId,
-        landingZoneResources,
         false,
         Some(context.traceId),
         workspaceDesc.get.displayName,
-        ContainerName("dummy")
+        BillingProfileId("spend-profile")
       )
       message shouldBe expectedMessage
     }
@@ -1083,7 +1074,7 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
           Some(disk.id),
           workspaceId,
           Some(wsmResourceId),
-          landingZoneResources,
+          BillingProfileId("spend-profile"),
           Some(context.traceId)
         )
       message shouldBe expectedMessage
@@ -1193,7 +1184,7 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
                                   Some(disk.id),
                                   workspaceId,
                                   None,
-                                  landingZoneResources,
+                                  BillingProfileId("spend-profile"),
                                   Some(context.traceId)
         )
       message shouldBe expectedMessage
@@ -1262,7 +1253,7 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
                                   Some(disk.id),
                                   workspaceId,
                                   None,
-                                  landingZoneResources,
+                                  BillingProfileId("spend-profile"),
                                   Some(context.traceId)
         )
       message shouldBe expectedMessage
@@ -1323,7 +1314,7 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
                                   None,
                                   workspaceId,
                                   Some(wsmResourceId),
-                                  landingZoneResources,
+                                  BillingProfileId("spend-profile"),
                                   Some(context.traceId)
         )
       message shouldBe expectedMessage
@@ -1518,14 +1509,14 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
                                   Some(disk_2.id),
                                   workspaceId,
                                   Some(wsmResourceId_2),
-                                  landingZoneResources,
+                                  BillingProfileId("spend-profile"),
                                   Some(context.traceId)
         ),
         DeleteAzureRuntimeMessage(preDeleteCluster_3.id,
                                   Some(disk_3.id),
                                   workspaceId,
                                   Some(wsmResourceId_3),
-                                  landingZoneResources,
+                                  BillingProfileId("spend-profile"),
                                   Some(context.traceId)
         )
       )

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeV2ServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeV2ServiceInterpSpec.scala
@@ -274,7 +274,7 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
       clusterRec.workspaceId shouldBe Some(workspaceId)
 
       azureRuntimeConfig.machineType.value shouldBe VirtualMachineSizeTypes.STANDARD_A1.toString
-      azureRuntimeConfig.region shouldBe azureRegion
+      azureRuntimeConfig.region shouldBe None
       disk.name.value shouldBe defaultCreateAzureRuntimeReq.azureDiskConfig.name.value
 
       val expectedRuntimeImage = Set(

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubCodecSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubCodecSpec.scala
@@ -1,27 +1,14 @@
 package org.broadinstitute.dsde.workbench.leonardo
 package monitor
 
-import java.time.Instant
-import java.util.UUID
 import _root_.io.circe.parser.decode
 import _root_.io.circe.syntax._
 import io.circe.Printer
-import org.broadinstitute.dsde.workbench.azure.{
-  AKSClusterName,
-  ApplicationInsightsName,
-  AzureCloudContext,
-  BatchAccountName,
-  ContainerName,
-  ManagedResourceGroupName,
-  RelayNamespace,
-  SubscriptionId,
-  TenantId
-}
+import org.broadinstitute.dsde.workbench.azure._
 import org.broadinstitute.dsde.workbench.google2.KubernetesSerializableName.NamespaceName
 import org.broadinstitute.dsde.workbench.google2.{DiskName, MachineTypeName, NetworkName, SubnetworkName, ZoneName}
 import org.broadinstitute.dsde.workbench.leonardo.AppType.Galaxy
 import org.broadinstitute.dsde.workbench.leonardo.JsonCodec._
-import org.broadinstitute.dsde.workbench.leonardo.dao.StorageContainerResponse
 import org.broadinstitute.dsde.workbench.leonardo.monitor.LeoPubsubCodec._
 import org.broadinstitute.dsde.workbench.leonardo.monitor.LeoPubsubMessage.{
   CreateAppMessage,
@@ -33,6 +20,9 @@ import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.broadinstitute.dsde.workbench.model.{TraceId, WorkbenchEmail}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+
+import java.time.Instant
+import java.util.UUID
 
 class LeoPubsubCodecSpec extends AnyFlatSpec with Matchers {
   val storageContainerResourceId = WsmControlledResourceId(UUID.randomUUID())
@@ -140,12 +130,10 @@ class LeoPubsubCodecSpec extends AnyFlatSpec with Matchers {
     val originalMessage =
       CreateAzureRuntimeMessage(1,
                                 WorkspaceId(UUID.randomUUID()),
-                                storageContainerResourceId,
-                                landingZoneResources,
                                 false,
                                 None,
                                 "WorkspaceName",
-                                ContainerName("dummy")
+                                BillingProfileId("spend-profile")
       )
 
     val res = decode[CreateAzureRuntimeMessage](originalMessage.asJson.printWith(Printer.noSpaces))
@@ -186,8 +174,7 @@ class LeoPubsubCodecSpec extends AnyFlatSpec with Matchers {
             ManagedResourceGroupName("rg-name")
           )
         ),
-        Some(landingZoneResources),
-        Some(StorageContainerResponse(ContainerName("sc-container"), storageContainerResourceId)),
+        BillingProfileId("spend-profile"),
         None
       )
 

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriberSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriberSpec.scala
@@ -16,7 +16,7 @@ import com.google.cloud.pubsub.v1.AckReplyConsumer
 import com.google.protobuf.Timestamp
 import fs2.Stream
 import org.broadinstitute.dsde.workbench.azure.mock.{FakeAzureRelayService, FakeAzureVmService}
-import org.broadinstitute.dsde.workbench.azure.{AzureCloudContext, AzureRelayService, AzureVmService, ContainerName}
+import org.broadinstitute.dsde.workbench.azure.{AzureCloudContext, AzureRelayService, AzureVmService}
 import org.broadinstitute.dsde.workbench.google.GoogleStorageDAO
 import org.broadinstitute.dsde.workbench.google.mock._
 import org.broadinstitute.dsde.workbench.google2.KubernetesModels.PodStatus
@@ -32,10 +32,9 @@ import org.broadinstitute.dsde.workbench.google2.{
   RegionName,
   ZoneName
 }
-import org.broadinstitute.dsde.workbench.leonardo.config.ApplicationConfig
 import org.broadinstitute.dsde.workbench.leonardo.AppRestore.GalaxyRestore
 import org.broadinstitute.dsde.workbench.leonardo.AsyncTaskProcessor.Task
-import org.broadinstitute.dsde.workbench.leonardo.CommonTestData.{azureRegion, _}
+import org.broadinstitute.dsde.workbench.leonardo.CommonTestData._
 import org.broadinstitute.dsde.workbench.leonardo.KubernetesTestData.{
   makeApp,
   makeKubeCluster,
@@ -44,7 +43,7 @@ import org.broadinstitute.dsde.workbench.leonardo.KubernetesTestData.{
 }
 import org.broadinstitute.dsde.workbench.leonardo.RuntimeImageType.BootSource
 import org.broadinstitute.dsde.workbench.leonardo.TestUtils.appContext
-import org.broadinstitute.dsde.workbench.leonardo.config.Config
+import org.broadinstitute.dsde.workbench.leonardo.config.{ApplicationConfig, Config}
 import org.broadinstitute.dsde.workbench.leonardo.dao._
 import org.broadinstitute.dsde.workbench.leonardo.db._
 import org.broadinstitute.dsde.workbench.leonardo.http._
@@ -1865,7 +1864,7 @@ class LeoPubsubMessageSubscriberSpec
 
         azureRuntimeConfig = RuntimeConfig.AzureConfig(MachineTypeName(VirtualMachineSizeTypes.STANDARD_A1.toString),
                                                        Some(disk.id),
-                                                       azureRegion
+                                                       None
         )
         runtime = makeCluster(1)
           .copy(
@@ -1876,12 +1875,10 @@ class LeoPubsubMessageSubscriberSpec
         jobId <- IO.delay(UUID.randomUUID())
         msg = CreateAzureRuntimeMessage(runtime.id,
                                         workspaceId,
-                                        storageContainerResourceId,
-                                        landingZoneResources,
                                         false,
                                         None,
                                         "WorkspaceName",
-                                        ContainerName("dummy")
+                                        BillingProfileId("spend-profile")
         )
 
         _ <- leoSubscriber.messageHandler(Event(msg, None, timestamp, mockAckConsumer))
@@ -1919,7 +1916,7 @@ class LeoPubsubMessageSubscriberSpec
 
         azureRuntimeConfig = RuntimeConfig.AzureConfig(MachineTypeName(VirtualMachineSizeTypes.STANDARD_A1.toString),
                                                        Some(disk.id),
-                                                       azureRegion
+                                                       None
         )
         runtime = makeCluster(1)
           .copy(
@@ -1932,7 +1929,7 @@ class LeoPubsubMessageSubscriberSpec
                                         Some(disk.id),
                                         workspaceId,
                                         Some(vmResourceId),
-                                        landingZoneResources,
+                                        BillingProfileId("spend-profile"),
                                         None
         )
 
@@ -1961,7 +1958,7 @@ class LeoPubsubMessageSubscriberSpec
       disk <- makePersistentDisk().copy(status = DiskStatus.Ready).save()
       azureRuntimeConfig = RuntimeConfig.AzureConfig(MachineTypeName(VirtualMachineSizeTypes.STANDARD_A1.toString),
                                                      Some(disk.id),
-                                                     azureRegion
+                                                     None
       )
       runtime <- IO(
         makeCluster(1)
@@ -1986,7 +1983,7 @@ class LeoPubsubMessageSubscriberSpec
       disk <- makePersistentDisk().copy(status = DiskStatus.Ready).save()
       azureRuntimeConfig = RuntimeConfig.AzureConfig(MachineTypeName(VirtualMachineSizeTypes.STANDARD_A1.toString),
                                                      Some(disk.id),
-                                                     azureRegion
+                                                     None
       )
       runtime <- IO(
         makeCluster(1)

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/AKSInterpreterSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/AKSInterpreterSpec.scala
@@ -1,7 +1,6 @@
 package org.broadinstitute.dsde.workbench.leonardo
 package util
 
-import java.util.ArrayList
 import bio.terra.workspace.api.{ControlledAzureResourceApi, ResourceApi}
 import bio.terra.workspace.model.{DeleteControlledAzureResourceRequest, _}
 import cats.effect.IO
@@ -11,7 +10,7 @@ import org.broadinstitute.dsde.workbench.azure._
 import org.broadinstitute.dsde.workbench.google2.KubernetesModels.PodStatus
 import org.broadinstitute.dsde.workbench.google2.KubernetesSerializableName.{NamespaceName, ServiceAccountName}
 import org.broadinstitute.dsde.workbench.google2.{NetworkName, SubnetworkName}
-import org.broadinstitute.dsde.workbench.leonardo.CommonTestData.{azureRegion, landingZoneResources, workspaceId}
+import org.broadinstitute.dsde.workbench.leonardo.CommonTestData.{azureRegion, billingProfileId, workspaceId}
 import org.broadinstitute.dsde.workbench.leonardo.KubernetesTestData.{makeApp, makeKubeCluster, makeNodepool}
 import org.broadinstitute.dsde.workbench.leonardo.TestUtils.appContext
 import org.broadinstitute.dsde.workbench.leonardo.app.AppInstall
@@ -33,7 +32,7 @@ import org.scalatestplus.mockito.MockitoSugar
 
 import java.net.URL
 import java.nio.file.Files
-import java.util.{Base64, UUID}
+import java.util.{ArrayList, Base64, UUID}
 import scala.collection.mutable
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.jdk.CollectionConverters._
@@ -65,7 +64,8 @@ class AKSInterpreterSpec extends AnyFlatSpecLike with TestComponent with Leonard
     mockSamDAO,
     mockWsmDAO,
     mockKube,
-    mockWsm
+    mockWsm,
+    mockWsmDAO
   )
 
   val aksInterp = newAksInterp(config)
@@ -137,13 +137,7 @@ class AKSInterpreterSpec extends AnyFlatSpecLike with TestComponent with Leonard
         appId = saveApp.id
         appName = saveApp.appName
 
-        params = CreateAKSAppParams(appId,
-                                    appName,
-                                    workspaceId,
-                                    cloudContext,
-                                    landingZoneResources,
-                                    Some(storageContainer)
-        )
+        params = CreateAKSAppParams(appId, appName, workspaceId, cloudContext, billingProfileId)
         _ <- aksInterp.createAndPollApp(params)
 
         app <- KubernetesServiceDbQueries
@@ -233,7 +227,7 @@ class AKSInterpreterSpec extends AnyFlatSpecLike with TestComponent with Leonard
 
         appName = saveApp.appName
 
-        _ <- aksInterp.deleteApp(DeleteAKSAppParams(appName, workspaceId, landingZoneResources, cloudContext))
+        _ <- aksInterp.deleteApp(DeleteAKSAppParams(appName, workspaceId, cloudContext, billingProfileId))
         app <- KubernetesServiceDbQueries
           .getActiveFullAppByName(CloudContext.Azure(cloudContext), appName)
           .transaction

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandlerSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandlerSpec.scala
@@ -10,7 +10,7 @@ import cats.mtl.Ask
 import com.azure.resourcemanager.compute.models.{PowerState, VirtualMachine, VirtualMachineSizeTypes}
 import com.azure.resourcemanager.network.models.PublicIpAddress
 import org.broadinstitute.dsde.workbench.azure.mock.{FakeAzureRelayService, FakeAzureVmService}
-import org.broadinstitute.dsde.workbench.azure.{AzureCloudContext, AzureRelayService, AzureVmService, ContainerName}
+import org.broadinstitute.dsde.workbench.azure.{AzureCloudContext, AzureRelayService, AzureVmService}
 import org.broadinstitute.dsde.workbench.google2.MachineTypeName
 import org.broadinstitute.dsde.workbench.leonardo.AsyncTaskProcessor.Task
 import org.broadinstitute.dsde.workbench.leonardo.CommonTestData._
@@ -83,7 +83,7 @@ class AzurePubsubHandlerSpec
 
         azureRuntimeConfig = RuntimeConfig.AzureConfig(MachineTypeName(VirtualMachineSizeTypes.STANDARD_A1.toString),
                                                        Some(disk.id),
-                                                       azureRegion
+                                                       None
         )
         runtime = makeCluster(1)
           .copy(
@@ -99,15 +99,7 @@ class AzurePubsubHandlerSpec
           getRuntime.status shouldBe RuntimeStatus.Running
         }
 
-        msg = CreateAzureRuntimeMessage(runtime.id,
-                                        workspaceId,
-                                        storageContainerResourceId,
-                                        landingZoneResources,
-                                        false,
-                                        None,
-                                        "WorkspaceName",
-                                        ContainerName("dummy")
-        )
+        msg = CreateAzureRuntimeMessage(runtime.id, workspaceId, false, None, "WorkspaceName", billingProfileId)
 
         asyncTaskProcessor = AsyncTaskProcessor(AsyncTaskProcessor.Config(10, 10), queue)
         _ <- azurePubsubHandler.createAndPollRuntime(msg)
@@ -161,7 +153,7 @@ class AzurePubsubHandlerSpec
 
         azureRuntimeConfig = RuntimeConfig.AzureConfig(MachineTypeName(VirtualMachineSizeTypes.STANDARD_A1.toString),
                                                        Some(disk.id),
-                                                       azureRegion
+                                                       None
         )
         runtime = makeCluster(1)
           .copy(
@@ -178,15 +170,7 @@ class AzurePubsubHandlerSpec
           getRuntime.auditInfo.dateAccessed.isAfter(startTime.plusMillis(mockLatencyMillis)) shouldBe true
         }
 
-        msg = CreateAzureRuntimeMessage(runtime.id,
-                                        workspaceId,
-                                        storageContainerResourceId,
-                                        landingZoneResources,
-                                        false,
-                                        None,
-                                        "WorkspaceName",
-                                        ContainerName("dummy")
-        )
+        msg = CreateAzureRuntimeMessage(runtime.id, workspaceId, false, None, "WorkspaceName", billingProfileId)
 
         asyncTaskProcessor = AsyncTaskProcessor(AsyncTaskProcessor.Config(10, 10), queue)
         _ <- azurePubsubHandler.createAndPollRuntime(msg)
@@ -236,7 +220,7 @@ class AzurePubsubHandlerSpec
 
         azureRuntimeConfig = RuntimeConfig.AzureConfig(MachineTypeName(VirtualMachineSizeTypes.STANDARD_A1.toString),
                                                        Some(disk.id),
-                                                       azureRegion
+                                                       None
         )
         runtime1 = makeCluster(1)
           .copy(
@@ -265,15 +249,7 @@ class AzurePubsubHandlerSpec
           getRuntime.status shouldBe RuntimeStatus.Running
         }
 
-        msg = CreateAzureRuntimeMessage(runtime2.id,
-                                        workspaceId,
-                                        storageContainerResourceId,
-                                        landingZoneResources,
-                                        true,
-                                        None,
-                                        "WorkspaceName",
-                                        ContainerName("dummy")
-        )
+        msg = CreateAzureRuntimeMessage(runtime2.id, workspaceId, true, None, "WorkspaceName", billingProfileId)
 
         asyncTaskProcessor = AsyncTaskProcessor(AsyncTaskProcessor.Config(10, 10), queue)
         _ <- azurePubsubHandler.createAndPollRuntime(msg)
@@ -323,7 +299,7 @@ class AzurePubsubHandlerSpec
 
         azureRuntimeConfig = RuntimeConfig.AzureConfig(MachineTypeName(VirtualMachineSizeTypes.STANDARD_A1.toString),
                                                        Some(disk.id),
-                                                       azureRegion
+                                                       None
         )
         runtime = makeCluster(1)
           .copy(
@@ -340,15 +316,7 @@ class AzurePubsubHandlerSpec
           diskStatus shouldBe (Some(DiskStatus.Deleted))
         }
 
-        msg = CreateAzureRuntimeMessage(runtime.id,
-                                        workspaceId,
-                                        storageContainerResourceId,
-                                        landingZoneResources,
-                                        false,
-                                        None,
-                                        "WorkspaceName",
-                                        ContainerName("dummy")
-        )
+        msg = CreateAzureRuntimeMessage(runtime.id, workspaceId, false, None, "WorkspaceName", billingProfileId)
 
         asyncTaskProcessor = AsyncTaskProcessor(AsyncTaskProcessor.Config(10, 10), queue)
         _ <- azurePubsubHandler.createAndPollRuntime(msg)
@@ -396,7 +364,7 @@ class AzurePubsubHandlerSpec
 
         azureRuntimeConfig = RuntimeConfig.AzureConfig(MachineTypeName(VirtualMachineSizeTypes.STANDARD_A1.toString),
                                                        Some(disk.id),
-                                                       azureRegion
+                                                       None
         )
         runtime = makeCluster(1)
           .copy(
@@ -409,15 +377,7 @@ class AzurePubsubHandlerSpec
           getRuntime = getRuntimeOpt.get
         } yield getRuntime.status shouldBe RuntimeStatus.Error
 
-        msg = CreateAzureRuntimeMessage(runtime.id,
-                                        workspaceId,
-                                        storageContainerResourceId,
-                                        landingZoneResources,
-                                        false,
-                                        None,
-                                        "WorkspaceName",
-                                        ContainerName("dummy")
-        )
+        msg = CreateAzureRuntimeMessage(runtime.id, workspaceId, false, None, "WorkspaceName", billingProfileId)
 
         asyncTaskProcessor = AsyncTaskProcessor(AsyncTaskProcessor.Config(10, 10), queue)
         _ <- azurePubsubHandler.createAndPollRuntime(msg)
@@ -465,7 +425,7 @@ class AzurePubsubHandlerSpec
 
         azureRuntimeConfig = RuntimeConfig.AzureConfig(MachineTypeName(VirtualMachineSizeTypes.STANDARD_A1.toString),
                                                        Some(disk.id),
-                                                       azureRegion
+                                                       None
         )
         runtime = makeCluster(2)
           .copy(
@@ -499,7 +459,7 @@ class AzurePubsubHandlerSpec
                                         Some(disk.id),
                                         workspaceId,
                                         Some(wsmResourceId),
-                                        landingZoneResources,
+                                        billingProfileId,
                                         None
         )
 
@@ -546,7 +506,7 @@ class AzurePubsubHandlerSpec
 
         azureRuntimeConfig = RuntimeConfig.AzureConfig(MachineTypeName(VirtualMachineSizeTypes.STANDARD_A1.toString),
                                                        Some(disk.id),
-                                                       azureRegion
+                                                       None
         )
         runtime = makeCluster(2)
           .copy(
@@ -580,7 +540,7 @@ class AzurePubsubHandlerSpec
         _ <- controlledResourceQuery
           .save(runtime.id, WsmControlledResourceId(UUID.randomUUID()), WsmResourceType.AzureStorageContainer)
           .transaction
-        msg = DeleteAzureRuntimeMessage(runtime.id, None, workspaceId, Some(wsmResourceId), landingZoneResources, None)
+        msg = DeleteAzureRuntimeMessage(runtime.id, None, workspaceId, Some(wsmResourceId), billingProfileId, None)
 
         asyncTaskProcessor = AsyncTaskProcessor(AsyncTaskProcessor.Config(10, 10), queue)
 
@@ -610,7 +570,7 @@ class AzurePubsubHandlerSpec
 
         azureRuntimeConfig = RuntimeConfig.AzureConfig(MachineTypeName(VirtualMachineSizeTypes.STANDARD_A1.toString),
                                                        Some(disk.id),
-                                                       azureRegion
+                                                       None
         )
         runtime = makeCluster(1)
           .copy(
@@ -628,15 +588,7 @@ class AzurePubsubHandlerSpec
           error.map(_.errorMessage).head should include(exceptionMsg)
         }
 
-        msg = CreateAzureRuntimeMessage(runtime.id,
-                                        workspaceId,
-                                        storageContainerResourceId,
-                                        landingZoneResources,
-                                        false,
-                                        None,
-                                        "WorkspaceName",
-                                        ContainerName("dummy")
-        )
+        msg = CreateAzureRuntimeMessage(runtime.id, workspaceId, false, None, "WorkspaceName", billingProfileId)
 
         asyncTaskProcessor = AsyncTaskProcessor(AsyncTaskProcessor.Config(10, 10), queue)
         _ <- azureInterp.createAndPollRuntime(msg)
@@ -670,7 +622,7 @@ class AzurePubsubHandlerSpec
 
         azureRuntimeConfig = RuntimeConfig.AzureConfig(MachineTypeName(VirtualMachineSizeTypes.STANDARD_A1.toString),
                                                        Some(disk.id),
-                                                       azureRegion
+                                                       None
         )
         runtime = makeCluster(1)
           .copy(
@@ -678,15 +630,7 @@ class AzurePubsubHandlerSpec
           )
           .saveWithRuntimeConfig(azureRuntimeConfig)
 
-        msg = CreateAzureRuntimeMessage(runtime.id,
-                                        workspaceId,
-                                        storageContainerResourceId,
-                                        landingZoneResources,
-                                        true,
-                                        None,
-                                        "WorkspaceName",
-                                        ContainerName("dummy")
-        )
+        msg = CreateAzureRuntimeMessage(runtime.id, workspaceId, true, None, "WorkspaceName", billingProfileId)
 
         err <- azureInterp.createAndPollRuntime(msg).attempt
 
@@ -727,7 +671,7 @@ class AzurePubsubHandlerSpec
 
         azureRuntimeConfig = RuntimeConfig.AzureConfig(MachineTypeName(VirtualMachineSizeTypes.STANDARD_A1.toString),
                                                        Some(disk.id),
-                                                       azureRegion
+                                                       None
         )
         runtime = makeCluster(1)
           .copy(
@@ -735,15 +679,7 @@ class AzurePubsubHandlerSpec
           )
           .saveWithRuntimeConfig(azureRuntimeConfig)
 
-        msg = CreateAzureRuntimeMessage(runtime.id,
-                                        workspaceId,
-                                        storageContainerResourceId,
-                                        landingZoneResources,
-                                        true,
-                                        None,
-                                        "WorkspaceName",
-                                        ContainerName("dummy")
-        )
+        msg = CreateAzureRuntimeMessage(runtime.id, workspaceId, true, None, "WorkspaceName", billingProfileId)
 
         err <- azureInterp.createAndPollRuntime(msg).attempt
 
@@ -776,7 +712,7 @@ class AzurePubsubHandlerSpec
 
         azureRuntimeConfig = RuntimeConfig.AzureConfig(MachineTypeName(VirtualMachineSizeTypes.STANDARD_A1.toString),
                                                        Some(disk.id),
-                                                       azureRegion
+                                                       None
         )
         runtime = makeCluster(2)
           .copy(
@@ -806,7 +742,7 @@ class AzurePubsubHandlerSpec
                                         Some(disk.id),
                                         workspaceId,
                                         Some(wsmResourceId),
-                                        landingZoneResources,
+                                        billingProfileId,
                                         None
         )
 
@@ -849,7 +785,7 @@ class AzurePubsubHandlerSpec
 
         azureRuntimeConfig = RuntimeConfig.AzureConfig(MachineTypeName(VirtualMachineSizeTypes.STANDARD_A1.toString),
                                                        Some(disk.id),
-                                                       azureRegion
+                                                       None
         )
         runtime = makeCluster(2)
           .copy(
@@ -879,7 +815,7 @@ class AzurePubsubHandlerSpec
                                         Some(disk.id),
                                         workspaceId,
                                         Some(wsmResourceId),
-                                        landingZoneResources,
+                                        billingProfileId,
                                         None
         )
 
@@ -909,7 +845,7 @@ class AzurePubsubHandlerSpec
 
         azureRuntimeConfig = RuntimeConfig.AzureConfig(MachineTypeName(VirtualMachineSizeTypes.STANDARD_A1.toString),
                                                        Some(disk.id),
-                                                       azureRegion
+                                                       None
         )
         runtime = makeCluster(2)
           .copy(
@@ -940,7 +876,7 @@ class AzurePubsubHandlerSpec
                                         Some(disk.id),
                                         workspaceId,
                                         Some(wsmResourceId),
-                                        landingZoneResources,
+                                        billingProfileId,
                                         None
         )
 
@@ -973,7 +909,7 @@ class AzurePubsubHandlerSpec
       disk <- makePersistentDisk().copy(status = DiskStatus.Ready).save()
       azureRuntimeConfig = RuntimeConfig.AzureConfig(MachineTypeName(VirtualMachineSizeTypes.STANDARD_A1.toString),
                                                      Some(disk.id),
-                                                     azureRegion
+                                                     None
       )
       runtime = makeCluster(1)
         .copy(
@@ -1015,7 +951,7 @@ class AzurePubsubHandlerSpec
       disk <- makePersistentDisk().copy(status = DiskStatus.Ready).save()
       azureRuntimeConfig = RuntimeConfig.AzureConfig(MachineTypeName(VirtualMachineSizeTypes.STANDARD_A1.toString),
                                                      Some(disk.id),
-                                                     azureRegion
+                                                     None
       )
       runtime = makeCluster(1)
         .copy(
@@ -1049,7 +985,7 @@ class AzurePubsubHandlerSpec
       disk <- makePersistentDisk().copy(status = DiskStatus.Ready).save()
       azureRuntimeConfig = RuntimeConfig.AzureConfig(MachineTypeName(VirtualMachineSizeTypes.STANDARD_A1.toString),
                                                      Some(disk.id),
-                                                     azureRegion
+                                                     None
       )
       runtime = makeCluster(1)
         .copy(
@@ -1091,7 +1027,7 @@ class AzurePubsubHandlerSpec
       disk <- makePersistentDisk().copy(status = DiskStatus.Ready).save()
       azureRuntimeConfig = RuntimeConfig.AzureConfig(MachineTypeName(VirtualMachineSizeTypes.STANDARD_A1.toString),
                                                      Some(disk.id),
-                                                     azureRegion
+                                                     None
       )
       runtime = makeCluster(1)
         .copy(
@@ -1125,13 +1061,7 @@ class AzurePubsubHandlerSpec
     val res = for {
       ctx <- appContext.ask[AppContext]
       result <- azureInterp
-        .createAndPollApp(appId,
-                          AppName("app"),
-                          WorkspaceId(UUID.randomUUID()),
-                          azureCloudContext,
-                          landingZoneResources,
-                          None
-        )
+        .createAndPollApp(appId, AppName("app"), WorkspaceId(UUID.randomUUID()), azureCloudContext, billingProfileId)
         .attempt
     } yield result shouldBe Left(
       PubsubKubernetesError(
@@ -1185,7 +1115,7 @@ class AzurePubsubHandlerSpec
 
         azureRuntimeConfig = RuntimeConfig.AzureConfig(MachineTypeName(VirtualMachineSizeTypes.STANDARD_A1.toString),
                                                        Some(disk.id),
-                                                       azureRegion
+                                                       None
         )
         runtime = makeCluster(2)
           .copy(

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandlerSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandlerSpec.scala
@@ -10,7 +10,7 @@ import cats.mtl.Ask
 import com.azure.resourcemanager.compute.models.{PowerState, VirtualMachine, VirtualMachineSizeTypes}
 import com.azure.resourcemanager.network.models.PublicIpAddress
 import org.broadinstitute.dsde.workbench.azure.mock.{FakeAzureRelayService, FakeAzureVmService}
-import org.broadinstitute.dsde.workbench.azure.{AzureCloudContext, AzureRelayService, AzureVmService}
+import org.broadinstitute.dsde.workbench.azure.{AzureCloudContext, AzureRelayService, AzureVmService, ContainerName}
 import org.broadinstitute.dsde.workbench.google2.MachineTypeName
 import org.broadinstitute.dsde.workbench.leonardo.AsyncTaskProcessor.Task
 import org.broadinstitute.dsde.workbench.leonardo.CommonTestData._
@@ -392,6 +392,12 @@ class AzurePubsubHandlerSpec
     val queue = QueueFactory.asyncTaskQueue()
     val mockWsmDao = mock[WsmDao[IO]]
     when {
+      mockWsmDao.getLandingZoneResources(BillingProfileId(any[String]), any[Authorization])(any[Ask[IO, AppContext]])
+    } thenReturn IO.pure(landingZoneResources)
+    when {
+      mockWsmDao.getWorkspaceStorageContainer(WorkspaceId(any[UUID]), any[Authorization])(any[Ask[IO, AppContext]])
+    } thenReturn IO.pure(Some(StorageContainerResponse(ContainerName("dummy"), storageContainerResourceId)))
+    when {
       mockWsmDao.deleteStorageContainer(any[DeleteWsmResourceRequest], any[Authorization])(any[Ask[IO, AppContext]])
     } thenReturn IO.pure(None)
     when {
@@ -475,6 +481,12 @@ class AzurePubsubHandlerSpec
   it should "delete azure vm but keep the disk if no disk specified" in isolatedDbTest {
     val queue = QueueFactory.asyncTaskQueue()
     val mockWsmDao = mock[WsmDao[IO]]
+    when {
+      mockWsmDao.getLandingZoneResources(BillingProfileId(any[String]), any[Authorization])(any[Ask[IO, AppContext]])
+    } thenReturn IO.pure(landingZoneResources)
+    when {
+      mockWsmDao.getWorkspaceStorageContainer(WorkspaceId(any[UUID]), any[Authorization])(any[Ask[IO, AppContext]])
+    } thenReturn IO.pure(Some(StorageContainerResponse(ContainerName("dummy"), storageContainerResourceId)))
     when {
       mockWsmDao.deleteStorageContainer(any[DeleteWsmResourceRequest], any[Authorization])(any[Ask[IO, AppContext]])
     } thenReturn IO.pure(None)

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandlerSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandlerSpec.scala
@@ -11,7 +11,7 @@ import com.azure.resourcemanager.compute.models.{PowerState, VirtualMachine, Vir
 import com.azure.resourcemanager.network.models.PublicIpAddress
 import org.broadinstitute.dsde.workbench.azure.mock.{FakeAzureRelayService, FakeAzureVmService}
 import org.broadinstitute.dsde.workbench.azure.{AzureCloudContext, AzureRelayService, AzureVmService, ContainerName}
-import org.broadinstitute.dsde.workbench.google2.MachineTypeName
+import org.broadinstitute.dsde.workbench.google2.{MachineTypeName, RegionName}
 import org.broadinstitute.dsde.workbench.leonardo.AsyncTaskProcessor.Task
 import org.broadinstitute.dsde.workbench.leonardo.CommonTestData._
 import org.broadinstitute.dsde.workbench.leonardo.TestUtils.appContext
@@ -68,7 +68,7 @@ class AzurePubsubHandlerSpec
       ): IO[GetCreateVmJobResult] =
         IO.pure(
           GetCreateVmJobResult(
-            Some(WsmVm(WsmVMMetadata(resourceId))),
+            Some(WsmVm(WsmVMMetadata(resourceId), WsmVMAttributes(RegionName("southcentralus")))),
             WsmJobReport(WsmJobId("job1"), "", WsmJobStatus.Succeeded, 200, ZonedDateTime.now(), None, "url"),
             None
           )
@@ -94,9 +94,11 @@ class AzurePubsubHandlerSpec
         assertions = for {
           getRuntimeOpt <- clusterQuery.getClusterById(runtime.id).transaction
           getRuntime = getRuntimeOpt.get
+          getRuntimeConfig <- RuntimeConfigQueries.getRuntimeConfig(getRuntime.runtimeConfigId).transaction
         } yield {
           getRuntime.asyncRuntimeFields.flatMap(_.hostIp).isDefined shouldBe true
           getRuntime.status shouldBe RuntimeStatus.Running
+          getRuntimeConfig shouldBe azureRuntimeConfig.copy(region = Some(RegionName("southcentralus")))
         }
 
         msg = CreateAzureRuntimeMessage(runtime.id, workspaceId, false, None, "WorkspaceName", billingProfileId)
@@ -137,7 +139,7 @@ class AzurePubsubHandlerSpec
         Thread.sleep(mockLatencyMillis)
         IO.pure(
           GetCreateVmJobResult(
-            Some(WsmVm(WsmVMMetadata(resourceId))),
+            Some(WsmVm(WsmVMMetadata(resourceId), WsmVMAttributes(RegionName("southcentralus")))),
             WsmJobReport(WsmJobId("job1"), "", WsmJobStatus.Succeeded, 200, ZonedDateTime.now(), None, "url"),
             None
           )
@@ -164,10 +166,12 @@ class AzurePubsubHandlerSpec
         assertions = for {
           getRuntimeOpt <- clusterQuery.getClusterById(runtime.id).transaction
           getRuntime = getRuntimeOpt.get
+          getRuntimeConfig <- RuntimeConfigQueries.getRuntimeConfig(getRuntime.runtimeConfigId).transaction
         } yield {
           getRuntime.asyncRuntimeFields.flatMap(_.hostIp).isDefined shouldBe true
           getRuntime.status shouldBe RuntimeStatus.Running
           getRuntime.auditInfo.dateAccessed.isAfter(startTime.plusMillis(mockLatencyMillis)) shouldBe true
+          getRuntimeConfig shouldBe azureRuntimeConfig.copy(region = Some(RegionName("southcentralus")))
         }
 
         msg = CreateAzureRuntimeMessage(runtime.id, workspaceId, false, None, "WorkspaceName", billingProfileId)
@@ -205,7 +209,7 @@ class AzurePubsubHandlerSpec
       ): IO[GetCreateVmJobResult] =
         IO.pure(
           GetCreateVmJobResult(
-            Some(WsmVm(WsmVMMetadata(resourceId))),
+            Some(WsmVm(WsmVMMetadata(resourceId), WsmVMAttributes(RegionName("southcentralus")))),
             WsmJobReport(WsmJobId("job1"), "", WsmJobStatus.Succeeded, 200, ZonedDateTime.now(), None, "url"),
             None
           )
@@ -243,10 +247,12 @@ class AzurePubsubHandlerSpec
         assertions = for {
           getRuntimeOpt <- clusterQuery.getClusterById(runtime2.id).transaction
           getRuntime = getRuntimeOpt.get
+          getRuntimeConfig <- RuntimeConfigQueries.getRuntimeConfig(getRuntime.runtimeConfigId).transaction
         } yield {
           // check diskId is correct
           getRuntime.asyncRuntimeFields.flatMap(_.hostIp).isDefined shouldBe true
           getRuntime.status shouldBe RuntimeStatus.Running
+          getRuntimeConfig shouldBe azureRuntimeConfig.copy(region = Some(RegionName("southcentralus")))
         }
 
         msg = CreateAzureRuntimeMessage(runtime2.id, workspaceId, true, None, "WorkspaceName", billingProfileId)
@@ -284,7 +290,7 @@ class AzurePubsubHandlerSpec
       ): IO[GetCreateVmJobResult] =
         IO.pure(
           GetCreateVmJobResult(
-            Some(WsmVm(WsmVMMetadata(resourceId))),
+            Some(WsmVm(WsmVMMetadata(resourceId), WsmVMAttributes(RegionName("southcentralus")))),
             WsmJobReport(WsmJobId("job1"), "", WsmJobStatus.Failed, 200, ZonedDateTime.now(), None, "url"),
             None
           )
@@ -346,7 +352,7 @@ class AzurePubsubHandlerSpec
       ): IO[GetCreateVmJobResult] =
         IO.pure(
           GetCreateVmJobResult(
-            Some(WsmVm(WsmVMMetadata(resourceId))),
+            Some(WsmVm(WsmVMMetadata(resourceId), WsmVMAttributes(RegionName("southcentralus")))),
             WsmJobReport(WsmJobId("job1"), "", WsmJobStatus.Succeeded, 200, ZonedDateTime.now(), None, "url"),
             None
           )
@@ -620,7 +626,7 @@ class AzurePubsubHandlerSpec
       ): IO[GetCreateVmJobResult] =
         IO.pure(
           GetCreateVmJobResult(
-            Some(WsmVm(WsmVMMetadata(resourceId))),
+            Some(WsmVm(WsmVMMetadata(resourceId), WsmVMAttributes(RegionName("southcentralus")))),
             WsmJobReport(WsmJobId("job1"), "", WsmJobStatus.Succeeded, 200, ZonedDateTime.now(), None, "url"),
             None
           )
@@ -667,7 +673,7 @@ class AzurePubsubHandlerSpec
       ): IO[GetCreateVmJobResult] =
         IO.pure(
           GetCreateVmJobResult(
-            Some(WsmVm(WsmVMMetadata(resourceId))),
+            Some(WsmVm(WsmVMMetadata(resourceId), WsmVMAttributes(RegionName("southcentralus")))),
             WsmJobReport(WsmJobId("job1"), "", WsmJobStatus.Succeeded, 200, ZonedDateTime.now(), None, "url"),
             None
           )


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-4607

<!-- ## Dependencies -->
<!-- Include any dependent tickets and describe the relationship. Include any other relevant Jira tickets. -->

## Summary of changes

We observed during [Terra on Azure Load Testing](https://docs.google.com/document/d/1s2bzXs8szI38mYW_rsiawcurohj1lTbKmw6U7GxZVJw/edit) that Front Leo was crashing during many (~80) simultaneous app creations. A major contributor seemed to be the LZ query, which makes a bunch of Azure cloud calls. This PR moves that call to Back Leo, and also adds a cache in front of it.

### What

Before, Front Leo was doing all this in the scope of the `create[Runtime|App]` request:
1. Query WSM `getWorkspace` to get the workspace cloud context
2. Query LZ `getLandingZoneResources` to get the LZ information
3. Query WSM `enumerateResources` to get shared workspace storage container

After this PR, only (1) now happens in the scope of the request. (2) and (3) happen in Back Leo. Additionally, (2) now has a cache since the LZ is immutable.

### Why

- Better support workshop scenarios, when many runtime and app creations may happen simultaneously.

## Testing these changes

### What to test

TODO: 

- ✅ Unit tests pass
- ✅ Tested runtime and app creation/use/deletion on a BEE
- Tested app update on a BEE
- Scale test 

<!-- ### Test data -->

### Who tested and where

- [ ] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [ ] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
