### PR TITLE
[AN-356] When a cluster fails to start up, don't detach persistent disk

### DIFF
--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/BaseCloudServiceRuntimeMonitor.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/BaseCloudServiceRuntimeMonitor.scala
@@ -118,8 +118,9 @@ abstract class BaseCloudServiceRuntimeMonitor[F[_]] {
   ): F[CheckResult] =
     for {
       ctx <- ev.ask
+      // Delete the runtime if deleteRuntime is true
+      // Stop the runtime otherwise
       _ <- List(
-        // Delete the cluster in Google
         runtimeAlg
           .deleteRuntime(
             DeleteRuntimeParams(runtimeAndRuntimeConfig, mainInstance)
@@ -131,7 +132,8 @@ abstract class BaseCloudServiceRuntimeMonitor[F[_]] {
             StopRuntimeParams(runtimeAndRuntimeConfig, ctx.now, true)
           )
           .void
-          .whenA(!deleteRuntime), // When we don't delete runtime, we should stop the runtime
+          .whenA(!deleteRuntime),
+
         // save cluster error in the DB
         saveRuntimeError(
           runtimeAndRuntimeConfig.runtime.id,
@@ -167,6 +169,9 @@ abstract class BaseCloudServiceRuntimeMonitor[F[_]] {
                 persistentDiskOpt <- rc.persistentDiskId.flatTraverse(did =>
                   persistentDiskQuery.getPersistentDiskRecord(did).transaction
                 )
+
+                // if there's a disk in Creating/Failed status, delete it
+                // any other state, detach from the runtime
                 _ <- persistentDiskOpt match {
                   case Some(value) =>
                     if (value.status == DiskStatus.Creating || value.status == DiskStatus.Failed) {
@@ -175,13 +180,14 @@ abstract class BaseCloudServiceRuntimeMonitor[F[_]] {
                           .delete(d.id, ctx.now)
                           .transaction
                       )
-                    } else F.unit
+                    } else clusterQuery.detachPersistentDisk(runtimeAndRuntimeConfig.runtime.id, ctx.now).transaction
                   case None => F.unit
                 }
               } yield ()
             }
           } yield ()
         } else F.unit
+
       // Update the cluster status to Error only if the runtime is non-Deleted.
       // If the user has explicitly deleted their runtime by this point then
       // we don't want to move it back to Error status.
@@ -191,7 +197,6 @@ abstract class BaseCloudServiceRuntimeMonitor[F[_]] {
           curStatusOpt,
           new Exception(s"Cluster with id ${runtimeAndRuntimeConfig.runtime.id} not found in the database")
         )
