### PR TITLE
[AN-231] Fix package persistence startup

### DIFF
--- a/http/src/main/resources/init-resources/shutdown.sh
+++ b/http/src/main/resources/init-resources/shutdown.sh
@@ -22,10 +22,6 @@ export RSTUDIO_DOCKER_IMAGE=$(rstudioDockerImage)
 export RSTUDIO_SERVER_NAME=$(rstudioServerName)
 export SHOULD_DELETE_JUPYTER_DIR=$(shouldDeleteJupyterDir)
 
-# If RStudio is installed, cleanly shut it down
-if [ ! -z "$RSTUDIO_DOCKER_IMAGE" ] ; then
-    docker exec -u rstudio -i $RSTUDIO_SERVER_NAME rstudio-server stop
-fi
 
 # Remove jupyter related files if user decides to delete the VM
 if [ -d '/mnt/disks/work/.jupyter' ] && [ "SHOULD_DELETE_JUPYTER_DIR" = "true" ] ; then

--- a/http/src/main/resources/init-resources/startup.sh
+++ b/http/src/main/resources/init-resources/startup.sh
@@ -50,7 +50,9 @@ export NOTEBOOKS_DIR=$(notebooksDir)
 export JUPYTER_DOCKER_IMAGE=$(jupyterDockerImage)
 export RSTUDIO_DOCKER_IMAGE=$(rstudioDockerImage)
 JUPYTER_DOCKER_COMPOSE=$(ls ${DOCKER_COMPOSE_FILES_DIRECTORY}/jupyter-docker*)
+COMPLETE_JUPYTER_DOCKER_COMPOSE="-f $JUPYTER_DOCKER_COMPOSE"
 RSTUDIO_DOCKER_COMPOSE=$(ls ${DOCKER_COMPOSE_FILES_DIRECTORY}/rstudio-docker*)
+COMPLETE_RSTUDIO_DOCKER_COMPOSE="-f $RSTUDIO_DOCKER_COMPOSE"
 export CRYPTO_DETECTOR_DOCKER_IMAGE=$(cryptoDetectorDockerImage)
 export WELDER_ENABLED=$(welderEnabled)
 export UPDATE_WELDER=$(updateWelder)
@@ -188,6 +190,11 @@ if [ "${GPU_ENABLED}" == "true" ] ; then
 
   mount --bind /var/lib/nvidia /var/lib/nvidia
   mount -o remount,exec /var/lib/nvidia
+
+  GPU_DOCKER_COMPOSE=$(ls ${DOCKER_COMPOSE_FILES_DIRECTORY}/gpu-docker*)
+  $GSUTIL_CMD cp gs://${INIT_BUCKET_NAME}/`basename ${GPU_DOCKER_COMPOSE}` $GPU_DOCKER_COMPOSE
+  COMPLETE_JUPYTER_DOCKER_COMPOSE="-f $JUPYTER_DOCKER_COMPOSE -f $GPU_DOCKER_COMPOSE"
+  COMPLETE_RSTUDIO_DOCKER_COMPOSE="-f $RSTUDIO_DOCKER_COMPOSE -f $GPU_DOCKER_COMPOSE"
 fi
 
 
@@ -243,16 +250,10 @@ MEM_LIMIT=${MEM_LIMIT}
 SHM_SIZE=${SHM_SIZE}
 END
 
-        COMPLETE_JUPYTER_DOCKER_COMPOSE="-f $JUPYTER_DOCKER_COMPOSE"
-        if [ "${GPU_ENABLED}" == "true" ] ; then
-          GPU_DOCKER_COMPOSE=$(ls ${DOCKER_COMPOSE_FILES_DIRECTORY}/gpu-docker*)
-          $GSUTIL_CMD cp gs://${INIT_BUCKET_NAME}/`basename ${GPU_DOCKER_COMPOSE}` $GPU_DOCKER_COMPOSE
-          COMPLETE_JUPYTER_DOCKER_COMPOSE="-f $JUPYTER_DOCKER_COMPOSE -f $GPU_DOCKER_COMPOSE"
-        fi
-
         ${DOCKER_COMPOSE} ${COMPLETE_JUPYTER_DOCKER_COMPOSE} stop
         ${DOCKER_COMPOSE} ${COMPLETE_JUPYTER_DOCKER_COMPOSE} rm -f
