### PR TITLE
[IA-4926] Reenable ssh portion of Azure automation tests

### DIFF
--- a/automation/run-tests.sh
+++ b/automation/run-tests.sh
@@ -37,19 +37,22 @@ mkdir -p /root/.ssh
 gcloud auth activate-service-account --key-file=$LEONARDO_ACCOUNT_JSON_PATH
 export GOOGLE_APPLICATION_CREDENTIALS=$LEONARDO_ACCOUNT_JSON_PATH
 
-# Install azure CLI
-curl -sL https://aka.ms/InstallAzureCLIDeb | bash > /dev/null
 
-# Log into service principal and set subscription
-az login --service-principal -u "$LEO_AZURE_CLIENT_ID" -p "$LEO_AZURE_CLIENT_SECRET" -t "$LEO_AZURE_TENANT_ID"
-az account set -s "$LEO_AZURE_SUBSCRIPTION_ID"
-echo "Showing account"
-az account show
+if [ ! -z "$LEO_AZURE_SUBSCRIPTION_ID" ] ; then
+  # Install azure CLI
+  curl -sL https://aka.ms/InstallAzureCLIDeb | bash > /dev/null
 
-# Install the bastion portion of the CLI
-echo "Installing bastion"
-yes | az network bastion list
-echo "Bastion installed"
+  # Log into service principal and set subscription
+  az login --service-principal -u "$LEO_AZURE_CLIENT_ID" -p "$LEO_AZURE_CLIENT_SECRET" -t "$LEO_AZURE_TENANT_ID"
+  az account set -s "$LEO_AZURE_SUBSCRIPTION_ID"
+  echo "Showing account"
+  az account show
+
+  # Install the bastion portion of the CLI
+  echo "Installing bastion"
+  yes | az network bastion list
+  echo "Bastion installed"
+fi
 
 echo "Installing lsof"
 yes | apt update > /dev/null

--- a/automation/run-tests.sh
+++ b/automation/run-tests.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -e -x
+set -x
 
 # Logs into an azure service principal and runs the SBT tests. Requires 5 env vars
 

--- a/automation/run-tests.sh
+++ b/automation/run-tests.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -x
+set -e -x
 
 # Logs into an azure service principal and runs the SBT tests. Requires 5 env vars
 

--- a/automation/run-tests.sh
+++ b/automation/run-tests.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+set -e -x
+
 # Logs into an azure service principal and runs the SBT tests. Requires 5 env vars
 
 # The below three are the leo service principal's credentials, and can be found at secret/dsde/terra/azure/qa/leonardo/managed-app-publisher

--- a/automation/src/test/resources/startTunnel.sh
+++ b/automation/src/test/resources/startTunnel.sh
@@ -34,5 +34,3 @@ done
 PID=$(lsof -i tcp:$PORT | tail -1 | awk '{print $2}')
 # The last line of this script needs to echo the pid for the sbt test suite to record and clean up
 echo "$PID"
-
-exit 0

--- a/automation/src/test/resources/startTunnel.sh
+++ b/automation/src/test/resources/startTunnel.sh
@@ -34,3 +34,5 @@ done
 PID=$(lsof -i tcp:$PORT | tail -1 | awk '{print $2}')
 # The last line of this script needs to echo the pid for the sbt test suite to record and clean up
 echo "$PID"
+
+exit 0

--- a/automation/src/test/resources/startTunnel.sh
+++ b/automation/src/test/resources/startTunnel.sh
@@ -14,13 +14,6 @@ echo "starting tunnel bastion ${BASTION_NAME} with resource id ${RESOURCE_ID} in
 
 nohup az network bastion tunnel --name "$BASTION_NAME" --resource-group "$RESOURCE_GROUP" --target-resource-id "${RESOURCE_ID}" --resource-port 22 --port $PORT > /dev/null 2>&1 &
 
-#nohup az network bastion tunnel --name "$BASTION_NAME" --resource-group "$RESOURCE_GROUP" --target-resource-id "${RESOURCE_ID}" --resource-port 22 --port $PORT > /tmp/nohup.out &
-#
-#
-#echo "displaying nohup output"
-#cat /tmp/nohup.out
-#echo "done displaying nohup output"
-
 NUM_LOOPS=0
 until lsof -i tcp:3000
 do

