### PR TITLE
RW-10711 fix sas proxy bug

### DIFF
--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/BuildHelmChartValues.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/BuildHelmChartValues.scala
@@ -333,7 +333,7 @@ private[leonardo] object BuildHelmChartValues {
           raw"""ingress.path.sas=${ingressPath}${"(/|$)(.*)"}""",
           raw"""ingress.path.welder=${welderIngressPath}${"(/|$)(.*)"}""",
           raw"""ingress.proxyPath=${ingressPath}""",
-          raw"""ingress.referer=${config.leoUrlBase}""",
+          raw"""ingress.referer=${config.proxyConfig.proxyUrlBase.dropRight(6)}""",
           raw"""ingress.annotations.nginx\.ingress\.kubernetes\.io/proxy-redirect-from=http://${k8sProxyHost
               .address()}""",
           raw"""imageCredentials.username=${config.allowedAppConfig.sasContainerRegistryCredentials.username.asString}""",

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/BuildHelmChartValues.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/BuildHelmChartValues.scala
@@ -333,7 +333,7 @@ private[leonardo] object BuildHelmChartValues {
           raw"""ingress.path.sas=${ingressPath}${"(/|$)(.*)"}""",
           raw"""ingress.path.welder=${welderIngressPath}${"(/|$)(.*)"}""",
           raw"""ingress.proxyPath=${ingressPath}""",
-          raw"""ingress.referer=${config.proxyConfig.proxyUrlBase.dropRight(6)}""",
+          raw"""ingress.referer=${config.proxyConfig.getProxyServerHostName}""",
           raw"""ingress.annotations.nginx\.ingress\.kubernetes\.io/proxy-redirect-from=http://${k8sProxyHost
               .address()}""",
           raw"""imageCredentials.username=${config.allowedAppConfig.sasContainerRegistryCredentials.username.asString}""",

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/BuildHelmChartValuesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/BuildHelmChartValuesSpec.scala
@@ -355,7 +355,7 @@ class BuildHelmChartValuesSpec extends AnyFlatSpecLike with LeonardoTestSuite {
       """ingress.path.sas=/proxy/google/v1/apps/dsp-leo-test1/app1/app(/|$)(.*),""" +
       """ingress.path.welder=/proxy/google/v1/apps/dsp-leo-test1/app1/welder-service(/|$)(.*),""" +
       """ingress.proxyPath=/proxy/google/v1/apps/dsp-leo-test1/app1/app,""" +
-      """ingress.referer=https://leo/,""" +
+      """ingress.referer=https://leo,""" +
       """ingress.annotations.nginx\.ingress\.kubernetes\.io/proxy-redirect-from=http://1455694897.jupyter.firecloud.org,""" +
       """imageCredentials.username=sasUserName,""" +
       """imageCredentials.password=sasPassword,""" +

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/BuildHelmChartValuesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/BuildHelmChartValuesSpec.scala
@@ -330,7 +330,8 @@ class BuildHelmChartValuesSpec extends AnyFlatSpecLike with LeonardoTestSuite {
       """welder.extraEnv[5].name=WSM_URL,""" +
       """welder.extraEnv[5].value=dummy,""" +
       """extraEnv[0].name=WORKSPACE_NAME,""" +
-      """extraEnv[0].value=test-workspace-name"""
+      """extraEnv[0].value=test-workspace-name,""" +
+      """replicaCount=2"""
   }
 
   it should "build SAS override values string" in {
@@ -355,7 +356,7 @@ class BuildHelmChartValuesSpec extends AnyFlatSpecLike with LeonardoTestSuite {
       """ingress.path.sas=/proxy/google/v1/apps/dsp-leo-test1/app1/app(/|$)(.*),""" +
       """ingress.path.welder=/proxy/google/v1/apps/dsp-leo-test1/app1/welder-service(/|$)(.*),""" +
       """ingress.proxyPath=/proxy/google/v1/apps/dsp-leo-test1/app1/app,""" +
-      """ingress.referer=https://replace_me,""" +
+      """ingress.referer=https://leo/,""" +
       """ingress.annotations.nginx\.ingress\.kubernetes\.io/proxy-redirect-from=http://1455694897.jupyter.firecloud.org,""" +
       """imageCredentials.username=sasUserName,""" +
       """imageCredentials.password=sasPassword,""" +
@@ -385,7 +386,8 @@ class BuildHelmChartValuesSpec extends AnyFlatSpecLike with LeonardoTestSuite {
       """welder.extraEnv[5].name=WSM_URL,""" +
       """welder.extraEnv[5].value=dummy,""" +
       """extraEnv[0].name=WORKSPACE_NAME,""" +
-      """extraEnv[0].value=test-workspace-name"""
+      """extraEnv[0].value=test-workspace-name,""" +
+      """replicaCount=2"""
   }
 
   it should "build relay listener override values string" in {

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/BuildHelmChartValuesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/BuildHelmChartValuesSpec.scala
@@ -330,8 +330,7 @@ class BuildHelmChartValuesSpec extends AnyFlatSpecLike with LeonardoTestSuite {
       """welder.extraEnv[5].name=WSM_URL,""" +
       """welder.extraEnv[5].value=dummy,""" +
       """extraEnv[0].name=WORKSPACE_NAME,""" +
-      """extraEnv[0].value=test-workspace-name,""" +
-      """replicaCount=2"""
+      """extraEnv[0].value=test-workspace-name"""
   }
 
   it should "build SAS override values string" in {
@@ -386,8 +385,7 @@ class BuildHelmChartValuesSpec extends AnyFlatSpecLike with LeonardoTestSuite {
       """welder.extraEnv[5].name=WSM_URL,""" +
       """welder.extraEnv[5].value=dummy,""" +
       """extraEnv[0].name=WORKSPACE_NAME,""" +
-      """extraEnv[0].value=test-workspace-name,""" +
-      """replicaCount=2"""
+      """extraEnv[0].value=test-workspace-name"""
   }
 
   it should "build relay listener override values string" in {


### PR DESCRIPTION
This value is passed to the SAS chart to define `sas.commons.web.security.csrf.allowedUris` so that SAS won't reject requests proxied from Leonardo.

In all other envs, Leo's referer is the same as proxy url's domain, but that's not the case for prod leonardo.

So change the variable to use leo's proxy url's domain, which will fix the bug


### Who tested and where

- [ ] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [ ] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
