### PR TITLE
Adjust script output to suggest non-split-tunnel.

### DIFF
--- a/local/depends.sh
+++ b/local/depends.sh
@@ -96,7 +96,7 @@ render_configs() {
 
 	local _cluster=terra-dev
 	echo "Configuring access to ${_cluster}..."
-	echo "(Note: VPN is required when working remotely)"
+	echo "(Note: non-split-tunnel VPN is required when working remotely)"
 	gcloud container clusters get-credentials --zone us-central1-a --project broad-dsde-dev ${_cluster}
 
 	# Get CloudSQL proxy GOOGLE_PROJECT and CLOUDSQL_ZONE from dev as defaults,


### PR DESCRIPTION
Clarify that non-split-tunnel must be used for the script to work correctly.

This was discovered while doing initial setup in prep for [IA-4736](https://broadworkbench.atlassian.net/browse/IA-4736) and intends to clarify steps required to set up the environment for the first time.

[IA-4736]: https://broadworkbench.atlassian.net/browse/IA-4736?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