### PR TITLE
[IA-5053] Add retries to SamService, flesh out more authz methods

### DIFF
--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/sam/SamApiClientProvider.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/sam/SamApiClientProvider.scala
@@ -5,7 +5,7 @@ import cats.mtl.Ask
 import cats.syntax.all._
 import okhttp3.Protocol
 import org.broadinstitute.dsde.workbench.client.sam.ApiClient
-import org.broadinstitute.dsde.workbench.client.sam.api.{AzureApi, GoogleApi, ResourcesApi}
+import org.broadinstitute.dsde.workbench.client.sam.api.{AzureApi, GoogleApi, ResourcesApi, UsersApi}
 import org.broadinstitute.dsde.workbench.leonardo.AppContext
 
 import scala.concurrent.duration._
@@ -15,11 +15,13 @@ import scala.jdk.DurationConverters._
 /**
  * Provides access to various Sam clients:
  * - ResourcesApi is used for interacting with Sam resources and policies to enforce access control.
+ * - UsersApi is used for retrieving information about Sam users.
  * - GoogleApi is used for Google-specific extensions for users, such as pet service accounts and proxy groups.
  * - AzureApi is used for Azure-specific extensions for users, such as pet managed identities.
  */
 trait SamApiClientProvider[F[_]] {
   def resourcesApi(token: String)(implicit ev: Ask[F, AppContext]): F[ResourcesApi]
+  def usersApi(token: String)(implicit ev: Ask[F, AppContext]): F[UsersApi]
   def googleApi(token: String)(implicit ev: Ask[F, AppContext]): F[GoogleApi]
   def azureApi(token: String)(implicit ev: Ask[F, AppContext]): F[AzureApi]
 }
@@ -48,4 +50,7 @@ class HttpSamApiClientProvider[F[_]](samUrl: String)(implicit F: Async[F]) exten
 
   override def azureApi(token: String)(implicit ev: Ask[F, AppContext]): F[AzureApi] =
     getApiClient(token).map(api => new AzureApi(api))
+
+  override def usersApi(token: String)(implicit ev: Ask[F, AppContext]): F[UsersApi] =
+    getApiClient(token).map(api => new UsersApi(api))
 }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/sam/SamException.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/sam/SamException.scala
@@ -30,6 +30,9 @@ object SamException {
       traceId
     )
 
+  def create(message: String, code: Int, traceId: TraceId): SamException =
+    new SamException(message, code, null, traceId)
+
   /**
    * Extracts a useful message from a Sam client ApiException.
    *

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/sam/SamRetry.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/sam/SamRetry.scala
@@ -18,7 +18,7 @@ object SamRetry {
   /**
    * Initial delay of 1 second, exponential retry up to 5 times.
    */
-  private val retryConfig =
+  private val defaultSamRetryConfig =
     RetryConfig(addJitter(1 seconds, 1 seconds), _ * 2, 5, isRetryable)
 
   /**
@@ -45,5 +45,11 @@ object SamRetry {
     logger: StructuredLogger[F],
     ev: Ask[F, TraceId]
   ): F[A] =
-    tracedRetryF(retryConfig)(F.blocking(thunk), action).compile.lastOrError
+    retry(defaultSamRetryConfig)(F.blocking(thunk), action)
+
+  def retry[F[_], A](retryConfig: RetryConfig)(fa: F[A], action: String)(implicit
+    F: Async[F],
+    logger: StructuredLogger[F],
+    ev: Ask[F, TraceId]
+  ): F[A] = tracedRetryF(retryConfig)(fa, action).compile.lastOrError
 }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/sam/SamRetry.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/sam/SamRetry.scala
@@ -1,0 +1,49 @@
+package org.broadinstitute.dsde.workbench.leonardo.dao.sam
+
+import cats.effect.Async
+import cats.mtl.Ask
+import org.broadinstitute.dsde.workbench.RetryConfig
+import org.broadinstitute.dsde.workbench.client.sam.ApiException
+import org.apache.http.HttpStatus
+import org.broadinstitute.dsde.workbench.util2.addJitter
+
+import java.net.SocketTimeoutException
+import scala.concurrent.duration._
+import org.broadinstitute.dsde.workbench.google2.tracedRetryF
+import org.broadinstitute.dsde.workbench.model.TraceId
+import org.typelevel.log4cats.StructuredLogger
+
+object SamRetry {
+
+  /**
+   * Initial delay of 1 second, exponential retry up to 5 times.
+   */
+  private val retryConfig =
+    RetryConfig(addJitter(1 seconds, 1 seconds), _ * 2, 5, isRetryable)
+
+  /**
+   * Requests made through the Sam client library sometimes fail with timeouts, generally due to
+   * transient network or connection issues. When this happens, the client library will throw an API
+   * exceptions with status code 0 wrapping a SocketTimeoutException. These errors should always be
+   * retried.
+   */
+  private def isTimeoutException(apiException: ApiException): Boolean =
+    (apiException.getCode == 0) && apiException.getCause.isInstanceOf[SocketTimeoutException]
+
+  private def isRetryable(throwable: Throwable): Boolean = throwable match {
+    case e: ApiException =>
+      isTimeoutException(e) ||
+      e.getCode == HttpStatus.SC_INTERNAL_SERVER_ERROR ||
+      e.getCode == HttpStatus.SC_BAD_GATEWAY ||
+      e.getCode == HttpStatus.SC_SERVICE_UNAVAILABLE ||
+      e.getCode == HttpStatus.SC_GATEWAY_TIMEOUT
+    case _ => false
+  }
+
+  def retry[F[_], A](thunk: => A, action: String)(implicit
+    F: Async[F],
+    logger: StructuredLogger[F],
+    ev: Ask[F, TraceId]
+  ): F[A] =
+    tracedRetryF(retryConfig)(F.blocking(thunk), action).compile.lastOrError
+}

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/sam/SamService.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/sam/SamService.scala
@@ -2,9 +2,15 @@ package org.broadinstitute.dsde.workbench.leonardo.dao.sam
 
 import cats.mtl.Ask
 import org.broadinstitute.dsde.workbench.azure.AzureCloudContext
-import org.broadinstitute.dsde.workbench.leonardo.{AppContext, CloudContext, WorkspaceId}
+import org.broadinstitute.dsde.workbench.leonardo.{
+  AppContext,
+  CloudContext,
+  SamResourceId,
+  SamResourceType,
+  WorkspaceId
+}
+import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
-import org.broadinstitute.dsde.workbench.model.{UserInfo, WorkbenchEmail}
 
 /**
  * This class contains Leonardo's interactions with Sam.
@@ -13,45 +19,45 @@ trait SamService[F[_]] {
 
   /**
    * Gets a user's pet GCP service account, using the user's token.
-   * @param userInfo the user info containing an access token
+   * @param bearerToken the user's access token
    * @param googleProject the google project of the pet
    * @param ev application context
    * @return email of the pet service account, or SamException if the pet
    *         could not be retrieved.
    */
