### PR TITLE
[WOR-1541] Point at a new static landing zone

### DIFF
--- a/.github/workflows/azure_automation_test.yml
+++ b/.github/workflows/azure_automation_test.yml
@@ -147,8 +147,8 @@ jobs:
           token: ${{ env.TOKEN }}
           inputs: '{
             "run-name": "${{ env.ATTACH_BP_TO_LZ_RUN_NAME }}",
-            "mrg-id": "e2e-8n6xqg",
-            "landing-zone-id": "c6489e53-85b6-4bf1-ada1-d05f9602315d",
+            "mrg-id": "e2e-n6bgy8",
+            "landing-zone-id": "9aa7e351-5448-4669-9f02-7e3466027c78",
             "bee-name": "${{ env.BEE_NAME }}",
             "billing-project": "${{ needs.params-gen.outputs.project-name }}",
             "billing-project-creator": "${{ needs.init-github-context.outputs.owner-subject }}",

--- a/.github/workflows/azure_e2e_release_promotion_tests.yml
+++ b/.github/workflows/azure_e2e_release_promotion_tests.yml
@@ -20,7 +20,7 @@ name: Azure E2E Release Promotion Tests
         description: 'Azure Managed Resource Group name. This is a shared identifier used by all Apps deployed for Azure End-to-End (E2E) tests. By default, it is set to the current Azure MRG name.'
         required: false
         type: string
-        default: 'e2e-8n6xqg'
+        default: 'e2e-n6bgy8'
 env:
   BEE_NAME: >-
     ${{ github.event.repository.name }}-${{ github.run_id }}-${{github.run_attempt }}-dev

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoAzureSuite.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoAzureSuite.scala
@@ -23,8 +23,8 @@ trait AzureBilling extends FixtureAnyFreeSpecLike {
   implicit val azureManagedAppCoordinates: AzureManagedAppCoordinates = AzureManagedAppCoordinates(
     UUID.fromString("fad90753-2022-4456-9b0a-c7e5b934e408"),
     UUID.fromString("f557c728-871d-408c-a28b-eb6b2141a087"),
-    "e2e-8n6xqg",
-    Some(UUID.fromString("c6489e53-85b6-4bf1-ada1-d05f9602315d"))
+    "e2e-n6bgy8",
+    Some(UUID.fromString("9aa7e351-5448-4669-9f02-7e3466027c78"))
   )
 
   override def withFixture(test: OneArgTest): Outcome = {


### PR DESCRIPTION
<!-- Welcome to your Leonardo pull request! -->
<!-- Contributor guidelines: https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md -->

__Jira ticket__: https://broadworkbench.atlassian.net/browse/WOR-1541

<!-- ## Dependencies -->
<!-- Include any dependent tickets and describe the relationship. Include any other relevant Jira tickets. -->


## Summary of changes
There is a new static landing zone for e2e testing, we should use it. 
<!-- Please give an abridged version of the ticket description here and/or fill out the following fields. -->

## Testing these changes
* [Example run](https://github.com/DataBiosphere/leonardo/actions/runs/8069548949)
### What to test

- <!-- Test case 1 -->

<!-- ### Test data -->

### Who tested and where

- [ ] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [ ] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
