### PR TITLE
[IA-4868] Update disk destroyedDate when runtime creation fails

### DIFF
--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/BaseCloudServiceRuntimeMonitor.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/BaseCloudServiceRuntimeMonitor.scala
@@ -172,7 +172,7 @@ abstract class BaseCloudServiceRuntimeMonitor[F[_]] {
                     if (value.status == DiskStatus.Creating || value.status == DiskStatus.Failed) {
                       persistentDiskOpt.traverse_(d =>
                         googleDisk.deleteDisk(googleProject, rc.zone, d.name) >> persistentDiskQuery
-                          .updateStatus(d.id, DiskStatus.Deleted, ctx.now)
+                          .delete(d.id, ctx.now)
                           .transaction
                       )
                     } else F.unit

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
@@ -1485,7 +1485,7 @@ class LeoPubsubMessageSubscriber[F[_]](
                           if (value.status == DiskStatus.Creating || value.status == DiskStatus.Failed) {
                             persistentDiskOpt.traverse_(d =>
                               googleDiskService.deleteDisk(googleProject, rc.zone, d.name) >> persistentDiskQuery
-                                .updateStatus(d.id, DiskStatus.Deleted, now)
+                                .delete(d.id, now)
                                 .transaction
                             )
                           } else F.unit


### PR DESCRIPTION
<!-- Welcome to your Leonardo pull request! -->
<!-- Contributor guidelines: https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md -->

__Jira ticket__: https://broadworkbench.atlassian.net/browse/IA-4868

<!-- ## Dependencies -->
<!-- Include any dependent tickets and describe the relationship. Include any other relevant Jira tickets. -->

## Summary of changes

<!-- Please give an abridged version of the ticket description here and/or fill out the following fields. -->

### What

- When resources are deleted, their destroyedDate in the DB needs to be updated as well as the status, this was not happening for disks when runtime creation failed

### Why

-

## Testing these changes

### What to test

- <!-- Test case 1 -->

<!-- ### Test data -->

### Who tested and where

- [ ] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [ ] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
