### PR TITLE
check runtime delete action instead of workspace owner role

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/samModels.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/samModels.scala
@@ -239,6 +239,9 @@ object WsmResourceAction {
   final case object Read extends WsmResourceAction {
     val asString = "read"
   }
+  final case object Delete extends WsmResourceAction {
+    val asString = "delete"
+  }
   val allActions = sealerate.values[WsmResourceAction]
   val stringToAction: Map[String, WsmResourceAction] =
     sealerate.collect[WsmResourceAction].map(a => (a.asString, a)).toMap

--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/samModels.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/samModels.scala
@@ -223,6 +223,9 @@ object WorkspaceAction {
   final case object CreateControlledUserResource extends WorkspaceAction {
     val asString = "create_controlled_user_private"
   }
+  final case object Delete extends WorkspaceAction {
+    val asString = "delete"
+  }
 
   val allActions = sealerate.values[WorkspaceAction]
   val stringToAction: Map[String, WorkspaceAction] =
@@ -238,9 +241,6 @@ object WsmResourceAction {
   }
   final case object Read extends WsmResourceAction {
     val asString = "read"
-  }
-  final case object Delete extends WsmResourceAction {
-    val asString = "delete"
   }
   val allActions = sealerate.values[WsmResourceAction]
   val stringToAction: Map[String, WsmResourceAction] =

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeV2ServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeV2ServiceInterp.scala
@@ -301,7 +301,10 @@ class RuntimeV2ServiceInterp[F[_]: Parallel](
         if (runtime.auditInfo.creator == userInfo.userEmail) F.pure(true)
         else
           authProvider
-            .hasPermission[WsmResourceSamResourceId, WsmResourceAction](WsmResourceSamResourceId(wsmResourceId), WsmResourceAction.Delete, userInfo)
+            .hasPermission[WsmResourceSamResourceId, WsmResourceAction](WsmResourceSamResourceId(wsmResourceId),
+                                                                        WsmResourceAction.Delete,
+                                                                        userInfo
+            )
 
       _ <- ctx.span.traverse(s => F.delay(s.addAnnotation("Done auth call for delete azure runtime permission")))
       _ <- F


### PR DESCRIPTION
<!-- Welcome to your Leonardo pull request! -->
<!-- Contributor guidelines: https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md -->

__Jira ticket__: https://broadworkbench.atlassian.net/browse/IA-5025

## Summary of changes

allow users with workspace delete action instead of workspace owner role to delete runtimes

### Why

requiring owner role requires granting too much access to the rawls SA which needs to perform workspace delete

## Testing these changes

### What to test

- <!-- Test case 1 -->

<!-- ### Test data -->

### Who tested and where

- [ ] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [ ] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
