### PR TITLE
[RW-12337] Support mount a workspace bucket when creating GKE apps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,8 +32,8 @@ ENV NGINX_VERSION 4.3.0
 # If you update this here, make sure to also update reference.conf:
 ENV CROMWELL_CHART_VERSION 0.2.506
 ENV HAIL_BATCH_CHART_VERSION 0.2.0
-ENV RSTUDIO_CHART_VERSION 0.9.0
-ENV SAS_CHART_VERSION 0.12.0
+ENV RSTUDIO_CHART_VERSION 0.11.0
+ENV SAS_CHART_VERSION 0.14.0
 
 RUN mkdir /leonardo
 COPY ./leonardo*.jar /leonardo

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoApiClient.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoApiClient.scala
@@ -131,6 +131,7 @@ object LeonardoApiClient {
     None,
     None,
     None,
+    None,
     None
   )
 

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/appRoutesModels.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/appRoutesModels.scala
@@ -108,8 +108,8 @@ object ListAppResponse {
           a.auditInfo,
           a.appAccessScope,
           a.labels.filter(l => labelsToReturn.contains(l._1)),
-          a.autodeleteEnabled,
-          a.autodeleteThreshold
+          a.autodelete.autodeleteEnabled,
+          a.autodelete.autodeleteThreshold
         )
       }
     )
@@ -137,7 +137,7 @@ object GetAppResponse {
       appResult.app.chart.name,
       appResult.app.appAccessScope,
       appResult.app.labels,
-      appResult.app.autodeleteEnabled,
-      appResult.app.autodeleteThreshold
+      appResult.app.autodelete.autodeleteEnabled,
+      appResult.app.autodelete.autodeleteThreshold
     )
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/appRoutesModels.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/appRoutesModels.scala
@@ -21,6 +21,7 @@ import org.broadinstitute.dsde.workbench.leonardo.{
   WorkspaceId
 }
 import org.broadinstitute.dsde.workbench.google2.RegionName
+import org.broadinstitute.dsde.workbench.model.google.GcsBucketName
 import org.broadinstitute.dsp.ChartName
 import org.http4s.Uri
 
