### PR TITLE
[AN-330] Update docker memory

### DIFF
--- a/http/src/main/resources/init-resources/shutdown.sh
+++ b/http/src/main/resources/init-resources/shutdown.sh
@@ -22,10 +22,6 @@ export RSTUDIO_DOCKER_IMAGE=$(rstudioDockerImage)
 export RSTUDIO_SERVER_NAME=$(rstudioServerName)
 export SHOULD_DELETE_JUPYTER_DIR=$(shouldDeleteJupyterDir)
 
-if [ ! -z "$RSTUDIO_DOCKER_IMAGE" ] ; then
-    docker exec -u rstudio -i $RSTUDIO_SERVER_NAME rstudio-server stop
-fi
-
 # Remove jupyter related files if user decides to delete the VM
 if [ -d '/mnt/disks/work/.jupyter' ] && [ "SHOULD_DELETE_JUPYTER_DIR" = "true" ] ; then
     rm -rf /mnt/disks/work/.jupyter

--- a/http/src/main/resources/init-resources/shutdown.sh
+++ b/http/src/main/resources/init-resources/shutdown.sh
@@ -28,6 +28,7 @@ if [ -d '/mnt/disks/work/.jupyter' ] && [ "SHOULD_DELETE_JUPYTER_DIR" = "true" ]
     rm -rf /mnt/disks/work/.local || true
 fi
 
+
 if [[ "${CLOUD_SERVICE}" == 'GCE' ]]; then
   # COS images need to run docker-compose as a container by design
   DOCKER_COMPOSE='docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v /var:/var docker/compose:1.29.2'

--- a/http/src/main/resources/init-resources/shutdown.sh
+++ b/http/src/main/resources/init-resources/shutdown.sh
@@ -22,6 +22,9 @@ export RSTUDIO_DOCKER_IMAGE=$(rstudioDockerImage)
 export RSTUDIO_SERVER_NAME=$(rstudioServerName)
 export SHOULD_DELETE_JUPYTER_DIR=$(shouldDeleteJupyterDir)
 
+if [ ! -z "$RSTUDIO_DOCKER_IMAGE" ] ; then
+    docker exec -u rstudio -i $RSTUDIO_SERVER_NAME rstudio-server stop
+fi
 
 # Remove jupyter related files if user decides to delete the VM
 if [ -d '/mnt/disks/work/.jupyter' ] && [ "SHOULD_DELETE_JUPYTER_DIR" = "true" ] ; then

--- a/http/src/main/resources/init-resources/shutdown.sh
+++ b/http/src/main/resources/init-resources/shutdown.sh
@@ -22,12 +22,12 @@ export RSTUDIO_DOCKER_IMAGE=$(rstudioDockerImage)
 export RSTUDIO_SERVER_NAME=$(rstudioServerName)
 export SHOULD_DELETE_JUPYTER_DIR=$(shouldDeleteJupyterDir)
 
+
 # Remove jupyter related files if user decides to delete the VM
 if [ -d '/mnt/disks/work/.jupyter' ] && [ "SHOULD_DELETE_JUPYTER_DIR" = "true" ] ; then
     rm -rf /mnt/disks/work/.jupyter
     rm -rf /mnt/disks/work/.local || true
 fi
-
 
 if [[ "${CLOUD_SERVICE}" == 'GCE' ]]; then
   # COS images need to run docker-compose as a container by design

--- a/http/src/main/resources/init-resources/startup.sh
+++ b/http/src/main/resources/init-resources/startup.sh
@@ -248,7 +248,7 @@ END
 
         # We do not want to recreate a new container, to make sure we preserve the changes that users made with the startup script
         # We only want to restart the existing container with the latest environment variables
-        ${DOCKER_COMPOSE} --env-file=/var/variables.env ${COMPLETE_JUPYTER_DOCKER_COMPOSE} up -d --no-recreate --memory ${MEM_LIMIT}
+        ${DOCKER_COMPOSE} --env-file=/var/variables.env ${COMPLETE_JUPYTER_DOCKER_COMPOSE} up -d --no-recreate --memory ${MEM_LIMIT} --memory-swap ${MEM_LIMIT}
         
         # the docker containers need to be restarted or the jupyter container
         # will fail to start until the appropriate volume/device exists
@@ -281,7 +281,7 @@ END
 
         # We do not want to recreate a new container, to make sure we preserve the changes that users made with the startup script
         # We only want to restart the existing container with the latest environment variables
-        ${DOCKER_COMPOSE} --env-file=/var/variables.env ${COMPLETE_RSTUDIO_DOCKER_COMPOSE} up -d --no-recreate --memory ${MEM_LIMIT}
+        ${DOCKER_COMPOSE} --env-file=/var/variables.env ${COMPLETE_RSTUDIO_DOCKER_COMPOSE} up -d --no-recreate --memory ${MEM_LIMIT} --memory-swap ${MEM_LIMIT}
 
         # the docker containers need to be restarted or the R container
         # will fail to start until the appropriate volume/device exists.

