### PR TITLE
[IA-4502] add workflow dispatch for leo gcp tests

### DIFF
--- a/.github/workflows/leo-build-tag-publish-and-run-tests.yml
+++ b/.github/workflows/leo-build-tag-publish-and-run-tests.yml
@@ -21,8 +21,6 @@ on:
         default: 'develop'
         type: string
   
-      
-
 env:
   BEE_NAME: '${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt}}-gcp-dev'
   TOKEN: '${{ secrets.BROADBOT_TOKEN }}' # github token for access to kick off a job in the private repo

--- a/.github/workflows/leo-build-tag-publish-and-run-tests.yml
+++ b/.github/workflows/leo-build-tag-publish-and-run-tests.yml
@@ -15,6 +15,13 @@ on:
         required: true
         default: 'develop'
         type: string
+      automation-branch:
+        description: 'Branch of leo to run tests from'
+        required: true
+        default: 'develop'
+        type: string
+  
+      
 
 env:
   BEE_NAME: '${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt}}-gcp-dev'
@@ -78,6 +85,8 @@ jobs:
             BRANCH_NAME=${{ github.ref_name }}
           elif [[ '${{ github.event_name }}' == 'pull_request' ]]; then
             BRANCH_NAME=${{ github.head_ref }}
+          elif [[ '${{ github.event_name }}' == 'workflow_dispatch' ]]; then
+            BRANCH_NAME=${{ inputs.automation-branch }}
           else
             echo "Failed to extract branch information"
             exit 1


### PR DESCRIPTION
I can't run the tests  multiple times if it doesn't support workflow_dispatch 🙃 .

Fun part is there is no way to test this is correct without merging either!

See this for why this logic is currently incorrect and why I'm fairly confident this is the proper fix: https://github.com/DataBiosphere/leonardo/actions/runs/8084499439/job/22089889997
