### PR TITLE
WX-1416

### DIFF
--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -220,7 +220,6 @@ azure {
     }
   }
 
-
   # We need the leo azure entity for this
   app-registration {
     client-id = ""

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -230,7 +230,7 @@ azure {
 
    coa-app-config {
      instrumentation-enabled = false
-     chart-name = "cromwell-helm/cromwell-on-azure"
+     chart-name = "coa-helm/cromwell-on-azure"
      chart-version = "0.2.397"
      release-name-suffix = "coa-rls"
      namespace-name-suffix = "coa-ns"

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/KubernetesTestData.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/KubernetesTestData.scala
@@ -57,7 +57,7 @@ object KubernetesTestData {
   val ingressChartVersion = ChartVersion("1.41.3")
   val ingressChart = Chart(ingressChartName, ingressChartVersion)
 
-  val coaChartName = ChartName("cromwell-helm/cromwell-on-azure")
+  val coaChartName = ChartName("coa-helm/cromwell-on-azure")
   val coaChartVersion = ChartVersion("0.2.397")
 
   val coaChart = Chart(coaChartName, coaChartVersion)

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/ConfigReaderSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/ConfigReaderSpec.scala
@@ -75,7 +75,7 @@ class ConfigReaderSpec extends AnyFlatSpec with Matchers {
         HttpWsmDaoConfig(Uri.unsafeFromString("https://localhost:8000")),
         AzureAppRegistrationConfig(ClientId(""), ClientSecret(""), ManagedAppTenantId("")),
         CoaAppConfig(
-          ChartName("cromwell-helm/cromwell-on-azure"),
+          ChartName("coa-helm/cromwell-on-azure"),
           ChartVersion("0.2.397"),
           ReleaseNameSuffix("coa-rls"),
           NamespaceNameSuffix("coa-ns"),


### PR DESCRIPTION
<!-- Welcome to your Leonardo pull request! -->
<!-- Contributor guidelines: https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md -->

__Jira ticket__: https://broadworkbench.atlassian.net/browse/WX-1416

## Summary of changes
- Change chart names for azure cromwell app from `cromwell-helm/cromwell-on-azure` to `coa-helm/cromwell-on-azure`

### Why
- When trying to upgrade `CROMWELL` apps using the `admin/v2/apps/update` endpoint, the upgraded app gets put into an `ERROR` state. 
- When listing apps for the workspace that was upgraded, the failed updated app has the following error message: 
  `        "errorMessage": "An error occurred with a kubernetes operation from source app during action updateApp. \nOriginal message: Error updating Azure app with id 5345 and cloudContext fad90753-2022-4456-9b0a-c7e5b934e408/f557c728-871d-408c-a28b-eb6b2141a087/devTestingMrg20230921: chart \"cromwell-on-azure\" matching 0.2.397 not found in terra-helm index. (try 'helm repo update'): no chart name found",` 
- I believe that leo is is looking for the wrong helm chart for cromwell on azure. The helm chart in question is actually in the [`coa-helm` directory of cromwhelm](https://github.com/broadinstitute/cromwhelm/tree/main/coa-helm), and not the `cromwell` directory. 
- It's possible that this bug was introduced in [this commit](https://github.com/DataBiosphere/leonardo/commit/12ea795fc68dc7d220a56290a6289def5dfb8c82#diff-9024d8d3f171d065fa3b61dbc7dc2c56bdc6587644fde470722fdc92e7068f61) 

## Testing these changes
- Currently working on testing this in my bee...