-        ${DOCKER_COMPOSE} --no-recreate --env-file=/var/variables.env ${COMPLETE_JUPYTER_DOCKER_COMPOSE} up -d
+        # We do not want to recreate a new container, to make sure we preserve the changes that users made with the startup script
+        ${DOCKER_COMPOSE} --env-file=/var/variables.env ${COMPLETE_JUPYTER_DOCKER_COMPOSE} up -d --no-recreate
         
         # the docker containers need to be restarted or the jupyter container
         # will fail to start until the appropriate volume/device exists
@@ -269,10 +270,30 @@ END
     if [ ! -z "$RSTUDIO_DOCKER_IMAGE" ] ; then
         echo "Restarting Rstudio Container $GOOGLE_PROJECT / $CLUSTER_NAME..."
 
+        # Make sure when runtimes restarts, they'll get a new version of rstudio docker compose file
+        $GSUTIL_CMD cp gs://${INIT_BUCKET_NAME}/`basename ${RSTUDIO_DOCKER_COMPOSE}` $RSTUDIO_DOCKER_COMPOSE
+
+tee /var/variables.env << END
+WORK_DIRECTORY=${WORK_DIRECTORY}
+RSTUDIO_SERVER_NAME=${RSTUDIO_SERVER_NAME}
+RSTUDIO_DOCKER_IMAGE=${RSTUDIO_DOCKER_IMAGE}
+RSTUDIO_USER_HOME=${RSTUDIO_USER_HOME}
+GOOGLE_PROJECT=${GOOGLE_PROJECT}
+RUNTIME_NAME=${RUNTIME_NAME}
+OWNER_EMAIL=${OWNER_EMAIL}
+PET_SA_EMAIL=${PET_SA_EMAIL}
+WELDER_ENABLED=${WELDER_ENABLED}
+MEM_LIMIT=${MEM_LIMIT}
+SHM_SIZE=${SHM_SIZE}
+END
+
+        ${DOCKER_COMPOSE} -f ${COMPLETE_RSTUDIO_DOCKER_COMPOSE} stop
+        ${DOCKER_COMPOSE} -f ${COMPLETE_RSTUDIO_DOCKER_COMPOSE} rm -f
+        # We do not want to recreate a new container, to make sure we preserve the changes that users made with the startup script
+        ${DOCKER_COMPOSE} --env-file=/var/variables.env -f ${COMPLETE_RSTUDIO_DOCKER_COMPOSE} up -d --no-recreate
+
         # the docker containers need to be restarted or the R container
         # will fail to start until the appropriate volume/device exists.
-        # We aren't fully stopping and starting the container here because this would reset the state
-        # of R system packages, which are stored inside the container, and which the user may have modified.
         docker restart $RSTUDIO_SERVER_NAME
         docker restart $WELDER_SERVER_NAME
 
@@ -286,9 +307,10 @@ else
         # Make sure when runtimes restarts, they'll get a new version of jupyter docker compose file
         $GSUTIL_CMD cp gs://${INIT_BUCKET_NAME}/`basename ${JUPYTER_DOCKER_COMPOSE}` $JUPYTER_DOCKER_COMPOSE
 
-        ${DOCKER_COMPOSE} -f ${JUPYTER_DOCKER_COMPOSE} stop
-        ${DOCKER_COMPOSE} -f ${JUPYTER_DOCKER_COMPOSE} rm -f
-        ${DOCKER_COMPOSE} -f ${JUPYTER_DOCKER_COMPOSE} --no-recreate up -d
+        ${DOCKER_COMPOSE} -f ${COMPLETE_JUPYTER_DOCKER_COMPOSE} stop
+        ${DOCKER_COMPOSE} -f ${COMPLETE_JUPYTER_DOCKER_COMPOSE} rm -f
+        # We do not want to recreate a new container, to make sure we preserve the changes that users made with the startup script
+        ${DOCKER_COMPOSE} -f ${COMPLETE_JUPYTER_DOCKER_COMPOSE} up -d --no-recreate
 
         log 'Copy Jupyter frontend notebook config...'
         $GSUTIL_CMD cp ${JUPYTER_NOTEBOOK_FRONTEND_CONFIG_URI} /var

--- a/http/src/main/resources/init-resources/startup.sh
+++ b/http/src/main/resources/init-resources/startup.sh
@@ -234,9 +234,6 @@ if [[ "${CLOUD_SERVICE}" == 'GCE' ]]; then
     if [ ! -z "$JUPYTER_DOCKER_IMAGE" ] ; then
         echo "Restarting Jupyter Container $GOOGLE_PROJECT / $CLUSTER_NAME..."
 
