### PR TITLE
[IA-5058] Remove azure automation tests from build-test-publish action

### DIFF
--- a/.github/workflows/leo-build-tag-publish-and-run-tests.yml
+++ b/.github/workflows/leo-build-tag-publish-and-run-tests.yml
@@ -32,7 +32,7 @@ env:
   LEO_SWAT_TESTS_RUN_NAME: 'leonardo-swat-tests-${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt }}'
   BEE_CREATE_RUN_NAME: 'bee-create-${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt }}'
   BEE_DESTROY_RUN_NAME: 'bee-destroy-${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt }}'
-  AZURE_SWAT_TESTS_RUN_NAME: 'azure-swat-tests-${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt }}'
+  # AZURE_SWAT_TESTS_RUN_NAME: 'azure-swat-tests-${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt }}'
 
 concurrency:
   # Don't run this workflow concurrently on the same branch
@@ -216,32 +216,33 @@ jobs:
               "custom-version-json": "${{ steps.render-leo-version.outputs.custom-version-json }}"
             }'
 
-  azure-automation-tests:
-    runs-on: ubuntu-latest
-    needs: [ leo-build-tag-publish-job, report-to-sherlock, init-github-context, create-bee-workflow ]
-    permissions:
-      contents: 'read'
-      id-token: 'write'
-    steps:
-      - name: dispatch to azure automation test workflow
-        uses: broadinstitute/workflow-dispatch@v4.0.0
-        with:
-          run-name: "${{ env.AZURE_SWAT_TESTS_RUN_NAME }}"
-          workflow: .github/workflows/azure_automation_test.yml
-          repo: DataBiosphere/leonardo
-          ref: refs/heads/develop
-          token: ${{ env.TOKEN }}
-          # this is not actually 85mins, the timeout is not working correctly and is summing from other jobs
-          wait-for-completion-timeout: 85m
-          inputs: '{
-            "terra-env": "${{ needs.init-github-context.outputs.test-env }}",
-            "automation-branch": "${{ needs.init-github-context.outputs.automation-branch }}",
-            "app-version": "${{ needs.leo-build-tag-publish-job.outputs.tag }}",
-            "bee-name": "${{ env.BEE_NAME }}",
-            "is-triggered-from-pr-dispatch": "true",
-            "run-name": "${{ env.AZURE_SWAT_TESTS_RUN_NAME }}"
-            }'
-          wait-for-completion: true
+## !! Commenting out until when/if the azure tests are necessary again...
+#  azure-automation-tests:
+#    runs-on: ubuntu-latest
+#    needs: [ leo-build-tag-publish-job, report-to-sherlock, init-github-context, create-bee-workflow ]
+#    permissions:
+#      contents: 'read'
+#      id-token: 'write'
+#    steps:
+#      - name: dispatch to azure automation test workflow
+#        uses: broadinstitute/workflow-dispatch@v4.0.0
+#        with:
+#          run-name: "${{ env.AZURE_SWAT_TESTS_RUN_NAME }}"
+#          workflow: .github/workflows/azure_automation_test.yml
+#          repo: DataBiosphere/leonardo
+#          ref: refs/heads/develop
+#          token: ${{ env.TOKEN }}
+#          # this is not actually 85mins, the timeout is not working correctly and is summing from other jobs
+#          wait-for-completion-timeout: 85m
+#          inputs: '{
+#            "terra-env": "${{ needs.init-github-context.outputs.test-env }}",
+#            "automation-branch": "${{ needs.init-github-context.outputs.automation-branch }}",
+#            "app-version": "${{ needs.leo-build-tag-publish-job.outputs.tag }}",
+#            "bee-name": "${{ env.BEE_NAME }}",
+#            "is-triggered-from-pr-dispatch": "true",
+#            "run-name": "${{ env.AZURE_SWAT_TESTS_RUN_NAME }}"
+#            }'
+#          wait-for-completion: true
 
   leo-swat-test-job:
     strategy:
@@ -298,7 +299,7 @@ jobs:
     needs:
       - init-github-context
       - leo-swat-test-job
-      - azure-automation-tests
+     # - azure-automation-tests
     if: ${{ needs.init-github-context.outputs.delete-bee && always() }} # always run to confirm bee is destroyed unless explicitly requested not to
     permissions:
       contents: 'read'


### PR DESCRIPTION
<!-- Welcome to your Leonardo pull request! -->
<!-- Contributor guidelines: https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md -->

__Jira ticket__: https://broadworkbench.atlassian.net/browse/IA-5058

<!-- ## Dependencies -->
<!-- Include any dependent tickets and describe the relationship. Include any other relevant Jira tickets. -->

## Summary of changes

<!-- Please give an abridged version of the ticket description here and/or fill out the following fields. -->

### What

Comments out the azure automation tests from the build-tag-publish-and-run-tests GHA

### Why

Just disabling the tests caused them to fail, this fully removes them from the pipeline

## Testing these changes

### What to test

- <!-- Test case 1 -->

<!-- ### Test data -->

### Who tested and where

- [ ] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [ ] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
