### PR TITLE
WM-2596: Log upgrade errors

### DIFF
--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
@@ -1436,7 +1436,7 @@ class LeoPubsubMessageSubscriber[F[_]](
             for {
               _ <- appQuery.updateStatus(msg.appId, AppStatus.Running).transaction
               errorContext = s"Error updating Azure app with id ${msg.appId.id} and cloudContext ${msg.cloudContext.asString}"
-              _ = logger.warn(ctx.loggingCtx, e)(errorContext)
+              _ <- logger.warn(ctx.loggingCtx, e)(errorContext)
               error = AppError(
                 s"${errorContext}: ${e.getMessage}",
                 ctx.now,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
@@ -1435,8 +1435,10 @@ class LeoPubsubMessageSubscriber[F[_]](
           case e =>
             for {
               _ <- appQuery.updateStatus(msg.appId, AppStatus.Running).transaction
+              errorContext = s"Error updating Azure app with id ${msg.appId.id} and cloudContext ${msg.cloudContext.asString}"
+              _ = logger.warn(ctx.loggingCtx, e)(errorContext)
               error = AppError(
-                s"Error updating Azure app with id ${msg.appId.id} and cloudContext ${msg.cloudContext.asString}: ${e.getMessage}",
+                s"${errorContext}: ${e.getMessage}",
                 ctx.now,
                 ErrorAction.UpdateApp,
                 ErrorSource.App,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
@@ -1435,7 +1435,8 @@ class LeoPubsubMessageSubscriber[F[_]](
           case e =>
             for {
               _ <- appQuery.updateStatus(msg.appId, AppStatus.Running).transaction
-              errorContext = s"Error updating Azure app with id ${msg.appId.id} and cloudContext ${msg.cloudContext.asString}"
+              errorContext =
+                s"Error updating Azure app with id ${msg.appId.id} and cloudContext ${msg.cloudContext.asString}"
               _ <- logger.warn(ctx.loggingCtx, e)(errorContext)
               error = AppError(
                 s"${errorContext}: ${e.getMessage}",


### PR DESCRIPTION
__Jira ticket__: https://broadworkbench.atlassian.net/browse/WM-2596

## Summary of changes

Logs any errors resulting from failed app upgrades (rolled back before applying any changes)

### Why

The messages written to the Leo DB are insufficient for tracking what actually went wrong during the upgrade. In particular errors such as `{"message":"Resource not found.","statusCode":404,"causes":[]}` cannot be debugged without additional context. This change makes sure the full error and stack trace are in application logs, without changing the short version of the message in the database.