-        # Make sure when runtimes restarts, they'll get a new version of jupyter docker compose file
-        $GSUTIL_CMD cp gs://${INIT_BUCKET_NAME}/`basename ${JUPYTER_DOCKER_COMPOSE}` $JUPYTER_DOCKER_COMPOSE
-
 tee /var/variables.env << END
 JUPYTER_SERVER_NAME=${JUPYTER_SERVER_NAME}
 JUPYTER_DOCKER_IMAGE=${JUPYTER_DOCKER_IMAGE}
@@ -270,9 +267,6 @@ END
     if [ ! -z "$RSTUDIO_DOCKER_IMAGE" ] ; then
         echo "Restarting Rstudio Container $GOOGLE_PROJECT / $CLUSTER_NAME..."
 
-        # Make sure when runtimes restarts, they'll get a new version of rstudio docker compose file
-        $GSUTIL_CMD cp gs://${INIT_BUCKET_NAME}/`basename ${RSTUDIO_DOCKER_COMPOSE}` $RSTUDIO_DOCKER_COMPOSE
-
 tee /var/variables.env << END
 WORK_DIRECTORY=${WORK_DIRECTORY}
 RSTUDIO_SERVER_NAME=${RSTUDIO_SERVER_NAME}
@@ -303,9 +297,6 @@ else
 
     if [ ! -z "$JUPYTER_DOCKER_IMAGE" ] ; then
         echo "Restarting Jupyter Container $GOOGLE_PROJECT / $CLUSTER_NAME..."
-
-        # Make sure when runtimes restarts, they'll get a new version of jupyter docker compose file
-        $GSUTIL_CMD cp gs://${INIT_BUCKET_NAME}/`basename ${JUPYTER_DOCKER_COMPOSE}` $JUPYTER_DOCKER_COMPOSE
 
         ${DOCKER_COMPOSE} -f ${COMPLETE_JUPYTER_DOCKER_COMPOSE} stop
         ${DOCKER_COMPOSE} -f ${COMPLETE_JUPYTER_DOCKER_COMPOSE} rm -f

--- a/http/src/main/resources/init-resources/startup.sh
+++ b/http/src/main/resources/init-resources/startup.sh
@@ -228,31 +228,31 @@ if [[ "${CLOUD_SERVICE}" == 'GCE' ]]; then
         echo "Restarting Jupyter Container $GOOGLE_PROJECT / $CLUSTER_NAME..."
 
         # Make sure when runtimes restarts, they'll get a new version of jupyter docker compose file
