### PR TITLE
[IA-4904] log wording

### DIFF
--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
@@ -1541,7 +1541,9 @@ class LeoPubsubMessageSubscriber[F[_]](
           case e =>
             for {
               _ <- appQuery.updateStatus(msg.appId, AppStatus.Running).transaction
-              // You cannot update this log wording without updating the corresponding alert here https://console.cloud.google.com/monitoring/alerting/policies/8184448493858086363?project=broad-dsde-prod
+              // You cannot update this log wording without updating the corresponding prod and staging alerts here
+              //     https://console.cloud.google.com/monitoring/alerting/policies/8184448493858086363?project=broad-dsde-prod
+              //     https://console.cloud.google.com/monitoring/alerting/policies/16136890211426349187?project=broad-dsde-staging
               errorContext =
                 s"Error updating Azure app with id ${msg.appId.id} and cloudContext ${msg.cloudContext.asString}"
               _ <- logger.warn(ctx.loggingCtx, e)(errorContext)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
@@ -1541,6 +1541,7 @@ class LeoPubsubMessageSubscriber[F[_]](
           case e =>
             for {
               _ <- appQuery.updateStatus(msg.appId, AppStatus.Running).transaction
+              // You cannot update this log wording without updating the corresponding alert here https://console.cloud.google.com/monitoring/alerting/policies/8184448493858086363?project=broad-dsde-prod
               errorContext =
                 s"Error updating Azure app with id ${msg.appId.id} and cloudContext ${msg.cloudContext.asString}"
               _ <- logger.warn(ctx.loggingCtx, e)(errorContext)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/leoPubsubMessageSubscriberModels.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/leoPubsubMessageSubscriberModels.scala
@@ -1023,7 +1023,9 @@ object PubsubHandleMessageError {
                                          diskId: Option[DiskId],
                                          clusterId: Option[KubernetesClusterLeoId]
   ) extends PubsubHandleMessageError {
-    // You cannot update this log wording without updating the corresponding alert here https://console.cloud.google.com/monitoring/alerting/policies/8184448493858086363?project=broad-dsde-prod
+    // You cannot update this log wording without updating the corresponding prod and staging alerts here
+    //     https://console.cloud.google.com/monitoring/alerting/policies/8184448493858086363?project=broad-dsde-prod
+    //     https://console.cloud.google.com/monitoring/alerting/policies/16136890211426349187?project=broad-dsde-staging
     override def getMessage: String =
       s"An error occurred with a kubernetes operation from source ${dbError.source} during action ${dbError.action}. \nOriginal message: ${dbError.errorMessage}"
   }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/leoPubsubMessageSubscriberModels.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/leoPubsubMessageSubscriberModels.scala
@@ -1023,6 +1023,7 @@ object PubsubHandleMessageError {
                                          diskId: Option[DiskId],
                                          clusterId: Option[KubernetesClusterLeoId]
   ) extends PubsubHandleMessageError {
+    // You cannot update this log wording without updating the corresponding alert here https://console.cloud.google.com/monitoring/alerting/policies/8184448493858086363?project=broad-dsde-prod
     override def getMessage: String =
       s"An error occurred with a kubernetes operation from source ${dbError.source} during action ${dbError.action}. \nOriginal message: ${dbError.errorMessage}"
   }


### PR DESCRIPTION
I would have really liked to assert that the log message is as expected in a unit test, but unfortunately we cannot test that with mockito since our logger curries the arguements (i.e. `logger.error(arg1, arg2)(arg3)`)

I found some [auxiliary articles ](https://stackoverflow.com/questions/18294830/how-to-mock-a-call-by-name-argument-like-getorelse-using-scalamock) that seem to claim I can use some product format to verify it, but this is further complicated because I cannot simply mock the logger and pass it in since its an implicit declared globally for all tests. I decided it is not worth my time beyond the few hours spent with us trying to move away from leo for app upgrades anyways. 

https://github.com/mockito/mockito/issues/1134