-        _ <- clusterQuery.detachPersistentDisk(runtimeAndRuntimeConfig.runtime.id, ctx.now).transaction
         _ <- curStatus match {
           case RuntimeStatus.Deleted =>
             logger.info(ctx.loggingCtx)(

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/BaseCloudServiceRuntimeMonitorSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/BaseCloudServiceRuntimeMonitorSpec.scala
@@ -101,6 +101,7 @@ class BaseCloudServiceRuntimeMonitorSpec extends AnyFlatSpec with Matchers with 
       disk <- makePersistentDisk().save()
       start <- IO.realTimeInstant
       tid <- traceId.ask[TraceId]
+      implicit0(ec: ExecutionContext) = scala.concurrent.ExecutionContext.Implicits.global
       runtime <- IO(
         makeCluster(0)
           .copy(status = RuntimeStatus.Creating)
@@ -115,12 +116,14 @@ class BaseCloudServiceRuntimeMonitorSpec extends AnyFlatSpec with Matchers with 
       runtimeConfig <- RuntimeConfigQueries
         .getRuntimeConfig(runtime.runtimeConfigId)(scala.concurrent.ExecutionContext.Implicits.global)
         .transaction
+      diskStatus <- persistentDiskQuery.getStatus(disk.id).transaction
     } yield {
       // handleCheckTools should have been interrupted after 10 seconds and moved the runtime to Error status
       elapsed shouldBe 10000L +- 2000L
       status shouldBe Some(RuntimeStatus.Error)
       res shouldBe (((), None))
-      runtimeConfig.asInstanceOf[RuntimeConfig.GceWithPdConfig].persistentDiskId shouldBe None
+      runtimeConfig.asInstanceOf[RuntimeConfig.GceWithPdConfig].persistentDiskId shouldBe Some(disk.id)
+      diskStatus shouldBe (Some(DiskStatus.Ready))
     }
 
     res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
@@ -141,6 +144,8 @@ class BaseCloudServiceRuntimeMonitorSpec extends AnyFlatSpec with Matchers with 
       disk <- makePersistentDisk().save()
       start <- IO.realTimeInstant
       tid <- traceId.ask[TraceId]
+      implicit0(ec: ExecutionContext) = scala.concurrent.ExecutionContext.Implicits.global
+
       runtime <- IO(
         makeCluster(0)
           .copy(status = RuntimeStatus.Creating)
@@ -161,13 +166,16 @@ class BaseCloudServiceRuntimeMonitorSpec extends AnyFlatSpec with Matchers with 
       runtimeConfig <- RuntimeConfigQueries
         .getRuntimeConfig(runtime.runtimeConfigId)(scala.concurrent.ExecutionContext.Implicits.global)
         .transaction
+      diskStatus <- persistentDiskQuery.getStatus(disk.id).transaction
     } yield {
       customInterval shouldBe 1.seconds
       // handleCheckTools should have been interrupted after 5 seconds and moved the runtime to Error status
       elapsed shouldBe 5000L +- 1000L
       status shouldBe Some(RuntimeStatus.Error)
       res shouldBe (((), None))
-      runtimeConfig.asInstanceOf[RuntimeConfig.GceWithPdConfig].persistentDiskId shouldBe None
+      runtimeConfig.asInstanceOf[RuntimeConfig.GceWithPdConfig].persistentDiskId shouldBe Some(disk.id)
+      diskStatus shouldBe (Some(DiskStatus.Ready))
+
     }
 
     res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
@@ -298,6 +306,47 @@ class BaseCloudServiceRuntimeMonitorSpec extends AnyFlatSpec with Matchers with 
       elapsed should be >= 10000L
       status shouldBe Some(RuntimeStatus.Deleted)
       diskStatus shouldBe (Some(DiskStatus.Deleted))
+    }
+
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
+  }
+
+  it should "detach Ready disk on failed runtime create" in isolatedDbTest {
+    val runtimeMonitor = baseRuntimeMonitor(false)
+
+    val res = for {
+      start <- IO.realTimeInstant
+      tid <- traceId.ask[TraceId]
+      implicit0(ec: ExecutionContext) = scala.concurrent.ExecutionContext.Implicits.global
+      disk <- makePersistentDisk().save()
+      _ <- persistentDiskQuery.updateStatus(disk.id, DiskStatus.Ready, Instant.now()).transaction
+      runtime <- IO(
+        makeCluster(0)
+          .copy(status = RuntimeStatus.Creating)
+          .saveWithRuntimeConfig(CommonTestData.defaultGceRuntimeWithPDConfig(Some(disk.id)))
+      )
+      runtimeConfig <- RuntimeConfigQueries.getRuntimeConfig(runtime.runtimeConfigId).transaction
+
+      runtimeAndRuntimeConfig = RuntimeAndRuntimeConfig(runtime, runtimeConfig)
+      monitorContext = MonitorContext(start, runtime.id, tid, RuntimeStatus.Creating)
+      runCheckTools = Stream.eval(
+        runtimeMonitor.handleCheckTools(monitorContext, runtimeAndRuntimeConfig, IP("1.2.3.4"), None, true, None)
+      )
+      deleteRuntime = Stream.sleep[IO](2 seconds) ++ Stream.eval(
+        clusterQuery.completeDeletion(runtime.id, start).transaction
+      )
+      // run above tasks concurrently and wait for both to terminate
+      _ <- Stream(runCheckTools, deleteRuntime).parJoin(2).compile.drain.timeout(15 seconds)
+
+      end <- IO.realTimeInstant
+      elapsed = end.toEpochMilli - start.toEpochMilli
+      status <- clusterQuery.getClusterStatus(runtime.id).transaction
+      diskStatus <- persistentDiskQuery.getStatus(disk.id).transaction
+    } yield {
+      // handleCheckTools should have timed out after 10 seconds and the runtime should remain in Deleted status
+      elapsed should be >= 10000L
+      status shouldBe Some(RuntimeStatus.Deleted)
+      diskStatus shouldBe (Some(DiskStatus.Ready))
     }
 
     res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)


### PR DESCRIPTION
<!-- Welcome to your Leonardo pull request! -->
<!-- Contributor guidelines: https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md -->

__Jira ticket__: https://broadworkbench.atlassian.net/browse/AN-356

<!-- ## Dependencies -->
<!-- Include any dependent tickets and describe the relationship. Include any other relevant Jira tickets. -->

## Summary of changes

<!-- Please give an abridged version of the ticket description here and/or fill out the following fields. -->

### What

This PR moves the detach logic so that the disk is only detached when a runtime fails to create and the disk isn't in creating or failed

### Why

When the startup script fails (due to a full disk etc) the persistent disk becomes ‘detached’ in the DB. (The disk id is removed from the RUNTIME_CONFIG)

 This means that the user cannot even try to increase their disk size in the UI when they have a full disk because they will get a persistent disk not found for runtime error.

## Testing these changes

### What to test

- create a jupyter runtime with a small disk
- go to the terminal and `df -Th` to see how much space is available on sdb
- `fallocate` a file to fill up the space
- pause the runtime
- start the runtime --> it should fail
- increase the disk size and starting again

### Who tested and where

- [ ] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [ ] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
