### PR TITLE
Fix for IA-5062: add get_parent action to enum

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/samModels.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/samModels.scala
@@ -149,6 +149,9 @@ object RuntimeAction {
   final case object SetParent extends RuntimeAction {
     val asString = "set_parent"
   }
+  final case object GetParent extends RuntimeAction {
+    val asString = "get_parent"
+  }
 
   val allActions = sealerate.values[RuntimeAction]
   val stringToAction: Map[String, RuntimeAction] =
@@ -174,6 +177,9 @@ object PersistentDiskAction {
   }
   final case object SetParent extends PersistentDiskAction {
     val asString = "set_parent"
+  }
+  final case object GetParent extends PersistentDiskAction {
+    val asString = "get_parent"
   }
 
   val allActions = sealerate.values[PersistentDiskAction]


### PR DESCRIPTION
<!-- Welcome to your Leonardo pull request! -->
<!-- Contributor guidelines: https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md -->

__Jira ticket__: https://broadworkbench.atlassian.net/browse/IA-5062

<!-- ## Dependencies -->
<!-- Include any dependent tickets and describe the relationship. Include any other relevant Jira tickets. -->

## Summary of changes

In https://github.com/broadinstitute/sam/pull/1543 we added the `get_parent` action to `notebook-cluster` and `persistent-disk`. Leo needs to enumerate all possible actions from Sam because it implements decoders for the [resourceActionsV2](https://sam.dsde-prod.broadinstitute.org/#/Resources/resourceActionsV2) endpoint. This should not be a hard dependency anymore once we switch to the generated Sam client.

### What

-

### Why

-

## Testing these changes

Reproed in a BEE by creating an app+disk then deleting it. 
Verified it is successful after this PR.

### Who tested and where

- [ ] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [ ] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
