### PR TITLE
[PROD-897] Lookup only one workspace's permissions if listRuntimes is filtered

### DIFF
--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeV2ServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeV2ServiceInterp.scala
@@ -554,19 +554,22 @@ class RuntimeV2ServiceInterp[F[_]: Parallel](config: RuntimeServiceConfig,
       readerV2WsmIds: Set[WsmResourceSamResourceId] <- authProvider
         .listResourceIds[WsmResourceSamResourceId](hasOwnerRole = false, userInfo)
       readerWorkspaceIds: Set[WorkspaceResourceSamResourceId] <- maybeWorkspaceSamId match {
-        case Some(workspaceSamId) => for {
-          isWorkspaceReader <- authProvider.isUserWorkspaceReader(workspaceSamId, userInfo)
-          workspaceIds: Set[WorkspaceResourceSamResourceId] = if (isWorkspaceReader) Set(workspaceSamId) else Set.empty
-        } yield workspaceIds
+        case Some(workspaceSamId) =>
+          for {
+            isWorkspaceReader <- authProvider.isUserWorkspaceReader(workspaceSamId, userInfo)
+            workspaceIds: Set[WorkspaceResourceSamResourceId] =
+              if (isWorkspaceReader) Set(workspaceSamId) else Set.empty
+          } yield workspaceIds
         case None => authProvider.listResourceIds[WorkspaceResourceSamResourceId](hasOwnerRole = false, userInfo)
       }
 
       // v2 runtimes are discoverable by owners on the corresponding Workspace
       ownerWorkspaceIds: Set[WorkspaceResourceSamResourceId] <- maybeWorkspaceSamId match {
-        case Some(workspaceSamId) => for {
-          isWorkspaceOwner <- authProvider.isUserWorkspaceOwner(workspaceSamId, userInfo)
-          workspaceIds: Set[WorkspaceResourceSamResourceId] = if (isWorkspaceOwner) Set(workspaceSamId) else Set.empty
-        } yield workspaceIds
+        case Some(workspaceSamId) =>
+          for {
+            isWorkspaceOwner <- authProvider.isUserWorkspaceOwner(workspaceSamId, userInfo)
+            workspaceIds: Set[WorkspaceResourceSamResourceId] = if (isWorkspaceOwner) Set(workspaceSamId) else Set.empty
+          } yield workspaceIds
         case None => authProvider.listResourceIds[WorkspaceResourceSamResourceId](hasOwnerRole = true, userInfo)
       }
 

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeV2ServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeV2ServiceInterpSpec.scala
@@ -196,13 +196,13 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
    * @return
    */
   def mockAuthorizeForOneWorkspace(userInfo: UserInfo,
-                    readerRuntimeSamIds: Set[RuntimeSamResourceId] = Set.empty,
-                    readerWsmSamIds: Set[WsmResourceSamResourceId] = Set.empty,
-                    readerWorkspaceSamIds: Set[WorkspaceResourceSamResourceId] = Set.empty,
-                    readerProjectSamIds: Set[ProjectSamResourceId] = Set.empty,
-                    ownerWorkspaceSamIds: Set[WorkspaceResourceSamResourceId] = Set.empty,
-                    ownerProjectSamIds: Set[ProjectSamResourceId] = Set.empty
-                   ): AllowlistAuthProvider = {
+                                   readerRuntimeSamIds: Set[RuntimeSamResourceId] = Set.empty,
+                                   readerWsmSamIds: Set[WsmResourceSamResourceId] = Set.empty,
+                                   readerWorkspaceSamIds: Set[WorkspaceResourceSamResourceId] = Set.empty,
+                                   readerProjectSamIds: Set[ProjectSamResourceId] = Set.empty,
+                                   ownerWorkspaceSamIds: Set[WorkspaceResourceSamResourceId] = Set.empty,
+                                   ownerProjectSamIds: Set[ProjectSamResourceId] = Set.empty
+  ): AllowlistAuthProvider = {
     val mockAuthProvider: AllowlistAuthProvider = mock[AllowlistAuthProvider](defaultMockitoAnswer[IO])
 
     when(mockAuthProvider.checkUserEnabled(isEq(userInfo))(any)).thenReturn(IO.unit)
@@ -252,7 +252,6 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
       )
     ).thenReturn(IO.pure(true))
     when(
-
       mockAuthProvider.listResourceIds[ProjectSamResourceId](isEq(true), isEq(userInfo))(
         any(projectSamResourceAction.getClass),
         any(AppSamResourceAction.getClass),


### PR DESCRIPTION
<!-- Welcome to your Leonardo pull request! -->
<!-- Contributor guidelines: https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md -->

__Jira ticket__: https://broadworkbench.atlassian.net/browse/PROD-897

<!-- ## Dependencies -->
<!-- Include any dependent tickets and describe the relationship. Include any other relevant Jira tickets. -->

## Summary of changes

<!-- Please give an abridged version of the ticket description here and/or fill out the following fields. -->

### What

- Change listRuntimes logic to request isWorkspaceReader/Owner instead of listResourceIds, if the request to listRuntimes is filtered to a single workspace ID

### Why

- Massive request load to Sam resourceType/Workspace API endpoint

## Testing these changes

### What to test

- See test cases in original PR https://github.com/DataBiosphere/leonardo/pull/3734
- This change affects results when filtering by *one* workspaceId - so open any workspace page where you and another user have a runtime, and verify that the runtime you see is yours.

<!-- ### Test data -->

### Who tested and where

- [x] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [x] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
