### PR TITLE
RW-10598 Stop/start cromwell app on GCP via scaling replicas

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/AppLifecycleSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/apps/AppLifecycleSpec.scala
@@ -58,7 +58,7 @@ class AppLifecycleSpec
 
   "create CROMWELL app, delete it and re-create it with same disk" taggedAs (Tags.SmokeTest, Retryable) in {
     googleProject =>
-      test(googleProject, createAppRequest(AppType.Cromwell, "cromwell-test-workspace", None), false, true)
+      test(googleProject, createAppRequest(AppType.Cromwell, "cromwell-test-workspace", None), true, true)
   }
 
   "create RSTUDIO app, delete it and re-create it with same disk" taggedAs (Tags.SmokeTest, Retryable) in {

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -640,9 +640,9 @@ gke {
     nodepoolLockCacheMaxSize = 200
   }
   defaultNodepool {
-    machineType = "n1-standard-1"
-    numNodes = 1
-    autoscalingEnabled = false
+    machineType = "n1-standard-2"
+    numNodes = 2
+    autoscalingEnabled = true
     maxNodepoolsPerDefaultNode = 16
   }
   galaxyNodepool {

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -640,7 +640,7 @@ gke {
     nodepoolLockCacheMaxSize = 200
   }
   defaultNodepool {
-    machineType = "n1-standard-2"
+    machineType = "n1-standard-1"
     numNodes = 1
     autoscalingEnabled = false
     maxNodepoolsPerDefaultNode = 16

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -641,6 +641,12 @@ gke {
   }
   defaultNodepool {
     machineType = "n1-standard-2"
+    numNodes = 1
+    autoscalingEnabled = false
+    maxNodepoolsPerDefaultNode = 16
+  }
+  defaultAutoScalingNodepool {
+    machineType = "n1-standard-4"
     numNodes = 2
     autoscalingEnabled = true
     maxNodepoolsPerDefaultNode = 16

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -742,6 +742,7 @@ gke {
     enabled = true
     # App developers - Please keep the list of non-backward compatible versions in the list below
     chartVersionsToExcludeFromUpdates = []
+    numOfReplicas = 1
   }
   allowedApp {
     # If you update this here, be sure to update in the dockerfile

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
@@ -756,13 +756,15 @@ object Config {
 
   val gkeClusterConfig = config.as[KubernetesClusterConfig]("gke.cluster")
   val gkeDefaultNodepoolConfig = config.as[DefaultNodepoolConfig]("gke.defaultNodepool")
+  val gkeAutoScalingDefaultNodepoolConfig = config.as[DefaultNodepoolConfig]("gke.defaultAutoScalingNodepool")
   val gkeGalaxyNodepoolConfig = config.as[GalaxyNodepoolConfig]("gke.galaxyNodepool")
   val gkeIngressConfig = config.as[KubernetesIngressConfig]("gke.ingress")
   val gkeGalaxyAppConfig = config.as[GalaxyAppConfig]("gke.galaxyApp")
   val gkeCromwellAppConfig = config.as[CromwellAppConfig]("gke.cromwellApp")
   val gkeCustomAppConfig = config.as[CustomAppConfig]("gke.customApp")
   val gkeAllowedAppConfig = config.as[AllowedAppConfig]("gke.allowedApp")
-  val gkeNodepoolConfig = NodepoolConfig(gkeDefaultNodepoolConfig, gkeGalaxyNodepoolConfig)
+  val gkeNodepoolConfig =
+    NodepoolConfig(gkeDefaultNodepoolConfig, gkeAutoScalingDefaultNodepoolConfig, gkeGalaxyNodepoolConfig)
   val gkeGalaxyDiskConfig = config.as[GalaxyDiskConfig]("gke.galaxyDisk")
 
   implicit private val leoPubsubMessageSubscriberConfigReader: ValueReader[LeoPubsubMessageSubscriberConfig] =

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
@@ -681,7 +681,8 @@ object Config {
       serviceAccountName = config.as[ServiceAccountName]("serviceAccountName"),
       dbPassword = config.as[DbPassword]("dbPassword"),
       enabled = config.as[Boolean]("enabled"),
-      chartVersionsToExcludeFromUpdates = config.as[List[ChartVersion]]("chartVersionsToExcludeFromUpdates")
+      chartVersionsToExcludeFromUpdates = config.as[List[ChartVersion]]("chartVersionsToExcludeFromUpdates"),
+      numOfReplicas = config.as[Option[Int]]("numOfReplicas")
     )
   }
 
@@ -717,7 +718,7 @@ object Config {
       config.as[ServiceAccountName]("serviceAccountName"),
       config.as[ContainerRegistryCredentials]("sasContainerRegistry"),
       config.as[List[ChartVersion]]("chartVersionsToExcludeFromUpdates"),
-      config.as[Int]("numOfReplicas")
+      config.as[Option[Int]]("numOfReplicas")
     )
   }
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/KubernetesAppConfig.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/KubernetesAppConfig.scala
@@ -33,6 +33,9 @@ sealed trait KubernetesAppConfig extends Product with Serializable {
   // corresponds to a specific app type and cloud provider.
   def cloudProvider: CloudProvider
   def appType: AppType
+
+  // Only CROMWELL, ALLOWED appTypes have replicas defined properly and used for pause/resume.
+  def numOfReplicas: Option[Int]
 }
 
 object KubernetesAppConfig {
@@ -70,6 +73,8 @@ final case class GalaxyAppConfig(releaseNameSuffix: ReleaseNameSuffix,
 
   val cloudProvider: CloudProvider = CloudProvider.Gcp
   val appType: AppType = AppType.Galaxy
+
+  def numOfReplicas: Option[Int] = None
 }
 
 final case class CromwellAppConfig(chartName: ChartName,
@@ -80,7 +85,8 @@ final case class CromwellAppConfig(chartName: ChartName,
                                    serviceAccountName: ServiceAccountName,
                                    dbPassword: DbPassword,
                                    enabled: Boolean,
-                                   chartVersionsToExcludeFromUpdates: List[ChartVersion]
+                                   chartVersionsToExcludeFromUpdates: List[ChartVersion],
+                                   numOfReplicas: Option[Int]
 ) extends KubernetesAppConfig {
   override val kubernetesServices: List[KubernetesService] = services.map(s => KubernetesService(ServiceId(-1), s))
 
@@ -104,6 +110,8 @@ final case class CustomAppConfig(chartName: ChartName,
 
   val cloudProvider: CloudProvider = CloudProvider.Gcp
   val appType: AppType = AppType.Custom
+
+  def numOfReplicas: Option[Int] = None
 }
 
 final case class CoaAppConfig(chartName: ChartName,
@@ -124,6 +132,9 @@ final case class CoaAppConfig(chartName: ChartName,
 
   val cloudProvider: CloudProvider = CloudProvider.Azure
   val appType: AppType = AppType.Cromwell
+
+  def numOfReplicas: Option[Int] = None
+
 }
 
 final case class WorkflowsAppConfig(chartName: ChartName,
@@ -142,6 +153,8 @@ final case class WorkflowsAppConfig(chartName: ChartName,
 
   val cloudProvider: CloudProvider = CloudProvider.Azure
   val appType: AppType = AppType.WorkflowsApp
+
+  def numOfReplicas: Option[Int] = None
 }
 
 final case class CromwellRunnerAppConfig(chartName: ChartName,
@@ -158,6 +171,8 @@ final case class CromwellRunnerAppConfig(chartName: ChartName,
   override val serviceAccountName = ServiceAccountName(ksaName.value)
   val cloudProvider: CloudProvider = CloudProvider.Azure
   val appType: AppType = AppType.CromwellRunnerApp
+
+  def numOfReplicas: Option[Int] = None
 }
 
 final case class WdsAppConfig(chartName: ChartName,
@@ -178,6 +193,8 @@ final case class WdsAppConfig(chartName: ChartName,
 
   val cloudProvider: CloudProvider = CloudProvider.Azure
   val appType: AppType = AppType.Wds
+
+  def numOfReplicas: Option[Int] = None
 }
 
 final case class HailBatchAppConfig(chartName: ChartName,
@@ -194,6 +211,9 @@ final case class HailBatchAppConfig(chartName: ChartName,
 
   val cloudProvider: CloudProvider = CloudProvider.Azure
   val appType: AppType = AppType.HailBatch
+
+  def numOfReplicas: Option[Int] = None
+
 }
 
 final case class ContainerRegistryUsername(asString: String) extends AnyVal
@@ -208,7 +228,7 @@ final case class AllowedAppConfig(chartName: ChartName,
                                   serviceAccountName: ServiceAccountName,
                                   sasContainerRegistryCredentials: ContainerRegistryCredentials,
                                   chartVersionsToExcludeFromUpdates: List[ChartVersion],
-                                  numOfReplicas: Int
+                                  numOfReplicas: Option[Int]
 ) extends KubernetesAppConfig {
   val cloudProvider: CloudProvider = CloudProvider.Gcp
   val appType: AppType = AppType.Allowed

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/NodepoolConfig.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/NodepoolConfig.scala
@@ -1,3 +1,6 @@
 package org.broadinstitute.dsde.workbench.leonardo
 package config
-case class NodepoolConfig(defaultNodepoolConfig: DefaultNodepoolConfig, galaxyNodepoolConfig: GalaxyNodepoolConfig)
+case class NodepoolConfig(defaultNodepoolConfig: DefaultNodepoolConfig,
+                          defaultAutoScalingNodepoolConfig: DefaultNodepoolConfig,
+                          galaxyNodepoolConfig: GalaxyNodepoolConfig
+)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/LeoAppServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/LeoAppServiceInterp.scala
@@ -653,7 +653,7 @@ final class LeoAppServiceInterp[F[_]: Parallel](config: AppServiceConfig,
 
       // Save or retrieve a KubernetesCluster record for the app
       saveCluster <- F.fromEither(
-        getSavableCluster(userInfo.userEmail, cloudContext, ctx.now)
+        getSavableCluster(userInfo.userEmail, cloudContext, false, ctx.now)
       )
       saveClusterResult <- KubernetesServiceDbQueries.saveOrGetClusterForApp(saveCluster).transaction
       _ <-

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/LeoAppServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/LeoAppServiceInterp.scala
@@ -1244,10 +1244,9 @@ final class LeoAppServiceInterp[F[_]: Parallel](config: AppServiceConfig,
           gkeAppConfig.kubernetesServices.appended(ConfigReader.appConfig.azure.listenerChartConfig.service)
         } else gkeAppConfig.kubernetesServices
 
-      numOfReplicas =
-        if (req.appType == AppType.Allowed)
-          Some(config.leoKubernetesConfig.allowedAppConfig.numOfReplicas)
-        else None
+      numOfReplicas = KubernetesAppConfig
+        .configForTypeAndCloud(req.appType, cloudContext.cloudProvider)
+        .flatMap(_.numOfReplicas)
     } yield SaveApp(
       App(
         AppId(-1),

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
@@ -6,6 +6,7 @@ import cats.effect.Async
 import cats.effect.implicits._
 import cats.mtl.Ask
 import cats.syntax.all._
+import com.google.api.services.container.model
 import com.google.auth.oauth2.GoogleCredentials
 import com.google.cloud.compute.v1.Disk
 import com.google.container.v1._

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
@@ -6,7 +6,6 @@ import cats.effect.Async
 import cats.effect.implicits._
 import cats.mtl.Ask
 import cats.syntax.all._
-import com.google.api.services.container.model
 import com.google.auth.oauth2.GoogleCredentials
 import com.google.cloud.compute.v1.Disk
 import com.google.container.v1._


### PR DESCRIPTION
https://precisionmedicineinitiative.atlassian.net/browse/RW-10598

1. Change the way we stop/start cromwell App on GCP to use scaling replicas
2. Use a different default nodepool config for apps that rely on scaling replicas for pause/resume. This setting is currently 2 `n1-standard-4` nodes, which we might be able to optimize this over time (I have a GCP support ticket open regarding this), but I think this is ok for this PR since it's not making things any worse (without this, kube system pods won't transfer to the default nodepool and preventing the user nodepool from scaling down). This won't affect Terra since this PR doesn't change default nodepool for non `ALLOWED` and non cromwell on GCP apps. But I'll have a discussion with Moira to confirm the price increase is ok from AoU perspective


Tested on BEE that pause/resume works as expected. Also observed autoscaling kicks in properly to scale down the user nodepool


### Who tested and where

- [ ] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [ ] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