-        $GSUTIL_CMD cp gs://${INIT_BUCKET_NAME}/`basename ${JUPYTER_DOCKER_COMPOSE}` $JUPYTER_DOCKER_COMPOSE
-
-tee /var/variables.env << END
-JUPYTER_SERVER_NAME=${JUPYTER_SERVER_NAME}
-JUPYTER_DOCKER_IMAGE=${JUPYTER_DOCKER_IMAGE}
-NOTEBOOKS_DIR=${NOTEBOOKS_DIR}
-GOOGLE_PROJECT=${GOOGLE_PROJECT}
-RUNTIME_NAME=${RUNTIME_NAME}
-OWNER_EMAIL=${OWNER_EMAIL}
-PET_SA_EMAIL=${PET_SA_EMAIL}
-WELDER_ENABLED=${WELDER_ENABLED}
-MEM_LIMIT=${MEM_LIMIT}
-SHM_SIZE=${SHM_SIZE}
-END
-
-        COMPLETE_JUPYTER_DOCKER_COMPOSE="-f $JUPYTER_DOCKER_COMPOSE"
-        if [ "${GPU_ENABLED}" == "true" ] ; then
-          GPU_DOCKER_COMPOSE=$(ls ${DOCKER_COMPOSE_FILES_DIRECTORY}/gpu-docker*)
-          $GSUTIL_CMD cp gs://${INIT_BUCKET_NAME}/`basename ${GPU_DOCKER_COMPOSE}` $GPU_DOCKER_COMPOSE
-          COMPLETE_JUPYTER_DOCKER_COMPOSE="-f $JUPYTER_DOCKER_COMPOSE -f $GPU_DOCKER_COMPOSE"
-        fi
-
-        ${DOCKER_COMPOSE} ${COMPLETE_JUPYTER_DOCKER_COMPOSE} stop
-        ${DOCKER_COMPOSE} ${COMPLETE_JUPYTER_DOCKER_COMPOSE} rm -f
-        ${DOCKER_COMPOSE} --env-file=/var/variables.env ${COMPLETE_JUPYTER_DOCKER_COMPOSE} up -d
+#        $GSUTIL_CMD cp gs://${INIT_BUCKET_NAME}/`basename ${JUPYTER_DOCKER_COMPOSE}` $JUPYTER_DOCKER_COMPOSE
+#
+#tee /var/variables.env << END
+#JUPYTER_SERVER_NAME=${JUPYTER_SERVER_NAME}
+#JUPYTER_DOCKER_IMAGE=${JUPYTER_DOCKER_IMAGE}
+#NOTEBOOKS_DIR=${NOTEBOOKS_DIR}
+#GOOGLE_PROJECT=${GOOGLE_PROJECT}
+#RUNTIME_NAME=${RUNTIME_NAME}
+#OWNER_EMAIL=${OWNER_EMAIL}
+#PET_SA_EMAIL=${PET_SA_EMAIL}
+#WELDER_ENABLED=${WELDER_ENABLED}
+#MEM_LIMIT=${MEM_LIMIT}
+#SHM_SIZE=${SHM_SIZE}
+#END
+#
+#        COMPLETE_JUPYTER_DOCKER_COMPOSE="-f $JUPYTER_DOCKER_COMPOSE"
+#        if [ "${GPU_ENABLED}" == "true" ] ; then
+#          GPU_DOCKER_COMPOSE=$(ls ${DOCKER_COMPOSE_FILES_DIRECTORY}/gpu-docker*)
+#          $GSUTIL_CMD cp gs://${INIT_BUCKET_NAME}/`basename ${GPU_DOCKER_COMPOSE}` $GPU_DOCKER_COMPOSE
+#          COMPLETE_JUPYTER_DOCKER_COMPOSE="-f $JUPYTER_DOCKER_COMPOSE -f $GPU_DOCKER_COMPOSE"
+#        fi
+#
+#        ${DOCKER_COMPOSE} ${COMPLETE_JUPYTER_DOCKER_COMPOSE} stop
+#        ${DOCKER_COMPOSE} ${COMPLETE_JUPYTER_DOCKER_COMPOSE} rm -f
+#        ${DOCKER_COMPOSE} --env-file=/var/variables.env ${COMPLETE_JUPYTER_DOCKER_COMPOSE} up -d
         
         # the docker containers need to be restarted or the jupyter container
         # will fail to start until the appropriate volume/device exists
@@ -283,12 +283,17 @@ else
     if [ ! -z "$JUPYTER_DOCKER_IMAGE" ] ; then
         echo "Restarting Jupyter Container $GOOGLE_PROJECT / $CLUSTER_NAME..."
 
-        # Make sure when runtimes restarts, they'll get a new version of jupyter docker compose file
-        $GSUTIL_CMD cp gs://${INIT_BUCKET_NAME}/`basename ${JUPYTER_DOCKER_COMPOSE}` $JUPYTER_DOCKER_COMPOSE
+#        # Make sure when runtimes restarts, they'll get a new version of jupyter docker compose file
+#        $GSUTIL_CMD cp gs://${INIT_BUCKET_NAME}/`basename ${JUPYTER_DOCKER_COMPOSE}` $JUPYTER_DOCKER_COMPOSE
+#
+#        ${DOCKER_COMPOSE} -f ${JUPYTER_DOCKER_COMPOSE} stop
+#        ${DOCKER_COMPOSE} -f ${JUPYTER_DOCKER_COMPOSE} rm -f
+#        ${DOCKER_COMPOSE} -f ${JUPYTER_DOCKER_COMPOSE} up -d
 
-        ${DOCKER_COMPOSE} -f ${JUPYTER_DOCKER_COMPOSE} stop
-        ${DOCKER_COMPOSE} -f ${JUPYTER_DOCKER_COMPOSE} rm -f
-        ${DOCKER_COMPOSE} -f ${JUPYTER_DOCKER_COMPOSE} up -d
+        # the docker containers need to be restarted or the jupyter container
+        # will fail to start until the appropriate volume/device exists
+        docker restart $JUPYTER_SERVER_NAME
+        docker restart $WELDER_SERVER_NAME
 
         log 'Copy Jupyter frontend notebook config...'
         $GSUTIL_CMD cp ${JUPYTER_NOTEBOOK_FRONTEND_CONFIG_URI} /var

--- a/http/src/main/resources/init-resources/startup.sh
+++ b/http/src/main/resources/init-resources/startup.sh
@@ -228,31 +228,31 @@ if [[ "${CLOUD_SERVICE}" == 'GCE' ]]; then
         echo "Restarting Jupyter Container $GOOGLE_PROJECT / $CLUSTER_NAME..."
 
         # Make sure when runtimes restarts, they'll get a new version of jupyter docker compose file