-  def getPetServiceAccount(userInfo: UserInfo, googleProject: GoogleProject)(implicit
+  def getPetServiceAccount(bearerToken: String, googleProject: GoogleProject)(implicit
     ev: Ask[F, AppContext]
   ): F[WorkbenchEmail]
 
   /**
    * Gets a user's pet Azure managed identity, using the user's token.
-   * @param userInfo the user info containing an access token
+   * @param bearerToken the user's access token
    * @param azureCloudContext the Azure cloud context
    * @param ev application context
    * @return email of the pet managed identity, or SamException if the pet
    *         could not be retrieved.
    */
-  def getPetManagedIdentity(userInfo: UserInfo, azureCloudContext: AzureCloudContext)(implicit
+  def getPetManagedIdentity(bearerToken: String, azureCloudContext: AzureCloudContext)(implicit
     ev: Ask[F, AppContext]
   ): F[WorkbenchEmail]
 
   /**
    * Gets a user's pet GCP service account or Azure managed identity using the user's token.
-   * @param userInfo the user info containing an access token
+   * @param bearerToken the user's access token
    * @param cloudContext GCP or Azure cloud context.
    * @param ev application context
    * @return email of the pet service account or pet managed identity, or SamException if
    *         the pet could not be retrieved.
    */
-  def getPetServiceAccountOrManagedIdentity(userInfo: UserInfo, cloudContext: CloudContext)(implicit
+  def getPetServiceAccountOrManagedIdentity(bearerToken: String, cloudContext: CloudContext)(implicit
     ev: Ask[F, AppContext]
   ): F[WorkbenchEmail] = cloudContext match {
-    case CloudContext.Gcp(googleProject)       => getPetServiceAccount(userInfo, googleProject)
-    case CloudContext.Azure(azureCloudContext) => getPetManagedIdentity(userInfo, azureCloudContext)
+    case CloudContext.Gcp(googleProject)       => getPetServiceAccount(bearerToken, googleProject)
+    case CloudContext.Azure(azureCloudContext) => getPetManagedIdentity(bearerToken, azureCloudContext)
   }
 
   /**
-   * Gets the user's proxy group, using the Leo token.
+   * Gets a user's proxy group, using a Leonardo token.
    * @param userEmail the user email
    * @param ev application context
    * @return email of the proxy group, or SamException if the pet could not be retrieved.
@@ -61,7 +67,7 @@ trait SamService[F[_]] {
   )(implicit ev: Ask[F, AppContext]): F[WorkbenchEmail]
 
   /**
-   * Gets a token for the user's pet service account, using the Leo token.
+   * Gets a token for a user's pet service account, using a Leonardo token.
    * @param userEmail the user email
    * @param googleProject the google project of the pet
    * @param ev application context
@@ -83,12 +89,75 @@ trait SamService[F[_]] {
    * method will not fail if a workspace cannot be retrieved. Logs and metrics are
    * emitted for successful and failed workspace retrievals.
    *
-   * @param userInfo the user info containing an access token
+   * @param bearerToken the user's access token
    * @param googleProject the google project whose workspace parent to look up
    * @param ev application context
    * @return optional workspace ID
    */
-  def lookupWorkspaceParentForGoogleProject(userInfo: UserInfo, googleProject: GoogleProject)(implicit
+  def lookupWorkspaceParentForGoogleProject(bearerToken: String, googleProject: GoogleProject)(implicit
     ev: Ask[F, AppContext]
   ): F[Option[WorkspaceId]]
+
+  /**
+   * Checks whether a user can perform an action on a Sam resource.
+   * @param bearerToken the user's access token
+   * @param samResourceId the Sam resource ID
+   * @param action the Sam action
+   * @param ev application context
+   * @return Unit if authorized, ForbiddenError if not authorized, SamException on errors.
+   */
+  def checkAuthz(bearerToken: String, samResourceId: SamResourceId, action: String)(implicit
+    ev: Ask[F, AppContext]
+  ): F[Unit]
+
+  /**
+   * List all Sam resources a user has access to.
+   * @param bearerToken the user's access token
+   * @param samResourceType Sam resource type to list
+   * @param ev application context
+   * @return list of Sam resource IDs, or SamException on errors.
+   */
+  def listResources(bearerToken: String, samResourceType: SamResourceType)(implicit
+    ev: Ask[F, AppContext]
+  ): F[List[String]]
+
+  /**
+   * Creates a Sam resource.
+   * @param bearerToken the user's access token
+   * @param samResourceId the Sam resource ID
+   * @param parentProject optional parent google project resource.
+   *                      One of parentProject or parentWorkspace is required.
+   * @param parentWorkspace optional parent workspace resource.
+   *                        One of parentProject or parentWorkspace is required.
+   * @param creator optional creator email to add to the resource's creator policy.
+   * @param ev application context
+   * @return Unit, or SamException on errors.
+   */
+  def createResource(bearerToken: String,
+                     samResourceId: SamResourceId,
+                     parentProject: Option[GoogleProject],
+                     parentWorkspace: Option[WorkspaceId],
+                     creator: Option[WorkbenchEmail]
+  )(implicit
+    ev: Ask[F, AppContext]
+  ): F[Unit]
+
+  /**
+   * Deletes a Sam resource.
+   * @param userEmail the user's access token
+   * @param samResourceId the Sam resource ID
+   * @param ev application context
+   * @return Unit, or SamException on errors
+   */
+  def deleteResource(bearerToken: String, samResourceId: SamResourceId)(implicit
+    ev: Ask[F, AppContext]
+  ): F[Unit]
+
+  /**
+   * Fetch the email from Sam associated with the user access token.
+   * @param bearerToken the user's access token
+   * @param ev application context
+   * @return user email, or SamException on errors
+   */
+  def getUserEmail(bearerToken: String)(implicit ev: Ask[F, AppContext]): F[WorkbenchEmail]
 }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/sam/SamService.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/sam/SamService.scala
@@ -5,6 +5,7 @@ import org.broadinstitute.dsde.workbench.azure.AzureCloudContext
 import org.broadinstitute.dsde.workbench.leonardo.{
   AppContext,
   CloudContext,
+  SamPolicyData,
   SamResourceId,
   SamResourceType,
   WorkspaceId
@@ -129,7 +130,8 @@ trait SamService[F[_]] {
    *                      One of parentProject or parentWorkspace is required.
    * @param parentWorkspace optional parent workspace resource.
    *                        One of parentProject or parentWorkspace is required.
-   * @param creator optional creator email to add to the resource's creator policy.
+   * @param policies optional mapping of policy name to policy data to set for
+   *                 the Sam resource.
    * @param ev application context
    * @return Unit, or SamException on errors.
    */
@@ -137,7 +139,7 @@ trait SamService[F[_]] {
                      samResourceId: SamResourceId,
                      parentProject: Option[GoogleProject],
                      parentWorkspace: Option[WorkspaceId],
-                     creator: Option[WorkbenchEmail]
+                     policies: Map[String, SamPolicyData]
   )(implicit
     ev: Ask[F, AppContext]
   ): F[Unit]

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/sam/SamService.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/sam/SamService.scala
@@ -107,7 +107,7 @@ trait SamService[F[_]] {
    * @param ev application context
    * @return Unit if authorized, ForbiddenError if not authorized, SamException on errors.
    */
-  def checkAuthz(bearerToken: String, samResourceId: SamResourceId, action: String)(implicit
+  def checkAuthorized(bearerToken: String, samResourceId: SamResourceId, action: String)(implicit
     ev: Ask[F, AppContext]
   ): F[Unit]
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/sam/SamService.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/sam/SamService.scala
@@ -130,8 +130,9 @@ trait SamService[F[_]] {
    *                      One of parentProject or parentWorkspace is required.
    * @param parentWorkspace optional parent workspace resource.
    *                        One of parentProject or parentWorkspace is required.
-   * @param policies optional mapping of policy name to policy data to set for
-   *                 the Sam resource.
+   * @param policies optional mapping of policy name to policy data for the Sam resource.
+   *                 Note policy name can be an arbitrary string, but must be unique per
+   *                 resource. Policy data contains emails and Sam roles.
    * @param ev application context
    * @return Unit, or SamException on errors.
    */

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/sam/SamServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/sam/SamServiceInterp.scala
@@ -15,7 +15,6 @@ import org.broadinstitute.dsde.workbench.client.sam.model.{
 }
 import org.broadinstitute.dsde.workbench.leonardo.SamResourceId.{ProjectSamResourceId, WorkspaceResourceSamResourceId}
 import org.broadinstitute.dsde.workbench.leonardo.auth.CloudAuthTokenProvider
-import org.broadinstitute.dsde.workbench.leonardo.http._
 import org.broadinstitute.dsde.workbench.leonardo.model.LeoInternalServerError
 import org.broadinstitute.dsde.workbench.leonardo.{
   AppContext,
@@ -55,9 +54,8 @@ class SamServiceInterp[F[_]](apiClientProvider: SamApiClientProvider[F],
       ctx <- ev.ask
       googleApi <- apiClientProvider.googleApi(bearerToken)
       userEmail <- getUserEmail(bearerToken)
-      pet <- SamRetry.retry(googleApi.getPetServiceAccount(googleProject.value), "getPetServiceAccount").adaptError {
-        case e: ApiException =>
-          SamException.create("Error getting pet service account from Sam", e, ctx.traceId)
+      pet <- SamRetry.retry(googleApi.getPetServiceAccount(googleProject.value)).adaptError { case e: ApiException =>
+        SamException.create("Error getting pet service account from Sam", e, ctx.traceId)
       }
       _ <- logger.info(ctx.loggingCtx)(
         s"Retrieved pet service account $pet for user $userEmail in project $googleProject"
@@ -78,8 +76,7 @@ class SamServiceInterp[F[_]](apiClientProvider: SamApiClientProvider[F],
               .tenantId(azureCloudContext.tenantId.value)
               .subscriptionId(azureCloudContext.subscriptionId.value)
               .managedResourceGroupName(azureCloudContext.managedResourceGroupName.value)
-          ),
-          "getPetManagedIdentity"
+          )
         )
         .adaptError { case e: ApiException =>
           SamException.create("Error getting pet managed identity from Sam", e, ctx.traceId)
@@ -96,9 +93,8 @@ class SamServiceInterp[F[_]](apiClientProvider: SamApiClientProvider[F],
       ctx <- ev.ask
       leoToken <- getLeoAuthToken
       googleApi <- apiClientProvider.googleApi(leoToken)
-      proxy <- SamRetry.retry(googleApi.getProxyGroup(userEmail.value), "getProxyGroup").adaptError {
-        case e: ApiException =>
-          SamException.create("Error getting proxy group from Sam", e, ctx.traceId)
+      proxy <- SamRetry.retry(googleApi.getProxyGroup(userEmail.value)).adaptError { case e: ApiException =>
+        SamException.create("Error getting proxy group from Sam", e, ctx.traceId)
       }
       _ <- logger.info(ctx.loggingCtx)(s"Retrieved proxy group $proxy for user $userEmail")
     } yield WorkbenchEmail(proxy)
@@ -110,9 +106,7 @@ class SamServiceInterp[F[_]](apiClientProvider: SamApiClientProvider[F],
     leoToken <- getLeoAuthToken
     googleApi <- apiClientProvider.googleApi(leoToken)
     petToken <- SamRetry
-      .retry(googleApi.getUserPetServiceAccountToken(googleProject.value, userEmail.value, saScopes.asJava),
-             "getUserPetServiceAccountToken"
-      )
+      .retry(googleApi.getUserPetServiceAccountToken(googleProject.value, userEmail.value, saScopes.asJava))
       .adaptError { case e: ApiException =>
         SamException.create("Error getting pet service account token from Sam", e, ctx.traceId)
       }
@@ -129,7 +123,7 @@ class SamServiceInterp[F[_]](apiClientProvider: SamApiClientProvider[F],
     // Get resource parent from Sam
     resourcesApi <- apiClientProvider.resourcesApi(bearerToken)
     parent <- SamRetry
-      .retry(resourcesApi.getResourceParent(SamResourceType.Project.asString, googleProject.value), "getResourceParent")
+      .retry(resourcesApi.getResourceParent(SamResourceType.Project.asString, googleProject.value))
       .attempt
 
     // Annotate error cases but don't fail
@@ -173,10 +167,7 @@ class SamServiceInterp[F[_]](apiClientProvider: SamApiClientProvider[F],
       ctx <- ev.ask
       resourcesApi <- apiClientProvider.resourcesApi(bearerToken)
       isAuthorized <- SamRetry
-        .retry(
-          resourcesApi.resourcePermissionV2(samResourceId.resourceType.asString, samResourceId.resourceId, action),
-          "resourcePermissionV2"
-        )
+        .retry(resourcesApi.resourcePermissionV2(samResourceId.resourceType.asString, samResourceId.resourceId, action))
         .adaptError { case e: ApiException =>
           SamException.create("Error checking resource permission in Sam", e, ctx.traceId)
         }
@@ -207,7 +198,7 @@ class SamServiceInterp[F[_]](apiClientProvider: SamApiClientProvider[F],
     ctx <- ev.ask
     resourcesApi <- apiClientProvider.resourcesApi(bearerToken)
     resources <- SamRetry
-      .retry(resourcesApi.listResourcesAndPoliciesV2(samResourceType.asString), "listResourcesAndPoliciesV2")
+      .retry(resourcesApi.listResourcesAndPoliciesV2(samResourceType.asString))
       .adaptError { case e: ApiException =>
         SamException.create("Error listing resources from Sam", e, ctx.traceId)
       }
@@ -283,9 +274,8 @@ class SamServiceInterp[F[_]](apiClientProvider: SamApiClientProvider[F],
     for {
       ctx <- ev.ask
       usersApi <- apiClientProvider.usersApi(bearerToken)
-      userStatus <- SamRetry.retry(usersApi.getUserStatusInfo(), "getUserStatusInfo").adaptError {
-        case e: ApiException =>
-          SamException.create(s"Error getting user status info from Sam", e, ctx.traceId)
+      userStatus <- SamRetry.retry(usersApi.getUserStatusInfo()).adaptError { case e: ApiException =>
+        SamException.create(s"Error getting user status info from Sam", e, ctx.traceId)
       }
     } yield WorkbenchEmail(userStatus.getUserEmail)
 }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/sam/SamServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/sam/SamServiceInterp.scala
@@ -16,7 +16,7 @@ import org.broadinstitute.dsde.workbench.client.sam.model.{
 import org.broadinstitute.dsde.workbench.leonardo.SamResourceId.{ProjectSamResourceId, WorkspaceResourceSamResourceId}
 import org.broadinstitute.dsde.workbench.leonardo.auth.CloudAuthTokenProvider
 import org.broadinstitute.dsde.workbench.leonardo.http._
-import org.broadinstitute.dsde.workbench.leonardo.model.{ForbiddenError, LeoInternalServerError}
+import org.broadinstitute.dsde.workbench.leonardo.model.LeoInternalServerError
 import org.broadinstitute.dsde.workbench.leonardo.{AppContext, SamResourceId, SamResourceType, SamRole, WorkspaceId}
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/sam/SamServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/sam/SamServiceInterp.scala
@@ -6,12 +6,19 @@ import cats.syntax.all._
 import com.google.api.services.storage.StorageScopes
 import org.broadinstitute.dsde.workbench.azure.AzureCloudContext
 import org.broadinstitute.dsde.workbench.client.sam.ApiException
-import org.broadinstitute.dsde.workbench.client.sam.model.GetOrCreateManagedIdentityRequest
+import org.broadinstitute.dsde.workbench.client.sam.model.{
+  AccessPolicyMembershipRequest,
+  CreateResourceRequestV2,
+  FullyQualifiedResourceId,
+  GetOrCreateManagedIdentityRequest
+}
+import org.broadinstitute.dsde.workbench.leonardo.SamResourceId.{ProjectSamResourceId, WorkspaceResourceSamResourceId}
 import org.broadinstitute.dsde.workbench.leonardo.auth.CloudAuthTokenProvider
-import org.broadinstitute.dsde.workbench.leonardo.model.LeoInternalServerError
-import org.broadinstitute.dsde.workbench.leonardo.{AppContext, SamResourceType, WorkspaceId}
+import org.broadinstitute.dsde.workbench.leonardo.http._
+import org.broadinstitute.dsde.workbench.leonardo.model.{ForbiddenError, LeoInternalServerError}
+import org.broadinstitute.dsde.workbench.leonardo.{AppContext, SamResourceId, SamResourceType, SamRole, WorkspaceId}
+import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
-import org.broadinstitute.dsde.workbench.model.{UserInfo, WorkbenchEmail}
 import org.broadinstitute.dsde.workbench.openTelemetry.OpenTelemetryMetrics
 import org.http4s.AuthScheme
 import org.http4s.Credentials.Token
@@ -34,38 +41,45 @@ class SamServiceInterp[F[_]](apiClientProvider: SamApiClientProvider[F],
     StorageScopes.DEVSTORAGE_READ_ONLY
   )
 
-  // TODO: pattern for retries
-  //  See: https://broadworkbench.atlassian.net/browse/IA-5053
-
-  override def getPetServiceAccount(userInfo: UserInfo, googleProject: GoogleProject)(implicit
+  override def getPetServiceAccount(bearerToken: String, googleProject: GoogleProject)(implicit
     ev: Ask[F, AppContext]
   ): F[WorkbenchEmail] =
     for {
       ctx <- ev.ask
-      googleApi <- apiClientProvider.googleApi(userInfo.accessToken.token)
-      pet <- F.blocking(googleApi.getPetServiceAccount(googleProject.value)).adaptError { case e: ApiException =>
-        SamException.create("Error getting pet service account from Sam", e, ctx.traceId)
+      googleApi <- apiClientProvider.googleApi(bearerToken)
+      userEmail <- getUserEmail(bearerToken)
+      pet <- SamRetry.retry(googleApi.getPetServiceAccount(googleProject.value), "getPetServiceAccount").adaptError {
+        case e: ApiException =>
+          SamException.create("Error getting pet service account from Sam", e, ctx.traceId)
       }
+      _ <- logger.info(ctx.loggingCtx)(
+        s"Retrieved pet service account $pet for user $userEmail in project $googleProject"
+      )
     } yield WorkbenchEmail(pet)
 
-  override def getPetManagedIdentity(userInfo: UserInfo, azureCloudContext: AzureCloudContext)(implicit
+  override def getPetManagedIdentity(bearerToken: String, azureCloudContext: AzureCloudContext)(implicit
     ev: Ask[F, AppContext]
   ): F[WorkbenchEmail] =
     for {
       ctx <- ev.ask
-      azureApi <- apiClientProvider.azureApi(userInfo.accessToken.token)
-      pet <- F
-        .blocking(
+      azureApi <- apiClientProvider.azureApi(bearerToken)
+      userEmail <- getUserEmail(bearerToken)
+      pet <- SamRetry
+        .retry(
           azureApi.getPetManagedIdentity(
             new GetOrCreateManagedIdentityRequest()
               .tenantId(azureCloudContext.tenantId.value)
               .subscriptionId(azureCloudContext.subscriptionId.value)
               .managedResourceGroupName(azureCloudContext.managedResourceGroupName.value)
-          )
+          ),
+          "getPetManagedIdentity"
         )
         .adaptError { case e: ApiException =>
           SamException.create("Error getting pet managed identity from Sam", e, ctx.traceId)
         }
+      _ <- logger.info(ctx.loggingCtx)(
+        s"Retrieved pet managed identity $pet for user $userEmail in Azure cloud context ${azureCloudContext.asString}"
+      )
     } yield WorkbenchEmail(pet)
 
   override def getProxyGroup(
@@ -75,9 +89,11 @@ class SamServiceInterp[F[_]](apiClientProvider: SamApiClientProvider[F],
       ctx <- ev.ask
       leoToken <- getLeoAuthToken
       googleApi <- apiClientProvider.googleApi(leoToken)
-      proxy <- F.blocking(googleApi.getProxyGroup(userEmail.value)).adaptError { case e: ApiException =>
-        SamException.create("Error getting proxy group from Sam", e, ctx.traceId)
+      proxy <- SamRetry.retry(googleApi.getProxyGroup(userEmail.value), "getProxyGroup").adaptError {
+        case e: ApiException =>
+          SamException.create("Error getting proxy group from Sam", e, ctx.traceId)
       }
+      _ <- logger.info(ctx.loggingCtx)(s"Retrieved proxy group $proxy for user $userEmail")
     } yield WorkbenchEmail(proxy)
 
   override def getPetServiceAccountToken(userEmail: WorkbenchEmail, googleProject: GoogleProject)(implicit
@@ -86,21 +102,28 @@ class SamServiceInterp[F[_]](apiClientProvider: SamApiClientProvider[F],
     ctx <- ev.ask
     leoToken <- getLeoAuthToken
     googleApi <- apiClientProvider.googleApi(leoToken)
-    petToken <- F
-      .blocking(googleApi.getUserPetServiceAccountToken(googleProject.value, userEmail.value, saScopes.asJava))
+    petToken <- SamRetry
+      .retry(googleApi.getUserPetServiceAccountToken(googleProject.value, userEmail.value, saScopes.asJava),
+             "getUserPetServiceAccountToken"
+      )
       .adaptError { case e: ApiException =>
         SamException.create("Error getting pet service account token from Sam", e, ctx.traceId)
       }
+    _ <- logger.info(ctx.loggingCtx)(
+      s"Retrieved pet service account token for user $userEmail in project $googleProject"
+    )
   } yield petToken
 
-  override def lookupWorkspaceParentForGoogleProject(userInfo: UserInfo, googleProject: GoogleProject)(implicit
+  override def lookupWorkspaceParentForGoogleProject(bearerToken: String, googleProject: GoogleProject)(implicit
     ev: Ask[F, AppContext]
   ): F[Option[WorkspaceId]] = for {
     ctx <- ev.ask
 
     // Get resource parent from Sam
-    resourcesApi <- apiClientProvider.resourcesApi(userInfo.accessToken.token)
-    parent <- F.blocking(resourcesApi.getResourceParent(SamResourceType.Project.asString, googleProject.value)).attempt
+    resourcesApi <- apiClientProvider.resourcesApi(bearerToken)
+    parent <- SamRetry
+      .retry(resourcesApi.getResourceParent(SamResourceType.Project.asString, googleProject.value), "getResourceParent")
+      .attempt
 
     // Annotate error cases but don't fail
     workspaceId = parent match {
@@ -135,4 +158,117 @@ class SamServiceInterp[F[_]](apiClientProvider: SamApiClientProvider[F],
           F.raiseError(LeoInternalServerError("Internal server error retrieving Leo credentials", Some(ctx.traceId)))
       }
     } yield token
+
+  private def isAuthorized(bearerToken: String, samResourceId: SamResourceId, action: String)(implicit
+    ev: Ask[F, AppContext]
+  ): F[Boolean] =
+    for {
+      ctx <- ev.ask
+      resourcesApi <- apiClientProvider.resourcesApi(bearerToken)
+      isAuthorized <- SamRetry
+        .retry(
+          resourcesApi.resourcePermissionV2(samResourceId.resourceType.asString, samResourceId.resourceId, action),
+          "resourcePermissionV2"
+        )
+        .adaptError { case e: ApiException =>
+          SamException.create("Error checking resource permission in Sam", e, ctx.traceId)
+        }
+
+    } yield isAuthorized
+
+  override def checkAuthz(bearerToken: String, samResourceId: SamResourceId, action: String)(implicit
+    ev: Ask[F, AppContext]
+  ): F[Unit] = for {
+    ctx <- ev.ask
+    isAuthorized <- isAuthorized(bearerToken, samResourceId, action)
+    userEmail <- getUserEmail(bearerToken)
+    _ <- F.raiseWhen(!isAuthorized)(ForbiddenError(userEmail, Some(ctx.traceId)))
+    _ <- logger.info(ctx.loggingCtx)(
+      s"User $userEmail is authorized to $action ${samResourceId.resourceType} ${samResourceId.resourceId}"
+    )
+  } yield ()
+
+  override def listResources(bearerToken: String, samResourceType: SamResourceType)(implicit
+    ev: Ask[F, AppContext]
+  ): F[List[String]] = for {
+    ctx <- ev.ask
+    resourcesApi <- apiClientProvider.resourcesApi(bearerToken)
+    resources <- SamRetry
+      .retry(resourcesApi.listResourcesAndPoliciesV2(samResourceType.asString), "listResourcesAndPoliciesV2")
+      .adaptError { case e: ApiException =>
+        SamException.create("Error listing resources from Sam", e, ctx.traceId)
+      }
+  } yield resources.asScala.toList.map(_.getResourceId)
+
+  override def createResource(bearerToken: String,
+                              samResourceId: SamResourceId,
+                              projectParent: Option[GoogleProject],
+                              workspaceParent: Option[WorkspaceId],
+                              creator: Option[WorkbenchEmail]
+  )(implicit
+    ev: Ask[F, AppContext]
+  ): F[Unit] =
+    for {
+      ctx <- ev.ask
+      resourcesApi <- apiClientProvider.resourcesApi(bearerToken)
+      // All Leo resources have a creator role
+      policies = creator
+        .map(c =>
+          Map(
+            SamRole.Creator.asString -> new AccessPolicyMembershipRequest()
+              .addMemberEmailsItem(c.value)
+              .addRolesItem(SamRole.Creator.asString)
+          )
+        )
+        .getOrElse(Map.empty)
+      // Parent is required, can be google-project or workspace
+      parent <- F.fromOption(
+        projectParent.map(ProjectSamResourceId).orElse(workspaceParent.map(WorkspaceResourceSamResourceId)),
+        LeoInternalServerError(
+          "Internal error creating Sam resource: google project or workspace parent is required",
+          Some(ctx.traceId)
+        )
+      )
+      body = new CreateResourceRequestV2()
+        .resourceId(samResourceId.resourceId)
+        .parent(
+          new FullyQualifiedResourceId().resourceTypeName(parent.resourceType.asString).resourceId(parent.resourceId)
+        )
+        .policies(policies.asJava)
+      _ <- SamRetry
+        .retry(resourcesApi.createResourceV2(samResourceId.resourceType.asString, body), "createResourceV2")
+        .adaptError { case e: ApiException =>
+          SamException.create(s"Error creating ${samResourceId.resourceType.asString} resource in Sam", e, ctx.traceId)
+        }
+      _ <- logger.info(ctx.loggingCtx)(
+        s"Created Sam resource for ${samResourceId.resourceType.asString} ${samResourceId.resourceId}"
+      )
+    } yield ()
+
+  override def deleteResource(bearerToken: String, samResourceId: SamResourceId)(implicit
+    ev: Ask[F, AppContext]
+  ): F[Unit] = for {
+    ctx <- ev.ask
+    resourcesApi <- apiClientProvider.resourcesApi(bearerToken)
+    _ <- SamRetry
+      .retry(resourcesApi.deleteResourceV2(samResourceId.resourceType.asString, samResourceId.resourceId),
+             "deleteResourceV2"
+      )
+      .adaptError { case e: ApiException =>
+        SamException.create(s"Error deleting ${samResourceId.resourceType.asString} resource in Sam", e, ctx.traceId)
+      }
+    _ <- logger.info(ctx.loggingCtx)(
+      s"Deleted Sam resource for ${samResourceId.resourceType.asString} ${samResourceId.resourceId}"
+    )
+  } yield ()
+
+  override def getUserEmail(bearerToken: String)(implicit ev: Ask[F, AppContext]): F[WorkbenchEmail] =
+    for {
+      ctx <- ev.ask
+      usersApi <- apiClientProvider.usersApi(bearerToken)
+      userStatus <- SamRetry.retry(usersApi.getUserStatusInfo(), "getUserStatusInfo").adaptError {
+        case e: ApiException =>
+          SamException.create(s"Error getting user status info from Sam", e, ctx.traceId)
+      }
+    } yield WorkbenchEmail(userStatus.getUserEmail)
 }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/sam/SamServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/sam/SamServiceInterp.scala
@@ -183,7 +183,7 @@ class SamServiceInterp[F[_]](apiClientProvider: SamApiClientProvider[F],
 
     } yield isAuthorized
 
-  override def checkAuthz(bearerToken: String, samResourceId: SamResourceId, action: String)(implicit
+  override def checkAuthorized(bearerToken: String, samResourceId: SamResourceId, action: String)(implicit
     ev: Ask[F, AppContext]
   ): F[Unit] = for {
     ctx <- ev.ask

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/DiskServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/DiskServiceInterp.scala
@@ -65,7 +65,7 @@ class DiskServiceInterp[F[_]: Parallel](config: PersistentDiskConfig,
       _ <- if (hasPermission) F.unit else F.raiseError[Unit](ForbiddenError(userInfo.userEmail))
 
       // Grab the pet service account for the user
-      petSA <- samService.getPetServiceAccount(userInfo, googleProject)
+      petSA <- samService.getPetServiceAccount(userInfo.accessToken.token, googleProject)
 
       _ <- req.sourceDisk.traverse(sd => verifyOkToClone(sd.googleProject, googleProject))
 
@@ -80,7 +80,9 @@ class DiskServiceInterp[F[_]: Parallel](config: PersistentDiskConfig,
             samResource <- F.delay(PersistentDiskSamResourceId(UUID.randomUUID().toString))
 
             // Retrieve parent workspaceId for the google project
-            parentWorkspaceId <- samService.lookupWorkspaceParentForGoogleProject(userInfo, googleProject)
+            parentWorkspaceId <- samService.lookupWorkspaceParentForGoogleProject(userInfo.accessToken.token,
+                                                                                  googleProject
+            )
 
             disk <- F.fromEither(
               convertToDisk(userInfo.userEmail,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/LeoAppServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/LeoAppServiceInterp.scala
@@ -160,7 +160,7 @@ final class LeoAppServiceInterp[F[_]: Parallel](config: AppServiceConfig,
       originatingUserEmail <- authProvider.lookupOriginatingUserEmail(userInfo)
 
       // Retrieve parent workspaceId for the google project
-      parentWorkspaceId <- samService.lookupWorkspaceParentForGoogleProject(userInfo, googleProject)
+      parentWorkspaceId <- samService.lookupWorkspaceParentForGoogleProject(userInfo.accessToken.token, googleProject)
 
       notifySamAndCreate = for {
         _ <- authProvider
@@ -229,7 +229,7 @@ final class LeoAppServiceInterp[F[_]: Parallel](config: AppServiceConfig,
             }
           }
 
-        petSA <- samService.getPetServiceAccount(userInfo, googleProject)
+        petSA <- samService.getPetServiceAccount(userInfo.accessToken.token, googleProject)
         _ <- ctx.span.traverse(s => F.delay(s.addAnnotation("Done Sam call for getPetServiceAccount")))
 
         // Fail fast if the Galaxy disk, memory, number of CPUs is too small
@@ -818,7 +818,7 @@ final class LeoAppServiceInterp[F[_]: Parallel](config: AppServiceConfig,
       nodepool = saveClusterResult.defaultNodepool.toNodepool()
 
       // Retrieve a pet identity from Sam
-      petSA <- samService.getPetServiceAccountOrManagedIdentity(userInfo, cloudContext)
+      petSA <- samService.getPetServiceAccountOrManagedIdentity(userInfo.accessToken.token, cloudContext)
       _ <- ctx.span.traverse(s => F.delay(s.addAnnotation("Done Sam call for getPetServiceAccount")))
 
       // Process persistent disk in the request, check if the disk was previously attached to any other app

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterp.scala
@@ -98,11 +98,11 @@ class RuntimeServiceInterp[F[_]: Parallel](
       _ <- context.span.traverse(s => F.delay(s.addAnnotation("Done Sam call for cluster permission")))
       _ <- F.raiseUnless(hasPermission)(ForbiddenError(userInfo.userEmail))
       // Grab the pet service account for the user
-      petSA <- samService.getPetServiceAccount(userInfo, googleProject)
+      petSA <- samService.getPetServiceAccount(userInfo.accessToken.token, googleProject)
       _ <- context.span.traverse(s => F.delay(s.addAnnotation("Done Sam call for getPetServiceAccount")))
 
       // Retrieve parent workspaceId for the google project
-      parentWorkspaceId <- samService.lookupWorkspaceParentForGoogleProject(userInfo, googleProject)
+      parentWorkspaceId <- samService.lookupWorkspaceParentForGoogleProject(userInfo.accessToken.token, googleProject)
 
       runtimeOpt <- RuntimeServiceDbQueries.getStatusByName(cloudContext, runtimeName).transaction
       _ <- context.span.traverse(s => F.delay(s.addAnnotation("Done DB query for active cluster")))

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeoException.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeoException.scala
@@ -44,6 +44,7 @@ final case class AuthenticationError(email: Option[WorkbenchEmail] = None, extra
     )
     with NoStackTrace
 
+// TODO fix message
 case class ForbiddenError(email: WorkbenchEmail, traceId: Option[TraceId] = None)
     extends LeoException(
       s"${email.value} is unauthorized. " +

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeoException.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeoException.scala
@@ -44,7 +44,6 @@ final case class AuthenticationError(email: Option[WorkbenchEmail] = None, extra
     )
     with NoStackTrace
 
-// TODO fix message
 case class ForbiddenError(email: WorkbenchEmail, traceId: Option[TraceId] = None)
     extends LeoException(
       s"${email.value} is unauthorized. " +

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/sam/SamRetrySpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/sam/SamRetrySpec.scala
@@ -1,10 +1,79 @@
 package org.broadinstitute.dsde.workbench.leonardo.dao.sam
 
+import cats.effect.unsafe.implicits.global
+import cats.effect.{IO, Ref}
+import cats.syntax.all._
+import org.broadinstitute.dsde.workbench.RetryConfig
 import org.broadinstitute.dsde.workbench.leonardo.LeonardoTestSuite
+import org.broadinstitute.dsde.workbench.leonardo.TestUtils.appContext
+import org.broadinstitute.dsde.workbench.leonardo.http._
 import org.scalatest.flatspec.AnyFlatSpec
 
-class SamRetrySpec extends AnyFlatSpec with LeonardoTestSuite {
-  "SamRetry" should "retry retriable exceptions" in {}
+import scala.concurrent.duration._
 
-  it should "retry timeout exceptions" in {}
+class SamRetrySpec extends AnyFlatSpec with LeonardoTestSuite {
+  val testRetryConfig = RetryConfig(100 millis, identity, 5, _.isInstanceOf[TestException])
+  val counter: IO[Ref[IO, Int]] = Ref[IO].of(0)
+  def incrementCounter(counter: Ref[IO, Int]): IO[Int] = counter.updateAndGet(_ + 1)
+
+  "SamRetry" should "not retry successes" in {
+    val test = for {
+      c <- counter
+      lastResult <- SamRetry.retry(testRetryConfig)(incrementCounter(c), "increment")
+      tries <- c.get
+    } yield {
+      // Counter should have been incremented once
+      lastResult shouldBe 1
+      tries shouldBe 1
+    }
+    test.unsafeRunSync()
+  }
+
+  it should "retry retryable exceptions" in {
+    val test = for {
+      c <- counter
+      exception = TestException("api error")
+      alwaysFail = incrementCounter(c) >> IO.raiseError(exception)
+      lastResult <- SamRetry.retry(testRetryConfig)(alwaysFail, "increment").attempt
+      tries <- c.get
+    } yield {
+      // Counter should have been incremented 5 times and result should be the TestException
+      lastResult shouldBe Left(exception)
+      tries shouldBe 5
+    }
+    test.unsafeRunSync()
+  }
+
+  it should "retry for n attempts" in {
+    val test = for {
+      c <- counter
+      exception = TestException("api error")
+      failTwice = incrementCounter(c).flatMap(n => IO.raiseWhen(n < 2)(exception).as(n))
+      lastResult <- SamRetry.retry(testRetryConfig)(failTwice, "increment").attempt
+      tries <- c.get
+    } yield {
+      // Counter should have been incremented twice
+      lastResult shouldBe Right(2)
+      tries shouldBe 2
+    }
+    test.unsafeRunSync()
+  }
+
+  it should "not retry non-retryable exceptions" in {
+    val test = for {
+      c <- counter
+      exception = new RuntimeException("runtime error")
+      alwaysFail = incrementCounter(c) >> IO.raiseError(exception)
+      lastResult <- SamRetry.retry(testRetryConfig)(alwaysFail, "increment").attempt
+      tries <- c.get
+    } yield {
+      // Counter should have been incremented once and result should be the RuntimeException
+      lastResult.isLeft shouldBe true
+      lastResult.leftMap(_.getMessage) shouldBe Left(exception.getMessage)
+      tries shouldBe 1
+    }
+    test.unsafeRunSync()
+  }
 }
+
+case class TestException(message: String) extends Exception(message)

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/sam/SamRetrySpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/sam/SamRetrySpec.scala
@@ -5,8 +5,6 @@ import cats.effect.{IO, Ref}
 import cats.syntax.all._
 import org.broadinstitute.dsde.workbench.RetryConfig
 import org.broadinstitute.dsde.workbench.leonardo.LeonardoTestSuite
-import org.broadinstitute.dsde.workbench.leonardo.TestUtils.appContext
-import org.broadinstitute.dsde.workbench.leonardo.http._
 import org.scalatest.flatspec.AnyFlatSpec
 
 import scala.concurrent.duration._
@@ -19,7 +17,7 @@ class SamRetrySpec extends AnyFlatSpec with LeonardoTestSuite {
   "SamRetry" should "not retry successes" in {
     val test = for {
       c <- counter
-      lastResult <- SamRetry.retry(testRetryConfig)(incrementCounter(c), "increment")
+      lastResult <- SamRetry.retry(testRetryConfig)(incrementCounter(c))
       tries <- c.get
     } yield {
       // Counter should have been incremented once
@@ -34,7 +32,7 @@ class SamRetrySpec extends AnyFlatSpec with LeonardoTestSuite {
       c <- counter
       exception = TestException("api error")
       alwaysFail = incrementCounter(c) >> IO.raiseError(exception)
-      lastResult <- SamRetry.retry(testRetryConfig)(alwaysFail, "increment").attempt
+      lastResult <- SamRetry.retry(testRetryConfig)(alwaysFail).attempt
       tries <- c.get
     } yield {
       // Counter should have been incremented 5 times and result should be the TestException
@@ -49,7 +47,7 @@ class SamRetrySpec extends AnyFlatSpec with LeonardoTestSuite {
       c <- counter
       exception = TestException("api error")
       failTwice = incrementCounter(c).flatMap(n => IO.raiseWhen(n < 2)(exception).as(n))
-      lastResult <- SamRetry.retry(testRetryConfig)(failTwice, "increment").attempt
+      lastResult <- SamRetry.retry(testRetryConfig)(failTwice).attempt
       tries <- c.get
     } yield {
       // Counter should have been incremented twice
@@ -64,7 +62,7 @@ class SamRetrySpec extends AnyFlatSpec with LeonardoTestSuite {
       c <- counter
       exception = new RuntimeException("runtime error")
       alwaysFail = incrementCounter(c) >> IO.raiseError(exception)
-      lastResult <- SamRetry.retry(testRetryConfig)(alwaysFail, "increment").attempt
+      lastResult <- SamRetry.retry(testRetryConfig)(alwaysFail).attempt
       tries <- c.get
     } yield {
       // Counter should have been incremented once and result should be the RuntimeException

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/sam/SamRetrySpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/sam/SamRetrySpec.scala
@@ -1,0 +1,10 @@
+package org.broadinstitute.dsde.workbench.leonardo.dao.sam
+
+import org.broadinstitute.dsde.workbench.leonardo.LeonardoTestSuite
+import org.scalatest.flatspec.AnyFlatSpec
+
+class SamRetrySpec extends AnyFlatSpec with LeonardoTestSuite {
+  "SamRetry" should "retry retriable exceptions" in {}
+
+  it should "retry timeout exceptions" in {}
+}

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/sam/SamServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/sam/SamServiceInterpSpec.scala
@@ -217,11 +217,11 @@ class SamServiceInterpSpec extends AnyFunSpecLike with LeonardoTestSuite with Be
       }
     }
 
-    describe("checkAuthz") {
+    describe("checkAuthorized") {
       it("should successfully check authorization") {
         // test
         newSamService()
-          .checkAuthz(tokenValue, runtimeSamResource, RuntimeAction.GetRuntimeStatus.asString)
+          .checkAuthorized(tokenValue, runtimeSamResource, RuntimeAction.GetRuntimeStatus.asString)
           .unsafeRunSync()
       }
 
@@ -237,7 +237,7 @@ class SamServiceInterpSpec extends AnyFunSpecLike with LeonardoTestSuite with Be
 
         // test
         val result = the[SamException] thrownBy newSamService(resourcesApi = resourcesApi)
-          .checkAuthz(tokenValue, runtimeSamResource, RuntimeAction.GetRuntimeStatus.asString)
+          .checkAuthorized(tokenValue, runtimeSamResource, RuntimeAction.GetRuntimeStatus.asString)
           .unsafeRunSync()
 
         // assert
@@ -254,7 +254,7 @@ class SamServiceInterpSpec extends AnyFunSpecLike with LeonardoTestSuite with Be
 
         // test
         val result = the[SamException] thrownBy newSamService(resourcesApi = resourcesApi)
-          .checkAuthz(tokenValue, runtimeSamResource, RuntimeAction.GetRuntimeStatus.asString)
+          .checkAuthorized(tokenValue, runtimeSamResource, RuntimeAction.GetRuntimeStatus.asString)
           .unsafeRunSync()
 
         // assert

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/sam/SamServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/sam/SamServiceInterpSpec.scala
@@ -27,7 +27,7 @@ class SamServiceInterpSpec extends AnyFunSpecLike with LeonardoTestSuite with Be
     describe("getPetServiceAccount") {
       it("should retrieve a pet service account from Sam") {
         // test
-        val result = newSamService().getPetServiceAccount(userInfo, project).unsafeRunSync()
+        val result = newSamService().getPetServiceAccount(tokenValue, project).unsafeRunSync()
 
         // assert
         result shouldBe serviceAccountEmail
@@ -41,7 +41,7 @@ class SamServiceInterpSpec extends AnyFunSpecLike with LeonardoTestSuite with Be
         // test
         val result =
           the[SamException] thrownBy newSamService(googleApi = googleApi)
-            .getPetServiceAccount(userInfo, project)
+            .getPetServiceAccount(tokenValue, project)
             .unsafeRunSync()
 
         // assert
@@ -53,7 +53,7 @@ class SamServiceInterpSpec extends AnyFunSpecLike with LeonardoTestSuite with Be
     describe("getPetManagedIdentity") {
       it("should retrieve a pet managed identity from Sam") {
         // test
-        val result = newSamService().getPetManagedIdentity(userInfo, azureCloudContext).unsafeRunSync()
+        val result = newSamService().getPetManagedIdentity(tokenValue, azureCloudContext).unsafeRunSync()
 
         // assert
         result shouldBe managedIdentityEmail
@@ -67,7 +67,7 @@ class SamServiceInterpSpec extends AnyFunSpecLike with LeonardoTestSuite with Be
         // test
         val result =
           the[SamException] thrownBy newSamService(azureApi = azureApi)
-            .getPetManagedIdentity(userInfo, azureCloudContext)
+            .getPetManagedIdentity(tokenValue, azureCloudContext)
             .unsafeRunSync()
 
         // assert
@@ -136,7 +136,7 @@ class SamServiceInterpSpec extends AnyFunSpecLike with LeonardoTestSuite with Be
       it("should successfully lookup a google project's parent workspace") {
         // test
         val result =
-          newSamService().lookupWorkspaceParentForGoogleProject(userInfo, project).unsafeRunSync()
+          newSamService().lookupWorkspaceParentForGoogleProject(tokenValue, project).unsafeRunSync()
 
         // assert
         result shouldBe Some(workspaceId)
@@ -151,7 +151,7 @@ class SamServiceInterpSpec extends AnyFunSpecLike with LeonardoTestSuite with Be
         // test
         val result =
           newSamService(resourcesApi)
-            .lookupWorkspaceParentForGoogleProject(userInfo, project)
+            .lookupWorkspaceParentForGoogleProject(tokenValue, project)
             .unsafeRunSync()
 
         // assert
@@ -166,7 +166,7 @@ class SamServiceInterpSpec extends AnyFunSpecLike with LeonardoTestSuite with Be
 
         // test
         val result =
-          newSamService(resourcesApi).lookupWorkspaceParentForGoogleProject(userInfo, project).unsafeRunSync()
+          newSamService(resourcesApi).lookupWorkspaceParentForGoogleProject(tokenValue, project).unsafeRunSync()
 
         // assert
         result shouldBe None
@@ -184,7 +184,7 @@ class SamServiceInterpSpec extends AnyFunSpecLike with LeonardoTestSuite with Be
 
         // test
         val result =
-          newSamService(resourcesApi).lookupWorkspaceParentForGoogleProject(userInfo, project).unsafeRunSync()
+          newSamService(resourcesApi).lookupWorkspaceParentForGoogleProject(tokenValue, project).unsafeRunSync()
 
         // assert
         result shouldBe None
@@ -202,11 +202,40 @@ class SamServiceInterpSpec extends AnyFunSpecLike with LeonardoTestSuite with Be
 
         // test
         val result =
-          newSamService(resourcesApi).lookupWorkspaceParentForGoogleProject(userInfo, project).unsafeRunSync()
+          newSamService(resourcesApi).lookupWorkspaceParentForGoogleProject(tokenValue, project).unsafeRunSync()
 
         // assert
         result shouldBe None
       }
+    }
+
+    describe("checkAuthz") {
+      it("should successfully check authorization") {}
+      it("should fail with ForbiddenError if unauthorized") {}
+      it("should fail with SamException on Sam errors") {}
+    }
+
+    describe("listResources") {
+      it("should successfully list resources") {}
+      it("should handle Sam errors") {}
+    }
+
+    describe("createResource") {
+      it("should create a Sam resource with a google project parent") {}
+      it("should create a Sam resource with a workspace parent") {}
+      it("should not allow resource creation with no parent") {}
+      it("should create a Sam resource with a creator policy") {}
+      it("should handle Sam errors") {}
+    }
+
+    describe("deleteResource") {
+      it("should delete a Sam resource") {}
+      it("should handle Sam errors") {}
+    }
+
+    describe("getUserEmail") {
+      it("should get a user email") {}
+      it("should handle Sam errors") {}
     }
   }
 

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/mocks.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/mocks.scala
@@ -307,11 +307,11 @@ class MockAKSInterp extends AKSAlgebra[IO] {
 }
 
 class BaseMockSamService extends SamService[IO] {
-  override def getPetServiceAccount(userInfo: UserInfo, googleProject: GoogleProject)(implicit
+  override def getPetServiceAccount(bearerToken: String, googleProject: GoogleProject)(implicit
     ev: Ask[IO, AppContext]
   ): IO[WorkbenchEmail] = IO.pure(serviceAccountEmail)
 
-  override def getPetManagedIdentity(userInfo: UserInfo, azureCloudContext: AzureCloudContext)(implicit
+  override def getPetManagedIdentity(bearerToken: String, azureCloudContext: AzureCloudContext)(implicit
     ev: Ask[IO, AppContext]
   ): IO[WorkbenchEmail] = IO.pure(managedIdentityEmail)
 
@@ -323,8 +323,30 @@ class BaseMockSamService extends SamService[IO] {
   ): IO[String] =
     IO.pure(tokenValue)
 
-  override def lookupWorkspaceParentForGoogleProject(userInfo: UserInfo, googleProject: GoogleProject)(implicit
+  override def lookupWorkspaceParentForGoogleProject(bearerToken: String, googleProject: GoogleProject)(implicit
     ev: Ask[IO, AppContext]
   ): IO[Option[WorkspaceId]] = IO.pure(Some(workspaceId))
+
+  override def checkAuthz(bearerToken: String, samResourceId: SamResourceId, action: String)(implicit
+    ev: Ask[IO, AppContext]
+  ): IO[Unit] = IO.unit
+
+  override def listResources(bearerToken: String, samResourceType: SamResourceType)(implicit
+    ev: Ask[IO, AppContext]
+  ): IO[List[String]] = IO.pure(List.empty)
+
+  override def createResource(bearerToken: String,
+                              samResourceId: SamResourceId,
+                              parentProject: Option[GoogleProject],
+                              parentWorkspace: Option[WorkspaceId],
+                              creator: Option[WorkbenchEmail]
+  )(implicit ev: Ask[IO, AppContext]): IO[Unit] = IO.unit
+
+  override def deleteResource(bearerToken: String, samResourceId: SamResourceId)(implicit
+    ev: Ask[IO, AppContext]
+  ): IO[Unit] = IO.unit
+
+  override def getUserEmail(bearerToken: String)(implicit ev: Ask[IO, AppContext]): IO[WorkbenchEmail] =
+    IO.pure(userEmail)
 }
 object MockSamService extends BaseMockSamService

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/mocks.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/mocks.scala
@@ -339,7 +339,7 @@ class BaseMockSamService extends SamService[IO] {
                               samResourceId: SamResourceId,
                               parentProject: Option[GoogleProject],
                               parentWorkspace: Option[WorkspaceId],
-                              creator: Option[WorkbenchEmail]
+                              policies: Map[String, SamPolicyData]
   )(implicit ev: Ask[IO, AppContext]): IO[Unit] = IO.unit
 
   override def deleteResource(bearerToken: String, samResourceId: SamResourceId)(implicit

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/mocks.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/mocks.scala
@@ -327,7 +327,7 @@ class BaseMockSamService extends SamService[IO] {
     ev: Ask[IO, AppContext]
   ): IO[Option[WorkspaceId]] = IO.pure(Some(workspaceId))
 
-  override def checkAuthz(bearerToken: String, samResourceId: SamResourceId, action: String)(implicit
+  override def checkAuthorized(bearerToken: String, samResourceId: SamResourceId, action: String)(implicit
     ev: Ask[IO, AppContext]
   ): IO[Unit] = IO.unit
 


### PR DESCRIPTION
<!-- Welcome to your Leonardo pull request! -->
<!-- Contributor guidelines: https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md -->

https://broadworkbench.atlassian.net/browse/IA-5053

<!-- ## Dependencies -->
<!-- Include any dependent tickets and describe the relationship. Include any other relevant Jira tickets. -->

## Summary of changes

Draft while I self-review and test. This PR fleshes out more authz logic in `SamService`/`SamServiceInterp`. It does NOT actually update Leo to use `SamService` for authorization yet (I think we will need to do some more testing and potential historical data migrations before that can happen).

### What

- Added pattern for retries in `SamServiceInterp`
- Added access control methods (`checkAuthz`, `create/deleteResource`, etc)
- Improved logging
- Added unit tests

### Why

- I'm trying to prepare for when we can cut over to `SamService` for real. Next step will be understanding/migrating historical data to the desired state. Docs [1](https://docs.google.com/document/d/1FAkxK25hqCdCJWXVdcmpaTE23IeTPHSm_lyR_MuoMf8/edit#heading=h.csta1rbbpzb3) and [2](https://broadworkbench.atlassian.net/wiki/spaces/IA/pages/3323592711/IA-4295+Use+Sam+client+in+leonardo) will help with this.

## Testing these changes

### What to test

- Unit tests
- Automation tests

<!-- ### Test data -->

### Who tested and where

- [ ] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [ ] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
