### PR TITLE
[IA-4825] Get drshub url from helm, not hardcoded reference.conf

### DIFF
--- a/http/src/main/resources/leo.conf
+++ b/http/src/main/resources/leo.conf
@@ -224,3 +224,7 @@ clusterFiles {
   proxyRootCaPem = ${?ROOT_CA_PEM_PATH}
   proxyRootCaKey = ${?ROOT_CA_KEY_PATH}
 }
+
+drs {
+  url = ${?DRS_URL}
+}


### PR DESCRIPTION
<!-- Welcome to your Leonardo pull request! -->
<!-- Contributor guidelines: https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md -->

__Jira ticket__: https://broadworkbench.atlassian.net/browse/IA-4825

<!-- ## Dependencies -->
<!-- Include any dependent tickets and describe the relationship. Include any other relevant Jira tickets. -->

## Summary of changes

<!-- Please give an abridged version of the ticket description here and/or fill out the following fields. -->

### What

- Make sure that the drs url is pulled from leonardo helm values to `leo.conf` and not what is hardcoded in `reference.conf`

### Why

-

## Testing these changes

### What to test

- <!-- Test case 1 -->

<!-- ### Test data -->

### Who tested and where

- [ ] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [ ] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