-#        $GSUTIL_CMD cp gs://${INIT_BUCKET_NAME}/`basename ${JUPYTER_DOCKER_COMPOSE}` $JUPYTER_DOCKER_COMPOSE
-#
-#tee /var/variables.env << END
-#JUPYTER_SERVER_NAME=${JUPYTER_SERVER_NAME}
-#JUPYTER_DOCKER_IMAGE=${JUPYTER_DOCKER_IMAGE}
-#NOTEBOOKS_DIR=${NOTEBOOKS_DIR}
-#GOOGLE_PROJECT=${GOOGLE_PROJECT}
-#RUNTIME_NAME=${RUNTIME_NAME}
-#OWNER_EMAIL=${OWNER_EMAIL}
-#PET_SA_EMAIL=${PET_SA_EMAIL}
-#WELDER_ENABLED=${WELDER_ENABLED}
-#MEM_LIMIT=${MEM_LIMIT}
-#SHM_SIZE=${SHM_SIZE}
-#END
-#
-#        COMPLETE_JUPYTER_DOCKER_COMPOSE="-f $JUPYTER_DOCKER_COMPOSE"
-#        if [ "${GPU_ENABLED}" == "true" ] ; then
-#          GPU_DOCKER_COMPOSE=$(ls ${DOCKER_COMPOSE_FILES_DIRECTORY}/gpu-docker*)
-#          $GSUTIL_CMD cp gs://${INIT_BUCKET_NAME}/`basename ${GPU_DOCKER_COMPOSE}` $GPU_DOCKER_COMPOSE
-#          COMPLETE_JUPYTER_DOCKER_COMPOSE="-f $JUPYTER_DOCKER_COMPOSE -f $GPU_DOCKER_COMPOSE"
-#        fi
-#
-#        ${DOCKER_COMPOSE} ${COMPLETE_JUPYTER_DOCKER_COMPOSE} stop
-#        ${DOCKER_COMPOSE} ${COMPLETE_JUPYTER_DOCKER_COMPOSE} rm -f
-#        ${DOCKER_COMPOSE} --env-file=/var/variables.env ${COMPLETE_JUPYTER_DOCKER_COMPOSE} up -d
+        $GSUTIL_CMD cp gs://${INIT_BUCKET_NAME}/`basename ${JUPYTER_DOCKER_COMPOSE}` $JUPYTER_DOCKER_COMPOSE
+
+tee /var/variables.env << END
+JUPYTER_SERVER_NAME=${JUPYTER_SERVER_NAME}
+JUPYTER_DOCKER_IMAGE=${JUPYTER_DOCKER_IMAGE}
+NOTEBOOKS_DIR=${NOTEBOOKS_DIR}
+GOOGLE_PROJECT=${GOOGLE_PROJECT}
+RUNTIME_NAME=${RUNTIME_NAME}
+OWNER_EMAIL=${OWNER_EMAIL}
+PET_SA_EMAIL=${PET_SA_EMAIL}
+WELDER_ENABLED=${WELDER_ENABLED}
+MEM_LIMIT=${MEM_LIMIT}
+SHM_SIZE=${SHM_SIZE}
+END
+
+        COMPLETE_JUPYTER_DOCKER_COMPOSE="-f $JUPYTER_DOCKER_COMPOSE"
+        if [ "${GPU_ENABLED}" == "true" ] ; then
+          GPU_DOCKER_COMPOSE=$(ls ${DOCKER_COMPOSE_FILES_DIRECTORY}/gpu-docker*)
+          $GSUTIL_CMD cp gs://${INIT_BUCKET_NAME}/`basename ${GPU_DOCKER_COMPOSE}` $GPU_DOCKER_COMPOSE
+          COMPLETE_JUPYTER_DOCKER_COMPOSE="-f $JUPYTER_DOCKER_COMPOSE -f $GPU_DOCKER_COMPOSE"
+        fi
+
+        ${DOCKER_COMPOSE} ${COMPLETE_JUPYTER_DOCKER_COMPOSE} stop
+        ${DOCKER_COMPOSE} ${COMPLETE_JUPYTER_DOCKER_COMPOSE} rm -f
+        ${DOCKER_COMPOSE} --no-recreate --env-file=/var/variables.env ${COMPLETE_JUPYTER_DOCKER_COMPOSE} up -d
         
         # the docker containers need to be restarted or the jupyter container
         # will fail to start until the appropriate volume/device exists
