### PR TITLE
[RW-12336] Enable GCSFuse driver when creating clusters

### DIFF
--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
@@ -163,7 +163,9 @@ class GKEInterpreter[F[_]](
         )
         .setAddonsConfig(
           new com.google.api.services.container.model.AddonsConfig()
-            .setGcsFuseCsiDriverConfig(new com.google.api.services.container.model.GcsFuseCsiDriverConfig().setEnabled(true))
+            .setGcsFuseCsiDriverConfig(
+              new com.google.api.services.container.model.GcsFuseCsiDriverConfig().setEnabled(true)
+            )
         )
         .setNodePoolAutoConfig(nodepoolConfig)
         .setLegacyAbac(new com.google.api.services.container.model.LegacyAbac().setEnabled(false))

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
@@ -161,6 +161,10 @@ class GKEInterpreter[F[_]](
         .setAutopilot(
           autopilot
         )
+        .setAddonsConfig(
+          new com.google.api.services.container.model.AddonsConfig()
+            .setGcsFuseCsiDriverConfig(new com.google.api.services.container.model.GcsFuseCsiDriverConfig().setEnabled(true))
+        )
         .setNodePoolAutoConfig(nodepoolConfig)
         .setLegacyAbac(new com.google.api.services.container.model.LegacyAbac().setEnabled(false))
         .setNetwork(kubeNetwork.idString)


### PR DESCRIPTION
Turn on gcsfuse driver when creating GKE cluster https://cloud.google.com/kubernetes-engine/docs/how-to/persistent-volumes/cloud-storage-fuse-csi-driver.
For now I just enabled this in all cluster as I don't think there will be any impact by having this driver on.

Note, turning this on does not mean app will have Fuse. It's just an driver. The real fuse on/off will be in Helm chart .
In the following PR, there will be a flag enableGcsFuse that will control whether to use GcsFuse in Helm chart
<!-- Welcome to your Leonardo pull request! -->
<!-- Contributor guidelines: https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md -->

__Jira ticket__: https://broadworkbench.atlassian.net/browse/[ticket_number]

<!-- ## Dependencies -->
<!-- Include any dependent tickets and describe the relationship. Include any other relevant Jira tickets. -->

## Summary of changes

<!-- Please give an abridged version of the ticket description here and/or fill out the following fields. -->

### What

-

### Why

-

## Testing these changes

### What to test

- <!-- Test case 1 -->

<!-- ### Test data -->

### Who tested and where

- [ ] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [ ] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
