### PR TITLE
[AN-1][AN-212] Automerge GHA reflects new teams and their Jira prefix

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -45,12 +45,10 @@ jobs:
       - name: Match the PR to the corresponding team's slack notification channel
         id: prepare-outputs
         run: |
-          if ${{ contains(github.event.pull_request.title, 'WM-') }}; then
-            echo 'notify-failure-channel=dsp-workflows'                 >> $GITHUB_OUTPUT
-          elif ${{ contains(github.event.pull_request.title, 'WX-') }}; then
-            echo 'notify-failure-channel=dsp-workflows'                >> $GITHUB_OUTPUT
-          else ${{ contains(github.event.pull_request.title, 'AJ-') }};
-           echo 'notify-failure-channel=dsp-analysis-journeys'        >> $GITHUB_OUTPUT
+          if ${{ contains(github.event.pull_request.title, 'AN-') }}; then
+            echo 'notify-failure-channel=dsp-analysis-non-prod-alerts' >> $GITHUB_OUTPUT
+          else ${{ contains(github.event.pull_request.title, 'CORE-') }};
+           echo 'notify-failure-channel=dsp-core-services'        >> $GITHUB_OUTPUT
           fi
 
   report-workflow:


### PR DESCRIPTION
<!-- Welcome to your Leonardo pull request! -->
<!-- Contributor guidelines: https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md -->

__Jira ticket__: https://broadworkbench.atlassian.net/browse/AN-1, https://broadworkbench.atlassian.net/browse/AN-212

<!-- ## Dependencies -->
<!-- Include any dependent tickets and describe the relationship. Include any other relevant Jira tickets. -->

Updates the `init-github-context` in automerge GHA to reflect new Jira prefixes and team names 