### PR TITLE
[IA-4639] Set HttpOnly flag

### DIFF
--- a/http/src/main/resources/init-resources/cluster-site-gce.conf
+++ b/http/src/main/resources/init-resources/cluster-site-gce.conf
@@ -34,7 +34,7 @@
     # Append SameSite=None to cookies set by RStudio. This is required by some browsers because we
     # render RStudio in an iframe. There does not appear to be a way within RStudio to do this, hence
     # doing it in the proxy.
-    Header edit Set-Cookie ^(.*)$ $1;Secure;SameSite=None; HttpOnly "expr=%{REQUEST_URI} =~ m#/proxy/[^/]*/[^/]*/rstudio/.*#"
+    Header edit Set-Cookie ^(.*)$ $1;Secure;SameSite=None;HttpOnly "expr=%{REQUEST_URI} =~ m#/proxy/[^/]*/[^/]*/rstudio/.*#"
 
     ####################
     # Welder

--- a/http/src/main/resources/init-resources/cluster-site-gce.conf
+++ b/http/src/main/resources/init-resources/cluster-site-gce.conf
@@ -34,7 +34,7 @@
     # Append SameSite=None to cookies set by RStudio. This is required by some browsers because we
     # render RStudio in an iframe. There does not appear to be a way within RStudio to do this, hence
     # doing it in the proxy.
-    Header edit Set-Cookie ^(.*)$ $1;Secure;SameSite=None "expr=%{REQUEST_URI} =~ m#/proxy/[^/]*/[^/]*/rstudio/.*#"
+    Header edit Set-Cookie ^(.*)$ $1;Secure;SameSite=None; HttpOnly "expr=%{REQUEST_URI} =~ m#/proxy/[^/]*/[^/]*/rstudio/.*#"
 
     ####################
     # Welder

--- a/http/src/main/resources/init-resources/cluster-site.conf
+++ b/http/src/main/resources/init-resources/cluster-site.conf
@@ -55,7 +55,7 @@
     # Append SameSite=None to cookies set by RStudio. This is required by some browsers because we
     # render RStudio in an iframe. There does not appear to be a way within RStudio to do this, hence
     # doing it in the proxy.
-    Header edit Set-Cookie ^(.*)$ $1;Secure;SameSite=None "expr=%{REQUEST_URI} =~ m#/proxy/[^/]*/[^/]*/rstudio/.*#"
+    Header edit Set-Cookie ^(.*)$ $1;Secure;SameSite=None; HttpOnly "expr=%{REQUEST_URI} =~ m#/proxy/[^/]*/[^/]*/rstudio/.*#"
 
     ####################
     # Welder

--- a/http/src/main/resources/init-resources/cluster-site.conf
+++ b/http/src/main/resources/init-resources/cluster-site.conf
@@ -55,7 +55,7 @@
     # Append SameSite=None to cookies set by RStudio. This is required by some browsers because we
     # render RStudio in an iframe. There does not appear to be a way within RStudio to do this, hence
     # doing it in the proxy.
-    Header edit Set-Cookie ^(.*)$ $1;Secure;SameSite=None; HttpOnly "expr=%{REQUEST_URI} =~ m#/proxy/[^/]*/[^/]*/rstudio/.*#"
+    Header edit Set-Cookie ^(.*)$ $1;Secure;SameSite=None;HttpOnly "expr=%{REQUEST_URI} =~ m#/proxy/[^/]*/[^/]*/rstudio/.*#"
 
     ####################
     # Welder

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/CookieSupport.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/CookieSupport.scala
@@ -41,13 +41,13 @@ object CookieSupport {
     RawHeader(
       name = "Set-Cookie",
       value =
-        s"$tokenCookieName=${userInfo.accessToken.token}; Max-Age=${userInfo.tokenExpiresIn.toString}; Path=/; Secure; SameSite=None"
+        s"$tokenCookieName=${userInfo.accessToken.token}; Max-Age=${userInfo.tokenExpiresIn.toString}; Path=/; Secure; SameSite=None; HttpOnly"
     )
 
   private def buildRawUnsetCookie(): RawHeader =
     RawHeader(
       name = "Set-Cookie",
-      value = s"$tokenCookieName=unset; expires=Thu, 01 Jan 1970 00:00:00 GMT; Path=/; Secure; SameSite=None"
+      value = s"$tokenCookieName=unset; expires=Thu, 01 Jan 1970 00:00:00 GMT; Path=/; Secure; SameSite=None; HttpOnly"
     )
 
 }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/BuildHelmChartValues.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/BuildHelmChartValues.scala
