### PR TITLE
Revert "[AN-256] Update mysql version to 8.0 for unit test and local leo"

### DIFF
--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -21,7 +21,7 @@ jobs:
 
     services:
       mysql:
-        image: mysql/mysql-server:8.0
+        image: mysql/mysql-server:5.6
         env:
           MYSQL_ROOT_PASSWORD: leonardo-test
           MYSQL_USER: leonardo-test

--- a/docker/run-mysql.sh
+++ b/docker/run-mysql.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-# The CloudSQL console simply states "MySQL 8.0" so we may not match the minor version number
-MYSQL_VERSION=8.0
+# The CloudSQL console simply states "MySQL 5.6" so we may not match the minor version number
+MYSQL_VERSION=5.6
 start() {
 
     echo "attempting to remove old $CONTAINER container..."

--- a/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/20170901_cluster-createdDate-default.xml
+++ b/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/20170901_cluster-createdDate-default.xml
@@ -2,6 +2,6 @@
 <databaseChangeLog logicalFilePath="leonardo" xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
     <changeSet logicalFilePath="leonardo" author="kumra" id="cluster-createdDate-default">
         <sql dbms="mysql">ALTER TABLE  CLUSTER
-            CHANGE createdDate createdDate TIMESTAMP(6) NOT NULL DEFAULT "1970-01-01 00:00:01.000000"</sql>
+            CHANGE createdDate createdDate TIMESTAMP(6) NOT NULL DEFAULT 0</sql>
     </changeSet>
 </databaseChangeLog>

--- a/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/20171011_cluster_destroyedDate_not_null.xml
+++ b/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/20171011_cluster_destroyedDate_not_null.xml
@@ -1,8 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <databaseChangeLog logicalFilePath="leonardo" xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
     <changeSet logicalFilePath="leonardo" author="vkumra" id="cluster_destroyeddate_not_null">
-        <sql>
-            ALTER TABLE CLUSTER MODIFY COLUMN destroyedDate TIMESTAMP(6) NOT NULL DEFAULT '1970-01-01 00:00:01.000000';
-        </sql>
+        <addNotNullConstraint columnDataType="TIMESTAMP(6)"
+                              columnName="destroyedDate"
+                              defaultNullValue="1970-01-01 00:00:01.000000"
+                              tableName="CLUSTER"/>
+        <addDefaultValue columnDataType="TIMESTAMP(6)"
+                         columnName="destroyedDate"
+                         defaultValue="1970-01-01 00:00:01.000000"
+                         tableName="CLUSTER"/>
     </changeSet>
 </databaseChangeLog>

--- a/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/20180515_cluster_dateaccessed.xml
+++ b/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/20180515_cluster_dateaccessed.xml
@@ -13,6 +13,8 @@
     </changeSet>
 
     <changeSet id="make dateAccessed not null" author="vkumra">
-        <sql>ALTER TABLE CLUSTER MODIFY COLUMN dateAccessed TIMESTAMP(6) NOT NULL DEFAULT '1970-01-01 00:00:01.000000'</sql>
+        <addNotNullConstraint columnDataType="TIMESTAMP(6)"
+                              columnName="dateAccessed"
+                              tableName="CLUSTER"/>
     </changeSet>
 </databaseChangeLog>

--- a/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/20200501_kubernetes_tables.xml
+++ b/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/20200501_kubernetes_tables.xml
@@ -27,13 +27,13 @@
             <column name="creator" type="VARCHAR(254)">
                 <constraints nullable="false"/>
             </column>
-            <column name="createdDate" type="TIMESTAMP(6)" defaultValue="1970-01-01 00:00:01.000000">
+            <column name="createdDate" type="TIMESTAMP(6)" defaultValue="0000-00-00 00:00:00.000000">
                 <constraints nullable="false"/>
             </column>
             <column name="destroyedDate" type="TIMESTAMP(6)" defaultValue="1970-01-01 00:00:01.000000">
                 <constraints nullable="false"/>
             </column>
-            <column name="dateAccessed" type="TIMESTAMP(6)" defaultValue="1970-01-01 00:00:01.000000">
+            <column name="dateAccessed" type="TIMESTAMP(6)" defaultValue="0000-00-00 00:00:00.000000">
                 <constraints nullable="false"/>
             </column>
             <column name="apiServerIp" type="VARCHAR(254)"/>
@@ -61,13 +61,13 @@
             <column name="creator" type="VARCHAR(254)">
                 <constraints nullable="false"/>
             </column>
-            <column name="createdDate" type="TIMESTAMP(6)" defaultValue="1970-01-01 00:00:01.000000">
+            <column name="createdDate" type="TIMESTAMP(6)" defaultValue="0000-00-00 00:00:00.000000">
                 <constraints nullable="false"/>
             </column>
             <column name="destroyedDate" type="TIMESTAMP(6)" defaultValue="1970-01-01 00:00:01.000000">
                 <constraints nullable="false"/>
             </column>
-            <column name="dateAccessed" type="TIMESTAMP(6)" defaultValue="1970-01-01 00:00:01.000000">
+            <column name="dateAccessed" type="TIMESTAMP(6)" defaultValue="0000-00-00 00:00:00.000000">
                 <constraints nullable="false"/>
             </column>
             <column name="machineType" type="VARCHAR(254)">

--- a/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/20200520_kubernetes_refactor.xml
+++ b/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/20200520_kubernetes_refactor.xml
@@ -41,13 +41,13 @@
             <column name="creator" type="VARCHAR(254)">
                 <constraints nullable="false"/>
             </column>
-            <column name="createdDate" type="TIMESTAMP(6)" defaultValue="1970-01-01 00:00:01.000000">
+            <column name="createdDate" type="TIMESTAMP(6)" defaultValue="0000-00-00 00:00:00.000000">
                 <constraints nullable="false"/>
             </column>
             <column name="destroyedDate" type="TIMESTAMP(6)" defaultValue="1970-01-01 00:00:01.000000">
                 <constraints nullable="false"/>
             </column>
-            <column name="dateAccessed" type="TIMESTAMP(6)" defaultValue="1970-01-01 00:00:01.000000">
+            <column name="dateAccessed" type="TIMESTAMP(6)" defaultValue="0000-00-00 00:00:00.000000">
                 <constraints nullable="false"/>
             </column>
             <column name="namespaceId" type="BIGINT">

--- a/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/20230911_create_app_usage_table.xml
+++ b/http/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/20230911_create_app_usage_table.xml
@@ -8,7 +8,7 @@
             <column name="appId" type="BIGINT(20)">
                 <constraints nullable="false"/>
             </column>
-            <column name="startTime" type="TIMESTAMP(6)" defaultValue="1970-01-01 00:00:01.000000">
+            <column name="startTime" type="TIMESTAMP(6)" defaultValue="0000-00-00 00:00:00.000000">
                 <constraints nullable="false"/>
             </column>
             <column name="stopTime" type="TIMESTAMP(6)" defaultValue="1970-01-01 00:00:01.000000">

--- a/http/src/test/resources/reference.conf
+++ b/http/src/test/resources/reference.conf
@@ -5,7 +5,7 @@
 # -e MYSQL_USER=leonardo-test \
 # -e MYSQL_PASSWORD=leonardo-test \
 # -e MYSQL_DATABASE=leotestdb \
-# -d -p 3311:3306 mysql/mysql-server:8.0
+# -d -p 3311:3306 mysql/mysql-server:5.6
 
 application {
   leoGoogleProject = "leo-project"
@@ -37,7 +37,7 @@ mysql {
   port = 3311
   db {
     driver = "com.mysql.cj.jdbc.Driver"
-    url = "jdbc:mysql://"${mysql.host}":"${mysql.port}"/leotestdb?createDatabaseIfNotExist=true&&allowPublicKeyRetrieval=true&useSSL=false&rewriteBatchedStatements=true&nullNamePatternMatchesAll=true"
+    url = "jdbc:mysql://"${mysql.host}":"${mysql.port}"/leotestdb?createDatabaseIfNotExist=true&useSSL=false&rewriteBatchedStatements=true&nullNamePatternMatchesAll=true"
     user = "leonardo-test"
     password = "leonardo-test"
     connectionTimeout = "5 seconds"  // default of 1 sec sometimes too short for docker local mysql

--- a/leonardo-example.conf
+++ b/leonardo-example.conf
@@ -61,7 +61,7 @@ dataproc {
 # Database connection information
 mysql {
   db {
-    url = "jdbc:mysql://YOUR_DB_HOST/leonardo?allowPublicKeyRetrieval=true&useSSL=false&rewriteBatchedStatements=true&nullNamePatternMatchesAll=true"
+    url = "jdbc:mysql://YOUR_DB_HOST/leonardo?requireSSL=true&useSSL=true&rewriteBatchedStatements=true&nullNamePatternMatchesAll=true"
     user = "USER_NAME"
     password = "PASSWORD"
   }


### PR DESCRIPTION
Reverts DataBiosphere/leonardo#4802

Leonardo dev looks pretty unheatlhy after merging this: https://argocd.dsp-devops-prod.broadinstitute.org/applications/leonardo-dev?resource=


Here is the error message on the leo backend dev pod:
```ERROR 2024-11-25T13:55:18.741677037Z [resource.labels.containerName: leonardo-backend] Nov 25, 2024 1:55:18 PM liquibase.changelog
ERROR 2024-11-25T13:55:18.741708111Z [resource.labels.containerName: leonardo-backend] INFO: Change failed validation!
ERROR 2024-11-25T13:55:18.837060051Z [resource.labels.containerName: leonardo-backend] liquibase.exception.ValidationFailedException: Validation Failed:
ERROR 2024-11-25T13:55:18.837101842Z [resource.labels.containerName: leonardo-backend] 7 changesets check sum
ERROR 2024-11-25T13:55:18.837107874Z [resource.labels.containerName: leonardo-backend] leonardo::cluster-createdDate-default::kumra was: 8:c1023fe139609a1cab82cda7caededc0 but is now: 8:af8d7086b9c7f53fd1aacaffd1df2190
ERROR 2024-11-25T13:55:18.837112181Z [resource.labels.containerName: leonardo-backend] leonardo::cluster_destroyeddate_not_null::vkumra was: 8:29280ede1de44e4c3f2966c6922e9865 but is now: 8:189a15dbba06e4fc1cbc5fe43e69bacb
ERROR 2024-11-25T13:55:18.837115617Z [resource.labels.containerName: leonardo-backend] leonardo::make dateAccessed not null::vkumra was: 8:5017000ff29d7873815c1bdb69895225 but is now: 8:7a98c11e2e4f293be62819b1e7800d75
ERROR 2024-11-25T13:55:18.837119603Z [resource.labels.containerName: leonardo-backend] leonardo::kubernetes_cluster_table::jcanas was: 8:599d13c602bc3a23e12dc577a848456f but is now: 8:4f14ddd6de38a6a5c11f8c88255d3081
ERROR 2024-11-25T13:55:18.837123364Z [resource.labels.containerName: leonardo-backend] leonardo::nodepool_table::jcanas was: 8:854fccdae58bc9906a94269397f04ae3 but is now: 8:6f36be18bd34a42bf9d0adae6d115b69
ERROR 2024-11-25T13:55:18.837126754Z [resource.labels.containerName: leonardo-backend] leonardo::kubernetes_add_app_tables::jcanas was: 8:a2cec6057088736af10dcdc3c2dd3091 but is now: 8:3fee946482c218e705c5791af226d7cf
ERROR 2024-11-25T13:55:18.837130131Z [resource.labels.containerName: leonardo-backend] leonardo::qi_create_app_usage_table::qi was: 8:10d891c4c811215803753f8b060621be but is now: 8:538a901354a77efb32d013285bee2d67
```