@@ -40,7 +41,7 @@ final case class CreateAppRequest(kubernetesRuntimeConfig: Option[KubernetesRunt
                                   autodeleteEnabled: Option[Boolean],
                                   autodeleteThreshold: Option[AutodeleteThreshold],
                                   autopilot: Option[Autopilot],
-                                  mountWorkspaceBucketName: Option[String]
+                                  bucketNameToMount: Option[GcsBucketName]
 )
 
 final case class UpdateAppRequest(autodeleteEnabled: Option[Boolean], autodeleteThreshold: Option[AutodeleteThreshold])

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/appRoutesModels.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/appRoutesModels.scala
@@ -39,7 +39,7 @@ final case class CreateAppRequest(kubernetesRuntimeConfig: Option[KubernetesRunt
                                   autodeleteThreshold: Option[Int],
                                   autodeleteEnabled: Option[Boolean],
                                   autopilot: Option[Autopilot],
-                                  mountWorkspaceBucketEnabled: Option[Boolean]
+                                  mountWorkspaceBucketName: Option[String]
 )
 
 final case class UpdateAppRequest(autodeleteEnabled: Option[Boolean], autodeleteThreshold: Option[Int])

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/appRoutesModels.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/appRoutesModels.scala
@@ -38,7 +38,8 @@ final case class CreateAppRequest(kubernetesRuntimeConfig: Option[KubernetesRunt
                                   sourceWorkspaceId: Option[WorkspaceId],
                                   autodeleteThreshold: Option[Int],
                                   autodeleteEnabled: Option[Boolean],
-                                  autopilot: Option[Autopilot]
+                                  autopilot: Option[Autopilot],
+                                  mountWorkspaceBucketEnabled: Option[Boolean]
 )
 
 final case class UpdateAppRequest(autodeleteEnabled: Option[Boolean], autodeleteThreshold: Option[Int])

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/kubernetesModels.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/kubernetesModels.scala
@@ -439,8 +439,7 @@ final case class App(id: AppId,
                      extraArgs: List[String],
                      sourceWorkspaceId: Option[WorkspaceId],
                      numOfReplicas: Option[Int],
-                     autodeleteEnabled: Boolean,
-                     autodeleteThreshold: Option[AutodeleteThreshold],
+                     autodelete: Autodelete,
                      autopilot: Option[Autopilot],
                      mountWorkspaceBucketName: Option[String]
 ) {
@@ -597,5 +596,5 @@ object ComputeClass {
   private def values: Set[ComputeClass] = sealerate.values[ComputeClass]
   val stringToObject = values.map(v => v.toString.toLowerCase -> v).toMap
 }
-final case class Autodelete(autodelete: ComputeClass, cpuInMillicores: Int, memoryInGb: Int, ephemeralStorageInGb: Int)
+final case class Autodelete(autodeleteEnabled: Boolean, autodeleteThreshold: Option[AutodeleteThreshold])
 final case class Autopilot(computeClass: ComputeClass, cpuInMillicores: Int, memoryInGb: Int, ephemeralStorageInGb: Int)

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/kubernetesModels.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/kubernetesModels.scala
@@ -595,4 +595,5 @@ object ComputeClass {
   private def values: Set[ComputeClass] = sealerate.values[ComputeClass]
   val stringToObject = values.map(v => v.toString.toLowerCase -> v).toMap
 }
+final case class Autodelete(autodelete: ComputeClass, cpuInMillicores: Int, memoryInGb: Int, ephemeralStorageInGb: Int)
 final case class Autopilot(computeClass: ComputeClass, cpuInMillicores: Int, memoryInGb: Int, ephemeralStorageInGb: Int)

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/kubernetesModels.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/kubernetesModels.scala
@@ -439,7 +439,8 @@ final case class App(id: AppId,
                      numOfReplicas: Option[Int],
                      autodeleteThreshold: Option[Int],
                      autodeleteEnabled: Boolean,
-                     autopilot: Option[Autopilot]
+                     autopilot: Option[Autopilot],
+                     mountWorkspaceBucketName: Option[String]
 ) {
 
   def getProxyUrls(cluster: KubernetesCluster, proxyUrlBase: String): Map[ServiceName, URL] =

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/kubernetesModels.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/kubernetesModels.scala
@@ -16,6 +16,7 @@ import org.broadinstitute.dsde.workbench.google2.{
   SubnetworkName
 }
 import org.broadinstitute.dsde.workbench.leonardo.SamResourceId._
+import org.broadinstitute.dsde.workbench.model.google.GcsBucketName
 import org.broadinstitute.dsde.workbench.model.{IP, TraceId, WorkbenchEmail}
 import org.broadinstitute.dsp.{ChartName, ChartVersion, Release}
 import org.http4s.Uri
@@ -441,7 +442,7 @@ final case class App(id: AppId,
                      numOfReplicas: Option[Int],
                      autodelete: Autodelete,
                      autopilot: Option[Autopilot],
-                     mountWorkspaceBucketName: Option[String]
+                     bucketNameToMount: Option[GcsBucketName]
 ) {
 
   def getProxyUrls(cluster: KubernetesCluster, proxyUrlBase: String): Map[ServiceName, URL] =

--- a/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changelog.xml
+++ b/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changelog.xml
@@ -114,4 +114,5 @@
     <include file="changesets/20240117_create_app_chart_version_table.xml" relativeToChangelogFile="true" />
     <include file="changesets/20240202_add_auto_delete_threshold_to_app_table.xml" relativeToChangelogFile="true" />
     <include file="changesets/20240202_add_autopilot_configs_to_app_table.xml" relativeToChangelogFile="true" />
+    <include file="changesets/20240202_add_mount_ws_bucket_to_app_table.xml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changelog.xml
+++ b/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changelog.xml
@@ -116,5 +116,4 @@
     <include file="changesets/20240202_add_autopilot_configs_to_app_table.xml" relativeToChangelogFile="true" />
     <include file="changesets/20240605_add_update_app_log_table.xml" relativeToChangelogFile="true" />
     <include file="changesets/20240202_add_mount_ws_bucket_to_app_table.xml" relativeToChangelogFile="true" />
-    <include file="changesets/20240605_add_update_app_log_table.xml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changelog.xml
+++ b/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changelog.xml
@@ -115,5 +115,5 @@
     <include file="changesets/20240202_add_auto_delete_threshold_to_app_table.xml" relativeToChangelogFile="true" />
     <include file="changesets/20240202_add_autopilot_configs_to_app_table.xml" relativeToChangelogFile="true" />
     <include file="changesets/20240605_add_update_app_log_table.xml" relativeToChangelogFile="true" />
-    <include file="changesets/20240202_add_mount_ws_bucket_to_app_table.xml" relativeToChangelogFile="true" />
+    <include file="changesets/20240620_add_mount_ws_bucket_to_app_table.xml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/20240202_add_mount_ws_bucket_to_app_table.xml
+++ b/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/20240202_add_mount_ws_bucket_to_app_table.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog logicalFilePath="leonardo" xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+    <changeSet logicalFilePath="leonardo" author="yonghao" id="20240202_add_autopilot_configs_to_app_table">
+        <addColumn tableName="APP">
+            <column name="mountWorkspaceBucketName" type="VARCHAR(254)">
+                <constraints nullable="true"/>
+            </column>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/20240202_add_mount_ws_bucket_to_app_table.xml
+++ b/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/20240202_add_mount_ws_bucket_to_app_table.xml
@@ -2,7 +2,7 @@
 <databaseChangeLog logicalFilePath="leonardo" xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
     <changeSet logicalFilePath="leonardo" author="yonghao" id="20240202_add_autopilot_configs_to_app_table">
         <addColumn tableName="APP">
-            <column name="mountWorkspaceBucketName" type="VARCHAR(254)">
+            <column name="bucketNameToMount" type="VARCHAR(254)">
                 <constraints nullable="true"/>
             </column>
         </addColumn>

--- a/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/20240620_add_mount_ws_bucket_to_app_table.xml
+++ b/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/20240620_add_mount_ws_bucket_to_app_table.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <databaseChangeLog logicalFilePath="leonardo" xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
-    <changeSet logicalFilePath="leonardo" author="yonghao" id="20240202_add_autopilot_configs_to_app_table">
+    <changeSet logicalFilePath="leonardo" author="yonghao" id="20240620_add_mount_ws_bucket_to_app_table">
         <addColumn tableName="APP">
             <column name="bucketNameToMount" type="VARCHAR(254)">
                 <constraints nullable="true"/>

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -843,8 +843,8 @@ gke {
     # This is really just a prefix of the chart name. Full chart name for AOU app will be
     # this chartName in config file appended with allowedChartName from createAppRequest
     chartName = "/leonardo/"
-    rstudioChartVersion = "0.10.0"
-    sasChartVersion = "0.13.0"
+    rstudioChartVersion = "0.11.0"
+    sasChartVersion = "0.14.0"
 
     services = [
           {

--- a/http/src/main/resources/swagger/api-docs.yaml
+++ b/http/src/main/resources/swagger/api-docs.yaml
@@ -4155,9 +4155,10 @@ components:
           description: Whether to turn on autodelete
         autopilot:
           $ref: '#/components/schemas/Autopilot'
-        mountWorkspaceBucketEnabled:
-          type: boolean
-          description: Whether to mount workspace bucket on this app.
+        mountWorkspaceBucketName:
+          type: string
+          description: >
+            The GCS bucket name (without gs://) that will be mounted in the app if present. 
 
     UpdateAppRequest:
       description: A request to update the configuration of an app

--- a/http/src/main/resources/swagger/api-docs.yaml
+++ b/http/src/main/resources/swagger/api-docs.yaml
@@ -4157,7 +4157,7 @@ components:
             threshold time has elapsed.
         autopilot:
           $ref: '#/components/schemas/Autopilot'
-        mountWorkspaceBucketName:
+        bucketNameToMount:
           type: string
           description: >
             The GCS bucket name (without gs://) that will be mounted in the app if present. 

--- a/http/src/main/resources/swagger/api-docs.yaml
+++ b/http/src/main/resources/swagger/api-docs.yaml
@@ -4155,6 +4155,9 @@ components:
           description: Whether to turn on autodelete
         autopilot:
           $ref: '#/components/schemas/Autopilot'
+        mountWorkspaceBucketEnabled:
+          type: boolean
+          description: Whether to mount workspace bucket on this app.
 
     UpdateAppRequest:
       description: A request to update the configuration of an app

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/AppComponent.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/AppComponent.scala
@@ -198,7 +198,7 @@ class AppTable(tag: Tag) extends Table[AppRecord](tag, "APP") {
           r.sourceWorkspaceId,
           r.numOfReplicas,
           // combine these values to allow tuple creation; longer than 22 elements is not allowed
-          r.autodelete,
+          (r.autodelete.autodeleteEnabled, r.autodelete.autodeleteThreshold),
           (r.autopilot.isDefined, autopilotComputeClass, autopilotCpu, autopilotMemory, autopilotEphemeralStorage),
           r.mountWorkspaceBucketName
         )

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/AppComponent.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/AppComponent.scala
@@ -317,7 +317,7 @@ object appQuery extends TableQuery(new AppTable(_)) {
         saveApp.app.autodeleteThreshold,
         saveApp.app.autodeleteEnabled,
         saveApp.app.autopilot,
-        saveApp.app.mountWorkspaceBucketName,
+        saveApp.app.mountWorkspaceBucketName
       )
       appId <- appQuery returning appQuery.map(_.id) += record
       _ <- labelQuery.saveAllForResource(appId.id, LabelResourceType.App, saveApp.app.labels)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/AppComponent.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/AppComponent.scala
@@ -79,7 +79,7 @@ class AppTable(tag: Tag) extends Table[AppRecord](tag, "APP") {
   def cpu = column[Option[Int]]("cpu")
   def memory = column[Option[Int]]("memory")
   def ephemeralStorage = column[Option[Int]]("ephemeralStorage")
-  def bucketNameToMount = column[Option[String]]("bucketNameToMount")
+  def bucketNameToMount = column[Option[GcsBucketName]]("bucketNameToMount")
 
   def * =
     (

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/LeoProfile.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/LeoProfile.scala
@@ -21,7 +21,7 @@ import org.broadinstitute.dsde.workbench.google2.KubernetesSerializableName.{
 }
 import org.broadinstitute.dsde.workbench.model.{IP, TraceId, WorkbenchEmail}
 import org.broadinstitute.dsde.workbench.leonardo.SamResourceId._
-import org.broadinstitute.dsde.workbench.model.google.{parseGcsPath, GcsPath, GoogleProject}
+import org.broadinstitute.dsde.workbench.model.google.{parseGcsPath, GcsBucketName, GcsPath, GoogleProject}
 import org.broadinstitute.dsp.Release
 import org.http4s.Uri
 import slick.jdbc.{MySQLProfile, SetParameter}
@@ -326,6 +326,9 @@ private[leonardo] object LeoProfile extends MySQLProfile {
 
     implicit val autodeleteThresholdColumnType: BaseColumnType[AutodeleteThreshold] =
       MappedColumnType.base[AutodeleteThreshold, Int](_.value, AutodeleteThreshold.apply)
+
+    implicit val bucketNameToMountColumnType: BaseColumnType[GcsBucketName] =
+      MappedColumnType.base[GcsBucketName, String](_.value, GcsBucketName.apply)
 
     implicit val updateAppTableIdColumnType: BaseColumnType[UpdateAppTableId] =
       MappedColumnType.base[UpdateAppTableId, Long](_.value, UpdateAppTableId.apply)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/AppV2Routes.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/AppV2Routes.scala
@@ -17,6 +17,7 @@ import org.broadinstitute.dsde.workbench.leonardo.JsonCodec._
 import org.broadinstitute.dsde.workbench.leonardo.http.api.AppV2Routes._
 import org.broadinstitute.dsde.workbench.leonardo.http.service.AppService
 import org.broadinstitute.dsde.workbench.model.UserInfo
+import org.broadinstitute.dsde.workbench.model.google.GcsBucketName
 import org.broadinstitute.dsde.workbench.openTelemetry.OpenTelemetryMetrics
 import org.http4s.Uri
 
@@ -177,7 +178,7 @@ object AppV2Routes {
         adte <- x.downField("autodeleteEnabled").as[Option[Boolean]]
         adtm <- x.downField("autodeleteThreshold").as[Option[AutodeleteThreshold]]
         autopilot <- x.downField("autopilot").as[Option[Autopilot]]
-        mountBucketName <- x.downField("mountWorkspaceBucketName").as[Option[String]]
+        bucketNameToMount <- x.downField("bucketNameToMount").as[Option[GcsBucketName]]
 
         optStr <- x.downField("appType").as[Option[String]]
         cn <- x.downField("allowedChartName").as[Option[AllowedChartName]]
@@ -210,7 +211,7 @@ object AppV2Routes {
         adte,
         adtm,
         autopilot,
-        mountBucketName
+        bucketNameToMount
       )
     }
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/AppV2Routes.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/AppV2Routes.scala
@@ -208,13 +208,9 @@ object AppV2Routes {
         wsi,
         swi,
         adte,
-<<<<<<< HEAD
+        adtm,
         autopilot,
         mountBucketName
-=======
-        adtm,
-        autopilot
->>>>>>> origin
       )
     }
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/AppV2Routes.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/AppV2Routes.scala
@@ -177,6 +177,7 @@ object AppV2Routes {
         adtm <- x.downField("autodeleteThreshold").as[Option[Int]]
         adte <- x.downField("autodeleteEnabled").as[Option[Boolean]]
         autopilot <- x.downField("autopilot").as[Option[Autopilot]]
+        mountBucketName <- x.downField("mountWorkspaceBucketName").as[Option[String]]
 
         optStr <- x.downField("appType").as[Option[String]]
         cn <- x.downField("allowedChartName").as[Option[AllowedChartName]]
@@ -208,7 +209,8 @@ object AppV2Routes {
         swi,
         adtm,
         adte,
-        autopilot
+        autopilot,
+        mountBucketName
       )
     }
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/LeoAppServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/LeoAppServiceInterp.scala
@@ -300,7 +300,7 @@ final class LeoAppServiceInterp[F[_]: Parallel](config: AppServiceConfig,
           appMachineType,
           Some(ctx.traceId),
           enableIntraNodeVisibility,
-          req.mountWorkspaceBucketName
+          req.bucketNameToMount
         )
         _ <- publisherQueue.offer(createAppMessage)
       } yield ()
@@ -1533,7 +1533,7 @@ final class LeoAppServiceInterp[F[_]: Parallel](config: AppServiceConfig,
         numOfReplicas,
         Autodelete(autodeleteEnabled, req.autodeleteThreshold),
         autopilot,
-        req.mountWorkspaceBucketName
+        req.bucketNameToMount
       )
     )
   }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/LeoAppServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/LeoAppServiceInterp.scala
@@ -88,7 +88,6 @@ final class LeoAppServiceInterp[F[_]: Parallel](config: AppServiceConfig,
       )
       _ <- F.raiseWhen(!hasPermission)(ForbiddenError(userInfo.userEmail))
 
-      mountWorkspaceBucketEnabled = req.mountWorkspaceBucketEnabled.getOrElse(false)
       enableIntraNodeVisibility = req.labels.get(AOU_UI_LABEL).exists(x => x == "true")
       // We only allow autopilot mode for members of CUSTOM_APP_USERS group
       // This is only needed while we're evaluating autopilot (6/3/2024).
@@ -301,7 +300,7 @@ final class LeoAppServiceInterp[F[_]: Parallel](config: AppServiceConfig,
           appMachineType,
           Some(ctx.traceId),
           enableIntraNodeVisibility,
-          mountWorkspaceBucketEnabled,
+          req.mountWorkspaceBucketName
         )
         _ <- publisherQueue.offer(createAppMessage)
       } yield ()

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/LeoAppServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/LeoAppServiceInterp.scala
@@ -88,6 +88,7 @@ final class LeoAppServiceInterp[F[_]: Parallel](config: AppServiceConfig,
       )
       _ <- F.raiseWhen(!hasPermission)(ForbiddenError(userInfo.userEmail))
 
+      mountWorkspaceBucketEnabled = req.mountWorkspaceBucketEnabled.getOrElse(false)
       enableIntraNodeVisibility = req.labels.get(AOU_UI_LABEL).exists(x => x == "true")
       // We only allow autopilot mode for members of CUSTOM_APP_USERS group
       // This is only needed while we're evaluating autopilot (6/3/2024).
@@ -299,7 +300,8 @@ final class LeoAppServiceInterp[F[_]: Parallel](config: AppServiceConfig,
           app.appResources.namespace,
           appMachineType,
           Some(ctx.traceId),
-          enableIntraNodeVisibility
+          enableIntraNodeVisibility,
+          mountWorkspaceBucketEnabled,
         )
         _ <- publisherQueue.offer(createAppMessage)
       } yield ()

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/LeoAppServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/LeoAppServiceInterp.scala
@@ -1532,13 +1532,13 @@ final class LeoAppServiceInterp[F[_]: Parallel](config: AppServiceConfig,
         req.sourceWorkspaceId,
         numOfReplicas,
         autodeleteEnabled,
-<<<<<<< HEAD
-        autopilot,
+        <<<<<<< HEAD
+          autopilot,
         req.mountWorkspaceBucketName
-=======
-        req.autodeleteThreshold,
+          =======
+            req.autodeleteThreshold,
         autopilot
->>>>>>> origin
+          >>>>>>> origin
       )
     )
   }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/LeoAppServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/LeoAppServiceInterp.scala
@@ -1533,7 +1533,8 @@ final class LeoAppServiceInterp[F[_]: Parallel](config: AppServiceConfig,
         numOfReplicas,
         req.autodeleteThreshold,
         autodeleteEnabled,
-        autopilot
+        autopilot,
+        req.mountWorkspaceBucketName
       )
     )
   }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/LeoAppServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/LeoAppServiceInterp.scala
@@ -725,8 +725,8 @@ final class LeoAppServiceInterp[F[_]: Parallel](config: AppServiceConfig,
       _ <- F.raiseWhen(!hasPermission)(AppNotFoundException(cloudContext, appName, ctx.traceId, "Permission Denied"))
 
       // confirm that the combination of the request and the existing DB values result in a valid configuration
-      resolvedAutodeleteEnabled = req.autodeleteEnabled.getOrElse(appResult.app.autodeleteEnabled)
-      resolvedAutodeleteThreshold = req.autodeleteThreshold.orElse(appResult.app.autodeleteThreshold)
+      resolvedAutodeleteEnabled = req.autodeleteEnabled.getOrElse(appResult.app.autodelete.autodeleteEnabled)
+      resolvedAutodeleteThreshold = req.autodeleteThreshold.orElse(appResult.app.autodelete.autodeleteThreshold)
       _ <- F.fromEither(validateAutodelete(resolvedAutodeleteEnabled, resolvedAutodeleteThreshold, ctx.traceId))
       _ <- getUpdateAppTransaction(appResult.app.id, req)
     } yield ()
@@ -1531,14 +1531,9 @@ final class LeoAppServiceInterp[F[_]: Parallel](config: AppServiceConfig,
         req.extraArgs,
         req.sourceWorkspaceId,
         numOfReplicas,
-        autodeleteEnabled,
-        <<<<<<< HEAD
-          autopilot,
+        Autodelete(autodeleteEnabled, req.autodeleteThreshold),
+        autopilot,
         req.mountWorkspaceBucketName
-          =======
-            req.autodeleteThreshold,
-        autopilot
-          >>>>>>> origin
       )
     )
   }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
@@ -1527,12 +1527,7 @@ class LeoPubsubMessageSubscriber[F[_]](
         case CloudContext.Gcp(_) =>
           getGkeAlgFromRegistry()
             .updateAndPollApp(
-              UpdateAppParams(msg.appId,
-                              msg.appName,
-                              latestAppChartVersion,
-                              msg.googleProject,
-                              msg.mountWorkspaceBucketName
-              )
+              UpdateAppParams(msg.appId, msg.appName, latestAppChartVersion, msg.googleProject)
             )
         case CloudContext.Azure(azureContext) =>
           azurePubsubHandler

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
@@ -1073,7 +1073,7 @@ class LeoPubsubMessageSubscriber[F[_]](
         // create and monitor app
         _ <- getGkeAlgFromRegistry()
           .createAndPollApp(
-            CreateAppParams(msg.appId, msg.project, msg.appName, msg.machineType)
+            CreateAppParams(msg.appId, msg.project, msg.appName, msg.machineType, msg.mountWorkspaceBucketEnabled)
           )
           .onError { case e =>
             cleanUpAfterCreateAppError(msg.appId, msg.appName, msg.project, msg.createDisk, e)
@@ -1526,7 +1526,7 @@ class LeoPubsubMessageSubscriber[F[_]](
       updateApp = msg.cloudContext match {
         case CloudContext.Gcp(_) =>
           getGkeAlgFromRegistry()
-            .updateAndPollApp(UpdateAppParams(msg.appId, msg.appName, latestAppChartVersion, msg.googleProject))
+            .updateAndPollApp(UpdateAppParams(msg.appId, msg.appName, latestAppChartVersion, msg.googleProject, msg.mountWorkspaceBucketEnabled))
         case CloudContext.Azure(azureContext) =>
           azurePubsubHandler
             .updateAndPollApp(msg.appId, msg.appName, latestAppChartVersion, msg.workspaceId, azureContext)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
@@ -1073,7 +1073,7 @@ class LeoPubsubMessageSubscriber[F[_]](
         // create and monitor app
         _ <- getGkeAlgFromRegistry()
           .createAndPollApp(
-            CreateAppParams(msg.appId, msg.project, msg.appName, msg.machineType, msg.mountWorkspaceBucketEnabled)
+            CreateAppParams(msg.appId, msg.project, msg.appName, msg.machineType, msg.mountWorkspaceBucketName)
           )
           .onError { case e =>
             cleanUpAfterCreateAppError(msg.appId, msg.appName, msg.project, msg.createDisk, e)
@@ -1526,7 +1526,14 @@ class LeoPubsubMessageSubscriber[F[_]](
       updateApp = msg.cloudContext match {
         case CloudContext.Gcp(_) =>
           getGkeAlgFromRegistry()
-            .updateAndPollApp(UpdateAppParams(msg.appId, msg.appName, latestAppChartVersion, msg.googleProject, msg.mountWorkspaceBucketEnabled))
+            .updateAndPollApp(
+              UpdateAppParams(msg.appId,
+                              msg.appName,
+                              latestAppChartVersion,
+                              msg.googleProject,
+                              msg.mountWorkspaceBucketName
+              )
+            )
         case CloudContext.Azure(azureContext) =>
           azurePubsubHandler
             .updateAndPollApp(msg.appId, msg.appName, latestAppChartVersion, msg.workspaceId, azureContext)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
@@ -1073,7 +1073,7 @@ class LeoPubsubMessageSubscriber[F[_]](
         // create and monitor app
         _ <- getGkeAlgFromRegistry()
           .createAndPollApp(
-            CreateAppParams(msg.appId, msg.project, msg.appName, msg.machineType, msg.mountWorkspaceBucketName)
+            CreateAppParams(msg.appId, msg.project, msg.appName, msg.machineType, msg.bucketNameToMount)
           )
           .onError { case e =>
             cleanUpAfterCreateAppError(msg.appId, msg.appName, msg.project, msg.createDisk, e)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/MonitorAtBoot.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/MonitorAtBoot.scala
@@ -210,7 +210,7 @@ class MonitorAtBoot[F[_]](publisherQueue: Queue[F, LeoPubsubMessage],
                     Some(AppMachineType(machineType.getMemoryMb / 1024, machineType.getGuestCpus)),
                     Some(appContext.traceId),
                     enableIntraNodeVisibility,
-                    app.mountWorkspaceBucketName
+                    app.bucketNameToMount
                   )
                 } yield msg
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/MonitorAtBoot.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/MonitorAtBoot.scala
@@ -210,7 +210,7 @@ class MonitorAtBoot[F[_]](publisherQueue: Queue[F, LeoPubsubMessage],
                     Some(AppMachineType(machineType.getMemoryMb / 1024, machineType.getGuestCpus)),
                     Some(appContext.traceId),
                     enableIntraNodeVisibility,
-                    mountWorkspaceBucketName
+                    app.mountWorkspaceBucketName
                   )
                 } yield msg
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/MonitorAtBoot.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/MonitorAtBoot.scala
@@ -209,7 +209,8 @@ class MonitorAtBoot[F[_]](publisherQueue: Queue[F, LeoPubsubMessage],
                     app.appResources.namespace,
                     Some(AppMachineType(machineType.getMemoryMb / 1024, machineType.getGuestCpus)),
                     Some(appContext.traceId),
-                    enableIntraNodeVisibility
+                    enableIntraNodeVisibility,
+                    mountWorkspaceBucketName
                   )
                 } yield msg
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/leoPubsubMessageSubscriberModels.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/leoPubsubMessageSubscriberModels.scala
@@ -363,8 +363,7 @@ object LeoPubsubMessage {
                                     cloudContext: CloudContext,
                                     workspaceId: Option[WorkspaceId],
                                     googleProject: Option[GoogleProject],
-                                    traceId: Option[TraceId],
-                                    mountWorkspaceBucketName: Option[String]
+                                    traceId: Option[TraceId]
   ) extends LeoPubsubMessage {
     val messageType: LeoPubsubMessageType = LeoPubsubMessageType.UpdateApp
   }
@@ -544,7 +543,7 @@ object LeoPubsubCodec {
   }
 
   implicit val createAppMessageDecoder: Decoder[CreateAppMessage] =
-    Decoder.forProduct11(
+    Decoder.forProduct12(
       "project",
       "clusterNodepoolAction",
       "appId",
@@ -555,7 +554,8 @@ object LeoPubsubCodec {
       "namespaceName",
       "machineType",
       "traceId",
-      "enableIntraNodeVisibility"
+      "enableIntraNodeVisibility",
+      "mountWorkspaceBucketName"
     )(CreateAppMessage.apply)
 
   implicit val deleteAppDecoder: Decoder[DeleteAppMessage] =

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/leoPubsubMessageSubscriberModels.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/leoPubsubMessageSubscriberModels.scala
@@ -23,7 +23,7 @@ import org.broadinstitute.dsde.workbench.leonardo.monitor.ClusterNodepoolAction.
   CreateNodepool
 }
 import org.broadinstitute.dsde.workbench.leonardo.monitor.LeoPubsubMessage._
-import org.broadinstitute.dsde.workbench.model.google.GoogleProject
+import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GoogleProject}
 import org.broadinstitute.dsde.workbench.model.{TraceId, WorkbenchEmail, WorkbenchException}
 
 import scala.concurrent.duration.FiniteDuration
@@ -276,7 +276,7 @@ object LeoPubsubMessage {
     ], // Currently only galaxy is using this info, but potentially other apps might take advantage of this info too
     traceId: Option[TraceId],
     enableIntraNodeVisibility: Boolean,
-    mountWorkspaceBucketName: Option[String]
+    bucketNameToMount: Option[GcsBucketName]
   ) extends LeoPubsubMessage {
     val messageType: LeoPubsubMessageType = LeoPubsubMessageType.CreateApp
   }
@@ -555,7 +555,7 @@ object LeoPubsubCodec {
       "machineType",
       "traceId",
       "enableIntraNodeVisibility",
-      "mountWorkspaceBucketName"
+      "bucketNameToMount"
     )(CreateAppMessage.apply)
 
   implicit val deleteAppDecoder: Decoder[DeleteAppMessage] =
@@ -919,7 +919,7 @@ object LeoPubsubCodec {
       "machineType",
       "traceId",
       "enableIntraNodeVisibility",
-      "mountWorkspaceBucketName"
+      "bucketNameToMount"
     )(x =>
       (x.messageType,
        x.project,
@@ -933,7 +933,7 @@ object LeoPubsubCodec {
        x.machineType,
        x.traceId,
        x.enableIntraNodeVisibility,
-       x.mountWorkspaceBucketName
+       x.bucketNameToMount
       )
     )
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/leoPubsubMessageSubscriberModels.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/leoPubsubMessageSubscriberModels.scala
@@ -275,7 +275,8 @@ object LeoPubsubMessage {
       AppMachineType
     ], // Currently only galaxy is using this info, but potentially other apps might take advantage of this info too
     traceId: Option[TraceId],
-    enableIntraNodeVisibility: Boolean
+    enableIntraNodeVisibility: Boolean,
+    mountWorkspaceBucketEnabled: Boolean
   ) extends LeoPubsubMessage {
     val messageType: LeoPubsubMessageType = LeoPubsubMessageType.CreateApp
   }
@@ -362,7 +363,8 @@ object LeoPubsubMessage {
                                     cloudContext: CloudContext,
                                     workspaceId: Option[WorkspaceId],
                                     googleProject: Option[GoogleProject],
-                                    traceId: Option[TraceId]
+                                    traceId: Option[TraceId],
+                                    mountWorkspaceBucketEnabled: Boolean
   ) extends LeoPubsubMessage {
     val messageType: LeoPubsubMessageType = LeoPubsubMessageType.UpdateApp
   }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/leoPubsubMessageSubscriberModels.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/leoPubsubMessageSubscriberModels.scala
@@ -276,7 +276,7 @@ object LeoPubsubMessage {
     ], // Currently only galaxy is using this info, but potentially other apps might take advantage of this info too
     traceId: Option[TraceId],
     enableIntraNodeVisibility: Boolean,
-    mountWorkspaceBucketEnabled: Boolean
+    mountWorkspaceBucketName: Option[String]
   ) extends LeoPubsubMessage {
     val messageType: LeoPubsubMessageType = LeoPubsubMessageType.CreateApp
   }
@@ -364,7 +364,7 @@ object LeoPubsubMessage {
                                     workspaceId: Option[WorkspaceId],
                                     googleProject: Option[GoogleProject],
                                     traceId: Option[TraceId],
-                                    mountWorkspaceBucketEnabled: Boolean
+                                    mountWorkspaceBucketName: Option[String]
   ) extends LeoPubsubMessage {
     val messageType: LeoPubsubMessageType = LeoPubsubMessageType.UpdateApp
   }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/leoPubsubMessageSubscriberModels.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/leoPubsubMessageSubscriberModels.scala
@@ -906,7 +906,7 @@ object LeoPubsubCodec {
     }
 
   implicit val createAppMessageEncoder: Encoder[CreateAppMessage] =
-    Encoder.forProduct12(
+    Encoder.forProduct13(
       "messageType",
       "project",
       "clusterNodepoolAction",
@@ -918,7 +918,8 @@ object LeoPubsubCodec {
       "namespaceName",
       "machineType",
       "traceId",
-      "enableIntraNodeVisibility"
+      "enableIntraNodeVisibility",
+      "mountWorkspaceBucketName"
     )(x =>
       (x.messageType,
        x.project,
@@ -931,7 +932,8 @@ object LeoPubsubCodec {
        x.namespaceName,
        x.machineType,
        x.traceId,
-       x.enableIntraNodeVisibility
+       x.enableIntraNodeVisibility,
+       x.mountWorkspaceBucketName
       )
     )
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/BuildHelmChartValues.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/BuildHelmChartValues.scala
@@ -301,7 +301,7 @@ private[leonardo] object BuildHelmChartValues {
                                                stagingBucket: GcsBucketName,
                                                customEnvironmentVariables: Map[String, String],
                                                autopilot: Option[Autopilot],
-                                               mountWorkspaceBucketName: Option[String]
+                                               bucketNameToMount: Option[GcsBucketName]
   ): List[String] = {
     val ingressPath = s"/proxy/google/v1/apps/${cluster.cloudContext.asString}/${appName.value}/app"
     val welderIngressPath = s"/proxy/google/v1/apps/${cluster.cloudContext.asString}/${appName.value}/welder-service"
@@ -320,7 +320,7 @@ private[leonardo] object BuildHelmChartValues {
       ingressPath,
       k8sProxyHost,
       autopilot,
-      mountWorkspaceBucketName
+      bucketNameToMount
     )
 
     allowedChartName match {
@@ -358,7 +358,7 @@ private[leonardo] object BuildHelmChartValues {
                                                            ingressPath: String,
                                                            k8sProxyHost: akka.http.scaladsl.model.Uri.Host,
                                                            autopilot: Option[Autopilot],
-                                                           mountWorkspaceBucketName: Option[String]
+                                                           bucketNameToMount: Option[GcsBucketName]
   ): List[String] = {
     val k8sProxyHostString = k8sProxyHost.address
     val leoProxyhost = config.proxyConfig.getProxyServerHostName
@@ -407,11 +407,11 @@ private[leonardo] object BuildHelmChartValues {
       case None => List.empty
     }
 
-    val gcsfuse = mountWorkspaceBucketName match {
+    val gcsfuse = bucketNameToMount match {
       case Some(bucketName) =>
         List(
           raw"""gcsfuse.enabled=true""",
-          raw"""gcsfuse.bucket=${bucketName}"""
+          raw"""gcsfuse.bucket=${bucketName.value}"""
         )
       case None =>
         List(

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEAlgebra.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEAlgebra.scala
@@ -151,5 +151,5 @@ final case class UpdateAppParams(appId: AppId,
                                  appName: AppName,
                                  appChartVersion: ChartVersion,
                                  googleProject: Option[GoogleProject],
-                                 mountWorkspaceBucketName: Boolean
+                                 mountWorkspaceBucketName: Option[String]
 )

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEAlgebra.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEAlgebra.scala
@@ -125,7 +125,8 @@ final case class CreateNodepoolParams(nodepoolId: NodepoolLeoId, googleProject: 
 final case class CreateAppParams(appId: AppId,
                                  googleProject: GoogleProject,
                                  appName: AppName,
-                                 appMachineType: Option[AppMachineType]
+                                 appMachineType: Option[AppMachineType],
+                                 mountWorkspaceBucketEnabled: Boolean
 )
 
 final case class DeleteClusterParams(clusterId: KubernetesClusterLeoId, googleProject: GoogleProject)
@@ -149,5 +150,6 @@ final case class StartAppParams(appId: AppId, appName: AppName, googleProject: G
 final case class UpdateAppParams(appId: AppId,
                                  appName: AppName,
                                  appChartVersion: ChartVersion,
-                                 googleProject: Option[GoogleProject]
+                                 googleProject: Option[GoogleProject],
+                                 mountWorkspaceBucketEnabled: Boolean
 )

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEAlgebra.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEAlgebra.scala
@@ -150,6 +150,5 @@ final case class StartAppParams(appId: AppId, appName: AppName, googleProject: G
 final case class UpdateAppParams(appId: AppId,
                                  appName: AppName,
                                  appChartVersion: ChartVersion,
-                                 googleProject: Option[GoogleProject],
-                                 mountWorkspaceBucketName: Option[String]
+                                 googleProject: Option[GoogleProject]
 )

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEAlgebra.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEAlgebra.scala
@@ -126,7 +126,7 @@ final case class CreateAppParams(appId: AppId,
                                  googleProject: GoogleProject,
                                  appName: AppName,
                                  appMachineType: Option[AppMachineType],
-                                 mountWorkspaceBucketName: Option[String]
+                                 bucketNameToMount: Option[GcsBucketName]
 )
 
 final case class DeleteClusterParams(clusterId: KubernetesClusterLeoId, googleProject: GoogleProject)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEAlgebra.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEAlgebra.scala
@@ -126,7 +126,7 @@ final case class CreateAppParams(appId: AppId,
                                  googleProject: GoogleProject,
                                  appName: AppName,
                                  appMachineType: Option[AppMachineType],
-                                 mountWorkspaceBucketEnabled: Boolean
+                                 mountWorkspaceBucketName: Option[String]
 )
 
 final case class DeleteClusterParams(clusterId: KubernetesClusterLeoId, googleProject: GoogleProject)
@@ -151,5 +151,5 @@ final case class UpdateAppParams(appId: AppId,
                                  appName: AppName,
                                  appChartVersion: ChartVersion,
                                  googleProject: Option[GoogleProject],
-                                 mountWorkspaceBucketEnabled: Boolean
+                                 mountWorkspaceBucketName: Boolean
 )

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
@@ -520,7 +520,7 @@ class GKEInterpreter[F[_]](
             app.auditInfo.creator,
             app.customEnvironmentVariables,
             app.autopilot,
-            params.mountWorkspaceBucketEnabled
+            params.mountWorkspaceBucketName
           )
         case AppType.Custom =>
           installCustomApp(
@@ -756,7 +756,7 @@ class GKEInterpreter[F[_]](
               stagingBucketName,
               app.customEnvironmentVariables,
               app.autopilot,
-              params.mountWorkspaceBucketEnabled
+              params.mountWorkspaceBucketName
             )
 
             last <- streamFUntilDone(
@@ -1541,7 +1541,7 @@ class GKEInterpreter[F[_]](
     userEmail: WorkbenchEmail,
     customEnvironmentVariables: Map[String, String],
     autopilot: Option[Autopilot],
-    mountWorkspaceBucketEnabled,
+    mountWorkspaceBucketName: Option[String]
   )(implicit ev: Ask[F, AppContext]): F[Unit] =
     for {
       ctx <- ev.ask
@@ -1568,19 +1568,20 @@ class GKEInterpreter[F[_]](
         new RuntimeException(s"invalid chart name for ALLOWED app: ${chart.name}")
       )
 
-      chartValues = buildAllowedAppChartOverrideValuesString(config,
-                                                             allowedChart,
-                                                             appName,
-                                                             cluster,
-                                                             nodepoolName,
-                                                             namespaceName,
-                                                             disk,
-                                                             ksaName,
-                                                             userEmail,
-                                                             stagingBucketName,
-                                                             customEnvironmentVariables,
-                                                             autopilot,
-        params.mountWorkspaceBucketEnabled
+      chartValues = buildAllowedAppChartOverrideValuesString(
+        config,
+        allowedChart,
+        appName,
+        cluster,
+        nodepoolName,
+        namespaceName,
+        disk,
+        ksaName,
+        userEmail,
+        stagingBucketName,
+        customEnvironmentVariables,
+        autopilot,
+        mountWorkspaceBucketName
       )
       _ <- logger.info(ctx.loggingCtx)(s"Chart override values are: $chartValues")
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
@@ -163,7 +163,9 @@ class GKEInterpreter[F[_]](
         )
         .setAddonsConfig(
           new com.google.api.services.container.model.AddonsConfig()
-            .setGcsFuseCsiDriverConfig(new com.google.api.services.container.model.GcsFuseCsiDriverConfig().setEnabled(true))
+            .setGcsFuseCsiDriverConfig(
+              new com.google.api.services.container.model.GcsFuseCsiDriverConfig().setEnabled(true)
+            )
         )
         .setNodePoolAutoConfig(nodepoolConfig)
         .setLegacyAbac(new com.google.api.services.container.model.LegacyAbac().setEnabled(false))

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
@@ -519,7 +519,8 @@ class GKEInterpreter[F[_]](
             gsa,
             app.auditInfo.creator,
             app.customEnvironmentVariables,
-            app.autopilot
+            app.autopilot,
+            params.mountWorkspaceBucketEnabled
           )
         case AppType.Custom =>
           installCustomApp(
@@ -754,7 +755,8 @@ class GKEInterpreter[F[_]](
               userEmail,
               stagingBucketName,
               app.customEnvironmentVariables,
-              app.autopilot
+              app.autopilot,
+              params.mountWorkspaceBucketEnabled
             )
 
             last <- streamFUntilDone(
@@ -1538,7 +1540,8 @@ class GKEInterpreter[F[_]](
     gsa: WorkbenchEmail,
     userEmail: WorkbenchEmail,
     customEnvironmentVariables: Map[String, String],
-    autopilot: Option[Autopilot]
+    autopilot: Option[Autopilot],
+    mountWorkspaceBucketEnabled,
   )(implicit ev: Ask[F, AppContext]): F[Unit] =
     for {
       ctx <- ev.ask
@@ -1576,7 +1579,8 @@ class GKEInterpreter[F[_]](
                                                              userEmail,
                                                              stagingBucketName,
                                                              customEnvironmentVariables,
-                                                             autopilot
+                                                             autopilot,
+        params.mountWorkspaceBucketEnabled
       )
       _ <- logger.info(ctx.loggingCtx)(s"Chart override values are: $chartValues")
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
@@ -391,11 +391,9 @@ class GKEInterpreter[F[_]](
         s"Begin App(${app.appName.value}) Creation."
       )
 
-
       _ <- logger.info(ctx.loggingCtx)(
         s"Begin App~~~~~ bucket is (${params.mountWorkspaceBucketName}) !!!!!!."
       )
-
 
       // Create KSA
       ksaName <- F.fromOption(

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
@@ -391,10 +391,6 @@ class GKEInterpreter[F[_]](
         s"Begin App(${app.appName.value}) Creation."
       )
 
-      _ <- logger.info(ctx.loggingCtx)(
-        s"Begin App~~~~~ bucket is (${params.mountWorkspaceBucketName}) !!!!!!."
-      )
-
       // Create KSA
       ksaName <- F.fromOption(
         app.appResources.kubernetesServiceAccountName,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
@@ -48,13 +48,14 @@ import org.broadinstitute.dsde.workbench.leonardo.util.BuildHelmChartValues.{
 import org.broadinstitute.dsde.workbench.leonardo.model.LeoException
 import org.broadinstitute.dsde.workbench.leonardo.monitor.PubsubHandleMessageError.PubsubKubernetesError
 import org.broadinstitute.dsde.workbench.leonardo.util.GKEAlgebra._
-import org.broadinstitute.dsde.workbench.model.google.{generateUniqueBucketName, GoogleProject}
+import org.broadinstitute.dsde.workbench.model.google.{generateUniqueBucketName, GcsBucketName, GoogleProject}
 import org.broadinstitute.dsde.workbench.model.{IP, TraceId, WorkbenchEmail}
 import org.broadinstitute.dsde.workbench.openTelemetry.OpenTelemetryMetrics
 import org.broadinstitute.dsp._
 import org.http4s.Uri
 import org.broadinstitute.dsde.workbench.leonardo.Autopilot
 import com.google.api.services.container.model.WorkloadPolicyConfig
+
 import java.net.URL
 import java.util.Base64
 import scala.concurrent.ExecutionContext
@@ -520,7 +521,7 @@ class GKEInterpreter[F[_]](
             app.auditInfo.creator,
             app.customEnvironmentVariables,
             app.autopilot,
-            params.mountWorkspaceBucketName
+            params.bucketNameToMount
           )
         case AppType.Custom =>
           installCustomApp(
@@ -756,7 +757,7 @@ class GKEInterpreter[F[_]](
               stagingBucketName,
               app.customEnvironmentVariables,
               app.autopilot,
-              app.mountWorkspaceBucketName
+              app.bucketNameToMount
             )
 
             last <- streamFUntilDone(
@@ -1541,7 +1542,7 @@ class GKEInterpreter[F[_]](
     userEmail: WorkbenchEmail,
     customEnvironmentVariables: Map[String, String],
     autopilot: Option[Autopilot],
-    mountWorkspaceBucketName: Option[String]
+    bucketNameToMount: Option[GcsBucketName]
   )(implicit ev: Ask[F, AppContext]): F[Unit] =
     for {
       ctx <- ev.ask
@@ -1581,7 +1582,7 @@ class GKEInterpreter[F[_]](
         stagingBucketName,
         customEnvironmentVariables,
         autopilot,
-        mountWorkspaceBucketName
+        bucketNameToMount
       )
       _ <- logger.info(ctx.loggingCtx)(s"Chart override values are: $chartValues")
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
@@ -391,6 +391,12 @@ class GKEInterpreter[F[_]](
         s"Begin App(${app.appName.value}) Creation."
       )
 
+
+      _ <- logger.info(ctx.loggingCtx)(
+        s"Begin App~~~~~ bucket is (${params.mountWorkspaceBucketName}) !!!!!!."
+      )
+
+
       // Create KSA
       ksaName <- F.fromOption(
         app.appResources.kubernetesServiceAccountName,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
@@ -756,7 +756,7 @@ class GKEInterpreter[F[_]](
               stagingBucketName,
               app.customEnvironmentVariables,
               app.autopilot,
-              params.mountWorkspaceBucketName
+              app.mountWorkspaceBucketName
             )
 
             last <- streamFUntilDone(

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
@@ -161,6 +161,10 @@ class GKEInterpreter[F[_]](
         .setAutopilot(
           autopilot
         )
+        .setAddonsConfig(
+          new com.google.api.services.container.model.AddonsConfig()
+            .setGcsFuseCsiDriverConfig(new com.google.api.services.container.model.GcsFuseCsiDriverConfig().setEnabled(true))
+        )
         .setNodePoolAutoConfig(nodepoolConfig)
         .setLegacyAbac(new com.google.api.services.container.model.LegacyAbac().setEnabled(false))
         .setNetwork(kubeNetwork.idString)

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/CommonTestData.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/CommonTestData.scala
@@ -127,7 +127,6 @@ object CommonTestData {
   val stagingBucketName = GcsBucketName("staging-bucket-name")
   val autopause = true
   val autopauseThreshold = 30
-  val autopauseThreshold = 30
   val defaultScopes = Set(
     "https://www.googleapis.com/auth/userinfo.email",
     "https://www.googleapis.com/auth/userinfo.profile",

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/CommonTestData.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/CommonTestData.scala
@@ -127,6 +127,7 @@ object CommonTestData {
   val stagingBucketName = GcsBucketName("staging-bucket-name")
   val autopause = true
   val autopauseThreshold = 30
+  val autopauseThreshold = 30
   val defaultScopes = Set(
     "https://www.googleapis.com/auth/userinfo.email",
     "https://www.googleapis.com/auth/userinfo.profile",

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/KubernetesTestData.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/KubernetesTestData.scala
@@ -249,8 +249,7 @@ object KubernetesTestData {
       List.empty,
       None,
       Some(1),
-      autodeleteEnabled,
-      autodeleteThreshold,
+      Autodelete(autodeleteEnabled, autodeleteThreshold),
       None,
       None
     )

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/KubernetesTestData.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/KubernetesTestData.scala
@@ -129,6 +129,7 @@ object KubernetesTestData {
       None,
       None,
       None,
+      None,
       None
     )
 
@@ -249,7 +250,7 @@ object KubernetesTestData {
       Some(1),
       Some(autodeleteThreshold),
       autodeleteEnabled,
-      None
+      None, None
     )
   }
 

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/KubernetesTestData.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/KubernetesTestData.scala
@@ -250,7 +250,8 @@ object KubernetesTestData {
       Some(1),
       Some(autodeleteThreshold),
       autodeleteEnabled,
-      None, None
+      None,
+      None
     )
   }
 

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/AppComponentSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/AppComponentSpec.scala
@@ -207,7 +207,7 @@ class AppComponentSpec extends AnyFlatSpecLike with TestComponent {
       )
       .save()
 
-    // App5, Not ready to delete:  AutodeleteEnabled is null (default value)
+    // App5, Not ready to delete:  AutodeleteEnabled is false eventhrough it has AutodeleteThreshold
     makeApp(5, savedNodepool.id)
       .copy(
         auditInfo = auditInfo.copy(dateAccessed = now.minus(5, ChronoUnit.MINUTES)),

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/AppComponentSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/AppComponentSpec.scala
@@ -175,9 +175,8 @@ class AppComponentSpec extends AnyFlatSpecLike with TestComponent {
       .copy(
         auditInfo = auditInfo.copy(dateAccessed = now.minus(5, ChronoUnit.MINUTES)),
         status = AppStatus.Running,
-        autodeleteThreshold = Some(AutodeleteThreshold(1)),
-        samResourceId = samResourceId1,
-        autodeleteEnabled = true
+        autodelete = Autodelete(true, Some(AutodeleteThreshold(1))),
+        samResourceId = samResourceId1
       )
       .save()
     // App2, Not ready to delete:  Last accessed 5 minutes ago, auto delete threshold is 10 minute.
@@ -185,8 +184,7 @@ class AppComponentSpec extends AnyFlatSpecLike with TestComponent {
       .copy(
         auditInfo = auditInfo.copy(dateAccessed = now.minus(5, ChronoUnit.MINUTES)),
         status = AppStatus.Running,
-        autodeleteThreshold = Some(AutodeleteThreshold(10)),
-        autodeleteEnabled = true
+        autodelete = Autodelete(true, Some(AutodeleteThreshold(10)))
       )
       .save()
 
@@ -195,8 +193,7 @@ class AppComponentSpec extends AnyFlatSpecLike with TestComponent {
       .copy(
         auditInfo = auditInfo.copy(dateAccessed = now.minus(5, ChronoUnit.MINUTES)),
         status = AppStatus.Deleting,
-        autodeleteThreshold = Some(AutodeleteThreshold(1)),
-        autodeleteEnabled = true
+        autodelete = Autodelete(true, Some(AutodeleteThreshold(1)))
       )
       .save()
 
@@ -205,9 +202,8 @@ class AppComponentSpec extends AnyFlatSpecLike with TestComponent {
       .copy(
         auditInfo = auditInfo.copy(dateAccessed = now.minus(5, ChronoUnit.MINUTES)),
         status = AppStatus.Running,
-        autodeleteThreshold = Some(AutodeleteThreshold(1)),
-        samResourceId = samResourceId1,
-        autodeleteEnabled = false
+        autodelete = Autodelete(false, Some(AutodeleteThreshold(1))),
+        samResourceId = samResourceId1
       )
       .save()
 
@@ -216,7 +212,7 @@ class AppComponentSpec extends AnyFlatSpecLike with TestComponent {
       .copy(
         auditInfo = auditInfo.copy(dateAccessed = now.minus(5, ChronoUnit.MINUTES)),
         status = AppStatus.Running,
-        autodeleteThreshold = Some(AutodeleteThreshold(1)),
+        autodelete = Autodelete(true, Some(AutodeleteThreshold(1))),
         samResourceId = samResourceId1
       )
       .save()

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/AppComponentSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/AppComponentSpec.scala
@@ -212,7 +212,7 @@ class AppComponentSpec extends AnyFlatSpecLike with TestComponent {
       .copy(
         auditInfo = auditInfo.copy(dateAccessed = now.minus(5, ChronoUnit.MINUTES)),
         status = AppStatus.Running,
-        autodelete = Autodelete(true, Some(AutodeleteThreshold(1))),
+        autodelete = Autodelete(false, Some(AutodeleteThreshold(1))),
         samResourceId = samResourceId1
       )
       .save()

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/AppComponentSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/AppComponentSpec.scala
@@ -207,7 +207,7 @@ class AppComponentSpec extends AnyFlatSpecLike with TestComponent {
       )
       .save()
 
-    // App5, Not ready to delete:  AutodeleteEnabled is false eventhrough it has AutodeleteThreshold
+    // App5, Not ready to delete:  AutodeleteEnabled is false even though it has AutodeleteThreshold
     makeApp(5, savedNodepool.id)
       .copy(
         auditInfo = auditInfo.copy(dateAccessed = now.minus(5, ChronoUnit.MINUTES)),

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/AppV2RouteSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/AppV2RouteSpec.scala
@@ -40,6 +40,7 @@ class AppV2RouteSpec extends AnyFlatSpec with LeonardoTestSuite {
       None,
       None,
       None,
+      None,
       None
     )
     res shouldBe (Right(expected))

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/AutoDeleteAppMonitorSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/AutoDeleteAppMonitorSpec.scala
@@ -5,7 +5,7 @@ import cats.effect.{Deferred, IO}
 import cats.syntax.all._
 import fs2.Stream
 import org.broadinstitute.dsde.workbench.leonardo.CommonTestData._
-import org.broadinstitute.dsde.workbench.leonardo.{AppStatus, AutodeleteThreshold, LeonardoTestSuite}
+import org.broadinstitute.dsde.workbench.leonardo.{AppStatus, Autodelete, AutodeleteThreshold, LeonardoTestSuite}
 import org.broadinstitute.dsde.workbench.leonardo.db.{appQuery, TestComponent}
 import org.broadinstitute.dsde.workbench.leonardo.http.dbioToIO
 import org.scalatest.flatspec.AnyFlatSpec
@@ -31,8 +31,7 @@ class AutoDeleteAppMonitorSpec extends AnyFlatSpec with LeonardoTestSuite with T
           .copy(
             auditInfo = auditInfo.copy(dateAccessed = now.minus(5, ChronoUnit.MINUTES)),
             status = AppStatus.Running,
-            autodeleteThreshold = Some(AutodeleteThreshold(1)),
-            autodeleteEnabled = true
+            autodelete = Autodelete(true, Some(AutodeleteThreshold(1)))
           )
           .save()
       )
@@ -59,8 +58,7 @@ class AutoDeleteAppMonitorSpec extends AnyFlatSpec with LeonardoTestSuite with T
           .copy(
             auditInfo = auditInfo.copy(dateAccessed = now.minus(5, ChronoUnit.MINUTES)),
             status = AppStatus.Running,
-            autodeleteThreshold = Some(AutodeleteThreshold(6)),
-            autodeleteEnabled = true
+            autodelete = Autodelete(true, Some(AutodeleteThreshold(6)))
           )
           .save()
       )

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubCodecSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubCodecSpec.scala
@@ -118,7 +118,8 @@ class LeoPubsubCodecSpec extends AnyFlatSpec with Matchers {
       NamespaceName("ns"),
       None,
       Some(traceId),
-      false
+      false,
+      Some("mountBucketName")
     )
 
     val res = decode[CreateAppMessage](originalMessage.asJson.printWith(Printer.noSpaces))

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubCodecSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubCodecSpec.scala
@@ -16,7 +16,7 @@ import org.broadinstitute.dsde.workbench.leonardo.monitor.LeoPubsubMessage.{
   CreateAzureRuntimeMessage,
   CreateRuntimeMessage
 }
-import org.broadinstitute.dsde.workbench.model.google.GoogleProject
+import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GoogleProject}
 import org.broadinstitute.dsde.workbench.model.{TraceId, WorkbenchEmail}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -119,7 +119,7 @@ class LeoPubsubCodecSpec extends AnyFlatSpec with Matchers {
       None,
       Some(traceId),
       false,
-      Some("bucketName")
+      Some(GcsBucketName("bucketName"))
     )
 
     val res = decode[CreateAppMessage](originalMessage.asJson.printWith(Printer.noSpaces))

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubCodecSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubCodecSpec.scala
@@ -119,7 +119,7 @@ class LeoPubsubCodecSpec extends AnyFlatSpec with Matchers {
       None,
       Some(traceId),
       false,
-      Some("mountBucketName")
+      None
     )
 
     val res = decode[CreateAppMessage](originalMessage.asJson.printWith(Printer.noSpaces))

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubCodecSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubCodecSpec.scala
@@ -119,7 +119,7 @@ class LeoPubsubCodecSpec extends AnyFlatSpec with Matchers {
       None,
       Some(traceId),
       false,
-      None
+      Some("bucketName")
     )
 
     val res = decode[CreateAppMessage](originalMessage.asJson.printWith(Printer.noSpaces))

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriberSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriberSpec.scala
@@ -52,7 +52,7 @@ import org.broadinstitute.dsde.workbench.leonardo.model.LeoAuthProvider
 import org.broadinstitute.dsde.workbench.leonardo.monitor.LeoPubsubMessage._
 import org.broadinstitute.dsde.workbench.leonardo.monitor.PubsubHandleMessageError.ClusterInvalidState
 import org.broadinstitute.dsde.workbench.leonardo.util.{AzurePubsubHandlerInterp, _}
-import org.broadinstitute.dsde.workbench.model.google.GoogleProject
+import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GoogleProject}
 import org.broadinstitute.dsde.workbench.model.{IP, TraceId, WorkbenchEmail}
 import org.broadinstitute.dsde.workbench.openTelemetry.OpenTelemetryMetrics
 import org.broadinstitute.dsde.workbench.util2.messaging.{AckHandler, CloudSubscriber, ReceivedMessage}
@@ -924,7 +924,7 @@ class LeoPubsubMessageSubscriberSpec
           Some(AppMachineType(5, 4)),
           Some(tr),
           false,
-          Some("fc-bucket")
+          Some(GcsBucketName("fc-bucket"))
         )
 
         asyncTaskProcessor = AsyncTaskProcessor(AsyncTaskProcessor.Config(10, 10), queue)
@@ -983,7 +983,7 @@ class LeoPubsubMessageSubscriberSpec
           None,
           Some(tr),
           false,
-          Some("fc-bucket")
+          Some(GcsBucketName("fc-bucket"))
         )
 
         asyncTaskProcessor = AsyncTaskProcessor(AsyncTaskProcessor.Config(10, 10), queue)
@@ -1082,7 +1082,7 @@ class LeoPubsubMessageSubscriberSpec
           Some(AppMachineType(5, 4)),
           Some(tr),
           false,
-          Some("fc-bucket")
+          Some(GcsBucketName("fc-bucket"))
         )
         msg2 = CreateAppMessage(
           savedCluster1.cloudContext.asInstanceOf[CloudContext.Gcp].value,
@@ -1096,7 +1096,7 @@ class LeoPubsubMessageSubscriberSpec
           Some(AppMachineType(5, 4)),
           Some(tr),
           false,
-          Some("fc-bucket")
+          Some(GcsBucketName("fc-bucket"))
         )
         asyncTaskProcessor = AsyncTaskProcessor(AsyncTaskProcessor.Config(10, 10), queue)
         _ <- leoSubscriber.handleCreateAppMessage(msg1)
@@ -1140,7 +1140,7 @@ class LeoPubsubMessageSubscriberSpec
           None,
           Some(tr),
           false,
-          Some("fc-bucket")
+          Some(GcsBucketName("fc-bucket"))
         )
         asyncTaskProcessor = AsyncTaskProcessor(AsyncTaskProcessor.Config(10, 10), queue)
         _ <- leoSubscriber.messageHandler(ReceivedMessage(msg, None, instantTimestamp, mockAckConsumer))
@@ -1386,7 +1386,7 @@ class LeoPubsubMessageSubscriberSpec
           Some(AppMachineType(5, 4)),
           Some(tr),
           false,
-          Some("fc-bucket")
+          Some(GcsBucketName("fc-bucket"))
         )
         asyncTaskProcessor = AsyncTaskProcessor(AsyncTaskProcessor.Config(10, 10), queue)
         _ <- leoSubscriber.handleCreateAppMessage(msg)
@@ -1498,7 +1498,7 @@ class LeoPubsubMessageSubscriberSpec
           None,
           Some(tr),
           false,
-          Some("fc-bucket")
+          Some(GcsBucketName("fc-bucket"))
         )
         asyncTaskProcessor = AsyncTaskProcessor(AsyncTaskProcessor.Config(10, 10), queue)
         _ <- leoSubscriber.handleCreateAppMessage(msg)
@@ -1569,7 +1569,7 @@ class LeoPubsubMessageSubscriberSpec
           None,
           Some(tr),
           false,
-          Some("fc-bucket")
+          Some(GcsBucketName("fc-bucket"))
         )
         asyncTaskProcessor = AsyncTaskProcessor(AsyncTaskProcessor.Config(10, 10), queue)
         _ <- leoSubscriber.handleCreateAppMessage(msg)
@@ -1651,7 +1651,7 @@ class LeoPubsubMessageSubscriberSpec
           None,
           Some(tr),
           false,
-          Some("fc-bucket")
+          Some(GcsBucketName("fc-bucket"))
         )
         asyncTaskProcessor = AsyncTaskProcessor(AsyncTaskProcessor.Config(10, 10), queue)
         _ <- leoSubscriber.messageHandler(ReceivedMessage(msg, None, instantTimestamp, mockAckConsumer))
@@ -1840,7 +1840,7 @@ class LeoPubsubMessageSubscriberSpec
           Some(AppMachineType(5, 4)),
           Some(tr),
           false,
-          Some("fc-bucket")
+          Some(GcsBucketName("fc-bucket"))
         )
         asyncTaskProcessor = AsyncTaskProcessor(AsyncTaskProcessor.Config(10, 10), queue)
         // send message twice
@@ -2388,7 +2388,7 @@ class LeoPubsubMessageSubscriberSpec
           None,
           Some(tr),
           false,
-          Some("fc-bucket")
+          Some(GcsBucketName("fc-bucket"))
         )
         asyncTaskProcessor = AsyncTaskProcessor(AsyncTaskProcessor.Config(10, 10), queue)
         _ <- leoSubscriber.messageHandler(ReceivedMessage(msg, None, instantTimestamp, mockAckConsumer))

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriberSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriberSpec.scala
@@ -923,7 +923,8 @@ class LeoPubsubMessageSubscriberSpec
           savedApp1.appResources.namespace,
           Some(AppMachineType(5, 4)),
           Some(tr),
-          false
+          false,
+          Some("fc-bucket")
         )
 
         asyncTaskProcessor = AsyncTaskProcessor(AsyncTaskProcessor.Config(10, 10), queue)
@@ -981,7 +982,8 @@ class LeoPubsubMessageSubscriberSpec
           savedApp1.appResources.namespace,
           None,
           Some(tr),
-          false
+          false,
+          Some("fc-bucket")
         )
 
         asyncTaskProcessor = AsyncTaskProcessor(AsyncTaskProcessor.Config(10, 10), queue)
@@ -1079,7 +1081,8 @@ class LeoPubsubMessageSubscriberSpec
           savedApp1.appResources.namespace,
           Some(AppMachineType(5, 4)),
           Some(tr),
-          false
+          false,
+          Some("fc-bucket")
         )
         msg2 = CreateAppMessage(
           savedCluster1.cloudContext.asInstanceOf[CloudContext.Gcp].value,
@@ -1092,7 +1095,8 @@ class LeoPubsubMessageSubscriberSpec
           savedApp2.appResources.namespace,
           Some(AppMachineType(5, 4)),
           Some(tr),
-          false
+          false,
+          Some("fc-bucket")
         )
         asyncTaskProcessor = AsyncTaskProcessor(AsyncTaskProcessor.Config(10, 10), queue)
         _ <- leoSubscriber.handleCreateAppMessage(msg1)
@@ -1135,7 +1139,8 @@ class LeoPubsubMessageSubscriberSpec
           savedApp1.appResources.namespace,
           None,
           Some(tr),
-          false
+          false,
+          Some("fc-bucket")
         )
         asyncTaskProcessor = AsyncTaskProcessor(AsyncTaskProcessor.Config(10, 10), queue)
         _ <- leoSubscriber.messageHandler(ReceivedMessage(msg, None, instantTimestamp, mockAckConsumer))
@@ -1380,7 +1385,8 @@ class LeoPubsubMessageSubscriberSpec
           savedApp1.appResources.namespace,
           Some(AppMachineType(5, 4)),
           Some(tr),
-          false
+          false,
+          Some("fc-bucket")
         )
         asyncTaskProcessor = AsyncTaskProcessor(AsyncTaskProcessor.Config(10, 10), queue)
         _ <- leoSubscriber.handleCreateAppMessage(msg)
@@ -1491,7 +1497,8 @@ class LeoPubsubMessageSubscriberSpec
           savedApp1.appResources.namespace,
           None,
           Some(tr),
-          false
+          false,
+          Some("fc-bucket")
         )
         asyncTaskProcessor = AsyncTaskProcessor(AsyncTaskProcessor.Config(10, 10), queue)
         _ <- leoSubscriber.handleCreateAppMessage(msg)
@@ -1561,7 +1568,8 @@ class LeoPubsubMessageSubscriberSpec
           savedApp1.appResources.namespace,
           None,
           Some(tr),
-          false
+          false,
+          Some("fc-bucket")
         )
         asyncTaskProcessor = AsyncTaskProcessor(AsyncTaskProcessor.Config(10, 10), queue)
         _ <- leoSubscriber.handleCreateAppMessage(msg)
@@ -1642,7 +1650,8 @@ class LeoPubsubMessageSubscriberSpec
           savedApp1.appResources.namespace,
           None,
           Some(tr),
-          false
+          false,
+          Some("fc-bucket")
         )
         asyncTaskProcessor = AsyncTaskProcessor(AsyncTaskProcessor.Config(10, 10), queue)
         _ <- leoSubscriber.messageHandler(ReceivedMessage(msg, None, instantTimestamp, mockAckConsumer))
@@ -1830,7 +1839,8 @@ class LeoPubsubMessageSubscriberSpec
           savedApp1.appResources.namespace,
           Some(AppMachineType(5, 4)),
           Some(tr),
-          false
+          false,
+          Some("fc-bucket")
         )
         asyncTaskProcessor = AsyncTaskProcessor(AsyncTaskProcessor.Config(10, 10), queue)
         // send message twice
@@ -2377,7 +2387,8 @@ class LeoPubsubMessageSubscriberSpec
           savedApp1.appResources.namespace,
           None,
           Some(tr),
-          false
+          false,
+          Some("fc-bucket")
         )
         asyncTaskProcessor = AsyncTaskProcessor(AsyncTaskProcessor.Config(10, 10), queue)
         _ <- leoSubscriber.messageHandler(ReceivedMessage(msg, None, instantTimestamp, mockAckConsumer))

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/MonitorAtBootSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/MonitorAtBootSpec.scala
@@ -139,7 +139,8 @@ class MonitorAtBootSpec extends AnyFlatSpec with TestComponent with LeonardoTest
         savedApp.appResources.namespace,
         Some(defaultFakeAppMachineType),
         None,
-        false
+        false,
+        Some("mountBucketName")
       )
       (msg eqv Some(expected)) shouldBe true
     }
@@ -243,7 +244,8 @@ class MonitorAtBootSpec extends AnyFlatSpec with TestComponent with LeonardoTest
         savedApp.appResources.namespace,
         Some(defaultFakeAppMachineType),
         None,
-        false
+        false,
+        Some("mountBucketName")
       )
       (msg eqv Some(expected)) shouldBe true
     }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/MonitorAtBootSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/MonitorAtBootSpec.scala
@@ -193,7 +193,7 @@ class MonitorAtBootSpec extends AnyFlatSpec with TestComponent with LeonardoTest
         Some(defaultFakeAppMachineType),
         None,
         false,
-        None,
+        None
       )
       (msg eqv Some(expected)) shouldBe true
     }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/MonitorAtBootSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/MonitorAtBootSpec.scala
@@ -192,7 +192,8 @@ class MonitorAtBootSpec extends AnyFlatSpec with TestComponent with LeonardoTest
         savedApp.appResources.namespace,
         Some(defaultFakeAppMachineType),
         None,
-        false
+        false,
+        Some("mountBucketName")
       )
       (msg eqv Some(expected)) shouldBe true
     }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/MonitorAtBootSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/MonitorAtBootSpec.scala
@@ -140,7 +140,7 @@ class MonitorAtBootSpec extends AnyFlatSpec with TestComponent with LeonardoTest
         Some(defaultFakeAppMachineType),
         None,
         false,
-        Some("mountBucketName")
+        None
       )
       (msg eqv Some(expected)) shouldBe true
     }
@@ -193,7 +193,7 @@ class MonitorAtBootSpec extends AnyFlatSpec with TestComponent with LeonardoTest
         Some(defaultFakeAppMachineType),
         None,
         false,
-        Some("mountBucketName")
+        None,
       )
       (msg eqv Some(expected)) shouldBe true
     }
@@ -246,7 +246,7 @@ class MonitorAtBootSpec extends AnyFlatSpec with TestComponent with LeonardoTest
         Some(defaultFakeAppMachineType),
         None,
         false,
-        Some("mountBucketName")
+        None
       )
       (msg eqv Some(expected)) shouldBe true
     }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/BuildHelmChartValuesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/BuildHelmChartValuesSpec.scala
@@ -295,7 +295,8 @@ class BuildHelmChartValuesSpec extends AnyFlatSpecLike with LeonardoTestSuite {
       userEmail = userEmail2,
       stagingBucket = GcsBucketName("test-staging-bucket"),
       envVariables,
-      None
+      None,
+      Some("fc-bucket")
     )
 
     res.mkString(",") shouldBe
@@ -329,7 +330,9 @@ class BuildHelmChartValuesSpec extends AnyFlatSpecLike with LeonardoTestSuite {
       """extraEnv[0].name=WORKSPACE_NAME,""" +
       """extraEnv[0].value=test-workspace-name,""" +
       """replicaCount=1,""" +
-      """nodeSelector.cloud\.google\.com/gke-nodepool=pool1"""
+      """nodeSelector.cloud\.google\.com/gke-nodepool=pool1""" +
+      """gcsfuse.enabled=true""" +
+      """gcsfuse.bucket=fc-bucket"""
   }
 
   it should "build SAS override values string" in {
@@ -348,7 +351,8 @@ class BuildHelmChartValuesSpec extends AnyFlatSpecLike with LeonardoTestSuite {
       userEmail = userEmail2,
       stagingBucket = GcsBucketName("test-staging-bucket"),
       envVariables,
-      None
+      None,
+      Some("fc-bucket")
     )
 
     res.mkString(",") shouldBe
@@ -386,7 +390,9 @@ class BuildHelmChartValuesSpec extends AnyFlatSpecLike with LeonardoTestSuite {
       """extraEnv[0].name=WORKSPACE_NAME,""" +
       """extraEnv[0].value=test-workspace-name,""" +
       """replicaCount=1,""" +
-      """nodeSelector.cloud\.google\.com/gke-nodepool=pool1"""
+      """nodeSelector.cloud\.google\.com/gke-nodepool=pool1""" +
+      """gcsfuse.enabled=true""" +
+      """gcsfuse.bucket=fc-bucket"""
   }
 
   it should "build SAS override values string in autopilot mode" in {
@@ -405,7 +411,8 @@ class BuildHelmChartValuesSpec extends AnyFlatSpecLike with LeonardoTestSuite {
       userEmail = userEmail2,
       stagingBucket = GcsBucketName("test-staging-bucket"),
       envVariables,
-      Some(Autopilot(ComputeClass.Balanced, 500, 1, 2))
+      Some(Autopilot(ComputeClass.Balanced, 500, 1, 2)),
+      Some("fc-bucket")
     )
 
     res.mkString(",") shouldBe
@@ -450,7 +457,9 @@ class BuildHelmChartValuesSpec extends AnyFlatSpecLike with LeonardoTestSuite {
       """autopilot.welder.ephemeral\-storage=1Gi,""" +
       """autopilot.wondershaper.cpu=500m,""" +
       """autopilot.wondershaper.memory=3Gi,""" +
-      """autopilot.wondershaper.ephemeral\-storage=1Gi""".stripMargin
+      """autopilot.wondershaper.ephemeral\-storage=1Gi""".stripMargin +
+      """gcsfuse.enabled=true""" +
+      """gcsfuse.bucket=fc-bucket"""
   }
 
   it should "build SAS override values string in autopilot mode without compute-class when it's General-purpose" in {
@@ -469,7 +478,8 @@ class BuildHelmChartValuesSpec extends AnyFlatSpecLike with LeonardoTestSuite {
       userEmail = userEmail2,
       stagingBucket = GcsBucketName("test-staging-bucket"),
       envVariables,
-      Some(Autopilot(ComputeClass.GeneralPurpose, 500, 1, 2))
+      Some(Autopilot(ComputeClass.GeneralPurpose, 500, 1, 2)),
+      Some("fc-bucket")
     )
 
     res.mkString(",") shouldBe
@@ -513,7 +523,9 @@ class BuildHelmChartValuesSpec extends AnyFlatSpecLike with LeonardoTestSuite {
       """autopilot.welder.ephemeral\-storage=1Gi,""" +
       """autopilot.wondershaper.cpu=500m,""" +
       """autopilot.wondershaper.memory=3Gi,""" +
-      """autopilot.wondershaper.ephemeral\-storage=1Gi""".stripMargin
+      """autopilot.wondershaper.ephemeral\-storage=1Gi""".stripMargin +
+      """gcsfuse.enabled=true""" +
+      """gcsfuse.bucket=fc-bucket"""
   }
 
   it should "build relay listener override values string" in {

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/BuildHelmChartValuesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/BuildHelmChartValuesSpec.scala
@@ -331,7 +331,7 @@ class BuildHelmChartValuesSpec extends AnyFlatSpecLike with LeonardoTestSuite {
       """extraEnv[0].value=test-workspace-name,""" +
       """replicaCount=1,""" +
       """nodeSelector.cloud\.google\.com/gke-nodepool=pool1""" +
-      """gcsfuse.enabled=true""" +
+      """gcsfuse.enabled=true,""" +
       """gcsfuse.bucket=fc-bucket"""
   }
 
@@ -391,7 +391,7 @@ class BuildHelmChartValuesSpec extends AnyFlatSpecLike with LeonardoTestSuite {
       """extraEnv[0].value=test-workspace-name,""" +
       """replicaCount=1,""" +
       """nodeSelector.cloud\.google\.com/gke-nodepool=pool1""" +
-      """gcsfuse.enabled=true""" +
+      """gcsfuse.enabled=true,""" +
       """gcsfuse.bucket=fc-bucket"""
   }
 
@@ -458,7 +458,7 @@ class BuildHelmChartValuesSpec extends AnyFlatSpecLike with LeonardoTestSuite {
       """autopilot.wondershaper.cpu=500m,""" +
       """autopilot.wondershaper.memory=3Gi,""" +
       """autopilot.wondershaper.ephemeral\-storage=1Gi""".stripMargin +
-      """gcsfuse.enabled=true""" +
+      """gcsfuse.enabled=true,""" +
       """gcsfuse.bucket=fc-bucket"""
   }
 
@@ -524,7 +524,7 @@ class BuildHelmChartValuesSpec extends AnyFlatSpecLike with LeonardoTestSuite {
       """autopilot.wondershaper.cpu=500m,""" +
       """autopilot.wondershaper.memory=3Gi,""" +
       """autopilot.wondershaper.ephemeral\-storage=1Gi""".stripMargin +
-      """gcsfuse.enabled=true""" +
+      """gcsfuse.enabled=true,""" +
       """gcsfuse.bucket=fc-bucket"""
   }
 

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/BuildHelmChartValuesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/BuildHelmChartValuesSpec.scala
@@ -352,7 +352,7 @@ class BuildHelmChartValuesSpec extends AnyFlatSpecLike with LeonardoTestSuite {
       stagingBucket = GcsBucketName("test-staging-bucket"),
       envVariables,
       None,
-      Some(GcsBucketName("fc-bucket"))
+      None
     )
 
     res.mkString(",") shouldBe
@@ -391,8 +391,7 @@ class BuildHelmChartValuesSpec extends AnyFlatSpecLike with LeonardoTestSuite {
       """extraEnv[0].value=test-workspace-name,""" +
       """replicaCount=1,""" +
       """nodeSelector.cloud\.google\.com/gke-nodepool=pool1,""" +
-      """gcsfuse.enabled=true,""" +
-      """gcsfuse.bucket=fc-bucket"""
+      """gcsfuse.enabled=false"""
   }
 
   it should "build SAS override values string in autopilot mode" in {

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/BuildHelmChartValuesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/BuildHelmChartValuesSpec.scala
@@ -296,7 +296,7 @@ class BuildHelmChartValuesSpec extends AnyFlatSpecLike with LeonardoTestSuite {
       stagingBucket = GcsBucketName("test-staging-bucket"),
       envVariables,
       None,
-      Some("fc-bucket")
+      Some(GcsBucketName("fc-bucket"))
     )
 
     res.mkString(",") shouldBe
@@ -352,7 +352,7 @@ class BuildHelmChartValuesSpec extends AnyFlatSpecLike with LeonardoTestSuite {
       stagingBucket = GcsBucketName("test-staging-bucket"),
       envVariables,
       None,
-      Some("fc-bucket")
+      Some(GcsBucketName("fc-bucket"))
     )
 
     res.mkString(",") shouldBe
@@ -412,7 +412,7 @@ class BuildHelmChartValuesSpec extends AnyFlatSpecLike with LeonardoTestSuite {
       stagingBucket = GcsBucketName("test-staging-bucket"),
       envVariables,
       Some(Autopilot(ComputeClass.Balanced, 500, 1, 2)),
-      Some("fc-bucket")
+      Some(GcsBucketName("fc-bucket"))
     )
 
     res.mkString(",") shouldBe
@@ -479,7 +479,7 @@ class BuildHelmChartValuesSpec extends AnyFlatSpecLike with LeonardoTestSuite {
       stagingBucket = GcsBucketName("test-staging-bucket"),
       envVariables,
       Some(Autopilot(ComputeClass.GeneralPurpose, 500, 1, 2)),
-      Some("fc-bucket")
+      Some(GcsBucketName("fc-bucket"))
     )
 
     res.mkString(",") shouldBe

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/BuildHelmChartValuesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/BuildHelmChartValuesSpec.scala
@@ -330,7 +330,7 @@ class BuildHelmChartValuesSpec extends AnyFlatSpecLike with LeonardoTestSuite {
       """extraEnv[0].name=WORKSPACE_NAME,""" +
       """extraEnv[0].value=test-workspace-name,""" +
       """replicaCount=1,""" +
-      """nodeSelector.cloud\.google\.com/gke-nodepool=pool1""" +
+      """nodeSelector.cloud\.google\.com/gke-nodepool=pool1,""" +
       """gcsfuse.enabled=true,""" +
       """gcsfuse.bucket=fc-bucket"""
   }
@@ -390,7 +390,7 @@ class BuildHelmChartValuesSpec extends AnyFlatSpecLike with LeonardoTestSuite {
       """extraEnv[0].name=WORKSPACE_NAME,""" +
       """extraEnv[0].value=test-workspace-name,""" +
       """replicaCount=1,""" +
-      """nodeSelector.cloud\.google\.com/gke-nodepool=pool1""" +
+      """nodeSelector.cloud\.google\.com/gke-nodepool=pool1,""" +
       """gcsfuse.enabled=true,""" +
       """gcsfuse.bucket=fc-bucket"""
   }
@@ -457,7 +457,7 @@ class BuildHelmChartValuesSpec extends AnyFlatSpecLike with LeonardoTestSuite {
       """autopilot.welder.ephemeral\-storage=1Gi,""" +
       """autopilot.wondershaper.cpu=500m,""" +
       """autopilot.wondershaper.memory=3Gi,""" +
-      """autopilot.wondershaper.ephemeral\-storage=1Gi""".stripMargin +
+      """autopilot.wondershaper.ephemeral\-storage=1Gi""".stripMargin + "," +
       """gcsfuse.enabled=true,""" +
       """gcsfuse.bucket=fc-bucket"""
   }
@@ -523,7 +523,7 @@ class BuildHelmChartValuesSpec extends AnyFlatSpecLike with LeonardoTestSuite {
       """autopilot.welder.ephemeral\-storage=1Gi,""" +
       """autopilot.wondershaper.cpu=500m,""" +
       """autopilot.wondershaper.memory=3Gi,""" +
-      """autopilot.wondershaper.ephemeral\-storage=1Gi""".stripMargin +
+      """autopilot.wondershaper.ephemeral\-storage=1Gi""".stripMargin + "," +
       """gcsfuse.enabled=true,""" +
       """gcsfuse.bucket=fc-bucket"""
   }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/BuildHelmChartValuesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/BuildHelmChartValuesSpec.scala
@@ -456,9 +456,9 @@ class BuildHelmChartValuesSpec extends AnyFlatSpecLike with LeonardoTestSuite {
       """autopilot.welder.ephemeral\-storage=1Gi,""" +
       """autopilot.wondershaper.cpu=500m,""" +
       """autopilot.wondershaper.memory=3Gi,""" +
-      """autopilot.wondershaper.ephemeral\-storage=1Gi""".stripMargin + "," +
+      """autopilot.wondershaper.ephemeral\-storage=1Gi,""" +
       """gcsfuse.enabled=true,""" +
-      """gcsfuse.bucket=fc-bucket"""
+      """gcsfuse.bucket=fc-bucket""".stripMargin
   }
 
   it should "build SAS override values string in autopilot mode without compute-class when it's General-purpose" in {
@@ -522,9 +522,9 @@ class BuildHelmChartValuesSpec extends AnyFlatSpecLike with LeonardoTestSuite {
       """autopilot.welder.ephemeral\-storage=1Gi,""" +
       """autopilot.wondershaper.cpu=500m,""" +
       """autopilot.wondershaper.memory=3Gi,""" +
-      """autopilot.wondershaper.ephemeral\-storage=1Gi""".stripMargin + "," +
+      """autopilot.wondershaper.ephemeral\-storage=1Gi,""" +
       """gcsfuse.enabled=true,""" +
-      """gcsfuse.bucket=fc-bucket"""
+      """gcsfuse.bucket=fc-bucket""".stripMargin
   }
 
   it should "build relay listener override values string" in {

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreterSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreterSpec.scala
@@ -349,6 +349,7 @@ class GKEInterpreterSpec extends AnyFlatSpecLike with TestComponent with Leonard
         CreateAppParams(savedApp1.id,
                         savedCluster1.cloudContext.asInstanceOf[CloudContext.Gcp].value,
                         savedApp1.appName,
+                        None,
                         None
         )
       )
@@ -439,6 +440,7 @@ class GKEInterpreterSpec extends AnyFlatSpecLike with TestComponent with Leonard
           CreateAppParams(AppId(-1),
                           savedCluster1.cloudContext.asInstanceOf[CloudContext.Gcp].value,
                           AppName("non-existent"),
+                          None,
                           None
           )
         )


### PR DESCRIPTION
Have verified in my Bee and it's working.
Change in this PR: 

1. A new parameter in CreateAppRequest - mountWorkspaceBucketName, if set, it will fill the helm chart value about bucket. 
2. Helm value is here: https://github.com/broadinstitute/terra-helmfile/blob/master/charts/sas/values.yaml#L77
3. Other change is unrelated but I have to make those change because I hit scala's 22 parameter limit
4. On AoU side, we will have a featureflag to control setting that bucket name or not. 

<!-- Welcome to your Leonardo pull request! -->
<!-- Contributor guidelines: https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md -->

__Jira ticket__: https://precisionmedicineinitiative.atlassian.net/browse/RW-12890

<!-- ## Dependencies -->
<!-- Include any dependent tickets and describe the relationship. Include any other relevant Jira tickets. -->

## Summary of changes

<!-- Please give an abridged version of the ticket description here and/or fill out the following fields. -->

### What

-

### Why

-

## Testing these changes

### What to test

- <!-- Test case 1 -->

<!-- ### Test data -->

### Who tested and where

- [ ] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [ ] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
