### PR TITLE
RW-12082 add more runtime failure details to metrics

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/runtimeModels.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/runtimeModels.scala
@@ -571,7 +571,7 @@ final case class RuntimeError(errorMessage: String,
 /**
  * @param longMessage: error message we use in logs to provide details for debugging purpose
  * @param code: error code that comes from GCP
- * @param shortMessage: short message we can potentially use for displaying to users. Today, this is mainly used for labels in runtime creation failure metrics
+ * @param shortMessage: This is mainly used for labels in runtime creation failure metrics today
  * @param labels: leonardo labels for a runtime
  */
 final case class RuntimeErrorDetails(longMessage: String,

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/runtimeModels.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/runtimeModels.scala
@@ -567,6 +567,13 @@ final case class RuntimeError(errorMessage: String,
                               timestamp: Instant,
                               traceId: Option[TraceId] = None
 )
+
+/**
+ * @param longMessage: error message we use in logs to provide details for debugging purpose
+ * @param code: error code that comes from GCP
+ * @param shortMessage: short message we can potentially use for displaying to users. Today, this is mainly used for labels in runtime creation failure metrics
+ * @param labels: leonardo labels for a runtime
+ */
 final case class RuntimeErrorDetails(longMessage: String,
                                      code: Option[Int] = None,
                                      shortMessage: Option[String] = None,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/DataprocRuntimeMonitor.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/DataprocRuntimeMonitor.scala
@@ -187,7 +187,9 @@ class DataprocRuntimeMonitor[F[_]: Parallel](
                         failedRuntime(
                           monitorContext,
                           runtimeAndRuntimeConfig,
-                          RuntimeErrorDetails(s"Can't find master instance for this cluster"),
+                          RuntimeErrorDetails(s"Can't find master instance for this cluster",
+                                              shortMessage = Some("dataproc_no_master_instance")
+                          ),
                           instances.find(_.dataprocRole == DataprocRole.Master)
                         )
                     }
@@ -342,14 +344,16 @@ class DataprocRuntimeMonitor[F[_]: Parallel](
             failedRuntime(
               monitorContext,
               runtimeAndRuntimeConfig,
-              RuntimeErrorDetails(s"Cluster failed to start"),
+              RuntimeErrorDetails(s"Cluster failed to start", shortMessage = Some("dataproc_cluster_fail_to_start")),
               instances.find(_.dataprocRole == DataprocRole.Master)
             )
           case ss =>
             failedRuntime(
               monitorContext,
               runtimeAndRuntimeConfig,
-              RuntimeErrorDetails(s"unexpected Cluster ${ss} when trying to start it"),
+              RuntimeErrorDetails(s"unexpected Cluster ${ss} when trying to start it",
+                                  shortMessage = Some("dataproc_unexpected_status")
+              ),
               instances.find(_.dataprocRole == DataprocRole.Master)
             )
         }
@@ -368,7 +372,7 @@ class DataprocRuntimeMonitor[F[_]: Parallel](
       failedRuntime(
         monitorContext,
         runtimeAndRuntimeConfig,
-        RuntimeErrorDetails(e.getMessage),
+        RuntimeErrorDetails(e.getMessage, shortMessage = Some("dataproc_invalid_stopping")),
         None
       ) >> F.raiseError[CheckResult](e)
     case Some(c) =>
@@ -414,7 +418,7 @@ class DataprocRuntimeMonitor[F[_]: Parallel](
       failedRuntime(
         monitorContext,
         runtimeAndRuntimeConfig,
-        RuntimeErrorDetails(e.getMessage),
+        RuntimeErrorDetails(e.getMessage, shortMessage = Some("dataproc_invalid_update")),
         None
       ) >> F.raiseError[CheckResult](e)
     case Some(c) =>
@@ -458,14 +462,16 @@ class DataprocRuntimeMonitor[F[_]: Parallel](
             failedRuntime(
               monitorContext,
               runtimeAndRuntimeConfig,
-              RuntimeErrorDetails(s"Cluster failed to Update"),
+              RuntimeErrorDetails(s"Cluster failed to Update", shortMessage = Some("dataproc_fail_to_update")),
               instances.find(_.dataprocRole == DataprocRole.Master)
             )
           case ss =>
             failedRuntime(
               monitorContext,
               runtimeAndRuntimeConfig,
-              RuntimeErrorDetails(s"unexpected Cluster ${ss} when trying to start an instance"),
+              RuntimeErrorDetails(s"unexpected Cluster ${ss} when trying to start an instance",
+                                  shortMessage = Some("dataproc_unexpected_status")
+              ),
               instances.find(_.dataprocRole == DataprocRole.Master)
             )
         }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/DataprocRuntimeMonitor.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/DataprocRuntimeMonitor.scala
@@ -237,9 +237,9 @@ class DataprocRuntimeMonitor[F[_]: Parallel](
                         monitorContext,
                         runtimeAndRuntimeConfig,
                         error
-                          .map(e => RuntimeErrorDetails(e.message, Some(e.code), Some("dataproc_creation_error")))
+                          .map(e => RuntimeErrorDetails(e.message, Some(e.code), Some("creation_error")))
                           .getOrElse(
-                            RuntimeErrorDetails("Error not available", shortMessage = Some("dataproc_creation_error"))
+                            RuntimeErrorDetails("Error not available", shortMessage = Some("creation_error"))
                           ),
                         instances.find(_.dataprocRole == DataprocRole.Master)
                       )
@@ -344,7 +344,7 @@ class DataprocRuntimeMonitor[F[_]: Parallel](
             failedRuntime(
               monitorContext,
               runtimeAndRuntimeConfig,
-              RuntimeErrorDetails(s"Cluster failed to start", shortMessage = Some("dataproc_cluster_fail_to_start")),
+              RuntimeErrorDetails(s"Cluster failed to start", shortMessage = Some("cluster_fail_to_start")),
               instances.find(_.dataprocRole == DataprocRole.Master)
             )
           case ss =>
@@ -352,7 +352,7 @@ class DataprocRuntimeMonitor[F[_]: Parallel](
               monitorContext,
               runtimeAndRuntimeConfig,
               RuntimeErrorDetails(s"unexpected Cluster ${ss} when trying to start it",
-                                  shortMessage = Some("dataproc_unexpected_status")
+                                  shortMessage = Some("unexpected_status")
               ),
               instances.find(_.dataprocRole == DataprocRole.Master)
             )
@@ -372,7 +372,7 @@ class DataprocRuntimeMonitor[F[_]: Parallel](
       failedRuntime(
         monitorContext,
         runtimeAndRuntimeConfig,
-        RuntimeErrorDetails(e.getMessage, shortMessage = Some("dataproc_invalid_stopping")),
+        RuntimeErrorDetails(e.getMessage, shortMessage = Some("invalid_stopping")),
         None
       ) >> F.raiseError[CheckResult](e)
     case Some(c) =>
@@ -418,7 +418,7 @@ class DataprocRuntimeMonitor[F[_]: Parallel](
       failedRuntime(
         monitorContext,
         runtimeAndRuntimeConfig,
-        RuntimeErrorDetails(e.getMessage, shortMessage = Some("dataproc_invalid_update")),
+        RuntimeErrorDetails(e.getMessage, shortMessage = Some("invalid_update")),
         None
       ) >> F.raiseError[CheckResult](e)
     case Some(c) =>
@@ -462,7 +462,7 @@ class DataprocRuntimeMonitor[F[_]: Parallel](
             failedRuntime(
               monitorContext,
               runtimeAndRuntimeConfig,
-              RuntimeErrorDetails(s"Cluster failed to Update", shortMessage = Some("dataproc_fail_to_update")),
+              RuntimeErrorDetails(s"Cluster failed to Update", shortMessage = Some("fail_to_update")),
               instances.find(_.dataprocRole == DataprocRole.Master)
             )
           case ss =>
@@ -470,7 +470,7 @@ class DataprocRuntimeMonitor[F[_]: Parallel](
               monitorContext,
               runtimeAndRuntimeConfig,
               RuntimeErrorDetails(s"unexpected Cluster ${ss} when trying to start an instance",
-                                  shortMessage = Some("dataproc_unexpected_status")
+                                  shortMessage = Some("unexpected_status")
               ),
               instances.find(_.dataprocRole == DataprocRole.Master)
             )

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/GceRuntimeMonitor.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/GceRuntimeMonitor.scala
@@ -76,7 +76,8 @@ class GceRuntimeMonitor[F[_]: Parallel](
         monitorContext,
         runtimeAndRuntimeConfig,
         RuntimeErrorDetails(
-          s"${monitorContext.action} ${runtimeAndRuntimeConfig.runtime.projectNameString} fail to complete in a timely manner"
+          s"${monitorContext.action} ${runtimeAndRuntimeConfig.runtime.projectNameString} fail to complete in a timely manner",
+          shortMessage = Some("gce_timeout")
         ),
         None
       )
@@ -241,7 +242,9 @@ class GceRuntimeMonitor[F[_]: Parallel](
             ) >> failedRuntime(
               monitorContext,
               runtimeAndRuntimeConfig,
-              RuntimeErrorDetails(s"unexpected GCE instance status ${ss} when trying to creating an instance"),
+              RuntimeErrorDetails(s"unexpected GCE instance status ${ss} when trying to creating an instance",
+                                  shortMessage = Some("gce_unexpected_status")
+              ),
               None
             )
         }
@@ -334,7 +337,9 @@ class GceRuntimeMonitor[F[_]: Parallel](
             failedRuntime(
               monitorContext,
               runtimeAndRuntimeConfig,
-              RuntimeErrorDetails(s"unexpected GCE instance status ${ss} when trying to start an instance"),
+              RuntimeErrorDetails(s"unexpected GCE instance status ${ss} when trying to start an instance",
+                                  shortMessage = Some("gce_unexpected_status")
+              ),
               None,
               false
             )

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/GceRuntimeMonitor.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/GceRuntimeMonitor.scala
@@ -77,7 +77,7 @@ class GceRuntimeMonitor[F[_]: Parallel](
         runtimeAndRuntimeConfig,
         RuntimeErrorDetails(
           s"${monitorContext.action} ${runtimeAndRuntimeConfig.runtime.projectNameString} fail to complete in a timely manner",
-          shortMessage = Some("gce_timeout")
+          shortMessage = Some("timeout")
         ),
         None
       )
@@ -243,7 +243,7 @@ class GceRuntimeMonitor[F[_]: Parallel](
               monitorContext,
               runtimeAndRuntimeConfig,
               RuntimeErrorDetails(s"unexpected GCE instance status ${ss} when trying to creating an instance",
-                                  shortMessage = Some("gce_unexpected_status")
+                                  shortMessage = Some("unexpected_status")
               ),
               None
             )
@@ -338,7 +338,7 @@ class GceRuntimeMonitor[F[_]: Parallel](
               monitorContext,
               runtimeAndRuntimeConfig,
               RuntimeErrorDetails(s"unexpected GCE instance status ${ss} when trying to start an instance",
-                                  shortMessage = Some("gce_unexpected_status")
+                                  shortMessage = Some("unexpected_status")
               ),
               None,
               false

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
@@ -364,7 +364,7 @@ class LeoPubsubMessageSubscriber[F[_]](
           fa,
           Some(handleRuntimeMessageError(runtime.id, ctx.now, s"deleting runtime ${runtime.projectNameString} failed")),
           ctx.now,
-          TaskMetricsTags("deleteRuntime", None, Some(isAoU), CloudProvider.Gcp)
+          TaskMetricsTags("deleteRuntime", None, Some(isAoU), CloudProvider.Gcp, Some(runtimeConfig.cloudService))
         )
       )
     } yield ()
@@ -441,7 +441,7 @@ class LeoPubsubMessageSubscriber[F[_]](
                   )
                 ),
                 ctx.now,
-                TaskMetricsTags("stopRuntime", None, Some(isAoU), CloudProvider.Gcp)
+                TaskMetricsTags("stopRuntime", None, Some(isAoU), CloudProvider.Gcp, Some(runtimeConfig.cloudService))
               )
             )
           } yield ()
@@ -501,7 +501,7 @@ class LeoPubsubMessageSubscriber[F[_]](
                   )
                 ),
                 ctx.now,
-                TaskMetricsTags("startRuntime", None, Some(isAoU), CloudProvider.Gcp)
+                TaskMetricsTags("startRuntime", None, Some(isAoU), CloudProvider.Gcp, Some(runtimeConfig.cloudService))
               )
             )
           } yield ()