--- a/automation/src/test/resources/startTunnel.sh
+++ b/automation/src/test/resources/startTunnel.sh
@@ -12,11 +12,14 @@ set -e -x
 
 echo "starting tunnel bastion ${BASTION_NAME} with resource id ${RESOURCE_ID} in resource group ${RESOURCE_GROUP} on port ${PORT}"
 
-nohup az network bastion tunnel --name "$BASTION_NAME" --resource-group "$RESOURCE_GROUP" --target-resource-id "${RESOURCE_ID}" --resource-port 22 --port $PORT > /tmp/nohup.out &
+nohup az network bastion tunnel --name "$BASTION_NAME" --resource-group "$RESOURCE_GROUP" --target-resource-id "${RESOURCE_ID}" --resource-port 22 --port $PORT > /dev/null 2>&1 &
 
-echo "displaying nohup output"
-cat /tmp/nohup.out
-echo "done displaying nohup output"
+#nohup az network bastion tunnel --name "$BASTION_NAME" --resource-group "$RESOURCE_GROUP" --target-resource-id "${RESOURCE_ID}" --resource-port 22 --port $PORT > /tmp/nohup.out &
+#
+#
+#echo "displaying nohup output"
+#cat /tmp/nohup.out
+#echo "done displaying nohup output"
 
 NUM_LOOPS=0
 until lsof -i tcp:3000