@@ -374,7 +374,7 @@ private[leonardo] object BuildHelmChartValues {
       raw"""ingress.annotations.nginx\.ingress\.kubernetes\.io/auth-tls-secret=${namespaceName.value}/ca-secret""",
       raw"""ingress.annotations.nginx\.ingress\.kubernetes\.io/proxy-redirect-to=${leoProxyhost}${ingressPath}""",
       raw"""ingress.annotations.nginx\.ingress\.kubernetes\.io/rewrite-target=/${rewriteTarget}""",
-      raw"""ingress.annotations.nginx\.ingress\.kubernetes\.io/proxy-cookie-path=/ "/; Secure; SameSite=None"""",
+      raw"""ingress.annotations.nginx\.ingress\.kubernetes\.io/proxy-cookie-path=/ "/; Secure; SameSite=None; HttpOnly"""",
       raw"""ingress.host=${k8sProxyHostString}""",
       raw"""ingress.tls[0].secretName=tls-secret""",
       raw"""ingress.tls[0].hosts[0]=${k8sProxyHostString}"""

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/TestLeoRoutes.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/TestLeoRoutes.scala
@@ -257,7 +257,7 @@ trait TestLeoRoutes {
     val replaced =
       cookieMaxAgeRegex.replaceAllIn(setCookie.get.value, m => s"Max-Age=${roundUpToNearestTen(m.group(1).toLong)};")
 
-    replaced shouldBe s"${expectedCookie.name}=${expectedCookie.value}; Max-Age=${age.toString}; Path=/; Secure; SameSite=None"
+    replaced shouldBe s"${expectedCookie.name}=${expectedCookie.value}; Max-Age=${age.toString}; Path=/; Secure; SameSite=None; HttpOnly"
   }
 
   protected def validateUnsetRawCookie(setCookie: Option[HttpHeader],
@@ -265,6 +265,6 @@ trait TestLeoRoutes {
   ): Unit = {
     setCookie shouldBe defined
     setCookie.get.name shouldBe "Set-Cookie"
-    setCookie.get.value shouldBe s"${tokenName}=unset; expires=Thu, 01 Jan 1970 00:00:00 GMT; Path=/; Secure; SameSite=None"
+    setCookie.get.value shouldBe s"${tokenName}=unset; expires=Thu, 01 Jan 1970 00:00:00 GMT; Path=/; Secure; SameSite=None; HttpOnly"
   }
 }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/BuildHelmChartValuesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/BuildHelmChartValuesSpec.scala
@@ -313,7 +313,7 @@ class BuildHelmChartValuesSpec extends AnyFlatSpecLike with LeonardoTestSuite {
       """ingress.annotations.nginx\.ingress\.kubernetes\.io/auth-tls-secret=ns/ca-secret,""" +
       """ingress.annotations.nginx\.ingress\.kubernetes\.io/proxy-redirect-to=https://leo/proxy/google/v1/apps/dsp-leo-test1/app1/app,""" +
       """ingress.annotations.nginx\.ingress\.kubernetes\.io/rewrite-target=/$2,""" +
-      """ingress.annotations.nginx\.ingress\.kubernetes\.io/proxy-cookie-path=/ "/; Secure; SameSite=None",""" +
+      """ingress.annotations.nginx\.ingress\.kubernetes\.io/proxy-cookie-path=/ "/; Secure; SameSite=None; HttpOnly",""" +
       """ingress.host=1455694897.jupyter.firecloud.org,""" +
       """ingress.tls[0].secretName=tls-secret,""" +
       """ingress.tls[0].hosts[0]=1455694897.jupyter.firecloud.org,""" +
@@ -369,7 +369,7 @@ class BuildHelmChartValuesSpec extends AnyFlatSpecLike with LeonardoTestSuite {
       """ingress.annotations.nginx\.ingress\.kubernetes\.io/auth-tls-secret=ns/ca-secret,""" +
       """ingress.annotations.nginx\.ingress\.kubernetes\.io/proxy-redirect-to=https://leo/proxy/google/v1/apps/dsp-leo-test1/app1/app,""" +
       """ingress.annotations.nginx\.ingress\.kubernetes\.io/rewrite-target=/$2,""" +
-      """ingress.annotations.nginx\.ingress\.kubernetes\.io/proxy-cookie-path=/ "/; Secure; SameSite=None",""" +
+      """ingress.annotations.nginx\.ingress\.kubernetes\.io/proxy-cookie-path=/ "/; Secure; SameSite=None; HttpOnly",""" +
       """ingress.host=1455694897.jupyter.firecloud.org,""" +
       """ingress.tls[0].secretName=tls-secret,""" +
       """ingress.tls[0].hosts[0]=1455694897.jupyter.firecloud.org,""" +


### PR DESCRIPTION
<!-- Welcome to your Leonardo pull request! -->
<!-- Contributor guidelines: https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md -->

__Jira ticket__: https://broadworkbench.atlassian.net/browse/IA-4639

<!-- ## Dependencies -->
<!-- Include any dependent tickets and describe the relationship. Include any other relevant Jira tickets. -->

## Summary of changes

<!-- Please give an abridged version of the ticket description here and/or fill out the following fields. -->

### What

- Adding httpOnly flag to the leoToken cookie

### Why

> Because Leo is launching apps that allow for arbitrary compute, it is important to protect the token value from being stolen through XSS or other attacks. 

## Testing these changes

### What to test

- <!-- Test case 1 -->

<!-- ### Test data -->

### Who tested and where

- [ ] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [ ] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
