### PR TITLE
RW-11279  Refactoring autopauseMonitor in preparation of adding more such monitors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ failure_screenshots/
 __pycache__
 .DS_Store
 .vscode/
+.sc
 
 # Automation exclusions
 automation/chrome/

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/Boot.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/Boot.scala
@@ -84,7 +84,6 @@ import org.http4s.client.middleware.{Logger => Http4sLogger, Metrics, Retry, Ret
 import org.typelevel.log4cats.StructuredLogger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 import scalacache.caffeine._
-
 import java.net.{InetSocketAddress, SocketException}
 import java.nio.file.Paths
 import java.time.Instant
@@ -269,7 +268,7 @@ object Boot extends IOApp {
               appDependencies.wsmDAO
             )
 
-          val autopauseMonitor = AutopauseMonitor(
+          val autopauseMonitorProcess = AutopauseMonitor.process(
             autoFreezeConfig,
             appDependencies.jupyterDAO,
             appDependencies.publisherQueue
@@ -314,7 +313,7 @@ object Boot extends IOApp {
             appDependencies.pubsubSubscriber.process,
             Stream.eval(appDependencies.subscriber.start),
             monitorAtBoot.process, // checks database to see if there's on-going runtime status transition
-            autopauseMonitor.process, // check database to autopause runtimes periodically
+            autopauseMonitorProcess, // check database to autopause runtimes periodically
             metricsMonitor.process // checks database and collects metrics about active runtimes and apps
           )
         }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/AutopauseMonitor.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/AutopauseMonitor.scala
@@ -81,7 +81,7 @@ class AutopauseMonitor[F[_]](
     }
   } yield filtered
 
-  override def doAction(a: RuntimeToAutoPause, traceId: TraceId, now: Instant)(implicit F: Async[F]): F[Unit] =
+  override def action(a: RuntimeToAutoPause, traceId: TraceId, now: Instant)(implicit F: Async[F]): F[Unit] =
     for {
       _ <- clusterQuery.updateClusterStatus(a.id, RuntimeStatus.PreStopping, now).transaction
       _ <- publisherQueue.offer(LeoPubsubMessage.StopRuntimeMessage(a.id, Some(traceId)))

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/AutopauseMonitor.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/AutopauseMonitor.scala
@@ -1,11 +1,10 @@
 package org.broadinstitute.dsde.workbench.leonardo
 package monitor
 
-import java.util.UUID
+import fs2.Stream
 import cats.effect.Async
 import cats.effect.std.Queue
 import cats.syntax.all._
-import fs2.Stream
 import org.typelevel.log4cats.StructuredLogger
 import org.broadinstitute.dsde.workbench.leonardo.config.AutoFreezeConfig
 import org.broadinstitute.dsde.workbench.leonardo.dao.JupyterDAO
@@ -13,7 +12,7 @@ import org.broadinstitute.dsde.workbench.leonardo.db._
 import org.broadinstitute.dsde.workbench.leonardo.http.dbioToIO
 import org.broadinstitute.dsde.workbench.model.TraceId
 import org.broadinstitute.dsde.workbench.openTelemetry.OpenTelemetryMetrics
-
+import cats.Show
 import java.time.Instant
 import scala.concurrent.ExecutionContext
 
@@ -25,84 +24,87 @@ class AutopauseMonitor[F[_]](
   jupyterDAO: JupyterDAO[F],
   publisherQueue: Queue[F, LeoPubsubMessage]
 )(implicit
-  F: Async[F],
-  metrics: OpenTelemetryMetrics[F],
-  logger: StructuredLogger[F],
   dbRef: DbReference[F],
   ec: ExecutionContext
-) {
+) extends BackgroundProcess[F, RuntimeToAutoPause] {
+  override def monitorType: String =
+    "autopause" // autopauseRuntime is more accurate. But keep the current name so that existing metrics won't break
+  override def interval: scala.concurrent.duration.FiniteDuration = config.autoFreezeCheckInterval
 
-  val process: Stream[F, Unit] =
-    (Stream.sleep[F](config.autoFreezeCheckInterval) ++ Stream.eval(
-      autoPauseCheck
-        .handleErrorWith(e => logger.error(e)("Unexpected error occurred during auto-pause monitoring"))
-    )).repeat
+  override def filterCriteria(cluster: RuntimeToAutoPause, now: Instant)(implicit
+    F: Async[F],
+    metrics: OpenTelemetryMetrics[F],
+    logger: StructuredLogger[F]
+  ): F[Boolean] =
+    jupyterDAO.isAllKernelsIdle(cluster.cloudContext, cluster.runtimeName).attempt.flatMap {
+      case Left(t) =>
+        logger.error(s"Fail to get kernel status for ${cluster.projectNameString} due to $t").as(true)
+      case Right(isIdle) =>
+        if (!isIdle) {
+          val maxKernelActiveTimeExceeded = cluster.kernelFoundBusyDate match {
+            case Some(attemptedDate) =>
+              val maxBusyLimitReached =
+                now.toEpochMilli - attemptedDate.toEpochMilli > config.maxKernelBusyLimit.toMillis
+              F.pure(maxBusyLimitReached)
+            case None =>
+              clusterQuery
+                .updateKernelFoundBusyDate(cluster.id, now, now)
+                .transaction
+                .as(false) // max kernel active time has not been exceeded
+          }
 
-  private[monitor] val autoPauseCheck: F[Unit] =
+          maxKernelActiveTimeExceeded.ifM(
+            metrics.incrementCounter("autoPause/maxKernelActiveTimeExceeded") >>
+              logger
+                .info(
+                  s"Auto pausing ${cluster.cloudContext}/${cluster.runtimeName} due to exceeded max kernel active time"
+                )
+                .as(true),
+            metrics.incrementCounter("autoPause/activeKernelClusters") >>
+              logger
+                .info(
+                  s"Not going to auto pause cluster ${cluster.cloudContext}/${cluster.runtimeName} due to active kernels"
+                )
+                .as(false)
+          )
+        } else F.pure(isIdle)
+    }
+
+  override def dbSource(): F[Seq[RuntimeToAutoPause]] =
+    clusterQuery.getClustersReadyToAutoFreeze.transaction
+
+  override def action(a: RuntimeToAutoPause, traceId: TraceId, now: Instant)(implicit F: Async[F]): F[Unit] =
     for {
-      _ <- logger.info(
-        s"[logAlert/autopauseHeartbeat] Executing autopause check at interval of ${config.autoFreezeCheckInterval}"
-      )
-      clusters <- clusterQuery.getClustersReadyToAutoFreeze.transaction
-      now <- F.realTimeInstant
-      pauseableClusters <- clusters.toList.filterA { cluster =>
-        jupyterDAO.isAllKernelsIdle(cluster.cloudContext, cluster.runtimeName).attempt.flatMap {
-          case Left(t) =>
-            logger.error(s"Fail to get kernel status for ${cluster.projectNameString} due to $t").as(true)
-          case Right(isIdle) =>
-            if (!isIdle) {
-              val maxKernelActiveTimeExceeded = cluster.kernelFoundBusyDate match {
-                case Some(attemptedDate) =>
-                  val maxBusyLimitReached =
-                    now.toEpochMilli - attemptedDate.toEpochMilli > config.maxKernelBusyLimit.toMillis
-                  F.pure(maxBusyLimitReached)
-                case None =>
-                  clusterQuery
-                    .updateKernelFoundBusyDate(cluster.id, now, now)
-                    .transaction
-                    .as(false) // max kernel active time has not been exceeded
-              }
-
-              maxKernelActiveTimeExceeded.ifM(
-                metrics.incrementCounter("autoPause/maxKernelActiveTimeExceeded") >>
-                  logger
-                    .info(
-                      s"Auto pausing ${cluster.cloudContext}/${cluster.runtimeName} due to exceeded max kernel active time"
-                    )
-                    .as(true),
-                metrics.incrementCounter("autoPause/activeKernelClusters") >>
-                  logger
-                    .info(
-                      s"Not going to auto pause cluster ${cluster.cloudContext}/${cluster.runtimeName} due to active kernels"
-                    )
-                    .as(false)
-              )
-            } else F.pure(isIdle)
-        }
-      }
-      _ <- metrics.gauge("autoPause/numOfRuntimes", pauseableClusters.length)
-      _ <- pauseableClusters.traverse_ { cl =>
-        val traceId = TraceId(s"fromAutopause_${UUID.randomUUID().toString}")
-        for {
-          _ <- clusterQuery.updateClusterStatus(cl.id, RuntimeStatus.PreStopping, now).transaction
-          _ <- metrics.incrementCounter("autoPause/pauseRuntimeCounter")
-          _ <- logger.info(Map("traceId" -> traceId.asString))(s"Auto freezing runtime ${cl.projectNameString}")
-          _ <- publisherQueue.offer(LeoPubsubMessage.StopRuntimeMessage(cl.id, Some(traceId)))
-        } yield ()
-      }
+      _ <- clusterQuery.updateClusterStatus(a.id, RuntimeStatus.PreStopping, now).transaction
+      _ <- publisherQueue.offer(LeoPubsubMessage.StopRuntimeMessage(a.id, Some(traceId)))
     } yield ()
 }
 
 object AutopauseMonitor {
-  def apply[F[_]](config: AutoFreezeConfig, jupyterDAO: JupyterDAO[F], publisherQueue: Queue[F, LeoPubsubMessage])(
+  def process[F[_]](config: AutoFreezeConfig, jupyterDAO: JupyterDAO[F], publisherQueue: Queue[F, LeoPubsubMessage])(
     implicit
+    dbRef: DbReference[F],
+    ec: ExecutionContext,
     F: Async[F],
-    metrics: OpenTelemetryMetrics[F],
-    logger: StructuredLogger[F],
+    openTelemetry: OpenTelemetryMetrics[F],
+    logger: StructuredLogger[F]
+  ): Stream[F, Unit] = {
+    val autopauseMonitor = apply(config, jupyterDAO, publisherQueue)
+
+    implicit val runtimeToAutoPauseShowInstance: Show[RuntimeToAutoPause] =
+      Show[RuntimeToAutoPause](runtimeToAutoPause => runtimeToAutoPause.projectNameString)
+    autopauseMonitor.process
+  }
+
+  private def apply[F[_]](config: AutoFreezeConfig,
+                          jupyterDAO: JupyterDAO[F],
+                          publisherQueue: Queue[F, LeoPubsubMessage]
+  )(implicit
     dbRef: DbReference[F],
     ec: ExecutionContext
   ): AutopauseMonitor[F] =
     new AutopauseMonitor(config, jupyterDAO, publisherQueue)
+
 }
 
 final case class RuntimeToAutoPause(id: Long,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/BackgroundProcess.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/BackgroundProcess.scala
@@ -37,9 +37,9 @@ trait BackgroundProcess[F[_], A] {
   ): F[Seq[A]]
 
   /**
-   * Perform some action on the candidate
+   * Describes an action that'll happen to each candidate
    */
-  def doAction(a: A, traceId: TraceId, now: Instant)(implicit F: Async[F]): F[Unit]
+  def action(a: A, traceId: TraceId, now: Instant)(implicit F: Async[F]): F[Unit]
 
   /**
    * The main logic of the background process at each interval
@@ -64,7 +64,7 @@ trait BackgroundProcess[F[_], A] {
           s"${name}/pauseRuntimeCounter"
         ) // TODO: update metrics once we add more monitors
         _ <- logger.info(Map("traceId" -> traceId.asString))(s"${name} | runtime ${a.show}")
-        _ <- doAction(a, traceId, now)
+        _ <- action(a, traceId, now)
       } yield ()
     }
   } yield ()

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/BackgroundProcess.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/BackgroundProcess.scala
@@ -16,8 +16,7 @@ import scala.concurrent.duration.FiniteDuration
  * Defines a common interface that certain background processes should implement.
  * This type of background processes do the following periodically:
  * 1. Query the database for a list of candidates
- * 2. Filter the candidates based on some criteria
- * 3. Perform some action on the filtered candidates
+ * 2. Perform some action on the candidates
  */
 trait BackgroundProcess[F[_], A] {
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/BackgroundProcess.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/BackgroundProcess.scala
@@ -23,14 +23,30 @@ trait BackgroundProcess[F[_], A] {
   def monitorType: String
   def interval: FiniteDuration
 
+  /**
+   * Given a candidate, determine whether it should be filtered out.
+   * true: keep the candidate
+   * false: filter out the candidate
+   */
   def filterCriteria(a: A, now: Instant)(implicit
     F: Async[F],
     metrics: OpenTelemetryMetrics[F],
     logger: StructuredLogger[F]
   ): F[Boolean]
+
+  /**
+   * Get a collection of candidates from the database
+   */
   def dbSource(): F[Seq[A]]
+
+  /**
+   * Perform some action on the candidate
+   */
   def action(a: A, traceId: TraceId, now: Instant)(implicit F: Async[F]): F[Unit]
 
+  /**
+   * The main logic of the background process at each interval
+   */
   private def check(implicit
     showA: Show[A],
     F: Async[F],

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/BackgroundProcess.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/BackgroundProcess.scala
@@ -1,0 +1,79 @@
+package org.broadinstitute.dsde.workbench.leonardo.monitor
+
+import cats.Show
+import cats.effect.Async
+import cats.syntax.all._
+import fs2.Stream
+import org.broadinstitute.dsde.workbench.model.TraceId
+import org.broadinstitute.dsde.workbench.openTelemetry.OpenTelemetryMetrics
+import org.typelevel.log4cats.StructuredLogger
+
+import java.time.Instant
+import java.util.UUID
+import scala.concurrent.duration.FiniteDuration
+
+/**
+ * Defines a common interface that certain background processes should implement.
+ * This type of background processes do the following periodically:
+ * 1. Query the database for a list of candidates
+ * 2. Filter the candidates based on some criteria
+ * 3. Perform some action on the filtered candidates
+ */
+trait BackgroundProcess[F[_], A] {
+  def monitorType: String
+  def interval: FiniteDuration
+
+  def filterCriteria(a: A, now: Instant)(implicit
+    F: Async[F],
+    metrics: OpenTelemetryMetrics[F],
+    logger: StructuredLogger[F]
+  ): F[Boolean]
+  def dbSource(): F[Seq[A]]
+  def action(a: A, traceId: TraceId, now: Instant)(implicit F: Async[F]): F[Unit]
+
+  private def check(implicit
+    showA: Show[A],
+    F: Async[F],
+    metrics: OpenTelemetryMetrics[F],
+    logger: StructuredLogger[F]
+  ): F[Unit] = for {
+    now <- F.realTimeInstant
+    _ <- logger.info(
+      s"[logAlert/${monitorType}Heartbeat] Executing ${monitorType} check at interval of ${interval}"
+    )
+    candidates <- dbSource()
+    filteredA <- candidates.toList.filterA { a =>
+      filterCriteria(a, now)
+    }
+    _ <- metrics.gauge(s"${monitorType}/numOfRuntimes",
+                       filteredA.length
+    ) // TODO: update metrics once we add more monitors
+    _ <- filteredA.traverse_ { a =>
+      for {
+        uuid <- F.delay(UUID.randomUUID())
+        traceId = TraceId(s"${monitorType}_${uuid.toString}")
+        _ <- metrics.incrementCounter(
+          s"${monitorType}/pauseRuntimeCounter"
+        ) // TODO: update metrics once we add more monitors
+        _ <- logger.info(Map("traceId" -> traceId.asString))(s"${monitorType} | runtime ${a.show}")
+        _ <- action(a, traceId, now)
+      } yield ()
+    }
+  } yield ()
+
+  def process(implicit
+    showA: Show[A],
+    F: Async[F],
+    openTelemetry: OpenTelemetryMetrics[F],
+    logger: StructuredLogger[F]
+  ): Stream[F, Unit] =
+    (Stream.sleep[F](interval) ++ Stream.eval(
+      check
+        .handleErrorWith {
+          case e: java.sql.SQLTransientConnectionException =>
+            logger.error(e)("DB connection failed transiently") >> F.raiseError[Unit](e)
+          case e =>
+            logger.error(e)("Unexpected error occurred during auto-pause monitoring. Recovering...")
+        }
+    )).repeat
+}

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/BackgroundProcess.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/BackgroundProcess.scala
@@ -85,11 +85,8 @@ trait BackgroundProcess[F[_], A] {
   ): Stream[F, Unit] =
     (Stream.sleep[F](interval) ++ Stream.eval(
       check
-        .handleErrorWith {
-          case e: java.sql.SQLTransientConnectionException =>
-            logger.error(e)("DB connection failed transiently") >> F.raiseError[Unit](e)
-          case e =>
-            logger.error(e)("Unexpected error occurred during auto-pause monitoring. Recovering...")
+        .handleErrorWith { case e =>
+          logger.error(e)("Unexpected error occurred during auto-pause monitoring. Recovering...")
         }
     )).repeat
 }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/BackgroundProcess.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/BackgroundProcess.scala
@@ -39,7 +39,7 @@ trait BackgroundProcess[F[_], A] {
   /**
    * Perform some action on the candidate
    */
-  def action(a: A, traceId: TraceId, now: Instant)(implicit F: Async[F]): F[Unit]
+  def doAction(a: A, traceId: TraceId, now: Instant)(implicit F: Async[F]): F[Unit]
 
   /**
    * The main logic of the background process at each interval
@@ -64,7 +64,7 @@ trait BackgroundProcess[F[_], A] {
           s"${name}/pauseRuntimeCounter"
         ) // TODO: update metrics once we add more monitors
         _ <- logger.info(Map("traceId" -> traceId.asString))(s"${name} | runtime ${a.show}")
-        _ <- action(a, traceId, now)
+        _ <- doAction(a, traceId, now)
       } yield ()
     }
   } yield ()


### PR DESCRIPTION
There's no functional change to `AutopauseMonitor` in this PR except a minor change to one log msg



- [ ] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [ ] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
