### PR TITLE
RW-12822 add workload separation per AppSec request

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,8 +32,8 @@ ENV NGINX_VERSION 4.3.0
 # If you update this here, make sure to also update reference.conf:
 ENV CROMWELL_CHART_VERSION 0.2.506
 ENV HAIL_BATCH_CHART_VERSION 0.2.0
-ENV RSTUDIO_CHART_VERSION 0.11.0
-ENV SAS_CHART_VERSION 0.16.0
+ENV RSTUDIO_CHART_VERSION 0.12.0
+ENV SAS_CHART_VERSION 0.17.0
 
 RUN mkdir /leonardo
 COPY ./leonardo*.jar /leonardo

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -845,8 +845,8 @@ gke {
     # This is really just a prefix of the chart name. Full chart name for AOU app will be
     # this chartName in config file appended with allowedChartName from createAppRequest
     chartName = "/leonardo/"
-    rstudioChartVersion = "0.11.0"
-    sasChartVersion = "0.16.0"
+    rstudioChartVersion = "0.12.0"
+    sasChartVersion = "0.17.0"
 
     services = [
           {
@@ -1200,7 +1200,7 @@ pubsub {
     // TODO change back to 5 minutes when PROD-869 is resolved
     timeout = 595 seconds // slightly less than ackDeadline
     // initial delay before we start polling for GKE cluster creation result
-    gke-cluster-creation-polling-initial-delay = 3 minutes
+    gke-cluster-creation-polling-initial-delay = 5 minutes
 
     persistent-disk-monitor {
       create {

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/LeoAppServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/LeoAppServiceInterp.scala
@@ -89,14 +89,6 @@ final class LeoAppServiceInterp[F[_]: Parallel](config: AppServiceConfig,
       _ <- F.raiseWhen(!hasPermission)(ForbiddenError(userInfo.userEmail))
 
       enableIntraNodeVisibility = req.labels.get(AOU_UI_LABEL).exists(x => x == "true")
-      // We only allow autopilot mode for members of CUSTOM_APP_USERS group
-      // This is only needed while we're evaluating autopilot (6/3/2024).
-      _ <- req.autopilot.traverse { _ =>
-        authProvider.isCustomAppAllowed(userInfo.userEmail) map { res =>
-          if (res) Right(())
-          else Left("You don't have permission to create APP in autopilot mode")
-        }
-      }
       _ <- req.appType match {
         case AppType.Galaxy | AppType.HailBatch | AppType.Wds | AppType.Cromwell | AppType.WorkflowsApp |
             AppType.CromwellRunnerApp =>

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/BuildHelmChartValues.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/BuildHelmChartValues.scala
@@ -395,7 +395,8 @@ private[leonardo] object BuildHelmChartValues {
     // spec.template.spec.tolerations[0].operator: Invalid value: "xxx": a valid label must be an empty string or
     // consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character
     // (e.g. 'MyValue',  or 'my_value',  or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')], string=
-    val base64EncodedEmail = Base64.getEncoder.encodeToString(userEmail.value.getBytes(StandardCharsets.UTF_8))
+    val base64EncodedEmail =
+      Base64.getEncoder.encodeToString(userEmail.value.getBytes(StandardCharsets.UTF_8)).replace("=", "")
     val nodeSelectorGroupValue = s"leonardo_${base64EncodedEmail}"
     val autopilotParams = autopilot match {
       case Some(v) =>

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/BuildHelmChartValues.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/BuildHelmChartValues.scala
@@ -15,7 +15,10 @@ import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
 import org.broadinstitute.dsde.workbench.model.google.GcsBucketName
 import org.broadinstitute.dsp.{Release, Values}
 
+import java.util.Base64
 import java.net.URL
+import java.nio.charset.StandardCharsets
+
 private[leonardo] object BuildHelmChartValues {
   def buildGalaxyChartOverrideValuesString(config: GKEInterpreterConfig,
                                            appName: AppName,
@@ -392,7 +395,8 @@ private[leonardo] object BuildHelmChartValues {
     // spec.template.spec.tolerations[0].operator: Invalid value: "xxx": a valid label must be an empty string or
     // consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character
     // (e.g. 'MyValue',  or 'my_value',  or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')], string=
-    val nodeSelectorGroupValue = s"a${userEmail.value.split("@")(0)}"
+    val base64EncodedEmail = Base64.getEncoder.encodeToString(userEmail.value.getBytes(StandardCharsets.UTF_8))
+    val nodeSelectorGroupValue = s"leonardo_${base64EncodedEmail}"
     val autopilotParams = autopilot match {
       case Some(v) =>
         val ls = List(

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/BuildHelmChartValues.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/BuildHelmChartValues.scala
@@ -15,7 +15,6 @@ import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
 import org.broadinstitute.dsde.workbench.model.google.GcsBucketName
 import org.broadinstitute.dsp.{Release, Values}
 
-import java.util.Base64
 import java.net.URL
 import java.nio.charset.StandardCharsets
 
@@ -395,9 +394,8 @@ private[leonardo] object BuildHelmChartValues {
     // spec.template.spec.tolerations[0].operator: Invalid value: "xxx": a valid label must be an empty string or
     // consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character
     // (e.g. 'MyValue',  or 'my_value',  or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')], string=
-    val base64EncodedEmail =
-      Base64.getEncoder.encodeToString(userEmail.value.getBytes(StandardCharsets.UTF_8)).replace("=", "")
-    val nodeSelectorGroupValue = s"leonardo_${base64EncodedEmail}"
+    val hashedEmail = com.google.common.hash.Hashing.sha256().hashString(userEmail.value, StandardCharsets.UTF_8)
+    val nodeSelectorGroupValue = s"leonardo_${hashedEmail}"
     val autopilotParams = autopilot match {
       case Some(v) =>
         val ls = List(

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/BuildHelmChartValues.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/BuildHelmChartValues.scala
@@ -385,6 +385,8 @@ private[leonardo] object BuildHelmChartValues {
       raw"""ingress.tls[0].hosts[0]=${k8sProxyHostString}"""
     )
 
+    // Support workload identity following https://cloud.google.com/kubernetes-engine/docs/how-to/workload-separation#separate-workloads-autopilot.
+    // nodeSelector.group value has the following restrictions:
     // a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character
     // (e.g. 'MyValue',  or 'my_value',  or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?'),
     // spec.template.spec.tolerations[0].operator: Invalid value: "xxx": a valid label must be an empty string or

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/BuildHelmChartValues.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/BuildHelmChartValues.scala
@@ -394,8 +394,12 @@ private[leonardo] object BuildHelmChartValues {
     // spec.template.spec.tolerations[0].operator: Invalid value: "xxx": a valid label must be an empty string or
     // consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character
     // (e.g. 'MyValue',  or 'my_value',  or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')], string=
-    val hashedEmail = com.google.common.hash.Hashing.sha256().hashString(userEmail.value, StandardCharsets.UTF_8)
-    val nodeSelectorGroupValue = s"leonardo_${hashedEmail}"
+    val hashedEmail = com.google.common.hash.Hashing
+      .sha256()
+      .hashString(userEmail.value, StandardCharsets.UTF_8)
+      .toString
+
+    val nodeSelectorGroupValue = s"leo_${hashedEmail}".substring(0, 60)
     val autopilotParams = autopilot match {
       case Some(v) =>
         val ls = List(

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/BuildHelmChartValues.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/BuildHelmChartValues.scala
@@ -385,9 +385,18 @@ private[leonardo] object BuildHelmChartValues {
       raw"""ingress.tls[0].hosts[0]=${k8sProxyHostString}"""
     )
 
+    // a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character
+    // (e.g. 'MyValue',  or 'my_value',  or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?'),
+    // spec.template.spec.tolerations[0].operator: Invalid value: "xxx": a valid label must be an empty string or
+    // consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character
+    // (e.g. 'MyValue',  or 'my_value',  or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')], string=
+    val nodeSelectorGroupValue = s"a${userEmail.value.split("@")(0)}"
     val autopilotParams = autopilot match {
       case Some(v) =>
         val ls = List(
+          raw"""tolerations.enabled=true""",
+          raw"""tolerations.keyValue=${nodeSelectorGroupValue}""",
+          raw"""nodeSelector.group=${nodeSelectorGroupValue}""",
           raw"""autopilot.enabled=true""",
           raw"""autopilot.app.cpu=${v.cpuInMillicores}m""",
           raw"""autopilot.app.memory=${v.memoryInGb}Gi""",

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/BuildHelmChartValuesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/BuildHelmChartValuesSpec.scala
@@ -450,6 +450,9 @@ class BuildHelmChartValuesSpec extends AnyFlatSpecLike with LeonardoTestSuite {
       """extraEnv[0].value=test-workspace-name,""" +
       """replicaCount=1,""" +
       """nodeSelector.cloud\.google\.com/compute-class=Balanced,""" +
+      """tolerations.enabled=true,""" +
+      """tolerations.keyValue=auser2,""" +
+      """nodeSelector.group=auser2,""" +
       """autopilot.enabled=true,autopilot.app.cpu=500m,""" +
       """autopilot.app.memory=1Gi,autopilot.app.ephemeral\-storage=2Gi,""" +
       """autopilot.welder.cpu=500m,autopilot.welder.memory=3Gi,""" +
@@ -516,6 +519,9 @@ class BuildHelmChartValuesSpec extends AnyFlatSpecLike with LeonardoTestSuite {
       """extraEnv[0].name=WORKSPACE_NAME,""" +
       """extraEnv[0].value=test-workspace-name,""" +
       """replicaCount=1,""" +
+      """tolerations.enabled=true,""" +
+      """tolerations.keyValue=auser2,""" +
+      """nodeSelector.group=auser2,""" +
       """autopilot.enabled=true,autopilot.app.cpu=500m,""" +
       """autopilot.app.memory=1Gi,autopilot.app.ephemeral\-storage=2Gi,""" +
       """autopilot.welder.cpu=500m,autopilot.welder.memory=3Gi,""" +


### PR DESCRIPTION
<!-- Welcome to your Leonardo pull request! -->
<!-- Contributor guidelines: https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md -->

__Jira ticket__: https://precisionmedicineinitiative.atlassian.net/browse/RW-12822

Followed https://cloud.google.com/kubernetes-engine/docs/how-to/workload-separation#separate-workloads-autopilot

Verified in BEE that apps live on different nodes
```
➜  Github kubectl get pods --all-namespaces -o wide|grep "\-app\-ns"
ihzdh1-app-ns     qi-rstudio-6-24-2-74ffb9ddd5-sbfr5                         0/3     ContainerCreating   0              2m17s   <none>       gk3-k51b094f-2d16-4bbf-8-nap-1rqpofco-a3da0221-g9s4   <none>           <none>
ovvehz-app-ns     qi-rstudio-6-24-1-7866996477-ld82r                         0/3     ContainerCreating   0              5m14s   <none>       gk3-k51b094f-2d16-4bbf-8-nap-hcblhnre-06dceee2-mvcg   <none>           <none>
```


<!-- ## Dependencies -->
<!-- Include any dependent tickets and describe the relationship. Include any other relevant Jira tickets. -->

## Summary of changes

<!-- Please give an abridged version of the ticket description here and/or fill out the following fields. -->

### What

-

### Why

-

## Testing these changes

### What to test

- <!-- Test case 1 -->

<!-- ### Test data -->

### Who tested and where

- [ ] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [ ] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
