### PR TITLE
AJ-1550: bump listener image and chart

### DIFF
--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -214,7 +214,7 @@ azure {
         minor-version-auto-upgrade = true,
         file-uris = ["https://raw.githubusercontent.com/DataBiosphere/leonardo/52aab3b7f252667f73b23682062ab3e0d9d533b9/http/src/main/resources/init-resources/azure_vm_init_script.sh"]
       }
-      listener-image = "terradevacrpublic.azurecr.io/terra-azure-relay-listeners:bd50dbc"
+      listener-image = "terradevacrpublic.azurecr.io/terra-azure-relay-listeners:ae65380"
     }
   }
 
@@ -412,7 +412,7 @@ azure {
 
   listener-chart-config {
     chart-name = "terra-helm/listener"
-    chart-version = "0.2.0"
+    chart-version = "0.3.0"
   }
 }
 

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/ConfigReaderSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/ConfigReaderSpec.scala
@@ -68,7 +68,7 @@ class ConfigReaderSpec extends AnyFlatSpec with Matchers {
                 "https://raw.githubusercontent.com/DataBiosphere/leonardo/52aab3b7f252667f73b23682062ab3e0d9d533b9/http/src/main/resources/init-resources/azure_vm_init_script.sh"
               )
             ),
-            "terradevacrpublic.azurecr.io/terra-azure-relay-listeners:bd50dbc",
+            "terradevacrpublic.azurecr.io/terra-azure-relay-listeners:ae65380",
             VMCredential(username = "username", password = "password")
           )
         ),
@@ -220,7 +220,7 @@ class ConfigReaderSpec extends AnyFlatSpec with Matchers {
         ),
         List(AppType.Wds, AppType.WorkflowsApp),
         TdrConfig("https://jade.datarepo-dev.broadinstitute.org"),
-        ListenerChartConfig(ChartName("terra-helm/listener"), ChartVersion("0.2.0"))
+        ListenerChartConfig(ChartName("terra-helm/listener"), ChartVersion("0.3.0"))
       ),
       OidcAuthConfig(
         Uri.unsafeFromString("https://fake"),


### PR DESCRIPTION
<!-- Welcome to your Leonardo pull request! -->
<!-- Contributor guidelines: https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md -->

__Jira ticket__: https://broadworkbench.atlassian.net/browse/AJ-1550

## Summary of changes
* Bump TARL image to [ae653801bfdbc289b48e3255aac9a7e05fa9879f](https://github.com/DataBiosphere/terra-azure-relay-listeners/commit/ae653801bfdbc289b48e3255aac9a7e05fa9879f)
* Bump TARL chart to [`listener-0.3.0`](https://github.com/broadinstitute/terra-helmfile/commit/cbe448fa2a67ed3467d734d8e613a827e09d318d)

### What
The TARL image and chart bumps aim to allow k8s to restart TARL in cases where it runs into a problem starting and attaching to Relay, such as when it encounters a DNS timeout.

The PRs included in this bump are:
1. https://github.com/broadinstitute/terra-helmfile/pull/4992
2. https://github.com/DataBiosphere/terra-azure-relay-listeners/pull/56
3. https://github.com/DataBiosphere/terra-azure-relay-listeners/pull/57

as well as two PRs which should have no impact on runtime:
1. https://github.com/DataBiosphere/terra-azure-relay-listeners/pull/53
2. https://github.com/DataBiosphere/terra-azure-relay-listeners/pull/54

-

### Why
In practice, we've seen recurring e2e test failures which, on the surface, look like WDS failed to start within the test's allowed 10 minutes. Upon digging in, we found that in every failure (15+), WDS started fine but the listener did not, and thus nothing could actually communicate with WDS. This problem likely occurs in production, too.

Allowing k8s to restart the listener pod if it hits an error will hopefully reduce the occurrence of this problem.


-

## Testing these changes

### What to test

- will we see a reduction in "WDS failed to start" errors in e2e tests over time?

<!-- ### Test data -->

### Who tested and where

- [ ] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [ ] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
