### PR TITLE
[IA-5000] Make sure to transition DELETING Azure disks to ERROR

### DIFF
--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
@@ -120,6 +120,7 @@ class LeoPubsubMessageSubscriber[F[_]](
           azurePubsubHandler.deleteAndPollRuntime(msg).adaptError { case e =>
             PubsubHandleMessageError.AzureRuntimeDeletionError(
               msg.runtimeId,
+              msg.diskIdToDelete,
               msg.workspaceId,
               e.getMessage
             )

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/leoPubsubMessageSubscriberModels.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/leoPubsubMessageSubscriberModels.scala
@@ -1134,8 +1134,11 @@ object PubsubHandleMessageError {
     val isRetryable: Boolean = false
   }
 
-  final case class AzureRuntimeDeletionError(runtimeId: Long, workspaceId: WorkspaceId, errorMsg: String)
-      extends PubsubHandleMessageError {
+  final case class AzureRuntimeDeletionError(runtimeId: Long,
+                                             diskId: Option[DiskId],
+                                             workspaceId: WorkspaceId,
+                                             errorMsg: String
+  ) extends PubsubHandleMessageError {
     override def getMessage: String =
       s"\n\truntimeId: ${runtimeId}, \n\tmsg: ${errorMsg})"
     val isRetryable: Boolean = false

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandler.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandler.scala
@@ -679,6 +679,7 @@ class AzurePubsubHandlerInterp[F[_]: Parallel](
             _ <- F.raiseError[Unit](
               AzureRuntimeDeletionError(
                 params.runtime.id,
+                params.diskId,
                 params.workspaceId,
                 s"Wsm deleteDisk job failed due to ${resp.getErrorReport.getMessage}, disk resource id ${params.wsmResourceId}"
               )
@@ -690,6 +691,7 @@ class AzurePubsubHandlerInterp[F[_]: Parallel](
           ) >> F.raiseError[Unit](
             AzureRuntimeDeletionError(
               params.runtime.id,
+              params.diskId,
               params.workspaceId,
               s"Wsm deleteDisk was not completed within ${config.deleteDiskPollConfig.maxAttempts} attempts with ${config.deleteDiskPollConfig.interval} delay, disk resource id ${params.wsmResourceId}"
             )
@@ -726,6 +728,7 @@ class AzurePubsubHandlerInterp[F[_]: Parallel](
           logger.error(s"Wsm deleteVm job failed due to ${resp.getErrorReport.getMessage}") >> F.raiseError[Unit](
             AzureRuntimeDeletionError(
               params.runtime.id,
+              None,
               params.workspaceId,
               s"WSM delete VM job failed due to ${resp.getErrorReport.getMessage}"
             )
@@ -734,6 +737,7 @@ class AzurePubsubHandlerInterp[F[_]: Parallel](
           F.raiseError[Unit](
             AzureRuntimeDeletionError(
               params.runtime.id,
+              None,
               params.workspaceId,
               s"WSM delete VM job was not completed within ${config.deleteVmPollConfig.maxAttempts} attempts with ${config.deleteVmPollConfig.interval} delay"
             )
@@ -774,6 +778,7 @@ class AzurePubsubHandlerInterp[F[_]: Parallel](
             .raiseError[Unit](
               AzureRuntimeDeletionError(
                 params.runtime.id,
+                None,
                 params.workspaceId,
                 s"WSM storage container delete job failed due to ${resp.getErrorReport.getMessage} for runtime ${params.runtime.id}"
               )
@@ -782,6 +787,7 @@ class AzurePubsubHandlerInterp[F[_]: Parallel](
           F.raiseError[Unit](
             AzureRuntimeDeletionError(
               params.runtime.id,
+              None,
               params.workspaceId,
               s"WSM delete storage container job was not completed within ${config.deleteStorageContainerPollConfig.maxAttempts} attempts with ${config.deleteStorageContainerPollConfig.interval} delay"
             )
@@ -1097,6 +1103,7 @@ class AzurePubsubHandlerInterp[F[_]: Parallel](
           Some { e =>
             handleAzureRuntimeDeletionError(
               AzureRuntimeDeletionError(msg.runtimeId,
+                                        msg.diskIdToDelete,
                                         msg.workspaceId,
                                         s"Fail to delete runtime due to ${e.getMessage}"
               )
@@ -1118,6 +1125,10 @@ class AzurePubsubHandlerInterp[F[_]: Parallel](
       .save(e.runtimeId, RuntimeError(e.errorMsg.take(1024), None, ctx.now, traceId = Some(ctx.traceId)))
       .transaction
     _ <- clusterQuery.updateClusterStatus(e.runtimeId, RuntimeStatus.Error, ctx.now).transaction
+    _ <- e.diskId match {
+      case Some(diskId) => persistentDiskQuery.updateStatus(diskId, DiskStatus.Error, ctx.now).transaction
+      case None         => F.unit
+    }
   } yield ()
 
   def handleAzureRuntimeStartError(e: AzureRuntimeStartingError, now: Instant)(implicit

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandlerAlgebra.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandlerAlgebra.scala
@@ -125,9 +125,13 @@ final case class PollDeleteDiskParams(workspaceId: WorkspaceId,
                                       wsmResourceId: WsmControlledResourceId
 )
 
-final case class PollVmParams(workspaceId: WorkspaceId, jobId: WsmJobId, runtime: Runtime)
+final case class PollVmParams(workspaceId: WorkspaceId, jobId: WsmJobId, runtime: Runtime, diskId: Option[DiskId])
 
-final case class PollStorageContainerParams(workspaceId: WorkspaceId, jobId: WsmJobId, runtime: Runtime)
+final case class PollStorageContainerParams(workspaceId: WorkspaceId,
+                                            jobId: WsmJobId,
+                                            runtime: Runtime,
+                                            diskId: Option[DiskId]
+)
 
 final case class CreateStorageContainerResourcesResult(containerName: ContainerName,
                                                        resourceId: WsmControlledResourceId

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandlerSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandlerSpec.scala
@@ -739,10 +739,12 @@ class AzurePubsubHandlerSpec
           getRuntimeOpt <- clusterQuery.getClusterById(runtime.id).transaction
           getRuntime = getRuntimeOpt.get
           error <- clusterErrorQuery.get(runtime.id).transaction
+          diskStatus <- persistentDiskQuery.getStatus(disk.id).transaction
         } yield {
           getRuntime.status shouldBe RuntimeStatus.Error
           error.length shouldBe 1
           error.map(_.errorMessage).head should include(exceptionMsg)
+          diskStatus shouldBe DiskStatus.Deleted
         }
 
         msg = CreateAzureRuntimeMessage(runtime.id, workspaceId2, false, None, "WorkspaceName", billingProfileId)
@@ -784,10 +786,12 @@ class AzurePubsubHandlerSpec
           getRuntimeOpt <- clusterQuery.getClusterById(runtime.id).transaction
           getRuntime = getRuntimeOpt.get
           error <- clusterErrorQuery.get(runtime.id).transaction
+          diskStatus <- persistentDiskQuery.getStatus(disk.id).transaction
         } yield {
           getRuntime.status shouldBe RuntimeStatus.Error
           error.length shouldBe 1
           error.map(_.errorMessage).head should include(exceptionMsg)
+          diskStatus shouldBe DiskStatus.Deleted
         }
 
         msg = CreateAzureRuntimeMessage(runtime.id, workspaceId, false, None, "WorkspaceName", billingProfileId)
@@ -930,9 +934,11 @@ class AzurePubsubHandlerSpec
           getRuntimeOpt <- clusterQuery.getClusterById(runtime.id).transaction
           getRuntime = getRuntimeOpt.get
           error <- clusterErrorQuery.get(runtime.id).transaction
+          diskStatus <- persistentDiskQuery.getStatus(disk.id).transaction
         } yield {
           getRuntime.status shouldBe RuntimeStatus.Error
           error.map(_.errorMessage).head should include("WSM delete VM job failed due")
+          diskStatus shouldBe DiskStatus.Error
         }
 
         msg = DeleteAzureRuntimeMessage(runtime.id,
@@ -985,9 +991,11 @@ class AzurePubsubHandlerSpec
           getRuntimeOpt <- clusterQuery.getClusterById(runtime.id).transaction
           getRuntime = getRuntimeOpt.get
           error <- clusterErrorQuery.get(runtime.id).transaction
+          diskStatus <- persistentDiskQuery.getStatus(disk.id).transaction
         } yield {
           getRuntime.status shouldBe RuntimeStatus.Error
           error.map(_.errorMessage).head should include(exceptionMsg)
+          diskStatus shouldBe DiskStatus.Error
         }
 
         msg = DeleteAzureRuntimeMessage(runtime.id,
@@ -1097,10 +1105,12 @@ class AzurePubsubHandlerSpec
           getRuntimeOpt <- clusterQuery.getClusterById(runtime.id).transaction
           getRuntime = getRuntimeOpt.get
           error <- clusterErrorQuery.get(runtime.id).transaction
+          diskStatus <- persistentDiskQuery.getStatus(disk.id).transaction
         } yield {
           getRuntime.status shouldBe RuntimeStatus.Error
           getRuntime.auditInfo.destroyedDate shouldBe None
           error.map(_.errorMessage).head should include(exceptionMsg)
+          diskStatus shouldBe DiskStatus.Error
         }
 
         msg = DeleteAzureRuntimeMessage(runtime.id,
@@ -1157,10 +1167,12 @@ class AzurePubsubHandlerSpec
           getRuntimeOpt <- clusterQuery.getClusterById(runtime.id).transaction
           getRuntime = getRuntimeOpt.get
           error <- clusterErrorQuery.get(runtime.id).transaction
+          diskStatus <- persistentDiskQuery.getStatus(disk.id).transaction
         } yield {
           getRuntime.status shouldBe RuntimeStatus.Error
           getRuntime.auditInfo.destroyedDate shouldBe None
           error.map(_.errorMessage).head should include(exceptionMsg)
+          diskStatus shouldBe DiskStatus.Error
         }
 
         msg = DeleteAzureRuntimeMessage(runtime.id,

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandlerSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandlerSpec.scala
@@ -401,10 +401,11 @@ class AzurePubsubHandlerSpec
         assertions = for {
           runtimeStatus <- clusterQuery.getClusterStatus(runtime.id).transaction
           diskIdOpt <- RuntimeConfigQueries.getDiskId(runtime.runtimeConfigId).transaction
-          diskStatus <- diskIdOpt.flatTraverse(id => persistentDiskQuery.getStatus(id).transaction)
+          getDiskOpt <- persistentDiskQuery.getById(disk.id).transaction
+          getDisk = getDiskOpt.get
         } yield {
           runtimeStatus shouldBe Some(RuntimeStatus.Error)
-          diskStatus shouldBe (Some(DiskStatus.Deleted))
+          getDisk.status shouldBe (Some(DiskStatus.Deleted))
         }
 
         msg = CreateAzureRuntimeMessage(runtime.id, workspaceId, false, None, "WorkspaceName", billingProfileId)
@@ -739,12 +740,13 @@ class AzurePubsubHandlerSpec
           getRuntimeOpt <- clusterQuery.getClusterById(runtime.id).transaction
           getRuntime = getRuntimeOpt.get
           error <- clusterErrorQuery.get(runtime.id).transaction
-          diskStatus <- persistentDiskQuery.getStatus(disk.id).transaction
+          getDiskOpt <- persistentDiskQuery.getById(disk.id).transaction
+          getDisk = getDiskOpt.get
         } yield {
           getRuntime.status shouldBe RuntimeStatus.Error
           error.length shouldBe 1
           error.map(_.errorMessage).head should include(exceptionMsg)
-          diskStatus shouldBe DiskStatus.Deleted
+          getDisk.status shouldBe DiskStatus.Deleted
         }
 
         msg = CreateAzureRuntimeMessage(runtime.id, workspaceId2, false, None, "WorkspaceName", billingProfileId)
@@ -786,12 +788,13 @@ class AzurePubsubHandlerSpec
           getRuntimeOpt <- clusterQuery.getClusterById(runtime.id).transaction
           getRuntime = getRuntimeOpt.get
           error <- clusterErrorQuery.get(runtime.id).transaction
-          diskStatus <- persistentDiskQuery.getStatus(disk.id).transaction
+          getDiskOpt <- persistentDiskQuery.getById(disk.id).transaction
+          getDisk = getDiskOpt.get
         } yield {
           getRuntime.status shouldBe RuntimeStatus.Error
           error.length shouldBe 1
           error.map(_.errorMessage).head should include(exceptionMsg)
-          diskStatus shouldBe DiskStatus.Deleted
+          getDisk.status shouldBe DiskStatus.Deleted
         }
 
         msg = CreateAzureRuntimeMessage(runtime.id, workspaceId, false, None, "WorkspaceName", billingProfileId)
@@ -934,11 +937,12 @@ class AzurePubsubHandlerSpec
           getRuntimeOpt <- clusterQuery.getClusterById(runtime.id).transaction
           getRuntime = getRuntimeOpt.get
           error <- clusterErrorQuery.get(runtime.id).transaction
-          diskStatus <- persistentDiskQuery.getStatus(disk.id).transaction
+          getDiskOpt <- persistentDiskQuery.getById(disk.id).transaction
+          getDisk = getDiskOpt.get
         } yield {
           getRuntime.status shouldBe RuntimeStatus.Error
           error.map(_.errorMessage).head should include("WSM delete VM job failed due")
-          diskStatus shouldBe DiskStatus.Error
+          getDisk.status shouldBe DiskStatus.Error
         }
 
         msg = DeleteAzureRuntimeMessage(runtime.id,
@@ -991,11 +995,12 @@ class AzurePubsubHandlerSpec
           getRuntimeOpt <- clusterQuery.getClusterById(runtime.id).transaction
           getRuntime = getRuntimeOpt.get
           error <- clusterErrorQuery.get(runtime.id).transaction
-          diskStatus <- persistentDiskQuery.getStatus(disk.id).transaction
+          getDiskOpt <- persistentDiskQuery.getById(disk.id).transaction
+          getDisk = getDiskOpt.get
         } yield {
           getRuntime.status shouldBe RuntimeStatus.Error
           error.map(_.errorMessage).head should include(exceptionMsg)
-          diskStatus shouldBe DiskStatus.Error
+          getDisk.status shouldBe DiskStatus.Error
         }
 
         msg = DeleteAzureRuntimeMessage(runtime.id,
@@ -1105,12 +1110,13 @@ class AzurePubsubHandlerSpec
           getRuntimeOpt <- clusterQuery.getClusterById(runtime.id).transaction
           getRuntime = getRuntimeOpt.get
           error <- clusterErrorQuery.get(runtime.id).transaction
-          diskStatus <- persistentDiskQuery.getStatus(disk.id).transaction
+          getDiskOpt <- persistentDiskQuery.getById(disk.id).transaction
+          getDisk = getDiskOpt.get
         } yield {
           getRuntime.status shouldBe RuntimeStatus.Error
           getRuntime.auditInfo.destroyedDate shouldBe None
           error.map(_.errorMessage).head should include(exceptionMsg)
-          diskStatus shouldBe DiskStatus.Error
+          getDisk.status shouldBe DiskStatus.Error
         }
 
         msg = DeleteAzureRuntimeMessage(runtime.id,
@@ -1167,12 +1173,13 @@ class AzurePubsubHandlerSpec
           getRuntimeOpt <- clusterQuery.getClusterById(runtime.id).transaction
           getRuntime = getRuntimeOpt.get
           error <- clusterErrorQuery.get(runtime.id).transaction
-          diskStatus <- persistentDiskQuery.getStatus(disk.id).transaction
+          getDiskOpt <- persistentDiskQuery.getById(disk.id).transaction
+          getDisk = getDiskOpt.get
         } yield {
           getRuntime.status shouldBe RuntimeStatus.Error
           getRuntime.auditInfo.destroyedDate shouldBe None
           error.map(_.errorMessage).head should include(exceptionMsg)
-          diskStatus shouldBe DiskStatus.Error
+          getDisk.status shouldBe DiskStatus.Error
         }
 
         msg = DeleteAzureRuntimeMessage(runtime.id,

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandlerSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandlerSpec.scala
@@ -400,12 +400,10 @@ class AzurePubsubHandlerSpec
 
         assertions = for {
           runtimeStatus <- clusterQuery.getClusterStatus(runtime.id).transaction
-          diskIdOpt <- RuntimeConfigQueries.getDiskId(runtime.runtimeConfigId).transaction
-          getDiskOpt <- persistentDiskQuery.getById(disk.id).transaction
-          getDisk = getDiskOpt.get
+          diskStatus <- persistentDiskQuery.getStatus(disk.id).transaction
         } yield {
           runtimeStatus shouldBe Some(RuntimeStatus.Error)
-          getDisk.status shouldBe (Some(DiskStatus.Deleted))
+          diskStatus shouldBe Some(DiskStatus.Deleted)
         }
 
         msg = CreateAzureRuntimeMessage(runtime.id, workspaceId, false, None, "WorkspaceName", billingProfileId)


### PR DESCRIPTION
<!-- Welcome to your Leonardo pull request! -->
<!-- Contributor guidelines: https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md -->

__Jira ticket__: https://broadworkbench.atlassian.net/browse/IA-5000

<!-- ## Dependencies -->
<!-- Include any dependent tickets and describe the relationship. Include any other relevant Jira tickets. -->

## Summary of changes

<!-- Please give an abridged version of the ticket description here and/or fill out the following fields. -->

### What

- Ensures that when an Azure runtime deletion fails, both the runtime AND the persistent disk (if provided) transition their statuses to ERROR

### Why

- Even though persistent disks where being deleted properly in the Azure portal, they were still marked as DELETING in the Leonardo database (and therefore the cloud environment page in the UI), leading users to believe that they were leaked resources

## Testing these changes

### What to test

- <!-- Test case 1 -->

<!-- ### Test data -->

### Who tested and where

- [ ] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [ ] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
