### PR TITLE
[AJ-1511] Pass AKS cluster tags to WDS

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/JsonCodec.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/JsonCodec.scala
@@ -687,6 +687,7 @@ object JsonCodec {
   implicit val allowedChartNameDecoder: Decoder[AllowedChartName] =
     Decoder.decodeString.emap(x => AllowedChartName.stringToObject.get(x).toRight("chart name not allowed"))
   implicit val aksClusterNameDecoder: Decoder[AKSClusterName] = Decoder.decodeString.map(AKSClusterName)
+  implicit val aksClusterDecoder: Decoder[AKSCluster] = Decoder.forProduct2("name", "tags")(AKSCluster)
   implicit val postgresServerDecoder: Decoder[PostgresServer] =
     Decoder.forProduct2("name", "pgBouncerEnabled")(PostgresServer)
 
@@ -759,6 +760,8 @@ object JsonCodec {
   implicit val azureDiskNameEncoder: Encoder[AzureDiskName] = Encoder.encodeString.contramap(_.value)
   implicit val relayNamespaceEncoder: Encoder[RelayNamespace] = Encoder.encodeString.contramap(_.value)
   implicit val aksClusterNameEncoder: Encoder[AKSClusterName] = Encoder.encodeString.contramap(_.value)
+  implicit val aksClusterEncoder: Encoder[AKSCluster] = 
+    Encoder.forProduct2("name", "tags")(x => (x.name, x.tags))
   implicit val postgresServerEncoder: Encoder[PostgresServer] =
     Encoder.forProduct2("name", "pgBouncerEnabled")(x => (x.name, x.pgBouncerEnabled))
 
@@ -800,7 +803,7 @@ object JsonCodec {
     "postgresName"
   )(x =>
     (x.landingZoneId,
-     x.clusterName,
+     x.aksCluster,
      x.batchAccountName,
      x.relayNamespace,
      x.storageAccountName,

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/JsonCodec.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/JsonCodec.scala
@@ -760,7 +760,7 @@ object JsonCodec {
   implicit val azureDiskNameEncoder: Encoder[AzureDiskName] = Encoder.encodeString.contramap(_.value)
   implicit val relayNamespaceEncoder: Encoder[RelayNamespace] = Encoder.encodeString.contramap(_.value)
   implicit val aksClusterNameEncoder: Encoder[AKSClusterName] = Encoder.encodeString.contramap(_.value)
-  implicit val aksClusterEncoder: Encoder[AKSCluster] = 
+  implicit val aksClusterEncoder: Encoder[AKSCluster] =
     Encoder.forProduct2("name", "tags")(x => (x.name, x.tags))
   implicit val postgresServerEncoder: Encoder[PostgresServer] =
     Encoder.forProduct2("name", "pgBouncerEnabled")(x => (x.name, x.pgBouncerEnabled))

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/azureModels.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/azureModels.scala
@@ -1,7 +1,6 @@
 package org.broadinstitute.dsde.workbench.leonardo
 
 import org.broadinstitute.dsde.workbench.azure.{
-  AKSClusterName,
   ApplicationInsightsName,
   BatchAccountName,
   RelayNamespace
@@ -27,12 +26,14 @@ final case class BatchAccountKey(value: String) extends AnyVal
 
 final case class PostgresServer(name: String, pgBouncerEnabled: Boolean)
 
+final case class AKSCluster(name: String, tags: Map[String, Boolean])
+
 final case class WsmManagedAzureIdentity(wsmResourceName: String, managedIdentityName: String)
 
 final case class WsmControlledDatabaseResource(wsmDatabaseName: String, azureDatabaseName: String)
 
 final case class LandingZoneResources(landingZoneId: UUID,
-                                      clusterName: AKSClusterName,
+                                      aksCluster: AKSCluster,
                                       batchAccountName: BatchAccountName,
                                       relayNamespace: RelayNamespace,
                                       storageAccountName: StorageAccountName,

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/azureModels.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/azureModels.scala
@@ -1,6 +1,11 @@
 package org.broadinstitute.dsde.workbench.leonardo
 
-import org.broadinstitute.dsde.workbench.azure.{ApplicationInsightsName, BatchAccountName, RelayNamespace}
+import org.broadinstitute.dsde.workbench.azure.{
+  AKSClusterName,
+  ApplicationInsightsName,
+  BatchAccountName,
+  RelayNamespace
+}
 
 import org.broadinstitute.dsde.workbench.google2.{NetworkName, SubnetworkName}
 
@@ -22,7 +27,9 @@ final case class BatchAccountKey(value: String) extends AnyVal
 
 final case class PostgresServer(name: String, pgBouncerEnabled: Boolean)
 
-final case class AKSCluster(name: String, tags: Map[String, Boolean])
+final case class AKSCluster(name: String, tags: Map[String, Boolean]) {
+  def asClusterName: AKSClusterName = AKSClusterName(name)
+}
 
 final case class WsmManagedAzureIdentity(wsmResourceName: String, managedIdentityName: String)
 

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/azureModels.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/azureModels.scala
@@ -1,10 +1,6 @@
 package org.broadinstitute.dsde.workbench.leonardo
 
-import org.broadinstitute.dsde.workbench.azure.{
-  ApplicationInsightsName,
-  BatchAccountName,
-  RelayNamespace
-}
+import org.broadinstitute.dsde.workbench.azure.{ApplicationInsightsName, BatchAccountName, RelayNamespace}
 
 import org.broadinstitute.dsde.workbench.google2.{NetworkName, SubnetworkName}
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/app/WdsAppInstall.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/app/WdsAppInstall.scala
@@ -61,7 +61,7 @@ class WdsAppInstall[F[_]](config: WdsAppConfig,
       )
 
       // Get Vpa enabled tag 
-      vpaEnabled <- params.landingZoneResources.aksCluster.tags.getOrElse("aks-cost-vpa-enabled", false)
+      vpaEnabled <- java.lang.Boolean.parseBoolean(params.landingZoneResources.aksCluster.tags.getOrElse("aks-cost-vpa-enabled", "false"))
 
       valuesList =
         List(
@@ -98,7 +98,7 @@ class WdsAppInstall[F[_]](config: WdsAppConfig,
           // general configs
           raw"fullnameOverride=wds-${params.app.release.asString}",
           raw"instrumentationEnabled=${config.instrumentationEnabled}",
-          raw"vpaEnabled"=${vpaEnabled},
+          raw"vpaEnabled=${vpaEnabled}",
 
           // import configs
           raw"import.dataRepoUrl=${tdrConfig.url}",

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/app/WdsAppInstall.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/app/WdsAppInstall.scala
@@ -61,7 +61,7 @@ class WdsAppInstall[F[_]](config: WdsAppConfig,
       )
 
       // Get Vpa enabled tag 
-      vpaEnabled <- params.landingZoneResources.aksCluster.tags.getOrElse("aks-cost-vpa-enabled", "false")
+      vpaEnabled <- F.pure(params.landingZoneResources.aksCluster.tags.getOrElse("aks-cost-vpa-enabled", false))
 
       valuesList =
         List(

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/app/WdsAppInstall.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/app/WdsAppInstall.scala
@@ -60,7 +60,7 @@ class WdsAppInstall[F[_]](config: WdsAppConfig,
         AppCreationException(s"Pet not found for user ${params.app.auditInfo.creator}", Some(ctx.traceId))
       )
 
-      // Get Vpa enabled tag 
+      // Get Vpa enabled tag
       vpaEnabled <- F.pure(params.landingZoneResources.aksCluster.tags.getOrElse("aks-cost-vpa-enabled", false))
 
       valuesList =

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/app/WdsAppInstall.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/app/WdsAppInstall.scala
@@ -60,6 +60,12 @@ class WdsAppInstall[F[_]](config: WdsAppConfig,
         AppCreationException(s"Pet not found for user ${params.app.auditInfo.creator}", Some(ctx.traceId))
       )
 
+      // Get AKS information 
+      aksCluster <- F.fromOption(
+        params.landingZoneResources.aksCluster,
+        AppCreationException("AKS cluster required for WDS app", Some(ctx.traceId))
+      )
+
       valuesList =
         List(
           // pass enviiroment information to wds so it can properly pick its config
@@ -95,6 +101,7 @@ class WdsAppInstall[F[_]](config: WdsAppConfig,
           // general configs
           raw"fullnameOverride=wds-${params.app.release.asString}",
           raw"instrumentationEnabled=${config.instrumentationEnabled}",
+          raw"vpaEnabled"=${aksCluster.tags.getOrElse("aks-cost-vpa-enabled", false)},
 
           // import configs
           raw"import.dataRepoUrl=${tdrConfig.url}",

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/app/WdsAppInstall.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/app/WdsAppInstall.scala
@@ -60,11 +60,8 @@ class WdsAppInstall[F[_]](config: WdsAppConfig,
         AppCreationException(s"Pet not found for user ${params.app.auditInfo.creator}", Some(ctx.traceId))
       )
 
-      // Get AKS information 
-      aksCluster <- F.fromOption(
-        params.landingZoneResources.aksCluster,
-        AppCreationException("AKS cluster required for WDS app", Some(ctx.traceId))
-      )
+      // Get Vpa enabled tag 
+      vpaEnabled <- params.landingZoneResources.aksCluster.tags.getOrElse("aks-cost-vpa-enabled", false)
 
       valuesList =
         List(
@@ -101,7 +98,7 @@ class WdsAppInstall[F[_]](config: WdsAppConfig,
           // general configs
           raw"fullnameOverride=wds-${params.app.release.asString}",
           raw"instrumentationEnabled=${config.instrumentationEnabled}",
-          raw"vpaEnabled"=${aksCluster.tags.getOrElse("aks-cost-vpa-enabled", false)},
+          raw"vpaEnabled"=${vpaEnabled},
 
           // import configs
           raw"import.dataRepoUrl=${tdrConfig.url}",

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/app/WdsAppInstall.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/app/WdsAppInstall.scala
@@ -72,6 +72,7 @@ class WdsAppInstall[F[_]](config: WdsAppConfig,
           // azure resources configs
           raw"config.resourceGroup=${params.cloudContext.managedResourceGroupName.value}",
           raw"config.applicationInsightsConnectionString=${applicationInsightsComponent.connectionString()}",
+          raw"config.aks.vpaEnabled=${vpaEnabled}",
 
           // Azure subscription configs currently unused
           raw"config.subscriptionId=${params.cloudContext.subscriptionId.value}",
@@ -98,7 +99,6 @@ class WdsAppInstall[F[_]](config: WdsAppConfig,
           // general configs
           raw"fullnameOverride=wds-${params.app.release.asString}",
           raw"instrumentationEnabled=${config.instrumentationEnabled}",
-          raw"vpaEnabled=${vpaEnabled}",
 
           // import configs
           raw"import.dataRepoUrl=${tdrConfig.url}",

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/app/WdsAppInstall.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/app/WdsAppInstall.scala
@@ -61,7 +61,7 @@ class WdsAppInstall[F[_]](config: WdsAppConfig,
       )
 
       // Get Vpa enabled tag 
-      vpaEnabled <- java.lang.Boolean.parseBoolean(params.landingZoneResources.aksCluster.tags.getOrElse("aks-cost-vpa-enabled", "false"))
+      vpaEnabled <- params.landingZoneResources.aksCluster.tags.getOrElse("aks-cost-vpa-enabled", "false")
 
       valuesList =
         List(

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpWsmDao.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpWsmDao.scala
@@ -156,11 +156,9 @@ class HttpWsmDao[F[_]](httpClient: Client[F], config: HttpWsmDaoConfig)(implicit
         val tagValue = getLandingZoneResourceTagValue(aksResource, "aks-cost-vpa-enabled")
         val tags: Map[String, Boolean] =
           Map("aks-cost-vpa-enabled" -> java.lang.Boolean.parseBoolean(tagValue.getOrElse("false")))
-        logger.info(
-          s"Landing Zone AKS has 'aks-cost-vpa-enabled' tag $tagValue."
-        )
         AKSCluster(aksName, tags)
       }
+      _ <- logger.info(s"Retrieved Landing Zone AKS cluster: ${aksCluster}")
       batchAccountName <- getLandingZoneResourceName(groupedLzResources,
                                                      "Microsoft.Batch/batchAccounts",
                                                      SHARED_RESOURCE,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpWsmDao.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpWsmDao.scala
@@ -5,11 +5,7 @@ import cats.data.OptionT
 import cats.effect.Async
 import cats.implicits._
 import cats.mtl.Ask
-import org.broadinstitute.dsde.workbench.azure.{
-  ApplicationInsightsName,
-  BatchAccountName,
-  RelayNamespace
-}
+import org.broadinstitute.dsde.workbench.azure.{ApplicationInsightsName, BatchAccountName, RelayNamespace}
 import org.broadinstitute.dsde.workbench.google2.{NetworkName, SubnetworkName}
 import org.broadinstitute.dsde.workbench.leonardo.config.HttpWsmDaoConfig
 import org.broadinstitute.dsde.workbench.leonardo.dao.LandingZoneResourcePurpose.{
@@ -153,16 +149,17 @@ class HttpWsmDao[F[_]](httpClient: Client[F], config: HttpWsmDaoConfig)(implicit
         a.deployedResources.groupBy(b => (a.purpose, b.resourceType.toLowerCase))
       )
       aksResource <- getLandingZoneResource(groupedLzResources,
-                                           "Microsoft.ContainerService/managedClusters",
+                                            "Microsoft.ContainerService/managedClusters",
                                             SHARED_RESOURCE
       )
       aksCluster <- getLandingZoneResourceName(aksResource, useParent = false).map { aksName =>
-          val tagValue = getLandingZoneResourceTagValue(aksResource, "aks-cost-vpa-enabled")
-          val tags: Map[String, Boolean] = Map("aks-cost-vpa-enabled" -> java.lang.Boolean.parseBoolean(tagValue.getOrElse("false")))
-          logger.info(
-            s"Landing Zone AKS has 'aks-cost-vpa-enabled' tag $tagValue."
-          )
-          AKSCluster(aksName, tags)
+        val tagValue = getLandingZoneResourceTagValue(aksResource, "aks-cost-vpa-enabled")
+        val tags: Map[String, Boolean] =
+          Map("aks-cost-vpa-enabled" -> java.lang.Boolean.parseBoolean(tagValue.getOrElse("false")))
+        logger.info(
+          s"Landing Zone AKS has 'aks-cost-vpa-enabled' tag $tagValue."
+        )
+        AKSCluster(aksName, tags)
       }
       batchAccountName <- getLandingZoneResourceName(groupedLzResources,
                                                      "Microsoft.Batch/batchAccounts",

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpWsmDao.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpWsmDao.scala
@@ -163,7 +163,6 @@ class HttpWsmDao[F[_]](httpClient: Client[F], config: HttpWsmDaoConfig)(implicit
             s"Landing Zone AKS has 'aks-cost-vpa-enabled' tag $tagValue."
           )
           AKSCluster(aksName, tags)
-        }
       }
       batchAccountName <- getLandingZoneResourceName(groupedLzResources,
                                                      "Microsoft.Batch/batchAccounts",

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpWsmDao.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpWsmDao.scala
@@ -156,14 +156,13 @@ class HttpWsmDao[F[_]](httpClient: Client[F], config: HttpWsmDaoConfig)(implicit
                                            "Microsoft.ContainerService/managedClusters",
                                             SHARED_RESOURCE
       )
-      aksCluster <- aksResource.toOption.traverse { resource =>
-        getLandingZoneResourceName(resource, useParent = false).map { aksName =>
-          val tagValue = getLandingZoneResourceTagValue(resource, "aks-cost-vpa-enabled")
+      aksCluster <- getLandingZoneResourceName(aksResource, useParent = false).map { aksName =>
+          val tagValue = getLandingZoneResourceTagValue(aksResource, "aks-cost-vpa-enabled")
           val tags: Map[String, Boolean] = Map("aks-cost-vpa-enabled" -> java.lang.Boolean.parseBoolean(tagValue.getOrElse("false")))
           logger.info(
             s"Landing Zone AKS has 'aks-cost-vpa-enabled' tag $tagValue."
           )
-          AksCluster(aksName, tags)
+          AKSCluster(aksName, tags)
         }
       }
       batchAccountName <- getLandingZoneResourceName(groupedLzResources,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/AKSInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/AKSInterpreter.scala
@@ -543,7 +543,7 @@ class AKSInterpreter[F[_]](config: AKSInterpreterConfig,
         if (deletedNamespace) F.unit
         else {
           for {
-            client <- kubeAlg.createAzureClient(cloudContext, landingZoneResources.aksCluster.name)
+            client <- kubeAlg.createAzureClient(cloudContext, AKSClusterName(landingZoneResources.aksCluster.name))
 
             kubernetesNamespace = KubernetesNamespace(app.appResources.namespace)
 

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/CommonTestData.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/CommonTestData.scala
@@ -67,7 +67,6 @@ import java.time.temporal.ChronoUnit
 import java.util.{Date, UUID}
 import com.azure.resourcemanager.compute.models.VirtualMachineSizeTypes
 import org.broadinstitute.dsde.workbench.azure.{
-  AKSClusterName,
   ApplicationInsightsName,
   AzureCloudContext,
   BatchAccountName,

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/CommonTestData.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/CommonTestData.scala
@@ -567,7 +567,7 @@ object CommonTestData {
 
   val landingZoneResources = LandingZoneResources(
     UUID.randomUUID(),
-    AKSClusterName("lzcluster"),
+    AKSCluster("lzcluster", Map.empty[String, Boolean]),
     BatchAccountName("lzbatch"),
     RelayNamespace("lznamespace"),
     StorageAccountName("lzstorage"),

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/app/BaseAppInstallSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/app/BaseAppInstallSpec.scala
@@ -50,7 +50,7 @@ class BaseAppInstallSpec extends AnyFlatSpecLike with LeonardoTestSuite with Moc
 
   val lzResources = LandingZoneResources(
     UUID.fromString("5c12f64b-f4ac-4be1-ae4a-4cace5de807d"),
-    AKSClusterName("cluster"),
+    AKSCluster("cluster", Map.empty[String, Boolean]),
     BatchAccountName("batch"),
     RelayNamespace("relay"),
     StorageAccountName("storage"),

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/app/BaseAppInstallSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/app/BaseAppInstallSpec.scala
@@ -14,6 +14,7 @@ import org.broadinstitute.dsde.workbench.leonardo.dao._
 import org.broadinstitute.dsde.workbench.leonardo.http.ConfigReader
 import org.broadinstitute.dsde.workbench.leonardo.util.AKSInterpreterConfig
 import org.broadinstitute.dsde.workbench.leonardo.{
+  AKSCluster,
   LandingZoneResources,
   LeonardoTestSuite,
   ManagedIdentityName,

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/app/WdsAppInstallSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/app/WdsAppInstallSpec.scala
@@ -38,6 +38,7 @@ class WdsAppInstallSpec extends BaseAppInstallSpec {
       "wds.environmentBase=live," +
       "config.resourceGroup=mrg," +
       "config.applicationInsightsConnectionString=applicationInsightsConnectionString," +
+      "config.aks.vpaEnabled=false," +
       "config.subscriptionId=sub," +
       s"config.region=${azureRegion}," +
       "general.leoAppInstanceName=app1," +
@@ -72,6 +73,7 @@ class WdsAppInstallSpec extends BaseAppInstallSpec {
       "wds.environmentBase=live," +
       "config.resourceGroup=mrg," +
       "config.applicationInsightsConnectionString=applicationInsightsConnectionString," +
+      "config.aks.vpaEnabled=false," +
       "config.subscriptionId=sub," +
       s"config.region=${azureRegion}," +
       "general.leoAppInstanceName=app1," +

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpWsmDaoSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpWsmDaoSpec.scala
@@ -141,7 +141,7 @@ class HttpWsmDaoSpec extends AnyFlatSpec with LeonardoTestSuite with BeforeAndAf
 
       val expectedLandingZoneResources = LandingZoneResources(
         landingZoneId,
-        AKSCluster("lzcluster", Map.empty[String, Boolean]),
+        AKSCluster("lzcluster", Map("aks-cost-vpa-enabled" -> false)),
         BatchAccountName("lzbatch"),
         RelayNamespace("lznamespace"),
         StorageAccountName("lzstorage"),

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpWsmDaoSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpWsmDaoSpec.scala
@@ -22,6 +22,7 @@ import org.broadinstitute.dsde.workbench.leonardo.dao.LandingZoneResourcePurpose
   WORKSPACE_COMPUTE_SUBNET
 }
 import org.broadinstitute.dsde.workbench.leonardo.{
+  AKSCluster,
   BillingProfileId,
   LandingZoneResources,
   LeonardoTestSuite,
@@ -145,7 +146,7 @@ class HttpWsmDaoSpec extends AnyFlatSpec with LeonardoTestSuite with BeforeAndAf
 
       val expectedLandingZoneResources = LandingZoneResources(
         landingZoneId,
-        AKSClusterName("lzcluster"),
+        AKSCluster("lzcluster", Map.empty[String, Boolean]),
         BatchAccountName("lzbatch"),
         RelayNamespace("lznamespace"),
         StorageAccountName("lzstorage"),

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpWsmDaoSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpWsmDaoSpec.scala
@@ -5,7 +5,6 @@ import cats.effect.unsafe.implicits.global
 import io.circe.syntax.EncoderOps
 import io.circe.{Encoder, Printer}
 import org.broadinstitute.dsde.workbench.azure.{
-  AKSClusterName,
   ApplicationInsightsName,
   BatchAccountName,
   RelayNamespace

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpWsmDaoSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpWsmDaoSpec.scala
@@ -4,11 +4,7 @@ import cats.effect.IO
 import cats.effect.unsafe.implicits.global
 import io.circe.syntax.EncoderOps
 import io.circe.{Encoder, Printer}
-import org.broadinstitute.dsde.workbench.azure.{
-  ApplicationInsightsName,
-  BatchAccountName,
-  RelayNamespace
-}
+import org.broadinstitute.dsde.workbench.azure.{ApplicationInsightsName, BatchAccountName, RelayNamespace}
 import org.broadinstitute.dsde.workbench.google2.{NetworkName, SubnetworkName}
 import org.broadinstitute.dsde.workbench.leonardo.TestUtils.appContext
 import org.broadinstitute.dsde.workbench.leonardo.config.HttpWsmDaoConfig

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubCodecSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubCodecSpec.scala
@@ -143,7 +143,7 @@ class LeoPubsubCodecSpec extends AnyFlatSpec with Matchers {
 
   val landingZoneResources = LandingZoneResources(
     UUID.randomUUID(),
-    AKSClusterName("cluster-name"),
+    AKSCluster("cluster-name", Map.empty[String, Boolean]),
     BatchAccountName("batch-account"),
     RelayNamespace("relay-ns"),
     StorageAccountName("storage-account"),

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/AKSInterpreterSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/AKSInterpreterSpec.scala
@@ -108,7 +108,7 @@ class AKSInterpreterSpec extends AnyFlatSpecLike with TestComponent with Leonard
 
   "AKSInterpreter" should "get a helm auth context" in {
     val res = for {
-      authContext <- aksInterp.getHelmAuthContext(lzResources.clusterName, cloudContext, NamespaceName("ns"))
+      authContext <- aksInterp.getHelmAuthContext(lzResources.aksCluster.name, cloudContext, NamespaceName("ns"))
     } yield {
       authContext.namespace.asString shouldBe "ns"
       authContext.kubeApiServer.asString shouldBe "server"

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/AKSInterpreterSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/AKSInterpreterSpec.scala
@@ -108,7 +108,10 @@ class AKSInterpreterSpec extends AnyFlatSpecLike with TestComponent with Leonard
 
   "AKSInterpreter" should "get a helm auth context" in {
     val res = for {
-      authContext <- aksInterp.getHelmAuthContext(lzResources.aksCluster.name, cloudContext, NamespaceName("ns"))
+      authContext <- aksInterp.getHelmAuthContext(lzResources.aksCluster.asClusterName,
+                                                  cloudContext,
+                                                  NamespaceName("ns")
+      )
     } yield {
       authContext.namespace.asString shouldBe "ns"
       authContext.kubeApiServer.asString shouldBe "server"

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/AKSInterpreterSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/AKSInterpreterSpec.scala
@@ -89,7 +89,7 @@ class AKSInterpreterSpec extends AnyFlatSpecLike with TestComponent with Leonard
 
   val lzResources = LandingZoneResources(
     UUID.fromString("5c12f64b-f4ac-4be1-ae4a-4cace5de807d"),
-    AKSClusterName("cluster"),
+    AKSCluster("cluster", Map.empty[String, Boolean]),
     BatchAccountName("batch"),
     RelayNamespace("relay"),
     StorageAccountName("storage"),


### PR DESCRIPTION
<!-- Welcome to your Leonardo pull request! -->
<!-- Contributor guidelines: https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md -->

__Jira ticket__: https://broadworkbench.atlassian.net/browse/AJ-1511

<!-- ## Dependencies -->
<!-- Include any dependent tickets and describe the relationship. Include any other relevant Jira tickets. -->

## Summary of changes

<!-- Please give an abridged version of the ticket description here and/or fill out the following fields. -->

### What
This PR pipes Azure tags on the LZ AKS cluster to WDS's helm chart. Corresponding helm chart configuration [here](https://github.com/broadinstitute/terra-helmfile/pull/4874). 
This required changing the AKSClusterName argument in LandingZoneResources to a newly defined `AKSCluster`, which includes both a name and a map of relevant tags (in this case aks-cost-vpa-enabled)
### Why
This is a necessary step to pass the cost saving flag for VPA from Landing Zone to WDS on startup. 
Note: passing tag modeled after this PR https://github.com/DataBiosphere/leonardo/pull/3614

## Testing these changes

### What to test

- <!-- Test case 1 -->

<!-- ### Test data -->

### Who tested and where

- [ ] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [ ] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
