### PR TITLE
RW-12221 File syncing bug fix

### DIFF
--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
@@ -48,7 +48,7 @@ import org.broadinstitute.dsde.workbench.leonardo.util.BuildHelmChartValues.{
 import org.broadinstitute.dsde.workbench.leonardo.model.LeoException
 import org.broadinstitute.dsde.workbench.leonardo.monitor.PubsubHandleMessageError.PubsubKubernetesError
 import org.broadinstitute.dsde.workbench.leonardo.util.GKEAlgebra._
-import org.broadinstitute.dsde.workbench.model.google.{generateUniqueBucketName, GoogleProject}
+import org.broadinstitute.dsde.workbench.model.google.{generateUniqueBucketName, GcsBucketName, GoogleProject}
 import org.broadinstitute.dsde.workbench.model.{IP, TraceId, WorkbenchEmail}
 import org.broadinstitute.dsde.workbench.openTelemetry.OpenTelemetryMetrics
 import org.broadinstitute.dsp._
@@ -1493,8 +1493,9 @@ class GKEInterpreter[F[_]](
         new RuntimeException("trying to create an azure runtime in GKEInterpreter. This should never happen")
       )
 
-      // Create the staging bucket to be used by Welder
-      stagingBucketName = generateUniqueBucketName("leostaging-" + appName.value)
+      // staging bucket stores welder's welder-metadata/gcs_metadata.json which keeps generation info for a file,
+      // this file needs to live across app creations and deletions, and it should be unique for each persistent disk
+      stagingBucketName = GcsBucketName(s"leostaging-${disk.name.value}")
 
       _ <- bucketHelper
         .createStagingBucket(userEmail, googleProject, stagingBucketName, gsa)

--- a/pact4s/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/provider/DiskStateManager.scala
+++ b/pact4s/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/provider/DiskStateManager.scala
@@ -19,7 +19,6 @@ import org.broadinstitute.dsde.workbench.leonardo.{
   DiskStatus,
   DiskType,
   FormattedBy,
-  LabelMap,
   SamResourceId
 }
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject


### PR DESCRIPTION
We have a bug that causing file syncing to fail. Welder log looks like this
```
{"@timestamp":"2024-04-01T19:08:44.075Z","@version":"1","message":"Remote version has changed for /work/Program.sas. Generation mismatch (local generation: 0). 412 Precondition Failed\nPUT https://storage.googleapis.com/upload/storage/v1/b/fc-secure-76fe21ff-4946-4402-bebd-0e7ed4db1fac/o?ifGenerationMatch=0&name=notebooks/Program.sas&uploadType=resumable&upload_id=ABPtcPrbtjgKt7wXxfjYUZh4GDuanTzqPWWDaxGJnYQRrg7nFgc4sDy7gzSJEd8tlxw4pimqnZ5rlT_M5M2KyGFoqVSz-oVJQWo4PVzDSu49aWnU9A\n{\n  \"error\": {\n    \"code\": 412,\n    \"message\": \"At least one of the pre-conditions you specified did not hold.\",\n    \"errors\": [\n      {\n        \"message\": \"At least one of the pre-conditions you specified did not hold.\",\n        \"domain\": \"global\",\n        \"reason\": \"conditionNotMet\",\n        \"locationType\": \"header\",\n        \"location\": \"If-Match\"\n      }\n    ]\n  }\n}\n","logger_name":"org.broadinstitute.dsp.workbench.welder.server.Main","thread_name":"io-compute-blocker-3","severity":"INFO","level_value":20000,"stack_trace":"com.google.cloud.storage.StorageException: 412 Precondition Failed\nPUT https://storage.googleapis.com/upload/storage/v1/b/fc-secure-76fe21ff-4946-4402-bebd-0e7ed4db1fac/o?ifGenerationMatch=0&name=notebooks/Program.sas&uploadType=resumable&upload_id=ABPtcPrbtjgKt7wXxfjYUZh4GDuanTzqPWWDaxGJnYQRrg7nFgc4sDy7gzSJEd8tlxw4pimqnZ5rlT_M5M2KyGFoqVSz-oVJQWo4PVzDSu49aWnU9A\n{\n  \"error\": {\n    \"code\": 412,\n    \"message\": \"At least one of the pre-conditions you specified did not hold.\",\n    \"errors\": [\n      {\n        \"message\": \"At least one of the pre-conditions you specified did not hold.\",\n        \"domain\": \"global\",\n        \"reason\": \"conditionNotMet\",\n        \"locationType\": \"header\",\n        \"location\": \"If-Match\"\n      }\n    ]\n  }\n}\n\n\tat com.google.cloud.storage.StorageException.translate(StorageException.java:163)\n\tat com.google.cloud.storage.spi.v1.HttpStorageRpc.translate(HttpStorageRpc.java:291)\n\tat com.google.cloud.storage.spi.v1.HttpStorageRpc.writeWithResponse(HttpStorageRpc.java:964)\n\tat com.google.cloud.storage.BlobWriteChannel.transmitChunk(BlobWriteChannel.java:73)\n\tat com.google.cloud.storage.BlobWriteChannel.access$1300(BlobWriteChannel.java:35)\n\tat com.google.cloud.storage.BlobWriteChannel$1.run(BlobWriteChannel.java:258)\n\tat java.base/java.util.concurrent.Executors$RunnableAdapter.call(Unknown Source)\n\tat com.google.api.gax.retrying.DirectRetryingExecutor.submit(DirectRetryingExecutor.java:103)\n\tat com.google.cloud.RetryHelper.run(RetryHelper.java:76)\n\tat com.google.cloud.RetryHelper.runWithRetries(RetryHelper.java:50)\n\tat com.google.cloud.storage.BlobWriteChannel.flushBuffer(BlobWriteChannel.java:189)\n\tat com.google.cloud.BaseWriteChannel.close(BaseWriteChannel.java:151)\n\tat java.base/java.nio.channels.Channels$1.close(Unknown Source)\n\tat fs2.io.package$.$anonfun$writeOutputStream$5(io.scala:110)\n\tat uncancelable @ fs2.Compiler$Target.uncancelable(Compiler.scala:165)\n\tat flatMap @ fs2.Compiler$Target.flatMap(Compiler.scala:163)\n\tat handleErrorWith @ fs2.Compiler$Target.handleErrorWith(Compiler.scala:161)\n\tat modify @ fs2.internal.Scope.close(Scope.scala:262)\n\tat flatMap @ fs2.Compiler$Target.flatMap(Compiler.scala:163)\n\tat flatMap @ fs2.Compiler$Target.flatMap(Compiler.scala:163)\n\tat flatMap @ fs2.Compiler$Target.flatMap(Compiler.scala:163)\n\tat flatMap @ fs2.Compiler$Target.flatMap(Compiler.scala:163)\n\tat flatMap @ fs2.Compiler$Target.flatMap(Compiler.scala:163)\n\tat flatMap @ fs2.Compiler$Target.flatMap(Compiler.scala:163)\n\tat flatMap @ fs2.Compiler$Target.flatMap(Compiler.scala:163)\n\tat modify @ fs2.internal.Scope.close(Scope.scala:262)\n\tat flatMap @ fs2.Compiler$Target.flatMap(Compiler.scala:163)\n\tat flatMap @ fs2.Pull$.$anonfun$compile$18(Pull.scala:1208)\n\tat handleErrorWith @ fs2.Compiler$Target.handleErrorWith(Compiler.scala:161)\nCaused by: com.google.api.client.http.HttpResponseException: 412 Precondition Failed\nPUT https://storage.googleapis.com/upload/storage/v1/b/fc-secure-76fe21ff-4946-4402-bebd-0e7ed4db1fac/o?ifGenerationMatch=0&name=notebooks/Program.sas&uploadType=resumable&upload_id=ABPtcPrbtjgKt7wXxfjYUZh4GDuanTzqPWWDaxGJnYQRrg7nFgc4sDy7gzSJEd8tlxw4pimqnZ5rlT_M5M2KyGFoqVSz-oVJQWo4PVzDSu49aWnU9A\n{\n  \"error\": {\n    \"code\": 412,\n    \"message\": \"At least one of the pre-conditions you specified did not hold.\",\n    \"errors\": [\n      {\n        \"message\": \"At least one of the pre-conditions you specified did not hold.\",\n        \"domain\": \"global\",\n        \"reason\": \"conditionNotMet\",\n        \"locationType\": \"header\",\n        \"location\": \"If-Match\"\n      }\n    ]\n  }\n}\n\n\tat com.google.api.client.http.HttpResponseException$Builder.build(HttpResponseException.java:293)\n\tat com.google.api.client.http.HttpRequest.execute(HttpRequest.java:1118)\n\tat com.google.cloud.storage.spi.v1.HttpStorageRpc.writeWithResponse(HttpStorageRpc.java:937)\n\tat com.google.cloud.storage.BlobWriteChannel.transmitChunk(BlobWriteChannel.java:73)\n\tat com.google.cloud.storage.BlobWriteChannel.access$1300(BlobWriteChannel.java:35)\n\tat com.google.cloud.storage.BlobWriteChannel$1.run(BlobWriteChannel.java:258)\n\tat java.base/java.util.concurrent.Executors$RunnableAdapter.call(Unknown Source)\n\tat com.google.api.gax.retrying.DirectRetryingExecutor.submit(DirectRetryingExecutor.java:103)\n\tat com.google.cloud.RetryHelper.run(RetryHelper.java:76)\n\tat com.google.cloud.RetryHelper.runWithRetries(RetryHelper.java:50)\n\tat com.google.cloud.storage.BlobWriteChannel.flushBuffer(BlobWriteChannel.java:189)\n\tat com.google.cloud.BaseWriteChannel.close(BaseWriteChannel.java:151)\n\tat java.base/java.nio.channels.Channels$1.close(Unknown Source)\n\tat fs2.io.package$.$anonfun$writeOutputStream$5(io.scala:110)\n\tat scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.scala:18)\n\tat cats.effect.unsafe.WorkerThread.blockOn(WorkerThread.scala:631)\n\tat scala.concurrent.package$.blocking(package.scala:124)\n\tat cats.effect.IOFiber.runLoop(IOFiber.scala:951)\n\tat cats.effect.IOFiber.asyncContinueSuccessfulR(IOFiber.scala:1322)\n\tat cats.effect.IOFiber.run(IOFiber.scala:119)\n\tat cats.effect.unsafe.WorkerThread.run(WorkerThread.scala:555)\n","traceId":"f24ce23e-dc94-4636-bb67-f452ca85c187"}
```

This is saying we're trying to delocalize the file with generation number being 0, which is because `leostaging-xxx/welder-metadata/gcs_metadata.json` is empty.

This is because we're currently creating new staging for each app. Hence previous version of `gcs_metadata.json` still lives in the old staging bucket, and the new staging bucket won't have the correct content.

Steps to reproduce the bug
1. create a SAS app
2. create a .sas file and save it
3. delete the app
4. create a second app
5. check welder log, you should see the error

This is not a problem for Jupyter, because with jupyter, UI will call welder to localize files, during which welder's cache will be updated. But we probably also don't have to recreate these files for every runtime (something to consider for future optimization).

This PR only affects ALLOWED app. Other apps aren't affected because they don't run welder

<!-- Welcome to your Leonardo pull request! -->
<!-- Contributor guidelines: https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md -->

__Jira ticket__: https://broadworkbench.atlassian.net/browse/[ticket_number]

<!-- ## Dependencies -->
<!-- Include any dependent tickets and describe the relationship. Include any other relevant Jira tickets. -->

## Summary of changes

<!-- Please give an abridged version of the ticket description here and/or fill out the following fields. -->

### What

-

### Why

-

## Testing these changes

### What to test

- <!-- Test case 1 -->

<!-- ### Test data -->

### Who tested and where

- [ ] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [ ] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
