### PR TITLE
[AN-304] Point to latest rstudio bioconductor image with fix (3.20.1)

### DIFF
--- a/.github/workflows/azure_automation_test.yml
+++ b/.github/workflows/azure_automation_test.yml
@@ -162,7 +162,7 @@ jobs:
     outputs:
       project-name: ${{ steps.gen.outputs.project_name }}
     steps:
-      - uses: 'actions/checkout@v3'
+      - uses: 'actions/checkout@v4'
 
       - name: Generate a random billing project name
         id: 'gen'

--- a/.github/workflows/consumer_contract_tests.yml
+++ b/.github/workflows/consumer_contract_tests.yml
@@ -94,7 +94,7 @@ jobs:
       fork: ${{ steps.extract-branch.outputs.fork }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Obtain branch properties
         id: extract-branch
@@ -137,7 +137,7 @@ jobs:
       pact-b64: ${{ steps.encode-pact.outputs.pact-b64 }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Run consumer tests
         run: |
           docker run --rm -v $PWD:/working \

--- a/.github/workflows/custom_image_generation.yml
+++ b/.github/workflows/custom_image_generation.yml
@@ -34,7 +34,7 @@ jobs:
       OUTPUT_FILE_RELATIVE_PATH: jenkins/gce-custom-images/output.txt
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - id: 'auth'
       name: 'Authenticate to Google Cloud'
@@ -81,7 +81,7 @@ jobs:
       DATAPROC_IMAGE_BUCKET: gs://leo-dataproc-image-creation-logs
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - id: 'auth'
         name: 'Authenticate to Google Cloud'

--- a/.github/workflows/publish_java_client.yml
+++ b/.github/workflows/publish_java_client.yml
@@ -29,7 +29,7 @@ jobs:
       SBT_OPTS: -Xmx3g
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       # coursier cache action caches both coursier and sbt caches
       - name: coursier-cache-action

--- a/.github/workflows/publish_java_client.yml
+++ b/.github/workflows/publish_java_client.yml
@@ -30,6 +30,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      - uses: sbt/setup-sbt@v1
 
       # coursier cache action caches both coursier and sbt caches
       - name: coursier-cache-action

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -46,7 +46,7 @@ jobs:
       new-tag: ${{ steps.tag.outputs.new_tag }}
     steps:
     - name: Checkout current code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         ref: ${{ inputs.ref }}
         token: ${{ secrets.BROADBOT_TOKEN }} # this allows the push to succeed later

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -7,7 +7,7 @@ jobs:
     name: DSP AppSec Trivy check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       # The Dockerfile copies this, so it needs
       # to exist for the build to succeed

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -37,6 +37,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+    - uses: sbt/setup-sbt@v1
 
     - name: Set up JDK 17
       uses: actions/setup-java@v3

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -36,7 +36,7 @@ jobs:
           - 3307:3306
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up JDK 17
       uses: actions/setup-java@v3

--- a/.github/workflows/verify_consumer_contracts.yml
+++ b/.github/workflows/verify_consumer_contracts.yml
@@ -107,7 +107,7 @@ jobs:
 
     steps:
     - name: Checkout current code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
 

--- a/automation/src/test/resources/reference.conf
+++ b/automation/src/test/resources/reference.conf
@@ -7,7 +7,7 @@ leonardo {
     baseImageUrl = "us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:1.1.3"
     gcrWelderUri = "us.gcr.io/broad-dsp-gcr-public/welder-server"
     dockerHubWelderUri = "broadinstitute/welder-server"
-    rstudioBioconductorImageUrl = "us.gcr.io/broad-dsp-gcr-public/anvil-rstudio-bioconductor:3.19.0"
+    rstudioBioconductorImageUrl = "us.gcr.io/broad-dsp-gcr-public/anvil-rstudio-bioconductor:3.20.1"
     //each fiab will have a unique topic name sourced from leonardo.conf, this is never published to in automation tests to ensure pub/sub components can auth properly, but never read from to avoid conflicts.
     topicName = "leonardo-pubsub-test"
     location = "us-central1-a"

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -70,7 +70,7 @@ dataproc {
   }
 
   # Cached dataproc image used by Terra
-  customDataprocImage = "projects/broad-dsp-gcr-public/global/images/leo-dataproc-image-2-1-11-debian11-2024-12-11-20-54-48"
+  customDataprocImage = "projects/broad-dsp-gcr-public/global/images/leo-dataproc-image-2-1-11-debian11-2024-12-16-17-22-28"
 
   # The ratio of memory allocated to spark. 0.8 = 80%.
   # Hail/Spark users generally allocate 80% of the ram to the JVM.
@@ -111,7 +111,7 @@ dataproc {
 }
 
 gce {
-  customGceImage = "projects/broad-dsp-gcr-public/global/images/leo-gce-image-2024-12-11-20-55-03"
+  customGceImage = "projects/broad-dsp-gcr-public/global/images/leo-gce-image-2024-12-16-17-22-39"
   userDiskDeviceName = "user-disk"
   defaultScopes = [
     "https://www.googleapis.com/auth/userinfo.email",

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/DbReference.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/DbReference.scala
@@ -55,7 +55,6 @@ object DbReference extends LazyLogging {
   ): Resource[F, DbReference[F]] = {
     val dbConfig =
       DatabaseConfig.forConfig[JdbcProfile]("mysql", org.broadinstitute.dsde.workbench.leonardo.config.Config.config)
-
     for {
       db <- Resource.make(Async[F].delay(dbConfig.db))(db => Async[F].delay(db.close()))
       initLiquibase =

--- a/jenkins/dataproc-custom-images/prepare-custom-leonardo-jupyter-dataproc-image.sh
+++ b/jenkins/dataproc-custom-images/prepare-custom-leonardo-jupyter-dataproc-image.sh
@@ -24,7 +24,7 @@ terra_jupyter_gatk="us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:2.3.8"
 terra_jupyter_aou="us.gcr.io/broad-dsp-gcr-public/terra-jupyter-aou:2.2.14"
 welder_server="us.gcr.io/broad-dsp-gcr-public/welder-server:8667bfe"
 openidc_proxy="broadinstitute/openidc-proxy:2.3.1_2"
-anvil_rstudio_bioconductor="us.gcr.io/broad-dsp-gcr-public/anvil-rstudio-bioconductor:3.19.0"
+anvil_rstudio_bioconductor="us.gcr.io/broad-dsp-gcr-public/anvil-rstudio-bioconductor:3.20.1"
 
 # Note that this is the version used currently by AOU in production, the one above can be staged for testing
 terra_jupyter_aou_old="us.gcr.io/broad-dsp-gcr-public/terra-jupyter-aou:2.2.13"

--- a/jenkins/gce-custom-images/prepare_gce_image.sh
+++ b/jenkins/gce-custom-images/prepare_gce_image.sh
@@ -23,7 +23,7 @@ terra_jupyter_gatk="us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:2.3.8"
 terra_jupyter_aou="us.gcr.io/broad-dsp-gcr-public/terra-jupyter-aou:2.2.14"
 welder_server="us.gcr.io/broad-dsp-gcr-public/welder-server:8667bfe"
 openidc_proxy="broadinstitute/openidc-proxy:2.3.1_2"
-anvil_rstudio_bioconductor="us.gcr.io/broad-dsp-gcr-public/anvil-rstudio-bioconductor:3.19.0"
+anvil_rstudio_bioconductor="us.gcr.io/broad-dsp-gcr-public/anvil-rstudio-bioconductor:3.20.1"
 
 # Note that this is the version used currently by AOU in production, the one above can be staged for testing
 terra_jupyter_aou_old="us.gcr.io/broad-dsp-gcr-public/terra-jupyter-aou:2.2.13"


### PR DESCRIPTION
<!-- Welcome to your Leonardo pull request! -->
<!-- Contributor guidelines: https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md -->

__Jira ticket__: https://broadworkbench.atlassian.net/browse/AN-304

<!-- ## Dependencies -->
<!-- Include any dependent tickets and describe the relationship. Include any other relevant Jira tickets. -->

## Summary of changes

<!-- Please give an abridged version of the ticket description here and/or fill out the following fields. -->

### What

- Deploys new Anvil RStudio Bioconductor image that fixes the bug that previously overwrote the rstudio user with a new ubuntu one, which prevented users from accessing pre-exising files or paths on their PD

### Why

-

## Testing these changes

### What to test

- <!-- Test case 1 -->

<!-- ### Test data -->

### Who tested and where

- [ ] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [ ] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