@@ -283,17 +283,12 @@ else
     if [ ! -z "$JUPYTER_DOCKER_IMAGE" ] ; then
         echo "Restarting Jupyter Container $GOOGLE_PROJECT / $CLUSTER_NAME..."
 
-#        # Make sure when runtimes restarts, they'll get a new version of jupyter docker compose file
-#        $GSUTIL_CMD cp gs://${INIT_BUCKET_NAME}/`basename ${JUPYTER_DOCKER_COMPOSE}` $JUPYTER_DOCKER_COMPOSE
-#
-#        ${DOCKER_COMPOSE} -f ${JUPYTER_DOCKER_COMPOSE} stop
-#        ${DOCKER_COMPOSE} -f ${JUPYTER_DOCKER_COMPOSE} rm -f
-#        ${DOCKER_COMPOSE} -f ${JUPYTER_DOCKER_COMPOSE} up -d
+        # Make sure when runtimes restarts, they'll get a new version of jupyter docker compose file
+        $GSUTIL_CMD cp gs://${INIT_BUCKET_NAME}/`basename ${JUPYTER_DOCKER_COMPOSE}` $JUPYTER_DOCKER_COMPOSE
 
-        # the docker containers need to be restarted or the jupyter container
-        # will fail to start until the appropriate volume/device exists
-        docker restart $JUPYTER_SERVER_NAME
-        docker restart $WELDER_SERVER_NAME
+        ${DOCKER_COMPOSE} -f ${JUPYTER_DOCKER_COMPOSE} stop
+        ${DOCKER_COMPOSE} -f ${JUPYTER_DOCKER_COMPOSE} rm -f
+        ${DOCKER_COMPOSE} -f ${JUPYTER_DOCKER_COMPOSE} --no-recreate up -d
 
         log 'Copy Jupyter frontend notebook config...'
         $GSUTIL_CMD cp ${JUPYTER_NOTEBOOK_FRONTEND_CONFIG_URI} /var

--- a/http/src/main/resources/init-resources/startup.sh
+++ b/http/src/main/resources/init-resources/startup.sh
@@ -192,7 +192,6 @@ if [ "${GPU_ENABLED}" == "true" ] ; then
   mount -o remount,exec /var/lib/nvidia
 
   GPU_DOCKER_COMPOSE=$(ls ${DOCKER_COMPOSE_FILES_DIRECTORY}/gpu-docker*)
-#  $GSUTIL_CMD cp gs://${INIT_BUCKET_NAME}/`basename ${GPU_DOCKER_COMPOSE}` $GPU_DOCKER_COMPOSE
   COMPLETE_JUPYTER_DOCKER_COMPOSE="-f $JUPYTER_DOCKER_COMPOSE -f $GPU_DOCKER_COMPOSE"
   COMPLETE_RSTUDIO_DOCKER_COMPOSE="-f $RSTUDIO_DOCKER_COMPOSE -f $GPU_DOCKER_COMPOSE"
 fi
@@ -233,6 +232,7 @@ if [[ "${CLOUD_SERVICE}" == 'GCE' ]]; then
     # (1/6/22) Restart Jupyter Container to reset `NOTEBOOKS_DIR` for existing runtimes. This code can probably be removed after a year
     if [ ! -z "$JUPYTER_DOCKER_IMAGE" ] ; then
         echo "Restarting Jupyter Container $GOOGLE_PROJECT / $CLUSTER_NAME..."
+        # The user might have updated the runtime, which would change some environment variables like MEM_LIMIT and SHM_SIZE
 
 tee /var/variables.env << END
 JUPYTER_SERVER_NAME=${JUPYTER_SERVER_NAME}
@@ -247,9 +247,8 @@ MEM_LIMIT=${MEM_LIMIT}
 SHM_SIZE=${SHM_SIZE}
 END
 
-#        ${DOCKER_COMPOSE} ${COMPLETE_JUPYTER_DOCKER_COMPOSE} stop
-#        ${DOCKER_COMPOSE} ${COMPLETE_JUPYTER_DOCKER_COMPOSE} rm -f
         # We do not want to recreate a new container, to make sure we preserve the changes that users made with the startup script
+        # We only want to restart the existing container with the latest environment variables
         ${DOCKER_COMPOSE} --env-file=/var/variables.env ${COMPLETE_JUPYTER_DOCKER_COMPOSE} up -d --no-recreate
         
         # the docker containers need to be restarted or the jupyter container
