### PR TITLE
ID-1266: Assign azure_private_storage_account action managed identities to Azure VMs 

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/samModels.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/samModels.scala
@@ -42,6 +42,10 @@ object SamResourceId {
     override def resourceId: String = controlledResourceId.value.toString
     override def resourceType: SamResourceType = SamResourceType.WsmResource
   }
+
+  final case class PrivateAzureStorageAccountSamResourceId(resourceId: String) extends SamResourceId {
+    override def resourceType = SamResourceType.PrivateAzureStorageAccount
+  }
 }
 
 sealed trait SamResourceType extends Product with Serializable {
@@ -68,6 +72,9 @@ object SamResourceType {
   }
   final case object WsmResource extends SamResourceType {
     val asString = "controlled-application-private-workspace-resource"
+  }
+  final case object PrivateAzureStorageAccount extends SamResourceType {
+    val asString = "private_azure_storage_account"
   }
 
   val stringToSamResourceType: Map[String, SamResourceType] =
@@ -235,6 +242,21 @@ object WsmResourceAction {
   val allActions = sealerate.values[WsmResourceAction]
   val stringToAction: Map[String, WsmResourceAction] =
     sealerate.collect[WsmResourceAction].map(a => (a.asString, a)).toMap
+}
+
+sealed trait PrivateAzureStorageAccountAction extends Product with Serializable {
+  def asString: String
+}
+object PrivateAzureStorageAccountAction {
+  final case object Write extends PrivateAzureStorageAccountAction {
+    val asString = "write"
+  }
+  final case object Read extends PrivateAzureStorageAccountAction {
+    val asString = "read"
+  }
+  val allActions = sealerate.values[PrivateAzureStorageAccountAction]
+  val stringToAction: Map[String, PrivateAzureStorageAccountAction] =
+    sealerate.collect[PrivateAzureStorageAccountAction].map(a => (a.asString, a)).toMap
 }
 
 // TODO [IA-4608] merge with SamPolicyName

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -885,7 +885,7 @@ gke {
 image {
   welderGcrUri = "us.gcr.io/broad-dsp-gcr-public/welder-server"
   welderDockerHubUri = "broadinstitute/welder-server"
-  welderHash = "2a3d22b"
+  welderHash = "fcb50d3"
   jupyterImage =  "us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:2.3.6"
   proxyImage = "broadinstitute/openidc-proxy:2.3.1_2"
   # Note: If you update this, please also update prepare_gce_image.sh and

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -885,7 +885,7 @@ gke {
 image {
   welderGcrUri = "us.gcr.io/broad-dsp-gcr-public/welder-server"
   welderDockerHubUri = "broadinstitute/welder-server"
-  welderHash = "2a3d22b"
+  welderHash = "51ef0f4"
   jupyterImage =  "us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:2.3.6"
   proxyImage = "broadinstitute/openidc-proxy:2.3.1_2"
   # Note: If you update this, please also update prepare_gce_image.sh and

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -885,7 +885,7 @@ gke {
 image {
   welderGcrUri = "us.gcr.io/broad-dsp-gcr-public/welder-server"
   welderDockerHubUri = "broadinstitute/welder-server"
-  welderHash = "2245db0"
+  welderHash = "2a3d22b"
   jupyterImage =  "us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:2.3.6"
   proxyImage = "broadinstitute/openidc-proxy:2.3.1_2"
   # Note: If you update this, please also update prepare_gce_image.sh and

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -885,7 +885,7 @@ gke {
 image {
   welderGcrUri = "us.gcr.io/broad-dsp-gcr-public/welder-server"
   welderDockerHubUri = "broadinstitute/welder-server"
-  welderHash = "fcb50d3"
+  welderHash = "2a3d22b"
   jupyterImage =  "us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:2.3.6"
   proxyImage = "broadinstitute/openidc-proxy:2.3.1_2"
   # Note: If you update this, please also update prepare_gce_image.sh and

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -885,7 +885,7 @@ gke {
 image {
   welderGcrUri = "us.gcr.io/broad-dsp-gcr-public/welder-server"
   welderDockerHubUri = "broadinstitute/welder-server"
-  welderHash = "6648f5c"
+  welderHash = "76f5bc7"
   jupyterImage =  "us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:2.3.6"
   proxyImage = "broadinstitute/openidc-proxy:2.3.1_2"
   # Note: If you update this, please also update prepare_gce_image.sh and

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -885,7 +885,7 @@ gke {
 image {
   welderGcrUri = "us.gcr.io/broad-dsp-gcr-public/welder-server"
   welderDockerHubUri = "broadinstitute/welder-server"
-  welderHash = "76f5bc7"
+  welderHash = "2245db0"
   jupyterImage =  "us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:2.3.6"
   proxyImage = "broadinstitute/openidc-proxy:2.3.1_2"
   # Note: If you update this, please also update prepare_gce_image.sh and

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/SamDAO.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/SamDAO.scala
@@ -4,6 +4,7 @@ package dao
 import cats.mtl.Ask
 import io.circe.{Decoder, Encoder}
 import org.broadinstitute.dsde.workbench.azure.AzureCloudContext
+import org.broadinstitute.dsde.workbench.leonardo.SamResourceId.PrivateAzureStorageAccountSamResourceId
 import org.broadinstitute.dsde.workbench.leonardo.model.{SamResource, SamResourceAction}
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.broadinstitute.dsde.workbench.model.{TraceId, UserInfo, WorkbenchEmail}
@@ -160,6 +161,13 @@ trait SamDAO[F[_]] {
   def isAdminUser(userInfo: UserInfo)(implicit
     ev: Ask[F, TraceId]
   ): F[Boolean]
+
+  /** Gets an action managed identity from Sam as the calling user for the given resource type,
+   * resource ID, and action. Returns the managed identity object ID. */
+  def getAzureActionManagedIdentity(authHeader: Authorization,
+                                    resource: PrivateAzureStorageAccountSamResourceId,
+                                    action: PrivateAzureStorageAccountAction
+  )(implicit ev: Ask[F, TraceId]): F[Option[String]]
 }
 
 final case class UserSubjectId(asString: String) extends AnyVal

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandler.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandler.scala
@@ -149,6 +149,7 @@ class AzurePubsubHandlerInterp[F[_]: Parallel](
       )
 
       // Get optional action managed identities from Sam
+      // Identities must be passed to WSM for application-managed resources
       tokenOpt <- samDAO.getCachedArbitraryPetAccessToken(runtime.auditInfo.creator)
       actionIdentityOpt <- tokenOpt.flatTraverse { token =>
         samDAO.getAzureActionManagedIdentity(

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandler.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandler.scala
@@ -148,8 +148,8 @@ class AzurePubsubHandlerInterp[F[_]: Parallel](
         CreateAzureDiskParams(msg.workspaceId, runtime, msg.useExistingDisk, azureConfig)
       )
 
-      // Get optional action managed identities from Sam
-      // Identities must be passed to WSM for application-managed resources
+      // Get optional action managed identity from Sam for the private_azure_storage_account/read action.
+      // Identities must be passed to WSM for application-managed resources.
       tokenOpt <- samDAO.getCachedArbitraryPetAccessToken(runtime.auditInfo.creator)
       actionIdentityOpt <- tokenOpt.flatTraverse { token =>
         samDAO.getAzureActionManagedIdentity(

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandlerAlgebra.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandlerAlgebra.scala
@@ -107,7 +107,8 @@ final case class PollRuntimeParams(workspaceId: WorkspaceId,
                                    vmImage: AzureImage,
                                    workspaceStorageContainer: StorageContainerResponse,
                                    workspaceName: String,
-                                   cloudContext: CloudContext.Azure
+                                   cloudContext: CloudContext.Azure,
+                                   userAssignedIdentities: List[String]
 )
 
 final case class PollDiskParams(workspaceId: WorkspaceId,

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/MockSamDAO.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/MockSamDAO.scala
@@ -497,6 +497,13 @@ class MockSamDAO extends SamDAO[IO] {
   override def getResourceRoles(authHeader: Authorization, resourceId: SamResourceId)(implicit
     ev: Ask[IO, TraceId]
   ): IO[Set[SamRole]] = ???
+
+  /** Gets an action managed identity from Sam as the calling user for the given resource type,
+   * resource ID, and action. Returns the managed identity object ID. */
+  override def getAzureActionManagedIdentity(authHeader: Authorization,
+                                             resource: PrivateAzureStorageAccountSamResourceId,
+                                             action: PrivateAzureStorageAccountAction
+  )(implicit ev: Ask[IO, TraceId]): IO[Option[String]] = ???
 }
 
 object MockSamDAO {

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/MockSamDAO.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/MockSamDAO.scala
@@ -503,7 +503,7 @@ class MockSamDAO extends SamDAO[IO] {
   override def getAzureActionManagedIdentity(authHeader: Authorization,
                                              resource: PrivateAzureStorageAccountSamResourceId,
                                              action: PrivateAzureStorageAccountAction
-  )(implicit ev: Ask[IO, TraceId]): IO[Option[String]] = ???
+  )(implicit ev: Ask[IO, TraceId]): IO[Option[String]] = IO(None)
 }
 
 object MockSamDAO {

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/ConfigReaderSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/ConfigReaderSpec.scala
@@ -45,7 +45,7 @@ class ConfigReaderSpec extends AnyFlatSpec with Matchers {
           Uri.unsafeFromString("https://sam.test.org:443"),
           Uri.unsafeFromString("https://localhost:8000"),
           "terradevacrpublic.azurecr.io/welder-server",
-          "6648f5c",
+          "2a3d22b",
           PollMonitorConfig(1 seconds, 10, 1 seconds),
           PollMonitorConfig(1 seconds, 20, 1 seconds),
           PollMonitorConfig(1 seconds, 10, 1 seconds),

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/ConfigReaderSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/ConfigReaderSpec.scala
@@ -45,7 +45,7 @@ class ConfigReaderSpec extends AnyFlatSpec with Matchers {
           Uri.unsafeFromString("https://sam.test.org:443"),
           Uri.unsafeFromString("https://localhost:8000"),
           "terradevacrpublic.azurecr.io/welder-server",
-          "2a3d22b",
+          "51ef0f4",
           PollMonitorConfig(1 seconds, 10, 1 seconds),
           PollMonitorConfig(1 seconds, 20, 1 seconds),
           PollMonitorConfig(1 seconds, 10, 1 seconds),

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandlerSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandlerSpec.scala
@@ -15,6 +15,7 @@ import org.broadinstitute.dsde.workbench.azure.{AzureCloudContext, AzureRelaySer
 import org.broadinstitute.dsde.workbench.google2.{MachineTypeName, RegionName}
 import org.broadinstitute.dsde.workbench.leonardo.AsyncTaskProcessor.Task
 import org.broadinstitute.dsde.workbench.leonardo.CommonTestData._
+import org.broadinstitute.dsde.workbench.leonardo.SamResourceId.PrivateAzureStorageAccountSamResourceId
 import org.broadinstitute.dsde.workbench.leonardo.TestUtils.appContext
 import org.broadinstitute.dsde.workbench.leonardo.config.ApplicationConfig
 import org.broadinstitute.dsde.workbench.leonardo.dao.{WsmApiClientProvider, _}
@@ -281,6 +282,71 @@ class AzurePubsubHandlerSpec
 
         _ <- withInfiniteStream(asyncTaskProcessor.process, assertions)
         controlledResources <- controlledResourceQuery.getAllForRuntime(runtime2.id).transaction
+      } yield {
+        controlledResources.length shouldBe 2
+        val resourceTypes = controlledResources.map(_.resourceType)
+        resourceTypes.contains(WsmResourceType.AzureDisk) shouldBe true
+        resourceTypes.contains(WsmResourceType.AzureStorageContainer) shouldBe true
+      }
+
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
+  }
+
+  it should "create an azure vm properly with an action managed identity" in isolatedDbTest {
+    val queue = QueueFactory.asyncTaskQueue()
+    val resourceId = WsmControlledResourceId(UUID.randomUUID())
+    val mockWsmDAO = new MockWsmDAO {
+      override def getCreateVmJobResult(request: GetJobResultRequest, authorization: Authorization)(implicit
+        ev: Ask[IO, AppContext]
+      ): IO[GetCreateVmJobResult] =
+        IO.pure(
+          GetCreateVmJobResult(
+            Some(WsmVm(WsmVMMetadata(resourceId), WsmVMAttributes(RegionName("southcentralus")))),
+            WsmJobReport(WsmJobId("job1"), "", WsmJobStatus.Succeeded, 200, ZonedDateTime.now(), None, "url"),
+            None
+          )
+        )
+    }
+    val mockSamDAO = new MockSamDAO {
+      override def getAzureActionManagedIdentity(authHeader: Authorization,
+                                                 resource: PrivateAzureStorageAccountSamResourceId,
+                                                 action: PrivateAzureStorageAccountAction
+      )(implicit ev: Ask[IO, TraceId]): IO[Option[String]] = IO(Some("awesome-identity"))
+    }
+    val azurePubsubHandler =
+      makeAzurePubsubHandler(asyncTaskQueue = queue, wsmDAO = mockWsmDAO, samDAO = mockSamDAO)
+
+    val res =
+      for {
+        disk <- makePersistentDisk().copy(status = DiskStatus.Ready).save()
+
+        azureRuntimeConfig = RuntimeConfig.AzureConfig(MachineTypeName(VirtualMachineSizeTypes.STANDARD_A1.toString),
+                                                       Some(disk.id),
+                                                       None
+        )
+        runtime = makeCluster(1)
+          .copy(
+            cloudContext = CloudContext.Azure(azureCloudContext)
+          )
+          .saveWithRuntimeConfig(azureRuntimeConfig)
+
+        assertions = for {
+          getRuntimeOpt <- clusterQuery.getClusterById(runtime.id).transaction
+          getRuntime = getRuntimeOpt.get
+          getRuntimeConfig <- RuntimeConfigQueries.getRuntimeConfig(getRuntime.runtimeConfigId).transaction
+        } yield {
+          getRuntime.asyncRuntimeFields.flatMap(_.hostIp).isDefined shouldBe true
+          getRuntime.status shouldBe RuntimeStatus.Running
+          getRuntimeConfig shouldBe azureRuntimeConfig.copy(region = Some(RegionName("southcentralus")))
+        }
+
+        msg = CreateAzureRuntimeMessage(runtime.id, workspaceId, false, None, "WorkspaceName", billingProfileId)
+
+        asyncTaskProcessor = AsyncTaskProcessor(AsyncTaskProcessor.Config(10, 10), queue)
+        _ <- azurePubsubHandler.createAndPollRuntime(msg)
+
+        _ <- withInfiniteStream(asyncTaskProcessor.process, assertions)
+        controlledResources <- controlledResourceQuery.getAllForRuntime(runtime.id).transaction
       } yield {
         controlledResources.length shouldBe 2
         val resourceTypes = controlledResources.map(_.resourceType)
@@ -1658,7 +1724,8 @@ class AzurePubsubHandlerSpec
                              welderDao: WelderDAO[IO] = new MockWelderDAO(),
                              azureVmService: AzureVmService[IO] = FakeAzureVmService,
                              aksAlg: AKSAlgebra[IO] = new MockAKSInterp,
-                             wsmClient: WsmApiClientProvider[IO] = mockWsm
+                             wsmClient: WsmApiClientProvider[IO] = mockWsm,
+                             samDAO: SamDAO[IO] = new MockSamDAO()
   ): AzurePubsubHandlerAlgebra[IO] =
     new AzurePubsubHandlerInterp[IO](
       ConfigReader.appConfig.azure.pubsubHandler,
@@ -1673,7 +1740,7 @@ class AzurePubsubHandlerSpec
       contentSecurityPolicy,
       asyncTaskQueue,
       wsmDAO,
-      new MockSamDAO(),
+      samDAO,
       welderDao,
       new MockJupyterDAO(),
       relayService,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,7 +17,7 @@ object Dependencies {
   val munitCatsEffectV = "1.0.7"
   val pact4sV = "0.10.0"
 
-  private val workbenchLibsHash = "a6ad7dc"
+  private val workbenchLibsHash = "b57a1ca"
   val serviceTestV = s"4.4-$workbenchLibsHash"
   val workbenchModelV = s"0.19-$workbenchLibsHash"
   val workbenchGoogleV = s"0.32-$workbenchLibsHash"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -223,7 +223,7 @@ object Dependencies {
   val automationOverrides = List(guava)
 
   val automationDependencies = List(
-    "com.fasterxml.jackson.module" %% "jackson-module-scala"   % "2.15.3" % "test",
+    "com.fasterxml.jackson.module" %% "jackson-module-scala"   % "2.17.1" % "test",
     logbackClassic % "test",
     leonardoClient,
     ssh,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -133,7 +133,7 @@ object Dependencies {
   val pact4sCirce =       "io.github.jbwheatley"  %% "pact4s-circe"     % pact4sV
   val okHttp =            "com.squareup.okhttp3"  % "okhttp"            % "4.12.0"
 
-  val workSpaceManagerV = "0.254.1118-rt-tmp-SNAPSHOT"
+  val workSpaceManagerV = "0.254.1121-rt-aami-SNAPSHOT"
   val terraCommonLibV = "0.0.94-SNAPSHOT"
 
   def excludeJakartaActivationApi = ExclusionRule("jakarta.activation", "jakarta.activation-api")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -133,7 +133,7 @@ object Dependencies {
   val pact4sCirce =       "io.github.jbwheatley"  %% "pact4s-circe"     % pact4sV
   val okHttp =            "com.squareup.okhttp3"  % "okhttp"            % "4.12.0"
 
-  val workSpaceManagerV = "0.254.1093-SNAPSHOT"
+  val workSpaceManagerV = "0.254.1118-rt-tmp-SNAPSHOT"
   val terraCommonLibV = "0.0.94-SNAPSHOT"
 
   def excludeJakartaActivationApi = ExclusionRule("jakarta.activation", "jakarta.activation-api")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -133,7 +133,7 @@ object Dependencies {
   val pact4sCirce =       "io.github.jbwheatley"  %% "pact4s-circe"     % pact4sV
   val okHttp =            "com.squareup.okhttp3"  % "okhttp"            % "4.12.0"
 
-  val workSpaceManagerV = "0.254.1121-rt-aami-SNAPSHOT"
+  val workSpaceManagerV = "0.254.1127-SNAPSHOT"
   val terraCommonLibV = "0.0.94-SNAPSHOT"
 
   def excludeJakartaActivationApi = ExclusionRule("jakarta.activation", "jakarta.activation-api")


### PR DESCRIPTION
<!-- Welcome to your Leonardo pull request! -->
<!-- Contributor guidelines: https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md -->

JIRA: https://broadworkbench.atlassian.net/browse/ID-1266

Design doc: https://docs.google.com/document/d/1VT__hmPH1cyYYm643cJzlsrVIyKeWPgEnjpC0fjV63E/edit

## Dependencies

Depends on WSM (https://github.com/DataBiosphere/terra-workspace-manager/pull/1754) and Welder (https://github.com/DataBiosphere/welder/pull/270/).

## Summary of changes

<!-- Please give an abridged version of the ticket description here and/or fill out the following fields. -->

### What

- This PR updates Back Leo VM creation to retrieve an action managed identity from Sam for the `private_azure_storage_account/read` action. If one is present, pass it to the WSM VM creation API.
- Also updates welder hash for https://github.com/DataBiosphere/welder/pull/270

### Why

- See design doc above. This supports the Enterprise Data Access team-sized problem. These AAMIs will be used to grant access to external resources (storage accounts, ACRs).

## Testing these changes

### What to test

- Unit testing
- Automation tests cover VM creation with no AAMI - confirm no breakages
- Manual testing on a BEE:
   - Created an AAMI for a user. Created a notebook VM, verified it starts correctly and the user has access to the AAMI (and the external storage account).
   - Created a notebook VM without an AAMI, verified things still work with no change in behavior.

<!-- ### Test data -->

### Who tested and where

- [x] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [x] I validated this change in a BEE
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
