### PR TITLE
RW-12082 more metrics change

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/AsyncTaskProcessor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/AsyncTaskProcessor.scala
@@ -84,7 +84,8 @@ object AsyncTaskProcessor {
   final case class TaskMetricsTags(taskName: String,
                                    toolType: Option[String] = None,
                                    isAoU: Option[Boolean],
-                                   cloudProvider: CloudProvider
+                                   cloudProvider: CloudProvider,
+                                   cloudService: Option[CloudService] = None
   )
   final case class Task[F[_]](traceId: TraceId,
                               op: F[Unit],
@@ -97,7 +98,8 @@ object AsyncTaskProcessor {
         "taskName" -> metricsTags.taskName,
         "toolType" -> metricsTags.toolType.getOrElse("unknown"),
         "isAoU" -> metricsTags.isAoU.map(_.toString).getOrElse("unknown"),
-        "cloud" -> metricsTags.cloudProvider.asString
+        "cloud" -> metricsTags.cloudProvider.asString,
+        "cloudService" -> metricsTags.cloudService.map(_.asString).getOrElse("unknown")
       )
   }
   final case class Config(queueBound: Int, maxConcurrentTasks: Int)

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriberSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriberSpec.scala
@@ -2389,8 +2389,8 @@ class LeoPubsubMessageSubscriberSpec
 
     res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
     verify(mockAckConsumer, times(1)).ack()
-    verify(metrics, times(1)).recordDuration(startsWith(s"pubsub/ack/createApp"), any(), any(), any())(any())
-    verify(metrics, times(1)).recordDuration(startsWith(s"pubsub/fail/createApp"), any(), any(), any())(any())
+    verify(metrics, times(1)).recordDuration(startsWith(s"pubsub/success"), any(), any(), any())(any())
+    verify(metrics, times(1)).recordDuration(startsWith(s"pubsub/fail"), any(), any(), any())(any())
   }
 
   def makeGKEInterp(lock: KeyLock[IO, GKEModels.KubernetesClusterId],


### PR DESCRIPTION
1. Add `isAoU` label for createApp task
2. Add `cloudService` label for createRuntime task
3. Update existing `pubsub` metrics to use labels so that it's easier to create charts in grafana. I didn't find charts using these metrics, but if there is let me know and happy to update them after this PR...

<!-- Welcome to your Leonardo pull request! -->
<!-- Contributor guidelines: https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md -->

__Jira ticket__: https://broadworkbench.atlassian.net/browse/[ticket_number]

<!-- ## Dependencies -->
<!-- Include any dependent tickets and describe the relationship. Include any other relevant Jira tickets. -->

## Summary of changes

<!-- Please give an abridged version of the ticket description here and/or fill out the following fields. -->

### What

-

### Why

-

## Testing these changes

### What to test

- <!-- Test case 1 -->

<!-- ### Test data -->

### Who tested and where

- [ ] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [ ] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
