### PR TITLE
[IA-4770] Fix docker test

### DIFF
--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpDockerDAOSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpDockerDAOSpec.scala
@@ -107,7 +107,7 @@ class HttpDockerDAOSpec extends AnyFlatSpec with Matchers with BeforeAndAfterAll
       val res = for {
         ctx <- appContext.ask[AppContext]
         response <- dockerDAO.detectTool(image, None, ctx.now).attempt
-      } yield response shouldBe Left(InvalidImage(ctx.traceId, image, None))
+      } yield response.left.map(t => t.asInstanceOf[InvalidImage].image) shouldBe Left(image)
       res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 


### PR DESCRIPTION
The error message was a bit funny, there is no actual diff between the two things printed, so it seems to be something wonky with scala equality. Rather than smash my head against why, I just extracted the field of the case class that is relevant to the test and it passes (the excluded fields are a `None` and the trace id). I'd rather not debate the finer points of syntax and equality checking, and get this in ASAP since it is failing on every PR and blocking any changes to Leo.

In particular, I'm trying to get a change in that fixes a bug that is affecting the development/passing of app e2e tests [here](https://github.com/DataBiosphere/leonardo/pull/4084)

Original error message:
```
[info] - should detect invalid dockerhub image if image doesn't have proper environment variables set *** FAILED ***
[info]   Left(org.broadinstitute.dsde.workbench.leonardo.model.InvalidImage: Image library/nginx:latest doesn't have JUPYTER_HOME or RSTUDIO_HOME environment variables defined. Make sure your custom image extends from one of the Terra base images.) was not equal to Left(org.broadinstitute.dsde.workbench.leonardo.model.InvalidImage: Image library/nginx:latest doesn't have JUPYTER_HOME or RSTUDIO_HOME environment variables defined. Make sure your custom image extends from one of the Terra base images.) (HttpDockerDAOSpec.scala:110)
```

`Left(org.broadinstitute.dsde.workbench.leonardo.model.InvalidImage: Image library/nginx:latest doesn't have JUPYTER_HOME or RSTUDIO_HOME environment variables defined. Make sure your custom image extends from one of the Terra base images.)`
was not equal to 
`Left(org.broadinstitute.dsde.workbench.leonardo.model.InvalidImage: Image library/nginx:latest doesn't have JUPYTER_HOME or RSTUDIO_HOME environment variables defined. Make sure your custom image extends from one of the Terra base images.)`