### PR TITLE
RW-11643 add nonDeleted filter

### DIFF
--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/LeoProfile.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/LeoProfile.scala
@@ -24,7 +24,7 @@ import org.broadinstitute.dsde.workbench.leonardo.SamResourceId._
 import org.broadinstitute.dsde.workbench.model.google.{parseGcsPath, GcsPath, GoogleProject}
 import org.broadinstitute.dsp.Release
 import org.http4s.Uri
-import slick.jdbc.MySQLProfile
+import slick.jdbc.{MySQLProfile, SetParameter}
 import slick.jdbc.MySQLProfile.api._
 
 import java.nio.file.{Path, Paths}
@@ -310,6 +310,9 @@ private[leonardo] object LeoProfile extends MySQLProfile {
           AppControlledResourceStatus.stringToObject
             .getOrElse(s, throw ColumnDecodingException(s"invalid app controlled resource status ${s}"))
       )
+
+    implicit val instantSetParameter: SetParameter[Instant] =
+      SetParameter.SetTimestamp.contramap(instant => java.sql.Timestamp.from(instant))
   }
 
   case class ColumnDecodingException(message: String) extends Exception

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/AppComponentSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/AppComponentSpec.scala
@@ -7,7 +7,6 @@ import org.broadinstitute.dsde.workbench.leonardo.CommonTestData._
 import org.broadinstitute.dsde.workbench.leonardo.SamResourceId.AppSamResourceId
 import org.broadinstitute.dsde.workbench.leonardo.{AppName, AppStatus, AppType, NodepoolLeoId}
 import org.broadinstitute.dsde.workbench.leonardo.TestUtils._
-
 import scala.concurrent.ExecutionContext.Implicits.global
 import org.scalatest.flatspec.AnyFlatSpecLike
 
@@ -81,15 +80,25 @@ class AppComponentSpec extends AnyFlatSpecLike with TestComponent {
 
     val app1 = makeApp(1, savedNodepool1.id)
     val savedApp1 = app1.save()
+
+    val deletedApp = makeApp(1, savedNodepool1.id).copy(auditInfo = auditInfo.copy(destroyedDate = Some(Instant.now())),
+                                                        status = AppStatus.Deleted
+    )
+    val savedDeletedApp = deletedApp.save()
+
     val dateAccessed = Instant.ofEpochMilli(2000)
 
-    savedApp1.status shouldEqual app1.status
     dbFutureValue(appQuery.updateDateAccessed(app1.appName, savedCluster1.cloudContext, dateAccessed)) shouldEqual 1
 
     val getApp = dbFutureValue {
-      KubernetesServiceDbQueries.getActiveFullAppByName(savedCluster1.cloudContext, savedApp1.appName)
+      KubernetesServiceDbQueries.getFullAppById(savedCluster1.cloudContext, savedApp1.id)
     }
-    getApp.get.app.auditInfo.dateAccessed shouldEqual dateAccessed
+    getApp.get.app.auditInfo.dateAccessed shouldBe dateAccessed
+
+    val getDeletedApp = dbFutureValue {
+      KubernetesServiceDbQueries.getFullAppById(savedCluster1.cloudContext, savedDeletedApp.id)
+    }
+    getDeletedApp.get.app.auditInfo.dateAccessed should not be dateAccessed
   }
 
   it should "fail to save an app without a nodepool" in isolatedDbTest {


### PR DESCRIPTION
new generated query
```
{"@timestamp":"2024-01-19T16:19:58.462384Z","@version":"1","logger_name":"slick.jdbc.JdbcBackend.statement","thread_name":"mysql.db-37","severity":"DEBUG","serviceContext":null,"message":"Preparing statement: \n            UPDATE APP\n            JOIN NODEPOOL ON APP.nodepoolId = NODEPOOL.id\n            JOIN KUBERNETES_CLUSTER ON KUBERNETES_CLUSTER.id = NODEPOOL.clusterId\n            SET APP.dateAccessed = ?\n            where APP.appName = ? AND\n                  KUBERNETES_CLUSTER.cloudContext = ? AND\n                  APP.destroyedDate = ? AND\n                  APP.status != 'DELETED'\n         "}
{"@timestamp":"2024-01-19T16:19:58.466795Z","@version":"1","logger_name":"slick.jdbc.JdbcBackend.benchmark","thread_name":"mysql.db-37","severity":"DEBUG","serviceContext":null,"message":"Execution of prepared statement took 2ms"}
```

<!-- Welcome to your Leonardo pull request! -->
<!-- Contributor guidelines: https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md -->

__Jira ticket__: https://broadworkbench.atlassian.net/browse/[ticket_number]

<!-- ## Dependencies -->
<!-- Include any dependent tickets and describe the relationship. Include any other relevant Jira tickets. -->

## Summary of changes

<!-- Please give an abridged version of the ticket description here and/or fill out the following fields. -->

### What

-

### Why

-

## Testing these changes

### What to test

- <!-- Test case 1 -->

<!-- ### Test data -->

### Who tested and where

- [ ] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [ ] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
