### PR TITLE
RW-11643 Don't filter out apps with workspaceId

### DIFF
--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/DateAccessedUpdater.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/DateAccessedUpdater.scala
@@ -54,7 +54,10 @@ class DateAccessedUpdater[F[_]](
           .transaction
           .void
     case UpdateTarget.App(appName) =>
-      appQuery.updateDateAccessed(appName, msg.cloudContext, msg.dateAccessd).transaction.void
+      metrics.incrementCounter("appAccessCount") >> appQuery
+        .updateDateAccessed(appName, msg.cloudContext, msg.dateAccessd)
+        .transaction
+        .void
   }
 }
 


### PR DESCRIPTION
https://precisionmedicineinitiative.atlassian.net/browse/RW-11643

There's recent change that we started passing workspaceId for AoU created apps. So the current query doesn't work anymore. 

This PR does the join to filter on `cloudContext`.

Actual prepared statement generated by Slick:
```
{"@timestamp":"2024-01-18T18:35:41.374558Z","@version":"1","logger_name":"slick.jdbc.JdbcBackend.statement","thread_name":"mysql.db-27","severity":"DEBUG","serviceContext":null,"message":"Preparing statement: \n            UPDATE APP\n            JOIN NODEPOOL ON APP.nodepoolId = NODEPOOL.id\n            JOIN KUBERNETES_CLUSTER ON KUBERNETES_CLUSTER.id = NODEPOOL.clusterId\n            SET APP.dateAccessed = ?\n            where APP.appName = ? AND cloudContext = ?\n         "}
{"@timestamp":"2024-01-18T18:35:41.381866Z","@version":"1","logger_name":"slick.jdbc.JdbcBackend.benchmark","thread_name":"mysql.db-27","severity":"DEBUG","serviceContext":null,"message":"Execution of prepared statement took 4ms"}
```

<!-- Welcome to your Leonardo pull request! -->
<!-- Contributor guidelines: https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md -->

__Jira ticket__: https://broadworkbench.atlassian.net/browse/[ticket_number]

<!-- ## Dependencies -->
<!-- Include any dependent tickets and describe the relationship. Include any other relevant Jira tickets. -->

## Summary of changes

<!-- Please give an abridged version of the ticket description here and/or fill out the following fields. -->

### What

-

### Why

-

## Testing these changes

### What to test

- <!-- Test case 1 -->

<!-- ### Test data -->

### Who tested and where

- [ ] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [ ] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
