### PR TITLE
[IA-4627] App deletion should succeed when sub-resources dont exist

### DIFF
--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/CommonTestData.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/CommonTestData.scala
@@ -595,5 +595,3 @@ class TestException(message: String = "Test error", statusCode: StatusCode = Sta
     extends ApiException {
   override def getCode: Int = statusCode.intValue
 }
-
-class TestSuccess(statusCode: StatusCode = StatusCodes.OK)

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/CommonTestData.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/CommonTestData.scala
@@ -1,6 +1,8 @@
 package org.broadinstitute.dsde.workbench.leonardo
 
+import akka.http.scaladsl.model.{StatusCode, StatusCodes}
 import akka.http.scaladsl.model.headers.{HttpCookiePair, OAuth2BearerToken}
+import bio.terra.workspace.client.ApiException
 import bio.terra.workspace.model.WorkspaceDescription
 import cats.effect.IO
 import cats.effect.Ref
@@ -589,3 +591,9 @@ trait GcsPathUtils {
   def gcsPath(str: String): GcsPath =
     parseGcsPath(str).right.get
 }
+class TestException(message: String = "Test error", statusCode: StatusCode = StatusCodes.NotFound)
+    extends ApiException {
+  override def getCode: Int = statusCode.intValue
+}
+
+class TestSuccess(statusCode: StatusCode = StatusCodes.OK)


### PR DESCRIPTION
<!-- Welcome to your Leonardo pull request! -->
<!-- Contributor guidelines: https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md -->

__Jira ticket__: https://broadworkbench.atlassian.net/browse/IA-4627

<!-- ## Dependencies -->
<!-- Include any dependent tickets and describe the relationship. Include any other relevant Jira tickets. -->

## Summary of changes

<!-- Please give an abridged version of the ticket description here and/or fill out the following fields. -->

### What

- When an app is deleted, many sub-resources (databases, managed identity, namespace) are deleted through WSM. If the underlying resource is deleted in WSM, the delete errors.
- This change handles the error and updates the database when this happens
- Also consolidates the WSM delete functions in the AKS interp so that all resource deletions are handled by the same function and can take advantage of the new error handling

### Why

- If a resource is deleted in WSM, then the deletion has already succeeded and Leo's database should reflect that

## Testing these changes

### What to test

- <!-- Test case 1 -->

<!-- ### Test data -->

### Who tested and where

- [ ] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [ ] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
