### PR TITLE
[IA-4821] Add branch name to leo release tag

### DIFF
--- a/.github/workflows/leo-build-tag-publish-and-run-tests.yml
+++ b/.github/workflows/leo-build-tag-publish-and-run-tests.yml
@@ -108,7 +108,7 @@ jobs:
           inputs: '{
               "repository": "${{ github.event.repository.full_name }}",
               "ref": "${{ needs.init-github-context.outputs.build-branch }}",
-              "leonardo-release-tag": "${{ steps.tag.outputs.tag }}"
+              "leonardo-release-tag": "${{ steps.tag.outputs.tag }}-${{ needs.init-github-context.outputs.build-branch }}"
             }'
 
   report-to-sherlock:


### PR DESCRIPTION
<!-- Welcome to your Leonardo pull request! -->
<!-- Contributor guidelines: https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md -->

__Jira ticket__: https://broadworkbench.atlassian.net/browse/IA-4821

<!-- ## Dependencies -->
<!-- Include any dependent tickets and describe the relationship. Include any other relevant Jira tickets. -->

## Summary of changes

<!-- Please give an abridged version of the ticket description here and/or fill out the following fields. -->

### What

Appends the build branch to the image release tag to make it more easily searchable on GCR

### Why

The move from jenkins to GHA removed the ability to tag the docker image with multiple tags, including the branch name that was very useful for developers when updating their BEEs. The [leonardo build GHA](https://github.com/broadinstitute/terra-github-workflows/blob/main/.github/workflows/leonardo-build.yaml) unfortunately only takes in one tag as an input so we could do:
- This PR that simply appends the name of the branch to the version (pending the syntax is correct)
- Modify the leonardo build GHA to add another tag to the docker image using the build branch name

## Testing these changes

### What to test

- <!-- Test case 1 -->

<!-- ### Test data -->

### Who tested and where

- [ ] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [ ] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
