### PR TITLE
RW-12371 Fix a bug when runtime fail to delete

### DIFF
--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/BaseCloudServiceRuntimeMonitor.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/BaseCloudServiceRuntimeMonitor.scala
@@ -193,7 +193,7 @@ abstract class BaseCloudServiceRuntimeMonitor[F[_]] {
         )
         _ <- clusterQuery.detachPersistentDisk(runtimeAndRuntimeConfig.runtime.id, ctx.now).transaction
         _ <- curStatus match {
-          case RuntimeStatus.Deleted =>
+          case RuntimeStatus.Deleted | RuntimeStatus.Deleting =>
             logger.info(ctx.loggingCtx)(
               s"failedRuntime: not moving runtime with id ${runtimeAndRuntimeConfig.runtime.id} because it is in ${curStatus} status."
             )

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/BaseCloudServiceRuntimeMonitorSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/BaseCloudServiceRuntimeMonitorSpec.scala
@@ -262,7 +262,7 @@ class BaseCloudServiceRuntimeMonitorSpec extends AnyFlatSpec with Matchers with 
   }
 
   it should "not move to ERROR status when an error happens during runtime deletion" in isolatedDbTest {
-    val runtimeMonitor = baseRuntimeMonitor(false)
+    val runtimeMonitor = baseRuntimeMonitor(false, timeouts = Map(RuntimeStatus.Deleting -> 1.minutes))
     val start = Instant.EPOCH
     val res = for {
       tid <- traceId.ask[TraceId]
@@ -280,7 +280,7 @@ class BaseCloudServiceRuntimeMonitorSpec extends AnyFlatSpec with Matchers with 
 
       _ <- runtimeMonitor.checkAgain(monitorContext, runtimeAndRuntimeConfig, None, None, None)
       status <- clusterQuery.getClusterStatus(runtime.id).transaction
-    } yield status shouldBe RuntimeStatus.Deleting
+    } yield status shouldBe Some(RuntimeStatus.Deleting)
 
     res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }


### PR DESCRIPTION
https://precisionmedicineinitiative.atlassian.net/browse/RW-12371

We had a support ticket when a user attempted to delete a dataproc cluster on 4/4. And leo transitioned the cluster to `ERROR` status because deletion timed out (there was an internal server error on dataproc side). User assumed the cluster is gone, and surprised by the unexpected extra spend when they looked at cloud cost.

This PR makes it so that if an error happens when a cluster is in `Deleting` status, `failedRuntime` function won't mark it as `ERROR`.

<!-- Welcome to your Leonardo pull request! -->
<!-- Contributor guidelines: https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md -->

__Jira ticket__: https://precisionmedicineinitiative.atlassian.net/browse/RW-12371

<!-- ## Dependencies -->
<!-- Include any dependent tickets and describe the relationship. Include any other relevant Jira tickets. -->

## Summary of changes

<!-- Please give an abridged version of the ticket description here and/or fill out the following fields. -->

### What

-

### Why

-

## Testing these changes

### What to test

- <!-- Test case 1 -->

<!-- ### Test data -->

### Who tested and where

- [ ] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [ ] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