--- a/http/src/main/resources/init-resources/startup.sh
+++ b/http/src/main/resources/init-resources/startup.sh
@@ -255,6 +255,9 @@ END
         docker restart $JUPYTER_SERVER_NAME
         docker restart $WELDER_SERVER_NAME
 
+        # update memory size
+        docker update --memory ${MEM_LIMIT} $JUPYTER_SERVER_NAME
+
         log 'Copy Jupyter frontend notebook config...'
         $GSUTIL_CMD cp ${JUPYTER_NOTEBOOK_FRONTEND_CONFIG_URI} /var
         JUPYTER_NOTEBOOK_FRONTEND_CONFIG=`basename ${JUPYTER_NOTEBOOK_FRONTEND_CONFIG_URI}`
@@ -281,7 +284,10 @@ END
 
         # We do not want to recreate a new container, to make sure we preserve the changes that users made with the startup script
         # We only want to restart the existing container with the latest environment variables
-        ${DOCKER_COMPOSE} --env-file=/var/variables.env ${COMPLETE_RSTUDIO_DOCKER_COMPOSE} up -d --no-recreate --memory ${MEM_LIMIT} --memory-swap ${MEM_LIMIT}
+        ${DOCKER_COMPOSE} --env-file=/var/variables.env ${COMPLETE_RSTUDIO_DOCKER_COMPOSE} up -d --no-recreate
+
+        # update memory size
+        docker update --memory ${MEM_LIMIT} $RSTUDIO_SERVER_NAME
 
         # the docker containers need to be restarted or the R container
         # will fail to start until the appropriate volume/device exists.

--- a/http/src/main/resources/init-resources/startup.sh
+++ b/http/src/main/resources/init-resources/startup.sh
@@ -248,7 +248,7 @@ END
 
         # We do not want to recreate a new container, to make sure we preserve the changes that users made with the startup script
         # We only want to restart the existing container with the latest environment variables
-        ${DOCKER_COMPOSE} --env-file=/var/variables.env ${COMPLETE_JUPYTER_DOCKER_COMPOSE} up -d --no-recreate -memory ${MEM_LIMIT}
+        ${DOCKER_COMPOSE} --env-file=/var/variables.env ${COMPLETE_JUPYTER_DOCKER_COMPOSE} up -d --no-recreate --memory ${MEM_LIMIT}
         
         # the docker containers need to be restarted or the jupyter container
         # will fail to start until the appropriate volume/device exists
@@ -285,7 +285,7 @@ END
 
         # the docker containers need to be restarted or the R container
         # will fail to start until the appropriate volume/device exists.
-        docker restart $RSTUDIO_SERVER_NAME --memory
+        docker restart $RSTUDIO_SERVER_NAME
         docker restart $WELDER_SERVER_NAME
 
     fi

--- a/http/src/main/resources/init-resources/startup.sh
+++ b/http/src/main/resources/init-resources/startup.sh
@@ -255,7 +255,7 @@ END
         docker restart $JUPYTER_SERVER_NAME
         docker restart $WELDER_SERVER_NAME
 
-        # update memory size
+        # update memory size, the memory swap must be updated as well (cannot be < memory)
         docker update  --memory ${MEM_LIMIT} --memory-swap ${MEM_LIMIT}  $JUPYTER_SERVER_NAME
 
         log 'Copy Jupyter frontend notebook config...'
@@ -286,7 +286,7 @@ END
         # We only want to restart the existing container with the latest environment variables
         ${DOCKER_COMPOSE} --env-file=/var/variables.env ${COMPLETE_RSTUDIO_DOCKER_COMPOSE} up -d --no-recreate
 
-        # update memory size
+        # update memory size, the memory swap must be updated as well (cannot be < memory)
         docker update  --memory ${MEM_LIMIT} --memory-swap ${MEM_LIMIT} $RSTUDIO_SERVER_NAME
 
         # the docker containers need to be restarted or the R container

--- a/http/src/main/resources/init-resources/startup.sh
+++ b/http/src/main/resources/init-resources/startup.sh
@@ -248,7 +248,7 @@ END
 
         # We do not want to recreate a new container, to make sure we preserve the changes that users made with the startup script
         # We only want to restart the existing container with the latest environment variables
