### PR TITLE
Revert "[IA-4828] Update GKE from 1.25 --> 1.28"

### DIFF
--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -689,7 +689,7 @@ gke {
                           "69.173.112.0/21"
     ]
     # See https://cloud.google.com/kubernetes-engine/docs/release-notes
-    version = "1.28"
+    version = "1.25"
     nodepoolLockCacheExpiryTime = 1 hour
     nodepoolLockCacheMaxSize = 200
   }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/config/ConfigSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/config/ConfigSpec.scala
@@ -83,7 +83,7 @@ final class ConfigSpec extends AnyFlatSpec with Matchers {
         "69.173.127.240/28",
         "69.173.112.0/21"
       ).map(CidrIP),
-      KubernetesClusterVersion("1.28"),
+      KubernetesClusterVersion("1.25"),
       1 hour,
       200
     )


### PR DESCRIPTION
Reverts DataBiosphere/leonardo#4364

AOU needs more time to test and verify certain logging errors aren't from this change