### PR TITLE
[CORE-182] Move listRuntimes over to new Sam permissions model

### DIFF
--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/RuntimeServiceDbQueries.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/RuntimeServiceDbQueries.scala
@@ -324,12 +324,20 @@ object RuntimeServiceDbQueries {
                    labelMap: LabelMap = Map.empty[String, String],
                    workspaceId: Option[WorkspaceId] = None
   )(implicit ec: ExecutionContext): DBIO[Vector[ListRuntimeResponse2]] = {
+    // Normalize filter params
+    val provider = if (cloudProvider.isEmpty) {
+      cloudContext match {
+        case Some(cContext) => Some(cContext.cloudProvider)
+        case None           => None
+      }
+    } else cloudProvider
+
     val runtimes = clusterQuery
       .filter(_.internalId inSetBind runtimeIds.map(_.asString))
       .filterOpt(workspaceId) { case (runtime, wId) =>
         runtime.workspaceId === (Some(wId): Rep[Option[WorkspaceId]])
       }
-      .filterOpt(cloudProvider) { case (runtime, cProvider) =>
+      .filterOpt(provider) { case (runtime, cProvider) =>
         runtime.cloudProvider === cProvider
       }
       .filterOpt(cloudContext) { case (runtime, cContext) =>

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/RuntimeServiceDbQueries.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/RuntimeServiceDbQueries.scala
@@ -6,11 +6,7 @@ import cats.syntax.all._
 import org.broadinstitute.dsde.workbench.azure.AzureCloudContext
 import org.broadinstitute.dsde.workbench.google2.OperationName
 import org.broadinstitute.dsde.workbench.leonardo.{LabelMap, Runtime}
-import org.broadinstitute.dsde.workbench.leonardo.SamResourceId.{
-  ProjectSamResourceId,
-  RuntimeSamResourceId,
-  WorkspaceResourceSamResourceId
-}
+import org.broadinstitute.dsde.workbench.leonardo.SamResourceId.RuntimeSamResourceId
 import org.broadinstitute.dsde.workbench.leonardo.config.Config
 import org.broadinstitute.dsde.workbench.leonardo.db.LeoProfile.api._
 import org.broadinstitute.dsde.workbench.leonardo.db.LeoProfile.dummyDate
@@ -28,7 +24,6 @@ import org.broadinstitute.dsde.workbench.leonardo.model.{
 import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GoogleProject}
 import org.broadinstitute.dsde.workbench.model.{IP, WorkbenchEmail}
 
-import java.util.UUID
 import java.sql.SQLDataException
 import java.time.Instant
 import scala.concurrent.ExecutionContext
@@ -70,6 +65,7 @@ object RuntimeServiceDbQueries {
     Option[WorkspaceId],
     Option[(String, String)]
   )
+
   private object ListRuntimesRecord {
     def apply(product: ListRuntimesProduct): ListRuntimesRecord = product match {
       case (l,
@@ -307,133 +303,33 @@ object RuntimeServiceDbQueries {
 
   /**
    * List runtimes filtered by the given terms. Only return authorized resources (per reader*Ids and/or owner*Ids).
+   *
    * @param labelMap
    * @param excludeStatuses
    * @param creatorEmail
    * @param workspaceId
    * @param cloudProvider
-   * @param readerRuntimeIds
+   * @param runtimeIds
    * @param readerWorkspaceIds
    * @param ownerWorkspaceIds
    * @param readerGoogleProjectIds
    * @param ownerGoogleProjectIds
    * @return
    */
-  def listRuntimes(
-    // Authorizations
-    ownerGoogleProjectIds: Set[ProjectSamResourceId] = Set.empty,
-    ownerWorkspaceIds: Set[WorkspaceResourceSamResourceId] = Set.empty,
-    readerGoogleProjectIds: Set[ProjectSamResourceId] = Set.empty,
-    readerRuntimeIds: Set[SamResourceId] = Set.empty,
-    readerWorkspaceIds: Set[WorkspaceResourceSamResourceId] = Set.empty,
-
-    // Filters
-    cloudContext: Option[CloudContext] = None,
-    cloudProvider: Option[CloudProvider] = None,
-    creatorEmail: Option[WorkbenchEmail] = None,
-    excludeStatuses: List[RuntimeStatus] = List.empty,
-    labelMap: LabelMap = Map.empty[String, String],
-    workspaceId: Option[WorkspaceId] = None
+  def listRuntimes(runtimeIds: Set[SamResourceId] = Set.empty,
+                   cloudContext: Option[CloudContext] = None,
+                   cloudProvider: Option[CloudProvider] = None,
+                   creatorEmail: Option[WorkbenchEmail] = None,
+                   excludeStatuses: List[RuntimeStatus] = List.empty,
+                   labelMap: LabelMap = Map.empty[String, String],
+                   workspaceId: Option[WorkspaceId] = None
   )(implicit ec: ExecutionContext): DBIO[Vector[ListRuntimeResponse2]] = {
-    // Normalize filter params
-    val provider = if (cloudProvider.isEmpty) {
-      cloudContext match {
-        case Some(cContext) => Some(cContext.cloudProvider)
-        case None           => None
-      }
-    } else cloudProvider
-
-    // Optimize Google project list if filtering to a specific cloud provider or context
-    val ownedProjects: Set[CloudContextDb] = ((provider, cloudContext) match {
-      case (Some(CloudProvider.Azure), _) => Set.empty[CloudContextDb]
-      case (Some(CloudProvider.Gcp), Some(CloudContext.Gcp(value))) =>
-        ownerGoogleProjectIds.filter(samId => samId.googleProject == value)
-      case _ => ownerGoogleProjectIds
-    }).map { case samId: SamResourceId =>
-      CloudContextDb(samId.resourceId)
-    }
-    val readProjects: Set[CloudContextDb] = ((provider, cloudContext) match {
-      case (Some(CloudProvider.Azure), _) => Set.empty[CloudContextDb]
-      case (Some(CloudProvider.Gcp), Some(CloudContext.Gcp(value))) =>
-        readerGoogleProjectIds.filter(samId => samId.googleProject == value)
-      case _ => readerGoogleProjectIds
-    }).map { case samId: SamResourceId =>
-      CloudContextDb(samId.resourceId)
-    }
-
-    // Optimize workspace list if filtering to a single workspace
-    val ownedWorkspaces: Set[WorkspaceId] = (workspaceId match {
-      case Some(wId) => ownerWorkspaceIds.filter(samId => WorkspaceId(UUID.fromString(samId.resourceId)) == wId)
-      case None      => ownerWorkspaceIds
-    }).map(samId => WorkspaceId(UUID.fromString(samId.resourceId)))
-    val readWorkspaces: Set[WorkspaceId] = (workspaceId match {
-      case Some(wId) => readerWorkspaceIds.filter(samId => WorkspaceId(UUID.fromString(samId.resourceId)) == wId)
-      case None      => readerWorkspaceIds
-    }).map(samId => WorkspaceId(UUID.fromString(samId.resourceId)))
-
-    val readRuntimes: Set[String] = readerRuntimeIds.map(readId => readId.asString)
-
-    val runtimeInReadWorkspaces: Option[ClusterTable => Rep[Option[Boolean]]] =
-      if (readRuntimes.isEmpty || readWorkspaces.isEmpty)
-        None
-      else
-        Some(runtime =>
-          (runtime.internalId inSetBind readRuntimes) &&
-            (runtime.workspaceId inSetBind readWorkspaces)
-        )
-
-    val runtimeInReadProjects: Option[ClusterTable => Rep[Option[Boolean]]] =
-      if (readRuntimes.isEmpty || readProjects.isEmpty)
-        None
-      else
-        Some(runtime =>
-          (runtime.internalId inSetBind readRuntimes) &&
-            (runtime.cloudProvider.? === (CloudProvider.Gcp: CloudProvider)) &&
-            (runtime.cloudContextDb inSetBind readProjects)
-        )
-
-    val runtimeInOwnedWorkspaces: Option[ClusterTable => Rep[Option[Boolean]]] =
-      if (ownedWorkspaces.isEmpty)
-        None
-      else
-        Some(runtime => runtime.workspaceId inSetBind ownedWorkspaces)
-
-    val runtimeInOwnedProjects: Option[ClusterTable => Rep[Option[Boolean]]] =
-      if (ownedProjects.isEmpty)
-        None
-      else if (cloudContext.isDefined) {
-        // If cloudContext is defined, we're already applying the filter in runtimesFiltered below.
-        // No need to filter by the list of user owned projects anymore as long as the specified
-        // project is owned by the user.
-        if (ownedProjects.exists(x => x.value == cloudContext.get.asString))
-          Some(_ => Some(true))
-        else None
-      } else
-        Some(runtime =>
-          (runtime.cloudProvider.? === (CloudProvider.Gcp: CloudProvider)) &&
-            (runtime.cloudContextDb inSetBind ownedProjects)
-        )
-
-    val runtimesAuthorized =
-      clusterQuery.filter[Rep[Option[Boolean]]] { runtime: ClusterTable =>
-        Seq(
-          runtimeInReadWorkspaces,
-          runtimeInOwnedWorkspaces,
-          runtimeInReadProjects,
-          runtimeInOwnedProjects
-        )
-          .mapFilter(opt => opt)
-          .map(_(runtime))
-          .reduceLeftOption(_ || _)
-          .getOrElse(Some(false): Rep[Option[Boolean]])
-      }
-
-    val runtimesFiltered = runtimesAuthorized
-      // Filter by params
+    val runtimes = clusterQuery
+      .filter(_.internalId inSetBind runtimeIds.map(_.asString))
       .filterOpt(workspaceId) { case (runtime, wId) =>
         runtime.workspaceId === (Some(wId): Rep[Option[WorkspaceId]])
       }
-      .filterOpt(provider) { case (runtime, cProvider) =>
+      .filterOpt(cloudProvider) { case (runtime, cProvider) =>
         runtime.cloudProvider === cProvider
       }
       .filterOpt(cloudContext) { case (runtime, cContext) =>
@@ -458,9 +354,6 @@ object RuntimeServiceDbQueries {
           )
           .length === labelMap.size
       }
-
-    // Assemble response
-    val runtimesJoined = runtimesFiltered
       .join(runtimeConfigs)
       .on((runtime, runtimeConfig) => runtime.runtimeConfigId === runtimeConfig.id)
       .map { case (runtime, runtimeConfig) =>
@@ -498,7 +391,7 @@ object RuntimeServiceDbQueries {
         )
       }
 
-    runtimesJoined.result
+    runtimes.result
       .map { records: Seq[ListRuntimesProduct] =>
         records
           .map(record => ListRuntimesRecord(record))

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterp.scala
@@ -39,6 +39,7 @@ import org.broadinstitute.dsde.workbench.leonardo.model.SamResourceAction.{
   workspaceSamResourceAction
 }
 import org.broadinstitute.dsde.workbench.leonardo.http.service.RuntimeServiceInterp._
+import org.broadinstitute.dsde.workbench.leonardo.model.SamResource.RuntimeSamResource
 import org.broadinstitute.dsde.workbench.leonardo.model.SamResourceAction._
 import org.broadinstitute.dsde.workbench.leonardo.model._
 import org.broadinstitute.dsde.workbench.leonardo.monitor.LeoPubsubMessage._
@@ -267,36 +268,19 @@ class RuntimeServiceInterp[F[_]: Parallel](
     for {
       ctx <- as.ask
 
-      // throw 403 if user doesn't have project permission
-      hasProjectPermission <- cloudContext.traverse(cc =>
-        authProvider.isUserProjectReader(
-          cc,
-          userInfo
-        )
-      )
-      _ <- ctx.span.traverse(s => F.delay(s.addAnnotation("Done checking project permission with Sam")))
-
-      _ <- F.raiseWhen(!hasProjectPermission.getOrElse(true))(ForbiddenError(userInfo.userEmail, Some(ctx.traceId)))
+      samResources <- samService.listResources(userInfo.accessToken.token, RuntimeSamResource.resourceType)
 
       (labelMap, includeDeleted, _) <- F.fromEither(processListParameters(params))
       excludeStatuses = if (includeDeleted) List.empty else List(RuntimeStatus.Deleted)
       creatorOnly <- F.fromEither(processCreatorOnlyParameter(userInfo.userEmail, params, ctx.traceId))
 
-      authorizedIds <- getAuthorizedIds(userInfo, creatorOnly)
       _ <- ctx.span.traverse(s => F.delay(s.addAnnotation("Start DB query for listRuntimes")))
       runtimes <- RuntimeServiceDbQueries
-        .listRuntimes(
-          // Authorization scopes
-          ownerGoogleProjectIds = authorizedIds.ownerGoogleProjectIds,
-          ownerWorkspaceIds = authorizedIds.ownerWorkspaceIds,
-          readerGoogleProjectIds = authorizedIds.readerGoogleProjectIds,
-          readerRuntimeIds = authorizedIds.readerRuntimeIds,
-          readerWorkspaceIds = authorizedIds.readerWorkspaceIds,
-          // Filters
-          excludeStatuses = excludeStatuses,
-          creatorEmail = creatorOnly,
-          cloudContext = cloudContext,
-          labelMap = labelMap
+        .listRuntimes(samResources.map(RuntimeSamResourceId).toSet,
+                      excludeStatuses = excludeStatuses,
+                      creatorEmail = creatorOnly,
+                      cloudContext = cloudContext,
+                      labelMap = labelMap
         )
         .transaction
 
@@ -1006,57 +990,6 @@ class RuntimeServiceInterp[F[_]: Parallel](
         else Async[F].pure((mt, true))
       }
     } yield targetMachineType
-
-  private[service] def getAuthorizedIds(
-    userInfo: UserInfo,
-    creatorEmail: Option[WorkbenchEmail] = None
-  )(implicit ev: Ask[F, AppContext]): F[AuthorizedIds] = for {
-    // Authorize: user has an active account and has accepted terms of service
-    _ <- authProvider.checkUserEnabled(userInfo)
-
-    // Authorize: get resource IDs the user can see
-    // HACK: leonardo is modeling access control here, handling inheritance
-    // of workspace and project-level permissions. Sam and WSM already do this,
-    // and should be considered the point of truth.
-
-    // HACK: leonardo short-circuits access control to grant access to runtime creators.
-    // This supports the use case where `terra-ui` requests status of runtimes that have
-    // not yet been provisioned in Sam.
-    creatorRuntimeIdsBackdoor: Set[RuntimeSamResourceId] <- creatorEmail match {
-      case Some(email: WorkbenchEmail) =>
-        RuntimeServiceDbQueries
-          .listRuntimeIdsForCreator(email)
-          .map(_.map(_.samResource).toSet)
-          .transaction
-      case None => F.pure(Set.empty: Set[RuntimeSamResourceId])
-    }
-
-    // v1 runtimes (sam resource type `notebook-cluster`) are readable only
-    // by their creators (`Creator` is the SamResource.Runtime `ownerRoleName`),
-    // if the creator also has read access to the corresponding SamResource.Project
-    creatorV1RuntimeIds: Set[RuntimeSamResourceId] <- authProvider
-      .listResourceIds[RuntimeSamResourceId](hasOwnerRole = true, userInfo)
-    readerProjectIds: Set[ProjectSamResourceId] <- authProvider
-      .listResourceIds[ProjectSamResourceId](hasOwnerRole = false, userInfo)
-
-    // v1 runtimes are discoverable by owners on the corresponding Project
-    ownerProjectIds: Set[ProjectSamResourceId] <- authProvider
-      .listResourceIds[ProjectSamResourceId](hasOwnerRole = true, userInfo)
-
-    // combine: to read a runtime, user needs to be at least one of:
-    // - creator of a v1 runtime (Sam-authenticated)
-    // - any role on a v2 runtime (Sam-authenticated)
-    // - creator of a runtime (in Leo db) and filtering their request by creator-only
-    readerRuntimeIds: Set[SamResourceId] = creatorV1RuntimeIds ++ creatorRuntimeIdsBackdoor
-  } yield AuthorizedIds(
-    ownerGoogleProjectIds = ownerProjectIds,
-    ownerWorkspaceIds = Set.empty,
-    readerGoogleProjectIds = readerProjectIds,
-    readerRuntimeIds = readerRuntimeIds,
-    readerWorkspaceIds = Set.empty
-  )
-
-}
 
 object RuntimeServiceInterp {
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterp.scala
@@ -20,7 +20,6 @@ import org.broadinstitute.dsde.workbench.google2.{
   MachineTypeName,
   ZoneName
 }
-import org.broadinstitute.dsde.workbench.leonardo.JsonCodec._
 import org.broadinstitute.dsde.workbench.leonardo.RuntimeImageType.{CryptoDetector, Jupyter, Proxy, Welder}
 import org.broadinstitute.dsde.workbench.leonardo.SamResourceId.{
   PersistentDiskSamResourceId,
@@ -990,6 +989,7 @@ class RuntimeServiceInterp[F[_]: Parallel](
         else Async[F].pure((mt, true))
       }
     } yield targetMachineType
+}
 
 object RuntimeServiceInterp {
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeV2ServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeV2ServiceInterp.scala
@@ -9,7 +9,6 @@ import cats.effect.std.Queue
 import cats.mtl.Ask
 import cats.syntax.all._
 import org.broadinstitute.dsde.workbench.google2.{DiskName, MachineTypeName, ZoneName}
-import org.broadinstitute.dsde.workbench.leonardo.JsonCodec._
 import org.broadinstitute.dsde.workbench.leonardo.SamResourceId.{
   PersistentDiskSamResourceId,
   ProjectSamResourceId,
@@ -26,11 +25,8 @@ import org.broadinstitute.dsde.workbench.leonardo.http.service.RuntimeServiceInt
 import org.broadinstitute.dsde.workbench.leonardo.model.SamResource.RuntimeSamResource
 // do not remove: `projectSamResourceAction`, `runtimeSamResourceAction`, `workspaceSamResourceAction`, `wsmResourceSamResourceAction`; `AppSamResourceAction` they are implicit
 import org.broadinstitute.dsde.workbench.leonardo.model.SamResourceAction.{
-  projectSamResourceAction,
-  runtimeSamResourceAction,
   workspaceSamResourceAction,
-  wsmResourceSamResourceAction,
-  AppSamResourceAction
+  wsmResourceSamResourceAction
 }
 import org.broadinstitute.dsde.workbench.leonardo.model._
 import org.broadinstitute.dsde.workbench.leonardo.monitor.LeoPubsubMessage.{

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeV2ServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeV2ServiceInterp.scala
@@ -23,6 +23,7 @@ import org.broadinstitute.dsde.workbench.leonardo.dao.sam.SamService
 import org.broadinstitute.dsde.workbench.leonardo.db._
 import org.broadinstitute.dsde.workbench.leonardo.http.service.DiskServiceInterp.getDiskSamPolicyMap
 import org.broadinstitute.dsde.workbench.leonardo.http.service.RuntimeServiceInterp.getRuntimeSamPolicyMap
+import org.broadinstitute.dsde.workbench.leonardo.model.SamResource.RuntimeSamResource
 // do not remove: `projectSamResourceAction`, `runtimeSamResourceAction`, `workspaceSamResourceAction`, `wsmResourceSamResourceAction`; `AppSamResourceAction` they are implicit
 import org.broadinstitute.dsde.workbench.leonardo.model.SamResourceAction.{
   projectSamResourceAction,
@@ -91,20 +92,14 @@ class RuntimeV2ServiceInterp[F[_]: Parallel](
       _ <- F.raiseUnless(hasPermission)(ForbiddenError(userEmail))
 
       // enforcing one runtime per workspace/user at a time
-      authorizedIds <- getAuthorizedIds(userInfo, Some(userEmail), Some(samResource))
+      samResources <- samService.listResources(userInfo.accessToken.token, RuntimeSamResource.resourceType)
       runtimes <- RuntimeServiceDbQueries
         .listRuntimes(
-          // Authorization scopes
-          ownerGoogleProjectIds = authorizedIds.ownerGoogleProjectIds,
-          ownerWorkspaceIds = authorizedIds.ownerWorkspaceIds,
-          readerGoogleProjectIds = authorizedIds.readerGoogleProjectIds,
-          readerRuntimeIds = authorizedIds.readerRuntimeIds,
-          readerWorkspaceIds = authorizedIds.readerWorkspaceIds,
-          // Filters
-          excludeStatuses = List(RuntimeStatus.Deleted, RuntimeStatus.Deleting),
+          runtimeIds = samResources.map(RuntimeSamResourceId).toSet,
+          cloudProvider = Some(cloudContext.cloudProvider),
           creatorEmail = Some(userEmail),
-          workspaceId = Some(workspaceId),
-          cloudProvider = Some(cloudContext.cloudProvider)
+          excludeStatuses = List(RuntimeStatus.Deleted, RuntimeStatus.Deleting),
+          workspaceId = Some(workspaceId)
         )
         .transaction
 
@@ -402,16 +397,10 @@ class RuntimeV2ServiceInterp[F[_]: Parallel](
       )
       _ <- F.raiseUnless(hasWorkspacePermission)(ForbiddenError(userInfo.userEmail))
 
-      authorizedIds <- getAuthorizedIds(userInfo, workspaceSamId = Some(workspaceSamId))
+      samResources <- samService.listResources(userInfo.accessToken.token, RuntimeSamResource.resourceType)
       runtimes <- RuntimeServiceDbQueries
         .listRuntimes(
-          // Authorization scopes
-          ownerGoogleProjectIds = authorizedIds.ownerGoogleProjectIds,
-          ownerWorkspaceIds = authorizedIds.ownerWorkspaceIds,
-          readerGoogleProjectIds = authorizedIds.readerGoogleProjectIds,
-          readerRuntimeIds = authorizedIds.readerRuntimeIds,
-          readerWorkspaceIds = authorizedIds.readerWorkspaceIds,
-          // Filters
+          runtimeIds = samResources.map(RuntimeSamResourceId).toSet,
           excludeStatuses = List(RuntimeStatus.Deleted),
           workspaceId = Some(workspaceId)
         )
@@ -545,23 +534,16 @@ class RuntimeV2ServiceInterp[F[_]: Parallel](
       (labelMap, includeDeleted, _) <- F.fromEither(processListParameters(params))
       excludeStatuses = if (includeDeleted) List.empty else List(RuntimeStatus.Deleted)
       creatorEmail <- F.fromEither(processCreatorOnlyParameter(userInfo.userEmail, params, ctx.traceId))
-      maybeWorkspaceSamId = workspaceId.map(WorkspaceResourceSamResourceId)
 
-      authorizedIds <- getAuthorizedIds(userInfo, creatorEmail, maybeWorkspaceSamId)
+      samResources <- samService.listResources(userInfo.accessToken.token, RuntimeSamResource.resourceType)
       runtimes <- RuntimeServiceDbQueries
         .listRuntimes(
-          // Authorization scopes
-          ownerGoogleProjectIds = authorizedIds.ownerGoogleProjectIds,
-          ownerWorkspaceIds = authorizedIds.ownerWorkspaceIds,
-          readerGoogleProjectIds = authorizedIds.readerGoogleProjectIds,
-          readerRuntimeIds = authorizedIds.readerRuntimeIds,
-          readerWorkspaceIds = authorizedIds.readerWorkspaceIds,
-          // Filters
-          cloudProvider = cloudProvider, // Google | Azure
-          creatorEmail = creatorEmail, // whether to filter out runtimes user did not create
-          excludeStatuses = excludeStatuses, // whether to filter out Deleted runtimes
-          labelMap = labelMap, // arbitrary key-value labels to filter by
-          workspaceId = workspaceId // whether to find only runtimes in a single workspace
+          runtimeIds = samResources.map(RuntimeSamResourceId).toSet,
+          cloudProvider = cloudProvider,
+          creatorEmail = creatorEmail,
+          excludeStatuses = excludeStatuses,
+          labelMap = labelMap,
+          workspaceId = workspaceId
         )
         .map(_.toList)
         .transaction
@@ -650,84 +632,6 @@ class RuntimeV2ServiceInterp[F[_]: Parallel](
         .save(runtimeId, RuntimeError(e.getMessage, None, ctx.now, Some(ctx.traceId)))
         .transaction >>
         clusterQuery.updateClusterStatus(runtimeId, RuntimeStatus.Error, ctx.now).transaction.void
-
-  private def getAuthorizedIds(
-    userInfo: UserInfo,
-    creatorEmail: Option[WorkbenchEmail] = None,
-    workspaceSamId: Option[WorkspaceResourceSamResourceId] = None
-  )(implicit ev: Ask[F, AppContext]): F[AuthorizedIds] = for {
-    // Authorize: user has an active account and has accepted terms of service
-    _ <- authProvider.checkUserEnabled(userInfo)
-
-    // Authorize: get resource IDs the user can see
-    // HACK: leonardo is modeling access control here, handling inheritance
-    // of workspace and project-level permissions. Sam and WSM already do this,
-    // and should be considered the point of truth.
-
-    // HACK: leonardo short-circuits access control to grant access to runtime creators.
-    // This supports the use case where `terra-ui` requests status of runtimes that have
-    // not yet been provisioned in Sam.
-    creatorRuntimeIdsBackdoor: Set[RuntimeSamResourceId] <- creatorEmail match {
-      case Some(email: WorkbenchEmail) =>
-        RuntimeServiceDbQueries
-          .listRuntimeIdsForCreator(email)
-          .map(_.map(_.samResource).toSet)
-          .transaction
-      case None => F.pure(Set.empty: Set[RuntimeSamResourceId])
-    }
-
-    // v1 runtimes (sam resource type `notebook-cluster`) are readable only
-    // by their creators (`Creator` is the SamResource.Runtime `ownerRoleName`),
-    // if the creator also has read access to the corresponding SamResource.Project
-    creatorV1RuntimeIds: Set[RuntimeSamResourceId] <- authProvider
-      .listResourceIds[RuntimeSamResourceId](hasOwnerRole = true, userInfo)
-    readerProjectIds: Set[ProjectSamResourceId] <- authProvider
-      .listResourceIds[ProjectSamResourceId](hasOwnerRole = false, userInfo)
-
-    // v1 runtimes are discoverable by owners on the corresponding Project
-    ownerProjectIds: Set[ProjectSamResourceId] <- authProvider
-      .listResourceIds[ProjectSamResourceId](hasOwnerRole = true, userInfo)
-
-    // v2 runtimes are WSM-managed resources and they're modeled as `WsmResourceSamResource`s.
-    // HACK: accept any ID in the list of readable WSM resources as a valid
-    // readable v2 runtime ID. Some of these IDs are for non-runtime resources.
-    // TODO [] call WSM to list workspaces, then list runtimes per workspace, to get these IDs?
-
-    // v2 runtimes are readable by users with read access to both runtime and workspace
-    readerV2WsmIds: Set[WsmResourceSamResourceId] <- authProvider
-      .listResourceIds[WsmResourceSamResourceId](hasOwnerRole = false, userInfo)
-    readerWorkspaceIds: Set[WorkspaceResourceSamResourceId] <- workspaceSamId match {
-      case Some(samId) =>
-        for {
-          isWorkspaceReader <- authProvider.isUserWorkspaceReader(samId, userInfo)
-          workspaceIds: Set[WorkspaceResourceSamResourceId] =
-            if (isWorkspaceReader) Set(samId) else Set.empty
-        } yield workspaceIds
-      case None => authProvider.listResourceIds[WorkspaceResourceSamResourceId](hasOwnerRole = false, userInfo)
-    }
-
-    // v2 runtimes are discoverable by owners on the corresponding Workspace
-    ownerWorkspaceIds: Set[WorkspaceResourceSamResourceId] <- workspaceSamId match {
-      case Some(samId) =>
-        for {
-          isWorkspaceOwner <- authProvider.isUserWorkspaceOwner(samId, userInfo)
-          workspaceIds: Set[WorkspaceResourceSamResourceId] = if (isWorkspaceOwner) Set(samId) else Set.empty
-        } yield workspaceIds
-      case None => authProvider.listResourceIds[WorkspaceResourceSamResourceId](hasOwnerRole = true, userInfo)
-    }
-
-    // combine: to read a runtime, user needs to be at least one of:
-    // - creator of a v1 runtime (Sam-authenticated)
-    // - any role on a v2 runtime (Sam-authenticated)
-    // - creator of a runtime (in Leo db) and filtering their request by creator-only
-    readerRuntimeIds: Set[SamResourceId] = creatorV1RuntimeIds ++ readerV2WsmIds ++ creatorRuntimeIdsBackdoor
-  } yield AuthorizedIds(
-    ownerGoogleProjectIds = ownerProjectIds,
-    ownerWorkspaceIds = ownerWorkspaceIds,
-    readerGoogleProjectIds = readerProjectIds,
-    readerRuntimeIds = readerRuntimeIds,
-    readerWorkspaceIds = readerWorkspaceIds
-  )
 
   private def convertToRuntime(
     workspaceId: WorkspaceId,

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/RuntimeServiceDbQueriesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/RuntimeServiceDbQueriesSpec.scala
@@ -67,11 +67,7 @@ class RuntimeServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent wit
         case None              => Set.empty[WorkspaceResourceSamResourceId]
       }
       list2 <- RuntimeServiceDbQueries
-        .listRuntimes(
-          readerRuntimeIds = Set(c1.samResource),
-          readerWorkspaceIds = c1WorkspaceIds,
-          excludeStatuses = List(RuntimeStatus.Deleted)
-        )
+        .listRuntimes(runtimeIds = Set(c1.samResource), excludeStatuses = List(RuntimeStatus.Deleted))
         .transaction
       // Two runtimes exist: c1, c2
       d2 <- makePersistentDisk(Some(DiskName("d2"))).save()
@@ -89,11 +85,7 @@ class RuntimeServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent wit
         WorkspaceResourceSamResourceId(workspaceId)
       }
       list3 <- RuntimeServiceDbQueries
-        .listRuntimes(
-          readerRuntimeIds = Set(c1.samResource, c2.samResource),
-          readerWorkspaceIds = bothWorkspaceIds,
-          excludeStatuses = List(RuntimeStatus.Deleted)
-        )
+        .listRuntimes(runtimeIds = Set(c1.samResource, c2.samResource), excludeStatuses = List(RuntimeStatus.Deleted))
         .transaction
 
       // no authorizations => no runtimes
@@ -184,17 +176,11 @@ class RuntimeServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent wit
       workspaceIds = Set(workspaceId1, workspaceId2).map(WorkspaceResourceSamResourceId)
 
       list0 <- RuntimeServiceDbQueries
-        .listRuntimes(
-          readerRuntimeIds = runtimeIds,
-          readerWorkspaceIds = workspaceIds,
-          readerGoogleProjectIds = projectIds
-        )
+        .listRuntimes(runtimeIds = runtimeIds)
         .transaction
       list1 <- RuntimeServiceDbQueries
         .listRuntimes(
-          readerRuntimeIds = runtimeIds,
-          readerWorkspaceIds = workspaceIds,
-          readerGoogleProjectIds = projectIds,
+          runtimeIds = runtimeIds,
           cloudContext = Some(CloudContext.Gcp(googleProject)),
           cloudProvider = Some(CloudProvider.Gcp),
           creatorEmail = Some(c1.auditInfo.creator),
@@ -205,9 +191,7 @@ class RuntimeServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent wit
         .transaction
       list2 <- RuntimeServiceDbQueries
         .listRuntimes(
-          readerRuntimeIds = runtimeIds,
-          readerWorkspaceIds = workspaceIds,
-          readerGoogleProjectIds = projectIds,
+          runtimeIds = runtimeIds,
           cloudProvider = Some(CloudProvider.Azure),
           creatorEmail = Some(c2.auditInfo.creator),
           excludeStatuses = List(RuntimeStatus.Deleted),
@@ -267,52 +251,26 @@ class RuntimeServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent wit
         ProjectSamResourceId(GoogleProject(c2.cloudContext.asString))
       )
       list0 <- RuntimeServiceDbQueries
-        .listRuntimes(
-          readerRuntimeIds = runtimeIds,
-          readerGoogleProjectIds = bothProjectIds,
-          excludeStatuses = List(RuntimeStatus.Deleted)
-        )
+        .listRuntimes(runtimeIds = runtimeIds, excludeStatuses = List(RuntimeStatus.Deleted))
         .transaction
       list1 <- RuntimeServiceDbQueries
-        .listRuntimes(
-          readerRuntimeIds = runtimeIds,
-          readerGoogleProjectIds = bothProjectIds,
-          labelMap = labels1,
-          excludeStatuses = List(RuntimeStatus.Deleted)
-        )
+        .listRuntimes(runtimeIds = runtimeIds, excludeStatuses = List(RuntimeStatus.Deleted), labelMap = labels1)
         .transaction
       list2 <- RuntimeServiceDbQueries
-        .listRuntimes(
-          readerRuntimeIds = runtimeIds,
-          readerGoogleProjectIds = bothProjectIds,
-          labelMap = labels2,
-          excludeStatuses = List(RuntimeStatus.Deleted)
-        )
+        .listRuntimes(runtimeIds = runtimeIds, excludeStatuses = List(RuntimeStatus.Deleted), labelMap = labels2)
         .transaction
       _ <- labelQuery.saveAllForResource(c1.id, LabelResourceType.Runtime, labels1).transaction
       _ <- labelQuery.saveAllForResource(c2.id, LabelResourceType.Runtime, labels2).transaction
       list3 <- RuntimeServiceDbQueries
-        .listRuntimes(
-          readerRuntimeIds = runtimeIds,
-          readerGoogleProjectIds = bothProjectIds,
-          labelMap = labels1,
-          excludeStatuses = List(RuntimeStatus.Deleted)
-        )
+        .listRuntimes(runtimeIds = runtimeIds, excludeStatuses = List(RuntimeStatus.Deleted), labelMap = labels1)
         .transaction
       list4 <- RuntimeServiceDbQueries
-        .listRuntimes(
-          readerRuntimeIds = runtimeIds,
-          readerGoogleProjectIds = bothProjectIds,
-          labelMap = labels2,
-          excludeStatuses = List(RuntimeStatus.Deleted)
-        )
+        .listRuntimes(runtimeIds = runtimeIds, excludeStatuses = List(RuntimeStatus.Deleted), labelMap = labels2)
         .transaction
       list5 <- RuntimeServiceDbQueries
-        .listRuntimes(
-          readerRuntimeIds = runtimeIds,
-          readerGoogleProjectIds = bothProjectIds,
-          labelMap = Map("googleProject" -> c1.cloudContext.asString),
-          excludeStatuses = List(RuntimeStatus.Deleted)
+        .listRuntimes(runtimeIds = runtimeIds,
+                      excludeStatuses = List(RuntimeStatus.Deleted),
+                      labelMap = Map("googleProject" -> c1.cloudContext.asString)
         )
         .transaction
       end <- IO.realTimeInstant
@@ -364,19 +322,15 @@ class RuntimeServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent wit
         ProjectSamResourceId(GoogleProject(c2.cloudContext.asString))
       )
       list1 <- RuntimeServiceDbQueries
-        .listRuntimes(
-          readerRuntimeIds = runtimeIds,
-          readerGoogleProjectIds = bothProjectIds,
-          excludeStatuses = List(RuntimeStatus.Deleted),
-          cloudContext = Some(cloudContextGcp)
+        .listRuntimes(runtimeIds = runtimeIds,
+                      cloudContext = Some(cloudContextGcp),
+                      excludeStatuses = List(RuntimeStatus.Deleted)
         )
         .transaction
       list2 <- RuntimeServiceDbQueries
-        .listRuntimes(
-          readerRuntimeIds = runtimeIds,
-          readerGoogleProjectIds = bothProjectIds,
-          excludeStatuses = List(RuntimeStatus.Deleted),
-          cloudContext = Some(cloudContext2Gcp)
+        .listRuntimes(runtimeIds = runtimeIds,
+                      cloudContext = Some(cloudContext2Gcp),
+                      excludeStatuses = List(RuntimeStatus.Deleted)
         )
         .transaction
       end <- IO.realTimeInstant
@@ -449,14 +403,10 @@ class RuntimeServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent wit
       )
 
       list1 <- RuntimeServiceDbQueries
-        .listRuntimes(readerRuntimeIds = runtimeIds, readerGoogleProjectIds = projectIds)
+        .listRuntimes(runtimeIds = runtimeIds)
         .transaction
       list2 <- RuntimeServiceDbQueries
-        .listRuntimes(
-          readerRuntimeIds = runtimeIds,
-          readerGoogleProjectIds = projectIds,
-          excludeStatuses = List(RuntimeStatus.Deleted)
-        )
+        .listRuntimes(runtimeIds = runtimeIds, excludeStatuses = List(RuntimeStatus.Deleted))
         .transaction
       end <- IO.realTimeInstant
       elapsed = (end.toEpochMilli - start.toEpochMilli).millis
@@ -518,19 +468,10 @@ class RuntimeServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent wit
         WorkspaceResourceSamResourceId(workspaceId)
       }
       list1 <- RuntimeServiceDbQueries
-        .listRuntimes(
-          readerRuntimeIds = runtimeIds,
-          readerGoogleProjectIds = projectIds,
-          readerWorkspaceIds = workspaceIds
-        )
+        .listRuntimes(runtimeIds = runtimeIds)
         .transaction
       list2 <- RuntimeServiceDbQueries
-        .listRuntimes(
-          readerRuntimeIds = runtimeIds,
-          readerGoogleProjectIds = projectIds,
-          readerWorkspaceIds = workspaceIds,
-          excludeStatuses = List(RuntimeStatus.Deleted)
-        )
+        .listRuntimes(runtimeIds = runtimeIds, excludeStatuses = List(RuntimeStatus.Deleted))
         .transaction
       end <- IO.realTimeInstant
       elapsed = (end.toEpochMilli - start.toEpochMilli).millis
@@ -595,18 +536,12 @@ class RuntimeServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent wit
       workspaceIds = Set(workspaceId1, workspaceId2).map(WorkspaceResourceSamResourceId)
 
       list1 <- RuntimeServiceDbQueries
-        .listRuntimes(
-          readerRuntimeIds = runtimeIds,
-          readerWorkspaceIds = workspaceIds,
-          workspaceId = Some(workspaceId1)
-        )
+        .listRuntimes(runtimeIds = runtimeIds, workspaceId = Some(workspaceId1))
         .transaction
       list2 <- RuntimeServiceDbQueries
-        .listRuntimes(
-          readerRuntimeIds = runtimeIds,
-          readerWorkspaceIds = workspaceIds,
-          excludeStatuses = List(RuntimeStatus.Deleted),
-          workspaceId = Some(workspaceId2)
+        .listRuntimes(runtimeIds = runtimeIds,
+                      excludeStatuses = List(RuntimeStatus.Deleted),
+                      workspaceId = Some(workspaceId2)
         )
         .transaction
       end <- IO.realTimeInstant
@@ -692,48 +627,39 @@ class RuntimeServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent wit
       workspaceIds = Set(workspaceId1, workspaceId2).map(WorkspaceResourceSamResourceId)
 
       list1 <- RuntimeServiceDbQueries
-        .listRuntimes(
-          readerRuntimeIds = runtimeIds,
-          readerWorkspaceIds = workspaceIds,
-          excludeStatuses = List(RuntimeStatus.Deleted),
-          workspaceId = Some(workspaceId1),
-          cloudProvider = Some(CloudProvider.Azure)
+        .listRuntimes(runtimeIds = runtimeIds,
+                      cloudProvider = Some(CloudProvider.Azure),
+                      excludeStatuses = List(RuntimeStatus.Deleted),
+                      workspaceId = Some(workspaceId1)
         )
         .transaction
       list2 <- RuntimeServiceDbQueries
-        .listRuntimes(
-          readerRuntimeIds = runtimeIds,
-          readerWorkspaceIds = workspaceIds,
-          excludeStatuses = List(RuntimeStatus.Deleted),
-          workspaceId = Some(workspaceId2),
-          cloudProvider = Some(CloudProvider.Azure)
+        .listRuntimes(runtimeIds = runtimeIds,
+                      cloudProvider = Some(CloudProvider.Azure),
+                      excludeStatuses = List(RuntimeStatus.Deleted),
+                      workspaceId = Some(workspaceId2)
         )
         .transaction
       list3 <- RuntimeServiceDbQueries
-        .listRuntimes(
-          readerRuntimeIds = runtimeIds,
-          readerWorkspaceIds = workspaceIds,
-          excludeStatuses = List(RuntimeStatus.Deleted),
-          workspaceId = Some(workspaceId1),
-          cloudProvider = Some(CloudProvider.Gcp)
+        .listRuntimes(runtimeIds = runtimeIds,
+                      cloudProvider = Some(CloudProvider.Gcp),
+                      excludeStatuses = List(RuntimeStatus.Deleted),
+                      workspaceId = Some(workspaceId1)
         )
         .transaction
       list4 <- RuntimeServiceDbQueries
-        .listRuntimes(
-          readerRuntimeIds = runtimeIds,
-          readerWorkspaceIds = workspaceIds,
-          excludeStatuses = List(RuntimeStatus.Deleted),
-          cloudProvider = Some(CloudProvider.Azure)
+        .listRuntimes(runtimeIds = runtimeIds,
+                      cloudProvider = Some(CloudProvider.Azure),
+                      excludeStatuses = List(RuntimeStatus.Deleted)
         )
         .transaction
       list5 <- RuntimeServiceDbQueries
         .listRuntimes(
-          readerRuntimeIds = runtimeIds,
-          readerWorkspaceIds = workspaceIds,
-          excludeStatuses = List(RuntimeStatus.Deleted),
+          runtimeIds = runtimeIds,
+          cloudProvider = Some(CloudProvider.Azure),
           creatorEmail = Some(c5ClusterRecord.get.auditInfo.creator),
-          workspaceId = Some(workspaceId2),
-          cloudProvider = Some(CloudProvider.Azure)
+          excludeStatuses = List(RuntimeStatus.Deleted),
+          workspaceId = Some(workspaceId2)
         )
         .transaction
       end <- IO.realTimeInstant

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/RuntimeServiceDbQueriesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/RuntimeServiceDbQueriesSpec.scala
@@ -62,10 +62,6 @@ class RuntimeServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent wit
       c1 <- IO(
         makeCluster(1).saveWithRuntimeConfig(d1RuntimeConfig)
       )
-      c1WorkspaceIds = c1.workspaceId match {
-        case Some(workspaceId) => Set(WorkspaceResourceSamResourceId(workspaceId))
-        case None              => Set.empty[WorkspaceResourceSamResourceId]
-      }
       list2 <- RuntimeServiceDbQueries
         .listRuntimes(runtimeIds = Set(c1.samResource), excludeStatuses = List(RuntimeStatus.Deleted))
         .transaction
@@ -81,9 +77,6 @@ class RuntimeServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent wit
       c2 <- IO(
         makeCluster(2).saveWithRuntimeConfig(d2RuntimeConfig)
       )
-      bothWorkspaceIds = Set(c1.workspaceId, c2.workspaceId).collect { case Some(workspaceId) =>
-        WorkspaceResourceSamResourceId(workspaceId)
-      }
       list3 <- RuntimeServiceDbQueries
         .listRuntimes(runtimeIds = Set(c1.samResource, c2.samResource), excludeStatuses = List(RuntimeStatus.Deleted))
         .transaction
@@ -171,9 +164,7 @@ class RuntimeServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent wit
 
       // Note that c3 exists but is not visible
       googleProject = GoogleProject(c1.cloudContext.asString)
-      projectIds = Set(ProjectSamResourceId(googleProject))
       runtimeIds = Set(c1.samResource: SamResourceId, c2.samResource: SamResourceId)
-      workspaceIds = Set(workspaceId1, workspaceId2).map(WorkspaceResourceSamResourceId)
 
       list0 <- RuntimeServiceDbQueries
         .listRuntimes(runtimeIds = runtimeIds)
@@ -246,10 +237,6 @@ class RuntimeServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent wit
         "creator" -> c2.auditInfo.creator.value
       )
       runtimeIds = Set(c1.samResource: SamResourceId, c2.samResource: SamResourceId)
-      bothProjectIds = Set(
-        ProjectSamResourceId(GoogleProject(c1.cloudContext.asString)),
-        ProjectSamResourceId(GoogleProject(c2.cloudContext.asString))
-      )
       list0 <- RuntimeServiceDbQueries
         .listRuntimes(runtimeIds = runtimeIds, excludeStatuses = List(RuntimeStatus.Deleted))
         .transaction
@@ -317,10 +304,6 @@ class RuntimeServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent wit
         makeCluster(2).saveWithRuntimeConfig(c2RuntimeConfig)
       )
       runtimeIds = Set(c1.samResource: SamResourceId, c2.samResource: SamResourceId)
-      bothProjectIds = Set(
-        ProjectSamResourceId(GoogleProject(c1.cloudContext.asString)),
-        ProjectSamResourceId(GoogleProject(c2.cloudContext.asString))
-      )
       list1 <- RuntimeServiceDbQueries
         .listRuntimes(runtimeIds = runtimeIds,
                       cloudContext = Some(cloudContextGcp),
@@ -396,11 +379,6 @@ class RuntimeServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent wit
         )
       )
       runtimeIds = Set(c1.samResource: SamResourceId, c2.samResource: SamResourceId, c3.samResource: SamResourceId)
-      projectIds = Set(
-        ProjectSamResourceId(GoogleProject(c1.cloudContext.asString)),
-        ProjectSamResourceId(GoogleProject(c2.cloudContext.asString)),
-        ProjectSamResourceId(GoogleProject(c3.cloudContext.asString))
-      )
 
       list1 <- RuntimeServiceDbQueries
         .listRuntimes(runtimeIds = runtimeIds)
@@ -460,13 +438,6 @@ class RuntimeServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent wit
         )
       )
       runtimeIds = Set(c1.samResource: SamResourceId, c2.samResource: SamResourceId, c3.samResource: SamResourceId)
-      projectIds = Set(
-        ProjectSamResourceId(GoogleProject(c1.cloudContext.asString)),
-        ProjectSamResourceId(GoogleProject(c2.cloudContext.asString))
-      )
-      workspaceIds = Set(c3.workspaceId).collect { case Some(workspaceId) =>
-        WorkspaceResourceSamResourceId(workspaceId)
-      }
       list1 <- RuntimeServiceDbQueries
         .listRuntimes(runtimeIds = runtimeIds)
         .transaction
@@ -533,7 +504,6 @@ class RuntimeServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent wit
           )
       )
       runtimeIds = Set(c1.samResource: SamResourceId, c2.samResource: SamResourceId, c3.samResource: SamResourceId)
-      workspaceIds = Set(workspaceId1, workspaceId2).map(WorkspaceResourceSamResourceId)
 
       list1 <- RuntimeServiceDbQueries
         .listRuntimes(runtimeIds = runtimeIds, workspaceId = Some(workspaceId1))
@@ -624,7 +594,6 @@ class RuntimeServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent wit
       )
       c5ClusterRecord <- clusterQuery.getActiveClusterRecordByName(c5.cloudContext, c5.runtimeName).transaction
       runtimeIds = Set(c1, c2, c3, c4, c5).map(_.samResource: SamResourceId)
-      workspaceIds = Set(workspaceId1, workspaceId2).map(WorkspaceResourceSamResourceId)
 
       list1 <- RuntimeServiceDbQueries
         .listRuntimes(runtimeIds = runtimeIds,

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterpSpec.scala
@@ -37,12 +37,14 @@ import org.broadinstitute.dsde.workbench.leonardo.TestUtils.{appContext, default
 import org.broadinstitute.dsde.workbench.leonardo.auth.AllowlistAuthProvider
 import org.broadinstitute.dsde.workbench.leonardo.config.Config
 import org.broadinstitute.dsde.workbench.leonardo.dao.MockDockerDAO
+import org.broadinstitute.dsde.workbench.leonardo.dao.sam.SamService
 import org.broadinstitute.dsde.workbench.leonardo.db._
 import org.broadinstitute.dsde.workbench.leonardo.http.service.RuntimeServiceInterp.{
   calculateAutopauseThreshold,
   getRuntimeSamPolicyMap,
   getToolFromImages
 }
+import org.broadinstitute.dsde.workbench.leonardo.model.SamResource.RuntimeSamResource
 import org.broadinstitute.dsde.workbench.leonardo.model.SamResourceAction.{
   projectSamResourceAction,
   runtimeSamResourceAction,
@@ -81,7 +83,8 @@ trait RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
   def makeRuntimeService(
     publisherQueue: Queue[IO, LeoPubsubMessage] = publisherQueue,
     computeService: GoogleComputeService[IO] = FakeGoogleComputeService,
-    authProvider: AllowlistAuthProvider = allowListAuthProvider
+    authProvider: AllowlistAuthProvider = allowListAuthProvider,
+    samService: SamService[IO] = MockSamService
   ) =
     new RuntimeServiceInterp(
       RuntimeServiceConfig(
@@ -98,7 +101,7 @@ trait RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
       Some(FakeGoogleStorageInterpreter),
       Some(computeService),
       publisherQueue,
-      MockSamService
+      samService
     )
 
   val runtimeService = makeRuntimeService()
@@ -210,6 +213,14 @@ class RuntimeServiceInterpTest
     with MockitoSugar {
 
   it should "fail if user doesn't have project level permission" in {
+    val samService = mock[SamService[IO]]
+    val runtimeService = makeRuntimeService(samService = samService)
+    when(
+      samService.checkAuthorized(isEq(unauthorizedUserInfo.accessToken.token),
+                                 isEq(ProjectSamResourceId(cloudContextGcp.value)),
+                                 isEq(ProjectAction.CreateRuntime)
+      )(any())
+    ).thenReturn(IO.raiseError(ForbiddenError(unauthorizedUserInfo.userEmail)))
     val res = for {
       r <- runtimeService
         .createRuntime(
@@ -827,7 +838,7 @@ class RuntimeServiceInterpTest
     res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
-  it should "throw ClusterNotFoundException for nonexistent clusters" in isolatedDbTest {
+  it should "throw RuntimeNotFoundException for nonexistent clusters" in isolatedDbTest {
     val exc = runtimeService
       .getRuntime(userInfo, CloudContext.Gcp(GoogleProject("nonexistent")), RuntimeName("cluster"))
       .attempt
@@ -838,28 +849,33 @@ class RuntimeServiceInterpTest
     exc shouldBe a[RuntimeNotFoundException]
   }
 
-  it should "fail to get a runtime when users don't have access to the project" in isolatedDbTest {
-    val exc = runtimeService
-      .getRuntime(unauthorizedUserInfo, cloudContextGcp, RuntimeName("cluster"))
-      .attempt
-      .unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
-      .swap
-      .toOption
-      .get
-    exc shouldBe a[ForbiddenError]
+  it should "throw RuntimeNotFoundException when users don't have permission on the runtime" in isolatedDbTest {
+    val samService = mock[SamService[IO]]
+    val runtimeService = makeRuntimeService(samService = samService)
+    val samResource = RuntimeSamResourceId(UUID.randomUUID.toString)
+    when(
+      samService.checkAuthorized(isEq(unauthorizedUserInfo.accessToken.token),
+                                 isEq(samResource),
+                                 isEq(RuntimeAction.GetRuntimeStatus)
+      )(any())
+    ).thenReturn(IO.raiseError(ForbiddenError(unauthorizedUserInfo.userEmail)))
+    val res = for {
+      testRuntime <- IO(makeCluster(1).copy(samResource = samResource).save())
+      getResponse <- runtimeService
+        .getRuntime(unauthorizedUserInfo, testRuntime.cloudContext, testRuntime.runtimeName)
+        .attempt
+    } yield getResponse.swap.toOption.get.isInstanceOf[RuntimeNotFoundException] shouldBe true
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   it should "list runtimes" in isolatedDbTest {
     val userInfo = mockUserInfo("grendel@mom.mere")
     val runtimeIds =
       Vector(RuntimeSamResourceId(UUID.randomUUID.toString), RuntimeSamResourceId(UUID.randomUUID.toString))
-    val mockAuthProvider = mockAuthorize(
-      userInfo,
-      readerRuntimeSamIds = Set(runtimeIds(0), runtimeIds(1)),
-      readerProjectSamIds = Set(ProjectSamResourceId(project))
-    )
-    when(mockAuthProvider.isUserProjectReader(any, isEq(userInfo))(any)).thenReturn(IO.pure(true))
-    val service = makeRuntimeService(authProvider = mockAuthProvider)
+    val samService = mock[SamService[IO]]
+    when(samService.listResources(isEq(userInfo.accessToken.token), isEq(RuntimeSamResource.resourceType))(any()))
+      .thenReturn(IO.pure(runtimeIds.map(_.resourceId).toList))
+    val service = makeRuntimeService(samService = samService)
 
     val res = for {
       _ <- IO(makeCluster(1, samResource = runtimeIds(0)).save())
@@ -876,13 +892,10 @@ class RuntimeServiceInterpTest
                             RuntimeSamResourceId(UUID.randomUUID.toString),
                             RuntimeSamResourceId(UUID.randomUUID.toString)
     )
-    val mockAuthProvider = mockAuthorize(
-      userInfo,
-      readerRuntimeSamIds = Set(runtimeIds(0), runtimeIds(1)),
-      readerProjectSamIds = Set(ProjectSamResourceId(project), ProjectSamResourceId(project2))
-    )
-    when(mockAuthProvider.isUserProjectReader(any, isEq(userInfo))(any)).thenReturn(IO.pure(true))
-    val service = makeRuntimeService(authProvider = mockAuthProvider)
+    val samService = mock[SamService[IO]]
+    when(samService.listResources(isEq(userInfo.accessToken.token), isEq(RuntimeSamResource.resourceType))(any()))
+      .thenReturn(IO.pure(runtimeIds.map(_.resourceId).toList))
+    val service = makeRuntimeService(samService = samService)
 
     val res = for {
       _ <- IO(makeCluster(1).copy(samResource = runtimeIds(0)).save())
@@ -898,13 +911,10 @@ class RuntimeServiceInterpTest
     val userInfo = mockUserInfo("grendel@mom.mere")
     val runtimeIds =
       Vector(RuntimeSamResourceId(UUID.randomUUID.toString), RuntimeSamResourceId(UUID.randomUUID.toString))
-    val mockAuthProvider = mockAuthorize(
-      userInfo,
-      readerRuntimeSamIds = Set(runtimeIds(0), runtimeIds(1)),
-      readerProjectSamIds = Set(ProjectSamResourceId(project))
-    )
-    when(mockAuthProvider.isUserProjectReader(any, isEq(userInfo))(any)).thenReturn(IO.pure(true))
-    val service = makeRuntimeService(authProvider = mockAuthProvider)
+    val samService = mock[SamService[IO]]
+    when(samService.listResources(isEq(userInfo.accessToken.token), isEq(RuntimeSamResource.resourceType))(any()))
+      .thenReturn(IO.pure(runtimeIds.map(_.resourceId).toList))
+    val service = makeRuntimeService(samService = samService)
 
     val res = for {
       runtime1 <- IO(makeCluster(1).copy(samResource = runtimeIds(0)).save())
@@ -923,12 +933,10 @@ class RuntimeServiceInterpTest
     val userInfo = mockUserInfo("grendel@mere.mom")
     val runtimeIds =
       Vector(RuntimeSamResourceId(UUID.randomUUID.toString), RuntimeSamResourceId(UUID.randomUUID.toString))
-    val mockAuthProvider = mockAuthorize(
-      userInfo,
-      ownerProjectSamIds = Set(ProjectSamResourceId(project))
-    )
-    when(mockAuthProvider.isUserProjectReader(any, isEq(userInfo))(any)).thenReturn(IO.pure(true))
-    val service = makeRuntimeService(authProvider = mockAuthProvider)
+    val samService = mock[SamService[IO]]
+    when(samService.listResources(isEq(userInfo.accessToken.token), isEq(RuntimeSamResource.resourceType))(any()))
+      .thenReturn(IO.pure(runtimeIds.map(_.resourceId).toList))
+    val service = makeRuntimeService(samService = samService)
 
     // Make runtimes belonging to different users than the calling user
     val res = for {
@@ -1000,13 +1008,10 @@ class RuntimeServiceInterpTest
       runtime2.patchInProgress
     )
 
-    val mockAuthProvider = mockAuthorize(
-      userInfo,
-      readerRuntimeSamIds = Set(runtime1.samResource, runtime2.samResource),
-      readerProjectSamIds = Set(ProjectSamResourceId(project))
-    )
-    when(mockAuthProvider.isUserProjectReader(any, isEq(userInfo))(any)).thenReturn(IO.pure(true))
-    val service = makeRuntimeService(authProvider = mockAuthProvider)
+    val samService = mock[SamService[IO]]
+    when(samService.listResources(isEq(userInfo.accessToken.token), isEq(RuntimeSamResource.resourceType))(any()))
+      .thenReturn(IO.pure(List(runtime1.samResource.resourceId, runtime2.samResource.resourceId)))
+    val service = makeRuntimeService(samService = samService)
 
     service
       .listRuntimes(userInfo, None, Map("_labels" -> "foo=bar"))
@@ -1333,9 +1338,13 @@ class RuntimeServiceInterpTest
           )
         )
       )
-
+    val samService = mock[SamService[IO]]
+    when(samService.listResources(isEq(userInfo.accessToken.token), isEq(RuntimeSamResource.resourceType))(any()))
+      .thenReturn(IO.pure(runtimeIds.map(_.resourceId).toList))
+    when(samService.deleteResource(any(), any())(any())).thenReturn(IO.unit)
     val publisherQueue = QueueFactory.makePublisherQueue()
-    val service = makeRuntimeService(authProvider = mockAuthProvider, publisherQueue = publisherQueue)
+    val service =
+      makeRuntimeService(authProvider = mockAuthProvider, publisherQueue = publisherQueue, samService = samService)
 
     val res = for {
       pd1 <- makePersistentDisk().save()
@@ -1403,9 +1412,14 @@ class RuntimeServiceInterpTest
           )
         )
       )
-
+    val samService = mock[SamService[IO]]
+    when(samService.listResources(isEq(userInfo.accessToken.token), isEq(RuntimeSamResource.resourceType))(any()))
+      .thenReturn(IO.pure(runtimeIds.map(_.resourceId).toList))
+    when(samService.getUserEmail(isEq(userInfo.accessToken.token))(any())).thenReturn(IO.pure(userInfo.userEmail))
+    when(samService.deleteResource(any(), any())(any())).thenReturn(IO.unit)
     val publisherQueue = QueueFactory.makePublisherQueue()
-    val service = makeRuntimeService(authProvider = mockAuthProvider, publisherQueue = publisherQueue)
+    val service =
+      makeRuntimeService(authProvider = mockAuthProvider, publisherQueue = publisherQueue, samService = samService)
 
     val res = for {
       pd1 <- makePersistentDisk().save()
@@ -1479,8 +1493,13 @@ class RuntimeServiceInterpTest
         )
       )
 
+    val samService = mock[SamService[IO]]
+    when(samService.listResources(isEq(userInfo.accessToken.token), isEq(RuntimeSamResource.resourceType))(any()))
+      .thenReturn(IO.pure(runtimeIds.map(_.resourceId).toList))
+
     val publisherQueue = QueueFactory.makePublisherQueue()
-    val service = makeRuntimeService(authProvider = mockAuthProvider, publisherQueue = publisherQueue)
+    val service =
+      makeRuntimeService(authProvider = mockAuthProvider, publisherQueue = publisherQueue, samService = samService)
 
     val res = for {
       pd1 <- makePersistentDisk().save()

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterpSpec.scala
@@ -213,14 +213,6 @@ class RuntimeServiceInterpTest
     with MockitoSugar {
 
   it should "fail if user doesn't have project level permission" in {
-    val samService = mock[SamService[IO]]
-    val runtimeService = makeRuntimeService(samService = samService)
-    when(
-      samService.checkAuthorized(isEq(unauthorizedUserInfo.accessToken.token),
-                                 isEq(ProjectSamResourceId(cloudContextGcp.value)),
-                                 isEq(ProjectAction.CreateRuntime)
-      )(any())
-    ).thenReturn(IO.raiseError(ForbiddenError(unauthorizedUserInfo.userEmail)))
     val res = for {
       r <- runtimeService
         .createRuntime(
@@ -849,23 +841,15 @@ class RuntimeServiceInterpTest
     exc shouldBe a[RuntimeNotFoundException]
   }
 
-  it should "throw RuntimeNotFoundException when users don't have permission on the runtime" in isolatedDbTest {
-    val samService = mock[SamService[IO]]
-    val runtimeService = makeRuntimeService(samService = samService)
-    val samResource = RuntimeSamResourceId(UUID.randomUUID.toString)
-    when(
-      samService.checkAuthorized(isEq(unauthorizedUserInfo.accessToken.token),
-                                 isEq(samResource),
-                                 isEq(RuntimeAction.GetRuntimeStatus)
-      )(any())
-    ).thenReturn(IO.raiseError(ForbiddenError(unauthorizedUserInfo.userEmail)))
-    val res = for {
-      testRuntime <- IO(makeCluster(1).copy(samResource = samResource).save())
-      getResponse <- runtimeService
-        .getRuntime(unauthorizedUserInfo, testRuntime.cloudContext, testRuntime.runtimeName)
-        .attempt
-    } yield getResponse.swap.toOption.get.isInstanceOf[RuntimeNotFoundException] shouldBe true
-    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
+  it should "fail to get a runtime when users don't have access to the project" in isolatedDbTest {
+    val exc = runtimeService
+      .getRuntime(unauthorizedUserInfo, cloudContextGcp, RuntimeName("cluster"))
+      .attempt
+      .unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
+      .swap
+      .toOption
+      .get
+    exc shouldBe a[ForbiddenError]
   }
 
   it should "list runtimes" in isolatedDbTest {

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeV2ServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeV2ServiceInterpSpec.scala
@@ -366,15 +366,6 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
     val runtimeName = RuntimeName("clusterName1")
     val workspaceId = WorkspaceId(UUID.randomUUID())
 
-    val samService = mock[SamService[IO]]
-    when(
-      samService.checkAuthorized(unauthorizedUserInfo.accessToken.token,
-                                 WorkspaceResourceSamResourceId(workspaceId),
-                                 WorkspaceAction.Compute
-      )
-    ).thenReturn(IO.raiseError(ForbiddenError(unauthorizedUserInfo.userEmail)))
-    val runtimeV2Service = makeInterp(samService = samService)
-
     val thrown = the[ForbiddenError] thrownBy {
       runtimeV2Service
         .createRuntime(unauthorizedUserInfo, runtimeName, workspaceId, false, defaultCreateAzureRuntimeReq)

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeV2ServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeV2ServiceInterpSpec.scala
@@ -27,7 +27,9 @@ import org.broadinstitute.dsde.workbench.leonardo.TestUtils.{appContext, default
 import org.broadinstitute.dsde.workbench.leonardo.auth.AllowlistAuthProvider
 import org.broadinstitute.dsde.workbench.leonardo.config.Config
 import org.broadinstitute.dsde.workbench.leonardo.dao._
+import org.broadinstitute.dsde.workbench.leonardo.dao.sam.SamService
 import org.broadinstitute.dsde.workbench.leonardo.db._
+import org.broadinstitute.dsde.workbench.leonardo.model.SamResource.RuntimeSamResource
 import org.broadinstitute.dsde.workbench.leonardo.model.SamResourceAction.{
   projectSamResourceAction,
   runtimeSamResourceAction,
@@ -74,15 +76,10 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
     queue: Queue[IO, LeoPubsubMessage] = QueueFactory.makePublisherQueue(),
     authProvider: AllowlistAuthProvider = allowListAuthProvider,
     dateAccessedQueue: Queue[IO, UpdateDateAccessedMessage] = QueueFactory.makeDateAccessedQueue(),
-    wsmClientProvider: WsmApiClientProvider[IO] = wsmClientProvider
+    wsmClientProvider: WsmApiClientProvider[IO] = wsmClientProvider,
+    samService: SamService[IO] = MockSamService
   ) =
-    new RuntimeV2ServiceInterp[IO](serviceConfig,
-                                   authProvider,
-                                   queue,
-                                   dateAccessedQueue,
-                                   wsmClientProvider,
-                                   MockSamService
-    )
+    new RuntimeV2ServiceInterp[IO](serviceConfig, authProvider, queue, dateAccessedQueue, wsmClientProvider, samService)
 
   // need to set previous runtime to deleted status before creating next to avoid exception
   def setRuntimeDeleted(workspaceId: WorkspaceId, name: RuntimeName): IO[Long] =
@@ -369,6 +366,15 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
     val runtimeName = RuntimeName("clusterName1")
     val workspaceId = WorkspaceId(UUID.randomUUID())
 
+    val samService = mock[SamService[IO]]
+    when(
+      samService.checkAuthorized(unauthorizedUserInfo.accessToken.token,
+                                 WorkspaceResourceSamResourceId(workspaceId),
+                                 WorkspaceAction.Compute
+      )
+    ).thenReturn(IO.raiseError(ForbiddenError(unauthorizedUserInfo.userEmail)))
+    val runtimeV2Service = makeInterp(samService = samService)
+
     val thrown = the[ForbiddenError] thrownBy {
       runtimeV2Service
         .createRuntime(unauthorizedUserInfo, runtimeName, workspaceId, false, defaultCreateAzureRuntimeReq)
@@ -507,6 +513,13 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
   }
 
   it should "fail to create a runtime with existing disk if disk is attached to non-deleted runtime" in isolatedDbTest {
+    val samService = mock[SamService[IO]]
+    when(samService.checkAuthorized(any(), any(), any())(any())).thenReturn(IO.unit)
+    when(samService.getUserEmail(userInfo.accessToken.token)).thenReturn(IO.pure(userInfo.userEmail))
+    when(samService.listResources(isEq(userInfo.accessToken.token), isEq(RuntimeSamResource.resourceType))(any()))
+      .thenReturn(IO.pure(List.empty))
+    when(samService.createResource(any(), any(), any(), any(), any())(any())).thenReturn(IO.unit)
+    val runtimeV2Service = makeInterp(samService = samService)
     val res = for {
       _ <- runtimeV2Service
         .createRuntime(userInfo, name0, workspaceId, false, defaultCreateAzureRuntimeReq)
@@ -519,6 +532,8 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
       _ <- persistentDiskQuery.updateStatus(disk.id, DiskStatus.Ready, now).transaction
 
       runtime <- clusterQuery.getClusterWithDiskId(disk.id).transaction
+      _ = when(samService.listResources(isEq(userInfo.accessToken.token), isEq(RuntimeSamResource.resourceType))(any()))
+        .thenReturn(IO.pure(List(runtime.get.internalId)))
 
       err <- runtimeV2Service
         .createRuntime(userInfo, name1, workspaceId, true, defaultCreateAzureRuntimeReq)
@@ -531,9 +546,22 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
   }
 
   it should "fail to create a runtime if one exists in the workspace" in isolatedDbTest {
+    val samService = mock[SamService[IO]]
+    when(samService.checkAuthorized(any(), any(), any())(any())).thenReturn(IO.unit)
+    when(samService.getUserEmail(userInfo.accessToken.token)).thenReturn(IO.pure(userInfo.userEmail))
+    when(samService.listResources(isEq(userInfo.accessToken.token), isEq(RuntimeSamResource.resourceType))(any()))
+      .thenReturn(IO.pure(List.empty))
+    when(samService.createResource(any(), any(), any(), any(), any())(any())).thenReturn(IO.unit)
+    val runtimeV2Service = makeInterp(samService = samService)
+
     runtimeV2Service
       .createRuntime(userInfo, name0, workspaceId, false, defaultCreateAzureRuntimeReq)
       .unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
+    val runtime =
+      runtimeV2Service.getRuntime(userInfo, name0, workspaceId).unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
+
+    when(samService.listResources(isEq(userInfo.accessToken.token), isEq(RuntimeSamResource.resourceType))(any()))
+      .thenReturn(IO.pure(List(runtime.samResource.resourceId)))
 
     val exc = runtimeV2Service
       .createRuntime(userInfo, name2, workspaceId, false, defaultCreateAzureRuntimeReq)
@@ -1501,9 +1529,16 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
     val runtimeName_2 = RuntimeName("clusterName2")
     val runtimeName_3 = RuntimeName("clusterName3")
     val workspaceId = WorkspaceId(UUID.randomUUID())
+    val samService = mock[SamService[IO]]
+    when(samService.checkAuthorized(any(), any(), any())(any())).thenReturn(IO.unit)
+    when(samService.getUserEmail(userInfo.accessToken.token)).thenReturn(IO.pure(userInfo.userEmail))
+    when(samService.getUserEmail(userInfo2.accessToken.token)).thenReturn(IO.pure(userInfo2.userEmail))
+    when(samService.getUserEmail(userInfo3.accessToken.token)).thenReturn(IO.pure(userInfo3.userEmail))
+    when(samService.listResources(any(), isEq(RuntimeSamResource.resourceType))(any())).thenReturn(IO.pure(List.empty))
+    when(samService.createResource(any(), any(), any(), any(), any())(any())).thenReturn(IO.unit)
 
     val publisherQueue = QueueFactory.makePublisherQueue()
-    val azureService = makeInterp(publisherQueue)
+    val azureService = makeInterp(publisherQueue, samService = samService)
 
     val res = for {
       context <- appContext.ask[AppContext]
@@ -1562,6 +1597,10 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
       preDeleteCluster_1 <- RuntimeServiceDbQueries.getActiveRuntimeRecord(workspaceId, runtimeName_1).transaction
       preDeleteCluster_2 <- RuntimeServiceDbQueries.getActiveRuntimeRecord(workspaceId, runtimeName_2).transaction
       preDeleteCluster_3 <- RuntimeServiceDbQueries.getActiveRuntimeRecord(workspaceId, runtimeName_3).transaction
+      _ = when(samService.listResources(isEq(userInfo.accessToken.token), isEq(RuntimeSamResource.resourceType))(any()))
+        .thenReturn(
+          IO.pure(List(preDeleteCluster_1.internalId, preDeleteCluster_2.internalId, preDeleteCluster_3.internalId))
+        )
 
       _ <- clusterQuery.updateClusterStatus(preDeleteCluster_1.id, RuntimeStatus.Deleted, context.now).transaction
       _ <- clusterQuery.updateClusterStatus(preDeleteCluster_2.id, RuntimeStatus.Running, context.now).transaction
@@ -1632,8 +1671,15 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
     val runtimeName_2 = RuntimeName("clusterName2")
     val workspaceId = WorkspaceId(UUID.randomUUID())
 
+    val samService = mock[SamService[IO]]
+    when(samService.checkAuthorized(any(), any(), any())(any())).thenReturn(IO.unit)
+    when(samService.getUserEmail(userInfo.accessToken.token)).thenReturn(IO.pure(userInfo.userEmail))
+    when(samService.getUserEmail(userInfo2.accessToken.token)).thenReturn(IO.pure(userInfo2.userEmail))
+    when(samService.listResources(any(), isEq(RuntimeSamResource.resourceType))(any())).thenReturn(IO.pure(List.empty))
+    when(samService.createResource(any(), any(), any(), any(), any())(any())).thenReturn(IO.unit)
+
     val publisherQueue = QueueFactory.makePublisherQueue()
-    val azureService = makeInterp(publisherQueue)
+    val azureService = makeInterp(publisherQueue, samService = samService)
 
     val res = for {
       context <- appContext.ask[AppContext]
@@ -1675,7 +1721,8 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
       _ <- clusterQuery.updateClusterStatus(preDeleteCluster_1.id, RuntimeStatus.Creating, context.now).transaction
       preDeleteCluster_2 = preDeleteClusterOpt_2.get
       _ <- clusterQuery.updateClusterStatus(preDeleteCluster_2.id, RuntimeStatus.Running, context.now).transaction
-
+      _ = when(samService.listResources(isEq(userInfo.accessToken.token), isEq(RuntimeSamResource.resourceType))(any()))
+        .thenReturn(IO.pure(List(preDeleteCluster_1.samResource.resourceId, preDeleteCluster_2.samResource.resourceId)))
       _ <- azureService.deleteAllRuntimes(userInfo, workspaceId, true)
 
     } yield ()
@@ -1699,7 +1746,10 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
       Set(ProjectSamResourceId(GoogleProject(projectIdGcp)))
     )
 
-    val testService = makeInterp(authProvider = mockAuthProvider)
+    val samService = mock[SamService[IO]]
+    when(samService.listResources(isEq(userInfo.accessToken.token), isEq(RuntimeSamResource.resourceType))(any()))
+      .thenReturn(IO.pure(List(runtimeId1, runtimeId2)))
+    val testService = makeInterp(authProvider = mockAuthProvider, samService = samService)
 
     val res = for {
       samResource1 <- IO(RuntimeSamResourceId(runtimeId1))
@@ -1740,171 +1790,6 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
     res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
-  it should "list runtimes, omitting runtimes for workspaces and projects user cannot read" in isolatedDbTest {
-    val runtimeId1 = UUID.randomUUID.toString
-    val runtimeId2 = UUID.randomUUID.toString
-    val runtimeId3 = UUID.randomUUID.toString
-    val runtimeId4 = UUID.randomUUID.toString
-    val projectIdGcp1 = "gcp-context-1"
-    val projectIdGcp2 = "gcp-context-2"
-    val workspaceIdAzure1 = UUID.randomUUID.toString
-    val workspaceIdAzure2 = UUID.randomUUID.toString
-
-    val userInfo = mockUserInfo("jerome@vore.gov")
-    val mockAuthProvider = mockAuthorize(
-      userInfo,
-      // user can read runtimes which are 'notebook-cluster' aka Runtimes
-      Set(RuntimeSamResourceId(runtimeId1), RuntimeSamResourceId(runtimeId2), RuntimeSamResourceId(runtimeId3)),
-      // user can read runtimes which are WsmResources
-      Set(
-        WsmResourceSamResourceId(WsmControlledResourceId(UUID.fromString(runtimeId3))),
-        WsmResourceSamResourceId(WsmControlledResourceId(UUID.fromString(runtimeId4)))
-      ),
-      // user can only read workspace1
-      Set(WorkspaceResourceSamResourceId(WorkspaceId(UUID.fromString(workspaceIdAzure1)))),
-      // user can only read project1
-      Set(ProjectSamResourceId(GoogleProject(projectIdGcp1)))
-    )
-    val testService = makeInterp(authProvider = mockAuthProvider)
-
-    val res = for {
-      // GCP runtime 1 (in project1): seen
-      samResource1 <- IO(RuntimeSamResourceId(runtimeId1))
-      runtime1 <- IO(
-        makeCluster(1)
-          .copy(samResource = samResource1, cloudContext = CloudContext.Gcp(GoogleProject(projectIdGcp1)))
-          .save()
-      )
-      // GCP runtime 2 (in project2): hidden
-      samResource2 <- IO(RuntimeSamResourceId(runtimeId2))
-      runtime2 <- IO(
-        makeCluster(2)
-          .copy(samResource = samResource2, cloudContext = CloudContext.Gcp(GoogleProject(projectIdGcp2)))
-          .save()
-      )
-      // Azure runtime 3 (in workspace1): seen
-      samResource3 <- IO(RuntimeSamResourceId(runtimeId3))
-      runtime3 <- IO(
-        makeCluster(3)
-          .copy(
-            samResource = samResource3,
-            cloudContext = CloudContext.Azure(CommonTestData.azureCloudContext),
-            workspaceId = Some(WorkspaceId(UUID.fromString(workspaceIdAzure1)))
-          )
-          .save()
-      )
-      // Azure runtime 4 (in workspace2): hidden
-      samResource4 <- IO(RuntimeSamResourceId(runtimeId4))
-      runtime4 <- IO(
-        makeCluster(4)
-          .copy(
-            samResource = samResource4,
-            cloudContext = CloudContext.Azure(CommonTestData.azureCloudContext),
-            workspaceId = Some(WorkspaceId(UUID.fromString(workspaceIdAzure2)))
-          )
-          .save()
-      )
-      listResponse <- testService.listRuntimes(userInfo, None, None, Map.empty)
-    } yield listResponse.map(_.samResource).toSet shouldBe Set(samResource1, samResource3)
-
-    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
-  }
-
-  it should "list runtimes given different user permissions" in isolatedDbTest {
-    forAll(
-      Table(
-        ("context", "runtimeAccess", "contextAccess", "isListed"),
-        // Any runtime access; no access to wrapper context => hidden
-        (TestContext.GoogleProject, TestRuntimeAccess.Nothing, TestContextAccess.Nothing, false),
-        (TestContext.GoogleWorkspace, TestRuntimeAccess.Nothing, TestContextAccess.Nothing, false),
-        (TestContext.AzureWorkspace, TestRuntimeAccess.Nothing, TestContextAccess.Nothing, false),
-        (TestContext.GoogleProject, TestRuntimeAccess.Reader, TestContextAccess.Nothing, false),
-        (TestContext.GoogleWorkspace, TestRuntimeAccess.Reader, TestContextAccess.Nothing, false),
-        (TestContext.AzureWorkspace, TestRuntimeAccess.Reader, TestContextAccess.Nothing, false),
-        // No access to runtime; read access to wrapper context => hidden
-        (TestContext.GoogleProject, TestRuntimeAccess.Nothing, TestContextAccess.Reader, false),
-        (TestContext.GoogleWorkspace, TestRuntimeAccess.Nothing, TestContextAccess.Reader, false),
-        (TestContext.AzureWorkspace, TestRuntimeAccess.Nothing, TestContextAccess.Reader, false),
-        // Read access to runtime; read access to wrapper context => shown
-        (TestContext.GoogleProject, TestRuntimeAccess.Reader, TestContextAccess.Reader, true),
-        (TestContext.GoogleWorkspace, TestRuntimeAccess.Reader, TestContextAccess.Reader, true),
-        (TestContext.AzureWorkspace, TestRuntimeAccess.Reader, TestContextAccess.Reader, true),
-        // Any runtime access; owner of wrapper context => shown
-        (TestContext.GoogleProject, TestRuntimeAccess.Nothing, TestContextAccess.Owner, true),
-        (TestContext.GoogleWorkspace, TestRuntimeAccess.Nothing, TestContextAccess.Owner, true),
-        (TestContext.AzureWorkspace, TestRuntimeAccess.Nothing, TestContextAccess.Owner, true),
-        (TestContext.GoogleProject, TestRuntimeAccess.Reader, TestContextAccess.Owner, true),
-        (TestContext.GoogleWorkspace, TestRuntimeAccess.Reader, TestContextAccess.Owner, true),
-        (TestContext.AzureWorkspace, TestRuntimeAccess.Reader, TestContextAccess.Owner, true)
-      )
-    ) {
-      (
-        context: TestContext.Context,
-        runtimeAccess: TestRuntimeAccess.Role,
-        contextAccess: TestContextAccess.Role,
-        isListed: Boolean
-      ) =>
-        val runtimeId = UUID.randomUUID.toString
-        val contextId = UUID.randomUUID.toString
-
-        val userInfo = mockUserInfo("jerome@vore.gov")
-        val mockAuthProvider = mockAuthorize(
-          userInfo,
-          readerRuntimeSamIds = Set(RuntimeSamResourceId(runtimeId))
-            .filter(_ => runtimeAccess == TestRuntimeAccess.Reader),
-          Set.empty,
-          readerWorkspaceSamIds = Set(WorkspaceResourceSamResourceId(WorkspaceId(UUID.fromString(contextId))))
-            .filter(_ => context != TestContext.GoogleProject && contextAccess != TestContextAccess.Nothing),
-          readerProjectSamIds = Set(ProjectSamResourceId(GoogleProject(contextId)))
-            .filter(_ => context == TestContext.GoogleProject && contextAccess != TestContextAccess.Nothing),
-          ownerWorkspaceSamIds = Set(WorkspaceResourceSamResourceId(WorkspaceId(UUID.fromString(contextId))))
-            .filter(_ => context != TestContext.GoogleProject && contextAccess == TestContextAccess.Owner),
-          ownerProjectSamIds = Set(ProjectSamResourceId(GoogleProject(contextId)))
-            .filter(_ => context == TestContext.GoogleProject && contextAccess == TestContextAccess.Owner)
-        )
-        val testService = makeInterp(authProvider = mockAuthProvider)
-
-        val res = for {
-          projectRuntime <- IO(
-            makeCluster(1)
-              .copy(
-                samResource = RuntimeSamResourceId(runtimeId),
-                cloudContext = CloudContext.Gcp(GoogleProject(contextId))
-              )
-          )
-          googleWorkspaceRuntime <- IO(
-            makeCluster(2)
-              .copy(
-                samResource = RuntimeSamResourceId(runtimeId),
-                cloudContext = CloudContext.Gcp(GoogleProject(contextId)),
-                workspaceId = Some(WorkspaceId(UUID.fromString(contextId)))
-              )
-          )
-          azureWorkspaceRuntime <- IO(
-            makeCluster(3)
-              .copy(
-                samResource = RuntimeSamResourceId(runtimeId),
-                cloudContext = CloudContext.Azure(
-                  AzureCloudContext(TenantId(contextId), SubscriptionId(contextId), ManagedResourceGroupName(contextId))
-                ),
-                workspaceId = Some(WorkspaceId(UUID.fromString(contextId)))
-              )
-          )
-          runtime = context match {
-            case TestContext.GoogleProject   => projectRuntime
-            case TestContext.GoogleWorkspace => googleWorkspaceRuntime
-            case TestContext.AzureWorkspace  => azureWorkspaceRuntime
-          }
-          _ = runtime.save()
-          expectedResults = if (isListed) Set(runtime.samResource) else Set.empty
-
-          listResponse <- testService.listRuntimes(userInfo, None, None, Map.empty)
-        } yield listResponse.map(_.samResource).toSet shouldBe expectedResults
-
-        res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
-    }
-  }
-
   it should "list runtimes with a workspace and/or cloudProvider" in isolatedDbTest {
     val runtimeId1 = UUID.randomUUID.toString
     val runtimeId2 = UUID.randomUUID.toString
@@ -1917,45 +1802,11 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
     val workspaceId2 = UUID.randomUUID.toString
     val workspaceId3 = UUID.randomUUID.toString
 
-    val userInfo = mockUserInfo("jerome@vore.gov")
-    val mockAuthProvider = mockAuthorize(
-      userInfo,
-      // user can read runtimes 3, 4, and 5
-      Set(RuntimeSamResourceId(runtimeId3), RuntimeSamResourceId(runtimeId4), RuntimeSamResourceId(runtimeId5)),
-      Set.empty,
-      // user can read all workspaces
-      Set(
-        WorkspaceResourceSamResourceId(WorkspaceId(UUID.fromString(workspaceId1))),
-        WorkspaceResourceSamResourceId(WorkspaceId(UUID.fromString(workspaceId2))),
-        WorkspaceResourceSamResourceId(WorkspaceId(UUID.fromString(workspaceId3)))
-      ),
-      // user can read all projects
-      Set(ProjectSamResourceId(GoogleProject(projectIdGcp1)), ProjectSamResourceId(GoogleProject(projectIdGcp2))),
-      // user owns workspace 1
-      Set(WorkspaceResourceSamResourceId(WorkspaceId(UUID.fromString(workspaceId1)))),
-      // user owns project 1
-      Set(ProjectSamResourceId(GoogleProject(projectIdGcp1)))
-    )
-    val mockAuthProviderForOneWorkspace = mockAuthorizeForOneWorkspace(
-      userInfo,
-      // user can read runtimes 3, 4, and 5
-      Set(RuntimeSamResourceId(runtimeId3), RuntimeSamResourceId(runtimeId4), RuntimeSamResourceId(runtimeId5)),
-      Set.empty,
-      // user can read all workspaces
-      Set(
-        WorkspaceResourceSamResourceId(WorkspaceId(UUID.fromString(workspaceId1))),
-        WorkspaceResourceSamResourceId(WorkspaceId(UUID.fromString(workspaceId2))),
-        WorkspaceResourceSamResourceId(WorkspaceId(UUID.fromString(workspaceId3)))
-      ),
-      // user can read all projects
-      Set(ProjectSamResourceId(GoogleProject(projectIdGcp1)), ProjectSamResourceId(GoogleProject(projectIdGcp2))),
-      // user owns workspace 1
-      Set(WorkspaceResourceSamResourceId(WorkspaceId(UUID.fromString(workspaceId1)))),
-      // user owns project 1
-      Set(ProjectSamResourceId(GoogleProject(projectIdGcp1)))
-    )
-    val testService = makeInterp(authProvider = mockAuthProvider)
-    val testServiceForOneWorkspace = makeInterp(authProvider = mockAuthProviderForOneWorkspace)
+    val samService = mock[SamService[IO]]
+    when(samService.listResources(any(), isEq(RuntimeSamResource.resourceType))(any()))
+      .thenReturn(IO.pure(List(runtimeId1, runtimeId2, runtimeId3, runtimeId4, runtimeId5)))
+
+    val testService = makeInterp(samService = samService)
 
     val res = for {
       samResource1 <- IO(RuntimeSamResourceId(runtimeId1))
@@ -2026,38 +1877,41 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
           .save()
       )
 
-      // Test the service call and pluck Sam resource IDs to compare with expected results
-      getResultIds = (
-        userInfo: UserInfo,
-        workspaceId: Option[WorkspaceId],
-        cloudProvider: Option[CloudProvider],
-        params: Map[String, String]
-      ) => {
-        val service = if (workspaceId.isEmpty) testService else testServiceForOneWorkspace
-        service
-          .listRuntimes(userInfo, workspaceId, cloudProvider, params)
-          .flatMap(result => IO(result.map(_.samResource).toSet))
-      }
-
-      responseIdsWorkspace1 <- getResultIds(userInfo, Some(workspace1), None, Map.empty)
-      responseIdsWorkspace2 <- getResultIds(userInfo, Some(workspace2), None, Map.empty)
-      responseIdsWorkspace3 <- getResultIds(userInfo, Some(workspace3), None, Map.empty)
-      responseIdsAzure <- getResultIds(userInfo, None, Some(CloudProvider.Azure), Map.empty)
-      responseIdsGcp <- getResultIds(userInfo, None, Some(CloudProvider.Gcp), Map.empty)
-      responseIdsAzureWorkspace1 <- getResultIds(userInfo, Some(workspace1), Some(CloudProvider.Azure), Map.empty)
-      responseIdsAzureWorkspace2 <- getResultIds(userInfo, Some(workspace2), Some(CloudProvider.Azure), Map.empty)
-      responseIdsGcpWorkspace1 <- getResultIds(userInfo, Some(workspace1), Some(CloudProvider.Gcp), Map.empty)
-      responseIdsGcpWorkspace2 <- getResultIds(userInfo, Some(workspace2), Some(CloudProvider.Gcp), Map.empty)
+      responseIdsWorkspace1 <- testService.listRuntimes(userInfo, Some(workspace1), None, Map.empty)
+      responseIdsWorkspace2 <- testService.listRuntimes(userInfo, Some(workspace2), None, Map.empty)
+      responseIdsWorkspace3 <- testService.listRuntimes(userInfo, Some(workspace3), None, Map.empty)
+      responseIdsAzure <- testService.listRuntimes(userInfo, None, Some(CloudProvider.Azure), Map.empty)
+      responseIdsGcp <- testService.listRuntimes(userInfo, None, Some(CloudProvider.Gcp), Map.empty)
+      responseIdsAzureWorkspace1 <- testService.listRuntimes(userInfo,
+                                                             Some(workspace1),
+                                                             Some(CloudProvider.Azure),
+                                                             Map.empty
+      )
+      responseIdsAzureWorkspace2 <- testService.listRuntimes(userInfo,
+                                                             Some(workspace2),
+                                                             Some(CloudProvider.Azure),
+                                                             Map.empty
+      )
+      responseIdsGcpWorkspace1 <- testService.listRuntimes(userInfo,
+                                                           Some(workspace1),
+                                                           Some(CloudProvider.Gcp),
+                                                           Map.empty
+      )
+      responseIdsGcpWorkspace2 <- testService.listRuntimes(userInfo,
+                                                           Some(workspace2),
+                                                           Some(CloudProvider.Gcp),
+                                                           Map.empty
+      )
     } yield {
-      responseIdsWorkspace1 shouldBe Set(samResource1)
-      responseIdsWorkspace2 shouldBe Set(samResource2, samResource3)
-      responseIdsWorkspace3 shouldBe Set(samResource4)
-      responseIdsAzure shouldBe Set(samResource1, samResource4)
-      responseIdsGcp shouldBe Set(samResource2, samResource3, samResource5)
-      responseIdsAzureWorkspace1 shouldBe Set(samResource1)
-      responseIdsAzureWorkspace2 shouldBe Set.empty
-      responseIdsGcpWorkspace1 shouldBe Set.empty
-      responseIdsGcpWorkspace2 shouldBe Set(samResource2, samResource3)
+      responseIdsWorkspace1.map(_.samResource).toSet shouldBe Set(samResource1)
+      responseIdsWorkspace2.map(_.samResource).toSet shouldBe Set(samResource2, samResource3)
+      responseIdsWorkspace3.map(_.samResource).toSet shouldBe Set(samResource4)
+      responseIdsAzure.map(_.samResource).toSet shouldBe Set(samResource1, samResource4)
+      responseIdsGcp.map(_.samResource).toSet shouldBe Set(samResource2, samResource3, samResource5)
+      responseIdsAzureWorkspace1.map(_.samResource).toSet shouldBe Set(samResource1)
+      responseIdsAzureWorkspace2.map(_.samResource).toSet shouldBe Set.empty
+      responseIdsGcpWorkspace1.map(_.samResource).toSet shouldBe Set.empty
+      responseIdsGcpWorkspace2.map(_.samResource).toSet shouldBe Set(samResource2, samResource3)
     }
 
     res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
@@ -2067,16 +1921,11 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
     val runtimeId1 = RuntimeSamResourceId(UUID.randomUUID.toString)
     val runtimeId2 = RuntimeSamResourceId(UUID.randomUUID.toString)
     val workspaceId1 = WorkspaceId(UUID.randomUUID)
-    val userInfo = mockUserInfo("karen@styx.hel")
-    val mockAuthProvider = mockAuthorize(
-      userInfo,
-      // can read all runtimes
-      Set(runtimeId1, runtimeId2),
-      Set.empty,
-      // can read all workspaces
-      Set(WorkspaceResourceSamResourceId(workspaceId1))
-    )
-    val testService = makeInterp(authProvider = mockAuthProvider)
+
+    val samService = mock[SamService[IO]]
+    when(samService.listResources(any(), isEq(RuntimeSamResource.resourceType))(any()))
+      .thenReturn(IO.pure(List(runtimeId1.resourceId, runtimeId2.resourceId)))
+    val testService = makeInterp(samService = samService)
     val res = for {
       samResource1 <- IO(runtimeId1)
       samResource2 <- IO(runtimeId2)
@@ -2145,15 +1994,13 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
     val workspaceId1 = WorkspaceId(UUID.randomUUID)
     val userInfoCreator = mockUserInfo("karen@styx.hel")
     val userInfoOther = mockUserInfo("mike@heavn.io")
-    val mockAuthProvider = mockAuthorize(
-      userInfoCreator,
-      // user has auth permission for runtime1
-      Set.empty,
-      Set(wsmId1),
-      // user can read workspace1
-      Set(WorkspaceResourceSamResourceId(workspaceId1))
+    val samService = mock[SamService[IO]]
+    when(
+      samService.listResources(isEq(userInfoCreator.accessToken.token), isEq(RuntimeSamResource.resourceType))(any())
     )
-    val testService = makeInterp(authProvider = mockAuthProvider)
+      .thenReturn(IO.pure(List(wsmId1.resourceId)))
+
+    val testService = makeInterp(samService = samService)
     val res = for {
       // runtime 1: I created, in a workspace I can read => visible
       samResource1 <- IO(RuntimeSamResourceId(wsmId1.resourceId.toString))
@@ -2163,7 +2010,7 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
           .save()
       )
 
-      // runtime 2: I created, but in a workspace I cannot read, and I DO NOT HAVE SAM PERMISSION => hidden
+      // runtime 2: I created, but in a workspace I cannot read => hidden
       samResource2 <- IO(runtimeId2)
       runtime2 <- IO(
         makeCluster(2, Some(userInfoCreator.userEmail))
@@ -2179,6 +2026,7 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
           .save()
       )
 
+      // todo: Don't really understand this scenario. If I don't have permission then I shouldn't be able to see it even if I created it
       // runtime 4: I created, in a workspace I can read, and I DO NOT HAVE SAM PERMISSION => seen if role=creator, else hid
       samResource4 <- IO(runtimeId4)
       runtime4 <- IO(
@@ -2190,7 +2038,7 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
       listResponseCreator <- testService.listRuntimes(userInfoCreator, None, None, Map("role" -> "creator"))
       listResponseAny <- testService.listRuntimes(userInfoCreator, None, None, Map.empty)
     } yield {
-      listResponseCreator.map(_.samResource).toSet shouldBe Set(samResource1, samResource4)
+      listResponseCreator.map(_.samResource).toSet shouldBe Set(samResource1)
       listResponseAny.map(_.samResource).toSet shouldBe Set(samResource1)
     }
 
@@ -2204,17 +2052,11 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
     val runtimeId2 = RuntimeSamResourceId(UUID.randomUUID.toString)
     val workspaceId1 = WorkspaceId(UUID.randomUUID)
     val userInfo = mockUserInfo("karen@styx.hel")
-    val mockAuthProvider = mockAuthorize(
-      userInfo,
-      // can read all runtimes
-      Set(runtimeId1, runtimeId2),
-      Set.empty,
-      // can read workspace
-      Set(WorkspaceResourceSamResourceId(workspaceId1)),
-      // owns workspace
-      ownerWorkspaceSamIds = Set(WorkspaceResourceSamResourceId(workspaceId1))
-    )
-    val testService = makeInterp(authProvider = mockAuthProvider)
+    val samService = mock[SamService[IO]]
+    when(samService.listResources(isEq(userInfo.accessToken.token), isEq(RuntimeSamResource.resourceType))(any()))
+      .thenReturn(IO.pure(List(runtimeId1.resourceId, runtimeId2.resourceId)))
+
+    val testService = makeInterp(samService = samService)
 
     // Make runtimes belonging to different users than the calling user
     val res = for {

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeV2ServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeV2ServiceInterpSpec.scala
@@ -94,6 +94,16 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
         .transaction
     } yield runtime.id
 
+  def mockSamForCreateRuntimeTest(userInfo: UserInfo): SamService[IO] = {
+    val samService = mock[SamService[IO]]
+    when(samService.checkAuthorized(any(), any(), any())(any())).thenReturn(IO.unit)
+    when(samService.getUserEmail(userInfo.accessToken.token)).thenReturn(IO.pure(userInfo.userEmail))
+    when(samService.listResources(any(), isEq(RuntimeSamResource.resourceType))(any()))
+      .thenReturn(IO.pure(List.empty))
+    when(samService.createResource(any(), any(), any(), any(), any())(any())).thenReturn(IO.unit)
+    samService
+  }
+
   /**
    * Generate a mocked AuthProvider which will permit action on the given resource IDs by the given user.
    * TODO: cover actions beside `checkUserEnabled` and `listResourceIds`
@@ -504,12 +514,7 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
   }
 
   it should "fail to create a runtime with existing disk if disk is attached to non-deleted runtime" in isolatedDbTest {
-    val samService = mock[SamService[IO]]
-    when(samService.checkAuthorized(any(), any(), any())(any())).thenReturn(IO.unit)
-    when(samService.getUserEmail(userInfo.accessToken.token)).thenReturn(IO.pure(userInfo.userEmail))
-    when(samService.listResources(isEq(userInfo.accessToken.token), isEq(RuntimeSamResource.resourceType))(any()))
-      .thenReturn(IO.pure(List.empty))
-    when(samService.createResource(any(), any(), any(), any(), any())(any())).thenReturn(IO.unit)
+    val samService = mockSamForCreateRuntimeTest(userInfo)
     val runtimeV2Service = makeInterp(samService = samService)
     val res = for {
       _ <- runtimeV2Service
@@ -537,12 +542,7 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
   }
 
   it should "fail to create a runtime if one exists in the workspace" in isolatedDbTest {
-    val samService = mock[SamService[IO]]
-    when(samService.checkAuthorized(any(), any(), any())(any())).thenReturn(IO.unit)
-    when(samService.getUserEmail(userInfo.accessToken.token)).thenReturn(IO.pure(userInfo.userEmail))
-    when(samService.listResources(isEq(userInfo.accessToken.token), isEq(RuntimeSamResource.resourceType))(any()))
-      .thenReturn(IO.pure(List.empty))
-    when(samService.createResource(any(), any(), any(), any(), any())(any())).thenReturn(IO.unit)
+    val samService = mockSamForCreateRuntimeTest(userInfo)
     val runtimeV2Service = makeInterp(samService = samService)
 
     runtimeV2Service
@@ -1520,13 +1520,9 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
     val runtimeName_2 = RuntimeName("clusterName2")
     val runtimeName_3 = RuntimeName("clusterName3")
     val workspaceId = WorkspaceId(UUID.randomUUID())
-    val samService = mock[SamService[IO]]
-    when(samService.checkAuthorized(any(), any(), any())(any())).thenReturn(IO.unit)
-    when(samService.getUserEmail(userInfo.accessToken.token)).thenReturn(IO.pure(userInfo.userEmail))
+    val samService = mockSamForCreateRuntimeTest(userInfo)
     when(samService.getUserEmail(userInfo2.accessToken.token)).thenReturn(IO.pure(userInfo2.userEmail))
     when(samService.getUserEmail(userInfo3.accessToken.token)).thenReturn(IO.pure(userInfo3.userEmail))
-    when(samService.listResources(any(), isEq(RuntimeSamResource.resourceType))(any())).thenReturn(IO.pure(List.empty))
-    when(samService.createResource(any(), any(), any(), any(), any())(any())).thenReturn(IO.unit)
 
     val publisherQueue = QueueFactory.makePublisherQueue()
     val azureService = makeInterp(publisherQueue, samService = samService)
@@ -1662,12 +1658,8 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
     val runtimeName_2 = RuntimeName("clusterName2")
     val workspaceId = WorkspaceId(UUID.randomUUID())
 
-    val samService = mock[SamService[IO]]
-    when(samService.checkAuthorized(any(), any(), any())(any())).thenReturn(IO.unit)
-    when(samService.getUserEmail(userInfo.accessToken.token)).thenReturn(IO.pure(userInfo.userEmail))
+    val samService = mockSamForCreateRuntimeTest(userInfo)
     when(samService.getUserEmail(userInfo2.accessToken.token)).thenReturn(IO.pure(userInfo2.userEmail))
-    when(samService.listResources(any(), isEq(RuntimeSamResource.resourceType))(any())).thenReturn(IO.pure(List.empty))
-    when(samService.createResource(any(), any(), any(), any(), any())(any())).thenReturn(IO.unit)
 
     val publisherQueue = QueueFactory.makePublisherQueue()
     val azureService = makeInterp(publisherQueue, samService = samService)

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeV2ServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeV2ServiceInterpSpec.scala
@@ -1981,7 +1981,7 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
     when(
       samService.listResources(isEq(userInfoCreator.accessToken.token), isEq(RuntimeSamResource.resourceType))(any())
     )
-      .thenReturn(IO.pure(List(wsmId1.resourceId)))
+      .thenReturn(IO.pure(List(wsmId1.resourceId, runtimeId3.resourceId)))
 
     val testService = makeInterp(samService = samService)
     val res = for {
@@ -1993,7 +1993,7 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
           .save()
       )
 
-      // runtime 2: I created, but in a workspace I cannot read => hidden
+      // runtime 2: I created, but I don't have permission => hidden
       samResource2 <- IO(runtimeId2)
       runtime2 <- IO(
         makeCluster(2, Some(userInfoCreator.userEmail))
@@ -2001,7 +2001,7 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
           .save()
       )
 
-      // runtime 3: someone else created, in a workspace I can read => hidden
+      // runtime 3: someone else created, but I can read => hidden if role=creator, else visible
       samResource3 <- IO(runtimeId3)
       runtime3 <- IO(
         makeCluster(3, Some(userInfoOther.userEmail))
@@ -2009,20 +2009,11 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
           .save()
       )
 
-      // todo: Don't really understand this scenario. If I don't have permission then I shouldn't be able to see it even if I created it
-      // runtime 4: I created, in a workspace I can read, and I DO NOT HAVE SAM PERMISSION => seen if role=creator, else hid
-      samResource4 <- IO(runtimeId4)
-      runtime4 <- IO(
-        makeCluster(4, Some(userInfoCreator.userEmail))
-          .copy(samResource = samResource4, workspaceId = Some(workspaceId1))
-          .save()
-      )
-
       listResponseCreator <- testService.listRuntimes(userInfoCreator, None, None, Map("role" -> "creator"))
       listResponseAny <- testService.listRuntimes(userInfoCreator, None, None, Map.empty)
     } yield {
       listResponseCreator.map(_.samResource).toSet shouldBe Set(samResource1)
-      listResponseAny.map(_.samResource).toSet shouldBe Set(samResource1)
+      listResponseAny.map(_.samResource).toSet shouldBe Set(samResource1, samResource3)
     }
 
     res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)


### PR DESCRIPTION
<!-- Welcome to your Leonardo pull request! -->
<!-- Contributor guidelines: https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md -->

__Jira ticket__: https://broadworkbench.atlassian.net/browse/CORE-182

<!-- ## Dependencies -->
<!-- Include any dependent tickets and describe the relationship. Include any other relevant Jira tickets. -->

## Summary of changes

Change how `listRuntimes` gathers user runtimes to rely on the new permissions model in Sam. See https://broadworkbench.atlassian.net/wiki/spaces/IA/pages/3362848772/Leonardo+Access+Control+-+Desired+State for more details.

### What

-

### Why

-

## Testing these changes

### What to test

- <!-- Test case 1 -->

<!-- ### Test data -->

### Who tested and where

- [ ] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [ ] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
