### PR TITLE
[RW-12525] Reduce autodelete monitor frequency from 2 hours to 5 minutes

### DIFF
--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -1228,6 +1228,8 @@ autoFreeze {
 }
 
 autodelete {
+  # chosen to be significantly less than the minimum autodelete threshold offered to
+  # All of Us Researcher Workbench users
   autodeleteCheckInterval = 5 minutes
 }
 

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -1228,7 +1228,7 @@ autoFreeze {
 }
 
 autodelete {
-  autodeleteCheckInterval = 2 hours
+  autodeleteCheckInterval = 5 minutes
 }
 
 jupyterConfig {

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -1228,8 +1228,8 @@ autoFreeze {
 }
 
 autodelete {
-  # chosen to be significantly less than the minimum autodelete threshold offered to
-  # All of Us Researcher Workbench users
+  # chosen to be significantly less than the minimum autodelete threshold (1 hour)
+  # offered to All of Us Researcher Workbench users
   autodeleteCheckInterval = 5 minutes
 }
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/AutoDeleteAppMonitor.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/AutoDeleteAppMonitor.scala
@@ -22,7 +22,7 @@ import java.time.Instant
 import scala.concurrent.ExecutionContext
 
 /**
- * This monitor periodically sweeps the Leo database and autodelete App that have been running for too long.
+ * This monitor periodically sweeps the Leo database and autodeletes Apps that have been running for too long.
  */
 class AutoDeleteAppMonitor[F[_]](
   config: AutoDeleteConfig,
@@ -35,8 +35,7 @@ class AutoDeleteAppMonitor[F[_]](
   ec: ExecutionContext,
   openTelemetry: OpenTelemetryMetrics[F]
 ) extends BackgroundProcess[F, AppToAutoDelete] {
-  override def name: String =
-    "autodeleteApp" //
+  override def name: String = "autodeleteApp"
   override def interval: scala.concurrent.duration.FiniteDuration = config.autodeleteCheckInterval
 
   override def getCandidates(now: Instant)(implicit
@@ -54,7 +53,7 @@ class AutoDeleteAppMonitor[F[_]](
       _ <- a.cloudContext match {
         case CloudContext.Gcp(googleProject) =>
           if (a.appStatus == AppStatus.Error) {
-            implicit val implicitAppContext = Ask.const(AppContext(traceId, now))
+            implicit val implicitAppContext: Ask[F, AppContext] = Ask.const(AppContext(traceId, now))
             for {
               // delete kubernetes-app Sam resource
               petToken <- samService.getPetServiceAccountToken(a.creator, googleProject)


### PR DESCRIPTION
<!-- Welcome to your Leonardo pull request! -->
<!-- Contributor guidelines: https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md -->

__Jira ticket__: https://precisionmedicineinitiative.atlassian.net/browse/RW-12525

## Summary of changes

### What

Change the autodeletion monitor from running every 2 hours to every 5 minutes

### Why

AoU RWB is adding an option for users to choose GKE App autodeletion after 1 hour.  The existing monitor frequency would mean that such apps would be deleted after 2:59 in the worst case.  Since we expect this option to be chosen by the most cost-conscious users, this could be an unpleasant surprise.  Deletion after 1:05 in the worst case would be much better. 

## Testing these changes

### What to test

- <!-- Test case 1 -->

<!-- ### Test data -->

### Who tested and where

- [ ] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [ ] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
