### PR TITLE
RW-12676 set service account when autopilot is enabled

### DIFF
--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
@@ -154,13 +154,26 @@ class GKEInterpreter[F[_]](
       networkPolicy =
         if (params.autopilot) null else new com.google.api.services.container.model.NetworkPolicy().setEnabled(true)
 
+      autoscaling =
+        if (params.autopilot) {
+          val serviceAccount = getNodepoolServiceAccount(projectLabels, params.googleProject)
+
+          serviceAccount match {
+            case Some(sa) =>
+              new com.google.api.services.container.model.ClusterAutoscaling().setAutoprovisioningNodePoolDefaults(
+                new com.google.api.services.container.model.AutoprovisioningNodePoolDefaults().setServiceAccount(sa)
+              )
+            case None => null
+          }
+
+        } else null
+
       legacyCreateClusterRec = new com.google.api.services.container.model.Cluster()
         .setName(dbCluster.clusterName.value)
         .setInitialClusterVersion(config.clusterConfig.version.value)
         .setNodePools(nodepools.asJava)
-        .setAutopilot(
-          autopilot
-        )
+        .setAutopilot(autopilot)
+        .setAutoscaling(autoscaling)
         .setNodePoolAutoConfig(nodepoolConfig)
         .setLegacyAbac(new com.google.api.services.container.model.LegacyAbac().setEnabled(false))
         .setNetwork(kubeNetwork.idString)


### PR DESCRIPTION
Getting the following error in dev
```
400 Bad Request
POST https://container.googleapis.com/v1/projects/terra-vpc-sc-dev-fb523401/locations/us-central1/clusters
{
  "code" : 400,
  "details" : [ {
    "@type" : "type.googleapis.com/google.rpc.RequestInfo",
    "requestId" : "0x16c2756d7185ca61"
  } ],
  "errors" : [ {
    "domain" : "global",
    "message" : "Failed precondition: failed to check status for \"30697941831-compute@developer.gserviceaccount.com\"; Verify if principal exists and is valid.",
    "reason" : "failedPrecondition"
  } ],
  "message" : "Failed precondition: failed to check status for \"30697941831-compute@developer.gserviceaccount.com\"; Verify if principal exists and is valid.",
  "status" : "FAILED_PRECONDITION"
}
```

This is because dev projects do not have GCE default SA like `30697941831-compute@developer.gserviceaccount.com` exists. This PR makes it uses a dedicated gke node SA which we're using during nodepool creation today

Tested in BEE that things work, but that doesn't necessarily mean the issue is fixed until I can verify in dev.

<!-- Welcome to your Leonardo pull request! -->
<!-- Contributor guidelines: https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md -->

__Jira ticket__: https://broadworkbench.atlassian.net/browse/[ticket_number]

<!-- ## Dependencies -->
<!-- Include any dependent tickets and describe the relationship. Include any other relevant Jira tickets. -->

## Summary of changes

<!-- Please give an abridged version of the ticket description here and/or fill out the following fields. -->

### What

-

### Why

-

## Testing these changes

### What to test

- <!-- Test case 1 -->

<!-- ### Test data -->

### Who tested and where

- [ ] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [ ] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
