### PR TITLE
RW-12516  fix slowness in listRuntime when cloudContext is defined

### DIFF
--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/RuntimeServiceDbQueries.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/RuntimeServiceDbQueries.scala
@@ -402,7 +402,7 @@ object RuntimeServiceDbQueries {
       if (ownedProjects.isEmpty)
         None
       else if (cloudContext.isDefined) {
-        // If cloudContext is defined, we're already applying the filter elsewhere.
+        // If cloudContext is defined, we're already applying the filter in runtimesFiltered below.
         // No need to filter by the list of user owned projects anymore as long as the specified
         // project is owned by the user.
         if (ownedProjects.exists(x => x.value == cloudContext.get.asString))


### PR DESCRIPTION
listRuntime is taking really long time in dev when we're using AoU SA. 

* Adding a bit tracing info to help identifying issue.
Related [slack convo](https://broadinstitute.slack.com/archives/CA3NP1733/p1714678940625759)
* Fix the slow query

Before the PR, the original query looks like this
```
SELECT 
    x2.x3, 
    x2.x4, 
    x2.x5, 
    x2.x6, 
    x2.x7, 
    x2.x8, 
    x2.x9, 
    x2.x10, 
    x2.x11, 
    x2.x12, 
    x2.x13, 
    x2.x14, 
    x2.x15, 
    x2.x16, 
    x2.x17, 
    x2.x18, 
    x2.x19, 
    x2.x20, 
    x2.x21, 
    x2.x22, 
    x2.x23, 
    x2.x24, 
    x2.x25, 
    x2.x26, 
    x2.x27, 
    x2.x28, 
    x2.x29, 
    x2.x30, 
    x2.x31, 
    x2.x32, 
    x2.x33, 
    x2.x34, 
    x35.`resourceId`, 
    x35.`key`, 
    x35.`value` 
FROM 
    (
        SELECT 
            EXISTS(
                SELECT TRUE 
                FROM `CLUSTER_PATCH` 
                WHERE (x36.x37 = `clusterId`) AND (`inProgress` = TRUE)
            ) AS x12, 
            x36.x38 AS x9, 
            x39.`componentGatewayEnabled` AS x29, 
            x39.`zone` AS x25, 
            x36.x40 AS x6, 
            x36.x41 AS x7, 
            x39.`numOfGpus` AS x28, 
            x39.`persistentDiskId` AS x24, 
            x39.`gpuType` AS x27, 
            x39.`numberOfWorkers` AS x15, 
            x39.`id` AS x13, 
            x36.x42 AS x5, 
            x36.x43 AS x34, 
            x39.`workerPrivateAccess` AS x30, 
            x36.x44 AS x32, 
            x36.x37 AS x3, 
            x39.`diskSize` AS x17, 
            x39.`machineType` AS x16, 
            x36.x45 AS x4, 
            x39.`workerMachineType` AS x19, 
            x39.`numberOfWorkerLocalSSDs` AS x21, 
            x39.`bootDiskSize` AS x18, 
            x36.x46 AS x11, 
            x39.`dateAccessed` AS x31, 
            x39.`region` AS x26, 
            x36.x47 AS x10, 
            x39.`cloudService` AS x14, 
            x39.`numberOfPreemptibleWorkers` AS x22, 
            x39.`workerDiskSize` AS x20, 
            x39.`dataprocProperties` AS x23, 
            x36.x48 AS x33, 
            x36.x49 AS x8 
        FROM 
            (
                SELECT 
                    `cloudProvider` AS x42, 
                    `cloudContext` AS x45, 
                    `status` AS x48, 
                    `startUserScriptUri` AS x50, 
                    `stagingBucket` AS x51, 
                    `defaultClientId` AS x52, 
                    `customClusterEnvironmentVariables` AS x53, 
                    `welderEnabled` AS x54, 
                    `internalId` AS x46, 
                    `serviceAccount` AS x55, 
                    `dateAccessed` AS x38, 
                    `createdDate` AS x41, 
                    `runtimeConfigId` AS x56, 
                    `deletedFrom` AS x57, 
                    `destroyedDate` AS x49, 
                    `autopauseThreshold` AS x58, 
                    `hostIp` AS x47, 
                    `workspaceId` AS x43, 
                    `operationName` AS x59, 
                    `userScriptUri` AS x60, 
                    `id` AS x37, 
                    `runtimeName` AS x44, 
                    `kernelFoundBusyDate` AS x61, 
                    `initBucket` AS x62, 
                    `creator` AS x40, 
                    `proxyHostName` AS x63 
                FROM 
                    `CLUSTER` 
                WHERE 
                    (
                        (
                            (
                                (`cloudProvider` = 'GCP') 
                                AND (`cloudContext` IN (?))
                            ) 
                            AND (`cloudProvider` = 'GCP')
                        ) 
                        AND (`cloudContext` = 'terra-quality-b6f0d502')
                    ) 
                    AND (NOT (`status` = 'Deleted'))
            ) x36, 
            `RUNTIME_CONFIG` x39 
        WHERE 
            x36.x56 = x39.`id`
    ) x2 
LEFT OUTER JOIN 
    `LABEL` x35 
ON 
    (x2.x3 = x35.`resourceId`) AND (x35.`resourceType` = 'runtime')
```

The problematic part is
```
WHERE 
                    (
                        (
                            (
                                (`cloudProvider` = 'GCP') 
                                AND (`cloudContext` IN (?))
                            ) 
                            AND (`cloudProvider` = 'GCP')
                        ) 
                        AND (`cloudContext` = 'terra-quality-b6f0d502')
                    ) 
                    AND (NOT (`status` = 'Deleted'))
```

When the caller has permission to many projects, where AoU SA is owner of all AoU projects, this query is really slow (38 seconds in dev), because `?` part will be a huge list, and this causes AoU's admin page to time out.

This PR changes this to sth like
```
select x2.x3,
       x2.x4,
       x2.x5,
       x2.x6,
       x2.x7,
       x2.x8,
       x2.x9,
       x2.x10,
       x2.x11,
       x2.x12,
       x2.x13,
       x2.x14,
       x2.x15,
       x2.x16,
       x2.x17,
       x2.x18,
       x2.x19,
       x2.x20,
       x2.x21,
       x2.x22,
       x2.x23,
       x2.x24,
       x2.x25,
       x2.x26,
       x2.x27,
       x2.x28,
       x2.x29,
       x2.x30,
       x2.x31,
       x2.x32,
       x2.x33,
       x2.x34,
       x35.`resourceId`,
       x35.`key`,
       x35.`value`
from   (select x36.x37                                    as x5,
               x38.`componentGatewayEnabled`              as x29,
               x38.`numberOfPreemptibleWorkers`           as x22,
               x38.`zone`                                 as x25,
               x36.x39                                    as x33,
               x36.x40                                    as x10,
               x38.`workerMachineType`                    as x19,
               x38.`diskSize`                             as x17,
               x36.x41                                    as x7,
               x36.x42                                    as x4,
               x38.`cloudService`                         as x14,
               x38.`id`                                   as x13,
               x36.x43                                    as x8,
               x38.`numberOfWorkerLocalSSDs`              as x21,
               exists(select true
                      from   `CLUSTER_PATCH`
                      where  ( x36.x44 = `clusterId` )
                             and ( `inProgress` = true )) as x12,
               x38.`numOfGpus`                            as x28,
               x36.x45                                    as x9,
               x38.`machineType`                          as x16,
               x38.`workerPrivateAccess`                  as x30,
               x38.`bootDiskSize`                         as x18,
               x36.x46                                    as x34,
               x38.`numberOfWorkers`                      as x15,
               x36.x47                                    as x32,
               x38.`gpuType`                              as x27,
               x38.`workerDiskSize`                       as x20,
               x38.`persistentDiskId`                     as x24,
               x36.x48                                    as x6,
               x38.`region`                               as x26,
               x36.x44                                    as x3,
               x38.`dateAccessed`                         as x31,
               x36.x49                                    as x11,
               x38.`dataprocProperties`                   as x23
        from   (select `cloudProvider`                     as x37,
                       `cloudContext`                      as x42,
                       `status`                            as x39,
                       `startUserScriptUri`                as x50,
                       `stagingBucket`                     as x51,
                       `defaultClientId`                   as x52,
                       `customClusterEnvironmentVariables` as x53,
                       `welderEnabled`                     as x54,
                       `internalId`                        as x49,
                       `serviceAccount`                    as x55,
                       `dateAccessed`                      as x45,
                       `createdDate`                       as x41,
                       `runtimeConfigId`                   as x56,
                       `deletedFrom`                       as x57,
                       `destroyedDate`                     as x43,
                       `autopauseThreshold`                as x58,
                       `hostIp`                            as x40,
                       `workspaceId`                       as x46,
                       `operationName`                     as x59,
                       `userScriptUri`                     as x60,
                       `id`                                as x44,
                       `runtimeName`                       as x47,
                       `kernelFoundBusyDate`               as x61,
                       `initBucket`                        as x62,
                       `creator`                           as x48,
                       `proxyHostName`                     as x63
                from   `CLUSTER`
                where  ( ( true
                           and ( `cloudProvider` = 'GCP' ) )
                         and ( `cloudContext` = 'terra-vpc-sc-dev-5cbb0e59' ) )
                       and ( not ( `status` = 'Deleted' ) )) x36,
               `RUNTIME_CONFIG` x38
        where  x36.x56 = x38.`id`) x2
       left outer join `LABEL` x35
                    on ( x2.x3 = x35.`resourceId` )
                       and ( x35.`resourceType` = 'runtime' ) 
```
Note when `cloudContext` is defined, there's no additional ` (`cloudContext` IN (?))` piece as long as `ownedProjects` contains the target project. 

<!-- Welcome to your Leonardo pull request! -->
<!-- Contributor guidelines: https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md -->

__Jira ticket__: https://broadworkbench.atlassian.net/browse/[ticket_number]

<!-- ## Dependencies -->
<!-- Include any dependent tickets and describe the relationship. Include any other relevant Jira tickets. -->

## Summary of changes

<!-- Please give an abridged version of the ticket description here and/or fill out the following fields. -->

### What

-

### Why

-

## Testing these changes

### What to test

- <!-- Test case 1 -->

<!-- ### Test data -->

### Who tested and where

- [ ] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [ ] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
