### PR TITLE
IA-4747 update chart locations for apps

### DIFF
--- a/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changelog.xml
+++ b/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changelog.xml
@@ -110,4 +110,5 @@
     <include file="changesets/20231002_drop_columns_in_nodepool_table.xml" relativeToChangelogFile="true" />
     <include file="changesets/20231002_drop_namespace_table.xml" relativeToChangelogFile="true" />
     <include file="changesets/20231030_add_replica_to_app_table.xml" relativeToChangelogFile="true" />
+    <include file="changesets/20231214_update_chart_location.xml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/20231214_update_chart_location.xml
+++ b/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/20231214_update_chart_location.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog logicalFilePath="leonardo" xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+    <changeSet logicalFilePath="leonardo" author="bmorgan" id="update-chart-location">
+        <sql dbms="mysql">UPDATE APP
+                          SET chart = REPLACE(chart, '/leonardo/', 'terra-helm/')
+                          WHERE appType IN ('WDS','CROMWELL_RUNNER_APP','WORKFLOWS_APP','CROMWELL');</sql>
+    </changeSet>
+</databaseChangeLog>


### PR DESCRIPTION
__Jira ticket__: https://broadworkbench.atlassian.net/browse/IA-4747

## Summary of changes
Adds a liquibase migration to change the chart location for existing apps from the local file directory to the remote terra-helm repository.

### What

-

### Why

- https://github.com/DataBiosphere/leonardo/pull/3987 changed app install (and upgrade!) to pull charts from remote instead of from a local cache.  However, we failed to update the chart location stored in the APP table of the database for already existing apps.  Therefore, when any of those apps are upgraded, helm attempts to pull the chart from the local cache which does not exist anymore.

## Testing these changes

### What to test

- <!-- Test case 1 -->

<!-- ### Test data -->

### Who tested and where

- [ ] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [x] I validated this change by deploying it to my bee and upgrading a WDS.
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
