### PR TITLE
RW-11059 Drop group check for AoU

### DIFF
--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -1203,7 +1203,7 @@ app-service {
   # Defaults to true, but disabled for fiab runs
   enable-custom-app-check = true
   # Defaults to true, but for Production, we'll use Consumption model (details TBD as of 8/18/2023), which doesn't require Sam group check
-  enable-sas-group-app-check = true
+  enable-sas-app = false
 }
 
 drs {

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
@@ -788,7 +788,7 @@ object Config {
 
   val appServiceConfig = AppServiceConfig(
     config.getBoolean("app-service.enable-custom-app-check"),
-    config.getBoolean("app-service.enable-sas-group-app-check"),
+    config.getBoolean("app-service.enable-sas-app"),
     leoKubernetesConfig
   )
   val pubsubConfig = config.as[PubsubConfig]("pubsub")

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/AppService.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/AppService.scala
@@ -72,6 +72,6 @@ trait AppService[F[_]] {
 }
 
 final case class AppServiceConfig(enableCustomAppCheck: Boolean,
-                                  enableSasAppGroupCheck: Boolean,
+                                  enableSasApp: Boolean,
                                   leoKubernetesConfig: LeoKubernetesConfig
 )

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/LeoAppServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/LeoAppServiceInterp.scala
@@ -111,7 +111,7 @@ final class LeoAppServiceInterp[F[_]: Parallel](config: AppServiceConfig,
                       }
                     }
 
-                  checkIfAllowed.whenA(config.enableSasAppGroupCheck)
+                  checkIfAllowed.whenA(config.enableSasApp)
               }
             case None =>
               F.raiseError(

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/LeoAppServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/LeoAppServiceInterp.scala
@@ -94,26 +94,24 @@ final class LeoAppServiceInterp[F[_]: Parallel](config: AppServiceConfig,
             case Some(cn) =>
               cn match {
                 case AllowedChartName.RStudio => F.unit
-                case AllowedChartName.Sas     =>
-                  // TODO: https://precisionmedicineinitiative.atlassian.net/browse/RW-11059
-                  if (config.enableSasAppGroupCheck)
-                    authProvider.isSasAppAllowed(userInfo.userEmail) flatMap { res =>
-                      if (res) {
-                        if (enableIntraNodeVisibility)
-                          checkIfSasAppCreationIsAllowed(userInfo.userEmail, googleProject)
-                        else {
+                case AllowedChartName.Sas =>
+                  val checkIfAllowed =
+                    if (enableIntraNodeVisibility)
+                      checkIfSasAppCreationIsAllowed(userInfo.userEmail, googleProject)
+                    else {
+                      authProvider.isSasAppAllowed(userInfo.userEmail) flatMap { res =>
+                        if (res) {
+                          F.unit
+                        } else
                           F.raiseError[Unit](
-                            AuthenticationError(Some(userInfo.userEmail), "SAS is not supported")
+                            AuthenticationError(Some(userInfo.userEmail),
+                                                "You need to obtain a license in order to create a SAS App"
+                            )
                           )
-                        }
-                      } else
-                        F.raiseError[Unit](
-                          AuthenticationError(Some(userInfo.userEmail),
-                                              "You need to obtain a license in order to create a SAS App"
-                          )
-                        )
+                      }
                     }
-                  else F.unit
+
+                  checkIfAllowed.whenA(config.enableSasAppGroupCheck)
               }
             case None =>
               F.raiseError(

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/AppServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/AppServiceInterpSpec.scala
@@ -171,7 +171,7 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
         IO(None)
     }
     val interp = new LeoAppServiceInterp[IO](
-      AppServiceConfig(enableCustomAppCheck = true, enableSasAppGroupCheck = true, leoKubernetesConfig),
+      AppServiceConfig(enableCustomAppCheck = true, enableSasApp = true, leoKubernetesConfig),
       authProvider,
       serviceAccountProvider,
       QueueFactory.makePublisherQueue(),
@@ -1269,7 +1269,7 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
     val customApplicationAllowList =
       CustomApplicationAllowListConfig(List(), List())
     val testInterp = new LeoAppServiceInterp[IO](
-      AppServiceConfig(enableCustomAppCheck = true, enableSasAppGroupCheck = true, leoKubernetesConfig),
+      AppServiceConfig(enableCustomAppCheck = true, enableSasApp = true, leoKubernetesConfig),
       allowListAuthProvider,
       serviceAccountProvider,
       QueueFactory.makePublisherQueue(),
@@ -1392,7 +1392,7 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
         IO.pure(true)
     }
     val testInterp = new LeoAppServiceInterp[IO](
-      AppServiceConfig(enableCustomAppCheck = true, enableSasAppGroupCheck = true, leoKubernetesConfig),
+      AppServiceConfig(enableCustomAppCheck = true, enableSasApp = true, leoKubernetesConfig),
       authProvider,
       serviceAccountProvider,
       QueueFactory.makePublisherQueue(),
@@ -1436,7 +1436,7 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
         IO(Some(Map("not-security-group" -> "any-val")))
     }
     val testInterp = new LeoAppServiceInterp[IO](
-      AppServiceConfig(enableCustomAppCheck = true, enableSasAppGroupCheck = true, leoKubernetesConfig),
+      AppServiceConfig(enableCustomAppCheck = true, enableSasApp = true, leoKubernetesConfig),
       authProvider,
       serviceAccountProvider,
       QueueFactory.makePublisherQueue(),
@@ -1479,7 +1479,7 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
         IO(Some(Map("security-group" -> "high")))
     }
     val testInterp = new LeoAppServiceInterp[IO](
-      AppServiceConfig(enableCustomAppCheck = true, enableSasAppGroupCheck = true, leoKubernetesConfig),
+      AppServiceConfig(enableCustomAppCheck = true, enableSasApp = true, leoKubernetesConfig),
       authProvider,
       serviceAccountProvider,
       QueueFactory.makePublisherQueue(),
@@ -1519,7 +1519,7 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
         IO(Some(Map("security-group" -> "high")))
     }
     val testInterp = new LeoAppServiceInterp[IO](
-      AppServiceConfig(enableCustomAppCheck = true, enableSasAppGroupCheck = true, leoKubernetesConfig),
+      AppServiceConfig(enableCustomAppCheck = true, enableSasApp = true, leoKubernetesConfig),
       allowListAuthProvider,
       serviceAccountProvider,
       QueueFactory.makePublisherQueue(),
@@ -1565,7 +1565,7 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
         IO(Some(Map("not-security-group" -> "any-val")))
     }
     val testInterp = new LeoAppServiceInterp[IO](
-      AppServiceConfig(enableCustomAppCheck = true, enableSasAppGroupCheck = true, leoKubernetesConfig),
+      AppServiceConfig(enableCustomAppCheck = true, enableSasApp = true, leoKubernetesConfig),
       authProvider,
       serviceAccountProvider,
       QueueFactory.makePublisherQueue(),
@@ -1611,7 +1611,7 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
         IO(Some(Map("not-security-group" -> "any-val")))
     }
     val testInterp = new LeoAppServiceInterp[IO](
-      AppServiceConfig(enableCustomAppCheck = true, enableSasAppGroupCheck = true, leoKubernetesConfig),
+      AppServiceConfig(enableCustomAppCheck = true, enableSasApp = true, leoKubernetesConfig),
       authProvider,
       serviceAccountProvider,
       QueueFactory.makePublisherQueue(),


### PR DESCRIPTION
https://precisionmedicineinitiative.atlassian.net/browse/RW-11059

AoU will be ready to use consumption model after this PR.

This PR does the following
1. Drop sas_app_users group check for AoU users
2. Keep sas_app_users group check for non_AoU users. This is so that in the future, when we integrate SAS to Terra, devs with individual licenses can be added to this group and work on UI integration before consumption model for Terra is finalized.

Once this PR is merged, SAS will be available for all users in AoU Test environment

Related https://github.com/broadinstitute/terra-helmfile/pull/4701

### Who tested and where

- [ ] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [ ] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