-        ${DOCKER_COMPOSE} --env-file=/var/variables.env ${COMPLETE_JUPYTER_DOCKER_COMPOSE} up -d --no-recreate --memory ${MEM_LIMIT} --memory-swap ${MEM_LIMIT}
+        ${DOCKER_COMPOSE} --env-file=/var/variables.env ${COMPLETE_JUPYTER_DOCKER_COMPOSE} up -d --no-recreate
         
         # the docker containers need to be restarted or the jupyter container
         # will fail to start until the appropriate volume/device exists
@@ -256,7 +256,7 @@ END
         docker restart $WELDER_SERVER_NAME
 
         # update memory size
-        docker update --memory ${MEM_LIMIT} $JUPYTER_SERVER_NAME
+        docker update  --memory ${MEM_LIMIT} --memory-swap ${MEM_LIMIT}  $JUPYTER_SERVER_NAME
 
         log 'Copy Jupyter frontend notebook config...'
         $GSUTIL_CMD cp ${JUPYTER_NOTEBOOK_FRONTEND_CONFIG_URI} /var
@@ -287,7 +287,7 @@ END
         ${DOCKER_COMPOSE} --env-file=/var/variables.env ${COMPLETE_RSTUDIO_DOCKER_COMPOSE} up -d --no-recreate
 
         # update memory size
-        docker update --memory ${MEM_LIMIT} $RSTUDIO_SERVER_NAME
+        docker update  --memory ${MEM_LIMIT} --memory-swap ${MEM_LIMIT} $RSTUDIO_SERVER_NAME
 
         # the docker containers need to be restarted or the R container
         # will fail to start until the appropriate volume/device exists.

--- a/http/src/main/resources/init-resources/startup.sh
+++ b/http/src/main/resources/init-resources/startup.sh
@@ -243,13 +243,12 @@ RUNTIME_NAME=${RUNTIME_NAME}
 OWNER_EMAIL=${OWNER_EMAIL}
 PET_SA_EMAIL=${PET_SA_EMAIL}
 WELDER_ENABLED=${WELDER_ENABLED}
-MEM_LIMIT=${MEM_LIMIT}
 SHM_SIZE=${SHM_SIZE}
 END
 
         # We do not want to recreate a new container, to make sure we preserve the changes that users made with the startup script
         # We only want to restart the existing container with the latest environment variables
-        ${DOCKER_COMPOSE} --env-file=/var/variables.env ${COMPLETE_JUPYTER_DOCKER_COMPOSE} up -d --no-recreate
+        ${DOCKER_COMPOSE} --env-file=/var/variables.env ${COMPLETE_JUPYTER_DOCKER_COMPOSE} up -d --no-recreate -memory ${MEM_LIMIT}
         
         # the docker containers need to be restarted or the jupyter container
         # will fail to start until the appropriate volume/device exists
@@ -277,17 +276,16 @@ RUNTIME_NAME=${RUNTIME_NAME}
 OWNER_EMAIL=${OWNER_EMAIL}
 PET_SA_EMAIL=${PET_SA_EMAIL}
 WELDER_ENABLED=${WELDER_ENABLED}
-MEM_LIMIT=${MEM_LIMIT}
 SHM_SIZE=${SHM_SIZE}
 END
 
         # We do not want to recreate a new container, to make sure we preserve the changes that users made with the startup script
         # We only want to restart the existing container with the latest environment variables
-        ${DOCKER_COMPOSE} --env-file=/var/variables.env ${COMPLETE_RSTUDIO_DOCKER_COMPOSE} up -d --no-recreate
+        ${DOCKER_COMPOSE} --env-file=/var/variables.env ${COMPLETE_RSTUDIO_DOCKER_COMPOSE} up -d --no-recreate --memory ${MEM_LIMIT}
 
         # the docker containers need to be restarted or the R container
         # will fail to start until the appropriate volume/device exists.
-        docker restart $RSTUDIO_SERVER_NAME
+        docker restart $RSTUDIO_SERVER_NAME --memory
         docker restart $WELDER_SERVER_NAME
 
     fi


### PR DESCRIPTION
<!-- Welcome to your Leonardo pull request! -->
<!-- Contributor guidelines: https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md -->

__Jira ticket__: https://broadworkbench.atlassian.net/browse/AN-330

<!-- ## Dependencies -->
<!-- Include any dependent tickets and describe the relationship. Include any other relevant Jira tickets. -->

## Summary of changes

<!-- Please give an abridged version of the ticket description here and/or fill out the following fields. -->

### What

- Add a docker update to specify the allowed memory for the docker container

### Why

- Adding it as an env variable doesn't change the docker memory size, need to perform an update in order for machine size updates to be reflected within the container

## Testing these changes

### What to test

-  create an Rstudio/Jupyter VM and wait for it to start running
- check the allowed memory (`cat /sys/fs/cgroup/memory.max` in the terminal)
- update the machine size in the CE page
- check if the allowed memory increased

### Who tested and where

- [ ] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [ ] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
