### PR TITLE
RW-12554 reduce chance of leaking Sam resource

### DIFF
--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/KubernetesServiceDbQueries.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/KubernetesServiceDbQueries.scala
@@ -124,7 +124,8 @@ object KubernetesServiceDbQueries {
     * Throws an error if the cluster is in creating status.
     */
   def saveOrGetClusterForApp(
-    saveKubernetesCluster: SaveKubernetesCluster
+    saveKubernetesCluster: SaveKubernetesCluster,
+    traceId: TraceId
   )(implicit ec: ExecutionContext): DBIO[SaveClusterResult] =
     for {
       clusterOpt <- kubernetesClusterQuery.getMinimalActiveClusterByCloudContext(saveKubernetesCluster.cloudContext)
@@ -136,7 +137,7 @@ object KubernetesServiceDbQueries {
               DBIO.failed(
                 KubernetesAppCreationException(
                   s"You cannot create an app while a cluster is in ${KubernetesClusterStatus.creatingStatuses}. Status: ${s}",
-                  None
+                  Some(traceId)
                 )
               )
             case _ => DBIO.successful(ClusterExists(cluster, DefaultNodepool.fromNodepool(cluster.nodepools.head)))

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/LeoAppServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/LeoAppServiceInterp.scala
@@ -156,128 +156,137 @@ final class LeoAppServiceInterp[F[_]: Parallel](config: AppServiceConfig,
       // Look up the original email in case this API was called by a pet SA
       originatingUserEmail <- authProvider.lookupOriginatingUserEmail(userInfo)
 
-      _ <- createSamResourceWithRollback(samResourceId, originatingUserEmail, googleProject).use { _ =>
-        for {
-          saveCluster <- F.fromEither(
-            getSavableCluster(originatingUserEmail, cloudContext, ctx.now)
-          )
+      notifySamAndCreate = for {
+        _ <- authProvider
+          .notifyResourceCreated(samResourceId, originatingUserEmail, googleProject)
+          .handleErrorWith { t =>
+            log.error(ctx.loggingCtx, t)(
+              s"Failed to notify the AuthProvider for creation of kubernetes app ${googleProject.value} / ${samResourceId.asString}"
+            ) >> F.raiseError[Unit](t)
+          }
+        saveCluster <- F.fromEither(
+          getSavableCluster(originatingUserEmail, cloudContext, ctx.now)
+        )
 
-          saveClusterResult <- KubernetesServiceDbQueries
-            .saveOrGetClusterForApp(saveCluster)
-            .transaction(isolationLevel = TransactionIsolation.Serializable)
-          // TODO Remove the block below to allow app creation on a new cluster when the existing cluster is in Error status
-          _ <-
-            if (saveClusterResult.minimalCluster.status == KubernetesClusterStatus.Error)
-              F.raiseError[Unit](
-                KubernetesAppCreationException(
-                  s"You cannot create an app while a cluster${saveClusterResult.minimalCluster.clusterName.value} is in status ${saveClusterResult.minimalCluster.status}",
-                  Some(ctx.traceId)
-                )
+        saveClusterResult <- KubernetesServiceDbQueries
+          .saveOrGetClusterForApp(saveCluster)
+          .transaction(isolationLevel = TransactionIsolation.Serializable)
+        // TODO Remove the block below to allow app creation on a new cluster when the existing cluster is in Error status
+        _ <-
+          if (saveClusterResult.minimalCluster.status == KubernetesClusterStatus.Error)
+            F.raiseError[Unit](
+              KubernetesAppCreationException(
+                s"You cannot create an app while a cluster${saveClusterResult.minimalCluster.clusterName.value} is in status ${saveClusterResult.minimalCluster.status}",
+                Some(ctx.traceId)
               )
-            else F.unit
-
-          clusterId = saveClusterResult.minimalCluster.id
-
-          machineConfigFromReqAndConfig = req.kubernetesRuntimeConfig.getOrElse(
-            KubernetesRuntimeConfig(
-              config.leoKubernetesConfig.nodepoolConfig.galaxyNodepoolConfig.numNodes,
-              config.leoKubernetesConfig.nodepoolConfig.galaxyNodepoolConfig.machineType,
-              config.leoKubernetesConfig.nodepoolConfig.galaxyNodepoolConfig.autoscalingEnabled
             )
+          else F.unit
+
+        clusterId = saveClusterResult.minimalCluster.id
+
+        machineConfigFromReqAndConfig = req.kubernetesRuntimeConfig.getOrElse(
+          KubernetesRuntimeConfig(
+            config.leoKubernetesConfig.nodepoolConfig.galaxyNodepoolConfig.numNodes,
+            config.leoKubernetesConfig.nodepoolConfig.galaxyNodepoolConfig.machineType,
+            config.leoKubernetesConfig.nodepoolConfig.galaxyNodepoolConfig.autoscalingEnabled
           )
+        )
 
-          // Always allow autoScaling for ALLOWED appType
-          machineConfig =
-            if (AppType.Allowed == req.appType) machineConfigFromReqAndConfig.copy(autoscalingEnabled = true)
-            else machineConfigFromReqAndConfig
-          // We want to know if the user already has a nodepool with the requested config that can be re-used
-          userNodepoolOpt <- nodepoolQuery
-            .getMinimalByUserAndConfig(originatingUserEmail, cloudContext, machineConfig)
-            .transaction
+        // Always allow autoScaling for ALLOWED appType
+        machineConfig =
+          if (AppType.Allowed == req.appType) machineConfigFromReqAndConfig.copy(autoscalingEnabled = true)
+          else machineConfigFromReqAndConfig
+        // We want to know if the user already has a nodepool with the requested config that can be re-used
+        userNodepoolOpt <- nodepoolQuery
+          .getMinimalByUserAndConfig(originatingUserEmail, cloudContext, machineConfig)
+          .transaction
 
-          nodepool <- userNodepoolOpt match {
-            case Some(n) =>
-              log.info(ctx.loggingCtx)(
-                s"Reusing user's nodepool ${n.id} in ${saveClusterResult.minimalCluster.cloudContext.asStringWithProvider} with ${machineConfig}"
-              ) >> F.pure(n)
-            case None =>
-              for {
-                _ <- log.info(ctx.loggingCtx)(
-                  s"No nodepool with ${machineConfig} found for this user in project ${saveClusterResult.minimalCluster.cloudContext.asStringWithProvider}. Will create a new nodepool."
-                )
-                saveNodepool <- F.fromEither(
-                  getUserNodepool(clusterId, cloudContext, originatingUserEmail, machineConfig, ctx.now)
-                )
-                savedNodepool <- nodepoolQuery.saveForCluster(saveNodepool).transaction
-              } yield savedNodepool
-          }
+        nodepool <- userNodepoolOpt match {
+          case Some(n) =>
+            log.info(ctx.loggingCtx)(
+              s"Reusing user's nodepool ${n.id} in ${saveClusterResult.minimalCluster.cloudContext.asStringWithProvider} with ${machineConfig}"
+            ) >> F.pure(n)
+          case None =>
+            for {
+              _ <- log.info(ctx.loggingCtx)(
+                s"No nodepool with ${machineConfig} found for this user in project ${saveClusterResult.minimalCluster.cloudContext.asStringWithProvider}. Will create a new nodepool."
+              )
+              saveNodepool <- F.fromEither(
+                getUserNodepool(clusterId, cloudContext, originatingUserEmail, machineConfig, ctx.now)
+              )
+              savedNodepool <- nodepoolQuery.saveForCluster(saveNodepool).transaction
+            } yield savedNodepool
+        }
 
-          runtimeServiceAccountOpt <- serviceAccountProvider
-            .getClusterServiceAccount(userInfo, cloudContext)
-          _ <- ctx.span.traverse(s => F.delay(s.addAnnotation("Done Sam call for getClusterServiceAccount")))
-          petSA <- F.fromEither(
-            runtimeServiceAccountOpt.toRight(new Exception(s"user ${userInfo.userEmail.value} doesn't have a PET SA"))
-          )
+        runtimeServiceAccountOpt <- serviceAccountProvider
+          .getClusterServiceAccount(userInfo, cloudContext)
+        _ <- ctx.span.traverse(s => F.delay(s.addAnnotation("Done Sam call for getClusterServiceAccount")))
+        petSA <- F.fromEither(
+          runtimeServiceAccountOpt.toRight(new Exception(s"user ${userInfo.userEmail.value} doesn't have a PET SA"))
+        )
 
-          // Fail fast if the Galaxy disk, memory, number of CPUs is too small
-          appMachineType <-
-            if (req.appType == AppType.Galaxy) {
-              validateGalaxy(googleProject, req.diskConfig.flatMap(_.size), machineConfig.machineType).map(_.some)
-            } else F.pure(None)
+        // Fail fast if the Galaxy disk, memory, number of CPUs is too small
+        appMachineType <-
+          if (req.appType == AppType.Galaxy) {
+            validateGalaxy(googleProject, req.diskConfig.flatMap(_.size), machineConfig.machineType).map(_.some)
+          } else F.pure(None)
 
-          // if request was created by pet SA, processPersistentDiskRequest will look up it's corresponding user email
-          // as needed
-          diskResultOpt <- req.diskConfig.traverse(diskReq =>
-            RuntimeServiceInterp.processPersistentDiskRequest(
-              diskReq,
-              config.leoKubernetesConfig.diskConfig.defaultZone, // this need to be updated if we support non-default zone for k8s apps
-              googleProject,
-              userInfo,
-              petSA,
-              appTypeToFormattedByType(req.appType),
-              authProvider,
-              config.leoKubernetesConfig.diskConfig
-            )
-          )
-          lastUsedApp <- getLastUsedAppForDisk(req, diskResultOpt)
-          saveApp <- F.fromEither(
-            getSavableApp(cloudContext,
-                          appName,
-                          originatingUserEmail,
-                          samResourceId,
-                          req,
-                          diskResultOpt.map(_.disk),
-                          lastUsedApp,
-                          petSA,
-                          nodepool.id,
-                          req.workspaceId,
-                          ctx
-            )
-          )
-          app <- appQuery.save(saveApp, Some(ctx.traceId)).transaction
-
-          clusterNodepoolAction = saveClusterResult match {
-            case ClusterExists(_, _) =>
-              // If we're using a pre-existing nodepool then don't specify CreateNodepool in the pubsub message
-              if (userNodepoolOpt.isDefined) None else Some(ClusterNodepoolAction.CreateNodepool(nodepool.id))
-            case ClusterDoesNotExist(c, n) =>
-              Some(ClusterNodepoolAction.CreateClusterAndNodepool(c.id, n.id, nodepool.id))
-          }
-          createAppMessage = CreateAppMessage(
+        // if request was created by pet SA, processPersistentDiskRequest will look up it's corresponding user email
+        // as needed
+        diskResultOpt <- req.diskConfig.traverse(diskReq =>
+          RuntimeServiceInterp.processPersistentDiskRequest(
+            diskReq,
+            config.leoKubernetesConfig.diskConfig.defaultZone, // this need to be updated if we support non-default zone for k8s apps
             googleProject,
-            clusterNodepoolAction,
-            app.id,
-            app.appName,
-            diskResultOpt.flatMap(d => if (d.creationNeeded) Some(d.disk.id) else None),
-            req.customEnvironmentVariables,
-            req.appType,
-            app.appResources.namespace,
-            appMachineType,
-            Some(ctx.traceId),
-            enableIntraNodeVisibility
+            userInfo,
+            petSA,
+            appTypeToFormattedByType(req.appType),
+            authProvider,
+            config.leoKubernetesConfig.diskConfig
           )
-          _ <- publisherQueue.offer(createAppMessage)
-        } yield ()
+        )
+        lastUsedApp <- getLastUsedAppForDisk(req, diskResultOpt)
+        saveApp <- F.fromEither(
+          getSavableApp(cloudContext,
+                        appName,
+                        originatingUserEmail,
+                        samResourceId,
+                        req,
+                        diskResultOpt.map(_.disk),
+                        lastUsedApp,
+                        petSA,
+                        nodepool.id,
+                        req.workspaceId,
+                        ctx
+          )
+        )
+        app <- appQuery.save(saveApp, Some(ctx.traceId)).transaction
+
+        clusterNodepoolAction = saveClusterResult match {
+          case ClusterExists(_, _) =>
+            // If we're using a pre-existing nodepool then don't specify CreateNodepool in the pubsub message
+            if (userNodepoolOpt.isDefined) None else Some(ClusterNodepoolAction.CreateNodepool(nodepool.id))
+          case ClusterDoesNotExist(c, n) =>
+            Some(ClusterNodepoolAction.CreateClusterAndNodepool(c.id, n.id, nodepool.id))
+        }
+        createAppMessage = CreateAppMessage(
+          googleProject,
+          clusterNodepoolAction,
+          app.id,
+          app.appName,
+          diskResultOpt.flatMap(d => if (d.creationNeeded) Some(d.disk.id) else None),
+          req.customEnvironmentVariables,
+          req.appType,
+          app.appResources.namespace,
+          appMachineType,
+          Some(ctx.traceId),
+          enableIntraNodeVisibility
+        )
+        _ <- publisherQueue.offer(createAppMessage)
+      } yield ()
+      _ <- notifySamAndCreate.handleErrorWith { t =>
+        authProvider
+          .notifyResourceDeleted(samResourceId, originatingUserEmail, googleProject) >> F.raiseError[Unit](t)
       }
     } yield ()
 
@@ -309,7 +318,7 @@ final class LeoAppServiceInterp[F[_]: Parallel](config: AppServiceConfig,
         if (hasPermission) F.unit
         else
           log.info(ctx.loggingCtx)(
-            s"User ${userInfo} tried to access app ${appName.value} without proper permissions. Returning 404"
+            s"User ${userInfo.userEmail} tried to access app ${appName.value} without proper permissions. Returning 404"
           ) >>
             F.raiseError[Unit](
               AppNotFoundException(cloudContext, appName, ctx.traceId, "Permission Denied")
@@ -1514,37 +1523,6 @@ final class LeoAppServiceInterp[F[_]: Parallel](config: AppServiceConfig,
       case (None, None)       => None
     }
   } yield samVisibleAppsOpt
-
-  private def createSamResourceWithRollback(samResourceId: AppSamResourceId,
-                                            user: WorkbenchEmail,
-                                            googleProject: GoogleProject
-  )(implicit
-    ev: Ask[F, AppContext]
-  ): Resource[F, Unit] = {
-    val createSamResource = for {
-      ctx <- ev.ask
-      _ <- authProvider
-        .notifyResourceCreated(samResourceId, user, googleProject)
-        .handleErrorWith { t =>
-          log.error(ctx.loggingCtx, t)(
-            s"Failed to notify the AuthProvider for creation of kubernetes app ${googleProject.value} / ${samResourceId.asString}"
-          ) >> F.raiseError[Unit](t)
-        }
-    } yield ()
-    val deleteSamResource = for {
-      ctx <- ev.ask
-      _ <- authProvider
-        .notifyResourceDeleted(samResourceId, user, googleProject)
-        .handleErrorWith { t =>
-          log.error(ctx.loggingCtx, t)(
-            s"Failed to notify the AuthProvider for deletion of kubernetes app ${googleProject.value} / ${samResourceId.asString}"
-          ) >> F.raiseError[Unit](t)
-        }
-    } yield ()
-    Resource.make(
-      createSamResource
-    )(_ => deleteSamResource)
-  }
 
   private def filterAppsBySamPermission(allClusters: List[KubernetesCluster],
                                         userInfo: UserInfo,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterp.scala
@@ -1414,7 +1414,7 @@ final case class DiskNotSupportedException(traceId: TraceId)
 
 final case class DiskAlreadyAttachedException(cloudContext: CloudContext, name: DiskName, traceId: TraceId)
     extends LeoException(
-      s"Your persistent disk ${cloudContext.asStringWithProvider}/${name.value} is already attached to another runtime. You might need to wait a few minutes if you just deleted a runtime.",
+      s"Your persistent disk ${cloudContext.asStringWithProvider}/${name.value} is already attached to another cloud environment. You might need to wait a few minutes if you just deleted a runtime.",
       StatusCodes.Conflict,
       traceId = Some(traceId)
     )


### PR DESCRIPTION
https://precisionmedicineinitiative.atlassian.net/browse/RW-12554

When investigating workspace deletion failures. I see a few examples like this one where there's an orphaned resourceId in Sam (and this is blocking user's workspace from getting deleted), but we don't have any record in Leo DB. Digging a bit further, here's what happened

```
INFO 2024-04-01T14:29:05.111189782Z Creating kubernetes-app resource in sam v2 for terra-vpc-sc-ca355aff/46161c59-fa2f-4bf1-bcff-875a93e8fdbb
INFO 2024-04-01T14:29:05.261976172Z Reusing user's nodepool NodepoolLeoId(6332) in Gcp/terra-vpc-sc-ca355aff with KubernetesRuntimeConfig(NumNodes(1),MachineTypeName(n1-standard-4),true)
ERROR 2024-04-01T14:29:05.362449580Z request failed due to: Your persistent disk Gcp/terra-vpc-sc-ca355aff/all-of-us-pd-15752-rstudio-eb21 is already attached to another runtime. You might need to wait a few minutes if you just deleted a runtime..
```
(jsonPayload.traceId="43451e3740413bec1ac8d547572572d2/7917773045753585985")

Basically the app creation failed in front leo because disk is already being used by another app (possibly just because an old app still in Deleting status). And we already created Sam resource at that point, just have not saved it in DB.

This PR makes it so that we creates Sam resource with rollback. If anything fails after the Sam resource creation in frontleo, we'll delete the created Sam resource.


<!-- Welcome to your Leonardo pull request! -->
<!-- Contributor guidelines: https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md -->

__Jira ticket__: https://broadworkbench.atlassian.net/browse/[ticket_number]

<!-- ## Dependencies -->
<!-- Include any dependent tickets and describe the relationship. Include any other relevant Jira tickets. -->

## Summary of changes

<!-- Please give an abridged version of the ticket description here and/or fill out the following fields. -->

### What

-

### Why

-

## Testing these changes

### What to test

- <!-- Test case 1 -->

<!-- ### Test data -->

### Who tested and where

- [ ] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [ ] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