@@ -266,6 +265,7 @@ END
 
     if [ ! -z "$RSTUDIO_DOCKER_IMAGE" ] ; then
         echo "Restarting Rstudio Container $GOOGLE_PROJECT / $CLUSTER_NAME..."
+        # The user might have updated the runtime, which would change some environment variables like MEM_LIMIT and SHM_SIZE
 
 tee /var/variables.env << END
 WORK_DIRECTORY=${WORK_DIRECTORY}
@@ -281,9 +281,8 @@ MEM_LIMIT=${MEM_LIMIT}
 SHM_SIZE=${SHM_SIZE}
 END
 
-#        ${DOCKER_COMPOSE} -f ${COMPLETE_RSTUDIO_DOCKER_COMPOSE} stop
-#        ${DOCKER_COMPOSE} -f ${COMPLETE_RSTUDIO_DOCKER_COMPOSE} rm -f
         # We do not want to recreate a new container, to make sure we preserve the changes that users made with the startup script
+        # We only want to restart the existing container with the latest environment variables
         ${DOCKER_COMPOSE} --env-file=/var/variables.env -f ${COMPLETE_RSTUDIO_DOCKER_COMPOSE} up -d --no-recreate
 
         # the docker containers need to be restarted or the R container
@@ -298,8 +297,6 @@ else
     if [ ! -z "$JUPYTER_DOCKER_IMAGE" ] ; then
         echo "Restarting Jupyter Container $GOOGLE_PROJECT / $CLUSTER_NAME..."
 
-#        ${DOCKER_COMPOSE} -f ${COMPLETE_JUPYTER_DOCKER_COMPOSE} stop
-#        ${DOCKER_COMPOSE} -f ${COMPLETE_JUPYTER_DOCKER_COMPOSE} rm -f
         # We do not want to recreate a new container, to make sure we preserve the changes that users made with the startup script
         ${DOCKER_COMPOSE} -f ${COMPLETE_JUPYTER_DOCKER_COMPOSE} up -d --no-recreate
 

--- a/http/src/main/resources/init-resources/startup.sh
+++ b/http/src/main/resources/init-resources/startup.sh
@@ -283,7 +283,7 @@ END
 
         # We do not want to recreate a new container, to make sure we preserve the changes that users made with the startup script
         # We only want to restart the existing container with the latest environment variables
-        ${DOCKER_COMPOSE} --env-file=/var/variables.env -f ${COMPLETE_RSTUDIO_DOCKER_COMPOSE} up -d --no-recreate
+        ${DOCKER_COMPOSE} --env-file=/var/variables.env ${COMPLETE_RSTUDIO_DOCKER_COMPOSE} up -d --no-recreate
 
         # the docker containers need to be restarted or the R container
         # will fail to start until the appropriate volume/device exists.
@@ -298,7 +298,7 @@ else
         echo "Restarting Jupyter Container $GOOGLE_PROJECT / $CLUSTER_NAME..."
 
         # We do not want to recreate a new container, to make sure we preserve the changes that users made with the startup script
-        ${DOCKER_COMPOSE} -f ${COMPLETE_JUPYTER_DOCKER_COMPOSE} up -d --no-recreate
+        ${DOCKER_COMPOSE} ${COMPLETE_JUPYTER_DOCKER_COMPOSE} up -d --no-recreate
 
         log 'Copy Jupyter frontend notebook config...'
         $GSUTIL_CMD cp ${JUPYTER_NOTEBOOK_FRONTEND_CONFIG_URI} /var

--- a/http/src/main/resources/init-resources/startup.sh
+++ b/http/src/main/resources/init-resources/startup.sh
@@ -192,7 +192,7 @@ if [ "${GPU_ENABLED}" == "true" ] ; then
   mount -o remount,exec /var/lib/nvidia
 
   GPU_DOCKER_COMPOSE=$(ls ${DOCKER_COMPOSE_FILES_DIRECTORY}/gpu-docker*)
-  $GSUTIL_CMD cp gs://${INIT_BUCKET_NAME}/`basename ${GPU_DOCKER_COMPOSE}` $GPU_DOCKER_COMPOSE
+#  $GSUTIL_CMD cp gs://${INIT_BUCKET_NAME}/`basename ${GPU_DOCKER_COMPOSE}` $GPU_DOCKER_COMPOSE
   COMPLETE_JUPYTER_DOCKER_COMPOSE="-f $JUPYTER_DOCKER_COMPOSE -f $GPU_DOCKER_COMPOSE"
   COMPLETE_RSTUDIO_DOCKER_COMPOSE="-f $RSTUDIO_DOCKER_COMPOSE -f $GPU_DOCKER_COMPOSE"
 fi
