### PR TITLE
[IA-4858] fix automerge notification syntax again

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -26,11 +26,11 @@ jobs:
       - name: Match the PR to the corresponding team's slack notification channel
         id: prepare-outputs
         run: |
-          if ${{ contains(github.event.pull_request.title, 'WM-' }}; then
+          if ${{ contains(github.event.pull_request.title, 'WM-') }}; then
             echo 'notify-failure-channel=dsp-workflows                 >> $GITHUB_OUTPUT
-          elif ${{ contains(github.event.pull_request.title, 'WX-' }}; then
+          elif ${{ contains(github.event.pull_request.title, 'WX-') }}; then
             echo 'notify-failure-channel=dsp-workflows'                >> $GITHUB_OUTPUT
-          else ${{ contains(github.event.pull_request.title, 'AJ-' }}; then
+          else ${{ contains(github.event.pull_request.title, 'AJ-') }}; then
             echo 'notify-failure-channel=dsp-analysis-journeys'        >> $GITHUB_OUTPUT
           fi
 

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -27,7 +27,7 @@ jobs:
         id: prepare-outputs
         run: |
           if ${{ contains(github.event.pull_request.title, 'WM-') }}; then
-            echo 'notify-failure-channel=dsp-workflows                 >> $GITHUB_OUTPUT
+            echo 'notify-failure-channel=dsp-workflows'                 >> $GITHUB_OUTPUT
           elif ${{ contains(github.event.pull_request.title, 'WX-') }}; then
             echo 'notify-failure-channel=dsp-workflows'                >> $GITHUB_OUTPUT
           else ${{ contains(github.event.pull_request.title, 'AJ-') }}; then


### PR DESCRIPTION
<!-- Welcome to your Leonardo pull request! -->
<!-- Contributor guidelines: https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md -->

__Jira ticket__: https://broadworkbench.atlassian.net/browse/[ticket_number]

<!-- ## Dependencies -->
<!-- Include any dependent tickets and describe the relationship. Include any other relevant Jira tickets. -->

## Summary of changes

<!-- Please give an abridged version of the ticket description here and/or fill out the following fields. -->

### What

-

### Why

-

## Testing these changes

### What to test

- <!-- Test case 1 -->

<!-- ### Test data -->

### Who tested and where

- [ ] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [ ] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
