### PR TITLE
[IA-4868] Set runtime destroyedDate upon deletion

### DIFF
--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandler.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandler.scala
@@ -741,7 +741,7 @@ class AzurePubsubHandlerInterp[F[_]: Parallel](
 
           // if no wsmResource to delete, delete the disk and set runtime to deleted
           _ <- deleteDiskAction
-          _ <- dbRef.inTransaction(clusterQuery.updateClusterStatus(runtime.id, RuntimeStatus.Deleted, ctx.now))
+          _ <- dbRef.inTransaction(clusterQuery.completeDeletion(runtime.id, ctx.now))
           _ <- logger.info(ctx.loggingCtx)(
             s"runtime ${msg.runtimeId} with name ${runtime.runtimeName.asString} is deleted successfully"
           )


### PR DESCRIPTION
<!-- Welcome to your Leonardo pull request! -->
<!-- Contributor guidelines: https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md -->

__Jira ticket__: https://broadworkbench.atlassian.net/browse/IA-4868

<!-- ## Dependencies -->
<!-- Include any dependent tickets and describe the relationship. Include any other relevant Jira tickets. -->

## Summary of changes

<!-- Please give an abridged version of the ticket description here and/or fill out the following fields. -->

### What

- Instead of just setting the status to deleted, we need to complete the deletion when a runtime is deleted (which updates the destroyedDate and runtimeConfig information)

### Why

-

## Testing these changes

### What to test

- <!-- Test case 1 -->

<!-- ### Test data -->

### Who tested and where

- [ ] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [ ] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
