### PR TITLE
Upgrade GKM chart version for Galaxy 24.0 [IA-4829]

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ ENV HELM_DEBUG 1
 ENV TERRA_APP_SETUP_VERSION 0.1.0
 ENV TERRA_APP_VERSION 0.5.0
 # This is galaxykubeman, which references Galaxy
-ENV GALAXY_VERSION 2.8.1
+ENV GALAXY_VERSION 2.9.0
 ENV NGINX_VERSION 4.3.0
 # If you update this here, make sure to also update reference.conf:
 ENV CROMWELL_CHART_VERSION 0.2.462

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -728,7 +728,7 @@ gke {
     chartName = "/leonardo/galaxykubeman"
     # If you change this here, be sure to update it in the dockerfile
     # This is galaxykubeman, which references Galaxy
-    chartVersion = "2.8.1"
+    chartVersion = "2.9.0"
     namespaceNameSuffix = "gxy-ns"
     serviceAccountName = "gxy-ksa"
     # Setting uninstallKeepHistory will cause the `helm uninstall` command to keep a record of
@@ -768,7 +768,8 @@ gke {
       "2.5.1",
       "2.5.2",
       "2.8.0",
-      "2.8.1"
+      "2.8.1",
+      "2.9.0"
     ]
   }
   galaxyDisk {

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/KubernetesTestData.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/KubernetesTestData.scala
@@ -48,7 +48,7 @@ object KubernetesTestData {
   val galaxyApp = AppType.Galaxy
 
   val galaxyChartName = ChartName("/leonardo/galaxykubeman")
-  val galaxyChartVersion = ChartVersion("2.8.1")
+  val galaxyChartVersion = ChartVersion("2.9.0")
   val galaxyChart = Chart(galaxyChartName, galaxyChartVersion)
 
   val galaxyReleasePrefix = "gxy-release"

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/config/ConfigSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/config/ConfigSpec.scala
@@ -138,7 +138,8 @@ final class ConfigSpec extends AnyFlatSpec with Matchers {
         ChartVersion("2.5.1"),
         ChartVersion("2.5.2"),
         ChartVersion("2.8.0"),
-        ChartVersion("2.8.1")
+        ChartVersion("2.8.1"),
+        ChartVersion("2.9.0")
       )
     )
     Config.gkeGalaxyAppConfig shouldBe expectedResult


### PR DESCRIPTION
This updates the Galaxykubeman chart to 2.9.0, which references the Galaxy Helm chart with support for Galaxy 24.0. Tested this on a GKE cluster with success. 

### Who tested and where

- [ ] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [x] I validated this change in GKE v1.28
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
