### PR TITLE
AJ-268: update to latest workbench-libs, which removes trial billing references

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,9 +17,9 @@ object Dependencies {
   val munitCatsEffectV = "1.0.7"
   val pact4sV = "0.10.0"
 
-  private val workbenchLibsHash = "b57a1ca"
-  val serviceTestV = s"4.4-$workbenchLibsHash"
-  val workbenchModelV = s"0.19-$workbenchLibsHash"
+  private val workbenchLibsHash = "9138393"
+  val serviceTestV = s"5.0-$workbenchLibsHash"
+  val workbenchModelV = s"0.20-$workbenchLibsHash"
   val workbenchGoogleV = s"0.32-$workbenchLibsHash"
   val workbenchGoogle2V = s"0.36-$workbenchLibsHash"
   val workbenchOpenTelemetryV = s"0.8-$workbenchLibsHash"


### PR DESCRIPTION
__Jira ticket__: https://broadworkbench.atlassian.net/browse/AJ-268

<!-- ## Dependencies -->
<!-- Include any dependent tickets and describe the relationship. Include any other relevant Jira tickets. -->

## Summary of changes

### What

This updates Leo's automation subdirectory (swat tests) to the latest versions of workbench-libs libraries. The latest version of service-test removes knowledge of the trial-billing SA. 

This pulls in https://github.com/broadinstitute/workbench-libs/pull/1692

I am making this change across Sam, Leo, Rawls, and Orch:
* https://github.com/DataBiosphere/leonardo/pull/4685
* https://github.com/broadinstitute/sam/pull/1471
* https://github.com/broadinstitute/rawls/pull/2940
* https://github.com/broadinstitute/firecloud-orchestration/pull/1385

### Why

This is a prerequisite for removing knowledge of trial-billing from the github workflows that run the swat tests, which in turn unblocks removing that unused SA entirely.

## Testing these changes

If swat tests continue to pass, these changes are solid.

- [ ] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [ ] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
