### PR TITLE
RW-9480 add workspaceId in v1 createApp API

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoApiClient.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoApiClient.scala
@@ -125,6 +125,7 @@ object LeonardoApiClient {
     Map.empty,
     None,
     List.empty,
+    None,
     None
   )
 

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/appRoutesModels.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/appRoutesModels.scala
@@ -33,6 +33,7 @@ final case class CreateAppRequest(kubernetesRuntimeConfig: Option[KubernetesRunt
                                   customEnvironmentVariables: Map[String, String],
                                   descriptorPath: Option[Uri],
                                   extraArgs: List[String],
+                                  workspaceId: Option[WorkspaceId],
                                   sourceWorkspaceId: Option[WorkspaceId]
 )
 

--- a/http/src/main/resources/swagger/api-docs.yaml
+++ b/http/src/main/resources/swagger/api-docs.yaml
@@ -4028,6 +4028,9 @@ components:
           items:
             type: string
           description: Extra arguments to pass to the application. Only used if appType is CUSTOM.
+        workspaceId:
+          type: string
+          description: Optional id of workspace. Every app must have a workspaceId, but this is not required for backwards-compatibility.
         sourceWorkspaceId:
           type: string
           description: Optional id of source workspace if app is a clone.

--- a/http/src/main/resources/swagger/api-docs.yaml
+++ b/http/src/main/resources/swagger/api-docs.yaml
@@ -4030,7 +4030,7 @@ components:
           description: Extra arguments to pass to the application. Only used if appType is CUSTOM.
         workspaceId:
           type: string
-          description: Optional id of workspace. Every app must have a workspaceId, but this is not required for backwards-compatibility.
+          description: Optional id of workspace. Every app must have a workspaceId, but this is not required for backwards-compatibility. Note, if you're using v2 APIs, this field is not used.
         sourceWorkspaceId:
           type: string
           description: Optional id of source workspace if app is a clone.

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/AppV2Routes.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/AppV2Routes.scala
@@ -175,6 +175,7 @@ object AppV2Routes {
         cv <- x.downField("customEnvironmentVariables").as[Option[LabelMap]]
         dp <- x.downField("descriptorPath").as[Option[Uri]]
         ea <- x.downField("extraArgs").as[Option[List[String]]]
+        wsi <- x.downField("workspaceId").as[Option[WorkspaceId]]
         swi <- x.downField("sourceWorkspaceId").as[Option[WorkspaceId]]
 
         optStr <- x.downField("appType").as[Option[String]]
@@ -202,6 +203,7 @@ object AppV2Routes {
                                cv.getOrElse(Map.empty),
                                dp,
                                ea.getOrElse(List.empty),
+                               wsi,
                                swi
       )
     }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/LeoAppServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/LeoAppServiceInterp.scala
@@ -250,7 +250,7 @@ final class LeoAppServiceInterp[F[_]: Parallel](config: AppServiceConfig,
                       lastUsedApp,
                       petSA,
                       nodepool.id,
-                      None,
+                      req.workspaceId,
                       ctx
         )
       )

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/KubernetesTestData.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/KubernetesTestData.scala
@@ -80,6 +80,7 @@ object KubernetesTestData {
     Map.empty,
     None,
     List.empty,
+    None,
     None
   )
 
@@ -121,6 +122,7 @@ object KubernetesTestData {
       customEnvironmentVariables = customEnvVars,
       descriptorPath = None,
       extraArgs = List.empty,
+      None,
       None
     )
 

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/AppV2RouteSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/AppV2RouteSpec.scala
@@ -1,0 +1,44 @@
+package org.broadinstitute.dsde.workbench.leonardo.http.api
+
+import io.circe.parser.decode
+import org.broadinstitute.dsde.workbench.google2.DiskName
+import org.broadinstitute.dsde.workbench.leonardo.http.api.AppV2Routes.createAppDecoder
+import org.broadinstitute.dsde.workbench.leonardo.http.{CreateAppRequest, PersistentDiskRequest}
+import org.broadinstitute.dsde.workbench.leonardo.{AllowedChartName, AppType, LeonardoTestSuite, WorkspaceId}
+import org.scalatest.flatspec.AnyFlatSpec
+
+import java.util.UUID
+
+class AppV2RouteSpec extends AnyFlatSpec with LeonardoTestSuite {
+  it should "decode createApp request properly" in {
+    val workspaceId = WorkspaceId(UUID.randomUUID())
+    val jsonString =
+      s"""
+         |{
+         |  "diskConfig": {
+         |    "name": "disk1"
+         |  },
+         |  "appType": "ALLOWED",
+         |  "allowedChartName": "rstudio",
+         |  "workspaceId": "${workspaceId.value.toString}"
+         |}
+         |""".stripMargin
+
+    val res = decode[CreateAppRequest](jsonString)
+
+    val expected = CreateAppRequest(
+      None,
+      AppType.Allowed,
+      Some(AllowedChartName.RStudio),
+      None,
+      Some(PersistentDiskRequest(DiskName("disk1"), None, None, Map.empty)),
+      Map.empty,
+      Map.empty,
+      None,
+      List.empty,
+      Some(workspaceId),
+      None
+    )
+    res shouldBe (Right(expected))
+  }
+}


### PR DESCRIPTION
This PR's scope is fairly small, which is to add an optional `workspaceId` field in createApp request. This will be good for a few different reasons as we're migrating to `workspaceId` centric APIs.

The direct motivation is [this doc](https://docs.google.com/document/d/13cfxxjTGXdn48m6kXSN5AL-D9usk5yFmBQ0nQaV0L5Y/edit)...This change is part of the current winning option. I'd like to talk with the team as well to go over options, but this change should be beneficial even if we end up taking a different option.

-

## Testing these changes

### What to test

- <!-- Test case 1 -->

<!-- ### Test data -->

### Who tested and where

- [ ] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [ ] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
