### PR TITLE
[IA-4175] FIrst pass at WSM Dao removal

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoAzureSuite.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoAzureSuite.scala
@@ -149,9 +149,9 @@ trait AzureBilling extends FixtureAnyFreeSpecLike {
 
 final class LeonardoAzureSuite
     extends Suites(
-      new AzureRuntimeSpec,
-      new AzureDiskSpec,
-      new AzureAutopauseSpec
+      new AzureRuntimeSpec
+//      new AzureDiskSpec,
+//      new AzureAutopauseSpec
     )
     with TestSuite
     with AzureBilling

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoAzureSuite.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoAzureSuite.scala
@@ -149,9 +149,9 @@ trait AzureBilling extends FixtureAnyFreeSpecLike {
 
 final class LeonardoAzureSuite
     extends Suites(
-      new AzureRuntimeSpec
-//      new AzureDiskSpec,
-//      new AzureAutopauseSpec
+      new AzureRuntimeSpec,
+      new AzureDiskSpec,
+      new AzureAutopauseSpec
     )
     with TestSuite
     with AzureBilling

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpWsmDao.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpWsmDao.scala
@@ -40,24 +40,6 @@ class HttpWsmDao[F[_]](httpClient: Client[F], config: HttpWsmDaoConfig)(implicit
 
   val defaultMediaType = `Content-Type`(MediaType.application.json)
 
-  override def getWorkspace(workspaceId: WorkspaceId, authorization: Authorization)(implicit
-    ev: Ask[F, AppContext]
-  ): F[Option[WorkspaceDescription]] =
-    for {
-      ctx <- ev.ask
-      res <- httpClient.expectOptionOr[WorkspaceDescription](
-        Request[F](
-          method = Method.GET,
-          uri = config.uri
-            .withPath(
-              Uri.Path
-                .unsafeFromString(s"/api/workspaces/v1/${workspaceId.value.toString}")
-            ),
-          headers = headers(authorization, ctx.traceId, false)
-        )
-      )(onError)
-    } yield res
-
   override def getLandingZoneResources(billingProfileId: BillingProfileId, userToken: Authorization)(implicit
     ev: Ask[F, AppContext]
   ): F[LandingZoneResources] =

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpWsmDao.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpWsmDao.scala
@@ -40,7 +40,6 @@ class HttpWsmDao[F[_]](httpClient: Client[F], config: HttpWsmDaoConfig)(implicit
 
   val defaultMediaType = `Content-Type`(MediaType.application.json)
 
-
   override def getWorkspace(workspaceId: WorkspaceId, authorization: Authorization)(implicit
     ev: Ask[F, AppContext]
   ): F[Option[WorkspaceDescription]] =

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpWsmDao.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpWsmDao.scala
@@ -257,7 +257,7 @@ class HttpWsmDao[F[_]](httpClient: Client[F], config: HttpWsmDaoConfig)(implicit
   ): F[Option[DeleteWsmResourceResult]] =
     deleteHelper(request, authorization, "disks")
 
-  // TODO: 1
+  // TODO: Next up for removal, IA-4175
   override def getCreateVmJobResult(request: GetJobResultRequest, authorization: Authorization)(implicit
     ev: Ask[F, AppContext]
   ): F[GetCreateVmJobResult] =

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpWsmDao.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpWsmDao.scala
@@ -40,67 +40,6 @@ class HttpWsmDao[F[_]](httpClient: Client[F], config: HttpWsmDaoConfig)(implicit
 
   val defaultMediaType = `Content-Type`(MediaType.application.json)
 
-  override def createDisk(request: CreateDiskRequest, authorization: Authorization)(implicit
-    ev: Ask[F, AppContext]
-  ): F[CreateDiskResponse] =
-    for {
-      ctx <- ev.ask
-      res <- httpClient.expectOr[CreateDiskResponse](
-        Request[F](
-          method = Method.POST,
-          uri = config.uri
-            .withPath(
-              Uri.Path
-                .unsafeFromString(
-                  s"/api/workspaces/v1/${request.workspaceId.value.toString}/resources/controlled/azure/disks"
-                )
-            ),
-          entity = request,
-          headers = headers(authorization, ctx.traceId, true)
-        )
-      )(onError)
-    } yield res
-
-  override def createVm(request: CreateVmRequest, authorization: Authorization)(implicit
-    ev: Ask[F, AppContext]
-  ): F[CreateVmResult] =
-    for {
-      ctx <- ev.ask
-      res <- httpClient.expectOr[CreateVmResult](
-        Request[F](
-          method = Method.POST,
-          uri = config.uri
-            .withPath(
-              Uri.Path
-                .unsafeFromString(
-                  s"/api/workspaces/v1/${request.workspaceId.value.toString}/resources/controlled/azure/vm"
-                )
-            ),
-          entity = request,
-          headers = headers(authorization, ctx.traceId, true)
-        )
-      )(onError)
-    } yield res
-
-  def createStorageContainer(request: CreateStorageContainerRequest, authorization: Authorization)(implicit
-    ev: Ask[F, AppContext]
-  ): F[CreateStorageContainerResult] = for {
-    ctx <- ev.ask
-    res <- httpClient.expectOr[CreateStorageContainerResult](
-      Request[F](
-        method = Method.POST,
-        uri = config.uri
-          .withPath(
-            Uri.Path
-              .unsafeFromString(
-                s"/api/workspaces/v1/${request.workspaceId.value.toString}/resources/controlled/azure/storageContainer"
-              )
-          ),
-        entity = request,
-        headers = headers(authorization, ctx.traceId, true)
-      )
-    )(onError)
-  } yield res
 
   override def getWorkspace(workspaceId: WorkspaceId, authorization: Authorization)(implicit
     ev: Ask[F, AppContext]
@@ -332,21 +271,12 @@ class HttpWsmDao[F[_]](httpClient: Client[F], config: HttpWsmDaoConfig)(implicit
       )(onError)
     } yield resOpt.fold(List.empty[LandingZoneResourcesByPurpose])(res => res.resources)
 
-  override def deleteVm(request: DeleteWsmResourceRequest, authorization: Authorization)(implicit
-    ev: Ask[F, AppContext]
-  ): F[Option[DeleteWsmResourceResult]] =
-    deleteHelper(request, authorization, "vm")
-
-  override def deleteStorageContainer(request: DeleteWsmResourceRequest, authorization: Authorization)(implicit
-    ev: Ask[F, AppContext]
-  ): F[Option[DeleteWsmResourceResult]] =
-    deleteHelper(request, authorization, "storageContainer")
-
   override def deleteDisk(request: DeleteWsmResourceRequest, authorization: Authorization)(implicit
     ev: Ask[F, AppContext]
   ): F[Option[DeleteWsmResourceResult]] =
     deleteHelper(request, authorization, "disks")
 
+  // TODO: 1
   override def getCreateVmJobResult(request: GetJobResultRequest, authorization: Authorization)(implicit
     ev: Ask[F, AppContext]
   ): F[GetCreateVmJobResult] =
@@ -360,26 +290,6 @@ class HttpWsmDao[F[_]](httpClient: Client[F], config: HttpWsmDaoConfig)(implicit
               Uri.Path
                 .unsafeFromString(
                   s"/api/workspaces/v1/${request.workspaceId.value.toString}/resources/controlled/azure/vm/create-result/${request.jobId.value}"
-                )
-            ),
-          headers = headers(authorization, ctx.traceId, false)
-        )
-      )(onError)
-    } yield res
-
-  override def getDeleteVmJobResult(request: GetJobResultRequest, authorization: Authorization)(implicit
-    ev: Ask[F, AppContext]
-  ): F[GetDeleteJobResult] =
-    for {
-      ctx <- ev.ask
-      res <- httpClient.expectOr[GetDeleteJobResult](
-        Request[F](
-          method = Method.GET,
-          uri = config.uri
-            .withPath(
-              Uri.Path
-                .unsafeFromString(
-                  s"/api/workspaces/v1/${request.workspaceId.value.toString}/resources/controlled/azure/vm/delete-result/${request.jobId.value}"
                 )
             ),
           headers = headers(authorization, ctx.traceId, false)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/WsmApiClientProvider.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/WsmApiClientProvider.scala
@@ -73,6 +73,10 @@ trait WsmApiClientProvider[F[_]] {
 
 class HttpWsmClientProvider[F[_]](baseWorkspaceManagerUrl: Uri)(implicit F: Async[F]) extends WsmApiClientProvider[F] {
 
+  /**
+   * This function wraps the wsm generated client getWorkspace
+   * The purpose of it is to sanitize the output into the same model our original custom DAO used to reduce the surface area of its removal
+   */
   override def getWorkspace(token: String, workspaceId: WorkspaceId, iamRole: IamRole = IamRole.READER)(implicit
     ev: Ask[F, AppContext]
   ): F[Option[WorkspaceDescription]] =

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/WsmDao.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/WsmDao.scala
@@ -89,8 +89,9 @@ final case class LandingZoneResource(resourceId: Option[String],
 
 object LandingZoneResourcePurpose extends Enumeration {
   type LandingZoneResourcePurpose = Value
-  val SHARED_RESOURCE = Value
-  val WORKSPACE_COMPUTE_SUBNET, AKS_NODE_POOL_SUBNET, POSTGRESQL_SUBNET, WORKSPACE_BATCH_SUBNET = Value
+  val SHARED_RESOURCE, WLZ_RESOURCE = Value
+  val WORKSPACE_COMPUTE_SUBNET, WORKSPACE_STORAGE_SUBNET, AKS_NODE_POOL_SUBNET, POSTGRESQL_SUBNET, POSTGRES_ADMIN,
+    WORKSPACE_BATCH_SUBNET = Value
 }
 
 final case class LandingZoneResourcesByPurpose(purpose: LandingZoneResourcePurpose,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/WsmDao.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/WsmDao.scala
@@ -8,6 +8,7 @@ import cats.mtl.Ask
 import com.azure.resourcemanager.compute.models.VirtualMachineSizeTypes
 import org.broadinstitute.dsde.workbench.azure._
 import org.broadinstitute.dsde.workbench.google2.RegionName
+//TODO: prune
 import org.broadinstitute.dsde.workbench.leonardo.JsonCodec.{
   azureImageEncoder,
   azureMachineTypeEncoder,
@@ -37,7 +38,7 @@ trait WsmDao[F[_]] {
     ev: Ask[F, AppContext]
   ): F[Option[DeleteWsmResourceResult]]
 
-  //TODO: 2
+  // TODO: 2
   def getCreateVmJobResult(request: GetJobResultRequest, authorization: Authorization)(implicit
     ev: Ask[F, AppContext]
   ): F[GetCreateVmJobResult]
@@ -46,8 +47,7 @@ trait WsmDao[F[_]] {
     ev: Ask[F, AppContext]
   ): F[GetDeleteJobResult]
 
-  //TODO: 1
-
+  // TODO: 1
   def getWorkspace(workspaceId: WorkspaceId, authorization: Authorization)(implicit
     ev: Ask[F, AppContext]
   ): F[Option[WorkspaceDescription]]
@@ -94,9 +94,8 @@ final case class LandingZoneResource(resourceId: Option[String],
 
 object LandingZoneResourcePurpose extends Enumeration {
   type LandingZoneResourcePurpose = Value
-  val SHARED_RESOURCE, WLZ_RESOURCE = Value
-  val WORKSPACE_COMPUTE_SUBNET, WORKSPACE_STORAGE_SUBNET, AKS_NODE_POOL_SUBNET, POSTGRESQL_SUBNET, POSTGRES_ADMIN,
-    WORKSPACE_BATCH_SUBNET = Value
+  val SHARED_RESOURCE = Value
+  val WORKSPACE_COMPUTE_SUBNET, AKS_NODE_POOL_SUBNET, POSTGRESQL_SUBNET, WORKSPACE_BATCH_SUBNET = Value
 }
 
 final case class LandingZoneResourcesByPurpose(purpose: LandingZoneResourcePurpose,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/WsmDao.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/WsmDao.scala
@@ -47,11 +47,6 @@ trait WsmDao[F[_]] {
     ev: Ask[F, AppContext]
   ): F[GetDeleteJobResult]
 
-  // TODO: 1
-  def getWorkspace(workspaceId: WorkspaceId, authorization: Authorization)(implicit
-    ev: Ask[F, AppContext]
-  ): F[Option[WorkspaceDescription]]
-
   def getLandingZoneResources(billingProfileId: BillingProfileId, userToken: Authorization)(implicit
     ev: Ask[F, AppContext]
   ): F[LandingZoneResources]

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/WsmDao.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/WsmDao.scala
@@ -8,7 +8,7 @@ import cats.mtl.Ask
 import com.azure.resourcemanager.compute.models.VirtualMachineSizeTypes
 import org.broadinstitute.dsde.workbench.azure._
 import org.broadinstitute.dsde.workbench.google2.RegionName
-//TODO: prune
+//TODO: IA-4175 prune
 import org.broadinstitute.dsde.workbench.leonardo.JsonCodec.{
   azureImageEncoder,
   azureMachineTypeEncoder,
@@ -38,7 +38,7 @@ trait WsmDao[F[_]] {
     ev: Ask[F, AppContext]
   ): F[Option[DeleteWsmResourceResult]]
 
-  // TODO: 2
+  // TODO: IA-4175 next up
   def getCreateVmJobResult(request: GetJobResultRequest, authorization: Authorization)(implicit
     ev: Ask[F, AppContext]
   ): F[GetCreateVmJobResult]

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/WsmDao.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/WsmDao.scala
@@ -33,41 +33,20 @@ import java.time.ZonedDateTime
 import java.util.UUID
 
 trait WsmDao[F[_]] {
-  def createDisk(request: CreateDiskRequest, authorization: Authorization)(implicit
-    ev: Ask[F, AppContext]
-  ): F[CreateDiskResponse]
-
-  def createVm(request: CreateVmRequest, authorization: Authorization)(implicit
-    ev: Ask[F, AppContext]
-  ): F[CreateVmResult]
-
-  def createStorageContainer(request: CreateStorageContainerRequest, authorization: Authorization)(implicit
-    ev: Ask[F, AppContext]
-  ): F[CreateStorageContainerResult]
-
-  def deleteVm(request: DeleteWsmResourceRequest, authorization: Authorization)(implicit
-    ev: Ask[F, AppContext]
-  ): F[Option[DeleteWsmResourceResult]]
-
-  def deleteStorageContainer(request: DeleteWsmResourceRequest, authorization: Authorization)(implicit
-    ev: Ask[F, AppContext]
-  ): F[Option[DeleteWsmResourceResult]]
-
   def deleteDisk(request: DeleteWsmResourceRequest, authorization: Authorization)(implicit
     ev: Ask[F, AppContext]
   ): F[Option[DeleteWsmResourceResult]]
 
+  //TODO: 2
   def getCreateVmJobResult(request: GetJobResultRequest, authorization: Authorization)(implicit
     ev: Ask[F, AppContext]
   ): F[GetCreateVmJobResult]
 
-  def getDeleteVmJobResult(request: GetJobResultRequest, authorization: Authorization)(implicit
-    ev: Ask[F, AppContext]
-  ): F[GetDeleteJobResult]
-
   def getDeleteDiskJobResult(request: GetJobResultRequest, authorization: Authorization)(implicit
     ev: Ask[F, AppContext]
   ): F[GetDeleteJobResult]
+
+  //TODO: 1
 
   def getWorkspace(workspaceId: WorkspaceId, authorization: Authorization)(implicit
     ev: Ask[F, AppContext]

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/AzureDependenciesBuilder.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/AzureDependenciesBuilder.scala
@@ -51,7 +51,7 @@ class AzureDependenciesBuilder extends CloudDependenciesBuilder {
         baselineDependencies.publisherQueue,
         None, // no GCP dependency
         baselineDependencies.samDAO,
-        baselineDependencies.wsmDAO
+        baselineDependencies.wsmClientProvider
       )
 
     List(monitorAtBoot.process)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/GcpDependenciesBuilder.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/GcpDependenciesBuilder.scala
@@ -98,7 +98,7 @@ class GcpDependencyBuilder extends CloudDependenciesBuilder {
         baselineDependencies.publisherQueue,
         Some(gcpDependencies.googleComputeService),
         baselineDependencies.samDAO,
-        baselineDependencies.wsmDAO
+        baselineDependencies.wsmClientProvider
       )
 
     val nonLeoMessageSubscriber =

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/LeoAppServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/LeoAppServiceInterp.scala
@@ -12,7 +12,6 @@ import cats.mtl.Ask
 import cats.syntax.all._
 import monocle.macros.syntax.lens._
 import org.apache.commons.lang3.RandomStringUtils
-import org.broadinstitute.dsde.workbench.azure.{AzureCloudContext, TenantId}
 import org.broadinstitute.dsde.workbench.google2.GKEModels.{KubernetesClusterName, NodepoolName}
 import org.broadinstitute.dsde.workbench.google2.KubernetesSerializableName.NamespaceName
 import org.broadinstitute.dsde.workbench.google2.{
@@ -30,7 +29,7 @@ import org.broadinstitute.dsde.workbench.leonardo.AppType._
 import org.broadinstitute.dsde.workbench.leonardo.JsonCodec._
 import org.broadinstitute.dsde.workbench.leonardo.SamResourceId._
 import org.broadinstitute.dsde.workbench.leonardo.config._
-import org.broadinstitute.dsde.workbench.leonardo.dao.{WsmApiClientProvider, WsmDao, WsmGcpContext}
+import org.broadinstitute.dsde.workbench.leonardo.dao.{WsmApiClientProvider, WsmDao}
 import org.broadinstitute.dsde.workbench.leonardo.db.DBIOInstances.dbioInstance
 import org.broadinstitute.dsde.workbench.leonardo.db.KubernetesServiceDbQueries.getActiveFullAppByWorkspaceIdAndAppName
 import org.broadinstitute.dsde.workbench.leonardo.db._
@@ -46,7 +45,7 @@ import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.broadinstitute.dsde.workbench.model.{TraceId, UserInfo, WorkbenchEmail}
 import org.broadinstitute.dsde.workbench.openTelemetry.OpenTelemetryMetrics
 import org.broadinstitute.dsp.{ChartName, ChartVersion, Release}
-import org.http4s.{AuthScheme, Uri}
+import org.http4s.Uri
 import org.typelevel.log4cats.StructuredLogger
 import slick.jdbc.TransactionIsolation
 
@@ -724,7 +723,6 @@ final class LeoAppServiceInterp[F[_]: Parallel](config: AppServiceConfig,
       _ <- getUpdateAppTransaction(appResult.app.id, req)
     } yield ()
 
-  import io.circe.syntax._
   override def createAppV2(userInfo: UserInfo, workspaceId: WorkspaceId, appName: AppName, req: CreateAppRequest)(
     implicit as: Ask[F, AppContext]
   ): F[Unit] =

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeV2ServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeV2ServiceInterp.scala
@@ -64,11 +64,7 @@ class RuntimeV2ServiceInterp[F[_]: Parallel](
     for {
       ctx <- as.ask
 
-      userToken = org.http4s.headers.Authorization(
-        org.http4s.Credentials.Token(AuthScheme.Bearer, userInfo.accessToken.token)
-      )
-
-      workspaceDescOpt <- wsmDao.getWorkspace(workspaceId, userToken)
+      workspaceDescOpt <- wsmClientProvider.getWorkspace(userInfo.accessToken.token, workspaceId)
       workspaceDesc <- F.fromOption(workspaceDescOpt, WorkspaceNotFoundException(workspaceId, ctx.traceId))
 
       // TODO: when we fully support google here, do something intelligent instead of defaulting to azure
@@ -362,10 +358,7 @@ class RuntimeV2ServiceInterp[F[_]: Parallel](
       wsmVMResourceSamId = if (wsmState.isDeleted) None else Some(wsmResourceId)
 
       // Query WSM for Landing Zone resources
-      userToken = org.http4s.headers.Authorization(
-        org.http4s.Credentials.Token(AuthScheme.Bearer, userInfo.accessToken.token)
-      )
-      workspaceDescOpt <- wsmDao.getWorkspace(workspaceId, userToken)
+      workspaceDescOpt <- wsmClientProvider.getWorkspace(userInfo.accessToken.token, workspaceId)
       workspaceDesc <- F.fromOption(workspaceDescOpt, WorkspaceNotFoundException(workspaceId, ctx.traceId))
 
       // Update DB record to Deleting status

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeV2ServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeV2ServiceInterp.scala
@@ -37,7 +37,6 @@ import org.broadinstitute.dsde.workbench.leonardo.monitor.LeoPubsubMessage.{
 }
 import org.broadinstitute.dsde.workbench.leonardo.monitor.{LeoPubsubMessage, UpdateDateAccessedMessage, UpdateTarget}
 import org.broadinstitute.dsde.workbench.model.{TraceId, UserInfo, WorkbenchEmail}
-import org.http4s.AuthScheme
 import org.typelevel.log4cats.StructuredLogger
 
 import java.time.Instant

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/AKSInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/AKSInterpreter.scala
@@ -333,8 +333,9 @@ class AKSInterpreter[F[_]](config: AKSInterpreterConfig,
       workspaceDescOpt <- childSpan("getWorkspace").use { implicit ev =>
         wsmClientProvider.getWorkspace(token, workspaceId)
       }
-      workspaceDesc <- F.fromOption(workspaceDescOpt,
-                                    AppUpdateException(s"Workspace $workspaceId not found in WSM", Some(ctx.traceId))
+      workspaceDesc <- F.fromOption(
+        workspaceDescOpt,
+        AppUpdateException(s"Workspace ${workspaceId.value.toString} not found in WSM", Some(ctx.traceId))
       )
       // Query the Landing Zone service for the landing zone resources
       billingProfileId = BillingProfileId(workspaceDesc.spendProfile)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/AKSInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/AKSInterpreter.scala
@@ -365,7 +365,7 @@ class AKSInterpreter[F[_]](config: AKSInterpreterConfig,
         app.appType,
         workspaceId,
         landingZoneResources,
-        wsmControlledResourceApi
+        wsmResourceApi
       )
 
       // get list of APP_CONTROLLED_RESOURCES

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandler.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandler.scala
@@ -163,7 +163,7 @@ class AzurePubsubHandlerInterp[F[_]: Parallel](
       }
 
       _ <- logger.info(
-        s"[AzurePubsubHandler/createAndPollRuntime] beginning to monitor runtime creation for runtime ${params.runtime.id}"
+        s"[AzurePubsubHandler/createAndPollRuntime] beginning to monitor runtime creation for runtime ${msg.runtimeId}"
       )
 
       // all other resources (hybrid connection, storage container, vm)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandler.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandler.scala
@@ -46,7 +46,6 @@ import org.broadinstitute.dsde.workbench.model.{IP, WorkbenchEmail}
 import org.broadinstitute.dsde.workbench.util2.InstanceName
 import org.broadinstitute.dsp.ChartVersion
 import org.http4s.AuthScheme
-import org.http4s.headers.Authorization
 import org.typelevel.log4cats.StructuredLogger
 import reactor.core.publisher.Mono
 
@@ -1186,7 +1185,7 @@ class AzurePubsubHandlerInterp[F[_]: Parallel](
               // if there is a disk record, the disk finished creating, so it must be deleted in WSM
               case Some(diskRecord) =>
                 for {
-                  _ <- deleteDiskInWSM(diskId, diskRecord.resourceId, e.workspaceId, auth, Some(e.runtimeId))
+                  _ <- deleteDiskInWSM(diskId, diskRecord.resourceId, e.workspaceId, Some(e.runtimeId))
                 } yield ()
               case _ =>
                 for {
@@ -1366,7 +1365,7 @@ class AzurePubsubHandlerInterp[F[_]: Parallel](
 
       _ <- msg.wsmResourceId match {
         case Some(wsmResourceId) =>
-          deleteDiskInWSM(msg.diskId, wsmResourceId, msg.workspaceId, auth, None)
+          deleteDiskInWSM(msg.diskId, wsmResourceId, msg.workspaceId, None)
         case None =>
           for {
             _ <- logger.info(s"No WSM resource found for Azure disk ${msg.diskId}, skipping deletion in WSM")

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/CommonTestData.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/CommonTestData.scala
@@ -3,7 +3,7 @@ package org.broadinstitute.dsde.workbench.leonardo
 import akka.http.scaladsl.model.{StatusCode, StatusCodes}
 import akka.http.scaladsl.model.headers.{HttpCookiePair, OAuth2BearerToken}
 import bio.terra.workspace.client.ApiException
-import bio.terra.workspace.model.WorkspaceDescription
+import bio.terra.workspace.model.{AzureContext, GcpContext, WorkspaceDescription}
 import cats.effect.IO
 import cats.effect.Ref
 import cats.effect.unsafe.implicits.global
@@ -541,7 +541,16 @@ object CommonTestData {
   val wsmResourceIdOpt = Some(wsmResourceId)
   val cloudContextAzure = CloudContext.Azure(azureCloudContext)
   val billingProfileId = BillingProfileId("spend-profile")
-  val wsmWorkspaceDesc = new WorkspaceDescription().id(workspaceId.value).spendProfile("spendProfile")
+  val wsmWorkspaceDesc = new WorkspaceDescription()
+    .id(workspaceId.value)
+    .spendProfile("spendProfile")
+    .azureContext(
+      new AzureContext()
+        .resourceGroupId(azureCloudContext.managedResourceGroupName.value)
+        .tenantId(azureCloudContext.tenantId.value)
+        .subscriptionId(azureCloudContext.subscriptionId.value)
+    )
+    .gcpContext(new GcpContext().projectId("googleProject"))
 
   val testCommonControlledResourceFields = InternalDaoControlledResourceCommonFields(
     ControlledResourceName("name"),

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpWsmDaoSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpWsmDaoSpec.scala
@@ -22,10 +22,7 @@ import org.broadinstitute.dsde.workbench.leonardo.{
   LandingZoneResources,
   LeonardoTestSuite,
   PostgresServer,
-  StorageAccountName,
-  WorkspaceId,
-  WsmControlledResourceId,
-  WsmJobId
+  StorageAccountName
 }
 import org.http4s._
 import org.http4s.client.Client
@@ -37,25 +34,6 @@ import java.util.UUID
 
 class HttpWsmDaoSpec extends AnyFlatSpec with LeonardoTestSuite with BeforeAndAfterAll {
   val config = HttpWsmDaoConfig(Uri.unsafeFromString("127.0.0.1"))
-
-  it should "not error when getting 404 during resource deletion" in {
-    val wsmClient = Client.fromHttpApp[IO](
-      HttpApp(_ => IO(Response(status = Status.NotFound)))
-    )
-
-    val wsmDao = new HttpWsmDao[IO](wsmClient, config)
-    val res = wsmDao
-      .deleteVm(
-        DeleteWsmResourceRequest(WorkspaceId(UUID.randomUUID()),
-                                 WsmControlledResourceId(UUID.randomUUID()),
-                                 WsmDaoDeleteControlledAzureResourceRequest(WsmJobControl(WsmJobId("job")))
-        ),
-        Authorization(Credentials.Token(AuthScheme.Bearer, "dummy"))
-      )
-      .attempt
-
-    res.unsafeRunSync().isRight shouldBe true
-  }
 
   val testCases: Map[Option[Map[String, String]], Boolean] = Map(
     None -> false,

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/MockWsmApiClientProvider.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/MockWsmApiClientProvider.scala
@@ -1,9 +1,10 @@
 package org.broadinstitute.dsde.workbench.leonardo.dao
 
 import bio.terra.workspace.api._
-import bio.terra.workspace.model.ResourceMetadata
+import bio.terra.workspace.model.{IamRole, ResourceMetadata}
 import cats.effect.IO
 import cats.mtl.Ask
+import org.broadinstitute.dsde.workbench.azure.{AzureCloudContext, ManagedResourceGroupName, SubscriptionId, TenantId}
 import org.broadinstitute.dsde.workbench.leonardo.db.WsmResourceType
 import org.broadinstitute.dsde.workbench.leonardo.{AppContext, WorkspaceId, WsmControlledResourceId, WsmState}
 import org.scalatestplus.mockito.MockitoSugar.mock
@@ -13,6 +14,25 @@ class MockWsmClientProvider(controlledAzureResourceApi: ControlledAzureResourceA
                             resourceApi: ResourceApi = mock[ResourceApi],
                             workspaceApi: WorkspaceApi = mock[WorkspaceApi]
 ) extends WsmApiClientProvider[IO] {
+
+  override def getWorkspace(token: String, workspaceId: WorkspaceId, iamRole: IamRole)(implicit
+    ev: Ask[IO, AppContext]
+  ): IO[Option[WorkspaceDescription]] = IO.pure(
+    Some(
+      WorkspaceDescription(
+        workspaceId,
+        "workspaceName" + workspaceId,
+        "spend-profile",
+        Some(
+          AzureCloudContext(TenantId(workspaceId.toString),
+                            SubscriptionId(workspaceId.toString),
+                            ManagedResourceGroupName(workspaceId.toString)
+          )
+        ),
+        None
+      )
+    )
+  )
 
   override def getControlledAzureResourceApi(token: String)(implicit
     ev: Ask[IO, AppContext]

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/MockWsmApiClientProvider.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/MockWsmApiClientProvider.scala
@@ -21,12 +21,12 @@ class MockWsmClientProvider(controlledAzureResourceApi: ControlledAzureResourceA
     Some(
       WorkspaceDescription(
         workspaceId,
-        "workspaceName" + workspaceId,
+        "workspaceName" + workspaceId.value.toString,
         "spend-profile",
         Some(
-          AzureCloudContext(TenantId(workspaceId.toString),
-                            SubscriptionId(workspaceId.toString),
-                            ManagedResourceGroupName(workspaceId.toString)
+          AzureCloudContext(TenantId(workspaceId.value.toString),
+                            SubscriptionId(workspaceId.value.toString),
+                            ManagedResourceGroupName(workspaceId.value.toString)
           )
         ),
         None

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/MockWsmDAO.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/MockWsmDAO.scala
@@ -12,41 +12,6 @@ import java.util.UUID
 
 class MockWsmDAO(jobStatus: WsmJobStatus = WsmJobStatus.Succeeded) extends WsmDao[IO] {
 
-  override def createDisk(request: CreateDiskRequest, authorization: Authorization)(implicit
-    ev: Ask[IO, AppContext]
-  ): IO[CreateDiskResponse] =
-    IO.pure(
-      CreateDiskResponse(
-        WsmControlledResourceId(UUID.randomUUID())
-      )
-    )
-
-  override def createVm(request: CreateVmRequest, authorization: Authorization)(implicit
-    ev: Ask[IO, AppContext]
-  ): IO[CreateVmResult] =
-    IO.pure(
-      CreateVmResult(
-        WsmJobReport(
-          WsmJobId("job1"),
-          "desc",
-          jobStatus,
-          200,
-          ZonedDateTime.parse("2022-03-18T15:02:29.264756Z"),
-          Some(ZonedDateTime.parse("2022-03-18T15:02:29.264756Z")),
-          "resultUrl"
-        ),
-        if (jobStatus.equals(WsmJobStatus.Failed))
-          Some(
-            WsmErrorReport(
-              "error",
-              500,
-              List.empty
-            )
-          )
-        else None
-      )
-    )
-
   override def getCreateVmJobResult(
     request: GetJobResultRequest,
     authorization: Authorization
@@ -76,54 +41,6 @@ class MockWsmDAO(jobStatus: WsmJobStatus = WsmJobStatus.Succeeded) extends WsmDa
             )
           )
         else None
-      )
-    )
-
-  override def deleteVm(request: DeleteWsmResourceRequest, authorization: Authorization)(implicit
-    ev: Ask[IO, AppContext]
-  ): IO[Option[DeleteWsmResourceResult]] =
-    IO.pure(
-      Some(
-        DeleteWsmResourceResult(
-          WsmJobReport(
-            request.deleteRequest.jobControl.id,
-            "desc",
-            jobStatus,
-            200,
-            ZonedDateTime.parse("2022-03-18T15:02:29.264756Z"),
-            Some(ZonedDateTime.parse("2022-03-18T15:02:29.264756Z")),
-            "resultUrl"
-          ),
-          if (jobStatus.equals(WsmJobStatus.Failed))
-            Some(
-              WsmErrorReport(
-                "error",
-                500,
-                List.empty
-              )
-            )
-          else None
-        )
-      )
-    )
-
-  override def getWorkspace(workspaceId: WorkspaceId, authorization: Authorization)(implicit
-    ev: Ask[IO, AppContext]
-  ): IO[Option[WorkspaceDescription]] =
-    IO.pure(
-      Some(
-        WorkspaceDescription(
-          workspaceId,
-          "workspaceName" + workspaceId,
-          "spend-profile",
-          Some(
-            AzureCloudContext(TenantId(workspaceId.toString),
-                              SubscriptionId(workspaceId.toString),
-                              ManagedResourceGroupName(workspaceId.toString)
-            )
-          ),
-          None
-        )
       )
     )
 
@@ -162,31 +79,6 @@ class MockWsmDAO(jobStatus: WsmJobStatus = WsmJobStatus.Succeeded) extends WsmDa
       )
     )
 
-  override def getDeleteVmJobResult(request: GetJobResultRequest, authorization: Authorization)(implicit
-    ev: Ask[IO, AppContext]
-  ): IO[GetDeleteJobResult] = IO.pure(
-    GetDeleteJobResult(
-      WsmJobReport(
-        request.jobId,
-        "desc",
-        jobStatus,
-        200,
-        ZonedDateTime.parse("2022-03-18T15:02:29.264756Z"),
-        Some(ZonedDateTime.parse("2022-03-18T15:02:29.264756Z")),
-        "resultUrl"
-      ),
-      if (jobStatus.equals(WsmJobStatus.Failed))
-        Some(
-          WsmErrorReport(
-            "error",
-            500,
-            List.empty
-          )
-        )
-      else None
-    )
-  )
-
   override def getDeleteDiskJobResult(request: GetJobResultRequest, authorization: Authorization)(implicit
     ev: Ask[IO, AppContext]
   ): IO[GetDeleteJobResult] = IO.pure(
@@ -216,13 +108,4 @@ class MockWsmDAO(jobStatus: WsmJobStatus = WsmJobStatus.Succeeded) extends WsmDa
     ev: Ask[IO, AppContext]
   ): IO[Option[StorageContainerResponse]] =
     IO.pure(Some(StorageContainerResponse(ContainerName("dummy"), WsmControlledResourceId(UUID.randomUUID()))))
-
-  override def createStorageContainer(request: CreateStorageContainerRequest, authorization: Authorization)(implicit
-    ev: Ask[IO, AppContext]
-  ): IO[CreateStorageContainerResult] =
-    IO.pure(CreateStorageContainerResult(WsmControlledResourceId(UUID.randomUUID())))
-
-  override def deleteStorageContainer(request: DeleteWsmResourceRequest, authorization: Authorization)(implicit
-    ev: Ask[IO, AppContext]
-  ): IO[Option[DeleteWsmResourceResult]] = IO.pure(None)
 }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/WsmApiClientProviderSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/WsmApiClientProviderSpec.scala
@@ -1,27 +1,39 @@
 package org.broadinstitute.dsde.workbench.leonardo.dao
 
-import bio.terra.workspace.api.ControlledAzureResourceApi
+import bio.terra.workspace.api.{ControlledAzureResourceApi, WorkspaceApi}
 import bio.terra.workspace.model.{
   AzureDatabaseResource,
   AzureDiskResource,
   AzureKubernetesNamespaceResource,
   AzureManagedIdentityResource,
   AzureVmResource,
+  IamRole,
   ResourceMetadata,
   ResourceType,
   State
 }
 import cats.effect.IO
 import cats.mtl.Ask
-import org.broadinstitute.dsde.workbench.leonardo.CommonTestData.{tokenValue, workspaceId, workspaceId2, wsmResourceId}
+import org.broadinstitute.dsde.workbench.azure.{AzureCloudContext, ManagedResourceGroupName, SubscriptionId, TenantId}
+import org.broadinstitute.dsde.workbench.leonardo.CommonTestData.{
+  tokenValue,
+  workspaceId,
+  workspaceId2,
+  wsmResourceId,
+  wsmWorkspaceDesc
+}
 import org.broadinstitute.dsde.workbench.leonardo.TestUtils.appContext
 import org.broadinstitute.dsde.workbench.leonardo.db.WsmResourceType
+import org.broadinstitute.dsde.workbench.leonardo.util.AzureTestUtils
 import org.broadinstitute.dsde.workbench.leonardo.{AppContext, LeonardoTestSuite}
 import org.http4s._
-import org.mockito.Mockito.when
+import org.mockito.Mockito.{times, verify, when}
+import org.mockito.ArgumentMatchers.{any, eq => mockitoEq}
 import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.flatspec.AnyFlatSpec
+
+import java.util.UUID
 
 class WsmApiClientProviderSpec extends AnyFlatSpec with LeonardoTestSuite with BeforeAndAfterAll with MockitoSugar {
 
@@ -93,6 +105,128 @@ class WsmApiClientProviderSpec extends AnyFlatSpec with LeonardoTestSuite with B
     val res = for {
       md <- wsmProvider.getWsmState(tokenValue, workspaceId2, wsmResourceId, WsmResourceType.AzureDisk)
     } yield md.value shouldBe "NONE"
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
+  }
+
+  it should "get a workspace id1" in {
+    val workspaceApi = mock[WorkspaceApi]
+    val wsmProvider = new HttpWsmClientProvider[IO](baseWorkspaceManagerUrl = Uri.unsafeFromString("test")) {
+      override def getWorkspaceApi(token: String)(implicit
+        ev: Ask[IO, AppContext]
+      ): IO[WorkspaceApi] = IO.pure(workspaceApi)
+    }
+
+    when {
+      workspaceApi.getWorkspace(any(), any())
+    } thenAnswer { invocation =>
+      val workspaceId = invocation.getArgument[UUID](0)
+      wsmWorkspaceDesc.id(workspaceId)
+    }
+
+    val res = for {
+      workspace <- wsmProvider.getWorkspace(tokenValue, workspaceId, IamRole.WRITER)
+    } yield {
+      workspace.isDefined shouldBe true
+      workspace.map(_.spendProfile) shouldBe Some(wsmWorkspaceDesc.getSpendProfile)
+      workspace.map(_.id) shouldBe Some(workspaceId)
+      workspace.flatMap(_.azureContext) shouldBe Some(
+        AzureCloudContext(
+          TenantId(wsmWorkspaceDesc.getAzureContext.getTenantId),
+          SubscriptionId(wsmWorkspaceDesc.getAzureContext.getSubscriptionId),
+          ManagedResourceGroupName(wsmWorkspaceDesc.getAzureContext.getResourceGroupId)
+        )
+      )
+      workspace.flatMap(_.gcpContext.map(_.value)) shouldBe Some(wsmWorkspaceDesc.getGcpContext.getProjectId)
+      workspace.map(_.displayName) shouldBe Some(wsmWorkspaceDesc.getDisplayName)
+      verify(workspaceApi, times(1)).getWorkspace(mockitoEq(workspaceId.value), mockitoEq(IamRole.WRITER))
+    }
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
+  }
+
+  it should "get a workspace" in {
+    val workspaceApi = mock[WorkspaceApi]
+    val wsmProvider = new HttpWsmClientProvider[IO](baseWorkspaceManagerUrl = Uri.unsafeFromString("test")) {
+      override def getWorkspaceApi(token: String)(implicit
+        ev: Ask[IO, AppContext]
+      ): IO[WorkspaceApi] = IO.pure(workspaceApi)
+    }
+
+    when {
+      workspaceApi.getWorkspace(any(), any())
+    } thenAnswer { invocation =>
+      val workspaceId = invocation.getArgument[UUID](0)
+      wsmWorkspaceDesc.id(workspaceId)
+    }
+
+    val res = for {
+      workspace <- wsmProvider.getWorkspace(tokenValue, workspaceId, IamRole.WRITER)
+    } yield {
+      workspace.isDefined shouldBe true
+      workspace.map(_.spendProfile) shouldBe Some(wsmWorkspaceDesc.getSpendProfile)
+      workspace.map(_.id) shouldBe Some(workspaceId)
+      workspace.flatMap(_.azureContext) shouldBe Some(
+        AzureCloudContext(
+          TenantId(wsmWorkspaceDesc.getAzureContext.getTenantId),
+          SubscriptionId(wsmWorkspaceDesc.getAzureContext.getSubscriptionId),
+          ManagedResourceGroupName(wsmWorkspaceDesc.getAzureContext.getResourceGroupId)
+        )
+      )
+      workspace.flatMap(_.gcpContext.map(_.value)) shouldBe Some(wsmWorkspaceDesc.getGcpContext.getProjectId)
+      workspace.map(_.displayName) shouldBe Some(wsmWorkspaceDesc.getDisplayName)
+      verify(workspaceApi, times(1)).getWorkspace(mockitoEq(workspaceId.value), mockitoEq(IamRole.WRITER))
+    }
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
+  }
+
+  it should "handle null contexts in get workspace" in {
+    val workspaceApi = mock[WorkspaceApi]
+    val wsmProvider = new HttpWsmClientProvider[IO](baseWorkspaceManagerUrl = Uri.unsafeFromString("test")) {
+      override def getWorkspaceApi(token: String)(implicit
+        ev: Ask[IO, AppContext]
+      ): IO[WorkspaceApi] = IO.pure(workspaceApi)
+    }
+
+    when {
+      workspaceApi.getWorkspace(any(), any())
+    } thenAnswer { invocation =>
+      val workspaceId = invocation.getArgument[UUID](0)
+      wsmWorkspaceDesc.id(workspaceId).azureContext(null).gcpContext(null)
+    }
+
+    val res = for {
+      workspace <- wsmProvider.getWorkspace(tokenValue, workspaceId, IamRole.WRITER)
+    } yield {
+      workspace.isDefined shouldBe true
+      workspace.map(_.spendProfile) shouldBe Some(wsmWorkspaceDesc.getSpendProfile)
+      workspace.map(_.id) shouldBe Some(workspaceId)
+      workspace.flatMap(_.azureContext) shouldBe None
+      workspace.flatMap(_.gcpContext) shouldBe None
+      workspace.map(_.displayName) shouldBe Some(wsmWorkspaceDesc.getDisplayName)
+      verify(workspaceApi, times(1)).getWorkspace(mockitoEq(workspaceId.value), mockitoEq(IamRole.WRITER))
+    }
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
+  }
+
+  it should "handle null for get workspace" in {
+    val workspaceApi = mock[WorkspaceApi]
+    val wsmProvider = new HttpWsmClientProvider[IO](baseWorkspaceManagerUrl = Uri.unsafeFromString("test")) {
+      override def getWorkspaceApi(token: String)(implicit
+        ev: Ask[IO, AppContext]
+      ): IO[WorkspaceApi] = IO.pure(workspaceApi)
+    }
+
+    when {
+      workspaceApi.getWorkspace(any(), any())
+    } thenAnswer { _ =>
+      null
+    }
+
+    val res = for {
+      workspace <- wsmProvider.getWorkspace(tokenValue, workspaceId, IamRole.WRITER)
+    } yield {
+      verify(workspaceApi, times(1)).getWorkspace(mockitoEq(workspaceId.value), mockitoEq(IamRole.WRITER))
+      workspace.isDefined shouldBe false
+    }
     res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/AppServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/AppServiceInterpSpec.scala
@@ -50,7 +50,6 @@ import org.typelevel.log4cats.StructuredLogger
 import org.scalatest.prop.TableDrivenPropertyChecks.forAll
 
 import java.time.Instant
-import java.util.UUID
 import scala.concurrent.ExecutionContext.Implicits.global
 
 trait AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with TestComponent with MockitoSugar {

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/AppServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/AppServiceInterpSpec.scala
@@ -72,6 +72,11 @@ trait AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with TestC
   } thenReturn {
     IO.pure(workspaceApi)
   }
+  when {
+    wsmClientProvider.getWorkspace(any, any, any)
+  } thenReturn {
+    IO.pure(Some(wsmWorkspaceDesc))
+  }
 
   val gcpWsmDao = new MockWsmDAO
 

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/AppServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/AppServiceInterpSpec.scala
@@ -39,7 +39,7 @@ import org.broadinstitute.dsde.workbench.util2.messaging.CloudPublisher
 import org.broadinstitute.dsp.{ChartName, ChartVersion}
 import org.http4s.Uri
 import org.http4s.headers.Authorization
-import org.mockito.ArgumentMatchers
+import org.mockito.{ArgumentCaptor, ArgumentMatchers}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{verify, when}
 import org.scalatest.Assertion
@@ -48,7 +48,9 @@ import org.scalatest.prop.TableDrivenPropertyChecks._
 import org.scalatestplus.mockito.MockitoSugar
 import org.typelevel.log4cats.StructuredLogger
 import org.scalatest.prop.TableDrivenPropertyChecks.forAll
+
 import java.time.Instant
+import java.util.UUID
 import scala.concurrent.ExecutionContext.Implicits.global
 
 trait AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with TestComponent with MockitoSugar {
@@ -72,10 +74,12 @@ trait AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with TestC
   } thenReturn {
     IO.pure(workspaceApi)
   }
+  val workspaceIdCaptor =
+    ArgumentCaptor.forClass(classOf[WorkspaceId])
   when {
-    wsmClientProvider.getWorkspace(any, any, any)
+    wsmClientProvider.getWorkspace(any, workspaceIdCaptor.capture(), any)
   } thenReturn {
-    IO.pure(Some(wsmWorkspaceDesc))
+    new MockWsmClientProvider().getWorkspace("token", workspaceIdCaptor.getValue.asInstanceOf[WorkspaceId])
   }
 
   val gcpWsmDao = new MockWsmDAO

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/AppServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/AppServiceInterpSpec.scala
@@ -73,12 +73,6 @@ trait AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with TestC
   } thenReturn {
     IO.pure(workspaceApi)
   }
-  when {
-    wsmClientProvider.getWorkspace(any, any, any)
-  } thenAnswer { invocation =>
-    val workspaceId = invocation.getArgument[WorkspaceId](1)
-    new MockWsmClientProvider().getWorkspace("token", workspaceId)
-  }
 
   val gcpWsmDao = new MockWsmDAO
 

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/AppServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/AppServiceInterpSpec.scala
@@ -74,12 +74,11 @@ trait AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with TestC
   } thenReturn {
     IO.pure(workspaceApi)
   }
-  val workspaceIdCaptor =
-    ArgumentCaptor.forClass(classOf[WorkspaceId])
   when {
-    wsmClientProvider.getWorkspace(any, workspaceIdCaptor.capture(), any)
-  } thenReturn {
-    new MockWsmClientProvider().getWorkspace("token", workspaceIdCaptor.getValue.asInstanceOf[WorkspaceId])
+    wsmClientProvider.getWorkspace(any, any, any)
+  } thenAnswer { invocation =>
+    val workspaceId = invocation.getArgument[WorkspaceId](1)
+    new MockWsmClientProvider().getWorkspace("token", workspaceId)
   }
 
   val gcpWsmDao = new MockWsmDAO

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/AppServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/AppServiceInterpSpec.scala
@@ -14,8 +14,7 @@ import org.broadinstitute.dsde.workbench.google2.{DiskName, GoogleResourceServic
 import org.broadinstitute.dsde.workbench.leonardo.AppRestore.{GalaxyRestore, Other}
 import org.broadinstitute.dsde.workbench.leonardo.CommonTestData._
 import org.broadinstitute.dsde.workbench.leonardo.KubernetesTestData._
-import org.broadinstitute.dsde.workbench.leonardo.SamResourceId.AppSamResourceId
-import org.broadinstitute.dsde.workbench.leonardo.TestUtils.{appContext, defaultMockitoAnswer}
+import org.broadinstitute.dsde.workbench.leonardo.TestUtils.appContext
 import org.broadinstitute.dsde.workbench.leonardo.auth.AllowlistAuthProvider
 import org.broadinstitute.dsde.workbench.leonardo.config.Config.leoKubernetesConfig
 import org.broadinstitute.dsde.workbench.leonardo.config.{Config, CustomAppConfig, CustomApplicationAllowListConfig}
@@ -74,22 +73,7 @@ trait AppServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with TestC
     IO.pure(workspaceApi)
   }
 
-  val gcpWsmDao = new MockWsmDAO {
-    override def getWorkspace(workspaceId: WorkspaceId, authorization: Authorization)(implicit
-      ev: Ask[IO, AppContext]
-    ): IO[Option[WorkspaceDescription]] =
-      IO.pure(
-        Some(
-          WorkspaceDescription(
-            workspaceId,
-            "someWorkspaceName" + workspaceId,
-            "9f3434cb-8f18-4595-95a9-d9b1ec9731d4",
-            None,
-            Some(GoogleProject(workspaceId.toString))
-          )
-        )
-      )
-  }
+  val gcpWsmDao = new MockWsmDAO
 
   val appServiceInterp = makeInterp(QueueFactory.makePublisherQueue())
   val appServiceInterp2 = makeInterp(QueueFactory.makePublisherQueue(), authProvider = allowListAuthProvider2)

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeV2ServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeV2ServiceInterpSpec.scala
@@ -288,7 +288,6 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
     ) // this email is allowlisted
     val runtimeName = RuntimeName("clusterName1")
     val workspaceId = WorkspaceId(UUID.randomUUID())
-    val relayNamespace = RelayNamespace("relay-ns")
 
     val publisherQueue = QueueFactory.makePublisherQueue()
     val storageContainerResourceId = WsmControlledResourceId(UUID.randomUUID())
@@ -318,7 +317,7 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
           defaultCreateAzureRuntimeReq
         )
         .attempt
-      workspaceDesc <- wsmDao.getWorkspace(workspaceId, dummyAuth)
+      workspaceDesc <- wsmClientProvider.getWorkspace("token", workspaceId)
       cloudContext = CloudContext.Azure(workspaceDesc.get.azureContext.get)
       clusterRecOpt <- clusterQuery
         .getActiveClusterRecordByName(cloudContext, runtimeName)(scala.concurrent.ExecutionContext.global)
@@ -600,7 +599,7 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
           )
         )
         .attempt
-      workspaceDesc <- wsmDao.getWorkspace(workspaceId, dummyAuth)
+      workspaceDesc <- wsmClientProvider.getWorkspace("token", workspaceId)
       cloudContext = CloudContext.Azure(workspaceDesc.get.azureContext.get)
       clusterOpt <- clusterQuery
         .getActiveClusterByNameMinimal(cloudContext, name2)(scala.concurrent.ExecutionContext.global)
@@ -670,7 +669,7 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
           )
         )
         .attempt
-      workspaceDesc <- wsmDao.getWorkspace(workspaceId, dummyAuth)
+      workspaceDesc <- wsmClientProvider.getWorkspace("token", workspaceId)
       cloudContext = CloudContext.Azure(workspaceDesc.get.azureContext.get)
       clusterOpt <- clusterQuery
         .getActiveClusterByNameMinimal(cloudContext, name2)(scala.concurrent.ExecutionContext.global)
@@ -717,7 +716,7 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
           false,
           defaultCreateAzureRuntimeReq
         )
-      azureCloudContext <- wsmDao.getWorkspace(workspaceId, dummyAuth).map(_.get.azureContext)
+      azureCloudContext <- wsmClientProvider.getWorkspace("token", workspaceId).map(_.get.azureContext)
       clusterOpt <- clusterQuery
         .getActiveClusterByNameMinimal(CloudContext.Azure(azureCloudContext.get), runtimeName)(
           scala.concurrent.ExecutionContext.global
@@ -772,7 +771,7 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
           false,
           defaultCreateAzureRuntimeReq
         )
-      azureCloudContext <- wsmDao.getWorkspace(workspaceId, dummyAuth).map(_.get.azureContext)
+      azureCloudContext <- wsmClientProvider.getWorkspace("token", workspaceId).map(_.get.azureContext)
       clusterOpt <- clusterQuery
         .getActiveClusterByNameMinimal(CloudContext.Azure(azureCloudContext.get), runtimeName)(
           scala.concurrent.ExecutionContext.global
@@ -827,7 +826,7 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
           false,
           defaultCreateAzureRuntimeReq
         )
-      azureCloudContext <- wsmDao.getWorkspace(workspaceId, dummyAuth).map(_.get.azureContext)
+      azureCloudContext <- wsmClientProvider.getWorkspace("token", workspaceId).map(_.get.azureContext)
       clusterOpt <- clusterQuery
         .getActiveClusterByNameMinimal(CloudContext.Azure(azureCloudContext.get), runtimeName)(
           scala.concurrent.ExecutionContext.global
@@ -867,7 +866,7 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
           false,
           defaultCreateAzureRuntimeReq
         )
-      azureCloudContext <- wsmDao.getWorkspace(workspaceId, dummyAuth).map(_.get.azureContext)
+      azureCloudContext <- wsmClientProvider.getWorkspace("token", workspaceId).map(_.get.azureContext)
       clusterOpt <- clusterQuery
         .getActiveClusterByNameMinimal(CloudContext.Azure(azureCloudContext.get), runtimeName)(
           scala.concurrent.ExecutionContext.global
@@ -907,7 +906,7 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
           false,
           defaultCreateAzureRuntimeReq
         )
-      azureCloudContext <- wsmDao.getWorkspace(workspaceId, dummyAuth).map(_.get.azureContext)
+      azureCloudContext <- wsmClientProvider.getWorkspace("token", workspaceId).map(_.get.azureContext)
       clusterOpt <- clusterQuery
         .getActiveClusterByNameMinimal(CloudContext.Azure(azureCloudContext.get), runtimeName)(
           scala.concurrent.ExecutionContext.global
@@ -1439,7 +1438,7 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
       _ <- persistentDiskQuery.updateStatus(disk.id, DiskStatus.Ready, context.now).transaction
 
       _ <- publisherQueue.tryTake // clean out create msg
-      azureCloudContext <- wsmDao.getWorkspace(workspaceId, dummyAuth).map(_.get.azureContext)
+      azureCloudContext <- wsmClientProvider.getWorkspace("token", workspaceId).map(_.get.azureContext)
       preDeleteClusterOpt <- clusterQuery
         .getActiveClusterByNameMinimal(CloudContext.Azure(azureCloudContext.get), runtimeName)(
           scala.concurrent.ExecutionContext.global
@@ -1569,7 +1568,7 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
           false,
           defaultCreateAzureRuntimeReq
         )
-      azureCloudContext <- wsmDao.getWorkspace(workspaceId, dummyAuth).map(_.get.azureContext)
+      azureCloudContext <- wsmClientProvider.getWorkspace("token", workspaceId).map(_.get.azureContext)
       clusterOpt <- clusterQuery
         .getActiveClusterByNameMinimal(CloudContext.Azure(azureCloudContext.get), runtimeName)(
           scala.concurrent.ExecutionContext.global
@@ -1612,7 +1611,7 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
           false,
           defaultCreateAzureRuntimeReq
         )
-      azureCloudContext <- wsmDao.getWorkspace(workspaceId, dummyAuth).map(_.get.azureContext)
+      azureCloudContext <- wsmClientProvider.getWorkspace("token", workspaceId).map(_.get.azureContext)
       clusterOpt <- clusterQuery
         .getActiveClusterByNameMinimal(CloudContext.Azure(azureCloudContext.get), runtimeName)(
           scala.concurrent.ExecutionContext.global
@@ -1646,7 +1645,7 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
 
     val res = for {
       context <- appContext.ask[AppContext]
-      azureCloudContextOpt <- wsmDao.getWorkspace(workspaceId, dummyAuth).map(_.get.azureContext)
+      azureCloudContextOpt <- wsmClientProvider.getWorkspace("token", workspaceId).map(_.get.azureContext)
       azureCloudContext = CloudContext.Azure(azureCloudContextOpt.get)
 
       _ <- azureService
@@ -1804,7 +1803,7 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
         )
 
       _ <- publisherQueue.tryTakeN(Some(2)) // clean out create msg
-      azureCloudContext <- wsmDao.getWorkspace(workspaceId, dummyAuth).map(_.get.azureContext)
+      azureCloudContext <- wsmClientProvider.getWorkspace("token", workspaceId).map(_.get.azureContext)
       preDeleteClusterOpt_1 <- clusterQuery
         .getActiveClusterByNameMinimal(CloudContext.Azure(azureCloudContext.get), runtimeName_1)(
           scala.concurrent.ExecutionContext.global
@@ -2443,7 +2442,7 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
           false,
           defaultCreateAzureRuntimeReq
         )
-      azureCloudContext <- wsmDao.getWorkspace(workspaceId, dummyAuth).map(_.get.azureContext)
+      azureCloudContext <- wsmClientProvider.getWorkspace("token", workspaceId).map(_.get.azureContext)
       clusterOpt <- clusterQuery
         .getActiveClusterByNameMinimal(CloudContext.Azure(azureCloudContext.get), runtimeName)(
           scala.concurrent.ExecutionContext.global
@@ -2485,7 +2484,7 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
           false,
           defaultCreateAzureRuntimeReq
         )
-      azureCloudContext <- wsmDao.getWorkspace(workspaceId, dummyAuth).map(_.get.azureContext)
+      azureCloudContext <- wsmClientProvider.getWorkspace("token", workspaceId).map(_.get.azureContext)
       _ <- azureService.updateDateAccessed(userInfo, workspaceId, runtimeName)
     } yield ()
 
@@ -2521,7 +2520,7 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
           false,
           defaultCreateAzureRuntimeReq
         )
-      azureCloudContext <- wsmDao.getWorkspace(workspaceId, dummyAuth).map(_.get.azureContext)
+      azureCloudContext <- wsmClientProvider.getWorkspace("token", workspaceId).map(_.get.azureContext)
       _ <- azureService2.updateDateAccessed(userInfo, workspaceId, runtimeName)
     } yield ()
 

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriberSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriberSpec.scala
@@ -1984,7 +1984,7 @@ class LeoPubsubMessageSubscriberSpec
   it should "handle top-level error in create azure disk properly" in isolatedDbTest {
     val mockAckConsumer = mock[AckHandler]
     val queue = makeTaskQueue()
-    val (mockWsm, _, _) = AzureTestUtils.setUpMockWsmApiClientProvider(JobReport.StatusEnum.FAILED)
+    val (mockWsm, _, _, _) = AzureTestUtils.setUpMockWsmApiClientProvider(JobReport.StatusEnum.FAILED)
     val leoSubscriber = makeLeoSubscriber(azureInterp =
                                             makeAzureInterp(asyncTaskQueue = queue, mockWsmClient = mockWsm),
                                           asyncTaskQueue = queue
@@ -2031,7 +2031,7 @@ class LeoPubsubMessageSubscriberSpec
   }
 
   it should "handle delete azure vm failure properly" in isolatedDbTest {
-    val (mockWsm, _, _) = AzureTestUtils.setUpMockWsmApiClientProvider(vmJobStatus = JobReport.StatusEnum.FAILED)
+    val (mockWsm, _, _, _) = AzureTestUtils.setUpMockWsmApiClientProvider(vmJobStatus = JobReport.StatusEnum.FAILED)
     val mockAckConsumer = mock[AckHandler]
     val queue = makeTaskQueue()
     val leoSubscriber =
@@ -2580,7 +2580,8 @@ class LeoPubsubMessageSubscriberSpec
       subscriberServicesRegistry
     )
   }
-  val (mockWsm, mockControlledResourceApi, mockResourceApi) = AzureTestUtils.setUpMockWsmApiClientProvider()
+  val (mockWsm, mockControlledResourceApi, mockResourceApi, workspaceApi) =
+    AzureTestUtils.setUpMockWsmApiClientProvider()
 
   // Needs to be made for each test its used in, otherwise queue will overlap
   def makeAzureInterp(asyncTaskQueue: Queue[IO, Task[IO]] = makeTaskQueue(),

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/MonitorAtBootSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/MonitorAtBootSpec.scala
@@ -7,7 +7,7 @@ import cats.syntax.all._
 import org.broadinstitute.dsde.workbench.google2.mock.FakeGoogleComputeService
 import org.broadinstitute.dsde.workbench.leonardo.CommonTestData._
 import org.broadinstitute.dsde.workbench.leonardo.KubernetesTestData._
-import org.broadinstitute.dsde.workbench.leonardo.dao.{MockSamDAO, MockWsmDAO}
+import org.broadinstitute.dsde.workbench.leonardo.dao.{MockSamDAO, MockWsmClientProvider, MockWsmDAO}
 import org.broadinstitute.dsde.workbench.leonardo.db.TestComponent
 import org.broadinstitute.dsde.workbench.leonardo.monitor.ClusterNodepoolAction.{
   CreateClusterAndNodepool,
@@ -356,5 +356,5 @@ class MonitorAtBootSpec extends AnyFlatSpec with TestComponent with LeonardoTest
     queue: Queue[IO, LeoPubsubMessage] =
       Queue.bounded[IO, LeoPubsubMessage](10).unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   ): MonitorAtBoot[IO] =
-    new MonitorAtBoot[IO](queue, Some(FakeGoogleComputeService), new MockSamDAO(), new MockWsmDAO())
+    new MonitorAtBoot[IO](queue, Some(FakeGoogleComputeService), new MockSamDAO(), new MockWsmClientProvider())
 }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/AKSInterpreterSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/AKSInterpreterSpec.scala
@@ -1067,10 +1067,12 @@ class AKSInterpreterSpec extends AnyFlatSpecLike with TestComponent with Leonard
     val dbsByJob = mutable.Map.empty[String, CreateControlledAzureDatabaseRequestBody]
     val namespacesByJob = mutable.Map.empty[String, CreateControlledAzureKubernetesNamespaceRequestBody]
 
+    val workspaceIdCaptor =
+      ArgumentCaptor.forClass(classOf[WorkspaceId])
     when {
-      wsm.getWorkspace(any, any, any)
+      wsm.getWorkspace(any, workspaceIdCaptor.capture(), any)
     } thenReturn {
-      new MockWsmClientProvider().getWorkspace("string", WorkspaceId(UUID.randomUUID()))
+      new MockWsmClientProvider().getWorkspace("string", workspaceIdCaptor.getValue.asInstanceOf[WorkspaceId])
     }
     // Create managed identity
     when {

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/AKSInterpreterSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/AKSInterpreterSpec.scala
@@ -1067,12 +1067,11 @@ class AKSInterpreterSpec extends AnyFlatSpecLike with TestComponent with Leonard
     val dbsByJob = mutable.Map.empty[String, CreateControlledAzureDatabaseRequestBody]
     val namespacesByJob = mutable.Map.empty[String, CreateControlledAzureKubernetesNamespaceRequestBody]
 
-    val workspaceIdCaptor =
-      ArgumentCaptor.forClass(classOf[WorkspaceId])
     when {
-      wsm.getWorkspace(any, workspaceIdCaptor.capture(), any)
-    } thenReturn {
-      new MockWsmClientProvider().getWorkspace("string", workspaceIdCaptor.getValue.asInstanceOf[WorkspaceId])
+      wsm.getWorkspace(any, any, any)
+    } thenAnswer { invocation =>
+      val workspaceId = invocation.getArgument[WorkspaceId](1)
+      new MockWsmClientProvider().getWorkspace("string", workspaceId)
     }
     // Create managed identity
     when {

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/AKSInterpreterSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/AKSInterpreterSpec.scala
@@ -1067,12 +1067,6 @@ class AKSInterpreterSpec extends AnyFlatSpecLike with TestComponent with Leonard
     val dbsByJob = mutable.Map.empty[String, CreateControlledAzureDatabaseRequestBody]
     val namespacesByJob = mutable.Map.empty[String, CreateControlledAzureKubernetesNamespaceRequestBody]
 
-    when {
-      wsm.getWorkspace(any, any, any)
-    } thenAnswer { invocation =>
-      val workspaceId = invocation.getArgument[WorkspaceId](1)
-      new MockWsmClientProvider().getWorkspace("string", workspaceId)
-    }
     // Create managed identity
     when {
       api.createAzureManagedIdentity(any, any)

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/AKSInterpreterSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/AKSInterpreterSpec.scala
@@ -1066,6 +1066,12 @@ class AKSInterpreterSpec extends AnyFlatSpecLike with TestComponent with Leonard
     val workspaceApi = mock[WorkspaceApi]
     val dbsByJob = mutable.Map.empty[String, CreateControlledAzureDatabaseRequestBody]
     val namespacesByJob = mutable.Map.empty[String, CreateControlledAzureKubernetesNamespaceRequestBody]
+
+    when {
+      wsm.getWorkspace(any, any, any)
+    } thenReturn {
+      new MockWsmClientProvider().getWorkspace("string", WorkspaceId(UUID.randomUUID()))
+    }
     // Create managed identity
     when {
       api.createAzureManagedIdentity(any, any)

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/AKSInterpreterSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/AKSInterpreterSpec.scala
@@ -1060,7 +1060,6 @@ class AKSInterpreterSpec extends AnyFlatSpecLike with TestComponent with Leonard
                                             namespaceExists: Boolean = true,
                                             identityExists: Boolean = true
   ): (WsmApiClientProvider[IO], ControlledAzureResourceApi, ResourceApi, WorkspaceApi) = {
-    val wsm = mock[WsmApiClientProvider[IO]]
     val api = mock[ControlledAzureResourceApi]
     val resourceApi = mock[ResourceApi]
     val workspaceApi = mock[WorkspaceApi]
@@ -1219,9 +1218,6 @@ class AKSInterpreterSpec extends AnyFlatSpecLike with TestComponent with Leonard
     } thenReturn {
       new DeleteControlledAzureResourceResult().jobReport(new JobReport().status(JobReport.StatusEnum.SUCCEEDED))
     }
-    when {
-      wsm.getControlledAzureResourceApi(any)(any)
-    } thenReturn IO.pure(api)
 
     // "ns-name" workspace database resource
 
@@ -1360,13 +1356,7 @@ class AKSInterpreterSpec extends AnyFlatSpecLike with TestComponent with Leonard
       new bio.terra.workspace.model.WorkspaceDescription().createdDate(workspaceCreatedDate);
     }
 
-    when {
-      wsm.getResourceApi(any)(any)
-    } thenReturn IO.pure(resourceApi)
-
-    when {
-      wsm.getWorkspaceApi(any)(any)
-    } thenReturn IO.pure(workspaceApi)
+    val wsm = new MockWsmClientProvider(api, resourceApi, workspaceApi)
 
     (wsm, api, resourceApi, workspaceApi)
 

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandlerSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandlerSpec.scala
@@ -524,6 +524,8 @@ class AzurePubsubHandlerSpec
   it should "delete azure vm properly" in isolatedDbTest {
     val queue = QueueFactory.asyncTaskQueue()
     val mockWsmDao = mock[WsmDao[IO]]
+    val (mockWsm, mockControlledResourceApi, _, _) =
+      AzureTestUtils.setUpMockWsmApiClientProvider()
     when {
       mockWsmDao.getLandingZoneResources(BillingProfileId(any[String]), any[Authorization])(any[Ask[IO, AppContext]])
     } thenReturn IO.pure(landingZoneResources)

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandlerSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzurePubsubHandlerSpec.scala
@@ -52,7 +52,8 @@ class AzurePubsubHandlerSpec
     with LeonardoTestSuite {
   val storageContainerResourceId = WsmControlledResourceId(UUID.randomUUID())
 
-  val (mockWsm, mockControlledResourceApi, mockResourceApi) = AzureTestUtils.setUpMockWsmApiClientProvider()
+  val (mockWsm, mockControlledResourceApi, mockResourceApi, workspaceApi) =
+    AzureTestUtils.setUpMockWsmApiClientProvider()
 
   it should "generate an Azure VM password properly" in {
     // Test this with a short password to make sure that the while loop works properly
@@ -419,7 +420,7 @@ class AzurePubsubHandlerSpec
   }
 
   it should "handle azure disk creation failure from wsm properly" in isolatedDbTest {
-    val (mockWsm, _, _) = AzureTestUtils.setUpMockWsmApiClientProvider(diskJobStatus = JobReport.StatusEnum.FAILED)
+    val (mockWsm, _, _, _) = AzureTestUtils.setUpMockWsmApiClientProvider(diskJobStatus = JobReport.StatusEnum.FAILED)
 
     val queue = QueueFactory.asyncTaskQueue()
 
@@ -589,7 +590,7 @@ class AzurePubsubHandlerSpec
       mockWsmDao.getLandingZoneResources(BillingProfileId(any[String]), any[Authorization])(any[Ask[IO, AppContext]])
     } thenReturn IO.pure(landingZoneResources)
 
-    val (mockWsm, mockControlledResourceApi, _) = AzureTestUtils.setUpMockWsmApiClientProvider()
+    val (mockWsm, mockControlledResourceApi, _, _) = AzureTestUtils.setUpMockWsmApiClientProvider()
     val azureInterp = makeAzurePubsubHandler(asyncTaskQueue = queue, wsmDAO = mockWsmDao, wsmClient = mockWsm)
 
     val res =
@@ -651,7 +652,7 @@ class AzurePubsubHandlerSpec
     when {
       mockWsmDao.getLandingZoneResources(BillingProfileId(any[String]), any[Authorization])(any[Ask[IO, AppContext]])
     } thenReturn IO.pure(landingZoneResources)
-    val (mockWsm, mockControlledResourceApi, _) = AzureTestUtils.setUpMockWsmApiClientProvider()
+    val (mockWsm, mockControlledResourceApi, _, _) = AzureTestUtils.setUpMockWsmApiClientProvider()
 
     val azureInterp = makeAzurePubsubHandler(asyncTaskQueue = queue, wsmDAO = mockWsmDao, wsmClient = mockWsm)
 
@@ -715,7 +716,7 @@ class AzurePubsubHandlerSpec
   it should "handle storage container creation error in async task properly" in isolatedDbTest {
     val queue = QueueFactory.asyncTaskQueue()
     val exceptionMsg = "storage container failed to create"
-    val (mockWsm, _, _) =
+    val (mockWsm, _, _, _) =
       AzureTestUtils.setUpMockWsmApiClientProvider(storageContainerJobStatus = JobReport.StatusEnum.FAILED)
 
     val azureInterp = makeAzurePubsubHandler(asyncTaskQueue = queue, wsmClient = mockWsm)
@@ -905,7 +906,7 @@ class AzurePubsubHandlerSpec
 
   it should "handle error in delete azure vm async task properly" in isolatedDbTest {
     val queue = QueueFactory.asyncTaskQueue()
-    val (mockWsm, _, _) = AzureTestUtils.setUpMockWsmApiClientProvider(vmJobStatus = JobReport.StatusEnum.FAILED)
+    val (mockWsm, _, _, _) = AzureTestUtils.setUpMockWsmApiClientProvider(vmJobStatus = JobReport.StatusEnum.FAILED)
     val azureInterp = makeAzurePubsubHandler(asyncTaskQueue = queue, wsmClient = mockWsm)
 
     val res =
@@ -963,7 +964,7 @@ class AzurePubsubHandlerSpec
   it should "fail if WSM delete VM job doesn't complete in time" in isolatedDbTest {
     val exceptionMsg = "WSM delete VM job was not completed within"
     val queue = QueueFactory.asyncTaskQueue()
-    val (mockWsm, _, _) = AzureTestUtils.setUpMockWsmApiClientProvider(vmJobStatus = JobReport.StatusEnum.RUNNING)
+    val (mockWsm, _, _, _) = AzureTestUtils.setUpMockWsmApiClientProvider(vmJobStatus = JobReport.StatusEnum.RUNNING)
     val azureInterp = makeAzurePubsubHandler(asyncTaskQueue = queue, wsmClient = mockWsm)
 
     val res =
@@ -1019,7 +1020,7 @@ class AzurePubsubHandlerSpec
 
   it should "update state correctly if WSM deleteDisk job fails during runtime deletion" in isolatedDbTest {
     val queue = QueueFactory.asyncTaskQueue()
-    val (mockWsm, _, _) = AzureTestUtils.setUpMockWsmApiClientProvider(diskJobStatus = JobReport.StatusEnum.FAILED)
+    val (mockWsm, _, _, _) = AzureTestUtils.setUpMockWsmApiClientProvider(diskJobStatus = JobReport.StatusEnum.FAILED)
     val azureInterp = makeAzurePubsubHandler(asyncTaskQueue = queue, wsmClient = mockWsm)
 
     val res =
@@ -1078,7 +1079,7 @@ class AzurePubsubHandlerSpec
   it should "update runtime correctly when wsm deleteDisk call errors on runtime deletion" in isolatedDbTest {
     val exceptionMsg = "Wsm deleteDisk job failed due to"
     val queue = QueueFactory.asyncTaskQueue()
-    val (mockWsm, _, _) = AzureTestUtils.setUpMockWsmApiClientProvider(diskJobStatus = JobReport.StatusEnum.FAILED)
+    val (mockWsm, _, _, _) = AzureTestUtils.setUpMockWsmApiClientProvider(diskJobStatus = JobReport.StatusEnum.FAILED)
     val azureInterp = makeAzurePubsubHandler(asyncTaskQueue = queue, wsmClient = mockWsm)
 
     val res =
@@ -1137,7 +1138,7 @@ class AzurePubsubHandlerSpec
   it should "update runtime correctly when wsm deleteStorageContainer call errors on runtime deletion" in isolatedDbTest {
     val exceptionMsg = "WSM storage container delete job failed due to"
     val queue = QueueFactory.asyncTaskQueue()
-    val (mockWsm, _, _) =
+    val (mockWsm, _, _, _) =
       AzureTestUtils.setUpMockWsmApiClientProvider(storageContainerJobStatus = JobReport.StatusEnum.FAILED)
     val azureInterp = makeAzurePubsubHandler(asyncTaskQueue = queue, wsmClient = mockWsm)
 
@@ -1622,7 +1623,7 @@ class AzurePubsubHandlerSpec
 
   it should "delete azure disk properly" in isolatedDbTest {
     val queue = QueueFactory.asyncTaskQueue()
-    val (mockWsm, mockControlledResourceApi, _) =
+    val (mockWsm, mockControlledResourceApi, _, _) =
       AzureTestUtils.setUpMockWsmApiClientProvider(storageContainerJobStatus = JobReport.StatusEnum.SUCCEEDED)
 
     val azureInterp = makeAzurePubsubHandler(asyncTaskQueue = queue, wsmClient = mockWsm)
@@ -1672,7 +1673,7 @@ class AzurePubsubHandlerSpec
   it should "not send delete to WSM without a disk record" in isolatedDbTest {
     val queue = QueueFactory.asyncTaskQueue()
 
-    val (mockWsm, mockControlledResourceApi, _) =
+    val (mockWsm, mockControlledResourceApi, _, _) =
       AzureTestUtils.setUpMockWsmApiClientProvider(storageContainerJobStatus = JobReport.StatusEnum.FAILED)
 
     val azureInterp = makeAzurePubsubHandler(asyncTaskQueue = queue, wsmClient = mockWsm)

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzureTestUtils.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzureTestUtils.scala
@@ -17,10 +17,9 @@ import cats.mtl.Ask
 import com.azure.resourcemanager.compute.models.{PowerState, VirtualMachine}
 import org.broadinstitute.dsde.workbench.azure.AzureCloudContext
 import org.broadinstitute.dsde.workbench.azure.mock.FakeAzureVmService
-import org.broadinstitute.dsde.workbench.leonardo.dao.{WsmApiClientProvider, WsmDaoDeleteControlledAzureResourceRequest}
+import org.broadinstitute.dsde.workbench.leonardo.dao.WsmApiClientProvider
 import org.broadinstitute.dsde.workbench.model.TraceId
 import org.broadinstitute.dsde.workbench.util2.InstanceName
-import org.broadinstitute.dsde.workbench.leonardo.dao.WsmApiClientProvider
 import org.scalatestplus.mockito.MockitoSugar
 import reactor.core.publisher.Mono
 

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzureTestUtils.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzureTestUtils.scala
@@ -21,6 +21,7 @@ import org.broadinstitute.dsde.workbench.leonardo.{AppContext, WorkspaceId}
 import org.broadinstitute.dsde.workbench.leonardo.dao.{MockWsmClientProvider, WsmApiClientProvider}
 import org.broadinstitute.dsde.workbench.model.TraceId
 import org.broadinstitute.dsde.workbench.util2.InstanceName
+import org.mockito.ArgumentCaptor
 import org.scalatestplus.mockito.MockitoSugar
 import reactor.core.publisher.Mono
 
@@ -41,10 +42,12 @@ object AzureTestUtils extends MockitoSugar {
     val resourceApi = mock[ResourceApi]
     val disksByJob = mutable.Map.empty[String, CreateControlledAzureDiskRequestV2Body]
 
+    val workspaceIdCaptor =
+      ArgumentCaptor.forClass(classOf[WorkspaceId])
     when {
-      wsm.getWorkspace(any, any, any)
+      wsm.getWorkspace(any, workspaceIdCaptor.capture(), any)
     } thenReturn {
-      new MockWsmClientProvider().getWorkspace("token", WorkspaceId(UUID.randomUUID()))
+      new MockWsmClientProvider().getWorkspace("token", workspaceIdCaptor.getValue.asInstanceOf[WorkspaceId])
     }
 
     // Create disk

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzureTestUtils.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzureTestUtils.scala
@@ -162,17 +162,7 @@ object AzureTestUtils extends MockitoSugar {
       wsmWorkspaceDesc.id(workspaceId)
     }
 
-    val wsm = new MockWsmClientProvider {
-      override def getControlledAzureResourceApi(token: String)(implicit
-        ev: Ask[IO, AppContext]
-      ): IO[ControlledAzureResourceApi] = IO.pure(api)
-
-      override def getResourceApi(token: String)(implicit ev: Ask[IO, AppContext]): IO[ResourceApi] =
-        IO.pure(resourceApi)
-
-      override def getWorkspaceApi(token: String)(implicit ev: Ask[IO, AppContext]): IO[WorkspaceApi] =
-        IO.pure(workspaceApi)
-
+    val wsm = new MockWsmClientProvider(api, resourceApi, workspaceApi) {
       override def getWorkspace(token: String, workspaceId: WorkspaceId, iamRole: IamRole)(implicit
         ev: Ask[IO, AppContext]
       ): IO[Option[WorkspaceDescription]] = {

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzureTestUtils.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzureTestUtils.scala
@@ -43,12 +43,6 @@ object AzureTestUtils extends MockitoSugar {
     val resourceApi = mock[ResourceApi]
     val disksByJob = mutable.Map.empty[String, CreateControlledAzureDiskRequestV2Body]
 
-//    doAnswer { invocation =>
-//      val workspaceId = invocation.getArgument[WorkspaceId](1)
-//      val token = invocation.getArgument[String](0)
-//      new MockWsmClientProvider().getWorkspace(token, workspaceId)
-//    } when wsm.getWorkspace(any, any)
-
     // Create disk
     when {
       api.createAzureDiskV2(any, any)

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzureTestUtils.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzureTestUtils.scala
@@ -2,8 +2,8 @@ package org.broadinstitute.dsde.workbench.leonardo.util
 
 import scala.collection.mutable
 import cats.effect.IO
-import org.mockito.Mockito.{doAnswer, doReturn, when}
-import org.mockito.ArgumentMatchers.{any, eq => mockitoEq}
+import org.mockito.Mockito.when
+import org.mockito.ArgumentMatchers.any
 import bio.terra.workspace.api.{ControlledAzureResourceApi, ResourceApi, WorkspaceApi}
 import bio.terra.workspace.model.{
   CreateControlledAzureDiskRequestV2Body,
@@ -18,10 +18,9 @@ import cats.mtl.Ask
 import com.azure.resourcemanager.compute.models.{PowerState, VirtualMachine}
 import org.broadinstitute.dsde.workbench.azure.{AzureCloudContext, ManagedResourceGroupName, SubscriptionId, TenantId}
 import org.broadinstitute.dsde.workbench.azure.mock.FakeAzureVmService
-import org.broadinstitute.dsde.workbench.leonardo.CommonTestData.{workspaceId, wsmWorkspaceDesc}
+import org.broadinstitute.dsde.workbench.leonardo.CommonTestData.wsmWorkspaceDesc
 import org.broadinstitute.dsde.workbench.leonardo.{AppContext, WorkspaceId}
 import org.broadinstitute.dsde.workbench.leonardo.dao.{
-  HttpWsmClientProvider,
   MockWsmClientProvider,
   WorkspaceDescription,
   WsmApiClientProvider
@@ -29,8 +28,6 @@ import org.broadinstitute.dsde.workbench.leonardo.dao.{
 import org.broadinstitute.dsde.workbench.model.TraceId
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.broadinstitute.dsde.workbench.util2.InstanceName
-import org.http4s.Uri
-import org.mockito.{ArgumentCaptor, ArgumentMatchers}
 import org.scalatestplus.mockito.MockitoSugar
 import reactor.core.publisher.Mono
 
@@ -47,7 +44,6 @@ object AzureTestUtils extends MockitoSugar {
     storageContainerJobStatus: JobReport.StatusEnum = JobReport.StatusEnum.SUCCEEDED,
     googleProject: Option[GoogleProject] = None
   ): (WsmApiClientProvider[IO], ControlledAzureResourceApi, ResourceApi, WorkspaceApi) = {
-//    val wsm = mock[WsmApiClientProvider[IO]]
     val api = mock[ControlledAzureResourceApi]
     val workspaceApi = mock[WorkspaceApi]
     val resourceApi = mock[ResourceApi]
@@ -189,45 +185,6 @@ object AzureTestUtils extends MockitoSugar {
         )
       }
     }
-    // Setup api builders
-//    when {
-//      wsm.getControlledAzureResourceApi(any)(any)
-//    } thenReturn IO.pure(api)
-//
-//    when {
-//      wsm.getResourceApi(any)(any)
-//    } thenReturn IO.pure(resourceApi)
-//
-//    when {
-//      wsm.getWorkspaceApi(any)(any)
-//    } thenReturn IO.pure(workspaceApi)
-
-//    when {
-//      wsm.getWorkspace(any, any, any)(any)
-//    } thenReturn IO.pure(None)
-
-//    doReturn { //invocation =>
-////      val workspaceId = invocation.getArgument[WorkspaceId](1)
-////      IO.pure(
-////        Some(
-////          WorkspaceDescription(
-////            workspaceId,
-////            "workspaceName" + workspaceId.value.toString,
-////            "spend-profile",
-////            Some(
-////              AzureCloudContext(TenantId(workspaceId.value.toString),
-////                SubscriptionId(workspaceId.value.toString),
-////                ManagedResourceGroupName(workspaceId.value.toString)
-////              )
-////            ),
-////            None
-////          )
-////        )
-////      )
-//      IO.pure(None)
-//    } when {
-//      wsm.getWorkspace(any, any, any)(any)
-//    }
 
     (wsm, api, resourceApi, workspaceApi)
   }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzureTestUtils.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/AzureTestUtils.scala
@@ -42,12 +42,11 @@ object AzureTestUtils extends MockitoSugar {
     val resourceApi = mock[ResourceApi]
     val disksByJob = mutable.Map.empty[String, CreateControlledAzureDiskRequestV2Body]
 
-    val workspaceIdCaptor =
-      ArgumentCaptor.forClass(classOf[WorkspaceId])
     when {
-      wsm.getWorkspace(any, workspaceIdCaptor.capture(), any)
-    } thenReturn {
-      new MockWsmClientProvider().getWorkspace("token", workspaceIdCaptor.getValue.asInstanceOf[WorkspaceId])
+      wsm.getWorkspace(any, any, any)
+    } thenAnswer { invocation =>
+      val workspaceId = invocation.getArgument[WorkspaceId](1)
+      new MockWsmClientProvider().getWorkspace("token", workspaceId)
     }
 
     // Create disk


### PR DESCRIPTION
This PR:
- removes getWorkspace from our custom wsmDao and migrates our code to use the generated wsm client
- adds a utility method to the wsm client wrapper to provide a consistent interface to the code expecting existing models
- removes the disk related methods from wsmdao