### PR TITLE
WM-2304: Support role=creator for azure listApps

### DIFF
--- a/http/src/main/resources/swagger/api-docs.yaml
+++ b/http/src/main/resources/swagger/api-docs.yaml
@@ -1829,6 +1829,12 @@ paths:
           required: false
           schema:
             type: string
+        - in: query
+          name: role
+          description: Optional filter that excludes apps you did not create. Accepts "creator" or nothing.
+          required: false
+          schema:
+            type: string
       responses:
         "200":
           description: List of apps

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/AppComponent.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/AppComponent.scala
@@ -301,22 +301,19 @@ object appQuery extends TableQuery(new AppTable(_)) {
       .filter(_.status =!= (AppStatus.Deleted: AppStatus))
       .filter(_.destroyedDate === dummyDate)
 
-  private[db] def filterByWorkspaceId(query: Query[AppTable, AppRecord, Seq],
-                                      workspaceId: Option[WorkspaceId]
-  ): Query[AppTable, AppRecord, Seq] =
-    workspaceId match {
+  private[db] def filterByWorkspaceIdAndCreator(query: Query[AppTable, AppRecord, Seq],
+                                                workspaceId: Option[WorkspaceId],
+                                                creatorOnly: Option[WorkbenchEmail]
+  ): Query[AppTable, AppRecord, Seq] = {
+    val queryWithWorkspaceFilter = workspaceId match {
       case Some(wid) => query.filter(_.workspaceId === wid)
       case None      => query
     }
-
-  private[db] def filterByCreator(query: Query[AppTable, AppRecord, Seq],
-                                  creatorOnly: Option[WorkbenchEmail]
-  ): Query[AppTable, AppRecord, Seq] =
     creatorOnly match {
-      case Some(email) => query.filter(_.creator === email)
-      case None        => query
+      case Some(email) => queryWithWorkspaceFilter.filter(_.creator === email)
+      case None        => queryWithWorkspaceFilter
     }
-
+  }
 }
 
 case class SaveApp(app: App)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/KubernetesServiceDbQueries.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/KubernetesServiceDbQueries.scala
@@ -39,10 +39,10 @@ object KubernetesServiceDbQueries {
     joinFullAppAndUnmarshal(
       listClustersByCloudContext(cloudContext),
       nodepoolQuery,
-      filterByWorkspaceIdAndCreator(
-        query = if (includeDeleted) appQuery else nonDeletedAppQuery,
-        workspaceId = None,
-        creatorOnly = creatorOnly),
+      filterByWorkspaceIdAndCreator(query = if (includeDeleted) appQuery else nonDeletedAppQuery,
+                                    workspaceId = None,
+                                    creatorOnly = creatorOnly
+      ),
       labelFilter
     )
 
@@ -60,10 +60,10 @@ object KubernetesServiceDbQueries {
     joinFullAppAndUnmarshal(
       kubernetesClusterQuery,
       nodepoolQuery,
-      filterByWorkspaceIdAndCreator(
-        query = if (includeDeleted) appQuery else nonDeletedAppQuery,
-        workspaceId = workspaceId,
-        creatorOnly = creatorOnly),
+      filterByWorkspaceIdAndCreator(query = if (includeDeleted) appQuery else nonDeletedAppQuery,
+                                    workspaceId = workspaceId,
+                                    creatorOnly = creatorOnly
+      ),
       labelFilter
     )
 
@@ -174,10 +174,10 @@ object KubernetesServiceDbQueries {
     getActiveFullApp(
       kubernetesClusterQuery,
       nodepoolQuery,
-      filterByWorkspaceIdAndCreator(
-        query = appQuery.findActiveByNameQuery(appName),
-        workspaceId = Some(workspaceId),
-        creatorOnly = None),
+      filterByWorkspaceIdAndCreator(query = appQuery.findActiveByNameQuery(appName),
+                                    workspaceId = Some(workspaceId),
+                                    creatorOnly = None
+      ),
       labelFilter
     )
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/KubernetesServiceDbQueries.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/KubernetesServiceDbQueries.scala
@@ -174,7 +174,10 @@ object KubernetesServiceDbQueries {
     getActiveFullApp(
       kubernetesClusterQuery,
       nodepoolQuery,
-      filterByWorkspaceIdAndCreator(appQuery.findActiveByNameQuery(appName), Some(workspaceId)),
+      filterByWorkspaceIdAndCreator(
+        query = appQuery.findActiveByNameQuery(appName),
+        workspaceId = Some(workspaceId),
+        creatorOnly = None),
       labelFilter
     )
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/LeoAppServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/LeoAppServiceInterp.scala
@@ -534,7 +534,7 @@ final class LeoAppServiceInterp[F[_]: Parallel](config: AppServiceConfig,
       paramMap <- F.fromEither(processListParameters(params))
       creatorOnly <- F.fromEither(processCreatorOnlyParameter(userInfo.userEmail, params, ctx.traceId))
       allClusters <- KubernetesServiceDbQueries
-        .listFullAppsByWorkspaceId(Some(workspaceId), paramMap._1, paramMap._2)
+        .listFullAppsByWorkspaceId(Some(workspaceId), paramMap._1, paramMap._2, creatorOnly)
         .transaction
       res <- filterAppsBySamPermission(allClusters, userInfo, paramMap._3, false)
 


### PR DESCRIPTION
Add a `role=creator` option to Leonardo listAppsV2 in analogy to the option for GCP apps.

- Without the new option specified, all apps are returned, as before ✅ 
- With the new option specified, no apps are returned ✅ 