### PR TITLE
RW-12021 Unblock recording stopTime even if there're multiple unresolved startTime recorded

### DIFF
--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/AppUsageComponent.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/AppUsageComponent.scala
@@ -88,7 +88,7 @@ object appUsageQuery extends TableQuery(new AppUsageTable(_)) {
         case x =>
           metrics.incrementCounter("duplicateStartTime") >> logger.warn(
             s"App(${appId.id} has ${x} rows of unresolved startTime recorded. This is an anomaly that needs to be addressed"
-          ) >> F.unit
+          )
       }
     } yield ()
   }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/AppUsageComponent.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/AppUsageComponent.scala
@@ -64,7 +64,6 @@ object appUsageQuery extends TableQuery(new AppUsageTable(_)) {
   }
 
   def recordStop[F[_]](appId: AppId, stopTime: Instant)(implicit
-    ec: ExecutionContext,
     dbReference: DbReference[F],
     metrics: OpenTelemetryMetrics[F],
     F: Sync[F],
@@ -75,25 +74,21 @@ object appUsageQuery extends TableQuery(new AppUsageTable(_)) {
       .filter(_.stopTime === dummyDate)
       .map(_.stopTime)
       .update(stopTime)
-      .flatMap { x =>
-        if (x == 1)
-          DBIO.successful(())
-        else
-          DBIO.failed(
-            FailToRecordStoptime(appId)
-          )
-      }
 
     for {
-      res <- dbio.transaction.attempt
+      res <- dbio.transaction
       _ <- res match {
-        case Left(e) if e.getMessage.contains("Cannot record stopTime") =>
-          // We should alert if this happens
-          metrics.incrementCounter("appStopUsageTimeRecordingFailure") >> logger.error(e)(e.getMessage) >> F.raiseError(
-            e
-          )
-        case Left(e)      => F.raiseError(e)
-        case Right(appId) => F.pure(appId)
+        case 0 =>
+          val error = FailToRecordStoptime(appId)
+          metrics.incrementCounter("appStopUsageTimeRecordingFailure") >> logger.error(error)(error.getMessage) >> F
+            .raiseError(
+              error
+            )
+        case 1 => F.unit
+        case x =>
+          metrics.incrementCounter("duplicateStartTime") >> logger.warn(
+            s"App(${appId.id} has ${x} rows of unresolved startTime recorded. This is an anomaly that needs to be addressed"
+          ) >> F.unit
       }
     } yield ()
   }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
@@ -1484,7 +1484,7 @@ class GKEInterpreter[F[_]](
       ctx <- ev.ask
 
       _ <- logger.info(ctx.loggingCtx)(
-        s"Installing helm chart for RStudio app ${appName.value} in cluster ${cluster.getClusterId.toString}"
+        s"Installing helm chart for Allowed app ${appName.value} in cluster ${cluster.getClusterId.toString}"
       )
 
       googleProject <- F.fromOption(

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/AppUsageComponentSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/AppUsageComponentSpec.scala
@@ -46,4 +46,38 @@ class AppUsageComponentSpec extends AnyFlatSpecLike with TestComponent {
     } yield succeed
     test.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
+
+  it should "recordStop even if there are multiple rows of unresolved startTime for the same app" in isolatedDbTest {
+    import org.broadinstitute.dsde.workbench.leonardo.db.LeoProfile.api._
+    import org.broadinstitute.dsde.workbench.leonardo.db.LeoProfile.mappedColumnImplicits._
+
+    val savedCluster1 = makeKubeCluster(1).save()
+    val savedNodepool1 = makeNodepool(1, savedCluster1.id).save()
+
+    val app = makeApp(1, savedNodepool1.id)
+    val savedApp = app.save()
+
+    def persistStartTime(startTime: Instant) =
+      appUsageQuery returning appUsageQuery.map(_.id) += AppUsageRecord(AppUsageId(-1),
+                                                                        savedApp.id,
+                                                                        startTime,
+                                                                        dummyDate
+      )
+
+    val test = for {
+      startTime1 <- IO.realTimeInstant
+      appUsageId1 <- testDbRef.inTransaction(persistStartTime(startTime1))
+      startTime2 = startTime1.plusSeconds(100)
+      appUsageId2 <- testDbRef.inTransaction(persistStartTime(startTime2))
+      stopTime = startTime1.plusSeconds(300)
+      _ <- appUsageQuery.recordStop(savedApp.id, stopTime)
+      appAfterRecordingStop <- testDbRef
+        .inTransaction(appUsageQuery.get(appUsageId1))
+      _ = appAfterRecordingStop.get.stopTime shouldBe stopTime
+      appAfterRecordingStop2 <- testDbRef
+        .inTransaction(appUsageQuery.get(appUsageId2))
+      _ = appAfterRecordingStop.get.stopTime shouldBe stopTime
+    } yield succeed
+    test.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
+  }
 }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/AppUsageComponentSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/AppUsageComponentSpec.scala
@@ -76,7 +76,7 @@ class AppUsageComponentSpec extends AnyFlatSpecLike with TestComponent {
       _ = appAfterRecordingStop.get.stopTime shouldBe stopTime
       appAfterRecordingStop2 <- testDbRef
         .inTransaction(appUsageQuery.get(appUsageId2))
-      _ = appAfterRecordingStop.get.stopTime shouldBe stopTime
+      _ = appAfterRecordingStop2.get.stopTime shouldBe stopTime
     } yield succeed
     test.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }


### PR DESCRIPTION
https://precisionmedicineinitiative.atlassian.net/browse/RW-12021

See more details in [this doc](https://docs.google.com/document/d/1c6PBPNN65A-wJnDK26Ksv0l0_MKoOUXwsbBYKqMBtHA/edit) for the explanation of the bug.

This PR doesn't try to fix the root cause of the duplicate usage recorded bug. But just to make it so that at least `stopTime` will be recorded. See [this part](https://docs.google.com/document/d/1c6PBPNN65A-wJnDK26Ksv0l0_MKoOUXwsbBYKqMBtHA/edit#heading=h.2j0xi9s3apcn).


<!-- Welcome to your Leonardo pull request! -->
<!-- Contributor guidelines: https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md -->


<!-- ## Dependencies -->
<!-- Include any dependent tickets and describe the relationship. Include any other relevant Jira tickets. -->

## Summary of changes

<!-- Please give an abridged version of the ticket description here and/or fill out the following fields. -->

### What

-

### Why

-

## Testing these changes

### What to test

- <!-- Test case 1 -->

<!-- ### Test data -->

### Who tested and where

- [ ] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [ ] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