--- a/automation/src/test/resources/startTunnel.sh
+++ b/automation/src/test/resources/startTunnel.sh
@@ -1,3 +1,6 @@
+#!/usr/bin/env bash
+set -e -x
+
 # This script is meant to be used from within leo automation tests, and starts a tunnel that allows a bastion to be used to ssh into an azure vm
 # It depends on the following env vars:
    # BASTION_NAME, the name of the pre-created bastion in the azure cloud

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/SSH.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/SSH.scala
@@ -51,7 +51,7 @@ object SSH {
       _ <- loggerIO.info(s"startTunnel process string: ${processString}")
       hasExit = process.hasExitValue
       _ <- loggerIO.info(s"startTunnel process hasExit: ${hasExit}")
-//      pid = process.lazyLines.last
+      processLazy = process.lazyLines
       pid = "1632"
 //      output <- IO(process)
       _ <- loggerIO.info(s"Bastion tunnel start command pid output:\n\t${pid}")

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/SSH.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/SSH.scala
@@ -16,6 +16,7 @@ import java.nio.file.{Files, Path, Paths}
 import java.util.UUID
 import java.util.concurrent.TimeUnit
 import scala.sys.process._
+import scala.concurrent.duration._
 
 case class TunnelName(value: String) extends AnyVal
 case class ResourceGroup(value: String)
@@ -52,7 +53,8 @@ object SSH {
       hasExit = process.hasExitValue
       _ <- loggerIO.info(s"startTunnel process hasExit: ${hasExit}")
       processLazy = process.lazyLines
-      pid = "1632"
+      _ <- IO.sleep(10 seconds)
+      pid = processLazy.last
 //      output <- IO(process)
       _ <- loggerIO.info(s"Bastion tunnel start command pid output:\n\t${pid}")
       tunnel = Tunnel(pid, port)

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/SSH.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/SSH.scala
@@ -51,7 +51,8 @@ object SSH {
       _ <- loggerIO.info(s"startTunnel process string: ${processString}")
       hasExit = process.hasExitValue
       _ <- loggerIO.info(s"startTunnel process hasExit: ${hasExit}")
-      pid = process.lazyLines.last
+//      pid = process.lazyLines.last
+      pid = "1632"
 //      output <- IO(process)
       _ <- loggerIO.info(s"Bastion tunnel start command pid output:\n\t${pid}")
       tunnel = Tunnel(pid, port)

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/SSH.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/SSH.scala
@@ -16,7 +16,6 @@ import java.nio.file.{Files, Path, Paths}
 import java.util.UUID
 import java.util.concurrent.TimeUnit
 import scala.sys.process._
-import scala.concurrent.duration._
 
 case class TunnelName(value: String) extends AnyVal
 case class ResourceGroup(value: String)

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/SSH.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/SSH.scala
@@ -48,7 +48,7 @@ object SSH {
         "PORT" -> port.toString
       )
       output <- IO(process !!)
-      _ <- loggerIO.info(s"Bastion tunnel start command pid output:\n\t${output}")
+      _ <- loggerIO.info(s"Bastion tunnel start command full output:\n\t${output}")
       tunnel = Tunnel(output.split('\n').last, port)
     } yield tunnel
 

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/SSH.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/SSH.scala
@@ -38,15 +38,17 @@ object SSH {
 
     val makeTunnel = for {
       scriptPath <- IO(getClass.getClassLoader.getResource("startTunnel.sh").getPath)
-      process = Process(
+      output = Process(
         scriptPath,
         None,
         "BASTION_NAME" -> LeonardoConfig.Azure.bastionName,
         "RESOURCE_GROUP" -> staticTestCoordinates.managedResourceGroupId,
         "RESOURCE_ID" -> targetResourceId,
         "PORT" -> port.toString
-      )
-      output <- IO(process !!)
+      ) !!
+
+      _ <- loggerIO.info(s"startTunnel output: ${output}")
+//      output <- IO(process)
       _ <- loggerIO.info(s"Bastion tunnel start command full output:\n\t${output}")
       tunnel = Tunnel(output.split('\n').last, port)
     } yield tunnel

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/SSH.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/SSH.scala
@@ -51,10 +51,10 @@ object SSH {
       _ <- loggerIO.info(s"startTunnel process string: ${processString}")
       hasExit = process.hasExitValue
       _ <- loggerIO.info(s"startTunnel process hasExit: ${hasExit}")
-      output = process.lazyLines
+      pid = process.lazyLines.last
 //      output <- IO(process)
-      _ <- loggerIO.info(s"Bastion tunnel start command full output:\n\t${output}")
-      tunnel = Tunnel(output.last, port)
+      _ <- loggerIO.info(s"Bastion tunnel start command pid output:\n\t${pid}")
+      tunnel = Tunnel(pid, port)
     } yield tunnel
 
     Resource.make(makeTunnel)(tunnel => loggerIO.info("Closing tunnel") >> closeTunnel(tunnel))

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/SSH.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/SSH.scala
@@ -47,17 +47,9 @@ object SSH {
         "RESOURCE_ID" -> targetResourceId,
         "PORT" -> port.toString
       )
-      _ <- loggerIO.info(s"startTunnel process")
-      processString = process.toString
-      _ <- loggerIO.info(s"startTunnel process string: ${processString}")
-      hasExit = process.hasExitValue
-      _ <- loggerIO.info(s"startTunnel process hasExit: ${hasExit}")
-      processLazy = process.lazyLines
-      _ <- IO.sleep(10 seconds)
-      pid = processLazy.last
-//      output <- IO(process)
-      _ <- loggerIO.info(s"Bastion tunnel start command pid output:\n\t${pid}")
-      tunnel = Tunnel(pid, port)
+      output <- IO(process !!)
+      _ <- loggerIO.info(s"Bastion tunnel start command pid output:\n\t${output}")
+      tunnel = Tunnel(output.split('\n').last, port)
     } yield tunnel
 
     Resource.make(makeTunnel)(tunnel => loggerIO.info("Closing tunnel") >> closeTunnel(tunnel))


### PR DESCRIPTION

<!-- Welcome to your Leonardo pull request! -->
<!-- Contributor guidelines: https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md -->

__Jira ticket__: https://broadworkbench.atlassian.net/browse/IA-4926

<!-- ## Dependencies -->
<!-- Include any dependent tickets and describe the relationship. Include any other relevant Jira tickets. -->

## Summary of changes

<!-- Please give an abridged version of the ticket description here and/or fill out the following fields. -->

### What

- Adds set -e -x to ssh scripts for easier debugging. Revert the changes made previously that was causing the startTunnel.sh script to hang

### Why

-

## Testing these changes

### What to test

- <!-- Test case 1 -->

<!-- ### Test data -->

### Who tested and where

- [ ] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [ ] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