@@ -648,7 +648,12 @@ class LeoPubsubMessageSubscriber[F[_]](
                   )
                 ),
                 ctx.now,
-                TaskMetricsTags("stopAndUpdateRuntime", None, Some(isAoU), CloudProvider.Gcp)
+                TaskMetricsTags("stopAndUpdateRuntime",
+                                None,
+                                Some(isAoU),
+                                CloudProvider.Gcp,
+                                Some(runtimeConfig.cloudService)
+                )
               )
             )
           } yield ()
@@ -666,7 +671,12 @@ class LeoPubsubMessageSubscriber[F[_]](
                     runtimeConfig.cloudService.process(runtime.id, RuntimeStatus.Updating, None).compile.drain,
                     Some(handleRuntimeMessageError(runtime.id, ctx.now, "updating runtime")),
                     ctx.now,
-                    TaskMetricsTags("updateRuntime", None, Some(isAoU), CloudProvider.Gcp)
+                    TaskMetricsTags("updateRuntime",
+                                    None,
+                                    Some(isAoU),
+                                    CloudProvider.Gcp,
+                                    Some(runtimeConfig.cloudService)
+                    )
                   )
                 )
               } else F.unit


### PR DESCRIPTION
https://precisionmedicineinitiative.atlassian.net/browse/RW-12082

1. This PR populates more details for `shortMessage` field when runtimes fail to create. This field is mostly used for populating runtime failure metrics labels.

Today, when `shortMessage` is not specified, we default to `leonardo`, which isn't very helpful.

2. Populate `cloudService` label in a few more pubsub events

<!-- Welcome to your Leonardo pull request! -->
<!-- Contributor guidelines: https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md -->

__Jira ticket__: https://broadworkbench.atlassian.net/browse/[ticket_number]

<!-- ## Dependencies -->
<!-- Include any dependent tickets and describe the relationship. Include any other relevant Jira tickets. -->

## Summary of changes

<!-- Please give an abridged version of the ticket description here and/or fill out the following fields. -->

### What

-

### Why

-

## Testing these changes

### What to test

- <!-- Test case 1 -->

<!-- ### Test data -->

### Who tested and where

- [ ] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [ ] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