@@ -247,8 +247,8 @@ MEM_LIMIT=${MEM_LIMIT}
 SHM_SIZE=${SHM_SIZE}
 END
 
-        ${DOCKER_COMPOSE} ${COMPLETE_JUPYTER_DOCKER_COMPOSE} stop
-        ${DOCKER_COMPOSE} ${COMPLETE_JUPYTER_DOCKER_COMPOSE} rm -f
+#        ${DOCKER_COMPOSE} ${COMPLETE_JUPYTER_DOCKER_COMPOSE} stop
+#        ${DOCKER_COMPOSE} ${COMPLETE_JUPYTER_DOCKER_COMPOSE} rm -f
         # We do not want to recreate a new container, to make sure we preserve the changes that users made with the startup script
         ${DOCKER_COMPOSE} --env-file=/var/variables.env ${COMPLETE_JUPYTER_DOCKER_COMPOSE} up -d --no-recreate
         
@@ -281,8 +281,8 @@ MEM_LIMIT=${MEM_LIMIT}
 SHM_SIZE=${SHM_SIZE}
 END
 
-        ${DOCKER_COMPOSE} -f ${COMPLETE_RSTUDIO_DOCKER_COMPOSE} stop
-        ${DOCKER_COMPOSE} -f ${COMPLETE_RSTUDIO_DOCKER_COMPOSE} rm -f
+#        ${DOCKER_COMPOSE} -f ${COMPLETE_RSTUDIO_DOCKER_COMPOSE} stop
+#        ${DOCKER_COMPOSE} -f ${COMPLETE_RSTUDIO_DOCKER_COMPOSE} rm -f
         # We do not want to recreate a new container, to make sure we preserve the changes that users made with the startup script
         ${DOCKER_COMPOSE} --env-file=/var/variables.env -f ${COMPLETE_RSTUDIO_DOCKER_COMPOSE} up -d --no-recreate
 
@@ -298,8 +298,8 @@ else
     if [ ! -z "$JUPYTER_DOCKER_IMAGE" ] ; then
         echo "Restarting Jupyter Container $GOOGLE_PROJECT / $CLUSTER_NAME..."
 
-        ${DOCKER_COMPOSE} -f ${COMPLETE_JUPYTER_DOCKER_COMPOSE} stop
-        ${DOCKER_COMPOSE} -f ${COMPLETE_JUPYTER_DOCKER_COMPOSE} rm -f
+#        ${DOCKER_COMPOSE} -f ${COMPLETE_JUPYTER_DOCKER_COMPOSE} stop
+#        ${DOCKER_COMPOSE} -f ${COMPLETE_JUPYTER_DOCKER_COMPOSE} rm -f
         # We do not want to recreate a new container, to make sure we preserve the changes that users made with the startup script
         ${DOCKER_COMPOSE} -f ${COMPLETE_JUPYTER_DOCKER_COMPOSE} up -d --no-recreate
 


### PR DESCRIPTION
<!-- Welcome to your Leonardo pull request! -->
<!-- Contributor guidelines: https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md -->

__Jira ticket__: https://broadworkbench.atlassian.net/browse/AN-231

<!-- ## Dependencies -->
<!-- Include any dependent tickets and describe the relationship. Include any other relevant Jira tickets. -->

## Summary of changes

<!-- Please give an abridged version of the ticket description here and/or fill out the following fields. -->

### What

- Removes pulling the latest docker compose files upon startup
- Ensures that the existing containers are not recreated

### Why

- Fixes the bug introduced by this PR https://github.com/DataBiosphere/leonardo/pull/4725
- Ensures that changes done by users outside of the persistent disk (e.g. by executing a startup script) will persist when the runtime is paused and resumed

## Testing these changes

### What to test

For GCE, RStudio, and Dataproc options with and without GPUs:
- Create the runtime with a startup script (see attached)
- Check that the startup script executed well (e.g. run `!sudo ls`)
- Update the runtime by requesting more memory
- After the runtime resumes, check that:
- - The changes from the startup script are still there
- - The docker shared memory has increased (should be half of what you requested), you can run `df -h | grep shm` to check that on the runtime terminal

[test-startup-script-liz.txt](https://github.com/user-attachments/files/17684375/test-startup-script-liz.txt)


### Who tested and where

- [ ] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [ ] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
