### PR TITLE
WOR-1519: Look up WSM resources by name instead of enumerating

### DIFF
--- a/README.md
+++ b/README.md
@@ -565,7 +565,7 @@ To build jar and leonardo docker image
 and push to repos `broadinstitute/leonardo`
 tagged with git hash
 ```
-./docker/build.sh jar -d -t push
+./docker/build.sh jar -d push
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -565,7 +565,7 @@ To build jar and leonardo docker image
 and push to repos `broadinstitute/leonardo`
 tagged with git hash
 ```
-./docker/build.sh jar -d push
+./docker/build.sh jar -d -t push
 ```
 
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/AKSInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/AKSInterpreter.scala
@@ -35,6 +35,7 @@ import java.net.URL
 import java.util.{Base64, UUID}
 import scala.concurrent.ExecutionContext
 import scala.jdk.CollectionConverters._
+import scala.util.Try
 
 class AKSInterpreter[F[_]](config: AKSInterpreterConfig,
                            helmClient: HelmAlgebra[F],
@@ -263,12 +264,16 @@ class AKSInterpreter[F[_]](config: AKSInterpreterConfig,
       appOk <- childSpan("pollAppCreation").use { implicit ev =>
         pollAppCreation(app.auditInfo.creator, relayPath, app.appType)
       }
-      _ <- F.raiseWhen(!appOk)(
-        AppCreationException(
-          s"App ${params.appName.value} failed to start in cluster ${landingZoneResources.aksCluster.name} in cloud context ${params.cloudContext.asString}",
-          Some(ctx.traceId)
-        )
-      )
+      _ <-
+        if (appOk)
+          F.unit
+        else
+          F.raiseError[Unit](
+            AppCreationException(
+              s"App ${params.appName.value} failed to start in cluster ${landingZoneResources.aksCluster.name} in cloud context ${params.cloudContext.asString}",
+              Some(ctx.traceId)
+            )
+          )
 
       // Populate async fields in the KUBERNETES_CLUSTER table.
       // For Azure we don't need each field, but we do need the relay https endpoint.
@@ -615,7 +620,7 @@ class AKSInterpreter[F[_]](config: AKSInterpreterConfig,
           )
           .handleErrorWith {
             case e: ManagementException if e.getResponse.getStatusCode == StatusCodes.NotFound.intValue =>
-              logger.info(ctx.loggingCtx)(s"${name} does not exist to delete in ${cloudContext}")
+              logger.info(s"${name} does not exist to delete in ${cloudContext}")
             case e => F.raiseError[Unit](e)
           }
       }
@@ -822,46 +827,49 @@ class AKSInterpreter[F[_]](config: AKSInterpreterConfig,
                                                       landingZoneResources: LandingZoneResources,
                                                       wsmResourceApi: ResourceApi
   )(implicit ev: Ask[F, AppContext]): F[List[WsmControlledDatabaseResource]] =
-    for {
-      ctx <- ev.ask
-      _ <- F.raiseWhen(landingZoneResources.postgresServer.isEmpty)(
-        AppCreationException("Postgres server not found in landing zone", Some(ctx.traceId))
-      )
-      wsmApi <- buildWsmControlledResourceApiClient
+    if (landingZoneResources.postgresServer.isDefined) {
+      for {
+        wsmApi <- buildWsmControlledResourceApiClient
 
-      // get a list of database types required for this app
-      controlledDbsForApp = appInstall.databases.collect { case d @ ControlledDatabase(_, _, _) => d }
-      // retrieve databases that might already be created in workspace
-      existingControlledDbsInWorkspace <- retrieveWsmDatabases(wsmResourceApi,
-                                                               controlledDbsForApp.map(_.prefix).toSet,
-                                                               workspaceId.value
-      )
-      wsmControlledDBResources <- controlledDbsForApp
-        .traverse { controlledDbForApp =>
-          // if a database already exists (because of workspace cloning or Leo restarting mid-app creation) use that otherwise create a new one
-          if (
-            existingControlledDbsInWorkspace
-              .exists(existingDb => controlledDbForApp.prefix == existingDb.wsmDatabaseName)
-          ) {
-            logger.info(
-              s"Database found in WSM for app ${app.appName}, using previously created database: $existingControlledDbsInWorkspace"
-            ) >>
+        // get a list of database types required for this app
+        controlledDbsForApp = appInstall.databases.collect { case d @ ControlledDatabase(_, _, _) => d }
+        // retrieve databases that might already be created in workspace
+        existingControlledDbsInWorkspace <- retrieveWsmDatabases(wsmResourceApi,
+                                                                 controlledDbsForApp.map(_.prefix).toSet,
+                                                                 workspaceId.value
+        )
+        wsmControlledDBResources <- controlledDbsForApp
+          .map { controlledDbForApp =>
+            // if a database already exists (because of workspace cloning or Leo restarting mid-app creation) use that otherwise create a new one
+            if (
+              existingControlledDbsInWorkspace
+                .exists(existingDb => controlledDbForApp.prefix == existingDb.wsmDatabaseName)
+            ) {
+              logger.info(
+                s"Database found in WSM for app ${app.appName}, using previously created database: $existingControlledDbsInWorkspace"
+              )
               F.pure(
                 existingControlledDbsInWorkspace
                   .find(clonedDatabase => controlledDbForApp.prefix == clonedDatabase.wsmDatabaseName)
                   .get
               )
-          } else {
-            logger.info(s"Creating databases for app ${app.appName}") >>
+            } else {
+              logger.info(s"Creating databases for app ${app.appName}")
               createWsmDatabaseResource(app, workspaceId, controlledDbForApp, namespacePrefix, owner, wsmApi).map {
                 db =>
                   WsmControlledDatabaseResource(db.getAzureDatabase.getMetadata.getName,
                                                 db.getAzureDatabase.getAttributes.getDatabaseName
                   )
               }
+            }
           }
-        }
-    } yield wsmControlledDBResources
+          .traverse(identity)
+      } yield wsmControlledDBResources
+    } else {
+      ev.ask.flatMap(ctx =>
+        F.raiseError(AppCreationException("Postgres server not found in landing zone", Some(ctx.traceId)))
+      )
+    }
 
   private[util] def createMissingAppControlledResources(app: App,
                                                         appInstall: AppInstall[F],
@@ -869,11 +877,8 @@ class AKSInterpreter[F[_]](config: AKSInterpreterConfig,
                                                         landingZoneResources: LandingZoneResources,
                                                         wsmResourceApi: ResourceApi
   )(implicit ev: Ask[F, AppContext]): F[Unit] =
-    for {
+    if (landingZoneResources.postgresServer.isDefined) for {
       ctx <- ev.ask
-      _ <- F.raiseWhen(landingZoneResources.postgresServer.isEmpty)(
-        AppCreationException("Postgres server not found in landing zone", Some(ctx.traceId))
-      )
       wsmApi <- buildWsmControlledResourceApiClient
 
       // get a list of database types required for this app
@@ -911,6 +916,11 @@ class AKSInterpreter[F[_]](config: AKSInterpreterConfig,
       }
 
     } yield ()
+    else {
+      ev.ask.flatMap(ctx =>
+        F.raiseError(AppCreationException("Postgres server not found in landing zone", Some(ctx.traceId)))
+      )
+    }
 
   private[util] def createWsmDatabaseResource(app: App,
                                               workspaceId: WorkspaceId,
@@ -983,12 +993,15 @@ class AKSInterpreter[F[_]](config: AKSInterpreterConfig,
 
       _ <- logger.info(ctx.loggingCtx)(s"WSM create database job result: ${result}")
 
-      _ <- F.raiseWhen(result.getJobReport.getStatus != JobReport.StatusEnum.SUCCEEDED)(
-        AppCreationException(
-          s"WSM database creation failed for app ${app.appName.value}. WSM response: ${result}",
-          Some(ctx.traceId)
-        )
-      )
+      _ <-
+        if (result.getJobReport.getStatus != JobReport.StatusEnum.SUCCEEDED) {
+          F.raiseError(
+            AppCreationException(
+              s"WSM database creation failed for app ${app.appName.value}. WSM response: ${result}",
+              Some(ctx.traceId)
+            )
+          )
+        } else F.unit
 
       // Save record in APP_CONTROLLED_RESOURCE table
       _ <- appControlledResourceQuery
@@ -1005,28 +1018,36 @@ class AKSInterpreter[F[_]](config: AKSInterpreterConfig,
                                                workspaceId: UUID
   ): F[Option[WsmManagedAzureIdentity]] = {
     val wsmResourceName = generateWsmNameForIdentity(appType)
-    F.blocking(Option(resourceApi.getResourceByName(workspaceId, wsmResourceName)))
-      .map(opt => opt.map(identity => WsmManagedAzureIdentity(wsmResourceName,
-      identity.getResourceAttributes.getAzureManagedIdentity.getManagedIdentityName
-    )))
+    F.blocking(
+      getWorkspaceResourceByName(workspaceId, wsmResourceName, resourceApi).map { identity =>
+        WsmManagedAzureIdentity(
+          wsmResourceName,
+          identity.getResourceAttributes.getAzureManagedIdentity.getManagedIdentityName
+        )
+      }
+    )
   }
 
   private[util] def retrieveWsmDatabases(resourceApi: ResourceApi,
                                          databaseNames: Set[String],
                                          workspaceId: UUID
-  ): F[List[WsmControlledDatabaseResource]] = {
+  ): F[List[WsmControlledDatabaseResource]] =
     // TODO: this currently matches on the 'name' (actually type) of database so for example
     // it compares for a 'cbas' or 'cromwellmetadata' database. In the future, their maybe
     // multiple of those in a workspace so this approach will have to be re-considered
     // see https://broadworkbench.atlassian.net/browse/IA-4844
     F.blocking(
-      databaseNames.flatMap(dbName => Option(resourceApi.getResourceByName(workspaceId, dbName)).map(r =>
-        WsmControlledDatabaseResource(r.getMetadata.getName,
-          r.getResourceAttributes.getAzureDatabase.getDatabaseName,
-          r.getMetadata.getResourceId
-      ))
-    ))
-  }
+      databaseNames
+        .flatMap(dbName =>
+          getWorkspaceResourceByName(workspaceId, dbName, resourceApi).map { r =>
+            WsmControlledDatabaseResource(r.getMetadata.getName,
+                                          r.getResourceAttributes.getAzureDatabase.getDatabaseName,
+                                          r.getMetadata.getResourceId
+            )
+          }
+        )
+        .toList
+    )
 
   private[util] def getWorkspaceDescription(workspaceApi: WorkspaceApi,
                                             workspaceId: UUID
@@ -1047,8 +1068,8 @@ class AKSInterpreter[F[_]](config: AKSInterpreterConfig,
           case Some(identity) =>
             logger.info(
               s"Managed ID found in WSM app ${app.appName}, using previously created identity: ${identity.managedIdentityName}"
-            ) >>
-              F.pure(Option(identity))
+            )
+            F.pure(Option(identity))
           case None =>
             createAzureManagedIdentity(app, namespacePrefix, workspaceId)
         }
@@ -1062,14 +1083,14 @@ class AKSInterpreter[F[_]](config: AKSInterpreterConfig,
                                               wsmManagedIdentityOpt: Option[WsmManagedAzureIdentity]
   )(implicit ev: Ask[F, AppContext]): F[WsmControlledKubernetesNamespaceResource] =
     for {
-      wsmNamespaces <- retrieveWsmNamespace(resourceApi, namespacePrefix, workspaceId.value)
-      namespace <- wsmNamespaces.length match {
-        case 1 =>
+      wsmNamespace <- retrieveWsmNamespace(resourceApi, namespacePrefix, workspaceId.value)
+      namespace <- wsmNamespace match {
+        case Some(ns) =>
           logger.info(
-            s"Namespace found in WSM for app ${app.appName}, using previously created namespace: ${wsmNamespaces.head.name}"
-          ) >>
-            F.pure(wsmNamespaces.head)
-        case 0 =>
+            s"Namespace found in WSM for app ${app.appName}, using previously created namespace: ${ns.name}"
+          )
+          F.pure(ns)
+        case None =>
           createWsmKubernetesNamespaceResource(
             app,
             workspaceId,
@@ -1077,42 +1098,27 @@ class AKSInterpreter[F[_]](config: AKSInterpreterConfig,
             wsmDatabases.map(_.wsmDatabaseName),
             wsmManagedIdentityOpt.map(_.wsmResourceName)
           )
-        case _ =>
-          F.raiseError(
-            AppCreationException(
-              s"App ${app.appName} has multiple namespaces $wsmNamespaces. Only one namespace per app allowed"
-            )
-          )
       }
     } yield namespace
 
   private[util] def retrieveWsmNamespace(resourceApi: ResourceApi,
                                          namespacePrefix: String,
                                          workspaceId: UUID
-  ): F[List[WsmControlledKubernetesNamespaceResource]] = {
-    // TODO: figure out how to switch this to looking up resources by name instead of using enumerateResources
-    val wsmNamespaces = F.blocking(
-      resourceApi
-        .enumerateResources(workspaceId, 0, 100, ResourceType.AZURE_KUBERNETES_NAMESPACE, StewardshipType.CONTROLLED)
-        .getResources
-        .asScala
-        .toList
-    )
-    wsmNamespaces.map { namespaces =>
-      namespaces
-        .filter(ns =>
-          ns.getResourceAttributes.getAzureKubernetesNamespace.getKubernetesNamespace.startsWith(namespacePrefix)
-        )
-        .map(filtered_ns =>
-          WsmControlledKubernetesNamespaceResource(
-            NamespaceName(filtered_ns.getResourceAttributes.getAzureKubernetesNamespace.getKubernetesNamespace),
-            WsmControlledResourceId(filtered_ns.getMetadata.getResourceId),
-            ServiceAccountName(
-              filtered_ns.getResourceAttributes.getAzureKubernetesNamespace.getKubernetesServiceAccount
-            )
+  ): F[Option[WsmControlledKubernetesNamespaceResource]] = {
+    // The full namespace name will be {namespacePrefix}-{workspaceId},
+    // and the resource name is the same as the kubernetes namespace
+    val namespaceName = s"$namespacePrefix-$workspaceId"
+    F.blocking(
+      getWorkspaceResourceByName(workspaceId, namespaceName, resourceApi).map { ns =>
+        WsmControlledKubernetesNamespaceResource(
+          NamespaceName(ns.getResourceAttributes.getAzureKubernetesNamespace.getKubernetesNamespace),
+          WsmControlledResourceId(ns.getMetadata.getResourceId),
+          ServiceAccountName(
+            ns.getResourceAttributes.getAzureKubernetesNamespace.getKubernetesServiceAccount
           )
         )
-    }
+      }
+    )
   }
 
   private[util] def createWsmKubernetesNamespaceResource(app: App,
@@ -1153,7 +1159,6 @@ class AKSInterpreter[F[_]](config: AKSInterpreterConfig,
       createNamespaceParams = new AzureKubernetesNamespaceCreationParameters()
         .namespacePrefix(namespacePrefix)
         .databases((databases ++ appExternalDatabaseNames).asJava)
-
       _ = identity.foreach(createNamespaceParams.setManagedIdentity)
 
       // Build request
@@ -1165,7 +1170,7 @@ class AKSInterpreter[F[_]](config: AKSInterpreterConfig,
         .azureKubernetesNamespace(createNamespaceParams)
         .jobControl(createNamespaceJobControl)
 
-      _ <- logger.info(ctx.loggingCtx)(s"WSM create namespace request: $createNamespaceRequest")
+      _ <- logger.info(ctx.loggingCtx)(s"WSM create namespace request: ${createNamespaceRequest}")
 
       _ <- appControlledResourceQuery
         .insert(
@@ -1193,12 +1198,15 @@ class AKSInterpreter[F[_]](config: AKSInterpreterConfig,
 
       _ <- logger.info(ctx.loggingCtx)(s"WSM create namespace job result: ${result}")
 
-      _ <- F.raiseWhen(result.getJobReport.getStatus != JobReport.StatusEnum.SUCCEEDED)(
-        AppCreationException(
-          s"WSM namespace creation failed for app ${app.appName.value}. WSM response: ${result}",
-          Some(ctx.traceId)
-        )
-      )
+      _ <-
+        if (result.getJobReport.getStatus != JobReport.StatusEnum.SUCCEEDED) {
+          F.raiseError(
+            AppCreationException(
+              s"WSM namespace creation failed for app ${app.appName.value}. WSM response: ${result}",
+              Some(ctx.traceId)
+            )
+          )
+        } else F.unit
 
       resourceId = WsmControlledResourceId(result.getAzureKubernetesNamespace.getMetadata.getResourceId)
 
@@ -1230,7 +1238,7 @@ class AKSInterpreter[F[_]](config: AKSInterpreterConfig,
 
       // Build delete namespace request
       jobId = UUID.randomUUID()
-      deleteNamespaceRequest = new DeleteControlledAzureResourceRequest().jobControl(
+      deleteNamespaceRequest = new bio.terra.workspace.model.DeleteControlledAzureResourceRequest().jobControl(
         new JobControl().id(jobId.toString)
       )
 
@@ -1257,78 +1265,24 @@ class AKSInterpreter[F[_]](config: AKSInterpreterConfig,
       )
       result <- streamFUntilDone(
         op,
-        config.appMonitorConfig.deleteApp.maxAttempts,
-        config.appMonitorConfig.deleteApp.interval
-      ).compile.lastOrError
+        config.appMonitorConfig.createApp.maxAttempts,
+        config.appMonitorConfig.createApp.interval
+      ).interruptAfter(config.appMonitorConfig.createApp.interruptAfter).compile.lastOrError
 
       _ <- logger.info(ctx.loggingCtx)(s"WSM delete namespace job result: ${result}")
 
-      _ <- F.raiseWhen(result.getJobReport.getStatus != JobReport.StatusEnum.SUCCEEDED)(
-        AppDeletionException(
-          s"WSM namespace deletion failed for app ${app.appName.value}. WSM response: $result"
-        )
-      )
+      _ <-
+        if (result.getJobReport.getStatus != JobReport.StatusEnum.SUCCEEDED) {
+          F.raiseError(
+            AppCreationException(
+              s"WSM namespace deletion failed for app ${app.appName.value}. WSM response: ${result}",
+              Some(ctx.traceId)
+            )
+          )
+        } else F.unit
 
       // Update record in APP_CONTROLLED_RESOURCE table
       _ <- appControlledResourceQuery.delete(wsmResource.resourceId).transaction
-    } yield ()
-
-  private[util] def deleteAzureDatabaseResource(workspaceId: WorkspaceId,
-                                                app: App,
-                                                wsmResource: AppControlledResourceRecord
-  )(implicit
-    ev: Ask[F, AppContext]
-  ): F[Unit] =
-    for {
-      ctx <- ev.ask
-
-      // Build WSM client
-      wsmApi <- buildWsmControlledResourceApiClient
-
-      // Build delete database request
-      jobId = UUID.randomUUID()
-      deleteDatabaseRequest = new DeleteControlledAzureResourceRequest().jobControl(
-        new JobControl().id(jobId.toString)
-      )
-
-      _ <- logger.info(ctx.loggingCtx)(
-        s"WSM delete database request for app ${app.appName.value}: $deleteDatabaseRequest"
-      )
-
-      // Execute WSM call
-      result <- F.blocking(
-        wsmApi.deleteAzureDatabaseAsync(deleteDatabaseRequest, workspaceId.value, wsmResource.resourceId.value)
-      )
-
-      _ <- logger.info(ctx.loggingCtx)(s"WSM delete database response for app ${app.appName.value}: $result")
-
-      // Update record in APP_CONTROLLED_RESOURCE table
-      _ <- appControlledResourceQuery
-        .updateStatus(
-          wsmResource.resourceId,
-          AppControlledResourceStatus.Deleting
-        )
-        .transaction
-
-      // Poll for database deletion
-      op = F.blocking(
-        wsmApi.getDeleteAzureDatabaseResult(workspaceId.value, jobId.toString)
-      )
-      result <- streamFUntilDone(
-        op,
-        config.appMonitorConfig.deleteApp.maxAttempts,
-        config.appMonitorConfig.deleteApp.interval
-      ).compile.lastOrError
-
-      _ <- logger.info(ctx.loggingCtx)(s"WSM delete database job result for app ${app.appName.value}: $result")
-
-      _ <- F.raiseWhen(result.getJobReport.getStatus != JobReport.StatusEnum.SUCCEEDED)(
-        AppDeletionException(
-          s"WSM database deletion failed for app ${app.appName.value}. WSM response: $result"
-        )
-      )
-
-      // record in APP_CONTROLLED_RESOURCE table is updated by caller
     } yield ()
 
   private[util] def deleteWsmResource(workspaceId: WorkspaceId, app: App, wsmResource: AppControlledResourceRecord)(
@@ -1344,7 +1298,7 @@ class AKSInterpreter[F[_]](config: AKSInterpreterConfig,
         case WsmResourceType.AzureManagedIdentity =>
           F.blocking(wsmApi.deleteAzureManagedIdentity(workspaceId.value, wsmResource.resourceId.value))
         case WsmResourceType.AzureDatabase =>
-          deleteAzureDatabaseResource(workspaceId, app, wsmResource)
+          F.blocking(wsmApi.deleteAzureDatabase(workspaceId.value, wsmResource.resourceId.value))
         case _ =>
           F.raiseError(AppDeletionException(s"Unexpected WSM resource type ${wsmResource.resourceType}"))
       }
@@ -1359,6 +1313,19 @@ class AKSInterpreter[F[_]](config: AKSInterpreterConfig,
       case e => F.raiseError(e)
     }
   }
+
+  // This should probably be moved to WsmDao, if HttpWsmDao switches to using the WSM api clients
+  private def getWorkspaceResourceByName(
+    workspaceId: UUID,
+    resourceName: String,
+    resourceApi: ResourceApi
+  ): Option[ResourceDescription] =
+    Try(resourceApi.getResourceByName(workspaceId, resourceName))
+      .map(Option.apply)
+      .handleError {
+        case e: ApiException if e.getCode == StatusCodes.NotFound.intValue => None
+      }
+      .get
 
   private[util] def updateListener(authContext: AuthContext,
                                    app: App,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/AKSInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/AKSInterpreter.scala
@@ -15,7 +15,7 @@ import org.broadinstitute.dsde.workbench.DoneCheckableSyntax._
 import org.broadinstitute.dsde.workbench.azure._
 import org.broadinstitute.dsde.workbench.google2.KubernetesModels.{KubernetesNamespace, PodStatus}
 import org.broadinstitute.dsde.workbench.google2.KubernetesSerializableName.{NamespaceName, ServiceAccountName}
-import org.broadinstitute.dsde.workbench.google2.{RegionName, streamFUntilDone, streamUntilDoneOrTimeout}
+import org.broadinstitute.dsde.workbench.google2.{streamFUntilDone, streamUntilDoneOrTimeout, RegionName}
 import org.broadinstitute.dsde.workbench.leonardo.app.Database.{ControlledDatabase, ReferenceDatabase}
 import org.broadinstitute.dsde.workbench.leonardo.app.{AppInstall, BuildHelmOverrideValuesParams}
 import org.broadinstitute.dsde.workbench.leonardo.auth.SamAuthProvider
@@ -32,7 +32,6 @@ import org.http4s.{AuthScheme, Credentials, Uri}
 import org.typelevel.log4cats.StructuredLogger
 
 import java.net.URL
-import java.time.OffsetDateTime
 import java.util.{Base64, UUID}
 import scala.concurrent.ExecutionContext
 import scala.jdk.CollectionConverters._
@@ -182,7 +181,7 @@ class AKSInterpreter[F[_]](config: AKSInterpreterConfig,
 
       // get workspaceDescription from WSM
       wsmWorkspaceApi <- buildWsmWorkspaceApiClient
-      //workspaceDescription <- getWorkspaceDescription(wsmWorkspaceApi, params.workspaceId.value)
+      workspaceDescription <- getWorkspaceDescription(wsmWorkspaceApi, params.workspaceId.value)
 
       // Create relay hybrid connection pool
       // TODO: make into a WSM resource
@@ -237,8 +236,7 @@ class AKSInterpreter[F[_]](config: AKSInterpreterConfig,
       helmOverrideValueParams = BuildHelmOverrideValuesParams(
         app,
         params.workspaceId,
-        OffsetDateTime.now(), // fixme: temporary
-        //workspaceDescription.getCreatedDate,
+        workspaceDescription.getCreatedDate,
         params.cloudContext,
         landingZoneResources,
         storageContainerOpt,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/AKSInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/AKSInterpreter.scala
@@ -15,7 +15,7 @@ import org.broadinstitute.dsde.workbench.DoneCheckableSyntax._
 import org.broadinstitute.dsde.workbench.azure._
 import org.broadinstitute.dsde.workbench.google2.KubernetesModels.{KubernetesNamespace, PodStatus}
 import org.broadinstitute.dsde.workbench.google2.KubernetesSerializableName.{NamespaceName, ServiceAccountName}
-import org.broadinstitute.dsde.workbench.google2.{streamFUntilDone, streamUntilDoneOrTimeout, RegionName}
+import org.broadinstitute.dsde.workbench.google2.{RegionName, streamFUntilDone, streamUntilDoneOrTimeout}
 import org.broadinstitute.dsde.workbench.leonardo.app.Database.{ControlledDatabase, ReferenceDatabase}
 import org.broadinstitute.dsde.workbench.leonardo.app.{AppInstall, BuildHelmOverrideValuesParams}
 import org.broadinstitute.dsde.workbench.leonardo.auth.SamAuthProvider
@@ -32,6 +32,7 @@ import org.http4s.{AuthScheme, Credentials, Uri}
 import org.typelevel.log4cats.StructuredLogger
 
 import java.net.URL
+import java.time.OffsetDateTime
 import java.util.{Base64, UUID}
 import scala.concurrent.ExecutionContext
 import scala.jdk.CollectionConverters._
@@ -181,7 +182,7 @@ class AKSInterpreter[F[_]](config: AKSInterpreterConfig,
 
       // get workspaceDescription from WSM
       wsmWorkspaceApi <- buildWsmWorkspaceApiClient
-      workspaceDescription <- getWorkspaceDescription(wsmWorkspaceApi, params.workspaceId.value)
+      //workspaceDescription <- getWorkspaceDescription(wsmWorkspaceApi, params.workspaceId.value)
 
       // Create relay hybrid connection pool
       // TODO: make into a WSM resource
@@ -236,7 +237,8 @@ class AKSInterpreter[F[_]](config: AKSInterpreterConfig,
       helmOverrideValueParams = BuildHelmOverrideValuesParams(
         app,
         params.workspaceId,
-        workspaceDescription.getCreatedDate,
+        OffsetDateTime.now(), // fixme: temporary
+        //workspaceDescription.getCreatedDate,
         params.cloudContext,
         landingZoneResources,
         storageContainerOpt,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/AKSInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/AKSInterpreter.scala
@@ -35,7 +35,6 @@ import java.net.URL
 import java.util.{Base64, UUID}
 import scala.concurrent.ExecutionContext
 import scala.jdk.CollectionConverters._
-import scala.util.Try
 
 class AKSInterpreter[F[_]](config: AKSInterpreterConfig,
                            helmClient: HelmAlgebra[F],
@@ -1018,36 +1017,28 @@ class AKSInterpreter[F[_]](config: AKSInterpreterConfig,
                                                workspaceId: UUID
   ): F[Option[WsmManagedAzureIdentity]] = {
     val wsmResourceName = generateWsmNameForIdentity(appType)
-    F.blocking(
-      getWorkspaceResourceByName(workspaceId, wsmResourceName, resourceApi).map { identity =>
-        WsmManagedAzureIdentity(
-          wsmResourceName,
-          identity.getResourceAttributes.getAzureManagedIdentity.getManagedIdentityName
-        )
-      }
-    )
+    F.blocking(Option(resourceApi.getResourceByName(workspaceId, wsmResourceName)))
+      .map(opt => opt.map(identity => WsmManagedAzureIdentity(wsmResourceName,
+      identity.getResourceAttributes.getAzureManagedIdentity.getManagedIdentityName
+    )))
   }
 
   private[util] def retrieveWsmDatabases(resourceApi: ResourceApi,
                                          databaseNames: Set[String],
                                          workspaceId: UUID
-  ): F[List[WsmControlledDatabaseResource]] =
+  ): F[List[WsmControlledDatabaseResource]] = {
     // TODO: this currently matches on the 'name' (actually type) of database so for example
     // it compares for a 'cbas' or 'cromwellmetadata' database. In the future, their maybe
     // multiple of those in a workspace so this approach will have to be re-considered
     // see https://broadworkbench.atlassian.net/browse/IA-4844
     F.blocking(
-      databaseNames
-        .flatMap(dbName =>
-          getWorkspaceResourceByName(workspaceId, dbName, resourceApi).map { r =>
-            WsmControlledDatabaseResource(r.getMetadata.getName,
-                                          r.getResourceAttributes.getAzureDatabase.getDatabaseName,
-                                          r.getMetadata.getResourceId
-            )
-          }
-        )
-        .toList
-    )
+      databaseNames.flatMap(dbName => Option(resourceApi.getResourceByName(workspaceId, dbName)).map(r =>
+        WsmControlledDatabaseResource(r.getMetadata.getName,
+          r.getResourceAttributes.getAzureDatabase.getDatabaseName,
+          r.getMetadata.getResourceId
+      ))
+    ))
+  }
 
   private[util] def getWorkspaceDescription(workspaceApi: WorkspaceApi,
                                             workspaceId: UUID
@@ -1083,14 +1074,14 @@ class AKSInterpreter[F[_]](config: AKSInterpreterConfig,
                                               wsmManagedIdentityOpt: Option[WsmManagedAzureIdentity]
   )(implicit ev: Ask[F, AppContext]): F[WsmControlledKubernetesNamespaceResource] =
     for {
-      wsmNamespace <- retrieveWsmNamespace(resourceApi, namespacePrefix, workspaceId.value)
-      namespace <- wsmNamespace match {
-        case Some(ns) =>
+      wsmNamespaces <- retrieveWsmNamespace(resourceApi, namespacePrefix, workspaceId.value)
+      namespace <- wsmNamespaces.length match {
+        case 1 =>
           logger.info(
-            s"Namespace found in WSM for app ${app.appName}, using previously created namespace: ${ns.name}"
+            s"Namespace found in WSM for app ${app.appName}, using previously created namespace: ${wsmNamespaces.head.name}"
           )
-          F.pure(ns)
-        case None =>
+          F.pure(wsmNamespaces.head)
+        case 0 =>
           createWsmKubernetesNamespaceResource(
             app,
             workspaceId,
@@ -1098,27 +1089,42 @@ class AKSInterpreter[F[_]](config: AKSInterpreterConfig,
             wsmDatabases.map(_.wsmDatabaseName),
             wsmManagedIdentityOpt.map(_.wsmResourceName)
           )
+        case _ =>
+          F.raiseError(
+            AppCreationException(
+              s"App ${app.appName} has multiple namespaces $wsmNamespaces. Only one namespace per app allowed"
+            )
+          )
       }
     } yield namespace
 
   private[util] def retrieveWsmNamespace(resourceApi: ResourceApi,
                                          namespacePrefix: String,
                                          workspaceId: UUID
-  ): F[Option[WsmControlledKubernetesNamespaceResource]] = {
-    // The full namespace name will be {namespacePrefix}-{workspaceId},
-    // and the resource name is the same as the kubernetes namespace
-    val namespaceName = s"$namespacePrefix-$workspaceId"
-    F.blocking(
-      getWorkspaceResourceByName(workspaceId, namespaceName, resourceApi).map { ns =>
-        WsmControlledKubernetesNamespaceResource(
-          NamespaceName(ns.getResourceAttributes.getAzureKubernetesNamespace.getKubernetesNamespace),
-          WsmControlledResourceId(ns.getMetadata.getResourceId),
-          ServiceAccountName(
-            ns.getResourceAttributes.getAzureKubernetesNamespace.getKubernetesServiceAccount
+  ): F[List[WsmControlledKubernetesNamespaceResource]] = {
+    // TODO: figure out how to switch this to looking up resources by name instead of using enumerateResources
+    val wsmNamespaces = F.blocking(
+      resourceApi
+        .enumerateResources(workspaceId, 0, 100, ResourceType.AZURE_KUBERNETES_NAMESPACE, StewardshipType.CONTROLLED)
+        .getResources
+        .asScala
+        .toList
+    )
+    wsmNamespaces.map { namespaces =>
+      namespaces
+        .filter(ns =>
+          ns.getResourceAttributes.getAzureKubernetesNamespace.getKubernetesNamespace.startsWith(namespacePrefix)
+        )
+        .map(filtered_ns =>
+          WsmControlledKubernetesNamespaceResource(
+            NamespaceName(filtered_ns.getResourceAttributes.getAzureKubernetesNamespace.getKubernetesNamespace),
+            WsmControlledResourceId(filtered_ns.getMetadata.getResourceId),
+            ServiceAccountName(
+              filtered_ns.getResourceAttributes.getAzureKubernetesNamespace.getKubernetesServiceAccount
+            )
           )
         )
-      }
-    )
+    }
   }
 
   private[util] def createWsmKubernetesNamespaceResource(app: App,
@@ -1313,19 +1319,6 @@ class AKSInterpreter[F[_]](config: AKSInterpreterConfig,
       case e => F.raiseError(e)
     }
   }
-
-  // This should probably be moved to WsmDao, if HttpWsmDao switches to using the WSM api clients
-  private def getWorkspaceResourceByName(
-    workspaceId: UUID,
-    resourceName: String,
-    resourceApi: ResourceApi
-  ): Option[ResourceDescription] =
-    Try(resourceApi.getResourceByName(workspaceId, resourceName))
-      .map(Option.apply)
-      .handleError {
-        case e: ApiException if e.getCode == StatusCodes.NotFound.intValue => None
-      }
-      .get
 
   private[util] def updateListener(authContext: AuthContext,
                                    app: App,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/AKSInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/AKSInterpreter.scala
@@ -1107,6 +1107,7 @@ class AKSInterpreter[F[_]](config: AKSInterpreterConfig,
   ): F[Option[WsmControlledKubernetesNamespaceResource]] = {
     // The full namespace name will be {namespacePrefix}-{workspaceId},
     // and the resource name is the same as the kubernetes namespace
+    // The construction of this is done in ControlledAzureResourceApiController.createAzureKubernetesNamespace
     val namespaceName = s"$namespacePrefix-$workspaceId"
     F.blocking(
       getWorkspaceResourceByName(workspaceId, namespaceName, resourceApi).map { ns =>

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/AKSInterpreterSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/AKSInterpreterSpec.scala
@@ -1196,27 +1196,6 @@ class AKSInterpreterSpec extends AnyFlatSpecLike with TestComponent with Leonard
         )
         .metadata(new ResourceMetadata().name(s"ns-name-${workspaceId.value.toString}"))
     }
-    /*
-    when {
-      resourceApi.enumerateResources(ArgumentMatchers.eq(workspaceId.value),
-                                     any,
-                                     any,
-                                     ArgumentMatchers.eq(ResourceType.AZURE_KUBERNETES_NAMESPACE),
-                                     any
-      )
-    } thenReturn {
-      val resourceList = new ArrayList[ResourceDescription]
-      val resourceDesc = new ResourceDescription()
-      resourceDesc.metadata(new ResourceMetadata().name("idworkflows_app"))
-      resourceDesc.resourceAttributes(
-        new ResourceAttributesUnion().azureKubernetesNamespace(
-          new AzureKubernetesNamespaceAttributes().kubernetesNamespace("ns-name")
-        )
-      )
-      resourceList.add(resourceDesc)
-      new ResourceList().resources(resourceList)
-    }
-     */
     when {
       workspaceApi.getWorkspace(ArgumentMatchers.eq(workspaceId.value), any)
     } thenReturn {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -141,7 +141,7 @@ object Dependencies {
   val pact4sCirce =       "io.github.jbwheatley"  %% "pact4s-circe"     % pact4sV
   val okHttp =            "com.squareup.okhttp3"  % "okhttp"            % "4.12.0"
 
-  val workSpaceManagerV = "0.254.1067-SNAPSHOT"
+  val workSpaceManagerV = "0.254.1073-SNAPSHOT"
   val terraCommonLibV = "0.0.94-SNAPSHOT"
 
   def excludeJakartaActivationApi = ExclusionRule("jakarta.activation", "jakarta.activation-api")


### PR DESCRIPTION
<!-- Welcome to your Leonardo pull request! -->
<!-- Contributor guidelines: https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md -->

__Jira ticket__: https://broadworkbench.atlassian.net/browse/WOR-1519
Supporting changes in WSM: https://github.com/DataBiosphere/terra-workspace-manager/pull/1687

<!-- ## Dependencies -->
<!-- Include any dependent tickets and describe the relationship. Include any other relevant Jira tickets. -->

## Summary of changes
* Change instances of resource enumeration to retrieve by name instead
<!-- Please give an abridged version of the ticket description here and/or fill out the following fields. -->
Switches to a new endpoint endpoint to look up resources by name, instead of enumerating all the resources in a workspace.

Using the new endpoint, I was able to get leo to create apps a workspace with an auth domain, in a BEE.
With the first attempt, the app creation still failed, because of a new call to retrieve the workspace description. After pushing a version that didn't have that call, leo was able to successfully create the apps.
Fixing that call will require a separate solution, tracked in this ticket: https://broadworkbench.atlassian.net/browse/WOR-1602

### What

-

### Why

-

## Testing these changes

### What to test

- <!-- Test case 1 -->

<!-- ### Test data -->

### Who tested and where

- [ ] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [ ] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
