### PR TITLE
IA-4673 fix metrics name

### DIFF
--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpSamDAO.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpSamDAO.scala
@@ -168,7 +168,7 @@ class HttpSamDAO[F[_]](httpClient: Client[F],
     ev: Ask[F, TraceId]
   ): F[Set[SamRole]] = for {
     ctx <- ev.ask
-    _ <- metrics.incrementCounter(s"sam/getRoles/${resourceId.resourceId}")
+    _ <- metrics.incrementCounter(s"sam/getRoles/${resourceId.resourceType.asString}")
     resp <- httpClient.expectOr[Set[SamRole]](
       Request[F](
         method = Method.GET,


### PR DESCRIPTION
This metrics name is wrong becuz it'll generate individual metrics that looks like `leonardo_sam_getRoles_03f93f45_9343_4c04_bca9_eae1c9931ef4_count_total`, which can't be aggregated meaningfully 

<!-- Welcome to your Leonardo pull request! -->
<!-- Contributor guidelines: https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md -->

__Jira ticket__: https://broadworkbench.atlassian.net/browse/IA-4673

<!-- ## Dependencies -->
<!-- Include any dependent tickets and describe the relationship. Include any other relevant Jira tickets. -->

## Summary of changes

<!-- Please give an abridged version of the ticket description here and/or fill out the following fields. -->

### What

-

### Why

-

## Testing these changes

### What to test

- <!-- Test case 1 -->

<!-- ### Test data -->

### Who tested and where

- [ ] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [ ] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
