### PR TITLE
RW-11593 adding -N so that the file isn't duplicated in gce-init script

### DIFF
--- a/http/src/main/resources/init-resources/gce-init.sh
+++ b/http/src/main/resources/init-resources/gce-init.sh
@@ -478,7 +478,7 @@ if [ ! -z "$JUPYTER_DOCKER_IMAGE" ] ; then
 
   # Copy gitignore into jupyter container
 
-  docker exec $JUPYTER_SERVER_NAME /bin/bash -c "wget https://raw.githubusercontent.com/DataBiosphere/terra-docker/045a139dbac19fbf2b8c4080b8bc7fff7fc8b177/terra-jupyter-aou/gitignore_global"
+  docker exec $JUPYTER_SERVER_NAME /bin/bash -c "wget -N https://raw.githubusercontent.com/DataBiosphere/terra-docker/045a139dbac19fbf2b8c4080b8bc7fff7fc8b177/terra-jupyter-aou/gitignore_global"
 
   # Install nbstripout and set gitignore in Git Config
 


### PR DESCRIPTION
https://precisionmedicineinitiative.atlassian.net/browse/RW-11593

Notice that we're downloading the same file multiple times if users are reusing the same disk.

Something like
```
# ls
UKB_AOU        gitignore_global    gitignore_global.10	gitignore_global.2  gitignore_global.4	gitignore_global.6  gitignore_global.8	jupyter.log  packages	 workspaces_playground
cromwell.conf  gitignore_global.1  gitignore_global.11	gitignore_global.3  gitignore_global.5	gitignore_global.7  gitignore_global.9	lost+found   workspaces
```

This PR makes it so that the `wget` cmd will download and overwrite the file only if the server has a newer version

<!-- Welcome to your Leonardo pull request! -->
<!-- Contributor guidelines: https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md -->

__Jira ticket__: https://broadworkbench.atlassian.net/browse/[ticket_number]

<!-- ## Dependencies -->
<!-- Include any dependent tickets and describe the relationship. Include any other relevant Jira tickets. -->

## Summary of changes

<!-- Please give an abridged version of the ticket description here and/or fill out the following fields. -->

### What

-

### Why

-

## Testing these changes

### What to test

- <!-- Test case 1 -->

<!-- ### Test data -->

### Who tested and where

- [ ] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [ ] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
