### PR TITLE
Ia 4997 third party cookies

### DIFF
--- a/http/src/main/resources/init-resources/cluster-site-gce.conf
+++ b/http/src/main/resources/init-resources/cluster-site-gce.conf
@@ -34,7 +34,7 @@
     # Append SameSite=None to cookies set by RStudio. This is required by some browsers because we
     # render RStudio in an iframe. There does not appear to be a way within RStudio to do this, hence
     # doing it in the proxy.
-    Header edit Set-Cookie ^(.*)$ $1;Secure;SameSite=None;HttpOnly "expr=%{REQUEST_URI} =~ m#/proxy/[^/]*/[^/]*/rstudio/.*#"
+    Header edit Set-Cookie ^(.*)$ $1;Secure;SameSite=None;HttpOnly;Partitioned "expr=%{REQUEST_URI} =~ m#/proxy/[^/]*/[^/]*/rstudio/.*#"
 
     ####################
     # Welder

--- a/http/src/main/resources/init-resources/cluster-site-gce.conf
+++ b/http/src/main/resources/init-resources/cluster-site-gce.conf
@@ -34,7 +34,8 @@
     # Append SameSite=None to cookies set by RStudio. This is required by some browsers because we
     # render RStudio in an iframe. There does not appear to be a way within RStudio to do this, hence
     # doing it in the proxy.
-    Header edit Set-Cookie ^(.*)$ $1;Secure;SameSite=None;HttpOnly;Partitioned "expr=%{REQUEST_URI} =~ m#/proxy/[^/]*/[^/]*/rstudio/.*#"
+    # Header edit Set-Cookie ^(.*)$ $1;Secure;SameSite=None;HttpOnly;Partitioned "expr=%{REQUEST_URI} =~ m#/proxy/[^/]*/[^/]*/rstudio/.*#"
+    Header edit Set-Cookie ^(.*)$ $1;Secure;SameSite=None;HttpOnly "expr=%{REQUEST_URI} =~ m#/proxy/[^/]*/[^/]*/rstudio/.*#"
 
     ####################
     # Welder

--- a/http/src/main/resources/init-resources/cluster-site-gce.conf
+++ b/http/src/main/resources/init-resources/cluster-site-gce.conf
@@ -34,6 +34,7 @@
     # Append SameSite=None to cookies set by RStudio. This is required by some browsers because we
     # render RStudio in an iframe. There does not appear to be a way within RStudio to do this, hence
     # doing it in the proxy.
+    # [IA-4997] to support CHIPS by setting partitioned cookies
     # Header edit Set-Cookie ^(.*)$ $1;Secure;SameSite=None;HttpOnly;Partitioned "expr=%{REQUEST_URI} =~ m#/proxy/[^/]*/[^/]*/rstudio/.*#"
     Header edit Set-Cookie ^(.*)$ $1;Secure;SameSite=None;HttpOnly "expr=%{REQUEST_URI} =~ m#/proxy/[^/]*/[^/]*/rstudio/.*#"
 

--- a/http/src/main/resources/init-resources/cluster-site.conf
+++ b/http/src/main/resources/init-resources/cluster-site.conf
@@ -55,6 +55,7 @@
     # Append SameSite=None to cookies set by RStudio. This is required by some browsers because we
     # render RStudio in an iframe. There does not appear to be a way within RStudio to do this, hence
     # doing it in the proxy.
+    # [IA-4997] to support CHIPS by setting partitioned cookies
     # Header edit Set-Cookie ^(.*)$ $1;Secure;SameSite=None;HttpOnly;Partitioned "expr=%{REQUEST_URI} =~ m#/proxy/[^/]*/[^/]*/rstudio/.*#"
     Header edit Set-Cookie ^(.*)$ $1;Secure;SameSite=None;HttpOnly "expr=%{REQUEST_URI} =~ m#/proxy/[^/]*/[^/]*/rstudio/.*#"
 

--- a/http/src/main/resources/init-resources/cluster-site.conf
+++ b/http/src/main/resources/init-resources/cluster-site.conf
@@ -55,7 +55,8 @@
     # Append SameSite=None to cookies set by RStudio. This is required by some browsers because we
     # render RStudio in an iframe. There does not appear to be a way within RStudio to do this, hence
     # doing it in the proxy.
-    Header edit Set-Cookie ^(.*)$ $1;Secure;SameSite=None;HttpOnly;Partitioned "expr=%{REQUEST_URI} =~ m#/proxy/[^/]*/[^/]*/rstudio/.*#"
+    # Header edit Set-Cookie ^(.*)$ $1;Secure;SameSite=None;HttpOnly;Partitioned "expr=%{REQUEST_URI} =~ m#/proxy/[^/]*/[^/]*/rstudio/.*#"
+    Header edit Set-Cookie ^(.*)$ $1;Secure;SameSite=None;HttpOnly "expr=%{REQUEST_URI} =~ m#/proxy/[^/]*/[^/]*/rstudio/.*#"
 
     ####################
     # Welder

--- a/http/src/main/resources/init-resources/cluster-site.conf
+++ b/http/src/main/resources/init-resources/cluster-site.conf
@@ -55,7 +55,7 @@
     # Append SameSite=None to cookies set by RStudio. This is required by some browsers because we
     # render RStudio in an iframe. There does not appear to be a way within RStudio to do this, hence
     # doing it in the proxy.
-    Header edit Set-Cookie ^(.*)$ $1;Secure;SameSite=None;HttpOnly "expr=%{REQUEST_URI} =~ m#/proxy/[^/]*/[^/]*/rstudio/.*#"
+    Header edit Set-Cookie ^(.*)$ $1;Secure;SameSite=None;HttpOnly;Partitioned "expr=%{REQUEST_URI} =~ m#/proxy/[^/]*/[^/]*/rstudio/.*#"
 
     ####################
     # Welder

