### PR TITLE
RW-12021 set transaction level to serializable

### DIFF
--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/AppUsageComponent.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/AppUsageComponent.scala
@@ -10,6 +10,7 @@ import org.broadinstitute.dsde.workbench.leonardo.db.LeoProfile.mappedColumnImpl
 import org.broadinstitute.dsde.workbench.leonardo.http.dbioToIO
 import org.broadinstitute.dsde.workbench.openTelemetry.OpenTelemetryMetrics
 import org.typelevel.log4cats.Logger
+import slick.jdbc.TransactionIsolation
 
 import java.sql.SQLDataException
 import java.time.Instant
@@ -51,7 +52,7 @@ object appUsageQuery extends TableQuery(new AppUsageTable(_)) {
     } yield id
 
     for {
-      res <- dbio.transaction.attempt
+      res <- dbio.transaction(TransactionIsolation.Serializable).attempt
       id <- res match {
         case Left(e) if e.getMessage.contains("usage startTime was recorded previously") =>
           // We should alert if this happens

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/AppUsageComponentSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/AppUsageComponentSpec.scala
@@ -5,6 +5,9 @@ import cats.implicits._
 import org.broadinstitute.dsde.workbench.leonardo.KubernetesTestData.{makeApp, makeKubeCluster, makeNodepool}
 import org.broadinstitute.dsde.workbench.leonardo.db.LeoProfile.dummyDate
 import org.scalatest.flatspec.AnyFlatSpecLike
+import org.broadinstitute.dsde.workbench.leonardo.db.LeoProfile.api._
+import org.broadinstitute.dsde.workbench.leonardo.db.LeoProfile.mappedColumnImplicits._
+import scala.concurrent.duration._
 
 import java.time.Instant
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -48,9 +51,6 @@ class AppUsageComponentSpec extends AnyFlatSpecLike with TestComponent {
   }
 
   it should "recordStop even if there are multiple rows of unresolved startTime for the same app" in isolatedDbTest {
-    import org.broadinstitute.dsde.workbench.leonardo.db.LeoProfile.api._
-    import org.broadinstitute.dsde.workbench.leonardo.db.LeoProfile.mappedColumnImplicits._
-
     val savedCluster1 = makeKubeCluster(1).save()
     val savedNodepool1 = makeNodepool(1, savedCluster1.id).save()
 
@@ -78,6 +78,23 @@ class AppUsageComponentSpec extends AnyFlatSpecLike with TestComponent {
         .inTransaction(appUsageQuery.get(appUsageId2))
       _ = appAfterRecordingStop2.get.stopTime shouldBe stopTime
     } yield succeed
+    test.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
+  }
+
+  it should "prevent race condition between 2 recordStart requests" in isolatedDbTest {
+    val savedCluster1 = makeKubeCluster(1).save()
+    val savedNodepool1 = makeNodepool(1, savedCluster1.id).save()
+
+    val app = makeApp(1, savedNodepool1.id)
+    val savedApp = app.save()
+
+    val test = for {
+      startTime <- IO.realTimeInstant
+      recordStart1 = appUsageQuery.recordStart(savedApp.id, startTime)
+      recordStart2 = IO.sleep(1 nanoseconds) >> appUsageQuery.recordStart(savedApp.id, startTime.plusSeconds(100))
+      _ <- List(recordStart1, recordStart2).parSequence.attempt
+      recordedStartTimes <- testDbRef.inTransaction(appUsageQuery.filter(_.appId === savedApp.id).result)
+    } yield recordedStartTimes.size shouldBe 1
     test.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/AppUsageComponentSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/AppUsageComponentSpec.scala
@@ -91,8 +91,10 @@ class AppUsageComponentSpec extends AnyFlatSpecLike with TestComponent {
     val test = for {
       startTime <- IO.realTimeInstant
       recordStart1 = appUsageQuery.recordStart(savedApp.id, startTime)
-      recordStart2 = IO.sleep(1 nanoseconds) >> appUsageQuery.recordStart(savedApp.id, startTime.plusSeconds(100))
-      _ <- List(recordStart1, recordStart2).parSequence.attempt
+      recordStart2 = appUsageQuery.recordStart(savedApp.id, startTime.plusSeconds(100))
+      _ <- List(recordStart1,
+                recordStart2
+      ).parSequence.attempt // use attempt because one of the recordStart is expected to fail
       recordedStartTimes <- testDbRef.inTransaction(appUsageQuery.filter(_.appId === savedApp.id).result)
     } yield recordedStartTimes.size shouldBe 1
     test.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)


### PR DESCRIPTION
https://precisionmedicineinitiative.atlassian.net/browse/RW-12021

See more details in [this doc](https://docs.google.com/document/d/1c6PBPNN65A-wJnDK26Ksv0l0_MKoOUXwsbBYKqMBtHA/edit#heading=h.r0s506xa7ph) in terms of why we're doing this.

This PR implements [Option 1](https://docs.google.com/document/d/1c6PBPNN65A-wJnDK26Ksv0l0_MKoOUXwsbBYKqMBtHA/edit#heading=h.dmiwwk7ozk2m)

My understanding is `Serielizable` will read-lock the table and does not allow new rows to be inserted until the transaction finishes, hence preventing 2 inserts for the same app.

I'm not exactly sure about performance penalty of this. But since createApp requests don't happen very often. This might be okay. But will observe metrics closely after this PR

### Who tested and where

- [ ] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [ ] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
