### PR TITLE
[IA-4654] Move workspaceId field in encoder to match getAppResponse

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/appRoutesModels.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/appRoutesModels.scala
@@ -37,6 +37,7 @@ final case class CreateAppRequest(kubernetesRuntimeConfig: Option[KubernetesRunt
 )
 
 final case class GetAppResponse(
+  workspaceId: Option[WorkspaceId],
   appName: AppName,
   cloudContext: CloudContext,
   region: RegionName,
@@ -50,7 +51,6 @@ final case class GetAppResponse(
   appType: AppType,
   chartName: ChartName,
   accessScope: Option[AppAccessScope],
-  workspaceId: Option[WorkspaceId],
   labels: LabelMap
 )
 
@@ -103,6 +103,7 @@ object ListAppResponse {
 object GetAppResponse {
   def fromDbResult(appResult: GetAppResult, proxyUrlBase: String): GetAppResponse =
     GetAppResponse(
+      appResult.app.workspaceId,
       appResult.app.appName,
       appResult.cluster.cloudContext,
       appResult.cluster.region,
@@ -120,7 +121,6 @@ object GetAppResponse {
       appResult.app.appType,
       appResult.app.chart.name,
       appResult.app.appAccessScope,
-      appResult.app.workspaceId,
       appResult.app.labels
     )
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/appRoutesModels.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/appRoutesModels.scala
@@ -37,7 +37,6 @@ final case class CreateAppRequest(kubernetesRuntimeConfig: Option[KubernetesRunt
 )
 
 final case class GetAppResponse(
-  workspaceId: Option[WorkspaceId],
   appName: AppName,
   cloudContext: CloudContext,
   region: RegionName,
@@ -51,6 +50,7 @@ final case class GetAppResponse(
   appType: AppType,
   chartName: ChartName,
   accessScope: Option[AppAccessScope],
+  workspaceId: Option[WorkspaceId],
   labels: LabelMap
 )
 
@@ -103,7 +103,6 @@ object ListAppResponse {
 object GetAppResponse {
   def fromDbResult(appResult: GetAppResult, proxyUrlBase: String): GetAppResponse =
     GetAppResponse(
-      appResult.app.workspaceId,
       appResult.app.appName,
       appResult.cluster.cloudContext,
       appResult.cluster.region,
@@ -121,6 +120,7 @@ object GetAppResponse {
       appResult.app.appType,
       appResult.app.chart.name,
       appResult.app.appAccessScope,
+      appResult.app.workspaceId,
       appResult.app.labels
     )
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/AppRoutesTestJsonCodec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/AppRoutesTestJsonCodec.scala
@@ -41,6 +41,7 @@ object AppRoutesTestJsonCodec {
 
   implicit val getAppResponseDecoder: Decoder[GetAppResponse] =
     Decoder.forProduct15(
+      "workspaceId",
       "appName",
       "cloudContext",
       "region",
@@ -54,7 +55,6 @@ object AppRoutesTestJsonCodec {
       "appType",
       "chartName",
       "accessScope",
-      "workspaceId",
       "labels"
     )(GetAppResponse.apply)
 

--- a/http/src/main/resources/swagger/api-docs.yaml
+++ b/http/src/main/resources/swagger/api-docs.yaml
@@ -4076,6 +4076,9 @@ components:
         - auditInfo
       type: object
       properties:
+        workspaceId:
+          type: string
+          description: 'The Terra workspace id for the app. This is not present for apps created with V1 endpoints.'
         appName:
           type: string
           description: the name of the app
@@ -4110,9 +4113,6 @@ components:
           $ref: '#/components/schemas/AppType'
         accessScope:
           $ref: '#/components/schemas/AppAccessScope'
-        workspaceId:
-          type: string
-          description: 'The Terra workspace id for the app. This is not present for apps created with V1 endpoints.'
         labels:
           type: object
           description: The labels of each app in the response whose key is in includeLabels in the request. Of type Map[String,String]

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/AppV2Routes.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/AppV2Routes.scala
@@ -243,6 +243,7 @@ object AppV2Routes {
 
   implicit val getAppResponseEncoder: Encoder[GetAppResponse] =
     Encoder.forProduct15(
+      "workspaceId",
       "appName",
       "cloudContext",
       "region",
@@ -256,7 +257,6 @@ object AppV2Routes {
       "appType",
       "chartName",
       "accessScope",
-      "workspaceId",
       "labels"
     )(x => GetAppResponse.unapply(x).get)
 }


### PR DESCRIPTION
<!-- Welcome to your Leonardo pull request! -->
<!-- Contributor guidelines: https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md -->

__Jira ticket__: https://broadworkbench.atlassian.net/browse/IA-4654

<!-- ## Dependencies -->
<!-- Include any dependent tickets and describe the relationship. Include any other relevant Jira tickets. -->

## Summary of changes

<!-- Please give an abridged version of the ticket description here and/or fill out the following fields. -->

### What

- Small fix to make GetAppResponse have the fields in the correct order, matching [this PR](https://github.com/DataBiosphere/leonardo/pull/3866/files)

## Testing these changes

### What to test

- <!-- Test case 1 -->

<!-- ### Test data -->

### Who tested and where

- [ ] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [ ] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
