### PR TITLE
[IA-4808] Specify jupyter and welder user IDs

### DIFF
--- a/http/src/main/resources/init-resources/azure_vm_init_script.sh
+++ b/http/src/main/resources/init-resources/azure_vm_init_script.sh
@@ -11,7 +11,7 @@ export DEBIAN_FRONTEND=noninteractive
 #create user to run jupyter
 VM_JUP_USER=jupyter
 
-sudo useradd -m -c "Jupyter User" $VM_JUP_USER
+sudo useradd -m -c "Jupyter User" -u 2000 $VM_JUP_USER
 sudo usermod -a -G $VM_JUP_USER,adm,dialout,cdrom,floppy,audio,dip,video,plugdev,lxd,netdev $VM_JUP_USER
 
 ## Change ownership for the new user


### PR DESCRIPTION
<!-- Welcome to your Leonardo pull request! -->
<!-- Contributor guidelines: https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md -->

__Jira ticket__: https://broadworkbench.atlassian.net/browse/IA-4808

## Dependencies
https://github.com/DataBiosphere/welder/pull/269
https://github.com/DataBiosphere/terra-docker/pull/487
## Summary of changes

<!-- Please give an abridged version of the ticket description here and/or fill out the following fields. -->

### What

- Updates the jupyter user id in the azure init script
- Updates the welder version
- Incorporates the new docker images (had to update the base image to change the welder uid)

### Why

- the user IDs after 1000 are reserved for 'normal' (non-system) users and they normally get assigned sequentially. 
- In order to avoid the case where 1001 is already assigned to a different user, this moves the uid into the 2000s.
- A new user was added via the Azure DSVM that bumped the sequence of UIDs back, so 1001 was taken by the leoAdmin user and that caused permission issues for the /work folder welder depends on

## Testing these changes

### What to test

- <!-- Test case 1 -->

<!-- ### Test data -->

### Who tested and where

- [ ] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [ ] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
