### PR TITLE
ID-1276 Fix bard url value injection to cromwell-runner-app

### DIFF
--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/app/CromwellRunnerAppInstall.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/app/CromwellRunnerAppInstall.scala
@@ -134,7 +134,7 @@ class CromwellRunnerAppInstall[F[_]](config: CromwellRunnerAppConfig,
         raw"sam.acrPullActionIdentityResourceId=${params.billingProfileId.value}",
 
         // Bard configs
-        raw"bard.baseUri=${config.bardBaseUri}",
+        raw"bard.bardUrl=${config.bardBaseUri}",
         raw"bard.enabled=${config.bardEnabled}"
       )
     } yield Values(values.mkString(","))

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/app/CromwellRunnerAppInstallSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/app/CromwellRunnerAppInstallSpec.scala
@@ -67,7 +67,7 @@ class CromwellRunnerAppInstallSpec extends BaseAppInstallSpec {
       s"ecm.baseUri=https://externalcreds.dsde-dev.broadinstitute.org," +
       s"sam.baseUri=https://sam.test.org:443," +
       s"sam.acrPullActionIdentityResourceId=spend-profile," +
-      "bard.baseUri=https://terra-bard-dev.appspot.com," +
+      "bard.bardUrl=https://terra-bard-dev.appspot.com," +
       "bard.enabled=false"
   }
 


### PR DESCRIPTION
<!-- Welcome to your Leonardo pull request! -->
<!-- Contributor guidelines: https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md -->

__Jira ticket__: https://broadworkbench.atlassian.net/browse/ID-1276

Followup of this PR:
https://github.com/DataBiosphere/leonardo/pull/4664

## Summary of changes

When I made the last pr above I made a typo, should be referencing bardUrl and not baseUri. This has only been pushed out to dev so far. Terra helmfile chart where this is setup:
https://github.com/broadinstitute/terra-helmfile/blob/master/charts/cromwell-runner-app/templates/cromwell-config.yaml#L220

## Testing these changes

### What to test

After this is merged and terra-helmfile version updated ill try running a workflow on azure in dev. 

### Who tested and where

- [ ] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [ ] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
