### PR TITLE
WOR-1810: Hide azure apps from Cloud Environments page

### DIFF
--- a/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changelog.xml
+++ b/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changelog.xml
@@ -117,4 +117,5 @@
     <include file="changesets/20240605_add_update_app_log_table.xml" relativeToChangelogFile="true" />
     <include file="changesets/20240620_add_mount_ws_bucket_to_app_table.xml" relativeToChangelogFile="true" />
     <include file="changesets/20240620_uuid_type.xml" relativeToChangelogFile="true" />
+    <include file="changesets/20240828_remove_saturnAutoCreated_label_from_azure_apps.xml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/20240828_remove_saturnAutoCreated_label_from_azure_apps.xml
+++ b/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/20240828_remove_saturnAutoCreated_label_from_azure_apps.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog logicalFilePath="leonardo" xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+    <changeSet logicalFilePath="leonardo" author="rtitle" id="remove-saturnAutoCreated-label-from-azure-apps">
+        <sql dbms="mysql">
+            DELETE FROM LABEL l
+            JOIN APP a ON l.resourceId = a.id AND l.resourceType = 'app'
+            WHERE l.`key` = 'saturnAutoCreated'
+            AND a.appType in ('WORKFLOWS_APP', 'CROMWELL_RUNNER_APP');
+        </sql>
+    </changeSet>
+</databaseChangeLog>
+
+

--- a/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/20240828_remove_saturnAutoCreated_label_from_azure_apps.xml
+++ b/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/20240828_remove_saturnAutoCreated_label_from_azure_apps.xml
@@ -2,8 +2,8 @@
 <databaseChangeLog logicalFilePath="leonardo" xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
     <changeSet logicalFilePath="leonardo" author="rtitle" id="remove-saturnAutoCreated-label-from-azure-apps">
         <sql dbms="mysql">
-            DELETE FROM LABEL l
-            JOIN APP a ON l.resourceId = a.id AND l.resourceType = 'app'
+            DELETE l FROM LABEL l
+            INNER JOIN APP a ON l.resourceId = a.id AND l.resourceType = 'app'
             WHERE l.`key` = 'saturnAutoCreated'
             AND a.appType in ('WORKFLOWS_APP', 'CROMWELL_RUNNER_APP');
         </sql>

--- a/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/20240828_remove_saturnAutoCreated_label_from_azure_apps.xml
+++ b/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/20240828_remove_saturnAutoCreated_label_from_azure_apps.xml
@@ -9,5 +9,3 @@
         </sql>
     </changeSet>
 </databaseChangeLog>
-
-


### PR DESCRIPTION
<!-- Welcome to your Leonardo pull request! -->
<!-- Contributor guidelines: https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md -->

__Jira ticket__: https://broadworkbench.atlassian.net/browse/WOR-1810

## Dependencies
Merge after https://github.com/DataBiosphere/terra-ui/pull/5041 is released.

## Summary of changes

<!-- Please give an abridged version of the ticket description here and/or fill out the following fields. -->

### What

- Migrate labels to remove `saturnAutoCreated` label for `WORKFLOWS_APP` and `CROMWELL_RUNNER_APP`.

### Why

- See Why in https://github.com/DataBiosphere/terra-ui/pull/5041 -- TLDR is we want to hide these app types from the Cloud Environments screen. (The UI uses `saturnAutoCreated` to populate the table.)

## Testing these changes

### What to test

Tested in a BEE via the following steps:

1. Created Azure workspace (WDS, CBAS, and Cromwell apps) using dev code
2. Verified I see CBAS and Cromwell in the Cloud Envs screen
3. Created Azure workspace using terra-ui PR code
4. Verified workspace functionality still works
5. Verified I do not see Azure apps from (3) in Cloud Envs screen
6. Deployed this Leo migration PR
7. Verified I no longer see any Azure apps in the Cloud Envs screen

### Who tested and where

- [x] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [x] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
