### PR TITLE
[IA-4788] Use userInfo not petSA when notifying Sam of resource cleanup

### DIFF
--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/DiskServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/DiskServiceInterp.scala
@@ -375,12 +375,11 @@ class DiskServiceInterp[F[_]: Parallel](config: PersistentDiskConfig,
 
       // Mark the resource as deleted in Leo's DB
       _ <- dbReference.inTransaction(persistentDiskQuery.delete(disk.id, ctx.now))
-      // Notify SAM that the resource has been deleted
+      // Notify SAM that the resource has been deleted using the user info, not the pet SA that was likely deleted
       _ <- authProvider
-        .notifyResourceDeleted(
+        .notifyResourceDeletedV2(
           dbdisk.samResource,
-          disk.auditInfo.creator,
-          cloudContext.value
+          userInfo
         )
     } yield ()
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/LeoAppServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/LeoAppServiceInterp.scala
@@ -487,12 +487,11 @@ final class LeoAppServiceInterp[F[_]: Parallel](config: AppServiceConfig,
       _ <- dbReference.inTransaction(appQuery.markAsDeleted(dbApp.app.id, ctx.now))
       _ <- dbReference.inTransaction(nodepoolQuery.markAsDeleted(dbApp.nodepool.id, ctx.now))
       _ <- dbReference.inTransaction(kubernetesClusterQuery.markAsDeleted(dbApp.cluster.id, ctx.now))
-      // Notify SAM that the resource has been deleted
+      // Notify SAM that the resource has been deleted using the user info, not the pet SA that was likely deleted
       _ <- authProvider
-        .notifyResourceDeleted(
+        .notifyResourceDeletedV2(
           dbApp.app.samResourceId,
-          dbApp.app.auditInfo.creator,
-          cloudContext.value
+          userInfo
         )
       // Stop the usage of the SAS app
       trackUsage = AllowedChartName.fromChartName(dbApp.app.chart.name).exists(_.trackUsage)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterp.scala
@@ -469,12 +469,11 @@ class RuntimeServiceInterp[F[_]: Parallel](
 
       // Mark the resource as deleted in Leo's DB
       _ <- dbReference.inTransaction(clusterQuery.completeDeletion(runtime.id, ctx.now))
-      // Notify SAM that the resource has been deleted
+      // Notify SAM that the resource has been deleted using the user info, not the pet SA that was likely deleted
       _ <- authProvider
-        .notifyResourceDeleted(
+        .notifyResourceDeletedV2(
           runtime.samResource,
-          runtime.auditInfo.creator,
-          cloudContext.value
+          userInfo
         )
     } yield ()
 

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterpSpec.scala
@@ -1447,7 +1447,7 @@ class RuntimeServiceInterpTest
         )
       )
     when(
-      mockAuthProvider.notifyResourceDeleted[RuntimeSamResourceId](any, any, any)(any, any)
+      mockAuthProvider.notifyResourceDeletedV2[RuntimeSamResourceId](any, isEq(userInfo))(any, any)
     ).thenReturn(IO.unit)
 
     val publisherQueue = QueueFactory.makePublisherQueue()


### PR DESCRIPTION
<!-- Welcome to your Leonardo pull request! -->
<!-- Contributor guidelines: https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md -->

__Jira ticket__: https://broadworkbench.atlassian.net/browse/IA-4788

<!-- ## Dependencies -->
<!-- Include any dependent tickets and describe the relationship. Include any other relevant Jira tickets. -->

## Summary of changes

<!-- Please give an abridged version of the ticket description here and/or fill out the following fields. -->

### What

- Small follow up to the delete Google workspace work done in https://github.com/DataBiosphere/leonardo/pull/4170 to use the user info instead of the pet SA to authenticate to Sam when notifying the service that the child resource was deleted

### Why

- The pet SA is being deleted with the google project by Rawls and might not be available by the time Leonardo notifies Sam and we should not use it to authenticate in this case

## Testing these changes

### What to test

- <!-- Test case 1 -->

<!-- ### Test data -->

### Who tested and where

- [ ] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [ ] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
