### PR TITLE
[IA-4749] Fix unrecoverable app upgrade errors

### DIFF
--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/LeoPublisher.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/LeoPublisher.scala
@@ -122,7 +122,7 @@ final class LeoPublisher[F[_]](
           appQuery.updateStatus(m.appId, AppStatus.Stopping).transaction
         case m: LeoPubsubMessage.StartAppMessage =>
           appQuery.updateStatus(m.appId, AppStatus.Starting).transaction
-        case m: LeoPubsubMessage.UpdateAppMessage =>
+        case _: LeoPubsubMessage.UpdateAppMessage =>
           F.unit
         case _: LeoPubsubMessage.UpdateDiskMessage =>
           F.unit

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/LeoPublisher.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/LeoPublisher.scala
@@ -122,6 +122,7 @@ final class LeoPublisher[F[_]](
           appQuery.updateStatus(m.appId, AppStatus.Stopping).transaction
         case m: LeoPubsubMessage.StartAppMessage =>
           appQuery.updateStatus(m.appId, AppStatus.Starting).transaction
+        // We update this in backleo to prevent apps getting stuck in updating as much as possible, https://broadworkbench.atlassian.net/browse/IA-4749
         case _: LeoPubsubMessage.UpdateAppMessage =>
           F.unit
         case _: LeoPubsubMessage.UpdateDiskMessage =>

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/LeoPublisher.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/LeoPublisher.scala
@@ -123,7 +123,7 @@ final class LeoPublisher[F[_]](
         case m: LeoPubsubMessage.StartAppMessage =>
           appQuery.updateStatus(m.appId, AppStatus.Starting).transaction
         case m: LeoPubsubMessage.UpdateAppMessage =>
-          appQuery.updateStatus(m.appId, AppStatus.Updating).transaction
+          F.unit
         case _: LeoPubsubMessage.UpdateDiskMessage =>
           F.unit
         case _: LeoPubsubMessage.UpdateRuntimeMessage =>

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
@@ -1401,6 +1401,8 @@ class LeoPubsubMessageSubscriber[F[_]](
           )
       }
 
+      _ <- logger.info(s"here in handle in Leopubsubmessage, ${msg.cloudContext}")
+
       updateApp = msg.cloudContext match {
         case CloudContext.Gcp(_) =>
           gkeAlg

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
@@ -42,7 +42,7 @@ import org.broadinstitute.dsde.workbench.leonardo.util._
 import org.broadinstitute.dsde.workbench.model.google.{GcsObjectName, GcsPath, GoogleProject}
 import org.broadinstitute.dsde.workbench.model.{ErrorReport, TraceId, WorkbenchException}
 import org.broadinstitute.dsde.workbench.openTelemetry.OpenTelemetryMetrics
-import org.broadinstitute.dsp.ChartVersion
+import org.broadinstitute.dsp.{ChartVersion, HelmException}
 
 import java.time.Instant
 import java.util.concurrent.TimeUnit
@@ -1410,16 +1410,39 @@ class LeoPubsubMessageSubscriber[F[_]](
             .updateAndPollApp(msg.appId, msg.appName, latestAppChartVersion, msg.workspaceId, azureContext)
       }
 
-      _ <- updateApp.adaptError { case e =>
-        PubsubKubernetesError(
-          AppError(e.getMessage, ctx.now, ErrorAction.UpdateApp, ErrorSource.App, None, Some(ctx.traceId)),
-          Some(msg.appId),
-          false,
-          None,
-          None,
-          None
-        )
-      }
+      _ <- updateApp
+        .handleErrorWith {
+          // Fatal case, polling app liveliness failed
+          // The two fatal cases are included separately, because later we may wish to fail fatally on `HelmException`, but roll back on `AppUpdatePollingException`
+          // This would provide more cases in which an app is left in a usable state
+          case e: AppUpdatePollingException => F.raiseError(e)
+          // Fatal case, helm call failed for either listener or app charts
+          case e: HelmException => F.raiseError(e)
+          // Non fatal catch-all case, set app status back to running but append whatever error occurred in db for traceability
+          case e =>
+            for {
+              _ <- appQuery.updateStatus(msg.appId, AppStatus.Running).transaction
+              error = AppError(
+                s"Error updating Azure app with id ${msg.appId.id} and cloudContext ${msg.cloudContext.asString}: ${e.getMessage}",
+                ctx.now,
+                ErrorAction.UpdateApp,
+                ErrorSource.App,
+                None,
+                Some(ctx.traceId)
+              )
+              _ <- appErrorQuery.save(msg.appId, error).transaction
+            } yield ()
+        }
+        .adaptError { case e =>
+          PubsubKubernetesError(
+            AppError(e.getMessage, ctx.now, ErrorAction.UpdateApp, ErrorSource.App, None, Some(ctx.traceId)),
+            Some(msg.appId),
+            false,
+            None,
+            None,
+            None
+          )
+        }
 
       _ <- asyncTasks.offer(Task(ctx.traceId, updateApp, Some(handleKubernetesError), ctx.now, "updateApp"))
     } yield ()

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
@@ -1412,7 +1412,7 @@ class LeoPubsubMessageSubscriber[F[_]](
 
       _ <- updateApp
         .handleErrorWith {
-          // Fatal case, polling app liveliness failed
+          // Fatal case (as in, the app is no longer usable), polling app liveliness failed
           // The two fatal cases are included separately, because later we may wish to fail fatally on `HelmException`, but roll back on `AppUpdatePollingException`
           // This would provide more cases in which an app is left in a usable state
           case e: AppUpdatePollingException => F.raiseError(e)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
@@ -1401,8 +1401,6 @@ class LeoPubsubMessageSubscriber[F[_]](
           )
       }
 
-      _ <- logger.info(s"here in handle in Leopubsubmessage, ${msg.cloudContext}")
-
       updateApp = msg.cloudContext match {
         case CloudContext.Gcp(_) =>
           gkeAlg

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/leoPubsubMessageSubscriberModels.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/leoPubsubMessageSubscriberModels.scala
@@ -1132,6 +1132,13 @@ object PubsubHandleMessageError {
 
     val isRetryable: Boolean = false
   }
+
+  final case class AppIsAlreadyUpdatingException(message: UpdateAppMessage) extends PubsubHandleMessageError {
+    override def getMessage: String =
+      s"Unable to process update for app ${message.appId} because it is already in updating status. \n\tPubsub message:${message} "
+
+    val isRetryable: Boolean = false
+  }
 }
 
 final case class PersistentDiskMonitor(maxAttempts: Int, interval: FiniteDuration)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/AKSInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/AKSInterpreter.scala
@@ -306,6 +306,7 @@ class AKSInterpreter[F[_]](config: AKSInterpreterConfig,
   override def updateAndPollApp(params: UpdateAKSAppParams)(implicit ev: Ask[F, AppContext]): F[Unit] = {
     for {
       ctx <- ev.ask
+      _ <- logger.info("here in aksinterp")
 
       workspaceId <- F.fromOption(
         params.workspaceId,
@@ -446,10 +447,6 @@ class AKSInterpreter[F[_]](config: AKSInterpreterConfig,
       _ <- appQuery.updateStatus(app.id, AppStatus.Updating).transaction
 
       // Update the relay listener deployment if the app is not already updating from a message submission
-      // TODO: discuss this check. (if (dbApp.app.status != AppStatus.Updating))
-      // TODO: This might be sufficient, but really, we would need to store >>what version<< the app is being updated to determine if we should pass-through to polling or ignore
-      // TODO: the issue is that if we simply exit out if `Updating` status, then the app can remain stuck in updating if leo restarts during polling
-      // TODO: perhaps monitor at boot should just grab all apps in Updating and transition them to running + save an error to avoid this complexity?
       _ <- childSpan("helmUpdateListener").use { implicit ev =>
         updateListener(authContext,
                        app,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/AKSInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/AKSInterpreter.scala
@@ -442,7 +442,8 @@ class AKSInterpreter[F[_]](config: AKSInterpreterConfig,
                                         namespaceName
       )
 
-      // The app is blocked in updating now
+      // The app is blocked in updating now (as in, if leo restarts between here and the app transitioning back to `Running`, it is unusable
+      // See: https://broadworkbench.atlassian.net/browse/IA-4867
       _ <- appQuery.updateStatus(app.id, AppStatus.Updating).transaction
 
       // Update the relay listener deployment

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/AKSInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/AKSInterpreter.scala
@@ -488,6 +488,7 @@ class AKSInterpreter[F[_]](config: AKSInterpreterConfig,
       }
 
       // Poll until all pods in the app namespace are running
+      // TODO: we should be able to test this method and the subsequent `AppUpdatePollingException` more easily when we start to implement rollbacks
       appOk <- childSpan("pollAppUpdate").use { implicit ev =>
         pollAppUpdate(app.auditInfo.creator, relayPath, app.appType)
       }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/AKSInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/AKSInterpreter.scala
@@ -306,7 +306,6 @@ class AKSInterpreter[F[_]](config: AKSInterpreterConfig,
   override def updateAndPollApp(params: UpdateAKSAppParams)(implicit ev: Ask[F, AppContext]): F[Unit] = {
     for {
       ctx <- ev.ask
-      _ <- logger.info("here in aksinterp")
 
       workspaceId <- F.fromOption(
         params.workspaceId,
@@ -446,7 +445,7 @@ class AKSInterpreter[F[_]](config: AKSInterpreterConfig,
       // The app is blocked in updating now
       _ <- appQuery.updateStatus(app.id, AppStatus.Updating).transaction
 
-      // Update the relay listener deployment if the app is not already updating from a message submission
+      // Update the relay listener deployment
       _ <- childSpan("helmUpdateListener").use { implicit ev =>
         updateListener(authContext,
                        app,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandler.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandler.scala
@@ -955,6 +955,7 @@ class AzurePubsubHandlerInterp[F[_]: Parallel](
     for {
       ctx <- ev.ask
       params = UpdateAKSAppParams(appId, appName, appChartVersion, workspaceId, cloudContext)
+      _ <- logger.info("here in azure pubsubhandler")
       _ <- aksAlgebra.updateAndPollApp(params)
     } yield ()
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandler.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandler.scala
@@ -34,7 +34,7 @@ import org.broadinstitute.dsde.workbench.leonardo.monitor.PubsubHandleMessageErr
 import org.broadinstitute.dsde.workbench.leonardo.monitor.PubsubHandleMessageError._
 import org.broadinstitute.dsde.workbench.model.{IP, WorkbenchEmail}
 import org.broadinstitute.dsde.workbench.util2.InstanceName
-import org.broadinstitute.dsp.{ChartVersion, HelmException}
+import org.broadinstitute.dsp.ChartVersion
 import org.http4s.AuthScheme
 import org.http4s.headers.Authorization
 import org.typelevel.log4cats.StructuredLogger

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandler.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandler.scala
@@ -952,12 +952,7 @@ class AzurePubsubHandlerInterp[F[_]: Parallel](
   )(implicit
     ev: Ask[F, AppContext]
   ): F[Unit] =
-    for {
-      ctx <- ev.ask
-      params = UpdateAKSAppParams(appId, appName, appChartVersion, workspaceId, cloudContext)
-      _ <- logger.info("here in azure pubsubhandler")
-      _ <- aksAlgebra.updateAndPollApp(params)
-    } yield ()
+    aksAlgebra.updateAndPollApp(UpdateAKSAppParams(appId, appName, appChartVersion, workspaceId, cloudContext))
 
   override def deleteApp(
     appId: AppId,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandler.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandler.scala
@@ -34,7 +34,7 @@ import org.broadinstitute.dsde.workbench.leonardo.monitor.PubsubHandleMessageErr
 import org.broadinstitute.dsde.workbench.leonardo.monitor.PubsubHandleMessageError._
 import org.broadinstitute.dsde.workbench.model.{IP, WorkbenchEmail}
 import org.broadinstitute.dsde.workbench.util2.InstanceName
-import org.broadinstitute.dsp.ChartVersion
+import org.broadinstitute.dsp.{ChartVersion, HelmException}
 import org.http4s.AuthScheme
 import org.http4s.headers.Authorization
 import org.typelevel.log4cats.StructuredLogger
@@ -955,23 +955,7 @@ class AzurePubsubHandlerInterp[F[_]: Parallel](
     for {
       ctx <- ev.ask
       params = UpdateAKSAppParams(appId, appName, appChartVersion, workspaceId, cloudContext)
-      _ <- aksAlgebra.updateAndPollApp(params).adaptError { case e =>
-        PubsubKubernetesError(
-          AppError(
-            s"Error updating Azure app with id ${appId.id} and cloudContext ${cloudContext.asString}: ${e.getMessage}",
-            ctx.now,
-            ErrorAction.UpdateApp,
-            ErrorSource.App,
-            None,
-            Some(ctx.traceId)
-          ),
-          Some(appId),
-          false,
-          None,
-          None,
-          None
-        )
-      }
+      _ <- aksAlgebra.updateAndPollApp(params)
     } yield ()
 
   override def deleteApp(

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandlerAlgebra.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandlerAlgebra.scala
@@ -25,7 +25,7 @@ import java.time.Instant
 trait AzurePubsubHandlerAlgebra[F[_]] {
 
   /** Creates an Azure VM but doesn't wait for its completion.
-   * This includes creation of all child Azure resources (disk, network, ip), and assumes these are created syncronously
+   * This includes creation of all child Azure resources (disk, network, ip), and assumes these are created synchronously
    * */
   def createAndPollRuntime(msg: CreateAzureRuntimeMessage)(implicit ev: Ask[F, AppContext]): F[Unit]
 

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/KubernetesTestData.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/KubernetesTestData.scala
@@ -178,7 +178,7 @@ object KubernetesTestData {
   ): KubernetesCluster = {
     val name = KubernetesClusterName("kubecluster" + index)
     val uniqueCloudContextAzure = CloudContext.Azure(
-      AzureCloudContext(tenantId = TenantId("tenant-id"),
+      AzureCloudContext(tenantId = TenantId("tenant-id" + index),
                         subscriptionId = SubscriptionId("sub-id"),
                         managedResourceGroupName = ManagedResourceGroupName("mrg-name")
       )

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriberSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriberSpec.scala
@@ -2068,7 +2068,7 @@ class LeoPubsubMessageSubscriberSpec
   }
 
   final case class TestExceptionIndexTuple(exception: Throwable, index: Int)
-  it should "save an error and transition app to error when a fatal error occurs in azure" in isolatedDbTest {
+  it should "save an error and transition app to error when a fatal error occurs in azure updateAndPollApp" in isolatedDbTest {
     val errors = Table(
       "exception",
       TestExceptionIndexTuple(HelmException("test helm exception"), 1),
@@ -2109,7 +2109,7 @@ class LeoPubsubMessageSubscriberSpec
             getApp.app.errors.size shouldBe 1
             getApp.app.errors.map(_.action) should contain(ErrorAction.UpdateApp)
             getApp.app.errors.map(_.source) should contain(ErrorSource.App)
-            getApp.app.errors.head.errorMessage should include("test")
+            getApp.app.errors.head.errorMessage should include(exception.getMessage)
             getApp.app.status shouldBe AppStatus.Error
           }
           asyncTaskProcessor = AsyncTaskProcessor(AsyncTaskProcessor.Config(10, 10), queue)
@@ -2121,7 +2121,7 @@ class LeoPubsubMessageSubscriberSpec
     }
   }
 
-  it should "save an error and transition app to running when a non-fatal error occurs in azure" in isolatedDbTest {
+  it should "save an error and transition app to running when a non-fatal error occurs in azure updateAndPollApp" in isolatedDbTest {
     val exception = new RuntimeException("random test exception")
     val queue = makeTaskQueue()
     val mockAckConsumer = mock[AckReplyConsumer]

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/AKSInterpreterSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/AKSInterpreterSpec.scala
@@ -3,6 +3,7 @@ package util
 
 import bio.terra.workspace.api.{ControlledAzureResourceApi, ResourceApi, WorkspaceApi}
 import bio.terra.workspace.model.{DeleteControlledAzureResourceRequest, _}
+import cats.data.Kleisli
 import cats.effect.IO
 import cats.mtl.Ask
 import com.azure.resourcemanager.containerservice.models.KubernetesCluster
@@ -24,7 +25,7 @@ import org.broadinstitute.dsde.workbench.leonardo.db._
 import org.broadinstitute.dsde.workbench.leonardo.http.{dbioToIO, ConfigReader}
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
 import org.broadinstitute.dsp.mocks.MockHelm
-import org.broadinstitute.dsp.{ChartName, ChartVersion, Values}
+import org.broadinstitute.dsp.{AuthContext, ChartName, ChartVersion, HelmException, Release, Values}
 import org.http4s.headers.Authorization
 import org.http4s.{AuthScheme, Credentials}
 import org.mockito.ArgumentMatchers.any
@@ -63,10 +64,13 @@ class AKSInterpreterSpec extends AnyFlatSpecLike with TestComponent with Leonard
     case AppType.WorkflowsApp => setUpMockWorkflowAppInstall
     case _                    => setUpMockAppInstall
   }
-  def newAksInterp(configuration: AKSInterpreterConfig, mockWsm: WsmApiClientProvider[IO] = mockWsm) =
+  def newAksInterp(configuration: AKSInterpreterConfig = config,
+                   mockWsm: WsmApiClientProvider[IO] = mockWsm,
+                   helmClient: MockHelm = new MockHelm
+  ) =
     new AKSInterpreter[IO](
       configuration,
-      MockHelm,
+      helmClient,
       mockAzureContainerService,
       mockAzureRelayService,
       mockSamDAO,
@@ -220,6 +224,62 @@ class AKSInterpreterSpec extends AnyFlatSpecLike with TestComponent with Leonard
       }
       res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
     }
+
+  it should s"exit with app in Updating status if error occurs in helm client" in isolatedDbTest {
+    val res = for {
+      cluster <- IO(makeKubeCluster(1).copy(cloudContext = CloudContext.Azure(cloudContext)).save())
+      nodepool <- IO(makeNodepool(1, cluster.id).save())
+      app = makeApp(1, nodepool.id).copy(
+        appType = AppType.Cromwell,
+        status = AppStatus.Running,
+        chart = Chart(ChartName("myapp"), ChartVersion("0.0.1")),
+        appResources = AppResources(
+          namespace = NamespaceName("ns-1"),
+          disk = None,
+          services = List.empty,
+          kubernetesServiceAccountName = Some(ServiceAccountName("ksa-1"))
+        )
+      )
+      saveApp <- IO(app.save())
+
+      appName = saveApp.appName
+      appId = saveApp.id
+
+      namespaceId = UUID.randomUUID()
+      _ <- appControlledResourceQuery
+        .insert(appId.id,
+                WsmControlledResourceId(namespaceId),
+                WsmResourceType.AzureKubernetesNamespace,
+                AppControlledResourceStatus.Created
+        )
+        .transaction
+
+      mockHelm = new MockHelm {
+        override def upgradeChart(release: Release,
+                                  chartName: ChartName,
+                                  chartVersion: ChartVersion,
+                                  values: Values
+        ): Kleisli[IO, AuthContext, Unit] = Kleisli.liftF(IO.raiseError(HelmException("test exception")))
+      }
+
+      aksInterp = newAksInterp(helmClient = mockHelm)
+
+      // Throw away the error here, we aren't trying to verify that the exception we are mocking above is being thrown
+      _ <- aksInterp
+        .updateAndPollApp(
+          UpdateAKSAppParams(appId, appName, ChartVersion("0.0.2"), Some(workspaceIdForUpdating), cloudContext)
+        )
+        .handleErrorWith(_ => IO.unit)
+
+      app <- KubernetesServiceDbQueries
+        .getActiveFullAppByName(CloudContext.Azure(cloudContext), appName)
+        .transaction
+    } yield {
+      app shouldBe defined
+      app.get.app.status shouldBe AppStatus.Updating
+    }
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
+  }
 
   // delete each app type
   for (
@@ -870,7 +930,6 @@ class AKSInterpreterSpec extends AnyFlatSpecLike with TestComponent with Leonard
     sam
   }
 
-  // TODO, delete if this works
   private def setUpMockWsmApiClientProvider
     : (WsmApiClientProvider[IO], ControlledAzureResourceApi, ResourceApi, WorkspaceApi) = {
     val wsm = mock[WsmApiClientProvider[IO]]

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/AKSInterpreterSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/AKSInterpreterSpec.scala
@@ -225,6 +225,8 @@ class AKSInterpreterSpec extends AnyFlatSpecLike with TestComponent with Leonard
       res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
     }
 
+  // Note that the app will eventually transition to error or running status, but `Running` occurs on success and `Error` occurs in `LeoPubsubMessageSubscriber` (the latter being applicable to this test).
+  // This test ensures that the underlying `AKSInterpreter` correctly transitions app to `Upgrading` and doesn't transition it to `Running` if an error occurs
   it should s"exit with app in Updating status if error occurs in helm client" in isolatedDbTest {
     val res = for {
       cluster <- IO(makeKubeCluster(1).copy(cloudContext = CloudContext.Azure(cloudContext)).save())

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/AKSInterpreterSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/AKSInterpreterSpec.scala
@@ -870,6 +870,7 @@ class AKSInterpreterSpec extends AnyFlatSpecLike with TestComponent with Leonard
     sam
   }
 
+  // TODO, delete if this works
   private def setUpMockWsmApiClientProvider
     : (WsmApiClientProvider[IO], ControlledAzureResourceApi, ResourceApi, WorkspaceApi) = {
     val wsm = mock[WsmApiClientProvider[IO]]

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/BuildHelmChartValuesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/BuildHelmChartValuesSpec.scala
@@ -10,10 +10,7 @@ import org.broadinstitute.dsde.workbench.leonardo.CommonTestData.{makePersistent
 import org.broadinstitute.dsde.workbench.leonardo.KubernetesTestData.{makeCustomAppService, makeKubeCluster}
 import org.broadinstitute.dsde.workbench.leonardo.SamResourceId.AppSamResourceId
 import org.broadinstitute.dsde.workbench.leonardo.config.Config
-import org.broadinstitute.dsde.workbench.leonardo.util.BuildHelmChartValues.{
-  buildCromwellAppChartOverrideValuesString,
-  _
-}
+import org.broadinstitute.dsde.workbench.leonardo.util.BuildHelmChartValues._
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
 import org.broadinstitute.dsde.workbench.model.google.GcsBucketName
 import org.broadinstitute.dsp.Release


### PR DESCRIPTION
This is a draft with the initial code to prevent apps getting stuck in `Updating` or inappropriately reporting an `Error` state.

It does this by delaying the transition to `Updating` until right before the helm calls, and ensures the app only gets into an `Error` state from fatal errors, while all others result in a transition back to `Running` with an error appended to the `AppError` table.

Note the `TODO` comment block that discusses a limitation of this approach. Mainly that if leo restarts after `Updating` transition before a terminal status, the app will be stuck in an unusable status. There will be a follow-on ticket to solve this edge case. 
