### PR TITLE
RW-10951 cgroup memory limit includes Spark Driver Memory

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/runtimeModels.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/runtimeModels.scala
@@ -545,6 +545,9 @@ object MemorySize {
  *
  * driverMemory will be populated if it's Dataproc, and machine type is either n1-standard-{x} or n1-highmem-{x} when using a different algorithm
  * for calculating spark:spark.driver.memory
+ *
+ * Note that the memory limit includes all the sub-procesess of the Notebook server including the
+ * Notebook kernel and the Spark driver process, if any.
  */
 final case class RuntimeResourceConstraints(memoryLimit: MemorySize,
                                             totalMachineMemory: MemorySize,

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/runtimeModels.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/runtimeModels.scala
@@ -543,8 +543,7 @@ object MemorySize {
  * See https://docs.docker.com/compose/compose-file/compose-file-v2/#cpu-and-other-resources
  * for other types of resources we may want to add here.
  *
- * driverMemory will be populated if it's Dataproc, and machine type is either n1-standard-{x} or n1-highmem-{x} when using a different algorithm
- * for calculating spark:spark.driver.memory
+ * driverMemory will be populated if it's Dataproc runtime.
  */
 final case class RuntimeResourceConstraints(memoryLimit: MemorySize,
                                             totalMachineMemory: MemorySize,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/DataprocInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/DataprocInterpreter.scala
@@ -783,7 +783,7 @@ class DataprocInterpreter[F[_]: Parallel](
       // For dataproc, we don't need much memory for Jupyter.
 
       // We still want a minimum to run Jupyter and other system processes.
-      val minRuntimeMemoryGb = config.dataprocConfig.minimumRuntimeMemoryInGb.getOrElse(4.0)
+      val minRuntimeMemoryGb = MemorySize.fromGb(config.dataprocConfig.minimumRuntimeMemoryInGb.getOrElse(4.0))
       // Note this algorithm is recommended by Hail team. See more info in https://broadworkbench.atlassian.net/browse/IA-4720
       val sparkDriverMemory = machineType match {
         case MachineTypeName(n1standard) if n1standard.startsWith("n1-standard") =>

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/DataprocInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/DataprocInterpreter.scala
@@ -782,8 +782,6 @@ class DataprocInterpreter[F[_]: Parallel](
     } yield {
       // For dataproc, we don't need much memory for Jupyter.
 
-      // Hail reserves about 80% of memory available to the machine to the JVM.
-      val sparkMemoryConfigRatio = config.dataprocConfig.sparkMemoryConfigRatio.getOrElse(0.8)
       // We still want a minimum to run Jupyter and other system processes.
       val minRuntimeMemoryGb = config.dataprocConfig.minimumRuntimeMemoryInGb.getOrElse(4.0)
       // Note this algorithm is recommended by Hail team. See more info in https://broadworkbench.atlassian.net/browse/IA-4720
@@ -794,13 +792,8 @@ class DataprocInterpreter[F[_]: Parallel](
           Some(MemorySize.fromGb((total.bytes / MemorySize.gbInBytes - 11) * 0.9))
         case _ => none[MemorySize]
       }
-      val runtimeAllocatedMemory =
-        Math.max(
-          (total.bytes * (1 - sparkMemoryConfigRatio)).toLong,
-          MemorySize.fromGb(minRuntimeMemoryGb).bytes
-        )
-
-      RuntimeResourceConstraints(MemorySize(runtimeAllocatedMemory), MemorySize(total.bytes), sparkDriverMemory)
+      val runtimeAllocatedMemory = MemorySize(sparkDriverMemory.map(_.bytes).getOrElse(0) + minRuntimeMemoryGb.bytes)
+      RuntimeResourceConstraints(runtimeAllocatedMemory, MemorySize(total.bytes), sparkDriverMemory)
     }
 
   /**

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/DataprocInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/DataprocInterpreter.scala
@@ -906,7 +906,6 @@ class DataprocInterpreter[F[_]: Parallel](
       Map("dataproc:dataproc.allow.zero.workers" -> "true")
     } else Map.empty[String, String]
 
-
     val driverMemoryProp = Map("spark:spark.driver.memory" -> s"${sparkDriverMemory.bytes / MemorySize.mbInBytes}m")
 
     val yarnProps = Map(

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/app/WorkflowsAppInstallSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/app/WorkflowsAppInstallSpec.scala
@@ -1,7 +1,7 @@
 package org.broadinstitute.dsde.workbench.leonardo.app
 
 import cats.effect.IO
-import org.broadinstitute.dsde.workbench.leonardo.CommonTestData.{azureRegion, landingZoneResources, petUserInfo}
+import org.broadinstitute.dsde.workbench.leonardo.CommonTestData.{landingZoneResources, petUserInfo}
 import org.broadinstitute.dsde.workbench.leonardo.TestUtils.appContext
 import org.broadinstitute.dsde.workbench.leonardo.WsmControlledDatabaseResource
 import org.broadinstitute.dsde.workbench.leonardo.http.ConfigReader

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/DataprocInterpreterSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/DataprocInterpreterSpec.scala
@@ -307,11 +307,14 @@ class DataprocInterpreterSpec
       )
 
       val propertyMap = dataProcSoftwareConfig.getPropertiesMap()
-      val expectedMemory =
+
+      val expectedDriverMemory =
         if (machineType == MachineTypeName("n1-standard-4")) (104 - 7) * 0.9 * 1024 else (104 - 11) * 0.9 * 1024
+      resourceConstraints.memoryLimit shouldBe MemorySize.fromMb(expectedDriverMemory + 4 * 1024)
+
       propertyMap.get(
         "spark:spark.driver.memory"
-      ) shouldBe s"${expectedMemory.toInt}m"
+      ) shouldBe s"${expectedDriverMemory.toInt}m"
     }
   }
 


### PR DESCRIPTION
<!-- Welcome to your Leonardo pull request! -->
<!-- Contributor guidelines: https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md -->

__Jira ticket__: https://precisionmedicineinitiative.atlassian.net/browse/RW-10951

<!-- ## Dependencies -->
<!-- Include any dependent tickets and describe the relationship. Include any other relevant Jira tickets. -->

## Summary of changes

<!-- Please give an abridged version of the ticket description here and/or fill out the following fields. -->

This resolves a bug related to Hail. It previously manifested as "py4j.protocol.Py4JNetworkError: Answer from Java side is empty" but, due to changes in Hail 0.2.126, it now manifests as "RemoteDisconnectedError". This occurs when a Spark Driver JVM killed by the OOMKiller. When this happens, the Hail log contains no indication of a problem and there is no `hs_err_pid*.log` file.

#### How Hail Works

Hail comprises three key components:

1. Python client.
2. Spark Driver JVM.
3. Spark Worker JVMs.

When Hail initializes, it uses PySpark to create a Spark Driver JVM. Unless the [--deploy-mode](https://spark.apache.org/docs/latest/submitting-applications.html#launching-applications-with-spark-submit) of `spark-submit` is overridden (this can be done with [PYSPARK_SUBMIT_ARGS](https://github.com/apache/spark/blob/d9f0fccd967b5c8686353d524d2b31e27b7a473b/python/pyspark/java_gateway.py#L70)), this Spark Driver JVM is a sub-process of the Python client process.

Suppose we execute this Python code:

```python3
mt = hl.read_matrix_table("gs://bucket/foo.mt")
mt.count()
```

Hail constructs an abstract representation of this:

```
!1 = MatrixRead [Matrix{ ... }, ..., (MatrixNativeReader gs://bucket/foo.mt )]
MatrixCount(!1)
```

And sends that over a local HTTP/TCP socket to the Spark Driver JVM. The Spark Driver JVM determines the number of partitions and processes each partition on the Spark Worker JVMs. The results are either written to cloud storage or serialized back to the Python process over the socket.

#### The Bugs

There were two related bugs in how Leonardo sets the memory of Hail:

1. Leonardo (and, indeed, the current version of `hailctl`), for n1-highmem-8, sets the JVM maximum heap size to a number too close to the practically available memory.

2. Leonardo, for all machine types, sets (via docker, which uses cgroupv1) a memory limit on the Jupyter Notebook server's cgroup. Since the Notebook kernel and the Spark Driver JVM are sub-processes of the Notebook server, they are all collectively subjected to the memory limit.


Bug 1 is described in detail in this [comment](https://github.com/hail-is/hail/issues/13960#issuecomment-1836844790) on Hail issue https://github.com/hail-is/hail/issues/13960 . The gist of the issue is that the amount of RAM available used by system daemons on the Dataproc Driver VM has grown substantially since Hail introduced the "80% of total RAM" rule. It has already been resolved by https://github.com/danking/leonardo/commit/ef0879015a4dd16e5566b190c915328ce030d5fb .

Bug 2 is superficially similar to Bug 1. In both cases, the user sees RemoteDisconnectedError because the OOMKiller kills the Spark Driver JVM. However, in Bug 2, the OOMKiller is invoked because the *cgroup exceeded its memory limit* whereas in Bug 1 the OOMKiller is invoked because the *the entire system was nearly out of memory*.

Let's look at the syslog of an example of Bug 2. In this case, the user is using an n1-standard-4 with four cores and 15000 MiB of RAM [1]. At 2023-12-08 2045, there is 4280 MiB of memory available to the system; however, the cgroup `/docker/8be415e240b32e8545043ce136fc17a1206d847f24ed507646339b8798e50316` has exceeded its memory limit. The syslog shows the two Python processes and the Java process and the resident set size (rss), in pages. This trio of processes are using more than 4GB of memory. A moment later the OOMKiller kills the java process.

```
Dec  8 20:45:17 all-of-us-263-m earlyoom[440]: mem avail:  4280 of 15000 MiB (28.54%), swap free:    0 of    0 MiB ( 0.00%)
...
Dec  8 20:45:17 all-of-us-263-m kernel: [ 1166.445565] Memory cgroup stats for /docker/8be415e240b32e8545043ce136fc17a1206d847f24ed507646339b8798e50316:
...
Dec  8 20:45:17 all-of-us-263-m kernel: [ 1166.588599] [  pid  ]   uid  tgid total_vm      rss pgtables_bytes swapents oom_score_adj name
...
Dec  8 20:45:18 all-of-us-263-m kernel: [ 1166.637384] [   3240]  1000  3240    72396    26654   339968        0             0 python3
Dec  8 20:45:18 all-of-us-263-m kernel: [ 1166.647309] [   4378]  1000  4378   440607    63412  1114112        0             0 python3
Dec  8 20:45:18 all-of-us-263-m kernel: [ 1166.657204] [   5942]  1000  5942  2904213   952126  8302592        0             0 java
...
Dec  8 20:45:18 all-of-us-263-m kernel: [ 1166.718428] Memory cgroup out of memory: Killed process 5942 (java) total-vm:11616852kB, anon-rss:3808504kB, file-rss:0kB, shmem-rss:0kB, UID:1000 pgtables:8108kB oom_score_adj:0
```

#### The Fix

The fix is to set the memory limit to the sum of the memory we expect Python and Java to use.

## Testing these changes

### What to test

### Who tested and where

- [ ] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [ ] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->

[1] 15,000 MiB is lower than the advertised memory for this machine type. This machine type should have 15 GiB = 15,360 MiB of memory.