### PR TITLE
PROD-981 Locking error in a non-shared notebook

### DIFF
--- a/http/src/main/resources/init-resources/startup.sh
+++ b/http/src/main/resources/init-resources/startup.sh
@@ -165,13 +165,13 @@ END
 
         if [ "$NEED_MIGRATE" == "true" ] ; then
           docker exec $JUPYTER_SERVER_NAME /bin/bash -c "[ ! -d $JUPYTER_USER_HOME/notebooks/.jupyter ] && rsync -av --progress --exclude notebooks . $JUPYTER_USER_HOME/notebooks || true"
-
-          log 'Copy Jupyter frontend notebook config...'
-          $GSUTIL_CMD cp ${JUPYTER_NOTEBOOK_FRONTEND_CONFIG_URI} /var
-          JUPYTER_NOTEBOOK_FRONTEND_CONFIG=`basename ${JUPYTER_NOTEBOOK_FRONTEND_CONFIG_URI}`
-          retry 3 docker exec -u root ${JUPYTER_SERVER_NAME} /bin/bash -c "mkdir -p $JUPYTER_HOME/nbconfig"
-          docker cp /var/${JUPYTER_NOTEBOOK_FRONTEND_CONFIG} ${JUPYTER_SERVER_NAME}:${JUPYTER_HOME}/nbconfig/
         fi
+
+        log 'Copy Jupyter frontend notebook config...'
+        $GSUTIL_CMD cp ${JUPYTER_NOTEBOOK_FRONTEND_CONFIG_URI} /var
+        JUPYTER_NOTEBOOK_FRONTEND_CONFIG=`basename ${JUPYTER_NOTEBOOK_FRONTEND_CONFIG_URI}`
+        retry 3 docker exec -u root ${JUPYTER_SERVER_NAME} /bin/bash -c "mkdir -p $JUPYTER_HOME/nbconfig"
+        docker cp /var/${JUPYTER_NOTEBOOK_FRONTEND_CONFIG} ${JUPYTER_SERVER_NAME}:${JUPYTER_HOME}/nbconfig/
     fi
 
     if [ "$UPDATE_WELDER" == "true" ] ; then
@@ -228,13 +228,14 @@ else
           ${DOCKER_COMPOSE} -f ${JUPYTER_DOCKER_COMPOSE} stop
           ${DOCKER_COMPOSE} -f ${JUPYTER_DOCKER_COMPOSE} rm -f
           ${DOCKER_COMPOSE} -f ${JUPYTER_DOCKER_COMPOSE} up -d
-
-          log 'Copy Jupyter frontend notebook config...'
-          $GSUTIL_CMD cp ${JUPYTER_NOTEBOOK_FRONTEND_CONFIG_URI} /var
-          JUPYTER_NOTEBOOK_FRONTEND_CONFIG=`basename ${JUPYTER_NOTEBOOK_FRONTEND_CONFIG_URI}`
-          retry 3 docker exec -u root ${JUPYTER_SERVER_NAME} /bin/bash -c "mkdir -p $JUPYTER_HOME/nbconfig"
-          docker cp /var/${JUPYTER_NOTEBOOK_FRONTEND_CONFIG} ${JUPYTER_SERVER_NAME}:${JUPYTER_HOME}/nbconfig/
         fi
+
+        log 'Copy Jupyter frontend notebook config...'
+        $GSUTIL_CMD cp ${JUPYTER_NOTEBOOK_FRONTEND_CONFIG_URI} /var
+        JUPYTER_NOTEBOOK_FRONTEND_CONFIG=`basename ${JUPYTER_NOTEBOOK_FRONTEND_CONFIG_URI}`
+        retry 3 docker exec -u root ${JUPYTER_SERVER_NAME} /bin/bash -c "mkdir -p $JUPYTER_HOME/nbconfig"
+        docker cp /var/${JUPYTER_NOTEBOOK_FRONTEND_CONFIG} ${JUPYTER_SERVER_NAME}:${JUPYTER_HOME}/nbconfig/
+
         # jupyter_delocalize.py now assumes welder's url is `http://welder:8080`, but on dataproc, we're still using host network
         # A better to do this might be to take welder host as an argument to the script
         docker exec $JUPYTER_SERVER_NAME /bin/bash -c "sed -i 's/http:\/\/welder/http:\/\/127.0.0.1/g' /etc/jupyter/custom/jupyter_delocalize.py"


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/PROD-981

<!-- ## Dependencies -->
<!-- Include any dependent tickets and describe the relationship. Include any other relevant Jira tickets. -->

## Summary of changes

Users are getting "lock expired" errors while working in notebooks. Example:

![image](https://github.com/user-attachments/assets/4997a167-b4ab-4d87-95f3-c04b8070951b)

I think this is because the `edit-mode.js` extension is not refreshing the object locks from welder, because it is not getting the right configs. The configs come from `/etc/jupyter/nbconfig/notebook.json`. This file is created in the `gce-init.sh` script, but not recreated after container startup in `startup.sh`. There was some logic to recreate `notebook.json` in [this PR](https://github.com/DataBiosphere/leonardo/pull/2559), but it was buried under a `NEEDS_MIGRATE` flag. This PR moves it out of the `NEEDS_MIGRATE` block.

## Testing these changes

### What to test

Deploy this PR to a BEE and run through the below repro steps:

Repro steps:

1. Create a workspace, runtime, and a notebook
2. Pause/resume the runtime manually
3. Open the notebook
4. Browser console should say `edit mode plugin initialized`
5. Browser console should NOT say `welder is disabled`
6. Network tab should show periodic calls to the welder `lock` API
7. Above error should not happen after several minutes

<!-- ### Test data -->

### Who tested and where

- [ ] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [ ] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
