### PR TITLE
[IA-4755] Forbid single quotes in params passed to SQL queries

### DIFF
--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterpSpec.scala
@@ -861,6 +861,26 @@ class RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
     res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
+  it should "list runtimes fails with corrupt label parameters" taggedAs SlickPlainQueryTest in isolatedDbTest {
+    val userInfo = UserInfo(OAuth2BearerToken(""),
+                            WorkbenchUserId("userId"),
+                            WorkbenchEmail("user1@example.com"),
+                            0
+    ) // this email is allowlisted
+
+    val res = for {
+      samResource1 <- IO(RuntimeSamResourceId(UUID.randomUUID.toString))
+      samResource2 <- IO(RuntimeSamResourceId(UUID.randomUUID.toString))
+      runtime1 <- IO(makeCluster(1).copy(samResource = samResource1).save())
+      _ <- IO(makeCluster(2).copy(samResource = samResource2).save())
+      _ <- labelQuery.save(runtime1.id, LabelResourceType.Runtime, "foo", "bar").transaction
+      _ <- runtimeService.listRuntimes(userInfo, None, Map("foo" -> "single'quote"))
+    } yield ()
+
+    the[BadRequestException] thrownBy {
+      res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
+    }
+  }
   // See https://broadworkbench.atlassian.net/browse/PROD-440
   // AoU relies on the ability for project owners to list other users' runtimes.
   it should "list runtimes belonging to other users" taggedAs SlickPlainQueryTest in isolatedDbTest {

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeV2ServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeV2ServiceInterpSpec.scala
@@ -2099,49 +2099,6 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
     res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
-  it should "list runtimes fails with invalid parameters" taggedAs SlickPlainQueryTest in isolatedDbTest {
-    val runtimeId1 = RuntimeSamResourceId(UUID.randomUUID.toString)
-    val runtimeId2 = RuntimeSamResourceId(UUID.randomUUID.toString)
-    val workspaceId1 = WorkspaceId(UUID.randomUUID)
-    val userInfo = mockUserInfo("karen@styx.hel")
-    val mockAuthProvider = mockAuthorize(
-      userInfo,
-      // can read all runtimes
-      Set(runtimeId1, runtimeId2),
-      Set.empty,
-      // can read all workspaces
-      Set(WorkspaceResourceSamResourceId(workspaceId1))
-    )
-    val testService = makeInterp(authProvider = mockAuthProvider)
-    val res = for {
-      samResource1 <- IO(runtimeId1)
-      samResource2 <- IO(runtimeId2)
-      runtime1 <- IO(
-        makeCluster(1)
-          .copy(samResource = samResource1, workspaceId = Some(workspaceId1))
-          .save()
-      )
-      _ <- setRuntimetoDeleted(workspaceId1, runtime1.runtimeName)
-
-      _ <- IO(makeCluster(2).copy(samResource = samResource2, workspaceId = Some(workspaceId1)).save())
-      _ <- labelQuery.save(runtime1.id, LabelResourceType.Runtime, "foo", "bar").transaction
-      _ <- testService.listRuntimes(userInfo,
-                                    None,
-                                    None,
-                                    Map("foo has single quote ' here" -> "not-bar", "includeDeleted" -> "true")
-      ) // miss value
-      _ <- testService.listRuntimes(userInfo,
-                                    None,
-                                    None,
-                                    Map("not-foo" -> "bar has single quote ' here", "includeDeleted" -> "true")
-      ) // miss key
-    } yield ()
-
-    the[BadRequestException] thrownBy {
-      res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
-    }
-  }
-
   it should "list runtimes filtered by creator" taggedAs SlickPlainQueryTest in isolatedDbTest {
     val wsmId1 = WsmResourceSamResourceId(WsmControlledResourceId(UUID.randomUUID))
     val runtimeId2 = RuntimeSamResourceId(UUID.randomUUID.toString)
@@ -2274,6 +2231,15 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
       .toOption
       .get
       .isInstanceOf[ParseLabelsException] shouldBe true
+
+    runtimeV2Service
+      .listRuntimes(userInfo, None, None, Map("_labels" -> "a=a'a,b'b=b"))
+      .attempt
+      .unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
+      .swap
+      .toOption
+      .get
+      .isInstanceOf[BadRequestException] shouldBe true
   }
 
   it should "update date accessed when user has permission" in isolatedDbTest {


### PR DESCRIPTION
<!-- Welcome to your Leonardo pull request! -->
<!-- Contributor guidelines: https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md -->

__Jira ticket__: Child of https://broadworkbench.atlassian.net/browse/IA-4626

<!-- ## Dependencies -->
<!-- Include any dependent tickets and describe the relationship. Include any other relevant Jira tickets. -->

## Summary of changes

Quick and dirty patch to SQL hole in RuntimeV2Service: forbid single quotes in the label parameters' key-value pairs.

## Testing these changes

### What to test

- Try submitting requests with single quotes in label fields
- Try submitting requests in general to assert no regression issues

<!-- ### Test data -->

### Who tested and where

- [ ] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [ ] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
