### PR TITLE
[IA-4932] Do not use random shuffle when generating passwords

### DIFF
--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandlerSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandlerSpec.scala
@@ -54,8 +54,9 @@ class AzurePubsubHandlerSpec
   val (mockWsm, mockControlledResourceApi, mockResourceApi) = AzureTestUtils.setUpMockWsmApiClientProvider()
 
   it should "generate an Azure VM password properly" in {
-    val password = AzurePubsubHandler.generateAzureVMSecurePassword
-    password.length shouldBe 16
+    // Test this with a short password to make sure that the while loop works properly
+    val password = AzurePubsubHandler.generateAzureVMSecurePassword(4)
+    password.length shouldBe 4
     password.exists(_.isLower) shouldBe true
     password.exists(_.isUpper) shouldBe true
     password.exists(_.isDigit) shouldBe true
@@ -65,7 +66,7 @@ class AzurePubsubHandlerSpec
   it should "not use the shared Azure VM credentials in prod" in {
     val password = AzurePubsubHandler.getAzureVMSecurePassword("prod", "sharedPassword")
     assert(password != "sharedPassword")
-    password.length shouldBe 16
+    password.length shouldBe 25
   }
 
   it should "create azure vm properly" in isolatedDbTest {


### PR DESCRIPTION
<!-- Welcome to your Leonardo pull request! -->
<!-- Contributor guidelines: https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md -->

__Jira ticket__: https://broadworkbench.atlassian.net/browse/IA-4932

<!-- ## Dependencies -->
<!-- Include any dependent tickets and describe the relationship. Include any other relevant Jira tickets. -->

## Summary of changes

<!-- Please give an abridged version of the ticket description here and/or fill out the following fields. -->

### What

- Reinforces the logic to generate the Azure VM random passwords based on recommendation from @sarahgibs 

### Why

- Fast follow from #4526 that generated the password using Java's normal Random number generator, which might be predictable

## Testing these changes

### What to test

- <!-- Test case 1 -->

<!-- ### Test data -->

### Who tested and where

- [x] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [x] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