--- a/http/src/main/resources/leo.conf
+++ b/http/src/main/resources/leo.conf
@@ -65,6 +65,7 @@ proxy {
   # Should match the jupyter wildcard cert
   proxyDomain = ${?PROXY_DOMAIN}
   proxyUrlBase = ${?PROXY_URL_BASE}
+  isProxyCookiePartitioned = ${?IS_PROXY_COOKIE_PARTITIONED}
 }
 
 app-service.enable-custom-app-check = ${?CUSTOM_APP_GROUP_PERMISSION_CHECK}

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -253,6 +253,7 @@ azure {
         minor-version-auto-upgrade = true,
         file-uris = ["https://raw.githubusercontent.com/DataBiosphere/leonardo/8390d25ccd761fb206cf388560a571be77a42bbd/http/src/main/resources/init-resources/azure_vm_init_script.sh"]
       }
+      # [IA-4997] to support CHIPS by setting partitioned cookies
       # listener-image = "terradevacrpublic.azurecr.io/terra-azure-relay-listeners:474f157"
       listener-image = "terradevacrpublic.azurecr.io/terra-azure-relay-listeners:76d982c"
     }

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -1014,6 +1014,7 @@ proxy {
   tokenCacheMaxSize = 5000
   internalIdCacheExpiryTime = 2 minutes
   internalIdCacheMaxSize = 500
+  isProxyCookiePartitioned = false
 }
 
 # The fields here will be combined to build a Content-Security-Policy header

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -253,7 +253,8 @@ azure {
         minor-version-auto-upgrade = true,
         file-uris = ["https://raw.githubusercontent.com/DataBiosphere/leonardo/8390d25ccd761fb206cf388560a571be77a42bbd/http/src/main/resources/init-resources/azure_vm_init_script.sh"]
       }
-      listener-image = "terradevacrpublic.azurecr.io/terra-azure-relay-listeners:474f157"
+      # listener-image = "terradevacrpublic.azurecr.io/terra-azure-relay-listeners:474f157"
+      listener-image = "terradevacrpublic.azurecr.io/terra-azure-relay-listeners:76d982c"
     }
   }
 

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -253,7 +253,7 @@ azure {
         minor-version-auto-upgrade = true,
         file-uris = ["https://raw.githubusercontent.com/DataBiosphere/leonardo/8390d25ccd761fb206cf388560a571be77a42bbd/http/src/main/resources/init-resources/azure_vm_init_script.sh"]
       }
