### PR TITLE
RW-12516  fix slowness in listRuntime when cloudContext is defined. Attempt 2

### DIFF
--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/RuntimeServiceDbQueries.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/RuntimeServiceDbQueries.scala
@@ -401,32 +401,31 @@ object RuntimeServiceDbQueries {
     val runtimeInOwnedProjects: Option[ClusterTable => Rep[Option[Boolean]]] =
       if (ownedProjects.isEmpty)
         None
-      else if (cloudContext.isDefined) {
-        // If cloudContext is defined, we're already applying the filter in runtimesFiltered below.
-        // No need to filter by the list of user owned projects anymore as long as the specified
-        // project is owned by the user.
-        if (ownedProjects.exists(x => x.value == cloudContext.get.asString))
-          Some(_ => Some(true))
-        else None
-      } else
+      else
         Some(runtime =>
           (runtime.cloudProvider.? === (CloudProvider.Gcp: CloudProvider)) &&
             (runtime.cloudContextDb inSetBind ownedProjects)
         )
 
-    val runtimesAuthorized =
-      clusterQuery.filter[Rep[Option[Boolean]]] { runtime: ClusterTable =>
-        Seq(
-          runtimeInReadWorkspaces,
-          runtimeInOwnedWorkspaces,
-          runtimeInReadProjects,
-          runtimeInOwnedProjects
-        )
-          .mapFilter(opt => opt)
-          .map(_(runtime))
-          .reduceLeftOption(_ || _)
-          .getOrElse(Some(false): Rep[Option[Boolean]])
-      }
+    val runtimesAuthorized = cloudContext match {
+      case Some(value) =>
+        // When cloudContext is defined, we don't need to further check authorization because we're already checking whether user
+        // has reader permission to the project
+        clusterQuery
+      case None =>
+        clusterQuery.filter[Rep[Option[Boolean]]] { runtime: ClusterTable =>
+          Seq(
+            runtimeInReadWorkspaces,
+            runtimeInOwnedWorkspaces,
+            runtimeInReadProjects,
+            runtimeInOwnedProjects
+          )
+            .mapFilter(opt => opt)
+            .map(_(runtime))
+            .reduceLeftOption(_ || _)
+            .getOrElse(Some(false): Rep[Option[Boolean]])
+        }
+    }
 
     val runtimesFiltered = runtimesAuthorized
       // Filter by params

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/RuntimeServiceDbQueries.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/RuntimeServiceDbQueries.scala
@@ -408,7 +408,7 @@ object RuntimeServiceDbQueries {
         )
 
     val runtimesAuthorized = cloudContext match {
-      case Some(value) =>
+      case Some(_) =>
         // When cloudContext is defined, we don't need to further check authorization because we're already checking whether user
         // has reader permission to the project
         clusterQuery

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterp.scala
@@ -268,6 +268,9 @@ class RuntimeServiceInterp[F[_]: Parallel](
     for {
       ctx <- as.ask
 
+      // Authorize: user has an active account and has accepted terms of service
+      _ <- authProvider.checkUserEnabled(userInfo)
+
       // throw 403 if user doesn't have project permission
       hasProjectPermission <- cloudContext.traverse(cc =>
         authProvider.isUserProjectReader(
@@ -1019,9 +1022,6 @@ class RuntimeServiceInterp[F[_]: Parallel](
     userInfo: UserInfo,
     creatorEmail: Option[WorkbenchEmail] = None
   )(implicit ev: Ask[F, AppContext]): F[AuthorizedIds] = for {
-    // Authorize: user has an active account and has accepted terms of service
-    _ <- authProvider.checkUserEnabled(userInfo)
-
     // Authorize: get resource IDs the user can see
     // HACK: leonardo is modeling access control here, handling inheritance
     // of workspace and project-level permissions. Sam and WSM already do this,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterp.scala
@@ -282,7 +282,7 @@ class RuntimeServiceInterp[F[_]: Parallel](
       (labelMap, includeDeleted, _) <- F.fromEither(processListParameters(params))
       excludeStatuses = if (includeDeleted) List.empty else List(RuntimeStatus.Deleted)
       creatorOnly <- F.fromEither(processCreatorOnlyParameter(userInfo.userEmail, params, ctx.traceId))
-
+      _ <- ctx.span.traverse(s => F.delay(s.addAnnotation("Start getting authorized IDs")))
       authorizedIds <- getAuthorizedIds(userInfo, creatorOnly)
       _ <- ctx.span.traverse(s => F.delay(s.addAnnotation("Start DB query for listRuntimes")))
       runtimes <- RuntimeServiceDbQueries


### PR DESCRIPTION
See the tracing that was added in previous PR below.
![Screenshot 2024-05-10 at 10 51 21 AM](https://github.com/DataBiosphere/leonardo/assets/32771737/2528729e-f8b1-4bbe-a858-337aec696964)

The majority time was spent before DB query. The query fixed in previous PR was good to fix, but wasn't the real slow part.
The real slow part is all the Sam calls for getting various authorized projectId/workspaceIds (added new tracing in this PR).

When cloudContext is defined, we're already checking if caller has reader permission on the project in [this line](https://github.com/DataBiosphere/leonardo/blob/develop/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterp.scala#L272). So we don't need to further gather all the projects/workspaces user has reader/owner roles.

SQL after this PR, with cloudContext defined 
```
SELECT x2.x3,
       x2.x4,
       x2.x5,
       x2.x6,
       x2.x7,
       x2.x8,
       x2.x9,
       x2.x10,
       x2.x11,
       x2.x12,
       x2.x13,
       x2.x14,
       x2.x15,
       x2.x16,
       x2.x17,
       x2.x18,
       x2.x19,
       x2.x20,
       x2.x21,
       x2.x22,
       x2.x23,
       x2.x24,
       x2.x25,
       x2.x26,
       x2.x27,
       x2.x28,
       x2.x29,
       x2.x30,
       x2.x31,
       x2.x32,
       x2.x33,
       x2.x34,
       x35.`resourceId`,
       x35.`key`,
       x35.`value`
FROM   (SELECT x36.x37                                    AS x6,
               x36.x38                                    AS x8,
               x39.`numOfGpus`                            AS x28,
               x36.x40                                    AS x33,
               x36.x41                                    AS x7,
               x39.`gpuType`                              AS x27,
               x39.`persistentDiskId`                     AS x24,
               x36.x42                                    AS x3,
               x39.`componentGatewayEnabled`              AS x29,
               x39.`region`                               AS x26,
               x39.`diskSize`                             AS x17,
               x36.x43                                    AS x34,
               x39.`dateAccessed`                         AS x31,
               x36.x44                                    AS x9,
               x39.`machineType`                          AS x16,
               x39.`numberOfWorkerLocalSSDs`              AS x21,
               x39.`numberOfPreemptibleWorkers`           AS x22,
               x36.x45                                    AS x10,
               x36.x46                                    AS x4,
               x39.`workerPrivateAccess`                  AS x30,
               x36.x47                                    AS x5,
               x39.`bootDiskSize`                         AS x18,
               x39.`numberOfWorkers`                      AS x15,
               x36.x48                                    AS x11,
               EXISTS(SELECT true
                      FROM   `CLUSTER_PATCH`
                      WHERE  ( x36.x42 = `clusterId` )
                             AND ( `inProgress` = true )) AS x12,
               x39.`zone`                                 AS x25,
               x39.`cloudService`                         AS x14,
               x39.`dataprocProperties`                   AS x23,
               x39.`id`                                   AS x13,
               x39.`workerMachineType`                    AS x19,
               x36.x49                                    AS x32,
               x39.`workerDiskSize`                       AS x20
        FROM   (SELECT `cloudProvider`                     AS x47,
                       `cloudContext`                      AS x46,
                       `status`                            AS x40,
                       `startUserScriptUri`                AS x50,
                       `stagingBucket`                     AS x51,
                       `defaultClientId`                   AS x52,
                       `customClusterEnvironmentVariables` AS x53,
                       `welderEnabled`                     AS x54,
                       `internalId`                        AS x48,
                       `serviceAccount`                    AS x55,
                       `dateAccessed`                      AS x44,
                       `createdDate`                       AS x41,
                       `runtimeConfigId`                   AS x56,
                       `deletedFrom`                       AS x57,
                       `destroyedDate`                     AS x38,
                       `autopauseThreshold`                AS x58,
                       `hostIp`                            AS x45,
                       `workspaceId`                       AS x43,
                       `operationName`                     AS x59,
                       `userScriptUri`                     AS x60,
                       `id`                                AS x42,
                       `runtimeName`                       AS x49,
                       `kernelFoundBusyDate`               AS x61,
                       `initBucket`                        AS x62,
                       `creator`                           AS x37,
                       `proxyHostName`                     AS x63
                FROM   `CLUSTER`
                WHERE  ( ( `cloudProvider` = 'GCP' )
                         AND ( `cloudContext` = 'terra-quality-b6f0d502' ) )
                       AND ( NOT ( `status` = 'Deleted' ) )) x36,
               `RUNTIME_CONFIG` x39
        WHERE  x36.x56 = x39.`id`) x2
       LEFT OUTER JOIN `LABEL` x35
                    ON ( x2.x3 = x35.`resourceId` )
                       AND ( x35.`resourceType` = 'runtime' ) 
```

Query for listRuntime when project is not defined (behaves same as before)
```
SELECT x2.x3,
       x2.x4,
       x2.x5,
       x2.x6,
       x2.x7,
       x2.x8,
       x2.x9,
       x2.x10,
       x2.x11,
       x2.x12,
       x2.x13,
       x2.x14,
       x2.x15,
       x2.x16,
       x2.x17,
       x2.x18,
       x2.x19,
       x2.x20,
       x2.x21,
       x2.x22,
       x2.x23,
       x2.x24,
       x2.x25,
       x2.x26,
       x2.x27,
       x2.x28,
       x2.x29,
       x2.x30,
       x2.x31,
       x2.x32,
       x2.x33,
       x2.x34,
       x35.`resourceId`,
       x35.`key`,
       x35.`value`
FROM   (SELECT x36.x37                                    AS x32,
               x38.`numberOfWorkerLocalSSDs`              AS x21,
               x36.x39                                    AS x11,
               x38.`persistentDiskId`                     AS x24,
               x38.`dateAccessed`                         AS x31,
               x38.`cloudService`                         AS x14,
               x38.`numOfGpus`                            AS x28,
               x38.`numberOfWorkers`                      AS x15,
               x38.`componentGatewayEnabled`              AS x29,
               x36.x40                                    AS x9,
               x38.`dataprocProperties`                   AS x23,
               x38.`id`                                   AS x13,
               x36.x41                                    AS x3,
               x38.`gpuType`                              AS x27,
               x36.x42                                    AS x10,
               x38.`region`                               AS x26,
               x36.x43                                    AS x5,
               EXISTS(SELECT true
                      FROM   `CLUSTER_PATCH`
                      WHERE  ( x36.x41 = `clusterId` )
                             AND ( `inProgress` = true )) AS x12,
               x38.`machineType`                          AS x16,
               x36.x44                                    AS x6,
               x36.x45                                    AS x4,
               x38.`numberOfPreemptibleWorkers`           AS x22,
               x38.`workerPrivateAccess`                  AS x30,
               x38.`workerDiskSize`                       AS x20,
               x36.x46                                    AS x33,
               x36.x47                                    AS x34,
               x36.x48                                    AS x8,
               x36.x49                                    AS x7,
               x38.`diskSize`                             AS x17,
               x38.`zone`                                 AS x25,
               x38.`workerMachineType`                    AS x19,
               x38.`bootDiskSize`                         AS x18
        FROM   (SELECT `cloudProvider`                     AS x43,
                       `cloudContext`                      AS x45,
                       `status`                            AS x46,
                       `startUserScriptUri`                AS x50,
                       `stagingBucket`                     AS x51,
                       `defaultClientId`                   AS x52,
                       `customClusterEnvironmentVariables` AS x53,
                       `welderEnabled`                     AS x54,
                       `internalId`                        AS x39,
                       `serviceAccount`                    AS x55,
                       `dateAccessed`                      AS x40,
                       `createdDate`                       AS x49,
                       `runtimeConfigId`                   AS x56,
                       `deletedFrom`                       AS x57,
                       `destroyedDate`                     AS x48,
                       `autopauseThreshold`                AS x58,
                       `hostIp`                            AS x42,
                       `workspaceId`                       AS x47,
                       `operationName`                     AS x59,
                       `userScriptUri`                     AS x60,
                       `id`                                AS x41,
                       `runtimeName`                       AS x37,
                       `kernelFoundBusyDate`               AS x61,
                       `initBucket`                        AS x62,
                       `creator`                           AS x44,
                       `proxyHostName`                     AS x63
                FROM   `CLUSTER`
                WHERE  ( ( `cloudProvider` = 'GCP' )
                         AND ( `cloudContext` IN ( ? ) ) )
                       AND ( NOT ( `status` = 'Deleted' ) )) x36,
               `RUNTIME_CONFIG` x38
        WHERE  x36.x56 = x38.`id`) x2
       LEFT OUTER JOIN `LABEL` x35
                    ON ( x2.x3 = x35.`resourceId` )
                       AND ( x35.`resourceType` = 'runtime' ) 
```
Logs when listRuntime is called with project defined
```
{"@timestamp":"2024-05-10T16:27:22.354938374Z","@version":"1","logger_name":"org.broadinstitute.dsde.workbench.leonardo.http.Boot","version":"7183320dd","thread_name":"io-compute-2","severity":"INFO","serviceContext":{"service":"leonardo","version":"7183320dd"},"message":"HTTP/1.1 GET https://sam.qi-aou.bee.envs-terra.bio/register/user/v2/self/info Headers(Authorization: <REDACTED>, Accept: application/json)"}
{"@timestamp":"2024-05-10T16:27:22.46984702Z","@version":"1","logger_name":"org.broadinstitute.dsde.workbench.leonardo.http.Boot","version":"7183320dd","thread_name":"io-compute-15","severity":"INFO","serviceContext":{"service":"leonardo","version":"7183320dd"},"message":"HTTP/1.1 200 OK Headers(Date: Fri, 10 May 2024 16:27:22 GMT, Content-Type: application/json, Content-Length: 129, Connection: keep-alive, X-Frame-Options: SAMEORIGIN, X-XSS-Protection: 1; mode=block, X-Content-Type-Options: nosniff, Strict-Transport-Security: max-age=15724800; includeSubDomains, Referrer-Policy: strict-origin-when-cross-origin, Access-Control-Allow-Origin: *, Access-Control-Allow-Headers: authorization,content-type,accept,origin,x-app-id, Access-Control-Allow-Methods: GET,POST,PUT,PATCH,DELETE,OPTIONS,HEAD, Access-Control-Max-Age: 1728000)"}
{"@timestamp":"2024-05-10T16:27:22.474748801Z","@version":"1","logger_name":"org.broadinstitute.dsde.workbench.leonardo.http.Boot","version":"7183320dd","thread_name":"io-compute-2","severity":"INFO","serviceContext":{"service":"leonardo","version":"7183320dd"},"message":"HTTP/1.1 GET https://sam.qi-aou.bee.envs-terra.bio/api/resources/v2/google-project/terra-quality-b6f0d502/roles Headers(Authorization: <REDACTED>, Accept: application/json)"}
{"@timestamp":"2024-05-10T16:27:22.491627593Z","@version":"1","logger_name":"org.broadinstitute.dsde.workbench.leonardo.http.Boot","version":"7183320dd","thread_name":"io-compute-15","severity":"INFO","serviceContext":{"service":"leonardo","version":"7183320dd"},"message":"HTTP/1.1 200 OK Headers(Date: Fri, 10 May 2024 16:27:22 GMT, Content-Type: application/json, Content-Length: 39, Connection: keep-alive, X-Frame-Options: SAMEORIGIN, X-XSS-Protection: 1; mode=block, X-Content-Type-Options: nosniff, Strict-Transport-Security: max-age=15724800; includeSubDomains, Referrer-Policy: strict-origin-when-cross-origin, Access-Control-Allow-Origin: *, Access-Control-Allow-Headers: authorization,content-type,accept,origin,x-app-id, Access-Control-Allow-Methods: GET,POST,PUT,PATCH,DELETE,OPTIONS,HEAD, Access-Control-Max-Age: 1728000)"}
{"@timestamp":"2024-05-10T16:27:22.526642933Z","@version":"1","logger_name":"slick.jdbc.JdbcBackend.statement","thread_name":"mysql.db-42","severity":"DEBUG","serviceContext":null,"message":"Preparing statement: select x2.x3, x2.x4, x2.x5, x2.x6, x2.x7, x2.x8, x2.x9, x2.x10, x2.x11, x2.x12, x2.x13, x2.x14, x2.x15, x2.x16, x2.x17, x2.x18, x2.x19, x2.x20, x2.x21, x2.x22, x2.x23, x2.x24, x2.x25, x2.x26, x2.x27, x2.x28, x2.x29, x2.x30, x2.x31, x2.x32, x2.x33, x2.x34, x35.`resourceId`, x35.`key`, x35.`value` from (select x36.`dateAccessed` as x31, x36.`numberOfWorkers` as x15, x37.x38 as x11, x36.`workerMachineType` as x19, x36.`numOfGpus` as x28, x37.x39 as x32, x36.`region` as x26, x36.`workerPrivateAccess` as x30, x36.`zone` as x25, x36.`workerDiskSize` as x20, x36.`cloudService` as x14, x37.x40 as x6, x37.x41 as x5, x37.x42 as x3, x37.x43 as x7, x37.x44 as x33, x36.`gpuType` as x27, x36.`diskSize` as x17, x36.`numberOfWorkerLocalSSDs` as x21, x36.`dataprocProperties` as x23, x36.`componentGatewayEnabled` as x29, exists(select true from `CLUSTER_PATCH` where (x37.x42 = `clusterId`) and (`inProgress` = true)) as x12, x37.x45 as x10, x36.`id` as x13, x36.`numberOfPreemptibleWorkers` as x22, x37.x46 as x34, x37.x47 as x9, x36.`persistentDiskId` as x24, x37.x48 as x8, x37.x49 as x4, x36.`machineType` as x16, x36.`bootDiskSize` as x18 from (select `cloudProvider` as x41, `cloudContext` as x49, `status` as x44, `startUserScriptUri` as x50, `stagingBucket` as x51, `defaultClientId` as x52, `customClusterEnvironmentVariables` as x53, `welderEnabled` as x54, `internalId` as x38, `serviceAccount` as x55, `dateAccessed` as x47, `createdDate` as x43, `runtimeConfigId` as x56, `deletedFrom` as x57, `destroyedDate` as x48, `autopauseThreshold` as x58, `hostIp` as x45, `workspaceId` as x46, `operationName` as x59, `userScriptUri` as x60, `id` as x42, `runtimeName` as x39, `kernelFoundBusyDate` as x61, `initBucket` as x62, `creator` as x40, `proxyHostName` as x63 from `CLUSTER` where ((`cloudProvider` = 'GCP') and (`cloudContext` = 'terra-quality-b6f0d502')) and (not (`status` = 'Deleted'))) x37, `RUNTIME_CONFIG` x36 where x37.x56 = x36.`id`) x2 left outer join `LABEL` x35 on (x2.x3 = x35.`resourceId`) and (x35.`resourceType` = 'runtime')"}
```


Logs without project defined (same as before)
```
{"@timestamp":"2024-05-10T16:26:19.841153636Z","@version":"1","logger_name":"org.broadinstitute.dsde.workbench.leonardo.http.Boot","version":"7183320dd","thread_name":"io-compute-9","severity":"INFO","serviceContext":{"service":"leonardo","version":"7183320dd"},"message":"HTTP/1.1 GET https://sam.qi-aou.bee.envs-terra.bio/register/user/v2/self/info Headers(Authorization: <REDACTED>, Accept: application/json)"}
{"@timestamp":"2024-05-10T16:26:19.927282914Z","@version":"1","logger_name":"org.broadinstitute.dsde.workbench.leonardo.http.Boot","version":"7183320dd","thread_name":"io-compute-2","severity":"INFO","serviceContext":{"service":"leonardo","version":"7183320dd"},"message":"HTTP/1.1 200 OK Headers(Date: Fri, 10 May 2024 16:26:19 GMT, Content-Type: application/json, Content-Length: 129, Connection: keep-alive, X-Frame-Options: SAMEORIGIN, X-XSS-Protection: 1; mode=block, X-Content-Type-Options: nosniff, Strict-Transport-Security: max-age=15724800; includeSubDomains, Referrer-Policy: strict-origin-when-cross-origin, Access-Control-Allow-Origin: *, Access-Control-Allow-Headers: authorization,content-type,accept,origin,x-app-id, Access-Control-Allow-Methods: GET,POST,PUT,PATCH,DELETE,OPTIONS,HEAD, Access-Control-Max-Age: 1728000)"}
{"@timestamp":"2024-05-10T16:26:19.957137969Z","@version":"1","logger_name":"org.broadinstitute.dsde.workbench.leonardo.http.Boot","version":"7183320dd","thread_name":"io-compute-3","severity":"INFO","serviceContext":{"service":"leonardo","version":"7183320dd"},"message":"HTTP/1.1 GET https://sam.qi-aou.bee.envs-terra.bio/api/resources/v2/notebook-cluster Headers(Authorization: <REDACTED>, Accept: application/json)"}
{"@timestamp":"2024-05-10T16:26:19.977159097Z","@version":"1","logger_name":"org.broadinstitute.dsde.workbench.leonardo.http.Boot","version":"7183320dd","thread_name":"io-compute-8","severity":"INFO","serviceContext":{"service":"leonardo","version":"7183320dd"},"message":"HTTP/1.1 200 OK Headers(Date: Fri, 10 May 2024 16:26:19 GMT, Content-Type: application/json, Content-Length: 2, Connection: keep-alive, X-Frame-Options: SAMEORIGIN, X-XSS-Protection: 1; mode=block, X-Content-Type-Options: nosniff, Strict-Transport-Security: max-age=15724800; includeSubDomains, Referrer-Policy: strict-origin-when-cross-origin, Access-Control-Allow-Origin: *, Access-Control-Allow-Headers: authorization,content-type,accept,origin,x-app-id, Access-Control-Allow-Methods: GET,POST,PUT,PATCH,DELETE,OPTIONS,HEAD, Access-Control-Max-Age: 1728000)"}
{"@timestamp":"2024-05-10T16:26:19.984951947Z","@version":"1","logger_name":"org.broadinstitute.dsde.workbench.leonardo.http.Boot","version":"7183320dd","thread_name":"io-compute-1","severity":"INFO","serviceContext":{"service":"leonardo","version":"7183320dd"},"message":"HTTP/1.1 GET https://sam.qi-aou.bee.envs-terra.bio/api/resources/v2/google-project Headers(Authorization: <REDACTED>, Accept: application/json)"}
{"@timestamp":"2024-05-10T16:26:20.003909943Z","@version":"1","logger_name":"org.broadinstitute.dsde.workbench.leonardo.http.Boot","version":"7183320dd","thread_name":"io-compute-3","severity":"INFO","serviceContext":{"service":"leonardo","version":"7183320dd"},"message":"HTTP/1.1 200 OK Headers(Date: Fri, 10 May 2024 16:26:20 GMT, Content-Type: application/json, Content-Length: 237, Connection: keep-alive, X-Frame-Options: SAMEORIGIN, X-XSS-Protection: 1; mode=block, X-Content-Type-Options: nosniff, Strict-Transport-Security: max-age=15724800; includeSubDomains, Referrer-Policy: strict-origin-when-cross-origin, Access-Control-Allow-Origin: *, Access-Control-Allow-Headers: authorization,content-type,accept,origin,x-app-id, Access-Control-Allow-Methods: GET,POST,PUT,PATCH,DELETE,OPTIONS,HEAD, Access-Control-Max-Age: 1728000, Vary: Accept-Encoding)"}
{"@timestamp":"2024-05-10T16:26:20.01235518Z","@version":"1","logger_name":"org.broadinstitute.dsde.workbench.leonardo.http.Boot","version":"7183320dd","thread_name":"io-compute-2","severity":"INFO","serviceContext":{"service":"leonardo","version":"7183320dd"},"message":"HTTP/1.1 GET https://sam.qi-aou.bee.envs-terra.bio/api/resources/v2/google-project Headers(Authorization: <REDACTED>, Accept: application/json)"}
{"@timestamp":"2024-05-10T16:26:20.032223476Z","@version":"1","logger_name":"org.broadinstitute.dsde.workbench.leonardo.http.Boot","version":"7183320dd","thread_name":"io-compute-2","severity":"INFO","serviceContext":{"service":"leonardo","version":"7183320dd"},"message":"HTTP/1.1 200 OK Headers(Date: Fri, 10 May 2024 16:26:20 GMT, Content-Type: application/json, Content-Length: 237, Connection: keep-alive, X-Frame-Options: SAMEORIGIN, X-XSS-Protection: 1; mode=block, X-Content-Type-Options: nosniff, Strict-Transport-Security: max-age=15724800; includeSubDomains, Referrer-Policy: strict-origin-when-cross-origin, Access-Control-Allow-Origin: *, Access-Control-Allow-Headers: authorization,content-type,accept,origin,x-app-id, Access-Control-Allow-Methods: GET,POST,PUT,PATCH,DELETE,OPTIONS,HEAD, Access-Control-Max-Age: 1728000, Vary: Accept-Encoding)"}
{"@timestamp":"2024-05-10T16:26:20.093901451Z","@version":"1","logger_name":"slick.jdbc.JdbcBackend.statement","thread_name":"mysql.db-27","severity":"DEBUG","serviceContext":null,"message":"Preparing statement: select x2.x3, x2.x4, x2.x5, x2.x6, x2.x7, x2.x8, x2.x9, x2.x10, x2.x11, x2.x12, x2.x13, x2.x14, x2.x15, x2.x16, x2.x17, x2.x18, x2.x19, x2.x20, x2.x21, x2.x22, x2.x23, x2.x24, x2.x25, x2.x26, x2.x27, x2.x28, x2.x29, x2.x30, x2.x31, x2.x32, x2.x33, x2.x34, x35.`resourceId`, x35.`key`, x35.`value` from (select x36.x37 as x34, x38.`dataprocProperties` as x23, x38.`bootDiskSize` as x18, x36.x39 as x7, x36.x40 as x10, x38.`zone` as x25, x36.x41 as x33, x38.`machineType` as x16, x38.`workerDiskSize` as x20, x38.`gpuType` as x27, x38.`diskSize` as x17, x38.`numOfGpus` as x28, x38.`numberOfPreemptibleWorkers` as x22, x36.x42 as x9, x38.`dateAccessed` as x31, x38.`workerPrivateAccess` as x30, x36.x43 as x11, x36.x44 as x8, x38.`persistentDiskId` as x24, x38.`numberOfWorkerLocalSSDs` as x21, x36.x45 as x5, exists(select true from `CLUSTER_PATCH` where (x36.x46 = `clusterId`) and (`inProgress` = true)) as x12, x38.`region` as x26, x36.x47 as x4, x38.`numberOfWorkers` as x15, x38.`cloudService` as x14, x38.`workerMachineType` as x19, x36.x46 as x3, x38.`componentGatewayEnabled` as x29, x38.`id` as x13, x36.x48 as x6, x36.x49 as x32 from (select `cloudProvider` as x45, `cloudContext` as x47, `status` as x41, `startUserScriptUri` as x50, `stagingBucket` as x51, `defaultClientId` as x52, `customClusterEnvironmentVariables` as x53, `welderEnabled` as x54, `internalId` as x43, `serviceAccount` as x55, `dateAccessed` as x42, `createdDate` as x39, `runtimeConfigId` as x56, `deletedFrom` as x57, `destroyedDate` as x44, `autopauseThreshold` as x58, `hostIp` as x40, `workspaceId` as x37, `operationName` as x59, `userScriptUri` as x60, `id` as x46, `runtimeName` as x49, `kernelFoundBusyDate` as x61, `initBucket` as x62, `creator` as x48, `proxyHostName` as x63 from `CLUSTER` where ((`cloudProvider` = 'GCP') and (`cloudContext` in (?))) and (not (`status` = 'Deleted'))) x36, `RUNTIME_CONFIG` x38 where x36.x56 = x38.`id`) x2 left outer join `LABEL` x35 on (x2.x3 = x35.`resourceId`) and (x35.`resourceType` = 'runtime')"}
```

<!-- Welcome to your Leonardo pull request! -->
<!-- Contributor guidelines: https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md -->

__Jira ticket__: https://broadworkbench.atlassian.net/browse/[ticket_number]

<!-- ## Dependencies -->
<!-- Include any dependent tickets and describe the relationship. Include any other relevant Jira tickets. -->

## Summary of changes

<!-- Please give an abridged version of the ticket description here and/or fill out the following fields. -->

### What

-

### Why

-

## Testing these changes

### What to test

- <!-- Test case 1 -->

<!-- ### Test data -->

### Who tested and where

- [ ] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [ ] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
