### PR TITLE
[WOR-1670] Update Azure E2E test LZ ids

### DIFF
--- a/.github/workflows/azure_automation_test.yml
+++ b/.github/workflows/azure_automation_test.yml
@@ -182,8 +182,8 @@ jobs:
           token: ${{ env.TOKEN }}
           inputs: '{
             "run-name": "${{ env.ATTACH_BP_TO_LZ_RUN_NAME }}",
-            "mrg-id": "e2e-n6bgy8",
-            "landing-zone-id": "9aa7e351-5448-4669-9f02-7e3466027c78",
+            "mrg-id": "e2e-xmx74y",
+            "landing-zone-id": "997743f4-1bee-43af-90be-29ae0a47fdfc",
             "bee-name": "${{ needs.init-github-context.outputs.bee-name }}",
             "billing-project": "${{ needs.params-gen.outputs.project-name }}",
             "billing-project-creator": "${{ needs.init-github-context.outputs.owner-subject }}",

--- a/.github/workflows/azure_e2e_release_promotion_tests.yml
+++ b/.github/workflows/azure_e2e_release_promotion_tests.yml
@@ -20,7 +20,7 @@ name: Azure E2E Release Promotion Tests
         description: 'Azure Managed Resource Group name. This is a shared identifier used by all Apps deployed for Azure End-to-End (E2E) tests. By default, it is set to the current Azure MRG name.'
         required: false
         type: string
-        default: 'e2e-n6bgy8'
+        default: 'e2e-xmx74y'
 env:
   BEE_NAME: >-
     ${{ github.event.repository.name }}-${{ github.run_id }}-${{github.run_attempt }}-dev

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoAzureSuite.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoAzureSuite.scala
@@ -23,8 +23,8 @@ trait AzureBilling extends FixtureAnyFreeSpecLike {
   implicit val azureManagedAppCoordinates: AzureManagedAppCoordinates = AzureManagedAppCoordinates(
     UUID.fromString("fad90753-2022-4456-9b0a-c7e5b934e408"),
     UUID.fromString("f557c728-871d-408c-a28b-eb6b2141a087"),
-    "e2e-n6bgy8",
-    Some(UUID.fromString("9aa7e351-5448-4669-9f02-7e3466027c78"))
+    "e2e-xmx74y",
+    Some(UUID.fromString("997743f4-1bee-43af-90be-29ae0a47fdfc"))
   )
 
   override def withFixture(test: OneArgTest): Outcome = {


### PR DESCRIPTION
<!-- Welcome to your Leonardo pull request! -->
<!-- Contributor guidelines: https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md -->

__Jira ticket__: https://broadworkbench.atlassian.net/browse/WOR-1670

<!-- ## Dependencies -->
<!-- Include any dependent tickets and describe the relationship. Include any other relevant Jira tickets. -->

## Summary of changes
We've created a new LZ for e2e testing, updating Leo to use it.

<!-- Please give an abridged version of the ticket description here and/or fill out the following fields. -->

### What

- Update the e2e testing configs

### Why

- We need to use the new e2e testing LZ

## Testing these changes

### What to test

- <!-- Test case 1 -->

<!-- ### Test data -->

### Who tested and where

- [ ] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [ ] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
