### PR TITLE
[IA-4938] upgrade workbench-libs to get the new bouncycastle 1.78

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -18,14 +18,14 @@ object Dependencies {
   val pact4sV = "0.10.0"
 
   private val workbenchLibsHash = "3b2d0f4"
-  private val workbenchAzureHash = "5762674"
+  // private val workbenchAzureHash = "5762674"
   val serviceTestV = s"4.3-$workbenchLibsHash"
   val workbenchModelV = s"0.19-$workbenchLibsHash"
   val workbenchGoogleV = s"0.30-$workbenchLibsHash"
   val workbenchGoogle2V = s"0.36-$workbenchLibsHash"
   val workbenchOpenTelemetryV = s"0.8-$workbenchLibsHash"
   val workbenchOauth2V = s"0.7-$workbenchLibsHash"
-  val workbenchAzureV = s"0.7-$workbenchAzureHash"
+  val workbenchAzureV = s"0.7-$workbenchLibsHash"
 
   val helmScalaSdkV = "0.0.8.5"
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -18,7 +18,6 @@ object Dependencies {
   val pact4sV = "0.10.0"
 
   private val workbenchLibsHash = "3b2d0f4"
-  // private val workbenchAzureHash = "5762674"
   val serviceTestV = s"4.3-$workbenchLibsHash"
   val workbenchModelV = s"0.19-$workbenchLibsHash"
   val workbenchGoogleV = s"0.30-$workbenchLibsHash"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -48,10 +48,6 @@ object Dependencies {
   val excludeHttpComponent = ExclusionRule(organization = "org.apache.httpcomponents", name = "httpclient")
   val excludeReactiveStream = ExclusionRule(organization = "org.reactivestreams", name = "reactive-streams")
   val excludeFirestore = ExclusionRule(organization = "com.google.cloud", name = s"google-cloud-firestore")
-  val excludeBouncyCastle = ExclusionRule(organization = "org.bouncycastle", name = s"bcprov-jdk15on")
-  val excludeBouncyCastleExt = ExclusionRule(organization = "org.bouncycastle", name = s"bcprov-ext-jdk15on")
-  val excludeBouncyCastleUtil = ExclusionRule(organization = "org.bouncycastle", name = s"bcutil-jdk15on")
-  val excludeBouncyCastlePkix = ExclusionRule(organization = "org.bouncycastle", name = s"bcpkix-jdk15on")
   val excludeSundrCodegen = ExclusionRule(organization = "io.sundr", name = s"sundr-codegen")
   val excludeStatsD = ExclusionRule(organization = "com.readytalk", name = s"metrics3-statsd")
   val excludeKms = ExclusionRule(organization = "com.google.cloud", name = s"google-cloud-kms")
@@ -112,11 +108,7 @@ object Dependencies {
   val workbenchAzureTest: ModuleID =  "org.broadinstitute.dsde.workbench" %% "workbench-azure"  % workbenchAzureV % "test" classifier "tests"
   val workbenchOpenTelemetry: ModuleID =     "org.broadinstitute.dsde.workbench" %% "workbench-opentelemetry" % workbenchOpenTelemetryV excludeAll (
     excludeIoGrpc,
-    excludeGuava,
-    excludeBouncyCastle,
-    excludeBouncyCastleExt,
-    excludeBouncyCastleUtil,
-    excludeBouncyCastlePkix)
+    excludeGuava)
   val workbenchOpenTelemetryTest: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-opentelemetry" % workbenchOpenTelemetryV % Test classifier "tests" excludeAll (excludeGuava)
 
   val helmScalaSdk: ModuleID = "org.broadinstitute.dsp" %% "helm-scala-sdk" % helmScalaSdkV

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -18,13 +18,14 @@ object Dependencies {
   val pact4sV = "0.10.0"
 
   private val workbenchLibsHash = "3b2d0f4"
+  private val workbenchAzureHash = "5762674"
   val serviceTestV = s"4.3-$workbenchLibsHash"
   val workbenchModelV = s"0.19-$workbenchLibsHash"
   val workbenchGoogleV = s"0.30-$workbenchLibsHash"
   val workbenchGoogle2V = s"0.36-$workbenchLibsHash"
   val workbenchOpenTelemetryV = s"0.8-$workbenchLibsHash"
   val workbenchOauth2V = s"0.7-$workbenchLibsHash"
-  val workbenchAzureV = s"0.7-$workbenchLibsHash"
+  val workbenchAzureV = s"0.7-$workbenchAzureHash"
 
   val helmScalaSdkV = "0.0.8.5"
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,7 +17,7 @@ object Dependencies {
   val munitCatsEffectV = "1.0.7"
   val pact4sV = "0.10.0"
 
-  private val workbenchLibsHash = "5762674"
+  private val workbenchLibsHash = "3b2d0f4"
   val serviceTestV = s"4.3-$workbenchLibsHash"
   val workbenchModelV = s"0.19-$workbenchLibsHash"
   val workbenchGoogleV = s"0.30-$workbenchLibsHash"

--- a/project/Merging.scala
+++ b/project/Merging.scala
@@ -23,6 +23,13 @@ object Merging {
     case x if x.endsWith("io.netty.versions.properties") => MergeStrategy.first
     case x if x.endsWith("/ModuleUtil.class")            => MergeStrategy.first
     case x if x.endsWith("/module-info.class")           => MergeStrategy.discard
+    // For the following error:
+    // Error:  Deduplicate found different file contents in the following:
+    // Error:    Jar name = bcpkix-jdk18on-1.78.jar, jar org = org.bouncycastle, entry target = META-INF/versions/9/OSGI-INF/MANIFEST.MF
+    // Error:    Jar name = bcprov-jdk18on-1.78.jar, jar org = org.bouncycastle, entry target = META-INF/versions/9/OSGI-INF/MANIFEST.MF
+    // Error:    Jar name = bcutil-jdk18on-1.78.jar, jar org = org.bouncycastle, entry target = META-INF/versions/9/OSGI-INF/MANIFEST.MF
+    case x if x.endsWith("/OSGI-INF/MANIFEST.MF") =>
+      MergeStrategy.first
     case x if x.contains("bouncycastle") =>
       MergeStrategy.first
     case "module-info.class" =>


### PR DESCRIPTION
<!-- Welcome to your Leonardo pull request! -->
<!-- Contributor guidelines: https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md -->

__Jira ticket__: https://broadworkbench.atlassian.net/browse/IA-4938

<!-- ## Dependencies -->
<!-- Include any dependent tickets and describe the relationship. Include any other relevant Jira tickets. -->

## Summary of changes

Vulnerability in bouncycastle-1.76, a Leonardo transitive dependency. Upgrade to a version of workbench-libs which uses v1.78.

## Testing these changes

### What to test

- App compiles and runs; dependency tree has bouncycastle-1.78

<!-- ### Test data -->

### Who tested and where

- [x] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [x] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
