### PR TITLE
[IA-4623] Pin depenedencies installed in azure_init_script

### DIFF
--- a/http/src/main/resources/init-resources/azure_vm_init_script.sh
+++ b/http/src/main/resources/init-resources/azure_vm_init_script.sh
@@ -163,13 +163,13 @@ echo "VALID_HOSTS = ${VALID_HOSTS}"
 
 # Install relevant libraries
 
-/anaconda/envs/py38_default/bin/pip3 install igv-jupyter
+/anaconda/envs/py38_default/bin/pip3 install igv-jupyter==2.0.1
 
-/anaconda/envs/py38_default/bin/pip3 install seaborn
+/anaconda/envs/py38_default/bin/pip3 install seaborn==0.13.0
 
 # Update rbase
 
-echo "Y"|sudo apt install --no-install-recommends r-base
+echo "Y"|sudo apt install --no-install-recommends r-base==4.3.1-4.2004.0
 
 #Update kernel list
 
@@ -183,7 +183,7 @@ echo "Y"| /anaconda/bin/jupyter kernelspec remove spark-3-python
 
 #echo "Y"| /anaconda/bin/jupyter kernelspec remove julia-1.6
 
-echo "Y"| /anaconda/envs/py38_default/bin/pip3 install ipykernel pydevd
+echo "Y"| /anaconda/envs/py38_default/bin/pip3 install ipykernel pydevd==2.10.0
 
 echo "Y"| /anaconda/envs/py38_default/bin/python3 -m ipykernel install
 

--- a/http/src/main/resources/init-resources/azure_vm_init_script.sh
+++ b/http/src/main/resources/init-resources/azure_vm_init_script.sh
@@ -169,7 +169,7 @@ echo "VALID_HOSTS = ${VALID_HOSTS}"
 
 # Update rbase
 
-echo "Y"|sudo apt install --no-install-recommends r-base==4.3.1-4.2004.0
+echo "Y"|sudo apt install --no-install-recommends r-base=4.3.1-4.2004.0
 
 #Update kernel list
 


### PR DESCRIPTION
<!-- Welcome to your Leonardo pull request! -->
<!-- Contributor guidelines: https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md -->

__Jira ticket__: https://broadworkbench.atlassian.net/browse/[ticket_number]

<!-- ## Dependencies -->
<!-- Include any dependent tickets and describe the relationship. Include any other relevant Jira tickets. -->

## Summary of changes

<!-- Please give an abridged version of the ticket description here and/or fill out the following fields. -->

### What

- Pinning the versions of packages installed in the azure_vm_init_script

### Why

- Creating azure VMs is failing with an error from Azure about a dependency conflict sporadically, hopefully pinning these versions will fix the error or reveal the true problem underneath it

## Testing these changes

### What to test

- create an Azure Vm, check that the pinned versions are correct once it starts up

### Who tested and where

- [ ] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [ ] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
