### PR TITLE
[IA-4612] Update galaxy app version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ ENV HELM_DEBUG 1
 ENV TERRA_APP_SETUP_VERSION 0.1.0
 ENV TERRA_APP_VERSION 0.5.0
 # This is galaxykubeman, which references Galaxy
-ENV GALAXY_VERSION 2.5.2
+ENV GALAXY_VERSION 2.8.0
 ENV NGINX_VERSION 4.3.0
 # If you update this here, make sure to also update reference.conf:
 ENV CROMWELL_CHART_VERSION 0.2.378

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -674,7 +674,7 @@ gke {
     chartName = "/leonardo/galaxykubeman"
     # If you change this here, be sure to update it in the dockerfile
     # This is galaxykubeman, which references Galaxy
-    chartVersion = "2.5.2"
+    chartVersion = "2.8.0"
     namespaceNameSuffix = "gxy-ns"
     serviceAccountName = "gxy-ksa"
     # Setting uninstallKeepHistory will cause the `helm uninstall` command to keep a record of
@@ -712,7 +712,8 @@ gke {
       "2.4.9",
       "2.5.0",
       "2.5.1",
-      "2.5.2"
+      "2.5.2",
+      "2.8.0"
     ]
   }
   galaxyDisk {

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/KubernetesTestData.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/KubernetesTestData.scala
@@ -48,7 +48,7 @@ object KubernetesTestData {
   val galaxyApp = AppType.Galaxy
 
   val galaxyChartName = ChartName("/leonardo/galaxykubeman")
-  val galaxyChartVersion = ChartVersion("2.5.2")
+  val galaxyChartVersion = ChartVersion("2.8.0")
   val galaxyChart = Chart(galaxyChartName, galaxyChartVersion)
 
   val galaxyReleasePrefix = "gxy-release"

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/config/ConfigSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/config/ConfigSpec.scala
@@ -136,7 +136,8 @@ final class ConfigSpec extends AnyFlatSpec with Matchers {
         ChartVersion("2.4.9"),
         ChartVersion("2.5.0"),
         ChartVersion("2.5.1"),
-        ChartVersion("2.5.2")
+        ChartVersion("2.5.2"),
+        ChartVersion("2.8.0")
       )
     )
     Config.gkeGalaxyAppConfig shouldBe expectedResult


### PR DESCRIPTION
<!-- Welcome to your Leonardo pull request! -->
<!-- Contributor guidelines: https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md -->

__Jira ticket__: https://broadworkbench.atlassian.net/browse/[ticket_number]

<!-- ## Dependencies -->
<!-- Include any dependent tickets and describe the relationship. Include any other relevant Jira tickets. -->

## Summary of changes

<!-- Please give an abridged version of the ticket description here and/or fill out the following fields. -->

### What

Update the GalaxyKubeman chart to 2.8.0 which uses Galaxy 23.1 NOTE Galaxy 23.1 requires Kubernetes 1.25 and does not work correctly with 1.26.

(built off of https://github.com/DataBiosphere/leonardo/pull/3860)

### Why

-

## Testing these changes

### What to test

- <!-- Test case 1 -->

<!-- ### Test data -->

### Who tested and where

- [ ] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [ ] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
