### PR TITLE
[TOAZ-341] Cloud-agnostic auth token provider for SAM calls from Leo

### DIFF
--- a/http/project/build.properties
+++ b/http/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.9.7

--- a/http/src/main/resources/leo.conf
+++ b/http/src/main/resources/leo.conf
@@ -156,6 +156,17 @@ auth {
 }
 
 azure {
+  hosting-mode-config{
+      # If true, it is assumed that Leo is hosted on Azure and will use Azure managed identity for authentication.
+      enabled = ${?AZURE_HOSTING_MODE_ENABLED}
+      # valid values are AZURE (Azure Commercial) and AZURE_GOV (Azure Government)
+      azure-environment = ${?AZURE_HOSTING_ENVIRONMENT}
+      managed-identity-auth-config{
+        token-scope = ${?AZURE_MI_TOKEN_SCOPE}
+        token-acquisition-timeout = ${?AZURE_MI_TOKEN_ACQUISITION_TIMEOUT}
+      }
+  }
+
   hail-batch-app-config {
     enabled = ${?HAIL_BATCH_APP_ENABLED}
   }

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -159,6 +159,17 @@ gce {
 }
 
 azure {
+    hosting-mode-config{
+      # If true, it is assumed that Leo is hosted on Azure and will use Azure managed identity for authentication.
+      # setting default to false so current GCP hosting is the default
+      enabled = false
+      azure-environment = "AZURE"
+      managed-identity-auth-config {
+        token-scope = ".default"
+        token-acquisition-timeout = 30
+      }
+  }
+
   wsm {
     uri = "https://localhost:8000"
   }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/auth/AzureCloudAuthTokenProvider.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/auth/AzureCloudAuthTokenProvider.scala
@@ -1,0 +1,49 @@
+package org.broadinstitute.dsde.workbench.leonardo.auth
+
+import cats.effect._
+import cats.syntax.all._
+import com.azure.core.credential.TokenRequestContext
+import com.azure.identity.DefaultAzureCredentialBuilder
+import org.broadinstitute.dsde.workbench.leonardo.config.{AzureEnvironmentConverter, AzureHostingModeConfig}
+
+import java.time.Duration
+
+/***
+ * AzureCloudAuthTokenProvider is a CloudServiceAuthTokenProvider for Azure.
+ * It uses the DefaultAzureCredentialBuilder to get a token for the managed identity.
+ * Supports multiple Azure environments.
+ */
+class AzureCloudAuthTokenProvider[F[_]](config: AzureHostingModeConfig)(implicit F: Async[F])
+    extends CloudServiceAuthTokenProvider[F](CloudProviders.Azure) {
+
+  private val credentialBuilder: DefaultAzureCredentialBuilder =
+    new DefaultAzureCredentialBuilder()
+      .authorityHost(
+        AzureEnvironmentConverter
+          .fromString(config.azureEnvironment)
+          .getActiveDirectoryEndpoint
+      )
+
+  private val tokenRequestContext: TokenRequestContext = {
+    val trc = new TokenRequestContext()
+    trc.addScopes(config.managedIdentityAuthConfig.tokenScope)
+    trc
+  }
+
+  override def getCloudProviderAuthToken: F[CloudToken] = {
+    val token = getManagedIdentityAccessToken
+    token.pure[F]
+  }
+  private def getManagedIdentityAccessToken: CloudToken = {
+    // The desired client id can be set using the env variable AZURE_CLIENT_ID.
+    // If not set, the client ID of the system assigned managed identity will be used.
+    val credentials = credentialBuilder
+      .build()
+
+    val token = credentials
+      .getToken(tokenRequestContext)
+      .block(Duration.ofSeconds(config.managedIdentityAuthConfig.tokenAcquisitionTimeout))
+
+    CloudToken(token.getToken, token.getExpiresAt.toInstant)
+  }
+}

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/auth/AzureCloudAuthTokenProvider.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/auth/AzureCloudAuthTokenProvider.scala
@@ -4,6 +4,7 @@ import cats.effect._
 import cats.syntax.all._
 import com.azure.core.credential.TokenRequestContext
 import com.azure.identity.DefaultAzureCredentialBuilder
+import org.broadinstitute.dsde.workbench.leonardo.CloudProvider
 import org.broadinstitute.dsde.workbench.leonardo.config.{AzureEnvironmentConverter, AzureHostingModeConfig}
 
 import java.time.Duration
@@ -14,7 +15,7 @@ import java.time.Duration
  * Supports multiple Azure environments.
  */
 class AzureCloudAuthTokenProvider[F[_]](config: AzureHostingModeConfig)(implicit F: Async[F])
-    extends CloudServiceAuthTokenProvider[F](CloudProviders.Azure) {
+    extends CloudServiceAuthTokenProvider[F](CloudProvider.Azure) {
 
   private val credentialBuilder: DefaultAzureCredentialBuilder =
     new DefaultAzureCredentialBuilder()

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/auth/CloudAuthTokenProvider.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/auth/CloudAuthTokenProvider.scala
@@ -1,0 +1,67 @@
+package org.broadinstitute.dsde.workbench.leonardo.auth
+
+import cats.effect.{Async, Ref}
+import cats.syntax.all._
+import org.broadinstitute.dsde.workbench.leonardo.config.AzureHostingModeConfig
+import org.broadinstitute.dsde.workbench.leonardo.model.ServiceAccountProviderConfig
+import org.http4s.headers.Authorization
+import org.http4s.{AuthScheme, Credentials}
+
+trait CloudAuthTokenProvider[F[_]] {
+  def getCloudProvider: String
+  def getAuthToken: F[Authorization]
+}
+
+/***
+ * Base class for cloud service auth token providers. Handles token caching and expiration.
+ * @param cloudProvider A string representing the cloud provider (e.g. "gcp", "azure")
+ */
+abstract class CloudServiceAuthTokenProvider[F[_]](cloudProvider: String)(implicit F: Async[F])
+    extends CloudAuthTokenProvider[F] {
+  // A reference to the token, so it can be updated when it expires.
+  private val tokenRef = Ref.unsafe(none[CloudToken])
+
+  override def getCloudProvider: String = cloudProvider
+
+  def getCloudProviderAuthToken: F[CloudToken]
+
+  override def getAuthToken: F[Authorization] =
+    for {
+      cloudTokenOpt <- tokenRef.get
+      now <- F.realTimeInstant
+      validAccessToken <- cloudTokenOpt match {
+        case None =>
+          for {
+            newToken <- getCloudProviderAuthToken
+            _ <- tokenRef.update(_ => Some(newToken))
+          } yield newToken
+        case Some(cloudToken) =>
+          if (cloudToken.expiration.toEpochMilli <= now.toEpochMilli) for {
+            newToken <- getCloudProviderAuthToken
+            _ <- tokenRef.update(_ => Some(newToken))
+          } yield newToken
+          else F.pure(cloudToken)
+      }
+    } yield {
+      val token = validAccessToken.value
+      Authorization(Credentials.Token(AuthScheme.Bearer, token))
+    }
+}
+
+object CloudAuthTokenProvider {
+  def apply[F[_]: Async](hostingModeConfig: AzureHostingModeConfig,
+                         serviceAccountProviderConfig: ServiceAccountProviderConfig
+  ): CloudAuthTokenProvider[F] =
+    if (hostingModeConfig.enabled) {
+      new AzureCloudAuthTokenProvider[F](hostingModeConfig)
+    } else {
+      new GcpCloudAuthTokenProvider[F](serviceAccountProviderConfig)
+    }
+}
+
+final case class CloudToken(value: String, expiration: java.time.Instant)
+
+object CloudProviders {
+  val GCP = "gcp"
+  val Azure = "azure"
+}

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/auth/CloudAuthTokenProvider.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/auth/CloudAuthTokenProvider.scala
@@ -2,26 +2,27 @@ package org.broadinstitute.dsde.workbench.leonardo.auth
 
 import cats.effect.{Async, Ref}
 import cats.syntax.all._
+import org.broadinstitute.dsde.workbench.leonardo.CloudProvider
 import org.broadinstitute.dsde.workbench.leonardo.config.AzureHostingModeConfig
 import org.broadinstitute.dsde.workbench.leonardo.model.ServiceAccountProviderConfig
 import org.http4s.headers.Authorization
 import org.http4s.{AuthScheme, Credentials}
 
 trait CloudAuthTokenProvider[F[_]] {
-  def getCloudProvider: String
+  def getCloudProvider: CloudProvider
   def getAuthToken: F[Authorization]
 }
 
 /***
  * Base class for cloud service auth token providers. Handles token caching and expiration.
- * @param cloudProvider A string representing the cloud provider (e.g. "gcp", "azure")
+ * @param cloudProvider Cloud provider
  */
-abstract class CloudServiceAuthTokenProvider[F[_]](cloudProvider: String)(implicit F: Async[F])
+abstract class CloudServiceAuthTokenProvider[F[_]](cloudProvider: CloudProvider)(implicit F: Async[F])
     extends CloudAuthTokenProvider[F] {
   // A reference to the token, so it can be updated when it expires.
   private val tokenRef = Ref.unsafe(none[CloudToken])
 
-  override def getCloudProvider: String = cloudProvider
+  override def getCloudProvider: CloudProvider = cloudProvider
 
   def getCloudProviderAuthToken: F[CloudToken]
 
@@ -60,8 +61,3 @@ object CloudAuthTokenProvider {
 }
 
 final case class CloudToken(value: String, expiration: java.time.Instant)
-
-object CloudProviders {
-  val GCP = "gcp"
-  val Azure = "azure"
-}

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/auth/GcpCloudAuthTokenProvider.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/auth/GcpCloudAuthTokenProvider.scala
@@ -4,6 +4,7 @@ import cats.effect.Async
 import cats.syntax.all._
 import com.google.api.services.storage.StorageScopes
 import org.broadinstitute.dsde.workbench.google2.credentialResource
+import org.broadinstitute.dsde.workbench.leonardo.CloudProvider
 import org.broadinstitute.dsde.workbench.leonardo.model.ServiceAccountProviderConfig
 
 import scala.jdk.CollectionConverters.SeqHasAsJava
@@ -14,7 +15,7 @@ import scala.jdk.CollectionConverters.SeqHasAsJava
 
  */
 class GcpCloudAuthTokenProvider[F[_]](config: ServiceAccountProviderConfig)(implicit F: Async[F])
-    extends CloudServiceAuthTokenProvider[F](CloudProviders.GCP) {
+    extends CloudServiceAuthTokenProvider[F](CloudProvider.Gcp) {
   // TODO:  The scopes were hardcoded in the previous implementation as well
   // Perhaps we should consider adding them to the configuration.
   private val saScopes = Seq(

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/auth/GcpCloudAuthTokenProvider.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/auth/GcpCloudAuthTokenProvider.scala
@@ -1,0 +1,38 @@
+package org.broadinstitute.dsde.workbench.leonardo.auth
+
+import cats.effect.Async
+import cats.syntax.all._
+import com.google.api.services.storage.StorageScopes
+import org.broadinstitute.dsde.workbench.google2.credentialResource
+import org.broadinstitute.dsde.workbench.leonardo.model.ServiceAccountProviderConfig
+
+import scala.jdk.CollectionConverters.SeqHasAsJava
+
+/***
+ * GcpCloudAuthTokenProvider is a CloudServiceAuthTokenProvider for GCP.
+ * Gets a token using the service account json file and the scopes.
+
+ */
+class GcpCloudAuthTokenProvider[F[_]](config: ServiceAccountProviderConfig)(implicit F: Async[F])
+    extends CloudServiceAuthTokenProvider[F](CloudProviders.GCP) {
+  // TODO:  The scopes were hardcoded in the previous implementation as well
+  // Perhaps we should consider adding them to the configuration.
+  private val saScopes = Seq(
+    "https://www.googleapis.com/auth/userinfo.email",
+    "https://www.googleapis.com/auth/userinfo.profile",
+    StorageScopes.DEVSTORAGE_READ_ONLY
+  )
+  override def getCloudProviderAuthToken: F[CloudToken] =
+    credentialResource(
+      config.leoServiceAccountJsonFile.toAbsolutePath.toString
+    ).use { credentials =>
+      val scopedCredential = credentials.createScoped(saScopes.asJava)
+
+      F.blocking(scopedCredential.refresh())
+        .map(_ =>
+          CloudToken(scopedCredential.getAccessToken.getTokenValue,
+                     scopedCredential.getAccessToken.getExpirationTime.toInstant
+          )
+        )
+    }
+}

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/AzureHostingModeConfig.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/AzureHostingModeConfig.scala
@@ -10,7 +10,7 @@ case class AzureHostingModeConfig(
 
 case class AzureManagedIdentityAuthConfig(
   tokenScope: String,
-  tokenAcquisitionTimeout: Int = 30
+  tokenAcquisitionTimeout: Int = 30 // in seconds
 )
 
 object AzureEnvironmentConverter {

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/AzureHostingModeConfig.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/AzureHostingModeConfig.scala
@@ -1,0 +1,26 @@
+package org.broadinstitute.dsde.workbench.leonardo.config
+
+import com.azure.core.management.AzureEnvironment
+
+case class AzureHostingModeConfig(
+  enabled: Boolean = false, // if true, the app will use Azure for hosting, default is false (GCP)
+  azureEnvironment: String = AzureEnvironmentConverter.Azure,
+  managedIdentityAuthConfig: AzureManagedIdentityAuthConfig
+)
+
+case class AzureManagedIdentityAuthConfig(
+  tokenScope: String,
+  tokenAcquisitionTimeout: Int = 30
+)
+
+object AzureEnvironmentConverter {
+  val Azure: String = "AZURE"
+  val AzureGov: String = "AZURE_GOV"
+
+  def fromString(s: String): AzureEnvironment = s match {
+    case AzureGov => AzureEnvironment.AZURE_US_GOVERNMENT
+    // a bit redundant, but I want to have a explicit case for Azure for clarity, even though it's the default
+    case Azure => AzureEnvironment.AZURE
+    case _     => AzureEnvironment.AZURE
+  }
+}

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
@@ -392,8 +392,7 @@ object Config {
       Uri.unsafeFromString(config.as[String]("samServer")),
       config.getOrElse("petKeyCacheEnabled", true),
       config.getAs[FiniteDuration]("petKeyCacheExpiryTime").getOrElse(60 minutes),
-      config.getAs[Int]("petKeyCacheMaxSize").getOrElse(1000),
-      serviceAccountProviderConfig
+      config.getAs[Int]("petKeyCacheMaxSize").getOrElse(1000)
     )
   }
 
@@ -907,5 +906,4 @@ object Config {
       proxyConfig,
       gkeGalaxyDiskConfig
     )
-
 }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/Boot.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/Boot.scala
@@ -54,7 +54,12 @@ import org.broadinstitute.dsde.workbench.leonardo.app.{
   WdsAppInstall,
   WorkflowsAppInstall
 }
-import org.broadinstitute.dsde.workbench.leonardo.auth.{AuthCacheKey, PetClusterServiceAccountProvider, SamAuthProvider}
+import org.broadinstitute.dsde.workbench.leonardo.auth.{
+  AuthCacheKey,
+  CloudAuthTokenProvider,
+  PetClusterServiceAccountProvider,
+  SamAuthProvider
+}
 import org.broadinstitute.dsde.workbench.leonardo.config.Config._
 import org.broadinstitute.dsde.workbench.leonardo.config.LeoExecutionModeConfig
 import org.broadinstitute.dsde.workbench.leonardo.dao._
@@ -84,6 +89,7 @@ import org.http4s.client.middleware.{Logger => Http4sLogger, Metrics, Retry, Ret
 import org.typelevel.log4cats.StructuredLogger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 import scalacache.caffeine._
+
 import java.net.{InetSocketAddress, SocketException}
 import java.nio.file.Paths
 import java.time.Instant
@@ -407,7 +413,12 @@ object Boot extends IOApp {
       )(_.close)
 
       samDao <- buildHttpClient(sslContext, proxyResolver.resolveHttp4s, Some("leo_sam_client"), true).map(client =>
-        HttpSamDAO[F](client, httpSamDaoConfig, petKeyCache)
+        HttpSamDAO[F](
+          client,
+          httpSamDaoConfig,
+          petKeyCache,
+          CloudAuthTokenProvider[F](ConfigReader.appConfig.azure.hostingModeConfig, serviceAccountProviderConfig)
+        )
       )
       cromwellDao <- buildHttpClient(sslContext, proxyResolver.resolveHttp4s, Some("leo_cromwell_client"), false).map(
         client => new HttpCromwellDAO[F](client)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/ConfigReader.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/ConfigReader.scala
@@ -30,7 +30,8 @@ final case class AzureConfig(
   hailBatchAppConfig: HailBatchAppConfig,
   allowedSharedApps: List[AppType],
   tdr: TdrConfig,
-  listenerChartConfig: ListenerChartConfig
+  listenerChartConfig: ListenerChartConfig,
+  hostingModeConfig: AzureHostingModeConfig
 )
 
 final case class OidcAuthConfig(

--- a/http/src/test/resources/reference.conf
+++ b/http/src/test/resources/reference.conf
@@ -333,6 +333,14 @@ akka.ssl-config {
 }
 
 azure {
+    hosting-mode-config{
+      enabled = false
+      azure-environment = "AZURE"
+      managed-identity-auth-config {
+        token-scope = ".default"
+        token-acquisition-timeout = 30
+      }
+    }
    pubsub-handler {
         create-vm-poll-config {
            initial-delay = 1 seconds

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/auth/CloudServiceAuthTokenProviderSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/auth/CloudServiceAuthTokenProviderSpec.scala
@@ -1,0 +1,113 @@
+package org.broadinstitute.dsde.workbench.leonardo.auth
+import cats.effect.unsafe.implicits.global
+import cats.effect.{Async, IO}
+import org.broadinstitute.dsde.workbench.leonardo.LeonardoTestSuite
+import org.http4s.Credentials
+import org.http4s.headers.Authorization
+import org.scalatest.BeforeAndAfter
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatestplus.mockito.MockitoSugar
+
+import scala.collection.mutable
+
+class CloudServiceAuthTokenProviderSpec
+    extends AnyFlatSpec
+    with LeonardoTestSuite
+    with BeforeAndAfter
+    with MockitoSugar {
+
+  val firstTokenValue = "token1"
+  val secondTokenValue = "token2"
+  val provider = "provider"
+  var tokens: mutable.Stack[CloudToken] = _
+
+  before {
+    tokens = new mutable.Stack[CloudToken]
+
+    val result = for {
+      now <- IO.realTimeInstant
+    } yield {
+      tokens.push(CloudToken(secondTokenValue, now.plusSeconds(10)))
+      tokens.push(CloudToken(firstTokenValue, now.plusSeconds(2)))
+    }
+
+    result.unsafeRunSync()
+  }
+
+  it should "get a new token if call for the first time" in {
+
+    val testProvider = new TestCloudServiceAuthTokenProvider[IO](provider, tokens)
+
+    val result = getTokenAndAssertResult(testProvider, firstTokenValue)
+
+    assertTokenInResultIsValid(result)
+
+  }
+
+  it should "get a new token if the first token is expired" in {
+
+    val testProvider = new TestCloudServiceAuthTokenProvider[IO](provider, tokens)
+
+    val result = getTokenAndAssertResult(testProvider, firstTokenValue)
+
+    assertTokenInResultIsValid(result)
+
+    // wait for the first token to expire
+    Thread.sleep(3 * 1000)
+
+    val result2 = getTokenAndAssertResult(testProvider, secondTokenValue)
+
+    assertTokenInResultIsValid(result2)
+  }
+
+  it should "return the same token if the token is not expired" in {
+
+    val testProvider = new TestCloudServiceAuthTokenProvider[IO](provider, tokens)
+
+    val result = getTokenAndAssertResult(testProvider, firstTokenValue)
+
+    assertTokenInResultIsValid(result)
+
+    // wait for the first token to expire
+    Thread.sleep(3 * 1000)
+
+    val result2 = getTokenAndAssertResult(testProvider, secondTokenValue)
+
+    assertTokenInResultIsValid(result2)
+
+    val result3 = getTokenAndAssertResult(testProvider, secondTokenValue)
+
+    assertTokenInResultIsValid(result3)
+  }
+
+  private def getTokenAndAssertResult(testProvider: TestCloudServiceAuthTokenProvider[IO],
+                                      expectedTokenValue: String
+  ) = {
+    val result2 = testProvider.getAuthToken
+      .map {
+        case Authorization(Credentials.Token(_, value)) => value == expectedTokenValue
+        case _                                          => false
+      }
+      .attempt
+      .unsafeRunSync()
+    result2
+  }
+
+  private def assertTokenInResultIsValid(result: Either[Throwable, Boolean]) =
+    result match {
+      case Left(error)         => fail(s"Unexpected error: $error")
+      case Right(isTokenValid) => assert(isTokenValid)
+    }
+}
+
+/**
+ * A test CloudServiceAuthTokenProvider that returns a fixed token.
+ */
+class TestCloudServiceAuthTokenProvider[F[_]](provider: String, cloudTokens: mutable.Stack[CloudToken])(implicit
+  F: Async[F]
+) extends CloudServiceAuthTokenProvider[F](provider) {
+  override def getCloudProviderAuthToken: F[CloudToken] = {
+    val token = cloudTokens.pop()
+    F.pure(token)
+  }
+}

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/auth/CloudServiceAuthTokenProviderSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/auth/CloudServiceAuthTokenProviderSpec.scala
@@ -1,7 +1,7 @@
 package org.broadinstitute.dsde.workbench.leonardo.auth
 import cats.effect.unsafe.implicits.global
 import cats.effect.{Async, IO}
-import org.broadinstitute.dsde.workbench.leonardo.LeonardoTestSuite
+import org.broadinstitute.dsde.workbench.leonardo.{CloudProvider, LeonardoTestSuite}
 import org.http4s.Credentials
 import org.http4s.headers.Authorization
 import org.scalatest.BeforeAndAfter
@@ -18,7 +18,7 @@ class CloudServiceAuthTokenProviderSpec
 
   val firstTokenValue = "token1"
   val secondTokenValue = "token2"
-  val provider = "provider"
+  val provider: CloudProvider = CloudProvider.Gcp
   var tokens: mutable.Stack[CloudToken] = _
 
   before {
@@ -103,7 +103,7 @@ class CloudServiceAuthTokenProviderSpec
 /**
  * A test CloudServiceAuthTokenProvider that returns a fixed token.
  */
-class TestCloudServiceAuthTokenProvider[F[_]](provider: String, cloudTokens: mutable.Stack[CloudToken])(implicit
+class TestCloudServiceAuthTokenProvider[F[_]](provider: CloudProvider, cloudTokens: mutable.Stack[CloudToken])(implicit
   F: Async[F]
 ) extends CloudServiceAuthTokenProvider[F](provider) {
   override def getCloudProviderAuthToken: F[CloudToken] = {

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpSamDAOSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpSamDAOSpec.scala
@@ -13,8 +13,6 @@ import org.broadinstitute.dsde.workbench.leonardo.auth.CloudAuthTokenProvider
 import org.broadinstitute.dsde.workbench.leonardo.config.Config.httpSamDaoConfig
 import org.broadinstitute.dsde.workbench.leonardo.dao.HttpSamDAO.listResourceResponseDecoder
 import org.broadinstitute.dsde.workbench.leonardo.http.ctxConversion
-import org.broadinstitute.dsde.workbench.leonardo.model.ServiceAccountProviderConfig
-import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
 import org.broadinstitute.dsde.workbench.util.health.Subsystems.{GoogleGroups, GoogleIam, GooglePubSub, OpenDJ}
 import org.broadinstitute.dsde.workbench.util.health.{StatusCheckResponse, SubsystemStatus}
 import org.http4s._
@@ -28,7 +26,6 @@ import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 import scalacache.caffeine.CaffeineCache
 
-import java.nio.file.Paths
 import java.util.UUID
 import scala.concurrent.duration._
 import scala.util.control.NoStackTrace

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpSamDAOSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpSamDAOSpec.scala
@@ -35,12 +35,7 @@ import scala.util.control.NoStackTrace
 
 class HttpSamDAOSpec extends AnyFlatSpec with LeonardoTestSuite with BeforeAndAfterAll with MockitoSugar {
   val cloudAuthProvider = mock[CloudAuthTokenProvider[IO]]
-  val config = HttpSamDaoConfig(Uri.unsafeFromString("localhost"),
-                                false,
-                                1 seconds,
-                                10
-                                // ServiceAccountProviderConfig(Paths.get("test"), WorkbenchEmail("test"))
-  )
+  val config = HttpSamDaoConfig(Uri.unsafeFromString("localhost"), false, 1 seconds, 10)
   implicit def unsafeLogger: Logger[IO] = Slf4jLogger.getLogger[IO]
   val underlyingPetTokenCache = Caffeine
     .newBuilder()

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/ConfigReaderSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/ConfigReaderSpec.scala
@@ -220,7 +220,12 @@ class ConfigReaderSpec extends AnyFlatSpec with Matchers {
         ),
         List(AppType.Wds, AppType.WorkflowsApp),
         TdrConfig("https://jade.datarepo-dev.broadinstitute.org"),
-        ListenerChartConfig(ChartName("terra-helm/listener"), ChartVersion("0.3.0"))
+        ListenerChartConfig(ChartName("terra-helm/listener"), ChartVersion("0.3.0")),
+        AzureHostingModeConfig(
+          false,
+          "AZURE",
+          AzureManagedIdentityAuthConfig(".default", 30)
+        )
       ),
       OidcAuthConfig(
         Uri.unsafeFromString("https://fake"),

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -217,7 +217,8 @@ object Dependencies {
     "com.auth0" % "java-jwt" % "4.4.0",
     http4sBlazeServer % Test,
     scalaTestSelenium,
-    scalaTestMockito
+    scalaTestMockito,
+    "com.azure" % "azure-identity" % "1.11.2"
   )
 
   val workbenchServiceTest: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-service-test" % serviceTestV % "test" classifier "tests" excludeAll (excludeGuava, excludeStatsD)


### PR DESCRIPTION
__Jira ticket__: https://broadworkbench.atlassian.net/browse/TOAZ-341

<!-- ## Dependencies -->
<!-- Include any dependent tickets and describe the relationship. Include any other relevant Jira tickets. -->

## Summary of changes

In this PR:
 -  A new trait that encapuslates getting a service auth token from different cloud providers `CloudAuthTokenProvider`.
 -  Implementations for GCP and Azure: `GcpCloudAuthTokenProvider` and `AzureCloudAuthTokenProvider`
 -  Token is now cached until it expires instead of a getting a new token every time. 
 - Refactoring of `HttpSamDAO` to use `CloudAuthTokenProvider`.
 - New config settings to indicate Leo is hosted on Azure, Azure environment, token scope and request timeouts. Defaults continue to be GCP. 

## Testing these changes

### Who tested and where

- [ ] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [ ] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
