### PR TITLE
RW-10598  Support updating replica for supporting stop/start (only ALLOWED apps for now)

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoSuite.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoSuite.scala
@@ -8,7 +8,6 @@ import io.circe.parser._
 import org.broadinstitute.dsde.rawls.model.WorkspaceName
 import org.broadinstitute.dsde.workbench.auth.AuthTokenScopes.billingScopes
 import org.broadinstitute.dsde.workbench.config.ServiceTestConfig
-import org.broadinstitute.dsde.workbench.fixture.BillingFixtures.withTemporaryAzureBillingProject
 import org.broadinstitute.dsde.workbench.leonardo.BillingProjectFixtureSpec._
 import org.broadinstitute.dsde.workbench.leonardo.TestUser.{Hermione, Ron}
 import org.broadinstitute.dsde.workbench.leonardo.lab.LabSpec

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/AppLifecycleSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/AppLifecycleSpec.scala
@@ -65,7 +65,7 @@ class AppLifecycleSpec
     googleProject =>
       test(googleProject,
            createAppRequest(AppType.Allowed, "rstudio-test-workspace", None, Some(AllowedChartName.RStudio)),
-           false,
+           true,
            true
       )
   }

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/kubernetesModels.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/kubernetesModels.scala
@@ -429,7 +429,8 @@ final case class App(id: AppId,
                      customEnvironmentVariables: Map[String, String],
                      descriptorPath: Option[Uri],
                      extraArgs: List[String],
-                     sourceWorkspaceId: Option[WorkspaceId]
+                     sourceWorkspaceId: Option[WorkspaceId],
+                     numOfReplicas: Option[Int]
 ) {
 
   def getProxyUrls(cluster: KubernetesCluster, proxyUrlBase: String): Map[ServiceName, URL] =

--- a/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changelog.xml
+++ b/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changelog.xml
@@ -109,4 +109,5 @@
     <include file="changesets/20230927_add_cluster_table_index_on_internal_id.xml" relativeToChangelogFile="true" />
     <include file="changesets/20231002_drop_columns_in_nodepool_table.xml" relativeToChangelogFile="true" />
     <include file="changesets/20231002_drop_namespace_table.xml" relativeToChangelogFile="true" />
+    <include file="changesets/20231030_add_replica_to_app_table.xml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/20231030_add_replica_to_app_table.xml
+++ b/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/20231030_add_replica_to_app_table.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog logicalFilePath="leonardo" xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+    <changeSet logicalFilePath="leonardo" author="qi" id="qi_20231030_add_replica_to_app_table">
+        <addColumn tableName="APP">
+            <column name="numOfReplicas" type="SMALLINT">
+                <constraints nullable="true"/>
+            </column>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -747,8 +747,8 @@ gke {
     # This is really just a prefix of the chart name. Full chart name for AOU app will be
     # this chartName in config file appended with allowedChartName from createAppRequest
     chartName = "/leonardo/"
-    rstudioChartVersion = "0.2.0"
-    sasChartVersion = "0.1.0"
+    rstudioChartVersion = "0.3.0"
+    sasChartVersion = "0.2.0"
 
     services = [
           {
@@ -766,6 +766,7 @@ gke {
     enabled = true
     # App developers - Please keep the list of non-backward compatible versions in the list below
     chartVersionsToExcludeFromUpdates = []
+    numOfReplicas = 2
   }
 
   customApp {

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -766,7 +766,7 @@ gke {
     enabled = true
     # App developers - Please keep the list of non-backward compatible versions in the list below
     chartVersionsToExcludeFromUpdates = []
-    numOfReplicas = 2
+    numOfReplicas = 1
   }
 
   customApp {

--- a/http/src/main/resources/swagger/api-docs.yaml
+++ b/http/src/main/resources/swagger/api-docs.yaml
@@ -4224,7 +4224,7 @@ components:
           example: n1-standard-1
         autoscalingEnabled:
           type: boolean
-          description: whether or not the nodes autoscale up and down for this app
+          description: whether or not the nodes autoscale up and down for this app. This is always `true` for ALLOWED apps.
 
     PersistentDiskRequest:
       description: configuration to create a disk

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
@@ -716,7 +716,8 @@ object Config {
       config.as[List[ServiceConfig]]("services"),
       config.as[ServiceAccountName]("serviceAccountName"),
       config.as[ContainerRegistryCredentials]("sasContainerRegistry"),
-      config.as[List[ChartVersion]]("chartVersionsToExcludeFromUpdates")
+      config.as[List[ChartVersion]]("chartVersionsToExcludeFromUpdates"),
+      config.as[Int]("numOfReplicas")
     )
   }
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/KubernetesAppConfig.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/KubernetesAppConfig.scala
@@ -207,7 +207,8 @@ final case class AllowedAppConfig(chartName: ChartName,
                                   services: List[ServiceConfig],
                                   serviceAccountName: ServiceAccountName,
                                   sasContainerRegistryCredentials: ContainerRegistryCredentials,
-                                  chartVersionsToExcludeFromUpdates: List[ChartVersion]
+                                  chartVersionsToExcludeFromUpdates: List[ChartVersion],
+                                  numOfReplicas: Int
 ) extends KubernetesAppConfig {
   val cloudProvider: CloudProvider = CloudProvider.Gcp
   val appType: AppType = AppType.Allowed

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/LeoAppServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/LeoAppServiceInterp.scala
@@ -178,7 +178,7 @@ final class LeoAppServiceInterp[F[_]: Parallel](config: AppServiceConfig,
 
       clusterId = saveClusterResult.minimalCluster.id
 
-      machineConfig = req.kubernetesRuntimeConfig.getOrElse(
+      machineConfigFromReqAndConfig = req.kubernetesRuntimeConfig.getOrElse(
         KubernetesRuntimeConfig(
           config.leoKubernetesConfig.nodepoolConfig.galaxyNodepoolConfig.numNodes,
           config.leoKubernetesConfig.nodepoolConfig.galaxyNodepoolConfig.machineType,
@@ -186,6 +186,10 @@ final class LeoAppServiceInterp[F[_]: Parallel](config: AppServiceConfig,
         )
       )
 
+      // Always allow autoScaling for ALLOWED appType
+      machineConfig =
+        if (AppType.Allowed == req.appType) machineConfigFromReqAndConfig.copy(autoscalingEnabled = true)
+        else machineConfigFromReqAndConfig
       // We want to know if the user already has a nodepool with the requested config that can be re-used
       userNodepoolOpt <- nodepoolQuery
         .getMinimalByUserAndConfig(originatingUserEmail, cloudContext, machineConfig)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/LeoAppServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/LeoAppServiceInterp.scala
@@ -1239,6 +1239,11 @@ final class LeoAppServiceInterp[F[_]: Parallel](config: AppServiceConfig,
         if (cloudContext.cloudProvider == CloudProvider.Azure) {
           gkeAppConfig.kubernetesServices.appended(ConfigReader.appConfig.azure.listenerChartConfig.service)
         } else gkeAppConfig.kubernetesServices
+
+      numOfReplicas =
+        if (req.appType == AppType.Allowed)
+          Some(config.leoKubernetesConfig.allowedAppConfig.numOfReplicas)
+        else None
     } yield SaveApp(
       App(
         AppId(-1),
@@ -1264,7 +1269,8 @@ final class LeoAppServiceInterp[F[_]: Parallel](config: AppServiceConfig,
         customEnvironmentVariables,
         req.descriptorPath,
         req.extraArgs,
-        req.sourceWorkspaceId
+        req.sourceWorkspaceId,
+        numOfReplicas
       )
     )
   }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoMetricsMonitor.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoMetricsMonitor.scala
@@ -375,6 +375,7 @@ class LeoMetricsMonitor[F[_]](config: LeoMetricsMonitorConfig,
                                              null,
                                              null,
                                              null,
+                                             null,
                                              null
                     )
                   )

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/BuildHelmChartValues.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/BuildHelmChartValues.scala
@@ -363,7 +363,8 @@ private[leonardo] object BuildHelmChartValues {
     val configs = customEnvironmentVariables.toList.zipWithIndex.flatMap { case ((k, v), i) =>
       List(
         raw"""extraEnv[$i].name=$k""",
-        raw"""extraEnv[$i].value=$v"""
+        raw"""extraEnv[$i].value=$v""",
+        raw"""replicaCount=${config.allowedAppConfig.numOfReplicas.toString}"""
       )
     }
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
@@ -1036,7 +1036,7 @@ class GKEInterpreter[F[_]](
             // Update nodepool status to Running and app status to Stopped
             _ <- attemptToStop match {
               case Left(e) =>
-                // This updates the APP back to `RUNNNING` status instead of putting it into `ERROR` status. This
+                // This updates the APP back to `RUNNING` status instead of putting it into `ERROR` status. This
                 // can be confusing to users since they will notice the APP is not stoppable.
                 // Currently, Leo doesn't have a good way to inform users about "an error happened during Stopping",
                 // which I think we should spend some effort design this out.

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
@@ -1014,101 +1014,47 @@ class GKEInterpreter[F[_]](
                                                  "No active app found in DB"
                             )
       )
-      dbNodepool = dbApp.nodepool
-      dbCluster = dbApp.cluster
-      nodepoolId = NodepoolId(dbCluster.getClusterId, dbNodepool.nodepoolName)
 
       _ <- logger.info(ctx.loggingCtx)(
-        s"Stopping app ${dbApp.app.appName.value} in cluster ${dbCluster.getClusterId.toString}"
+        s"Stopping app ${dbApp.app.appName.value} in cluster ${dbApp.cluster.getClusterId.toString}"
       )
 
-      _ <- nodepoolQuery.updateStatus(dbNodepool.id, NodepoolStatus.Provisioning).transaction
-
-      // If autoscaling is enabled, disable it first
-      _ <-
-        if (dbNodepool.autoscalingEnabled) {
-          nodepoolLock.withKeyLock(dbCluster.getClusterId) {
-            for {
-              opOrError <- gkeService
-                .setNodepoolAutoscaling(
-                  nodepoolId,
-                  NodePoolAutoscaling.newBuilder().setEnabled(false).build()
-                )
-                .attempt
-              _ <- opOrError match {
-                case Left(e: com.google.api.gax.rpc.NotFoundException) =>
-                  // Mark the app as `DELETED` instead of bubbling this error up to generic error handler
-                  for {
-                    _ <- appErrorQuery
-                      .save(
-                        dbApp.app.id,
-                        AppError(e.getMessage, ctx.now, ErrorAction.StopApp, ErrorSource.App, None, Some(ctx.traceId))
-                      )
-                      .transaction
-                    _ <- appQuery.markAsDeleted(dbApp.app.id, ctx.now).transaction
-                    _ <-
-                      nodepoolQuery.markAsDeleted(dbApp.nodepool.id, ctx.now).transaction
-                  } yield ()
-                case Left(e) => F.raiseError(e)
-                case Right(op) =>
-                  for {
-                    _ <- F.sleep(config.monitorConfig.scalingDownNodepool.initialDelay)
-                    lastOp <- gkeService
-                      .pollOperation(
-                        KubernetesOperationId(params.googleProject, dbCluster.location, op.getName),
-                        config.monitorConfig.scalingDownNodepool.interval,
-                        config.monitorConfig.scalingDownNodepool.maxAttempts
-                      )
-                      .compile
-                      .lastOrError
-                    _ <-
-                      if (lastOp.isDone)
-                        logger.info(ctx.loggingCtx)(
-                          s"setNodepoolAutoscaling operation has finished for nodepool ${dbNodepool.id}"
-                        )
-                      else
-                        logger.error(ctx.loggingCtx)(
-                          s"setNodepoolAutoscaling operation has failed or timed out for nodepool ${dbNodepool.id}"
-                        ) >>
-                          F.raiseError[Unit](NodepoolStopException(dbNodepool.id))
-
-                  } yield ()
-              }
-            } yield ()
-          }
-        } else F.unit
-
-      // Scale the nodepool to zero nodes
-      _ <- nodepoolLock.withKeyLock(dbCluster.getClusterId) {
-        for {
-          op <- gkeService.setNodepoolSize(nodepoolId, 0)
-          _ <- F.sleep(config.monitorConfig.scalingDownNodepool.initialDelay)
-          lastOp <- gkeService
-            .pollOperation(
-              KubernetesOperationId(params.googleProject, dbCluster.location, op.getName),
-              config.monitorConfig.scalingDownNodepool.interval,
-              config.monitorConfig.scalingDownNodepool.maxAttempts
-            )
-            .compile
-            .lastOrError
-          _ <-
-            if (lastOp.isDone)
-              logger.info(ctx.loggingCtx)(
-                s"setNodepoolSize operation has finished for nodepool ${dbNodepool.id}"
+      _ <- dbApp.app.numOfReplicas match {
+        case Some(_) =>
+          // If the app has a numOfReplicas field, we'll stop it by scaling down replicas to 0
+          for {
+            // Scale the nodepool to zero nodes
+            attemptToStop <- kubeService
+              .patchReplicas(
+                dbApp.cluster.getClusterId,
+                KubernetesNamespace(dbApp.app.appResources.namespace),
+                KubernetesDeployment(dbApp.app.appName.value), // appNames are the same as deployments
+                0
               )
-            else
-              logger.error(ctx.loggingCtx)(
-                s"setNodepoolSize operation has failed or timed out for nodepool ${dbNodepool.id}"
-              ) >>
-                F.raiseError[Unit](NodepoolStopException(dbNodepool.id))
-        } yield ()
+              .attempt
+
+            // Update nodepool status to Running and app status to Stopped
+            _ <- attemptToStop match {
+              case Left(e) =>
+                // This updates the APP back to `RUNNNING` status instead of putting it into `ERROR` status. This
+                // can be confusing to users since they will notice the APP is not stoppable.
+                // Currently, Leo doesn't have a good way to inform users about "an error happened during Stopping",
+                // which I think we should spend some effort design this out.
+                // For now, I think this is better behavior than putting the APP into ERROR status, which will make the APP
+                // unusable.
+                // TODO: think about update appUsage
+                logger.info(ctx.loggingCtx, e)("Failed to stop app") >> appQuery
+                  .updateStatus(params.appId, AppStatus.Running)
+                  .transaction
+              case Right(_) => F.unit
+            }
+          } yield ()
+        case None =>
+          // If the app does not a numOfReplicas field, we'll stop it by scaling down nodepool
+          scaleDownNodepool(dbApp.app.id, params.googleProject, dbApp.nodepool, dbApp.cluster)
       }
 
-      // Update nodepool status to Running and app status to Stopped
-      _ <- dbRef.inTransaction {
-        nodepoolQuery.updateStatus(dbNodepool.id, NodepoolStatus.Running) >>
-          appQuery.updateStatus(params.appId, AppStatus.Stopped)
-      }
+      _ <- appQuery.updateStatus(params.appId, AppStatus.Stopped).transaction
     } yield F.unit
 
   override def startAndPollApp(params: StartAppParams)(implicit
@@ -1127,54 +1073,46 @@ class GKEInterpreter[F[_]](
                                                  "No active app found in DB"
                             )
       )
-      dbNodepool = dbApp.nodepool
       dbCluster = dbApp.cluster
-      nodepoolId = NodepoolId(dbCluster.getClusterId, dbNodepool.nodepoolName)
 
       _ <- logger.info(ctx.loggingCtx)(
         s"Starting app ${dbApp.app.appName.value} in cluster ${dbCluster.getClusterId.toString}"
       )
 
-      _ <- nodepoolQuery.updateStatus(dbNodepool.id, NodepoolStatus.Provisioning).transaction
-
-      // First scale the node pool to > 0 nodes
-      _ <- nodepoolLock.withKeyLock(dbCluster.getClusterId) {
-        for {
-          op <- gkeService.setNodepoolSize(
-            nodepoolId,
-            dbNodepool.numNodes.amount
-          )
-          _ <- F.sleep(config.monitorConfig.scalingUpNodepool.initialDelay)
-          lastOp <- gkeService
-            .pollOperation(
-              KubernetesOperationId(params.googleProject, dbCluster.location, op.getName),
-              config.monitorConfig.scalingUpNodepool.interval,
-              config.monitorConfig.scalingUpNodepool.maxAttempts
-            )
-            .compile
-            .lastOrError
-          _ <-
-            if (lastOp.isDone)
-              logger.info(ctx.loggingCtx)(
-                s"setNodepoolSize operation has finished for nodepool ${dbNodepool.id}"
+      _ <- dbApp.app.numOfReplicas match {
+        case Some(count) =>
+          for {
+            attemptToStart <- kubeService
+              .patchReplicas(
+                dbApp.cluster.getClusterId,
+                KubernetesNamespace(dbApp.app.appResources.namespace),
+                KubernetesDeployment(dbApp.app.appName.value), // appNames are the same as deployments
+                count
               )
-            else
-              logger.error(ctx.loggingCtx)(
-                s"setNodepoolSize operation has failed or timed out for nodepool ${dbNodepool.id}"
-              ) >>
-                F.raiseError[Unit](NodepoolStartException(dbNodepool.id))
-        } yield ()
-      }
+              .attempt
 
-      googleProject <- F.fromOption(
-        LeoLenses.cloudContextToGoogleProject.get(dbCluster.cloudContext),
-        new RuntimeException("trying to create an azure runtime in GKEInterpreter. This should never happen")
-      )
+            // Update nodepool status to Running and app status to Stopped
+            _ <- attemptToStart match {
+              case Left(e) =>
+                // This updates the APP back to `RUNNNING` status instead of putting it into `ERROR` status. This
+                // can be confusing to users since they will notice the APP is not stoppable.
+                // Currently, Leo doesn't have a good way to inform users about "an error happened during Stopping",
+                // which I think we should spend some effort design this out.
+                // For now, I think this is better behavior than putting the APP into ERROR status, which will make the APP
+                // unusable.
+                logger.info(ctx.loggingCtx, e)("Failed to start app") >> appQuery
+                  .updateStatus(params.appId, AppStatus.Stopped)
+                  .transaction
+              case Right(_) => F.unit
+            }
+          } yield ()
+        case None => scaleUpNodepool(params.googleProject, dbApp.nodepool, dbApp.cluster)
+      }
 
       isUp <- dbApp.app.appType match {
         case AppType.Galaxy =>
           streamFUntilDone(
-            appDao.isProxyAvailable(googleProject, dbApp.app.appName, ServiceName("galaxy")),
+            appDao.isProxyAvailable(params.googleProject, dbApp.app.appName, ServiceName("galaxy")),
             config.monitorConfig.startApp.maxAttempts,
             config.monitorConfig.startApp.interval
           ).interruptAfter(config.monitorConfig.startApp.interruptAfter).compile.lastOrError
@@ -1182,7 +1120,7 @@ class GKEInterpreter[F[_]](
           streamFUntilDone(
             config.cromwellAppConfig.services
               .map(_.name)
-              .traverse(s => appDao.isProxyAvailable(googleProject, dbApp.app.appName, s)),
+              .traverse(s => appDao.isProxyAvailable(params.googleProject, dbApp.app.appName, s)),
             config.monitorConfig.startApp.maxAttempts,
             config.monitorConfig.startApp.interval
           ).interruptAfter(config.monitorConfig.startApp.interruptAfter).compile.lastOrError.map(x => x.isDone)
@@ -1190,7 +1128,7 @@ class GKEInterpreter[F[_]](
           streamFUntilDone(
             config.allowedAppConfig.services
               .map(_.name)
-              .traverse(s => appDao.isProxyAvailable(googleProject, dbApp.app.appName, s)),
+              .traverse(s => appDao.isProxyAvailable(params.googleProject, dbApp.app.appName, s)),
             config.monitorConfig.startApp.maxAttempts,
             config.monitorConfig.startApp.interval
           ).interruptAfter(config.monitorConfig.startApp.interruptAfter).compile.lastOrError.map(x => x.isDone)
@@ -1204,7 +1142,7 @@ class GKEInterpreter[F[_]](
             }
             last <- streamFUntilDone(
               descriptor.services.keys.toList.traverse(s =>
-                appDao.isProxyAvailable(googleProject, dbApp.app.appName, ServiceName(s))
+                appDao.isProxyAvailable(params.googleProject, dbApp.app.appName, ServiceName(s))
               ),
               config.monitorConfig.startApp.maxAttempts,
               config.monitorConfig.startApp.interval
@@ -1235,15 +1173,14 @@ class GKEInterpreter[F[_]](
             _ <- appQuery.updateStatus(dbApp.app.id, AppStatus.Running).transaction
             trackUsage = AllowedChartName.fromChartName(dbApp.app.chart.name).exists(_.trackUsage)
             _ <- appUsageQuery.recordStart(dbApp.app.id, startTime).whenA(trackUsage)
-
             // If autoscaling should be enabled, enable it now. Galaxy can still be used while this is in progress
             _ <-
-              if (dbNodepool.autoscalingEnabled) {
-                dbNodepool.autoscalingConfig.traverse_ { autoscalingConfig =>
+              if (dbApp.app.numOfReplicas.isEmpty && dbApp.nodepool.autoscalingEnabled) {
+                dbApp.nodepool.autoscalingConfig.traverse_ { autoscalingConfig =>
                   nodepoolLock.withKeyLock(dbCluster.getClusterId) {
                     for {
                       op <- gkeService.setNodepoolAutoscaling(
-                        nodepoolId,
+                        nodepoolId = NodepoolId(dbCluster.getClusterId, dbApp.nodepool.nodepoolName),
                         NodePoolAutoscaling
                           .newBuilder()
                           .setEnabled(true)
@@ -1251,7 +1188,6 @@ class GKEInterpreter[F[_]](
                           .setMaxNodeCount(autoscalingConfig.autoscalingMax.amount)
                           .build
                       )
-
                       _ <- F.sleep(config.monitorConfig.scalingUpNodepool.initialDelay)
                       lastOp <- gkeService
                         .pollOperation(
@@ -1264,20 +1200,17 @@ class GKEInterpreter[F[_]](
                       _ <-
                         if (lastOp.isDone)
                           logger.info(ctx.loggingCtx)(
-                            s"setNodepoolAutoscaling operation has finished for nodepool ${dbNodepool.id}"
+                            s"setNodepoolAutoscaling operation has finished for nodepool ${dbApp.nodepool.id}"
                           )
                         else
                           logger.error(ctx.loggingCtx)(
-                            s"setNodepoolAutoscaling operation has failed or timed out for nodepool ${dbNodepool.id}"
+                            s"setNodepoolAutoscaling operation has failed or timed out for nodepool ${dbApp.nodepool.id}"
                           ) >>
-                            F.raiseError[Unit](NodepoolStartException(dbNodepool.id))
+                            F.raiseError[Unit](NodepoolStartException(dbApp.nodepool.id))
                     } yield ()
                   }
                 }
               } else F.unit
-
-            // Finally update the nodepool status to Running
-            _ <- nodepoolQuery.updateStatus(dbNodepool.id, NodepoolStatus.Running).transaction
           } yield ()
         }
     } yield ()
@@ -1874,6 +1807,134 @@ class GKEInterpreter[F[_]](
       }
     )
   }
+
+  private def scaleDownNodepool(appId: AppId,
+                                googleProject: GoogleProject,
+                                nodepool: Nodepool,
+                                dbCluster: KubernetesCluster
+  )(implicit
+    ev: Ask[F, AppContext]
+  ): F[Unit] = for {
+    ctx <- ev.ask
+    _ <- nodepoolQuery.updateStatus(nodepool.id, NodepoolStatus.Provisioning).transaction
+    nodepoolId = NodepoolId(dbCluster.getClusterId, nodepool.nodepoolName)
+    // If autoscaling is enabled, disable it first
+    _ <-
+      if (nodepool.autoscalingEnabled) {
+        nodepoolLock.withKeyLock(dbCluster.getClusterId) {
+          for {
+            opOrError <- gkeService
+              .setNodepoolAutoscaling(
+                nodepoolId,
+                NodePoolAutoscaling.newBuilder().setEnabled(false).build()
+              )
+              .attempt
+            _ <- opOrError match {
+              case Left(e: com.google.api.gax.rpc.NotFoundException) =>
+                // Mark the app as `DELETED` instead of bubbling this error up to generic error handler
+                for {
+                  _ <- appErrorQuery
+                    .save(
+                      appId,
+                      AppError(e.getMessage, ctx.now, ErrorAction.StopApp, ErrorSource.App, None, Some(ctx.traceId))
+                    )
+                    .transaction
+                  _ <- appQuery.markAsDeleted(appId, ctx.now).transaction
+                  _ <-
+                    nodepoolQuery.markAsDeleted(nodepool.id, ctx.now).transaction
+                } yield ()
+              case Left(e) => F.raiseError(e)
+              case Right(op) =>
+                for {
+                  _ <- F.sleep(config.monitorConfig.scalingDownNodepool.initialDelay)
+                  lastOp <- gkeService
+                    .pollOperation(
+                      KubernetesOperationId(googleProject, dbCluster.location, op.getName),
+                      config.monitorConfig.scalingDownNodepool.interval,
+                      config.monitorConfig.scalingDownNodepool.maxAttempts
+                    )
+                    .compile
+                    .lastOrError
+                  _ <-
+                    if (lastOp.isDone)
+                      logger.info(ctx.loggingCtx)(
+                        s"setNodepoolAutoscaling operation has finished for nodepool ${nodepool.id}"
+                      )
+                    else
+                      logger.error(ctx.loggingCtx)(
+                        s"setNodepoolAutoscaling operation has failed or timed out for nodepool ${nodepool.id}"
+                      ) >>
+                        F.raiseError[Unit](NodepoolStopException(nodepool.id))
+                } yield ()
+            }
+          } yield ()
+        }
+      } else F.unit
+    _ <- nodepoolLock.withKeyLock(dbCluster.getClusterId) {
+      for {
+        op <- gkeService.setNodepoolSize(nodepoolId, 0)
+        _ <- F.sleep(config.monitorConfig.scalingDownNodepool.initialDelay)
+        lastOp <- gkeService
+          .pollOperation(
+            KubernetesOperationId(googleProject, dbCluster.location, op.getName),
+            config.monitorConfig.scalingDownNodepool.interval,
+            config.monitorConfig.scalingDownNodepool.maxAttempts
+          )
+          .compile
+          .lastOrError
+        _ <-
+          if (lastOp.isDone)
+            logger.info(ctx.loggingCtx)(
+              s"setNodepoolSize operation has finished for nodepool ${nodepool.id}"
+            )
+          else
+            logger.error(ctx.loggingCtx)(
+              s"setNodepoolSize operation has failed or timed out for nodepool ${nodepool.id}"
+            ) >>
+              F.raiseError[Unit](NodepoolStopException(nodepool.id))
+      } yield ()
+    }
+    _ <- nodepoolQuery.updateStatus(nodepool.id, NodepoolStatus.Running).transaction
+  } yield ()
+
+  private def scaleUpNodepool(googleProject: GoogleProject, nodepool: Nodepool, dbCluster: KubernetesCluster)(implicit
+    ev: Ask[F, AppContext]
+  ): F[Unit] = for {
+    ctx <- ev.ask
+    _ <- nodepoolQuery.updateStatus(nodepool.id, NodepoolStatus.Provisioning).transaction
+    nodepoolId = NodepoolId(dbCluster.getClusterId, nodepool.nodepoolName)
+    // First scale the node pool to > 0 nodes
+    _ <- nodepoolLock.withKeyLock(dbCluster.getClusterId) {
+      for {
+        op <- gkeService.setNodepoolSize(
+          nodepoolId,
+          nodepool.numNodes.amount
+        )
+        _ <- F.sleep(config.monitorConfig.scalingUpNodepool.initialDelay)
+        lastOp <- gkeService
+          .pollOperation(
+            KubernetesOperationId(googleProject, dbCluster.location, op.getName),
+            config.monitorConfig.scalingUpNodepool.interval,
+            config.monitorConfig.scalingUpNodepool.maxAttempts
+          )
+          .compile
+          .lastOrError
+        _ <-
+          if (lastOp.isDone)
+            logger.info(ctx.loggingCtx)(
+              s"setNodepoolSize operation has finished for nodepool ${nodepool.id}"
+            )
+          else
+            logger.error(ctx.loggingCtx)(
+              s"setNodepoolSize operation has failed or timed out for nodepool ${nodepool.id}"
+            ) >>
+              F.raiseError[Unit](NodepoolStartException(nodepool.id))
+      } yield ()
+    }
+
+    // Finally update the nodepool status to Running
+    _ <- nodepoolQuery.updateStatus(nodepool.id, NodepoolStatus.Running).transaction
+  } yield ()
 
   private def getTerraAppSetupChartReleaseName(appReleaseName: Release): Release =
     Release(s"${appReleaseName.asString}-setup-rls")

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/KubernetesInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/KubernetesInterpreter.scala
@@ -89,7 +89,19 @@ class KubernetesInterpreter[F[_]](azureContainerService: AzureContainerService[F
       ctx <- ev.ask
       call =
         F.blocking(
-          client.listNamespacedPod(namespace.name.value, "true", null, null, null, null, null, null, null, null, null)
+          client.listNamespacedPod(namespace.name.value,
+                                   "true",
+                                   null,
+                                   null,
+                                   null,
+                                   null,
+                                   null,
+                                   null,
+                                   null,
+                                   null,
+                                   null,
+                                   null
+          )
         )
 
       response <- withLogging(
@@ -177,7 +189,7 @@ class KubernetesInterpreter[F[_]](azureContainerService: AzureContainerService[F
       call =
         recoverF(
           F.blocking(
-            client.listNamespace("true", false, null, null, null, null, null, null, null, false)
+            client.listNamespace("true", false, null, null, null, null, null, null, null, null, false)
           ),
           whenStatusCode(409)
         )

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/KubernetesTestData.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/KubernetesTestData.scala
@@ -235,7 +235,8 @@ object KubernetesTestData {
       customEnvironmentVariables,
       None,
       List.empty,
-      None
+      None,
+      Some(1)
     )
   }
 

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/AppServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/AppServiceInterpSpec.scala
@@ -2292,7 +2292,7 @@ final class AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
     val messages = publisherQueue.tryTakeN(Some(2)).unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
     messages.map(_.messageType) shouldBe List(LeoPubsubMessageType.DeleteAppV2, LeoPubsubMessageType.DeleteAppV2)
     val deleteAppMessages = messages.map(_.asInstanceOf[DeleteAppV2Message])
-    deleteAppMessages.map(_.appId) shouldBe apps.map(_.id)
+    deleteAppMessages.map(_.appId) should contain theSameElementsAs apps.map(_.id)
     deleteAppMessages.map(_.workspaceId) shouldBe List(workspaceId, workspaceId)
     deleteAppMessages.map(_.diskId) shouldBe List(None, None)
   }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoMetricsMonitorSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoMetricsMonitorSpec.scala
@@ -772,7 +772,7 @@ class LeoMetricsMonitorSpec extends AnyFlatSpec with LeonardoTestSuite with Test
       podList.getItems
     } thenReturn List(pod).asJava
     when {
-      client.listNamespacedPod(any, any, any, any, any, any, any, any, any, any, any)
+      client.listNamespacedPod(any, any, any, any, any, any, any, any, any, any, any, any)
     } thenReturn podList
     when {
       kube.createAzureClient(any, any[String].asInstanceOf[AKSClusterName])(any)

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/AKSInterpreterSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/AKSInterpreterSpec.scala
@@ -4,12 +4,13 @@ package util
 import bio.terra.workspace.api.{ControlledAzureResourceApi, ResourceApi}
 import bio.terra.workspace.model.{DeleteControlledAzureResourceRequest, _}
 import cats.effect.IO
+import cats.mtl.Ask
 import com.azure.resourcemanager.containerservice.models.KubernetesCluster
 import io.kubernetes.client.openapi.apis.CoreV1Api
 import org.broadinstitute.dsde.workbench.azure._
 import org.broadinstitute.dsde.workbench.google2.KubernetesModels.PodStatus
 import org.broadinstitute.dsde.workbench.google2.KubernetesSerializableName.{NamespaceName, ServiceAccountName}
-import org.broadinstitute.dsde.workbench.google2.{NetworkName, SubnetworkName}
+import org.broadinstitute.dsde.workbench.google2.{GKEModels, KubernetesModels, NetworkName, SubnetworkName}
 import org.broadinstitute.dsde.workbench.leonardo.CommonTestData.{azureRegion, billingProfileId, workspaceId}
 import org.broadinstitute.dsde.workbench.leonardo.KubernetesTestData.{makeApp, makeKubeCluster, makeNodepool}
 import org.broadinstitute.dsde.workbench.leonardo.TestUtils.appContext
@@ -479,25 +480,28 @@ class AKSInterpreterSpec extends AnyFlatSpecLike with TestComponent with Leonard
     mockAzureRelayService
   }
 
-  private def setUpMockKube: KubernetesAlgebra[IO] = {
-    val kube = mock[KubernetesAlgebra[IO]]
+  private def setUpMockKube(): KubernetesAlgebra[IO] = {
     val coreV1Api = mock[CoreV1Api]
-    when {
-      kube.createAzureClient(any, any[String].asInstanceOf[AKSClusterName])(any)
-    } thenReturn IO.pure(coreV1Api)
-    when {
-      kube.listPodStatus(any, any)(any)
-    } thenReturn IO.pure(List(PodStatus.Failed))
-    when {
-      kube.deleteNamespace(any, any)(any)
-    } thenReturn IO.unit
-    when {
-      kube.namespaceExists(any, any)(any)
-    } thenReturn IO.pure(false)
-    when {
-      kube.createNamespace(any, any)(any)
-    } thenReturn IO.unit
-    kube
+    new KubernetesAlgebra[IO] {
+      override def createAzureClient(cloudContext: AzureCloudContext, clusterName: AKSClusterName)(implicit
+        ev: Ask[IO, AppContext]
+      ): IO[CoreV1Api] = IO.pure(coreV1Api)
+      override def createGcpClient(clusterId: GKEModels.KubernetesClusterId)(implicit
+        ev: Ask[IO, AppContext]
+      ): IO[CoreV1Api] = IO.pure(coreV1Api)
+      override def listPodStatus(clusterId: CoreV1Api, namespace: KubernetesModels.KubernetesNamespace)(implicit
+        ev: Ask[IO, AppContext]
+      ): IO[List[PodStatus]] = IO.pure(List(PodStatus.Failed))
+      override def createNamespace(client: CoreV1Api, namespace: KubernetesModels.KubernetesNamespace)(implicit
+        ev: Ask[IO, AppContext]
+      ): IO[Unit] = IO.unit
+      override def deleteNamespace(client: CoreV1Api, namespace: KubernetesModels.KubernetesNamespace)(implicit
+        ev: Ask[IO, AppContext]
+      ): IO[Unit] = IO.unit
+      override def namespaceExists(client: CoreV1Api, namespace: KubernetesModels.KubernetesNamespace)(implicit
+        ev: Ask[IO, AppContext]
+      ): IO[Boolean] = IO.pure(false)
+    }
   }
 
   private def setUpMockSamDAO: SamDAO[IO] = {

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/BuildHelmChartValuesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/BuildHelmChartValuesSpec.scala
@@ -330,7 +330,8 @@ class BuildHelmChartValuesSpec extends AnyFlatSpecLike with LeonardoTestSuite {
       """welder.extraEnv[5].name=WSM_URL,""" +
       """welder.extraEnv[5].value=dummy,""" +
       """extraEnv[0].name=WORKSPACE_NAME,""" +
-      """extraEnv[0].value=test-workspace-name"""
+      """extraEnv[0].value=test-workspace-name,""" +
+      """replicaCount=1"""
   }
 
   it should "build SAS override values string" in {
@@ -385,7 +386,8 @@ class BuildHelmChartValuesSpec extends AnyFlatSpecLike with LeonardoTestSuite {
       """welder.extraEnv[5].name=WSM_URL,""" +
       """welder.extraEnv[5].value=dummy,""" +
       """extraEnv[0].name=WORKSPACE_NAME,""" +
-      """extraEnv[0].value=test-workspace-name"""
+      """extraEnv[0].value=test-workspace-name,""" +
+      """replicaCount=1"""
   }
 
   it should "build relay listener override values string" in {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,8 +17,8 @@ object Dependencies {
   val munitCatsEffectV = "1.0.7"
   val pact4sV = "0.10.0"
 
-  private val workbenchLibsHash = "8fcafd0f-SNAP"
-  val serviceTestV = s"4.1-$workbenchLibsHash"
+  private val workbenchLibsHash = "f20e49d"
+  val serviceTestV = s"4.2-$workbenchLibsHash"
   val workbenchModelV = s"0.19-$workbenchLibsHash"
   val workbenchGoogleV = s"0.30-$workbenchLibsHash"
   val workbenchGoogle2V = s"0.34-$workbenchLibsHash"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,7 +17,7 @@ object Dependencies {
   val munitCatsEffectV = "1.0.7"
   val pact4sV = "0.10.0"
 
-  private val workbenchLibsHash = "2eac218"
+  private val workbenchLibsHash = "8fcafd0f-SNAP"
   val serviceTestV = s"4.1-$workbenchLibsHash"
   val workbenchModelV = s"0.19-$workbenchLibsHash"
   val workbenchGoogleV = s"0.30-$workbenchLibsHash"

--- a/project/Merging.scala
+++ b/project/Merging.scala
@@ -7,6 +7,7 @@ object Merging {
     // [error]   Jar name = auto-value-1.10.1.jar, jar org = com.google.auto.value, entry target = META-INF/kotlin-stdlib.kotlin_module
     // [error]   Jar name = kotlin-stdlib-1.6.20.jar, jar org = org.jetbrains.kotlin, entry target = META-INF/kotlin-stdlib.kotlin_module
     case PathList("META-INF", "kotlin-stdlib.kotlin_module") => MergeStrategy.preferProject
+    case PathList("META-INF", "okio.kotlin_module")          => MergeStrategy.first
     // For the following error:
     // [error] Deduplicate found different file contents in the following:
     // [error]   Jar name = auto-value-1.10.1.jar, jar org = com.google.auto.value, entry target = META-INF/kotlin-stdlib-common.kotlin_module


### PR DESCRIPTION
https://precisionmedicineinitiative.atlassian.net/browse/RW-10598

More changes coming..No need to review yet

See [this](https://docs.google.com/document/d/1T2Sqq9x4YAuhpYZX1budhnU-Hc7J2mKCult69oOsW5o/edit) for more details. [Related PR](https://github.com/broadinstitute/workbench-libs/pull/1592)

This PR changes stop/start to use scaling up/down replicas for `ALLOWED` apps. I think this is a good start as we try out this new approach. For Galaxy to adopt this approach, it'll be tricky because it has a few more deployments instead of just one deployment. I'll try to add CROMWELL in a follow up PR.

Tested on a BEE
1. Stop/start behaves as expected for `ALLOWED` apps. Verified autoscaling is working as expected as well (nodepool gets resized to 0 automatically when there's no PODs running on the nodepool). One rule I'm enforcing here is that if an app is using `replica` for stop/start, then `autoscaling` has to be `true`..In this case, `ALLOWED` app always have `autoscaling` enabled
2. There's no change to all other apps' stop/start behavior.

- [ ] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [ ] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
