### PR TITLE
[IA-4864] Use UUID for createDisk jobId

### DIFF
--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandler.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandler.scala
@@ -436,7 +436,7 @@ class AzurePubsubHandlerInterp[F[_]: Parallel](
                                                         params.runtime.auditInfo.creator
           )
 
-          createDiskJobId = WsmJobId(s"create-disk-${disk.id.toString.take(10)}")
+          createDiskJobId = WsmJobId(s"${UUID.randomUUID()}")
           jobControl = new JobControl()
             .id(createDiskJobId.value)
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandler.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandler.scala
@@ -436,7 +436,7 @@ class AzurePubsubHandlerInterp[F[_]: Parallel](
                                                         params.runtime.auditInfo.creator
           )
 
-          createDiskJobId = WsmJobId(s"${UUID.randomUUID().toString}")
+          createDiskJobId = WsmJobId(UUID.randomUUID().toString)
           jobControl = new JobControl()
             .id(createDiskJobId.value)
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandler.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandler.scala
@@ -436,7 +436,7 @@ class AzurePubsubHandlerInterp[F[_]: Parallel](
                                                         params.runtime.auditInfo.creator
           )
 
-          createDiskJobId = WsmJobId(s"${UUID.randomUUID()}")
+          createDiskJobId = WsmJobId(s"${UUID.randomUUID().toString}")
           jobControl = new JobControl()
             .id(createDiskJobId.value)
 


### PR DESCRIPTION
<!-- Welcome to your Leonardo pull request! -->
<!-- Contributor guidelines: https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md -->

__Jira ticket__: https://broadworkbench.atlassian.net/browse/IA-4864

<!-- ## Dependencies -->
<!-- Include any dependent tickets and describe the relationship. Include any other relevant Jira tickets. -->

## Summary of changes

<!-- Please give an abridged version of the ticket description here and/or fill out the following fields. -->

### What

- Fixes bug in https://github.com/DataBiosphere/leonardo/pull/4238 that was cutting off the disk Id, causing a duplicate job id error from WSM

### Why

-

## Testing these changes

### What to test

- <!-- Test case 1 -->

<!-- ### Test data -->

### Who tested and where

- [ ] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [ ] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
