### PR TITLE
[IA-5066] DO NOT MERGE getRuntime v1 checks notebook-cluster-status action assuming hiera…

### DIFF
--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterp.scala
@@ -235,6 +235,7 @@ class RuntimeServiceInterp[F[_]: Parallel](
   ): F[GetRuntimeResponse] = for {
     ctx <- as.ask
 
+    // raises RuntimeNotFoundException
     runtime <- RuntimeServiceDbQueries.getRuntime(cloudContext, runtimeName).transaction
 
     bearerToken = userInfo.accessToken.token

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterpSpec.scala
@@ -37,6 +37,7 @@ import org.broadinstitute.dsde.workbench.leonardo.TestUtils.{appContext, default
 import org.broadinstitute.dsde.workbench.leonardo.auth.AllowlistAuthProvider
 import org.broadinstitute.dsde.workbench.leonardo.config.Config
 import org.broadinstitute.dsde.workbench.leonardo.dao.MockDockerDAO
+import org.broadinstitute.dsde.workbench.leonardo.dao.sam.{SamException, SamService}
 import org.broadinstitute.dsde.workbench.leonardo.db._
 import org.broadinstitute.dsde.workbench.leonardo.http.service.RuntimeServiceInterp.{
   calculateAutopauseThreshold,
@@ -81,7 +82,8 @@ trait RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
   def makeRuntimeService(
     publisherQueue: Queue[IO, LeoPubsubMessage] = publisherQueue,
     computeService: GoogleComputeService[IO] = FakeGoogleComputeService,
-    authProvider: AllowlistAuthProvider = allowListAuthProvider
+    authProvider: AllowlistAuthProvider = allowListAuthProvider,
+    samService: SamService[IO] = MockSamService
   ) =
     new RuntimeServiceInterp(
       RuntimeServiceConfig(
@@ -98,7 +100,7 @@ trait RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
       Some(FakeGoogleStorageInterpreter),
       Some(computeService),
       publisherQueue,
-      MockSamService
+      samService
     )
 
   val runtimeService = makeRuntimeService()
@@ -819,16 +821,58 @@ class RuntimeServiceInterpTest
   }
 
   it should "get a runtime" in isolatedDbTest {
+    val mockSamService: SamService[IO] = mock[SamService[IO]](defaultMockitoAnswer[IO])
+    when(
+      mockSamService.checkAuthorized(
+        isEq(userInfo.accessToken.token),
+        any(runtimeSamResource.getClass),
+        isEq(RuntimeAction.GetRuntimeStatus)
+      )(any(Ask[IO, AppContext].getClass))
+    ).thenReturn(IO.unit)
+    val service = makeRuntimeService(samService = mockSamService)
     val res = for {
       samResource <- IO(RuntimeSamResourceId(UUID.randomUUID.toString))
       testRuntime <- IO(makeCluster(1).copy(samResource = samResource).save())
-      getResponse <- runtimeService.getRuntime(userInfo, testRuntime.cloudContext, testRuntime.runtimeName)
+      getResponse <- service.getRuntime(userInfo, testRuntime.cloudContext, testRuntime.runtimeName)
     } yield getResponse.samResource shouldBe testRuntime.samResource
     res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
-  it should "throw ClusterNotFoundException for nonexistent clusters" in isolatedDbTest {
-    val exc = runtimeService
+  it should "throw RuntimeNotFoundException when user has no access" in isolatedDbTest {
+    val mockSamService: SamService[IO] = mock[SamService[IO]](defaultMockitoAnswer[IO])
+    when(
+      mockSamService.checkAuthorized(
+        isEq(userInfo.accessToken.token),
+        any(runtimeSamResource.getClass),
+        isEq(RuntimeAction.GetRuntimeStatus)
+      )(any(Ask[IO, AppContext].getClass))
+    ).thenReturn(
+      IO.pure(
+        Left(
+          SamException.create(
+            s"USER is not authorized to perform ACTION on RUNTIME",
+            StatusCodes.Forbidden.intValue,
+            TraceId(UUID.randomUUID)
+          )
+        )
+      )
+    )
+    val service = makeRuntimeService(samService = mockSamService)
+
+    val exc = service
+      .getRuntime(unauthorizedUserInfo, cloudContextGcp, RuntimeName("cluster"))
+      .attempt
+      .unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
+      .swap
+      .toOption
+      .get
+
+    exc shouldBe a[RuntimeNotFoundException]
+  }
+
+  it should "throw RuntimeNotFoundException when runtime does not exist" in isolatedDbTest {
+    val service = makeRuntimeService()
+    val exc = service
       .getRuntime(userInfo, CloudContext.Gcp(GoogleProject("nonexistent")), RuntimeName("cluster"))
       .attempt
       .unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
@@ -836,17 +880,6 @@ class RuntimeServiceInterpTest
       .toOption
       .get
     exc shouldBe a[RuntimeNotFoundException]
-  }
-
-  it should "fail to get a runtime when users don't have access to the project" in isolatedDbTest {
-    val exc = runtimeService
-      .getRuntime(unauthorizedUserInfo, cloudContextGcp, RuntimeName("cluster"))
-      .attempt
-      .unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
-      .swap
-      .toOption
-      .get
-    exc shouldBe a[ForbiddenError]
   }
 
   it should "list runtimes" in isolatedDbTest {

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterpSpec.scala
@@ -838,7 +838,7 @@ class RuntimeServiceInterpTest
     res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
-  it should "raise RuntimeNotFoundException when user has no access" in isolatedDbTest {
+  it should "raise SamException when user has no access" in isolatedDbTest {
     val mockSamService: SamService[IO] = mock[SamService[IO]](defaultMockitoAnswer[IO])
     doAnswer { _ =>
       IO.raiseError(
@@ -860,7 +860,7 @@ class RuntimeServiceInterpTest
       testRuntime <- IO(makeCluster(1, None, cloudContextGcp, samResource).save())
       getResponse <- service.getRuntime(userInfo, cloudContextGcp, testRuntime.runtimeName)
     } yield getResponse
-    the[RuntimeNotFoundException] thrownBy {
+    the[SamException] thrownBy {
       res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
     }
   }


### PR DESCRIPTION
Assumes Sam model hierarchy of runtime under project parent, uses checkPermission as best practice.

<!-- Welcome to your Leonardo pull request! -->
<!-- Contributor guidelines: https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md -->

__Jira ticket__: https://broadworkbench.atlassian.net/browse/IA-5066

<!-- ## Dependencies -->
<!-- Include any dependent tickets and describe the relationship. Include any other relevant Jira tickets. -->
https://broadworkbench.atlassian.net/browse/IA-5063

## Summary of changes

getRuntime now checks permission once, for the relevant runtime action, using the preferred SamService `checkPermission`.