### PR TITLE
RW-12258 bump sas and rstudio chart version

### DIFF
--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -827,8 +827,8 @@ gke {
     # This is really just a prefix of the chart name. Full chart name for AOU app will be
     # this chartName in config file appended with allowedChartName from createAppRequest
     chartName = "/leonardo/"
-    rstudioChartVersion = "0.4.0"
-    sasChartVersion = "0.10.0"
+    rstudioChartVersion = "0.5.0"
+    sasChartVersion = "0.11.0"
 
     services = [
           {


### PR DESCRIPTION
We should probably update welder version for in `reference.conf` as well so that we have welder logs in cloud logging for GCE VMs properly as well. But we can't update it yet because Azure VM uses the same welder hash, and latest welder image isn't in ACR yet because of https://broadworkbench.atlassian.net/browse/IA-4899 (cc @LizBaldo )

<!-- Welcome to your Leonardo pull request! -->
<!-- Contributor guidelines: https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md -->

__Jira ticket__: https://precisionmedicineinitiative.atlassian.net/browse/RW-12258

<!-- ## Dependencies -->
<!-- Include any dependent tickets and describe the relationship. Include any other relevant Jira tickets. -->

## Summary of changes

<!-- Please give an abridged version of the ticket description here and/or fill out the following fields. -->

### What

-

### Why

-

## Testing these changes

### What to test

- <!-- Test case 1 -->

<!-- ### Test data -->

### Who tested and where

- [ ] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [ ] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
