### PR TITLE
IA-4831: use originatingUserEmail instead of userInfo.userEmail

### DIFF
--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/LeoAppServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/LeoAppServiceInterp.scala
@@ -780,7 +780,7 @@ final class LeoAppServiceInterp[F[_]: Parallel](config: AppServiceConfig,
         getSavableApp(
           cloudContext,
           appName,
-          userInfo.userEmail,
+          originatingUserEmail,
           samResourceId,
           req,
           diskResultOpt.map(_.disk),

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/LeoAppServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/LeoAppServiceInterp.scala
@@ -732,7 +732,7 @@ final class LeoAppServiceInterp[F[_]: Parallel](config: AppServiceConfig,
 
       // Save or retrieve a KubernetesCluster record for the app
       saveCluster <- F.fromEither(
-        getSavableCluster(userInfo.userEmail, cloudContext, ctx.now)
+        getSavableCluster(originatingUserEmail, cloudContext, ctx.now)
       )
       saveClusterResult <- KubernetesServiceDbQueries
         .saveOrGetClusterForApp(saveCluster)


### PR DESCRIPTION
__Jira ticket__: https://broadworkbench.atlassian.net/browse/IA-4831
Required for: https://broadworkbench.atlassian.net/browse/WOR-1545

## Summary of changes

Pass in `originatingUserEmail` instead of `userInfo.userEmail` for `AppInstall`, so it can get a pet with the email.
Most places the service was already doing the right thing, but there were a couple of places it wasn't.

### What

-

### Why

-

## Testing these changes

### What to test
WDS is created in a cloned workspace via async flows (which use a Pet to start WDS)
- <!-- Test case 1 -->

<!-- ### Test data -->

### Who tested and where

I tested creating a workspace, creating apps, cloning a workspace, deleting a workspace, all in a bee.


- [ ] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [ ] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
