### PR TITLE
RW-12956 Fixing a bug where PD is not cleaned up properly

### DIFF
--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/LeoAppServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/LeoAppServiceInterp.scala
@@ -1231,7 +1231,9 @@ final class LeoAppServiceInterp[F[_]: Parallel](config: AppServiceConfig,
             case (Some(FormattedBy.Galaxy), None) | (Some(FormattedBy.Cromwell), None) |
                 (Some(FormattedBy.Allowed), None) =>
               F.raiseError[Option[LastUsedApp]](
-                new LeoException("Existing disk found, but no restore info found in DB", traceId = Some(ctx.traceId))
+                new LeoException(s"Existing ${diskResult.disk.id} found, but no restore info found in DB",
+                                 traceId = Some(ctx.traceId)
+                )
               )
             case (Some(FormattedBy.Custom), _) =>
               F.raiseError[Option[LastUsedApp]](

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
@@ -1085,9 +1085,7 @@ class LeoPubsubMessageSubscriber[F[_]](
               Some(msg.appId),
               false,
               None,
-              disk.map(
-                _.id
-              ), // If App creation fails, we're going to mark the newly created disk as `FAILED`. `disk` is only populated if there's a new disk created for this request
+              None, // we're not specifying diskId here because cleanUpAfterCreateAppError a few lines above will clean up Disk properly
               None
             )
           }
@@ -1263,7 +1261,7 @@ class LeoPubsubMessageSubscriber[F[_]](
                 Some(msg.appId),
                 false,
                 None,
-                None,
+                Some(diskId),
                 None
               )
             }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
@@ -1085,7 +1085,9 @@ class LeoPubsubMessageSubscriber[F[_]](
               Some(msg.appId),
               false,
               None,
-              None,
+              disk.map(
+                _.id
+              ), // If App creation fails, we're going to mark the newly created disk as `FAILED`. `disk` is only populated if there's a new disk created for this request
               None
             )
           }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/AppServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/AppServiceInterpSpec.scala
@@ -705,7 +705,7 @@ class AppServiceInterpTest extends AnyFlatSpec with AppServiceInterpSpec with Le
       .attempt
       .unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
 
-    res.swap.toOption.get.getMessage shouldBe "Existing disk found, but no restore info found in DB"
+    res.swap.toOption.get.getMessage shouldBe s"Existing ${disk.id} found, but no restore info found in DB"
   }
 
   it should "error on creation of a galaxy app without a disk" in isolatedDbTest {
@@ -736,7 +736,7 @@ class AppServiceInterpTest extends AnyFlatSpec with AppServiceInterpSpec with Le
       .attempt
       .unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
 
-    res.swap.toOption.get.getMessage shouldBe "Existing disk found, but no restore info found in DB"
+    res.swap.toOption.get.getMessage shouldBe s"Existing ${disk.id} found, but no restore info found in DB"
   }
 
   it should "error creating Galaxy app with an existing disk that was formatted by Cromwell" in isolatedDbTest {


### PR DESCRIPTION
Last week, we had some bug in SAS chart that was preventing app creation to succeed. This revealed a different bug that if an app creation fails, the newly created PD may not be cleaned up, and this causes all future app creation in the same workspace to fail because the following error

```
[ERROR] [06/19/2024 20:37:56.262] [leonardo-akka.actor.default-dispatcher-9] [akka.actor.ActorSystemImpl(leonardo)] HttpMethod(POST) http://notebooks.firecloud.org/api/google/v1/apps/terra-vpc-sc-9614c68a/all-of-us-4275-cromwell-6348: 500 Internal Server Error entity: {"source":"leonardo","message":"Existing disk found, but no restore info found in DB","statusCode":500,"exceptionClass":"class org.broadinstitute.dsde.workbench.leonardo.model.LeoException","traceId":"df17b4103e731dfbac5abc2ab2595fb8/16266843891970221338"}
```

What this PR will does is pass the diskId to the `handleKubernetesError` function, where it'll transition the disk status to `Failed`. This way, UI won't attempt to reuse this disk and run into the above exception. We might want to consider adding a step to delete PD in GCP in the error handler for future improvements.

<!-- Welcome to your Leonardo pull request! -->
<!-- Contributor guidelines: https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md -->

__Jira ticket__: https://precisionmedicineinitiative.atlassian.net/browse/RW-12956

<!-- ## Dependencies -->
<!-- Include any dependent tickets and describe the relationship. Include any other relevant Jira tickets. -->

## Summary of changes

<!-- Please give an abridged version of the ticket description here and/or fill out the following fields. -->

### What

-

### Why

-

## Testing these changes

### What to test

- <!-- Test case 1 -->

<!-- ### Test data -->

### Who tested and where

- [ ] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [ ] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
