### PR TITLE
[IA-4795] Remove unneeded permission checks from v1 listRuntimes

### DIFF
--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterp.scala
@@ -27,7 +27,6 @@ import org.broadinstitute.dsde.workbench.leonardo.SamResourceId.{
   ProjectSamResourceId,
   RuntimeSamResourceId,
   WorkspaceResourceSamResourceId,
-  WsmResourceSamResourceId
 }
 import org.broadinstitute.dsde.workbench.leonardo.config._
 import org.broadinstitute.dsde.workbench.leonardo.dao.DockerDAO
@@ -39,8 +38,6 @@ import org.broadinstitute.dsde.workbench.leonardo.model.SamResourceAction.{
   runtimeSamResourceAction,
 // do not remove `workspaceSamResourceAction`; it is implicit
   workspaceSamResourceAction,
-// do not remove `wsmResourceSamResourceAction`; it is implicit
-  wsmResourceSamResourceAction,
 // do not remove `AppSamResourceAction`; it is implicit
   AppSamResourceAction
 }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterp.scala
@@ -26,7 +26,7 @@ import org.broadinstitute.dsde.workbench.leonardo.SamResourceId.{
   PersistentDiskSamResourceId,
   ProjectSamResourceId,
   RuntimeSamResourceId,
-  WorkspaceResourceSamResourceId,
+  WorkspaceResourceSamResourceId
 }
 import org.broadinstitute.dsde.workbench.leonardo.config._
 import org.broadinstitute.dsde.workbench.leonardo.dao.DockerDAO


### PR DESCRIPTION
This method does not need checks for workspace permissions or wsm resource permissions, as these relate to v2 runtimes. Google runtimes are created using the Sam resource types google-project and notebook-cluster, and permission checks on other resource types are irrelevant.

<!-- Welcome to your Leonardo pull request! -->
<!-- Contributor guidelines: https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md -->

__Jira ticket__: https://broadworkbench.atlassian.net/browse/IA-4795

<!-- ## Dependencies -->
<!-- Include any dependent tickets and describe the relationship. Include any other relevant Jira tickets. -->

## Testing these changes

### What to test

- CRUD operations on google workspaces and Azure workspace; verify all appear and function as expected

<!-- ### Test data -->

### Who tested and where

- [x] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [x] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