-      listener-image = "terradevacrpublic.azurecr.io/terra-azure-relay-listeners:76d982c"
+      listener-image = "terradevacrpublic.azurecr.io/terra-azure-relay-listeners:474f157"
     }
   }
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
@@ -254,7 +254,8 @@ object Config {
       toScalaDuration(config.getDuration("tokenCacheExpiryTime")),
       config.getInt("tokenCacheMaxSize"),
       toScalaDuration(config.getDuration("internalIdCacheExpiryTime")),
-      config.getInt("internalIdCacheMaxSize")
+      config.getInt("internalIdCacheMaxSize"),
+      config.getBoolean("isProxyCookiePartitioned")
     )
   }
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/ProxyConfig.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/ProxyConfig.scala
@@ -12,7 +12,7 @@ case class ProxyConfig(proxyDomain: String,
                        tokenCacheMaxSize: Int,
                        internalIdCacheExpiryTime: FiniteDuration,
                        internalIdCacheMaxSize: Int,
-                       isProxyCookiePartitioned: boolean
+                       isProxyCookiePartitioned: Boolean
 ) {
   def getProxyServerHostName: String = {
     val url = new URL(proxyUrlBase)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/ProxyConfig.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/ProxyConfig.scala
@@ -11,7 +11,8 @@ case class ProxyConfig(proxyDomain: String,
                        tokenCacheExpiryTime: FiniteDuration,
                        tokenCacheMaxSize: Int,
                        internalIdCacheExpiryTime: FiniteDuration,
-                       internalIdCacheMaxSize: Int
+                       internalIdCacheMaxSize: Int,
+                       isProxyCookiePartitioned: boolean
 ) {
   def getProxyServerHostName: String = {
     val url = new URL(proxyUrlBase)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/CookieSupport.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/CookieSupport.scala
@@ -9,7 +9,6 @@ import java.net.URL
 import org.broadinstitute.dsde.workbench.leonardo.config.Config
 import org.broadinstitute.dsde.workbench.model.UserInfo
 
-
 object CookieSupport {
   val tokenCookieName = "LeoToken"
   val proxyTokenCookieName = "LeoProxyToken"

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/CookieSupport.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/CookieSupport.scala
@@ -4,11 +4,16 @@ package api
 import akka.http.scaladsl.model.headers.RawHeader
 import akka.http.scaladsl.server.Directive0
 import akka.http.scaladsl.server.directives.RespondWithDirectives.respondWithHeaders
+import java.net.URL
+
+import org.broadinstitute.dsde.workbench.leonardo.config.Config
 import org.broadinstitute.dsde.workbench.model.UserInfo
+
 
 object CookieSupport {
   val tokenCookieName = "LeoToken"
   val proxyTokenCookieName = "LeoProxyToken"
+  val proxyUrl = new URL(Config.proxyConfig.proxyUrlBase)
 
   /**
    * Sets a token cookie in the HTTP response.
@@ -40,13 +45,13 @@ object CookieSupport {
     RawHeader(
       name = "Set-Cookie",
       value =
-        s"$proxyTokenCookieName=${userInfo.accessToken.token}; Domain=leonardo.dsde-dev.broadinstitute.org; Max-Age=${userInfo.tokenExpiresIn.toString}; Path=/; Secure; SameSite=None; HttpOnly; Partitioned"
+        s"$proxyTokenCookieName=${userInfo.accessToken.token}; Domain=${proxyUrl.getHost}; Max-Age=${userInfo.tokenExpiresIn.toString}; Path=/; Secure; SameSite=None; HttpOnly; Partitioned"
     )
 
   private def buildRawUnsetProxyCookie(): RawHeader =
     RawHeader(
       name = "Set-Cookie",
       value =
-        s"$proxyTokenCookieName=unset; Domain=leonardo.dsde-dev.broadinstitute.org; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Path=/; Secure; SameSite=None; HttpOnly; Partitioned"
+        s"$proxyTokenCookieName=unset; Domain=${proxyUrl.getHost}; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Path=/; Secure; SameSite=None; HttpOnly; Partitioned"
     )
 }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/CookieSupport.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/CookieSupport.scala
@@ -14,18 +14,25 @@ object CookieSupport {
   val partitionedTokenCookieName = "TerraToken"
   val partitionedProxyTokenCookieName = "LeoProxyToken"
   val proxyUrl = new URL(Config.proxyConfig.proxyUrlBase)
+  val isPartitioned = Config.proxyConfig.isProxyCookiePartitioned
 
   /**
    * Sets a token cookie in the HTTP response.
    */
   def setTokenCookie(userInfo: UserInfo): Directive0 =
-    respondWithHeaders(buildRawCookie(userInfo), buildRawTerraCookie(userInfo), buildRawProxyCookie(userInfo))
+    if (isPartitioned)
+      respondWithHeaders(buildRawCookie(userInfo), buildRawTerraCookie(userInfo), buildRawProxyCookie(userInfo))
+    else
+      respondWithHeaders(buildRawCookie(userInfo))
 
   /**
    * Unsets a token cookie in the HTTP response.
    */
   def unsetTokenCookie(): Directive0 =
-    respondWithHeaders(buildRawUnsetCookie(), buildRawUnsetTerraCookie(), buildRawUnsetProxyCookie())
+    if (isPartitioned)
+      respondWithHeaders(buildRawUnsetCookie(), buildRawUnsetTerraCookie(), buildRawUnsetProxyCookie())
+    else
+      respondWithHeaders(buildRawUnsetCookie())
 
   private def buildRawCookie(userInfo: UserInfo) =
     RawHeader(
@@ -37,8 +44,7 @@ object CookieSupport {
   private def buildRawUnsetCookie(): RawHeader =
     RawHeader(
       name = "Set-Cookie",
-      value =
-        s"$tokenCookieName=unset; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Path=/; Secure; SameSite=None; HttpOnly"
+      value = s"$tokenCookieName=unset; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Path=/; Secure; SameSite=None; HttpOnly"
     )
 
   private def buildRawTerraCookie(userInfo: UserInfo) =

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/CookieSupport.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/CookieSupport.scala
@@ -8,18 +8,19 @@ import org.broadinstitute.dsde.workbench.model.UserInfo
 
 object CookieSupport {
   val tokenCookieName = "LeoToken"
+  val proxyTokenCookieName = "LeoProxyToken"
 
   /**
    * Sets a token cookie in the HTTP response.
    */
   def setTokenCookie(userInfo: UserInfo): Directive0 =
-    respondWithHeaders(buildRawCookie(userInfo))
+    respondWithHeaders(buildRawCookie(userInfo), buildRawProxyCookie(userInfo))
 
   /**
    * Unsets a token cookie in the HTTP response.
    */
   def unsetTokenCookie(): Directive0 =
-    respondWithHeaders(buildRawUnsetCookie())
+    respondWithHeaders(buildRawUnsetCookie(), buildRawUnsetProxyCookie())
 
   private def buildRawCookie(userInfo: UserInfo) =
     RawHeader(
@@ -32,7 +33,20 @@ object CookieSupport {
     RawHeader(
       name = "Set-Cookie",
       value =
-        s"$tokenCookieName=unset; expires=Thu, 01 Jan 1970 00:00:00 GMT; Path=/; Secure; SameSite=None; HttpOnly; Partitioned"
+        s"$tokenCookieName=unset; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Path=/; Secure; SameSite=None; HttpOnly; Partitioned"
     )
 
+  private def buildRawProxyCookie(userInfo: UserInfo) =
+    RawHeader(
+      name = "Set-Cookie",
+      value =
+        s"$proxyTokenCookieName=${userInfo.accessToken.token}; Domain=leonardo.dsde-dev.broadinstitute.org; Max-Age=${userInfo.tokenExpiresIn.toString}; Path=/; Secure; SameSite=None; HttpOnly; Partitioned"
+    )
+
+  private def buildRawUnsetProxyCookie(): RawHeader =
+    RawHeader(
+      name = "Set-Cookie",
+      value =
+        s"$proxyTokenCookieName=unset; Domain=leonardo.dsde-dev.broadinstitute.org; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Path=/; Secure; SameSite=None; HttpOnly; Partitioned"
+    )
 }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/CookieSupport.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/CookieSupport.scala
@@ -1,7 +1,7 @@
 package org.broadinstitute.dsde.workbench.leonardo.http
 package api
 
-import akka.http.scaladsl.model.headers.{HttpCookie, RawHeader}
+import akka.http.scaladsl.model.headers.RawHeader
 import akka.http.scaladsl.server.Directive0
 import akka.http.scaladsl.server.directives.RespondWithDirectives.respondWithHeaders
 import org.broadinstitute.dsde.workbench.model.UserInfo
@@ -9,16 +9,10 @@ import org.broadinstitute.dsde.workbench.model.UserInfo
 object CookieSupport {
   val tokenCookieName = "LeoToken"
 
-  // TODO: in the below 2 methods we set a cookie by building a RawHeader because the cookie
-  // SameSite attribute is not natively supported in akka-http. Support is tentatively
-  // slated for version 10.2.0, after which we can switch back to using HttpCookie.
-  // See https://github.com/akka/akka-http/issues/1354
-
   /**
    * Sets a token cookie in the HTTP response.
    */
   def setTokenCookie(userInfo: UserInfo): Directive0 =
-    // setCookie(buildCookie(userInfo, cookieName))
     respondWithHeaders(buildRawCookie(userInfo))
 
   /**
@@ -27,27 +21,18 @@ object CookieSupport {
   def unsetTokenCookie(): Directive0 =
     respondWithHeaders(buildRawUnsetCookie())
 
-  private def buildCookie(userInfo: UserInfo, cookieName: String): HttpCookie =
-    HttpCookie(
-      name = cookieName,
-      value = userInfo.accessToken.token,
-      secure = true, // cookie is only sent for SSL requests
-      domain = None, // Do not specify domain, making it default to Leo's domain
-      maxAge = Option(userInfo.tokenExpiresIn), // cookie expiry is tied to the token expiry
-      path = Some("/") // needed so it works for AJAX requests
-    )
-
   private def buildRawCookie(userInfo: UserInfo) =
     RawHeader(
       name = "Set-Cookie",
       value =
-        s"$tokenCookieName=${userInfo.accessToken.token}; Max-Age=${userInfo.tokenExpiresIn.toString}; Path=/; Secure; SameSite=None; HttpOnly"
+        s"$tokenCookieName=${userInfo.accessToken.token}; Max-Age=${userInfo.tokenExpiresIn.toString}; Path=/; Secure; SameSite=None; HttpOnly; Partitioned"
     )
 
   private def buildRawUnsetCookie(): RawHeader =
     RawHeader(
       name = "Set-Cookie",
-      value = s"$tokenCookieName=unset; expires=Thu, 01 Jan 1970 00:00:00 GMT; Path=/; Secure; SameSite=None; HttpOnly"
+      value =
+        s"$tokenCookieName=unset; expires=Thu, 01 Jan 1970 00:00:00 GMT; Path=/; Secure; SameSite=None; HttpOnly; Partitioned"
     )
 
 }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/CookieSupport.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/CookieSupport.scala
@@ -11,46 +11,61 @@ import org.broadinstitute.dsde.workbench.model.UserInfo
 
 object CookieSupport {
   val tokenCookieName = "LeoToken"
-  val proxyTokenCookieName = "LeoProxyToken"
+  val partitionedTokenCookieName = "TerraToken"
+  val partitionedProxyTokenCookieName = "LeoProxyToken"
   val proxyUrl = new URL(Config.proxyConfig.proxyUrlBase)
 
   /**
    * Sets a token cookie in the HTTP response.
    */
   def setTokenCookie(userInfo: UserInfo): Directive0 =
-    respondWithHeaders(buildRawCookie(userInfo), buildRawProxyCookie(userInfo))
+    respondWithHeaders(buildRawCookie(userInfo), buildRawTerraCookie(userInfo), buildRawProxyCookie(userInfo))
 
   /**
    * Unsets a token cookie in the HTTP response.
    */
   def unsetTokenCookie(): Directive0 =
-    respondWithHeaders(buildRawUnsetCookie(), buildRawUnsetProxyCookie())
+    respondWithHeaders(buildRawUnsetCookie(), buildRawUnsetTerraCookie(), buildRawUnsetProxyCookie())
 
   private def buildRawCookie(userInfo: UserInfo) =
     RawHeader(
       name = "Set-Cookie",
       value =
-        s"$tokenCookieName=${userInfo.accessToken.token}; Max-Age=${userInfo.tokenExpiresIn.toString}; Path=/; Secure; SameSite=None; HttpOnly; Partitioned"
+        s"$tokenCookieName=${userInfo.accessToken.token}; Max-Age=${userInfo.tokenExpiresIn.toString}; Path=/; Secure; SameSite=None; HttpOnly"
     )
 
   private def buildRawUnsetCookie(): RawHeader =
     RawHeader(
       name = "Set-Cookie",
       value =
-        s"$tokenCookieName=unset; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Path=/; Secure; SameSite=None; HttpOnly; Partitioned"
+        s"$tokenCookieName=unset; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Path=/; Secure; SameSite=None; HttpOnly"
+    )
+
+  private def buildRawTerraCookie(userInfo: UserInfo) =
+    RawHeader(
+      name = "Set-Cookie",
+      value =
+        s"$partitionedTokenCookieName=${userInfo.accessToken.token}; Max-Age=${userInfo.tokenExpiresIn.toString}; Path=/; Secure; SameSite=None; HttpOnly; Partitioned"
+    )
+
+  private def buildRawUnsetTerraCookie(): RawHeader =
+    RawHeader(
+      name = "Set-Cookie",
+      value =
+        s"$partitionedTokenCookieName=unset; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Path=/; Secure; SameSite=None; HttpOnly; Partitioned"
     )
 
   private def buildRawProxyCookie(userInfo: UserInfo) =
     RawHeader(
       name = "Set-Cookie",
       value =
-        s"$proxyTokenCookieName=${userInfo.accessToken.token}; Domain=${proxyUrl.getHost}; Max-Age=${userInfo.tokenExpiresIn.toString}; Path=/; Secure; SameSite=None; HttpOnly; Partitioned"
+        s"$partitionedProxyTokenCookieName=${userInfo.accessToken.token}; Domain=${proxyUrl.getHost}; Max-Age=${userInfo.tokenExpiresIn.toString}; Path=/; Secure; SameSite=None; HttpOnly; Partitioned"
     )
 
   private def buildRawUnsetProxyCookie(): RawHeader =
     RawHeader(
       name = "Set-Cookie",
       value =
-        s"$proxyTokenCookieName=unset; Domain=${proxyUrl.getHost}; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Path=/; Secure; SameSite=None; HttpOnly; Partitioned"
+        s"$partitionedProxyTokenCookieName=unset; Domain=${proxyUrl.getHost}; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Path=/; Secure; SameSite=None; HttpOnly; Partitioned"
     )
 }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/BuildHelmChartValues.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/BuildHelmChartValues.scala
@@ -381,7 +381,7 @@ private[leonardo] object BuildHelmChartValues {
       raw"""ingress.annotations.nginx\.ingress\.kubernetes\.io/auth-tls-secret=${namespaceName.value}/ca-secret""",
       raw"""ingress.annotations.nginx\.ingress\.kubernetes\.io/proxy-redirect-to=${leoProxyhost}${ingressPath}""",
       raw"""ingress.annotations.nginx\.ingress\.kubernetes\.io/rewrite-target=/${rewriteTarget}""",
-      raw"""ingress.annotations.nginx\.ingress\.kubernetes\.io/proxy-cookie-path=/ "/; Secure; SameSite=None; HttpOnly"""",
+      raw"""ingress.annotations.nginx\.ingress\.kubernetes\.io/proxy-cookie-path=/ "/; Secure; SameSite=None; HttpOnly; Partitioned"""",
       raw"""ingress.host=${k8sProxyHostString}""",
       raw"""ingress.tls[0].secretName=tls-secret""",
       raw"""ingress.tls[0].hosts[0]=${k8sProxyHostString}"""

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/BuildHelmChartValues.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/BuildHelmChartValues.scala
@@ -381,7 +381,8 @@ private[leonardo] object BuildHelmChartValues {
       raw"""ingress.annotations.nginx\.ingress\.kubernetes\.io/auth-tls-secret=${namespaceName.value}/ca-secret""",
       raw"""ingress.annotations.nginx\.ingress\.kubernetes\.io/proxy-redirect-to=${leoProxyhost}${ingressPath}""",
       raw"""ingress.annotations.nginx\.ingress\.kubernetes\.io/rewrite-target=/${rewriteTarget}""",
-      raw"""ingress.annotations.nginx\.ingress\.kubernetes\.io/proxy-cookie-path=/ "/; Secure; SameSite=None; HttpOnly; Partitioned"""",
+      // raw"""ingress.annotations.nginx\.ingress\.kubernetes\.io/proxy-cookie-path=/ "/; Secure; SameSite=None; HttpOnly; Partitioned"""",
+      raw"""ingress.annotations.nginx\.ingress\.kubernetes\.io/proxy-cookie-path=/ "/; Secure; SameSite=None; HttpOnly"""",
       raw"""ingress.host=${k8sProxyHostString}""",
       raw"""ingress.tls[0].secretName=tls-secret""",
       raw"""ingress.tls[0].hosts[0]=${k8sProxyHostString}"""

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/BuildHelmChartValues.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/BuildHelmChartValues.scala
@@ -381,6 +381,7 @@ private[leonardo] object BuildHelmChartValues {
       raw"""ingress.annotations.nginx\.ingress\.kubernetes\.io/auth-tls-secret=${namespaceName.value}/ca-secret""",
       raw"""ingress.annotations.nginx\.ingress\.kubernetes\.io/proxy-redirect-to=${leoProxyhost}${ingressPath}""",
       raw"""ingress.annotations.nginx\.ingress\.kubernetes\.io/rewrite-target=/${rewriteTarget}""",
+      // [IA-4997] to support CHIPS by setting partitioned cookies
       // raw"""ingress.annotations.nginx\.ingress\.kubernetes\.io/proxy-cookie-path=/ "/; Secure; SameSite=None; HttpOnly; Partitioned"""",
       raw"""ingress.annotations.nginx\.ingress\.kubernetes\.io/proxy-cookie-path=/ "/; Secure; SameSite=None; HttpOnly"""",
       raw"""ingress.host=${k8sProxyHostString}""",

--- a/http/src/test/resources/reference.conf
+++ b/http/src/test/resources/reference.conf
@@ -147,6 +147,7 @@ proxy {
   proxyDomain = ".jupyter.firecloud.org"
   proxyUrlBase = "https://leo/proxy/"
   proxyPort = 8001
+  isProxyCookiePartitioned = false
 }
 
 oidc {

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/ConfigReaderSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/ConfigReaderSpec.scala
@@ -76,7 +76,7 @@ class ConfigReaderSpec extends AnyFlatSpec with Matchers {
                 "https://raw.githubusercontent.com/DataBiosphere/leonardo/8390d25ccd761fb206cf388560a571be77a42bbd/http/src/main/resources/init-resources/azure_vm_init_script.sh"
               )
             ),
-            "terradevacrpublic.azurecr.io/terra-azure-relay-listeners:76d982c",
+            "terradevacrpublic.azurecr.io/terra-azure-relay-listeners:474f157",
             VMCredential(username = "username", password = "password")
           ),
           PollMonitorConfig(1 seconds, 10, 1 seconds),

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/ConfigReaderSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/ConfigReaderSpec.scala
@@ -76,7 +76,8 @@ class ConfigReaderSpec extends AnyFlatSpec with Matchers {
                 "https://raw.githubusercontent.com/DataBiosphere/leonardo/8390d25ccd761fb206cf388560a571be77a42bbd/http/src/main/resources/init-resources/azure_vm_init_script.sh"
               )
             ),
-            "terradevacrpublic.azurecr.io/terra-azure-relay-listeners:474f157",
+            // "terradevacrpublic.azurecr.io/terra-azure-relay-listeners:474f157",
+            "terradevacrpublic.azurecr.io/terra-azure-relay-listeners:76d982c",
             VMCredential(username = "username", password = "password")
           ),
           PollMonitorConfig(1 seconds, 10, 1 seconds),

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/ConfigReaderSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/ConfigReaderSpec.scala
@@ -76,6 +76,7 @@ class ConfigReaderSpec extends AnyFlatSpec with Matchers {
                 "https://raw.githubusercontent.com/DataBiosphere/leonardo/8390d25ccd761fb206cf388560a571be77a42bbd/http/src/main/resources/init-resources/azure_vm_init_script.sh"
               )
             ),
+            // [IA-4997] to support CHIPS by setting partitioned cookies
             // "terradevacrpublic.azurecr.io/terra-azure-relay-listeners:474f157",
             "terradevacrpublic.azurecr.io/terra-azure-relay-listeners:76d982c",
             VMCredential(username = "username", password = "password")

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/TestLeoRoutes.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/TestLeoRoutes.scala
@@ -270,6 +270,6 @@ trait TestLeoRoutes {
   ): Unit = {
     setCookie shouldBe defined
     setCookie.get.name shouldBe "Set-Cookie"
-    setCookie.get.value shouldBe s"${tokenName}=unset; expires=Thu, 01 Jan 1970 00:00:00 GMT; Path=/; Secure; SameSite=None; HttpOnly"
+    setCookie.get.value shouldBe s"${tokenName}=unset; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Path=/; Secure; SameSite=None; HttpOnly"
   }
 }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/TestLeoRoutes.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/TestLeoRoutes.scala
@@ -262,7 +262,7 @@ trait TestLeoRoutes {
     val replaced =
       cookieMaxAgeRegex.replaceAllIn(setCookie.get.value, m => s"Max-Age=${roundUpToNearestTen(m.group(1).toLong)};")
 
-    replaced shouldBe s"${expectedCookie.name}=${expectedCookie.value}; Max-Age=${age.toString}; Path=/; Secure; SameSite=None; HttpOnly"
+    replaced shouldBe s"${expectedCookie.name}=${expectedCookie.value}; Max-Age=${age.toString}; Path=/; Secure; SameSite=None; HttpOnly; Partitioned"
   }
 
   protected def validateUnsetRawCookie(setCookie: Option[HttpHeader],
@@ -270,6 +270,6 @@ trait TestLeoRoutes {
   ): Unit = {
     setCookie shouldBe defined
     setCookie.get.name shouldBe "Set-Cookie"
-    setCookie.get.value shouldBe s"${tokenName}=unset; expires=Thu, 01 Jan 1970 00:00:00 GMT; Path=/; Secure; SameSite=None; HttpOnly"
+    setCookie.get.value shouldBe s"${tokenName}=unset; expires=Thu, 01 Jan 1970 00:00:00 GMT; Path=/; Secure; SameSite=None; HttpOnly; Partitioned"
   }
 }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/TestLeoRoutes.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/TestLeoRoutes.scala
@@ -262,7 +262,7 @@ trait TestLeoRoutes {
     val replaced =
       cookieMaxAgeRegex.replaceAllIn(setCookie.get.value, m => s"Max-Age=${roundUpToNearestTen(m.group(1).toLong)};")
 
-    replaced shouldBe s"${expectedCookie.name}=${expectedCookie.value}; Max-Age=${age.toString}; Path=/; Secure; SameSite=None; HttpOnly; Partitioned"
+    replaced shouldBe s"${expectedCookie.name}=${expectedCookie.value}; Max-Age=${age.toString}; Path=/; Secure; SameSite=None; HttpOnly"
   }
 
   protected def validateUnsetRawCookie(setCookie: Option[HttpHeader],
@@ -270,6 +270,6 @@ trait TestLeoRoutes {
   ): Unit = {
     setCookie shouldBe defined
     setCookie.get.name shouldBe "Set-Cookie"
-    setCookie.get.value shouldBe s"${tokenName}=unset; expires=Thu, 01 Jan 1970 00:00:00 GMT; Path=/; Secure; SameSite=None; HttpOnly; Partitioned"
+    setCookie.get.value shouldBe s"${tokenName}=unset; expires=Thu, 01 Jan 1970 00:00:00 GMT; Path=/; Secure; SameSite=None; HttpOnly"
   }
 }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/BuildHelmChartValuesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/BuildHelmChartValuesSpec.scala
@@ -311,7 +311,8 @@ class BuildHelmChartValuesSpec extends AnyFlatSpecLike with LeonardoTestSuite {
       """ingress.annotations.nginx\.ingress\.kubernetes\.io/auth-tls-secret=ns/ca-secret,""" +
       """ingress.annotations.nginx\.ingress\.kubernetes\.io/proxy-redirect-to=https://leo/proxy/google/v1/apps/dsp-leo-test1/app1/app,""" +
       """ingress.annotations.nginx\.ingress\.kubernetes\.io/rewrite-target=/$2,""" +
-      """ingress.annotations.nginx\.ingress\.kubernetes\.io/proxy-cookie-path=/ "/; Secure; SameSite=None; HttpOnly; Partitioned",""" +
+      // """ingress.annotations.nginx\.ingress\.kubernetes\.io/proxy-cookie-path=/ "/; Secure; SameSite=None; HttpOnly; Partitioned",""" +
+      """ingress.annotations.nginx\.ingress\.kubernetes\.io/proxy-cookie-path=/ "/; Secure; SameSite=None; HttpOnly",""" +
       """ingress.host=1455694897.jupyter.firecloud.org,""" +
       """ingress.tls[0].secretName=tls-secret,""" +
       """ingress.tls[0].hosts[0]=1455694897.jupyter.firecloud.org,""" +
@@ -371,7 +372,8 @@ class BuildHelmChartValuesSpec extends AnyFlatSpecLike with LeonardoTestSuite {
       """ingress.annotations.nginx\.ingress\.kubernetes\.io/auth-tls-secret=ns/ca-secret,""" +
       """ingress.annotations.nginx\.ingress\.kubernetes\.io/proxy-redirect-to=https://leo/proxy/google/v1/apps/dsp-leo-test1/app1/app,""" +
       """ingress.annotations.nginx\.ingress\.kubernetes\.io/rewrite-target=/$2,""" +
-      """ingress.annotations.nginx\.ingress\.kubernetes\.io/proxy-cookie-path=/ "/; Secure; SameSite=None; HttpOnly; Partitioned",""" +
+      // """ingress.annotations.nginx\.ingress\.kubernetes\.io/proxy-cookie-path=/ "/; Secure; SameSite=None; HttpOnly; Partitioned",""" +
+      """ingress.annotations.nginx\.ingress\.kubernetes\.io/proxy-cookie-path=/ "/; Secure; SameSite=None; HttpOnly",""" +
       """ingress.host=1455694897.jupyter.firecloud.org,""" +
       """ingress.tls[0].secretName=tls-secret,""" +
       """ingress.tls[0].hosts[0]=1455694897.jupyter.firecloud.org,""" +
@@ -430,7 +432,8 @@ class BuildHelmChartValuesSpec extends AnyFlatSpecLike with LeonardoTestSuite {
       """ingress.annotations.nginx\.ingress\.kubernetes\.io/auth-tls-secret=ns/ca-secret,""" +
       """ingress.annotations.nginx\.ingress\.kubernetes\.io/proxy-redirect-to=https://leo/proxy/google/v1/apps/dsp-leo-test1/app1/app,""" +
       """ingress.annotations.nginx\.ingress\.kubernetes\.io/rewrite-target=/$2,""" +
-      """ingress.annotations.nginx\.ingress\.kubernetes\.io/proxy-cookie-path=/ "/; Secure; SameSite=None; HttpOnly; Partitioned",""" +
+      // """ingress.annotations.nginx\.ingress\.kubernetes\.io/proxy-cookie-path=/ "/; Secure; SameSite=None; HttpOnly; Partitioned",""" +
+      """ingress.annotations.nginx\.ingress\.kubernetes\.io/proxy-cookie-path=/ "/; Secure; SameSite=None; HttpOnly",""" +
       """ingress.host=1455694897.jupyter.firecloud.org,""" +
       """ingress.tls[0].secretName=tls-secret,""" +
       """ingress.tls[0].hosts[0]=1455694897.jupyter.firecloud.org,""" +
@@ -500,7 +503,8 @@ class BuildHelmChartValuesSpec extends AnyFlatSpecLike with LeonardoTestSuite {
       """ingress.annotations.nginx\.ingress\.kubernetes\.io/auth-tls-secret=ns/ca-secret,""" +
       """ingress.annotations.nginx\.ingress\.kubernetes\.io/proxy-redirect-to=https://leo/proxy/google/v1/apps/dsp-leo-test1/app1/app,""" +
       """ingress.annotations.nginx\.ingress\.kubernetes\.io/rewrite-target=/$2,""" +
-      """ingress.annotations.nginx\.ingress\.kubernetes\.io/proxy-cookie-path=/ "/; Secure; SameSite=None; HttpOnly; Partitioned",""" +
+      // """ingress.annotations.nginx\.ingress\.kubernetes\.io/proxy-cookie-path=/ "/; Secure; SameSite=None; HttpOnly; Partitioned",""" +
+      """ingress.annotations.nginx\.ingress\.kubernetes\.io/proxy-cookie-path=/ "/; Secure; SameSite=None; HttpOnly",""" +
       """ingress.host=1455694897.jupyter.firecloud.org,""" +
       """ingress.tls[0].secretName=tls-secret,""" +
       """ingress.tls[0].hosts[0]=1455694897.jupyter.firecloud.org,""" +

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/BuildHelmChartValuesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/BuildHelmChartValuesSpec.scala
@@ -311,6 +311,7 @@ class BuildHelmChartValuesSpec extends AnyFlatSpecLike with LeonardoTestSuite {
       """ingress.annotations.nginx\.ingress\.kubernetes\.io/auth-tls-secret=ns/ca-secret,""" +
       """ingress.annotations.nginx\.ingress\.kubernetes\.io/proxy-redirect-to=https://leo/proxy/google/v1/apps/dsp-leo-test1/app1/app,""" +
       """ingress.annotations.nginx\.ingress\.kubernetes\.io/rewrite-target=/$2,""" +
+      // [IA-4997] to support CHIPS by setting partitioned cookies
       // """ingress.annotations.nginx\.ingress\.kubernetes\.io/proxy-cookie-path=/ "/; Secure; SameSite=None; HttpOnly; Partitioned",""" +
       """ingress.annotations.nginx\.ingress\.kubernetes\.io/proxy-cookie-path=/ "/; Secure; SameSite=None; HttpOnly",""" +
       """ingress.host=1455694897.jupyter.firecloud.org,""" +
@@ -372,6 +373,7 @@ class BuildHelmChartValuesSpec extends AnyFlatSpecLike with LeonardoTestSuite {
       """ingress.annotations.nginx\.ingress\.kubernetes\.io/auth-tls-secret=ns/ca-secret,""" +
       """ingress.annotations.nginx\.ingress\.kubernetes\.io/proxy-redirect-to=https://leo/proxy/google/v1/apps/dsp-leo-test1/app1/app,""" +
       """ingress.annotations.nginx\.ingress\.kubernetes\.io/rewrite-target=/$2,""" +
+      // [IA-4997] to support CHIPS by setting partitioned cookies
       // """ingress.annotations.nginx\.ingress\.kubernetes\.io/proxy-cookie-path=/ "/; Secure; SameSite=None; HttpOnly; Partitioned",""" +
       """ingress.annotations.nginx\.ingress\.kubernetes\.io/proxy-cookie-path=/ "/; Secure; SameSite=None; HttpOnly",""" +
       """ingress.host=1455694897.jupyter.firecloud.org,""" +
@@ -432,6 +434,7 @@ class BuildHelmChartValuesSpec extends AnyFlatSpecLike with LeonardoTestSuite {
       """ingress.annotations.nginx\.ingress\.kubernetes\.io/auth-tls-secret=ns/ca-secret,""" +
       """ingress.annotations.nginx\.ingress\.kubernetes\.io/proxy-redirect-to=https://leo/proxy/google/v1/apps/dsp-leo-test1/app1/app,""" +
       """ingress.annotations.nginx\.ingress\.kubernetes\.io/rewrite-target=/$2,""" +
+      // [IA-4997] to support CHIPS by setting partitioned cookies
       // """ingress.annotations.nginx\.ingress\.kubernetes\.io/proxy-cookie-path=/ "/; Secure; SameSite=None; HttpOnly; Partitioned",""" +
       """ingress.annotations.nginx\.ingress\.kubernetes\.io/proxy-cookie-path=/ "/; Secure; SameSite=None; HttpOnly",""" +
       """ingress.host=1455694897.jupyter.firecloud.org,""" +
@@ -503,6 +506,7 @@ class BuildHelmChartValuesSpec extends AnyFlatSpecLike with LeonardoTestSuite {
       """ingress.annotations.nginx\.ingress\.kubernetes\.io/auth-tls-secret=ns/ca-secret,""" +
       """ingress.annotations.nginx\.ingress\.kubernetes\.io/proxy-redirect-to=https://leo/proxy/google/v1/apps/dsp-leo-test1/app1/app,""" +
       """ingress.annotations.nginx\.ingress\.kubernetes\.io/rewrite-target=/$2,""" +
+      // [IA-4997] to support CHIPS by setting partitioned cookies
       // """ingress.annotations.nginx\.ingress\.kubernetes\.io/proxy-cookie-path=/ "/; Secure; SameSite=None; HttpOnly; Partitioned",""" +
       """ingress.annotations.nginx\.ingress\.kubernetes\.io/proxy-cookie-path=/ "/; Secure; SameSite=None; HttpOnly",""" +
       """ingress.host=1455694897.jupyter.firecloud.org,""" +

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/BuildHelmChartValuesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/BuildHelmChartValuesSpec.scala
@@ -311,7 +311,7 @@ class BuildHelmChartValuesSpec extends AnyFlatSpecLike with LeonardoTestSuite {
       """ingress.annotations.nginx\.ingress\.kubernetes\.io/auth-tls-secret=ns/ca-secret,""" +
       """ingress.annotations.nginx\.ingress\.kubernetes\.io/proxy-redirect-to=https://leo/proxy/google/v1/apps/dsp-leo-test1/app1/app,""" +
       """ingress.annotations.nginx\.ingress\.kubernetes\.io/rewrite-target=/$2,""" +
-      """ingress.annotations.nginx\.ingress\.kubernetes\.io/proxy-cookie-path=/ "/; Secure; SameSite=None; HttpOnly",""" +
+      """ingress.annotations.nginx\.ingress\.kubernetes\.io/proxy-cookie-path=/ "/; Secure; SameSite=None; HttpOnly; Partitioned",""" +
       """ingress.host=1455694897.jupyter.firecloud.org,""" +
       """ingress.tls[0].secretName=tls-secret,""" +
       """ingress.tls[0].hosts[0]=1455694897.jupyter.firecloud.org,""" +
@@ -371,7 +371,7 @@ class BuildHelmChartValuesSpec extends AnyFlatSpecLike with LeonardoTestSuite {
       """ingress.annotations.nginx\.ingress\.kubernetes\.io/auth-tls-secret=ns/ca-secret,""" +
       """ingress.annotations.nginx\.ingress\.kubernetes\.io/proxy-redirect-to=https://leo/proxy/google/v1/apps/dsp-leo-test1/app1/app,""" +
       """ingress.annotations.nginx\.ingress\.kubernetes\.io/rewrite-target=/$2,""" +
-      """ingress.annotations.nginx\.ingress\.kubernetes\.io/proxy-cookie-path=/ "/; Secure; SameSite=None; HttpOnly",""" +
+      """ingress.annotations.nginx\.ingress\.kubernetes\.io/proxy-cookie-path=/ "/; Secure; SameSite=None; HttpOnly; Partitioned",""" +
       """ingress.host=1455694897.jupyter.firecloud.org,""" +
       """ingress.tls[0].secretName=tls-secret,""" +
       """ingress.tls[0].hosts[0]=1455694897.jupyter.firecloud.org,""" +
@@ -430,7 +430,7 @@ class BuildHelmChartValuesSpec extends AnyFlatSpecLike with LeonardoTestSuite {
       """ingress.annotations.nginx\.ingress\.kubernetes\.io/auth-tls-secret=ns/ca-secret,""" +
       """ingress.annotations.nginx\.ingress\.kubernetes\.io/proxy-redirect-to=https://leo/proxy/google/v1/apps/dsp-leo-test1/app1/app,""" +
       """ingress.annotations.nginx\.ingress\.kubernetes\.io/rewrite-target=/$2,""" +
-      """ingress.annotations.nginx\.ingress\.kubernetes\.io/proxy-cookie-path=/ "/; Secure; SameSite=None; HttpOnly",""" +
+      """ingress.annotations.nginx\.ingress\.kubernetes\.io/proxy-cookie-path=/ "/; Secure; SameSite=None; HttpOnly; Partitioned",""" +
       """ingress.host=1455694897.jupyter.firecloud.org,""" +
       """ingress.tls[0].secretName=tls-secret,""" +
       """ingress.tls[0].hosts[0]=1455694897.jupyter.firecloud.org,""" +
@@ -500,7 +500,7 @@ class BuildHelmChartValuesSpec extends AnyFlatSpecLike with LeonardoTestSuite {
       """ingress.annotations.nginx\.ingress\.kubernetes\.io/auth-tls-secret=ns/ca-secret,""" +
       """ingress.annotations.nginx\.ingress\.kubernetes\.io/proxy-redirect-to=https://leo/proxy/google/v1/apps/dsp-leo-test1/app1/app,""" +
       """ingress.annotations.nginx\.ingress\.kubernetes\.io/rewrite-target=/$2,""" +
-      """ingress.annotations.nginx\.ingress\.kubernetes\.io/proxy-cookie-path=/ "/; Secure; SameSite=None; HttpOnly",""" +
+      """ingress.annotations.nginx\.ingress\.kubernetes\.io/proxy-cookie-path=/ "/; Secure; SameSite=None; HttpOnly; Partitioned",""" +
       """ingress.host=1455694897.jupyter.firecloud.org,""" +
       """ingress.tls[0].secretName=tls-secret,""" +
       """ingress.tls[0].hosts[0]=1455694897.jupyter.firecloud.org,""" +

--- a/local/overrides.env
+++ b/local/overrides.env
@@ -23,6 +23,7 @@ NON_LEO_SUBSCRIPTION_NAME=nonLeoMessageSubscription${USER}
 # Proxy
 PROXY_DOMAIN=.jupyter-dev.firecloud.org
 PROXY_URL_BASE=https://local.dsde-dev.broadinstitute.org/proxy/
+IS_PROXY_COOKIE_PARTITIONED=true
 
 # Liquibase
 SHOULD_INIT_WITH_LIQUIBASE=false


### PR DESCRIPTION
<!-- Welcome to your Leonardo pull request! -->
<!-- Contributor guidelines: https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md -->

__Jira ticket__: https://broadworkbench.atlassian.net/browse/IA-4997

<!-- ## Dependencies -->
<!-- Include any dependent tickets and describe the relationship. Include any other relevant Jira tickets. -->

## Summary of changes

Can't test this locally or in a BEE, so here is a change which should be disabled everywhere by default.

NOTE: There are a bunch of nginx rewrites in the app helm charts here to add the Partitioned flag; for now I've commented them out and left the old logic in place. They ought not to be needed for me to test Galaxy under CHIPS.

Let's see what the Domain header does in Set-Cookie!
<!-- Please give an abridged version of the ticket description here and/or fill out the following fields. -->

When the config flag IS_PROXY_COOKIE_PARTITIONED is set, Leo `setCookie` will respond with *three* Set-Cookie headers: one unscoped (will be blocked as a top-level third party cookie), one partitioned without a domain (will be scoped to the embedding domain, thus terra-ui), and one partitioned with a domain set to the proxy URL (might?? be scoped to the proxy domain and get past third-party protections on the new Galaxy tab!)

## Testing these changes

We'll need to check Galaxy, Jupyter, Rstudio, and AoU tools with the flag set. This should be possible by pointing a local terra-ui at dev, with the proxy cookie flag set in leo's `overrides.env` file.

This is not intended as a final fix, just an attempt to understand whether the Domain attribute could possibly allow us to use CHIPS for now to get past our third-party cookie woes.

### What to test

- Can you open and use each tool?

<!-- ### Test data -->

### Who tested and where

- [ ] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [ ] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
