### PR TITLE
[IA-4636] add some config to perhaps fix socket timeout

### DIFF
--- a/automation/src/test/resources/reference.conf
+++ b/automation/src/test/resources/reference.conf
@@ -17,7 +17,7 @@ azure {
     workspaceId="e1aaf25b-b298-46eb-891b-e4c326f29b0c"
 }
 leonardoClient {
-    writeTimeout = 300000 //in ms, 5 minutes * 60 sec/min * 1000 ms/sec
-    readTimeout = 300000 //in ms, 5 minutes * 60 sec/min * 1000 ms/sec
-    connectionTimeout = 300000 //in ms, 5 minutes * 60 sec/min * 1000 ms/sec
+    writeTimeout = 600000 //in ms, 10 minutes * 60 sec/min * 1000 ms/sec
+    readTimeout = 600000 //in ms, 10 minutes * 60 sec/min * 1000 ms/sec
+    connectionTimeout = 600000 //in ms, 10 minutes * 60 sec/min * 1000 ms/sec
 }

--- a/automation/src/test/resources/reference.conf
+++ b/automation/src/test/resources/reference.conf
@@ -16,3 +16,8 @@ azure {
     subscriptionId= "3efc5bdf-be0e-44e7-b1d7-c08931e3c16c"
     workspaceId="e1aaf25b-b298-46eb-891b-e4c326f29b0c"
 }
+leonardoClient {
+    writeTimeout = 300000 //in ms, 5 minutes * 60 sec/min * 1000 ms/sec
+    readTimeout = 300000 //in ms, 5 minutes * 60 sec/min * 1000 ms/sec
+    connectionTimeout = 300000 //in ms, 5 minutes * 60 sec/min * 1000 ms/sec
+}

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/GeneratedLeonardoClient.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/GeneratedLeonardoClient.scala
@@ -19,7 +19,6 @@ import org.http4s.client.middleware.{Logger, Retry, RetryPolicy}
 import org.http4s.headers.Authorization
 import org.http4s.blaze.client.BlazeClientBuilder
 
-import java.util.concurrent.TimeUnit
 import scala.concurrent.duration._
 
 /**

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/GeneratedLeonardoClient.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/GeneratedLeonardoClient.scala
@@ -18,6 +18,8 @@ import org.http4s.client.Client
 import org.http4s.client.middleware.{Logger, Retry, RetryPolicy}
 import org.http4s.headers.Authorization
 import org.http4s.blaze.client.BlazeClientBuilder
+
+import java.util.concurrent.TimeUnit
 import scala.concurrent.duration._
 
 /**
@@ -84,4 +86,7 @@ object GeneratedLeonardoClient {
       _ <- IO(apiClient.setBasePath(uri.toString()))
       _ <- IO(apiClient.setAccessToken(token.value))
     } yield apiClient
+      .setWriteTimeout(LeonardoConfig.LeonardoClient.writeTimeout)
+      .setReadTimeout(LeonardoConfig.LeonardoClient.readTimeout)
+      .setConnectTimeout(LeonardoConfig.LeonardoClient.connectionTimeout)
 }

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoConfig.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoConfig.scala
@@ -10,6 +10,7 @@ object LeonardoConfig extends CommonConfig {
   private val leonardo = config.getConfig("leonardo")
   private val azure = config.getConfig("azure")
   private val gcs = config.getConfig("gcs")
+  private val leonardoClient = config.getConfig("leonardoClient")
 
   object Leonardo {
     val apiUrl: String = leonardo.getString("apiUrl")
@@ -42,6 +43,12 @@ object LeonardoConfig extends CommonConfig {
   // TODO: this should be updated once we're able to run azure automation tests as part of CI
   object WSM {
     val wsmUri: String = "https://workspace.dsde-dev.broadinstitute.org"
+  }
+
+  object LeonardoClient {
+    val writeTimeout = leonardoClient.getInt("writeTimeout")
+    val readTimeout = leonardoClient.getInt("readTimeout")
+    val connectionTimeout = leonardoClient.getInt("connectionTimeout")
   }
 
   // for NotebooksWhitelisted


### PR DESCRIPTION
I think its the leonardo java client timing out on polling operations. The java client should not be timing out, we have other timeouts in place. 

```
[info]   org.broadinstitute.dsde.workbench.client.leonardo.ApiException: Message: java.net.SocketTimeoutException: timeout
[info] HTTP response code: 0
[info] HTTP response body: null
[info] HTTP response headers: null
[info]   at org.broadinstitute.dsde.workbench.client.leonardo.ApiClient.execute(ApiClient.java:1124)
...
```

Full example run here: https://github.com/broadinstitute/terra-github-workflows/actions/runs/6511714509/job/17687928862#step:7:3924
