### PR TITLE
TOAZ-357 Open id connect api yaml

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN mkdir /helm-go-lib-build && \
 
 # Use this graalvm image if we need to use jstack etc
 # FROM ghcr.io/graalvm/graalvm-ce:ol8-java11-21.0.0.2
-FROM us.gcr.io/broad-dsp-gcr-public/base/jre:17-debian
+FROM us.gcr.io/broad-dsp-gcr-public/base/jre@sha256:632bfba41693ae3017b78d12c59fdc86ed2b80d5872445ee78f18f9d1235d4b2
 
 EXPOSE 8080
 EXPOSE 5050

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN mkdir /helm-go-lib-build && \
 
 # Use this graalvm image if we need to use jstack etc
 # FROM ghcr.io/graalvm/graalvm-ce:ol8-java11-21.0.0.2
-FROM us.gcr.io/broad-dsp-gcr-public/base/jre@sha256:632bfba41693ae3017b78d12c59fdc86ed2b80d5872445ee78f18f9d1235d4b2
+FROM us.gcr.io/broad-dsp-gcr-public/base/jre:17-debian
 
 EXPOSE 8080
 EXPOSE 5050

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/ConfigImplicits.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/ConfigImplicits.scala
@@ -41,8 +41,6 @@ object ConfigImplicits {
     ConfigReader.stringConfigReader.map(s => ClientSecret(s))
   implicit val oauth2ClientIdConfigReader: ConfigReader[org.broadinstitute.dsde.workbench.oauth2.ClientId] =
     ConfigReader.stringConfigReader.map(s => org.broadinstitute.dsde.workbench.oauth2.ClientId(s))
-  implicit val oauth2ClientSecretConfigReader: ConfigReader[org.broadinstitute.dsde.workbench.oauth2.ClientSecret] =
-    ConfigReader.stringConfigReader.map(s => org.broadinstitute.dsde.workbench.oauth2.ClientSecret(s))
   implicit val tentantIdConfigReader: ConfigReader[ManagedAppTenantId] =
     ConfigReader.stringConfigReader.map(s => ManagedAppTenantId(s))
   implicit val uriConfigReader: ConfigReader[Uri] =

--- a/http/src/main/resources/swagger/api-docs.yaml
+++ b/http/src/main/resources/swagger/api-docs.yaml
@@ -29,8 +29,6 @@ tags:
 security:
   - oidc:
       - openid
-      - email
-      - profile
 
 ##########################################################################################
 ## PATHS
@@ -2928,15 +2926,9 @@ components:
 
   securitySchemes:
     oidc:
-      type: oauth2
-      flows:
-        authorizationCode:
-          authorizationUrl: /oauth2/authorize
-          tokenUrl: /oauth2/token
-          scopes:
-            openid: open id authorization
-            email: email authorization
-            profile: profile authorization
+      type: openIdConnect
+      openIdConnectUrl: OPEN_ID_CONNECT_URL
+      x-tokenName: id_token
   schemas:
     AppType:
       type: string

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/BaselineDependenciesBuilder.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/BaselineDependenciesBuilder.scala
@@ -249,8 +249,6 @@ class BaselineDependenciesBuilder {
         OpenIDConnectConfiguration[F](
           ConfigReader.appConfig.oidc.authorityEndpoint.renderString,
           ConfigReader.appConfig.oidc.clientId,
-          oidcClientSecret = ConfigReader.appConfig.oidc.clientSecret,
-          extraGoogleClientId = Some(ConfigReader.appConfig.oidc.legacyGoogleClientId),
           extraAuthParams = Some("prompt=login")
         )
       )

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/ConfigReader.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/ConfigReader.scala
@@ -35,9 +35,7 @@ final case class AzureConfig(
 
 final case class OidcAuthConfig(
   authorityEndpoint: Uri,
-  clientId: org.broadinstitute.dsde.workbench.oauth2.ClientId,
-  clientSecret: Option[org.broadinstitute.dsde.workbench.oauth2.ClientSecret],
-  legacyGoogleClientId: org.broadinstitute.dsde.workbench.oauth2.ClientId
+  clientId: org.broadinstitute.dsde.workbench.oauth2.ClientId
 )
 
 final case class DrsConfig(url: String)

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/ConfigReaderSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/ConfigReaderSpec.scala
@@ -243,9 +243,7 @@ class ConfigReaderSpec extends AnyFlatSpec with Matchers {
       ),
       OidcAuthConfig(
         Uri.unsafeFromString("https://fake"),
-        org.broadinstitute.dsde.workbench.oauth2.ClientId("fakeClientId"),
-        Some(org.broadinstitute.dsde.workbench.oauth2.ClientSecret("fakeClientSecret")),
-        org.broadinstitute.dsde.workbench.oauth2.ClientId("legacyClientSecret")
+        org.broadinstitute.dsde.workbench.oauth2.ClientId("fakeClientId")
       ),
       DrsConfig(
         "https://drshub.dsde-dev.broadinstitute.org/api/v4/drs/resolve"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,13 +17,13 @@ object Dependencies {
   val munitCatsEffectV = "1.0.7"
   val pact4sV = "0.10.0"
 
-  private val workbenchLibsHash = "1c0cf92"
+  private val workbenchLibsHash = "5762674"
   val serviceTestV = s"4.3-$workbenchLibsHash"
   val workbenchModelV = s"0.19-$workbenchLibsHash"
   val workbenchGoogleV = s"0.30-$workbenchLibsHash"
   val workbenchGoogle2V = s"0.36-$workbenchLibsHash"
   val workbenchOpenTelemetryV = s"0.8-$workbenchLibsHash"
-  val workbenchOauth2V = s"0.5-$workbenchLibsHash"
+  val workbenchOauth2V = s"0.7-$workbenchLibsHash"
   val workbenchAzureV = s"0.7-$workbenchLibsHash"
 
   val helmScalaSdkV = "0.0.8.5"


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/TOAZ-357

use openIdConnect security scheme in open api instead of oauth2 so we can remove the custom implementations of authorize and token endpoints and work with a central swagger ui

## Testing these changes

### What to test

- <!-- Test case 1 -->

<!-- ### Test data -->

### Who tested and where

- [ ] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [ ] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
