### PR TITLE
Revert "[CORE-182] Move listRuntimes over to new Sam permissions model (#4810)"

### DIFF
--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/RuntimeServiceDbQueries.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/RuntimeServiceDbQueries.scala
@@ -6,7 +6,11 @@ import cats.syntax.all._
 import org.broadinstitute.dsde.workbench.azure.AzureCloudContext
 import org.broadinstitute.dsde.workbench.google2.OperationName
 import org.broadinstitute.dsde.workbench.leonardo.{LabelMap, Runtime}
-import org.broadinstitute.dsde.workbench.leonardo.SamResourceId.RuntimeSamResourceId
+import org.broadinstitute.dsde.workbench.leonardo.SamResourceId.{
+  ProjectSamResourceId,
+  RuntimeSamResourceId,
+  WorkspaceResourceSamResourceId
+}
 import org.broadinstitute.dsde.workbench.leonardo.config.Config
 import org.broadinstitute.dsde.workbench.leonardo.db.LeoProfile.api._
 import org.broadinstitute.dsde.workbench.leonardo.db.LeoProfile.dummyDate
@@ -24,6 +28,7 @@ import org.broadinstitute.dsde.workbench.leonardo.model.{
 import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GoogleProject}
 import org.broadinstitute.dsde.workbench.model.{IP, WorkbenchEmail}
 
+import java.util.UUID
 import java.sql.SQLDataException
 import java.time.Instant
 import scala.concurrent.ExecutionContext
@@ -65,7 +70,6 @@ object RuntimeServiceDbQueries {
     Option[WorkspaceId],
     Option[(String, String)]
   )
-
   private object ListRuntimesRecord {
     def apply(product: ListRuntimesProduct): ListRuntimesRecord = product match {
       case (l,
@@ -303,26 +307,33 @@ object RuntimeServiceDbQueries {
 
   /**
    * List runtimes filtered by the given terms. Only return authorized resources (per reader*Ids and/or owner*Ids).
-   *
    * @param labelMap
    * @param excludeStatuses
    * @param creatorEmail
    * @param workspaceId
    * @param cloudProvider
-   * @param runtimeIds
+   * @param readerRuntimeIds
    * @param readerWorkspaceIds
    * @param ownerWorkspaceIds
    * @param readerGoogleProjectIds
    * @param ownerGoogleProjectIds
    * @return
    */
-  def listRuntimes(runtimeIds: Set[SamResourceId] = Set.empty,
-                   cloudContext: Option[CloudContext] = None,
-                   cloudProvider: Option[CloudProvider] = None,
-                   creatorEmail: Option[WorkbenchEmail] = None,
-                   excludeStatuses: List[RuntimeStatus] = List.empty,
-                   labelMap: LabelMap = Map.empty[String, String],
-                   workspaceId: Option[WorkspaceId] = None
+  def listRuntimes(
+    // Authorizations
+    ownerGoogleProjectIds: Set[ProjectSamResourceId] = Set.empty,
+    ownerWorkspaceIds: Set[WorkspaceResourceSamResourceId] = Set.empty,
+    readerGoogleProjectIds: Set[ProjectSamResourceId] = Set.empty,
+    readerRuntimeIds: Set[SamResourceId] = Set.empty,
+    readerWorkspaceIds: Set[WorkspaceResourceSamResourceId] = Set.empty,
+
+    // Filters
+    cloudContext: Option[CloudContext] = None,
+    cloudProvider: Option[CloudProvider] = None,
+    creatorEmail: Option[WorkbenchEmail] = None,
+    excludeStatuses: List[RuntimeStatus] = List.empty,
+    labelMap: LabelMap = Map.empty[String, String],
+    workspaceId: Option[WorkspaceId] = None
   )(implicit ec: ExecutionContext): DBIO[Vector[ListRuntimeResponse2]] = {
     // Normalize filter params
     val provider = if (cloudProvider.isEmpty) {
@@ -332,8 +343,93 @@ object RuntimeServiceDbQueries {
       }
     } else cloudProvider
 
-    val runtimes = clusterQuery
-      .filter(_.internalId inSetBind runtimeIds.map(_.asString))
+    // Optimize Google project list if filtering to a specific cloud provider or context
+    val ownedProjects: Set[CloudContextDb] = ((provider, cloudContext) match {
+      case (Some(CloudProvider.Azure), _) => Set.empty[CloudContextDb]
+      case (Some(CloudProvider.Gcp), Some(CloudContext.Gcp(value))) =>
+        ownerGoogleProjectIds.filter(samId => samId.googleProject == value)
+      case _ => ownerGoogleProjectIds
+    }).map { case samId: SamResourceId =>
+      CloudContextDb(samId.resourceId)
+    }
+    val readProjects: Set[CloudContextDb] = ((provider, cloudContext) match {
+      case (Some(CloudProvider.Azure), _) => Set.empty[CloudContextDb]
+      case (Some(CloudProvider.Gcp), Some(CloudContext.Gcp(value))) =>
+        readerGoogleProjectIds.filter(samId => samId.googleProject == value)
+      case _ => readerGoogleProjectIds
+    }).map { case samId: SamResourceId =>
+      CloudContextDb(samId.resourceId)
+    }
+
+    // Optimize workspace list if filtering to a single workspace
+    val ownedWorkspaces: Set[WorkspaceId] = (workspaceId match {
+      case Some(wId) => ownerWorkspaceIds.filter(samId => WorkspaceId(UUID.fromString(samId.resourceId)) == wId)
+      case None      => ownerWorkspaceIds
+    }).map(samId => WorkspaceId(UUID.fromString(samId.resourceId)))
+    val readWorkspaces: Set[WorkspaceId] = (workspaceId match {
+      case Some(wId) => readerWorkspaceIds.filter(samId => WorkspaceId(UUID.fromString(samId.resourceId)) == wId)
+      case None      => readerWorkspaceIds
+    }).map(samId => WorkspaceId(UUID.fromString(samId.resourceId)))
+
+    val readRuntimes: Set[String] = readerRuntimeIds.map(readId => readId.asString)
+
+    val runtimeInReadWorkspaces: Option[ClusterTable => Rep[Option[Boolean]]] =
+      if (readRuntimes.isEmpty || readWorkspaces.isEmpty)
+        None
+      else
+        Some(runtime =>
+          (runtime.internalId inSetBind readRuntimes) &&
+            (runtime.workspaceId inSetBind readWorkspaces)
+        )
+
+    val runtimeInReadProjects: Option[ClusterTable => Rep[Option[Boolean]]] =
+      if (readRuntimes.isEmpty || readProjects.isEmpty)
+        None
+      else
+        Some(runtime =>
+          (runtime.internalId inSetBind readRuntimes) &&
+            (runtime.cloudProvider.? === (CloudProvider.Gcp: CloudProvider)) &&
+            (runtime.cloudContextDb inSetBind readProjects)
+        )
+
+    val runtimeInOwnedWorkspaces: Option[ClusterTable => Rep[Option[Boolean]]] =
+      if (ownedWorkspaces.isEmpty)
+        None
+      else
+        Some(runtime => runtime.workspaceId inSetBind ownedWorkspaces)
+
+    val runtimeInOwnedProjects: Option[ClusterTable => Rep[Option[Boolean]]] =
+      if (ownedProjects.isEmpty)
+        None
+      else if (cloudContext.isDefined) {
+        // If cloudContext is defined, we're already applying the filter in runtimesFiltered below.
+        // No need to filter by the list of user owned projects anymore as long as the specified
+        // project is owned by the user.
+        if (ownedProjects.exists(x => x.value == cloudContext.get.asString))
+          Some(_ => Some(true))
+        else None
+      } else
+        Some(runtime =>
+          (runtime.cloudProvider.? === (CloudProvider.Gcp: CloudProvider)) &&
+            (runtime.cloudContextDb inSetBind ownedProjects)
+        )
+
+    val runtimesAuthorized =
+      clusterQuery.filter[Rep[Option[Boolean]]] { runtime: ClusterTable =>
+        Seq(
+          runtimeInReadWorkspaces,
+          runtimeInOwnedWorkspaces,
+          runtimeInReadProjects,
+          runtimeInOwnedProjects
+        )
+          .mapFilter(opt => opt)
+          .map(_(runtime))
+          .reduceLeftOption(_ || _)
+          .getOrElse(Some(false): Rep[Option[Boolean]])
+      }
+
+    val runtimesFiltered = runtimesAuthorized
+      // Filter by params
       .filterOpt(workspaceId) { case (runtime, wId) =>
         runtime.workspaceId === (Some(wId): Rep[Option[WorkspaceId]])
       }
@@ -362,6 +458,9 @@ object RuntimeServiceDbQueries {
           )
           .length === labelMap.size
       }
+
+    // Assemble response
+    val runtimesJoined = runtimesFiltered
       .join(runtimeConfigs)
       .on((runtime, runtimeConfig) => runtime.runtimeConfigId === runtimeConfig.id)
       .map { case (runtime, runtimeConfig) =>
@@ -399,7 +498,7 @@ object RuntimeServiceDbQueries {
         )
       }
 
-    runtimes.result
+    runtimesJoined.result
       .map { records: Seq[ListRuntimesProduct] =>
         records
           .map(record => ListRuntimesRecord(record))

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/AppDependenciesBuilder.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/AppDependenciesBuilder.scala
@@ -98,6 +98,7 @@ class AppDependenciesBuilder(baselineDependenciesBuilder: BaselineDependenciesBu
 
     val azureService = new RuntimeV2ServiceInterp[IO](
       baselineDependencies.runtimeServicesConfig,
+      baselineDependencies.authProvider,
       baselineDependencies.publisherQueue,
       baselineDependencies.dateAccessedUpdaterQueue,
       baselineDependencies.wsmClientProvider,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterp.scala
@@ -20,6 +20,7 @@ import org.broadinstitute.dsde.workbench.google2.{
   MachineTypeName,
   ZoneName
 }
+import org.broadinstitute.dsde.workbench.leonardo.JsonCodec._
 import org.broadinstitute.dsde.workbench.leonardo.RuntimeImageType.{CryptoDetector, Jupyter, Proxy, Welder}
 import org.broadinstitute.dsde.workbench.leonardo.SamResourceId.{
   PersistentDiskSamResourceId,
@@ -37,7 +38,6 @@ import org.broadinstitute.dsde.workbench.leonardo.model.SamResourceAction.{
   workspaceSamResourceAction
 }
 import org.broadinstitute.dsde.workbench.leonardo.http.service.RuntimeServiceInterp._
-import org.broadinstitute.dsde.workbench.leonardo.model.SamResource.RuntimeSamResource
 import org.broadinstitute.dsde.workbench.leonardo.model.SamResourceAction._
 import org.broadinstitute.dsde.workbench.leonardo.model._
 import org.broadinstitute.dsde.workbench.leonardo.monitor.LeoPubsubMessage._
@@ -249,19 +249,36 @@ class RuntimeServiceInterp[F[_]: Parallel](
     for {
       ctx <- as.ask
 
-      samResources <- samService.listResources(userInfo.accessToken.token, RuntimeSamResource.resourceType)
+      // throw 403 if user doesn't have project permission
+      hasProjectPermission <- cloudContext.traverse(cc =>
+        authProvider.isUserProjectReader(
+          cc,
+          userInfo
+        )
+      )
+      _ <- ctx.span.traverse(s => F.delay(s.addAnnotation("Done checking project permission with Sam")))
+
+      _ <- F.raiseWhen(!hasProjectPermission.getOrElse(true))(ForbiddenError(userInfo.userEmail, Some(ctx.traceId)))
 
       (labelMap, includeDeleted, _) <- F.fromEither(processListParameters(params))
       excludeStatuses = if (includeDeleted) List.empty else List(RuntimeStatus.Deleted)
       creatorOnly <- F.fromEither(processCreatorOnlyParameter(userInfo.userEmail, params, ctx.traceId))
 
+      authorizedIds <- getAuthorizedIds(userInfo, creatorOnly)
       _ <- ctx.span.traverse(s => F.delay(s.addAnnotation("Start DB query for listRuntimes")))
       runtimes <- RuntimeServiceDbQueries
-        .listRuntimes(samResources.map(RuntimeSamResourceId).toSet,
-                      excludeStatuses = excludeStatuses,
-                      creatorEmail = creatorOnly,
-                      cloudContext = cloudContext,
-                      labelMap = labelMap
+        .listRuntimes(
+          // Authorization scopes
+          ownerGoogleProjectIds = authorizedIds.ownerGoogleProjectIds,
+          ownerWorkspaceIds = authorizedIds.ownerWorkspaceIds,
+          readerGoogleProjectIds = authorizedIds.readerGoogleProjectIds,
+          readerRuntimeIds = authorizedIds.readerRuntimeIds,
+          readerWorkspaceIds = authorizedIds.readerWorkspaceIds,
+          // Filters
+          excludeStatuses = excludeStatuses,
+          creatorEmail = creatorOnly,
+          cloudContext = cloudContext,
+          labelMap = labelMap
         )
         .transaction
 
@@ -823,6 +840,55 @@ class RuntimeServiceInterp[F[_]: Parallel](
 
       _ <- checkRuntimeAction(userInfo, cloudContext, runtimeName, runtime.samResource, action, userEmail)
     } yield runtime
+
+  private[service] def getAuthorizedIds(
+    userInfo: UserInfo,
+    creatorEmail: Option[WorkbenchEmail] = None
+  )(implicit ev: Ask[F, AppContext]): F[AuthorizedIds] = for {
+    // Authorize: user has an active account and has accepted terms of service
+    _ <- authProvider.checkUserEnabled(userInfo)
+
+    // Authorize: get resource IDs the user can see
+    // HACK: leonardo is modeling access control here, handling inheritance
+    // of workspace and project-level permissions. Sam and WSM already do this,
+    // and should be considered the point of truth.
+
+    // HACK: leonardo short-circuits access control to grant access to runtime creators.
+    // This supports the use case where `terra-ui` requests status of runtimes that have
+    // not yet been provisioned in Sam.
+    creatorRuntimeIdsBackdoor: Set[RuntimeSamResourceId] <- creatorEmail match {
+      case Some(email: WorkbenchEmail) =>
+        RuntimeServiceDbQueries
+          .listRuntimeIdsForCreator(email)
+          .map(_.map(_.samResource).toSet)
+          .transaction
+      case None => F.pure(Set.empty: Set[RuntimeSamResourceId])
+    }
+
+    // v1 runtimes (sam resource type `notebook-cluster`) are readable only
+    // by their creators (`Creator` is the SamResource.Runtime `ownerRoleName`),
+    // if the creator also has read access to the corresponding SamResource.Project
+    creatorV1RuntimeIds: Set[RuntimeSamResourceId] <- authProvider
+      .listResourceIds[RuntimeSamResourceId](hasOwnerRole = true, userInfo)
+    readerProjectIds: Set[ProjectSamResourceId] <- authProvider
+      .listResourceIds[ProjectSamResourceId](hasOwnerRole = false, userInfo)
+
+    // v1 runtimes are discoverable by owners on the corresponding Project
+    ownerProjectIds: Set[ProjectSamResourceId] <- authProvider
+      .listResourceIds[ProjectSamResourceId](hasOwnerRole = true, userInfo)
+
+    // combine: to read a runtime, user needs to be at least one of:
+    // - creator of a v1 runtime (Sam-authenticated)
+    // - any role on a v2 runtime (Sam-authenticated)
+    // - creator of a runtime (in Leo db) and filtering their request by creator-only
+    readerRuntimeIds: Set[SamResourceId] = creatorV1RuntimeIds ++ creatorRuntimeIdsBackdoor
+  } yield AuthorizedIds(
+    ownerGoogleProjectIds = ownerProjectIds,
+    ownerWorkspaceIds = Set.empty,
+    readerGoogleProjectIds = readerProjectIds,
+    readerRuntimeIds = readerRuntimeIds,
+    readerWorkspaceIds = Set.empty
+  )
 }
 
 object RuntimeServiceInterp {

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeV2ServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeV2ServiceInterp.scala
@@ -10,7 +10,13 @@ import cats.mtl.Ask
 import cats.syntax.all._
 import org.broadinstitute.dsde.workbench.google2.{DiskName, MachineTypeName, ZoneName}
 import org.broadinstitute.dsde.workbench.leonardo.JsonCodec._
-import org.broadinstitute.dsde.workbench.leonardo.SamResourceId.{PersistentDiskSamResourceId, ProjectSamResourceId, RuntimeSamResourceId, WorkspaceResourceSamResourceId, WsmResourceSamResourceId}
+import org.broadinstitute.dsde.workbench.leonardo.SamResourceId.{
+  PersistentDiskSamResourceId,
+  ProjectSamResourceId,
+  RuntimeSamResourceId,
+  WorkspaceResourceSamResourceId,
+  WsmResourceSamResourceId
+}
 import org.broadinstitute.dsde.workbench.leonardo.config.PersistentDiskConfig
 import org.broadinstitute.dsde.workbench.leonardo.dao._
 import org.broadinstitute.dsde.workbench.leonardo.dao.sam.{SamException, SamService, SamUtils}
@@ -676,12 +682,12 @@ class RuntimeV2ServiceInterp[F[_]: Parallel](
 
 }
 final case class AuthorizedIds(
-                                val ownerGoogleProjectIds: Set[ProjectSamResourceId],
-                                val ownerWorkspaceIds: Set[WorkspaceResourceSamResourceId],
-                                val readerGoogleProjectIds: Set[ProjectSamResourceId],
-                                val readerRuntimeIds: Set[SamResourceId],
-                                val readerWorkspaceIds: Set[WorkspaceResourceSamResourceId]
-                              )
+  val ownerGoogleProjectIds: Set[ProjectSamResourceId],
+  val ownerWorkspaceIds: Set[WorkspaceResourceSamResourceId],
+  val readerGoogleProjectIds: Set[ProjectSamResourceId],
+  val readerRuntimeIds: Set[SamResourceId],
+  val readerWorkspaceIds: Set[WorkspaceResourceSamResourceId]
+)
 
 final case class WorkspaceNotFoundException(workspaceId: WorkspaceId, traceId: TraceId)
     extends LeoException(

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeV2ServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeV2ServiceInterp.scala
@@ -9,19 +9,22 @@ import cats.effect.std.Queue
 import cats.mtl.Ask
 import cats.syntax.all._
 import org.broadinstitute.dsde.workbench.google2.{DiskName, MachineTypeName, ZoneName}
-import org.broadinstitute.dsde.workbench.leonardo.SamResourceId.{
-  PersistentDiskSamResourceId,
-  RuntimeSamResourceId,
-  WorkspaceResourceSamResourceId,
-  WsmResourceSamResourceId
-}
+import org.broadinstitute.dsde.workbench.leonardo.JsonCodec._
+import org.broadinstitute.dsde.workbench.leonardo.SamResourceId.{PersistentDiskSamResourceId, ProjectSamResourceId, RuntimeSamResourceId, WorkspaceResourceSamResourceId, WsmResourceSamResourceId}
 import org.broadinstitute.dsde.workbench.leonardo.config.PersistentDiskConfig
 import org.broadinstitute.dsde.workbench.leonardo.dao._
 import org.broadinstitute.dsde.workbench.leonardo.dao.sam.{SamException, SamService, SamUtils}
 import org.broadinstitute.dsde.workbench.leonardo.db._
 import org.broadinstitute.dsde.workbench.leonardo.http.service.DiskServiceInterp.getDiskSamPolicyMap
 import org.broadinstitute.dsde.workbench.leonardo.http.service.RuntimeServiceInterp.getRuntimeSamPolicyMap
-import org.broadinstitute.dsde.workbench.leonardo.model.SamResource.RuntimeSamResource
+// do not remove: `projectSamResourceAction`, `runtimeSamResourceAction`, `workspaceSamResourceAction`, `wsmResourceSamResourceAction`; `AppSamResourceAction` they are implicit
+import org.broadinstitute.dsde.workbench.leonardo.model.SamResourceAction.{
+  projectSamResourceAction,
+  runtimeSamResourceAction,
+  workspaceSamResourceAction,
+  wsmResourceSamResourceAction,
+  AppSamResourceAction
+}
 import org.broadinstitute.dsde.workbench.leonardo.model._
 import org.broadinstitute.dsde.workbench.leonardo.monitor.LeoPubsubMessage.{
   CreateAzureRuntimeMessage,
@@ -39,6 +42,7 @@ import scala.concurrent.ExecutionContext
 
 class RuntimeV2ServiceInterp[F[_]: Parallel](
   config: RuntimeServiceConfig,
+  authProvider: LeoAuthProvider[F],
   publisherQueue: Queue[F, LeoPubsubMessage],
   dateAccessUpdaterQueue: Queue[F, UpdateDateAccessedMessage],
   wsmClientProvider: WsmApiClientProvider[F],
@@ -77,18 +81,26 @@ class RuntimeV2ServiceInterp[F[_]: Parallel](
         case (None, None) => F.raiseError[CloudContext](CloudContextNotFoundException(workspaceId, ctx.traceId))
       }
 
+      samResource = WorkspaceResourceSamResourceId(workspaceId)
+
       // Resolve the user email in Sam from the user token. This translates a pet token to the owner email.
       userEmail <- samService.getUserEmail(userInfo.accessToken.token)
 
       // enforcing one runtime per workspace/user at a time
-      samResources <- samService.listResources(userInfo.accessToken.token, RuntimeSamResource.resourceType)
+      authorizedIds <- getAuthorizedIds(userInfo, Some(userEmail), Some(samResource))
       runtimes <- RuntimeServiceDbQueries
         .listRuntimes(
-          runtimeIds = samResources.map(RuntimeSamResourceId).toSet,
-          cloudProvider = Some(cloudContext.cloudProvider),
-          creatorEmail = Some(userEmail),
+          // Authorization scopes
+          ownerGoogleProjectIds = authorizedIds.ownerGoogleProjectIds,
+          ownerWorkspaceIds = authorizedIds.ownerWorkspaceIds,
+          readerGoogleProjectIds = authorizedIds.readerGoogleProjectIds,
+          readerRuntimeIds = authorizedIds.readerRuntimeIds,
+          readerWorkspaceIds = authorizedIds.readerWorkspaceIds,
+          // Filters
           excludeStatuses = List(RuntimeStatus.Deleted, RuntimeStatus.Deleting),
-          workspaceId = Some(workspaceId)
+          creatorEmail = Some(userEmail),
+          workspaceId = Some(workspaceId),
+          cloudProvider = Some(cloudContext.cloudProvider)
         )
         .transaction
 
@@ -333,10 +345,25 @@ class RuntimeV2ServiceInterp[F[_]: Parallel](
     as: Ask[F, AppContext]
   ): F[Unit] =
     for {
-      samResources <- samService.listResources(userInfo.accessToken.token, RuntimeSamResource.resourceType)
+      ctx <- as.ask
+
+      workspaceSamId = WorkspaceResourceSamResourceId(workspaceId)
+      hasWorkspacePermission <- authProvider.isUserWorkspaceReader(
+        workspaceSamId,
+        userInfo
+      )
+      _ <- F.raiseUnless(hasWorkspacePermission)(ForbiddenError(userInfo.userEmail))
+
+      authorizedIds <- getAuthorizedIds(userInfo, workspaceSamId = Some(workspaceSamId))
       runtimes <- RuntimeServiceDbQueries
         .listRuntimes(
-          runtimeIds = samResources.map(RuntimeSamResourceId).toSet,
+          // Authorization scopes
+          ownerGoogleProjectIds = authorizedIds.ownerGoogleProjectIds,
+          ownerWorkspaceIds = authorizedIds.ownerWorkspaceIds,
+          readerGoogleProjectIds = authorizedIds.readerGoogleProjectIds,
+          readerRuntimeIds = authorizedIds.readerRuntimeIds,
+          readerWorkspaceIds = authorizedIds.readerWorkspaceIds,
+          // Filters
           excludeStatuses = List(RuntimeStatus.Deleted),
           workspaceId = Some(workspaceId)
         )
@@ -421,16 +448,23 @@ class RuntimeV2ServiceInterp[F[_]: Parallel](
       (labelMap, includeDeleted, _) <- F.fromEither(processListParameters(params))
       excludeStatuses = if (includeDeleted) List.empty else List(RuntimeStatus.Deleted)
       creatorEmail <- F.fromEither(processCreatorOnlyParameter(userInfo.userEmail, params, ctx.traceId))
+      maybeWorkspaceSamId = workspaceId.map(WorkspaceResourceSamResourceId)
 
-      samResources <- samService.listResources(userInfo.accessToken.token, RuntimeSamResource.resourceType)
+      authorizedIds <- getAuthorizedIds(userInfo, creatorEmail, maybeWorkspaceSamId)
       runtimes <- RuntimeServiceDbQueries
         .listRuntimes(
-          runtimeIds = samResources.map(RuntimeSamResourceId).toSet,
-          cloudProvider = cloudProvider,
-          creatorEmail = creatorEmail,
-          excludeStatuses = excludeStatuses,
-          labelMap = labelMap,
-          workspaceId = workspaceId
+          // Authorization scopes
+          ownerGoogleProjectIds = authorizedIds.ownerGoogleProjectIds,
+          ownerWorkspaceIds = authorizedIds.ownerWorkspaceIds,
+          readerGoogleProjectIds = authorizedIds.readerGoogleProjectIds,
+          readerRuntimeIds = authorizedIds.readerRuntimeIds,
+          readerWorkspaceIds = authorizedIds.readerWorkspaceIds,
+          // Filters
+          cloudProvider = cloudProvider, // Google | Azure
+          creatorEmail = creatorEmail, // whether to filter out runtimes user did not create
+          excludeStatuses = excludeStatuses, // whether to filter out Deleted runtimes
+          labelMap = labelMap, // arbitrary key-value labels to filter by
+          workspaceId = workspaceId // whether to find only runtimes in a single workspace
         )
         .map(_.toList)
         .transaction
@@ -504,6 +538,84 @@ class RuntimeV2ServiceInterp[F[_]: Parallel](
         .transaction >>
         clusterQuery.updateClusterStatus(runtimeId, RuntimeStatus.Error, ctx.now).transaction.void
 
+  private def getAuthorizedIds(
+    userInfo: UserInfo,
+    creatorEmail: Option[WorkbenchEmail] = None,
+    workspaceSamId: Option[WorkspaceResourceSamResourceId] = None
+  )(implicit ev: Ask[F, AppContext]): F[AuthorizedIds] = for {
+    // Authorize: user has an active account and has accepted terms of service
+    _ <- authProvider.checkUserEnabled(userInfo)
+
+    // Authorize: get resource IDs the user can see
+    // HACK: leonardo is modeling access control here, handling inheritance
+    // of workspace and project-level permissions. Sam and WSM already do this,
+    // and should be considered the point of truth.
+
+    // HACK: leonardo short-circuits access control to grant access to runtime creators.
+    // This supports the use case where `terra-ui` requests status of runtimes that have
+    // not yet been provisioned in Sam.
+    creatorRuntimeIdsBackdoor: Set[RuntimeSamResourceId] <- creatorEmail match {
+      case Some(email: WorkbenchEmail) =>
+        RuntimeServiceDbQueries
+          .listRuntimeIdsForCreator(email)
+          .map(_.map(_.samResource).toSet)
+          .transaction
+      case None => F.pure(Set.empty: Set[RuntimeSamResourceId])
+    }
+
+    // v1 runtimes (sam resource type `notebook-cluster`) are readable only
+    // by their creators (`Creator` is the SamResource.Runtime `ownerRoleName`),
+    // if the creator also has read access to the corresponding SamResource.Project
+    creatorV1RuntimeIds: Set[RuntimeSamResourceId] <- authProvider
+      .listResourceIds[RuntimeSamResourceId](hasOwnerRole = true, userInfo)
+    readerProjectIds: Set[ProjectSamResourceId] <- authProvider
+      .listResourceIds[ProjectSamResourceId](hasOwnerRole = false, userInfo)
+
+    // v1 runtimes are discoverable by owners on the corresponding Project
+    ownerProjectIds: Set[ProjectSamResourceId] <- authProvider
+      .listResourceIds[ProjectSamResourceId](hasOwnerRole = true, userInfo)
+
+    // v2 runtimes are WSM-managed resources and they're modeled as `WsmResourceSamResource`s.
+    // HACK: accept any ID in the list of readable WSM resources as a valid
+    // readable v2 runtime ID. Some of these IDs are for non-runtime resources.
+    // TODO [] call WSM to list workspaces, then list runtimes per workspace, to get these IDs?
+
+    // v2 runtimes are readable by users with read access to both runtime and workspace
+    readerV2WsmIds: Set[WsmResourceSamResourceId] <- authProvider
+      .listResourceIds[WsmResourceSamResourceId](hasOwnerRole = false, userInfo)
+    readerWorkspaceIds: Set[WorkspaceResourceSamResourceId] <- workspaceSamId match {
+      case Some(samId) =>
+        for {
+          isWorkspaceReader <- authProvider.isUserWorkspaceReader(samId, userInfo)
+          workspaceIds: Set[WorkspaceResourceSamResourceId] =
+            if (isWorkspaceReader) Set(samId) else Set.empty
+        } yield workspaceIds
+      case None => authProvider.listResourceIds[WorkspaceResourceSamResourceId](hasOwnerRole = false, userInfo)
+    }
+
+    // v2 runtimes are discoverable by owners on the corresponding Workspace
+    ownerWorkspaceIds: Set[WorkspaceResourceSamResourceId] <- workspaceSamId match {
+      case Some(samId) =>
+        for {
+          isWorkspaceOwner <- authProvider.isUserWorkspaceOwner(samId, userInfo)
+          workspaceIds: Set[WorkspaceResourceSamResourceId] = if (isWorkspaceOwner) Set(samId) else Set.empty
+        } yield workspaceIds
+      case None => authProvider.listResourceIds[WorkspaceResourceSamResourceId](hasOwnerRole = true, userInfo)
+    }
+
+    // combine: to read a runtime, user needs to be at least one of:
+    // - creator of a v1 runtime (Sam-authenticated)
+    // - any role on a v2 runtime (Sam-authenticated)
+    // - creator of a runtime (in Leo db) and filtering their request by creator-only
+    readerRuntimeIds: Set[SamResourceId] = creatorV1RuntimeIds ++ readerV2WsmIds ++ creatorRuntimeIdsBackdoor
+  } yield AuthorizedIds(
+    ownerGoogleProjectIds = ownerProjectIds,
+    ownerWorkspaceIds = ownerWorkspaceIds,
+    readerGoogleProjectIds = readerProjectIds,
+    readerRuntimeIds = readerRuntimeIds,
+    readerWorkspaceIds = readerWorkspaceIds
+  )
+
   private def convertToRuntime(
     workspaceId: WorkspaceId,
     runtimeName: RuntimeName,
@@ -563,6 +675,13 @@ class RuntimeV2ServiceInterp[F[_]: Parallel](
   }
 
 }
+final case class AuthorizedIds(
+                                val ownerGoogleProjectIds: Set[ProjectSamResourceId],
+                                val ownerWorkspaceIds: Set[WorkspaceResourceSamResourceId],
+                                val readerGoogleProjectIds: Set[ProjectSamResourceId],
+                                val readerRuntimeIds: Set[SamResourceId],
+                                val readerWorkspaceIds: Set[WorkspaceResourceSamResourceId]
+                              )
 
 final case class WorkspaceNotFoundException(workspaceId: WorkspaceId, traceId: TraceId)
     extends LeoException(

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/RuntimeServiceDbQueriesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/RuntimeServiceDbQueriesSpec.scala
@@ -62,8 +62,16 @@ class RuntimeServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent wit
       c1 <- IO(
         makeCluster(1).saveWithRuntimeConfig(d1RuntimeConfig)
       )
+      c1WorkspaceIds = c1.workspaceId match {
+        case Some(workspaceId) => Set(WorkspaceResourceSamResourceId(workspaceId))
+        case None              => Set.empty[WorkspaceResourceSamResourceId]
+      }
       list2 <- RuntimeServiceDbQueries
-        .listRuntimes(runtimeIds = Set(c1.samResource), excludeStatuses = List(RuntimeStatus.Deleted))
+        .listRuntimes(
+          readerRuntimeIds = Set(c1.samResource),
+          readerWorkspaceIds = c1WorkspaceIds,
+          excludeStatuses = List(RuntimeStatus.Deleted)
+        )
         .transaction
       // Two runtimes exist: c1, c2
       d2 <- makePersistentDisk(Some(DiskName("d2"))).save()
@@ -77,8 +85,15 @@ class RuntimeServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent wit
       c2 <- IO(
         makeCluster(2).saveWithRuntimeConfig(d2RuntimeConfig)
       )
+      bothWorkspaceIds = Set(c1.workspaceId, c2.workspaceId).collect { case Some(workspaceId) =>
+        WorkspaceResourceSamResourceId(workspaceId)
+      }
       list3 <- RuntimeServiceDbQueries
-        .listRuntimes(runtimeIds = Set(c1.samResource, c2.samResource), excludeStatuses = List(RuntimeStatus.Deleted))
+        .listRuntimes(
+          readerRuntimeIds = Set(c1.samResource, c2.samResource),
+          readerWorkspaceIds = bothWorkspaceIds,
+          excludeStatuses = List(RuntimeStatus.Deleted)
+        )
         .transaction
 
       // no authorizations => no runtimes
@@ -164,14 +179,22 @@ class RuntimeServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent wit
 
       // Note that c3 exists but is not visible
       googleProject = GoogleProject(c1.cloudContext.asString)
+      projectIds = Set(ProjectSamResourceId(googleProject))
       runtimeIds = Set(c1.samResource: SamResourceId, c2.samResource: SamResourceId)
+      workspaceIds = Set(workspaceId1, workspaceId2).map(WorkspaceResourceSamResourceId)
 
       list0 <- RuntimeServiceDbQueries
-        .listRuntimes(runtimeIds = runtimeIds)
+        .listRuntimes(
+          readerRuntimeIds = runtimeIds,
+          readerWorkspaceIds = workspaceIds,
+          readerGoogleProjectIds = projectIds
+        )
         .transaction
       list1 <- RuntimeServiceDbQueries
         .listRuntimes(
-          runtimeIds = runtimeIds,
+          readerRuntimeIds = runtimeIds,
+          readerWorkspaceIds = workspaceIds,
+          readerGoogleProjectIds = projectIds,
           cloudContext = Some(CloudContext.Gcp(googleProject)),
           cloudProvider = Some(CloudProvider.Gcp),
           creatorEmail = Some(c1.auditInfo.creator),
@@ -182,7 +205,9 @@ class RuntimeServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent wit
         .transaction
       list2 <- RuntimeServiceDbQueries
         .listRuntimes(
-          runtimeIds = runtimeIds,
+          readerRuntimeIds = runtimeIds,
+          readerWorkspaceIds = workspaceIds,
+          readerGoogleProjectIds = projectIds,
           cloudProvider = Some(CloudProvider.Azure),
           creatorEmail = Some(c2.auditInfo.creator),
           excludeStatuses = List(RuntimeStatus.Deleted),
@@ -237,27 +262,57 @@ class RuntimeServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent wit
         "creator" -> c2.auditInfo.creator.value
       )
       runtimeIds = Set(c1.samResource: SamResourceId, c2.samResource: SamResourceId)
+      bothProjectIds = Set(
+        ProjectSamResourceId(GoogleProject(c1.cloudContext.asString)),
+        ProjectSamResourceId(GoogleProject(c2.cloudContext.asString))
+      )
       list0 <- RuntimeServiceDbQueries
-        .listRuntimes(runtimeIds = runtimeIds, excludeStatuses = List(RuntimeStatus.Deleted))
+        .listRuntimes(
+          readerRuntimeIds = runtimeIds,
+          readerGoogleProjectIds = bothProjectIds,
+          excludeStatuses = List(RuntimeStatus.Deleted)
+        )
         .transaction
       list1 <- RuntimeServiceDbQueries
-        .listRuntimes(runtimeIds = runtimeIds, excludeStatuses = List(RuntimeStatus.Deleted), labelMap = labels1)
+        .listRuntimes(
+          readerRuntimeIds = runtimeIds,
+          readerGoogleProjectIds = bothProjectIds,
+          labelMap = labels1,
+          excludeStatuses = List(RuntimeStatus.Deleted)
+        )
         .transaction
       list2 <- RuntimeServiceDbQueries
-        .listRuntimes(runtimeIds = runtimeIds, excludeStatuses = List(RuntimeStatus.Deleted), labelMap = labels2)
+        .listRuntimes(
+          readerRuntimeIds = runtimeIds,
+          readerGoogleProjectIds = bothProjectIds,
+          labelMap = labels2,
+          excludeStatuses = List(RuntimeStatus.Deleted)
+        )
         .transaction
       _ <- labelQuery.saveAllForResource(c1.id, LabelResourceType.Runtime, labels1).transaction
       _ <- labelQuery.saveAllForResource(c2.id, LabelResourceType.Runtime, labels2).transaction
       list3 <- RuntimeServiceDbQueries
-        .listRuntimes(runtimeIds = runtimeIds, excludeStatuses = List(RuntimeStatus.Deleted), labelMap = labels1)
+        .listRuntimes(
+          readerRuntimeIds = runtimeIds,
+          readerGoogleProjectIds = bothProjectIds,
+          labelMap = labels1,
+          excludeStatuses = List(RuntimeStatus.Deleted)
+        )
         .transaction
       list4 <- RuntimeServiceDbQueries
-        .listRuntimes(runtimeIds = runtimeIds, excludeStatuses = List(RuntimeStatus.Deleted), labelMap = labels2)
+        .listRuntimes(
+          readerRuntimeIds = runtimeIds,
+          readerGoogleProjectIds = bothProjectIds,
+          labelMap = labels2,
+          excludeStatuses = List(RuntimeStatus.Deleted)
+        )
         .transaction
       list5 <- RuntimeServiceDbQueries
-        .listRuntimes(runtimeIds = runtimeIds,
-                      excludeStatuses = List(RuntimeStatus.Deleted),
-                      labelMap = Map("googleProject" -> c1.cloudContext.asString)
+        .listRuntimes(
+          readerRuntimeIds = runtimeIds,
+          readerGoogleProjectIds = bothProjectIds,
+          labelMap = Map("googleProject" -> c1.cloudContext.asString),
+          excludeStatuses = List(RuntimeStatus.Deleted)
         )
         .transaction
       end <- IO.realTimeInstant
@@ -304,16 +359,24 @@ class RuntimeServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent wit
         makeCluster(2).saveWithRuntimeConfig(c2RuntimeConfig)
       )
       runtimeIds = Set(c1.samResource: SamResourceId, c2.samResource: SamResourceId)
+      bothProjectIds = Set(
+        ProjectSamResourceId(GoogleProject(c1.cloudContext.asString)),
+        ProjectSamResourceId(GoogleProject(c2.cloudContext.asString))
+      )
       list1 <- RuntimeServiceDbQueries
-        .listRuntimes(runtimeIds = runtimeIds,
-                      cloudContext = Some(cloudContextGcp),
-                      excludeStatuses = List(RuntimeStatus.Deleted)
+        .listRuntimes(
+          readerRuntimeIds = runtimeIds,
+          readerGoogleProjectIds = bothProjectIds,
+          excludeStatuses = List(RuntimeStatus.Deleted),
+          cloudContext = Some(cloudContextGcp)
         )
         .transaction
       list2 <- RuntimeServiceDbQueries
-        .listRuntimes(runtimeIds = runtimeIds,
-                      cloudContext = Some(cloudContext2Gcp),
-                      excludeStatuses = List(RuntimeStatus.Deleted)
+        .listRuntimes(
+          readerRuntimeIds = runtimeIds,
+          readerGoogleProjectIds = bothProjectIds,
+          excludeStatuses = List(RuntimeStatus.Deleted),
+          cloudContext = Some(cloudContext2Gcp)
         )
         .transaction
       end <- IO.realTimeInstant
@@ -379,12 +442,21 @@ class RuntimeServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent wit
         )
       )
       runtimeIds = Set(c1.samResource: SamResourceId, c2.samResource: SamResourceId, c3.samResource: SamResourceId)
+      projectIds = Set(
+        ProjectSamResourceId(GoogleProject(c1.cloudContext.asString)),
+        ProjectSamResourceId(GoogleProject(c2.cloudContext.asString)),
+        ProjectSamResourceId(GoogleProject(c3.cloudContext.asString))
+      )
 
       list1 <- RuntimeServiceDbQueries
-        .listRuntimes(runtimeIds = runtimeIds)
+        .listRuntimes(readerRuntimeIds = runtimeIds, readerGoogleProjectIds = projectIds)
         .transaction
       list2 <- RuntimeServiceDbQueries
-        .listRuntimes(runtimeIds = runtimeIds, excludeStatuses = List(RuntimeStatus.Deleted))
+        .listRuntimes(
+          readerRuntimeIds = runtimeIds,
+          readerGoogleProjectIds = projectIds,
+          excludeStatuses = List(RuntimeStatus.Deleted)
+        )
         .transaction
       end <- IO.realTimeInstant
       elapsed = (end.toEpochMilli - start.toEpochMilli).millis
@@ -438,11 +510,27 @@ class RuntimeServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent wit
         )
       )
       runtimeIds = Set(c1.samResource: SamResourceId, c2.samResource: SamResourceId, c3.samResource: SamResourceId)
+      projectIds = Set(
+        ProjectSamResourceId(GoogleProject(c1.cloudContext.asString)),
+        ProjectSamResourceId(GoogleProject(c2.cloudContext.asString))
+      )
+      workspaceIds = Set(c3.workspaceId).collect { case Some(workspaceId) =>
+        WorkspaceResourceSamResourceId(workspaceId)
+      }
       list1 <- RuntimeServiceDbQueries
-        .listRuntimes(runtimeIds = runtimeIds)
+        .listRuntimes(
+          readerRuntimeIds = runtimeIds,
+          readerGoogleProjectIds = projectIds,
+          readerWorkspaceIds = workspaceIds
+        )
         .transaction
       list2 <- RuntimeServiceDbQueries
-        .listRuntimes(runtimeIds = runtimeIds, excludeStatuses = List(RuntimeStatus.Deleted))
+        .listRuntimes(
+          readerRuntimeIds = runtimeIds,
+          readerGoogleProjectIds = projectIds,
+          readerWorkspaceIds = workspaceIds,
+          excludeStatuses = List(RuntimeStatus.Deleted)
+        )
         .transaction
       end <- IO.realTimeInstant
       elapsed = (end.toEpochMilli - start.toEpochMilli).millis
@@ -504,14 +592,21 @@ class RuntimeServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent wit
           )
       )
       runtimeIds = Set(c1.samResource: SamResourceId, c2.samResource: SamResourceId, c3.samResource: SamResourceId)
+      workspaceIds = Set(workspaceId1, workspaceId2).map(WorkspaceResourceSamResourceId)
 
       list1 <- RuntimeServiceDbQueries
-        .listRuntimes(runtimeIds = runtimeIds, workspaceId = Some(workspaceId1))
+        .listRuntimes(
+          readerRuntimeIds = runtimeIds,
+          readerWorkspaceIds = workspaceIds,
+          workspaceId = Some(workspaceId1)
+        )
         .transaction
       list2 <- RuntimeServiceDbQueries
-        .listRuntimes(runtimeIds = runtimeIds,
-                      excludeStatuses = List(RuntimeStatus.Deleted),
-                      workspaceId = Some(workspaceId2)
+        .listRuntimes(
+          readerRuntimeIds = runtimeIds,
+          readerWorkspaceIds = workspaceIds,
+          excludeStatuses = List(RuntimeStatus.Deleted),
+          workspaceId = Some(workspaceId2)
         )
         .transaction
       end <- IO.realTimeInstant
@@ -594,41 +689,51 @@ class RuntimeServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent wit
       )
       c5ClusterRecord <- clusterQuery.getActiveClusterRecordByName(c5.cloudContext, c5.runtimeName).transaction
       runtimeIds = Set(c1, c2, c3, c4, c5).map(_.samResource: SamResourceId)
+      workspaceIds = Set(workspaceId1, workspaceId2).map(WorkspaceResourceSamResourceId)
 
       list1 <- RuntimeServiceDbQueries
-        .listRuntimes(runtimeIds = runtimeIds,
-                      cloudProvider = Some(CloudProvider.Azure),
-                      excludeStatuses = List(RuntimeStatus.Deleted),
-                      workspaceId = Some(workspaceId1)
+        .listRuntimes(
+          readerRuntimeIds = runtimeIds,
+          readerWorkspaceIds = workspaceIds,
+          excludeStatuses = List(RuntimeStatus.Deleted),
+          workspaceId = Some(workspaceId1),
+          cloudProvider = Some(CloudProvider.Azure)
         )
         .transaction
       list2 <- RuntimeServiceDbQueries
-        .listRuntimes(runtimeIds = runtimeIds,
-                      cloudProvider = Some(CloudProvider.Azure),
-                      excludeStatuses = List(RuntimeStatus.Deleted),
-                      workspaceId = Some(workspaceId2)
+        .listRuntimes(
+          readerRuntimeIds = runtimeIds,
+          readerWorkspaceIds = workspaceIds,
+          excludeStatuses = List(RuntimeStatus.Deleted),
+          workspaceId = Some(workspaceId2),
+          cloudProvider = Some(CloudProvider.Azure)
         )
         .transaction
       list3 <- RuntimeServiceDbQueries
-        .listRuntimes(runtimeIds = runtimeIds,
-                      cloudProvider = Some(CloudProvider.Gcp),
-                      excludeStatuses = List(RuntimeStatus.Deleted),
-                      workspaceId = Some(workspaceId1)
+        .listRuntimes(
+          readerRuntimeIds = runtimeIds,
+          readerWorkspaceIds = workspaceIds,
+          excludeStatuses = List(RuntimeStatus.Deleted),
+          workspaceId = Some(workspaceId1),
+          cloudProvider = Some(CloudProvider.Gcp)
         )
         .transaction
       list4 <- RuntimeServiceDbQueries
-        .listRuntimes(runtimeIds = runtimeIds,
-                      cloudProvider = Some(CloudProvider.Azure),
-                      excludeStatuses = List(RuntimeStatus.Deleted)
+        .listRuntimes(
+          readerRuntimeIds = runtimeIds,
+          readerWorkspaceIds = workspaceIds,
+          excludeStatuses = List(RuntimeStatus.Deleted),
+          cloudProvider = Some(CloudProvider.Azure)
         )
         .transaction
       list5 <- RuntimeServiceDbQueries
         .listRuntimes(
-          runtimeIds = runtimeIds,
-          cloudProvider = Some(CloudProvider.Azure),
-          creatorEmail = Some(c5ClusterRecord.get.auditInfo.creator),
+          readerRuntimeIds = runtimeIds,
+          readerWorkspaceIds = workspaceIds,
           excludeStatuses = List(RuntimeStatus.Deleted),
-          workspaceId = Some(workspaceId2)
+          creatorEmail = Some(c5ClusterRecord.get.auditInfo.creator),
+          workspaceId = Some(workspaceId2),
+          cloudProvider = Some(CloudProvider.Azure)
         )
         .transaction
       end <- IO.realTimeInstant

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/TestLeoRoutes.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/TestLeoRoutes.scala
@@ -130,6 +130,7 @@ trait TestLeoRoutes {
   val runtimev2Service =
     new RuntimeV2ServiceInterp[IO](
       serviceConfig,
+      allowListAuthProvider,
       QueueFactory.makePublisherQueue(),
       QueueFactory.makeDateAccessedQueue(),
       wsmClientProvider,

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterpSpec.scala
@@ -840,7 +840,7 @@ class RuntimeServiceInterpTest
     res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
-  it should "throw RuntimeNotFoundException for nonexistent clusters" in isolatedDbTest {
+  it should "throw ClusterNotFoundException for nonexistent clusters" in isolatedDbTest {
     val exc = runtimeService
       .getRuntime(userInfo, CloudContext.Gcp(GoogleProject("nonexistent")), RuntimeName("cluster"))
       .attempt
@@ -874,10 +874,13 @@ class RuntimeServiceInterpTest
     val userInfo = mockUserInfo("grendel@mom.mere")
     val runtimeIds =
       Vector(RuntimeSamResourceId(UUID.randomUUID.toString), RuntimeSamResourceId(UUID.randomUUID.toString))
-    val samService = mock[SamService[IO]]
-    when(samService.listResources(isEq(userInfo.accessToken.token), isEq(RuntimeSamResource.resourceType))(any()))
-      .thenReturn(IO.pure(runtimeIds.map(_.resourceId).toList))
-    val service = makeRuntimeService(samService = samService)
+    val mockAuthProvider = mockAuthorize(
+      userInfo,
+      readerRuntimeSamIds = Set(runtimeIds(0), runtimeIds(1)),
+      readerProjectSamIds = Set(ProjectSamResourceId(project))
+    )
+    when(mockAuthProvider.isUserProjectReader(any, isEq(userInfo))(any)).thenReturn(IO.pure(true))
+    val service = makeRuntimeService(authProvider = mockAuthProvider)
 
     val res = for {
       _ <- IO(makeCluster(1, samResource = runtimeIds(0)).save())
@@ -894,10 +897,13 @@ class RuntimeServiceInterpTest
                             RuntimeSamResourceId(UUID.randomUUID.toString),
                             RuntimeSamResourceId(UUID.randomUUID.toString)
     )
-    val samService = mock[SamService[IO]]
-    when(samService.listResources(isEq(userInfo.accessToken.token), isEq(RuntimeSamResource.resourceType))(any()))
-      .thenReturn(IO.pure(runtimeIds.map(_.resourceId).toList))
-    val service = makeRuntimeService(samService = samService)
+    val mockAuthProvider = mockAuthorize(
+      userInfo,
+      readerRuntimeSamIds = Set(runtimeIds(0), runtimeIds(1)),
+      readerProjectSamIds = Set(ProjectSamResourceId(project), ProjectSamResourceId(project2))
+    )
+    when(mockAuthProvider.isUserProjectReader(any, isEq(userInfo))(any)).thenReturn(IO.pure(true))
+    val service = makeRuntimeService(authProvider = mockAuthProvider)
 
     val res = for {
       _ <- IO(makeCluster(1).copy(samResource = runtimeIds(0)).save())
@@ -913,10 +919,13 @@ class RuntimeServiceInterpTest
     val userInfo = mockUserInfo("grendel@mom.mere")
     val runtimeIds =
       Vector(RuntimeSamResourceId(UUID.randomUUID.toString), RuntimeSamResourceId(UUID.randomUUID.toString))
-    val samService = mock[SamService[IO]]
-    when(samService.listResources(isEq(userInfo.accessToken.token), isEq(RuntimeSamResource.resourceType))(any()))
-      .thenReturn(IO.pure(runtimeIds.map(_.resourceId).toList))
-    val service = makeRuntimeService(samService = samService)
+    val mockAuthProvider = mockAuthorize(
+      userInfo,
+      readerRuntimeSamIds = Set(runtimeIds(0), runtimeIds(1)),
+      readerProjectSamIds = Set(ProjectSamResourceId(project))
+    )
+    when(mockAuthProvider.isUserProjectReader(any, isEq(userInfo))(any)).thenReturn(IO.pure(true))
+    val service = makeRuntimeService(authProvider = mockAuthProvider)
 
     val res = for {
       runtime1 <- IO(makeCluster(1).copy(samResource = runtimeIds(0)).save())
@@ -935,10 +944,12 @@ class RuntimeServiceInterpTest
     val userInfo = mockUserInfo("grendel@mere.mom")
     val runtimeIds =
       Vector(RuntimeSamResourceId(UUID.randomUUID.toString), RuntimeSamResourceId(UUID.randomUUID.toString))
-    val samService = mock[SamService[IO]]
-    when(samService.listResources(isEq(userInfo.accessToken.token), isEq(RuntimeSamResource.resourceType))(any()))
-      .thenReturn(IO.pure(runtimeIds.map(_.resourceId).toList))
-    val service = makeRuntimeService(samService = samService)
+    val mockAuthProvider = mockAuthorize(
+      userInfo,
+      ownerProjectSamIds = Set(ProjectSamResourceId(project))
+    )
+    when(mockAuthProvider.isUserProjectReader(any, isEq(userInfo))(any)).thenReturn(IO.pure(true))
+    val service = makeRuntimeService(authProvider = mockAuthProvider)
 
     // Make runtimes belonging to different users than the calling user
     val res = for {
@@ -1010,10 +1021,13 @@ class RuntimeServiceInterpTest
       runtime2.patchInProgress
     )
 
-    val samService = mock[SamService[IO]]
-    when(samService.listResources(isEq(userInfo.accessToken.token), isEq(RuntimeSamResource.resourceType))(any()))
-      .thenReturn(IO.pure(List(runtime1.samResource.resourceId, runtime2.samResource.resourceId)))
-    val service = makeRuntimeService(samService = samService)
+    val mockAuthProvider = mockAuthorize(
+      userInfo,
+      readerRuntimeSamIds = Set(runtime1.samResource, runtime2.samResource),
+      readerProjectSamIds = Set(ProjectSamResourceId(project))
+    )
+    when(mockAuthProvider.isUserProjectReader(any, isEq(userInfo))(any)).thenReturn(IO.pure(true))
+    val service = makeRuntimeService(authProvider = mockAuthProvider)
 
     service
       .listRuntimes(userInfo, None, Map("_labels" -> "foo=bar"))
@@ -1374,9 +1388,27 @@ class RuntimeServiceInterpTest
     when(samService.checkAuthorized(isEq(userInfo.accessToken.token), any(), isEq(RuntimeAction.DeleteRuntime))(any()))
       .thenReturn(IO.unit)
     when(samService.deleteResource(any(), any())(any())).thenReturn(IO.unit)
+    val mockAuthProvider = mockAuthorize(
+      userInfo,
+      readerRuntimeSamIds = Set(runtimeIds(0), runtimeIds(1)),
+      readerProjectSamIds = Set(ProjectSamResourceId(project))
+    )
+    when(mockAuthProvider.isUserProjectReader(any, isEq(userInfo))(any)).thenReturn(IO.pure(true))
+    when(
+      mockAuthProvider.getActionsWithProjectFallback[RuntimeSamResourceId, RuntimeAction](any, any, isEq(userInfo))(any,
+                                                                                                                    any
+      )
+    )
+      .thenReturn(
+        IO.pure(
+          (List(RuntimeAction.GetRuntimeStatus, RuntimeAction.DeleteRuntime),
+           List(ProjectAction.GetRuntimeStatus, ProjectAction.DeleteRuntime)
+          )
+        )
+      )
+
     val publisherQueue = QueueFactory.makePublisherQueue()
-    val service =
-      makeRuntimeService(publisherQueue = publisherQueue, samService = samService)
+    val service = makeRuntimeService(authProvider = mockAuthProvider, publisherQueue = publisherQueue, samService = samService)
 
     val res = for {
       pd1 <- makePersistentDisk().save()
@@ -1433,9 +1465,27 @@ class RuntimeServiceInterpTest
     when(samService.getUserEmail(isEq(userInfo.accessToken.token))(any())).thenReturn(IO.pure(userInfo.userEmail))
     when(samService.checkAuthorized(any(), any(), any())(any())).thenReturn(IO.unit)
     when(samService.deleteResource(any(), any())(any())).thenReturn(IO.unit)
+    val mockAuthProvider = mockAuthorize(
+      userInfo,
+      readerRuntimeSamIds = Set(runtimeIds(0), runtimeIds(1)),
+      readerProjectSamIds = Set(ProjectSamResourceId(project))
+    )
+    when(mockAuthProvider.isUserProjectReader(any, isEq(userInfo))(any)).thenReturn(IO.pure(true))
+    when(
+      mockAuthProvider.getActionsWithProjectFallback[RuntimeSamResourceId, RuntimeAction](any, any, isEq(userInfo))(any,
+                                                                                                                    any
+      )
+    )
+      .thenReturn(
+        IO.pure(
+          (List(RuntimeAction.GetRuntimeStatus, RuntimeAction.DeleteRuntime),
+           List(ProjectAction.GetRuntimeStatus, ProjectAction.DeleteRuntime)
+          )
+        )
+      )
+
     val publisherQueue = QueueFactory.makePublisherQueue()
-    val service =
-      makeRuntimeService(publisherQueue = publisherQueue, samService = samService)
+    val service = makeRuntimeService(authProvider = mockAuthProvider, publisherQueue = publisherQueue, samService = samService)
 
     val res = for {
       pd1 <- makePersistentDisk().save()
@@ -1509,13 +1559,8 @@ class RuntimeServiceInterpTest
         )
       )
 
-    val samService = mock[SamService[IO]]
-    when(samService.listResources(isEq(userInfo.accessToken.token), isEq(RuntimeSamResource.resourceType))(any()))
-      .thenReturn(IO.pure(runtimeIds.map(_.resourceId).toList))
-
     val publisherQueue = QueueFactory.makePublisherQueue()
-    val service =
-      makeRuntimeService(authProvider = mockAuthProvider, publisherQueue = publisherQueue, samService = samService)
+    val service = makeRuntimeService(authProvider = mockAuthProvider, publisherQueue = publisherQueue)
 
     val res = for {
       pd1 <- makePersistentDisk().save()

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterpSpec.scala
@@ -1408,7 +1408,8 @@ class RuntimeServiceInterpTest
       )
 
     val publisherQueue = QueueFactory.makePublisherQueue()
-    val service = makeRuntimeService(authProvider = mockAuthProvider, publisherQueue = publisherQueue, samService = samService)
+    val service =
+      makeRuntimeService(authProvider = mockAuthProvider, publisherQueue = publisherQueue, samService = samService)
 
     val res = for {
       pd1 <- makePersistentDisk().save()
@@ -1485,7 +1486,8 @@ class RuntimeServiceInterpTest
       )
 
     val publisherQueue = QueueFactory.makePublisherQueue()
-    val service = makeRuntimeService(authProvider = mockAuthProvider, publisherQueue = publisherQueue, samService = samService)
+    val service =
+      makeRuntimeService(authProvider = mockAuthProvider, publisherQueue = publisherQueue, samService = samService)
 
     val res = for {
       pd1 <- makePersistentDisk().save()

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeV2ServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeV2ServiceInterpSpec.scala
@@ -8,20 +8,36 @@ import cats.effect.IO
 import cats.effect.std.Queue
 import cats.mtl.Ask
 import com.azure.resourcemanager.compute.models.VirtualMachineSizeTypes
+import io.circe.Decoder
 import org.broadinstitute.dsde.workbench.azure._
 import org.broadinstitute.dsde.workbench.google2.DiskName
 import org.broadinstitute.dsde.workbench.leonardo.CommonTestData._
+import org.broadinstitute.dsde.workbench.leonardo.JsonCodec.{
+  projectSamResourceDecoder,
+  runtimeSamResourceDecoder,
+  workspaceSamResourceIdDecoder,
+  wsmResourceSamResourceIdDecoder
+}
 import org.broadinstitute.dsde.workbench.leonardo.SamResourceId.{
+  ProjectSamResourceId,
   RuntimeSamResourceId,
   WorkspaceResourceSamResourceId,
   WsmResourceSamResourceId
 }
-import org.broadinstitute.dsde.workbench.leonardo.TestUtils.appContext
+import org.broadinstitute.dsde.workbench.leonardo.auth.AllowlistAuthProvider
+import org.broadinstitute.dsde.workbench.leonardo.TestUtils.{appContext, defaultMockitoAnswer}
 import org.broadinstitute.dsde.workbench.leonardo.config.Config
 import org.broadinstitute.dsde.workbench.leonardo.dao._
 import org.broadinstitute.dsde.workbench.leonardo.dao.sam.{SamException, SamService}
 import org.broadinstitute.dsde.workbench.leonardo.db._
 import org.broadinstitute.dsde.workbench.leonardo.model.SamResource.RuntimeSamResource
+import org.broadinstitute.dsde.workbench.leonardo.model.SamResourceAction.{
+  projectSamResourceAction,
+  runtimeSamResourceAction,
+  workspaceSamResourceAction,
+  wsmResourceSamResourceAction,
+  AppSamResourceAction
+}
 import org.broadinstitute.dsde.workbench.leonardo.model._
 import org.broadinstitute.dsde.workbench.leonardo.monitor.LeoPubsubMessage.{
   CreateAzureRuntimeMessage,
@@ -33,7 +49,8 @@ import org.broadinstitute.dsde.workbench.leonardo.monitor.{LeoPubsubMessage, Upd
 import org.broadinstitute.dsde.workbench.leonardo.util.QueueFactory
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.broadinstitute.dsde.workbench.model.{TraceId, UserInfo, WorkbenchEmail, WorkbenchUserId}
-import org.mockito.ArgumentMatchers.{any, eq => isEq}
+import org.mockito.ArgumentMatchers.{any, argThat, eq => isEq}
+import org.scalatest.prop.TableDrivenPropertyChecks._
 import org.mockito.Mockito.when
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatestplus.mockito.MockitoSugar
@@ -58,11 +75,18 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
   // used when we care about queue state
   def makeInterp(
     queue: Queue[IO, LeoPubsubMessage] = QueueFactory.makePublisherQueue(),
+    authProvider: AllowlistAuthProvider = allowListAuthProvider,
     dateAccessedQueue: Queue[IO, UpdateDateAccessedMessage] = QueueFactory.makeDateAccessedQueue(),
     wsmClientProvider: WsmApiClientProvider[IO] = wsmClientProvider,
     samService: SamService[IO] = MockSamService
   ) =
-    new RuntimeV2ServiceInterp[IO](serviceConfig, queue, dateAccessedQueue, wsmClientProvider, samService)
+    new RuntimeV2ServiceInterp[IO](serviceConfig,
+                                   authProvider,
+                                   queue,
+                                   dateAccessedQueue,
+                                   wsmClientProvider,
+      samService
+    )
 
   // need to set previous runtime to deleted status before creating next to avoid exception
   def setRuntimeDeleted(workspaceId: WorkspaceId, name: RuntimeName): IO[Long] =
@@ -87,12 +111,174 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
     samService
   }
 
+  /**
+   * Generate a mocked AuthProvider which will permit action on the given resource IDs by the given user.
+   * TODO: cover actions beside `checkUserEnabled` and `listResourceIds`
+   * @param userInfo
+   * @param readerRuntimeSamIds
+   * @param readerWorkspaceSamIds
+   * @param readerProjectSamIds
+   * @param ownerWorkspaceSamIds
+   * @param ownerProjectSamIds
+   * @return
+   */
+  def mockAuthorize(
+    userInfo: UserInfo,
+    readerRuntimeSamIds: Set[RuntimeSamResourceId] = Set.empty,
+    readerWsmSamIds: Set[WsmResourceSamResourceId] = Set.empty,
+    readerWorkspaceSamIds: Set[WorkspaceResourceSamResourceId] = Set.empty,
+    readerProjectSamIds: Set[ProjectSamResourceId] = Set.empty,
+    ownerWorkspaceSamIds: Set[WorkspaceResourceSamResourceId] = Set.empty,
+    ownerProjectSamIds: Set[ProjectSamResourceId] = Set.empty
+  ): AllowlistAuthProvider = {
+    val mockAuthProvider: AllowlistAuthProvider = mock[AllowlistAuthProvider](defaultMockitoAnswer[IO])
+
+    when(mockAuthProvider.checkUserEnabled(isEq(userInfo))(any)).thenReturn(IO.unit)
+    when(
+      mockAuthProvider.listResourceIds[RuntimeSamResourceId](isEq(true), isEq(userInfo))(
+        any(runtimeSamResourceAction.getClass),
+        any(AppSamResourceAction.getClass),
+        any(Decoder[RuntimeSamResourceId].getClass),
+        any(Ask[IO, TraceId].getClass)
+      )
+    ).thenReturn(IO.pure(readerRuntimeSamIds))
+    when(
+      mockAuthProvider.listResourceIds[WsmResourceSamResourceId](isEq(false), isEq(userInfo))(
+        any(wsmResourceSamResourceAction.getClass),
+        any(AppSamResourceAction.getClass),
+        any(Decoder[WsmResourceSamResourceId].getClass),
+        any(Ask[IO, TraceId].getClass)
+      )
+    ).thenReturn(IO.pure(readerWsmSamIds))
+    when(
+      mockAuthProvider.listResourceIds[WorkspaceResourceSamResourceId](isEq(false), isEq(userInfo))(
+        any(workspaceSamResourceAction.getClass),
+        any(AppSamResourceAction.getClass),
+        any(Decoder[WorkspaceResourceSamResourceId].getClass),
+        any(Ask[IO, TraceId].getClass)
+      )
+    ).thenReturn(IO.pure(readerWorkspaceSamIds))
+    when(
+      mockAuthProvider.listResourceIds[ProjectSamResourceId](isEq(false), isEq(userInfo))(
+        any(projectSamResourceAction.getClass),
+        any(AppSamResourceAction.getClass),
+        any(Decoder[ProjectSamResourceId].getClass),
+        any(Ask[IO, TraceId].getClass)
+      )
+    )
+      .thenReturn(IO.pure(readerProjectSamIds))
+    when(
+      mockAuthProvider.listResourceIds[WorkspaceResourceSamResourceId](isEq(true), isEq(userInfo))(
+        any(workspaceSamResourceAction.getClass),
+        any(AppSamResourceAction.getClass),
+        any(Decoder[WorkspaceResourceSamResourceId].getClass),
+        any(Ask[IO, TraceId].getClass)
+      )
+    )
+      .thenReturn(IO.pure(ownerWorkspaceSamIds))
+    when(
+      mockAuthProvider.listResourceIds[ProjectSamResourceId](isEq(true), isEq(userInfo))(
+        any(projectSamResourceAction.getClass),
+        any(AppSamResourceAction.getClass),
+        any(Decoder[ProjectSamResourceId].getClass),
+        any(Ask[IO, TraceId].getClass)
+      )
+    )
+      .thenReturn(IO.pure(ownerProjectSamIds))
+
+    mockAuthProvider
+  }
+
+  /**
+   * Generate a mocked AuthProvider which will permit action on the given resource IDs by the given user,
+   * when the list request is restricted to one workspace. Expects isUserWorkspace* instead of listResourceIds.
+   * TODO: cover actions beside `checkUserEnabled` and `listResourceIds`
+   *
+   * @param userInfo
+   * @param readerRuntimeSamIds
+   * @param readerWorkspaceSamIds
+   * @param readerProjectSamIds
+   * @param ownerWorkspaceSamIds
+   * @param ownerProjectSamIds
+   * @return
+   */
+  def mockAuthorizeForOneWorkspace(
+    userInfo: UserInfo,
+    readerRuntimeSamIds: Set[RuntimeSamResourceId] = Set.empty,
+    readerWsmSamIds: Set[WsmResourceSamResourceId] = Set.empty,
+    readerWorkspaceSamIds: Set[WorkspaceResourceSamResourceId] = Set.empty,
+    readerProjectSamIds: Set[ProjectSamResourceId] = Set.empty,
+    ownerWorkspaceSamIds: Set[WorkspaceResourceSamResourceId] = Set.empty,
+    ownerProjectSamIds: Set[ProjectSamResourceId] = Set.empty
+  ): AllowlistAuthProvider = {
+    val mockAuthProvider: AllowlistAuthProvider = mock[AllowlistAuthProvider](defaultMockitoAnswer[IO])
+
+    when(mockAuthProvider.checkUserEnabled(isEq(userInfo))(any)).thenReturn(IO.unit)
+    when(
+      mockAuthProvider.listResourceIds[RuntimeSamResourceId](isEq(true), isEq(userInfo))(
+        any(runtimeSamResourceAction.getClass),
+        any(AppSamResourceAction.getClass),
+        any(Decoder[RuntimeSamResourceId].getClass),
+        any(Ask[IO, TraceId].getClass)
+      )
+    ).thenReturn(IO.pure(readerRuntimeSamIds))
+    when(
+      mockAuthProvider.listResourceIds[WsmResourceSamResourceId](isEq(false), isEq(userInfo))(
+        any(wsmResourceSamResourceAction.getClass),
+        any(AppSamResourceAction.getClass),
+        any(Decoder[WsmResourceSamResourceId].getClass),
+        any(Ask[IO, TraceId].getClass)
+      )
+    ).thenReturn(IO.pure(readerWsmSamIds))
+    when(
+      mockAuthProvider.isUserWorkspaceReader(any, isEq(userInfo))(
+        any(Ask[IO, TraceId].getClass)
+      )
+    ).thenReturn(IO.pure(false))
+    when(
+      mockAuthProvider.isUserWorkspaceReader(argThat(readerWorkspaceSamIds.contains(_)), isEq(userInfo))(
+        any(Ask[IO, TraceId].getClass)
+      )
+    ).thenReturn(IO.pure(true))
+    when(
+      mockAuthProvider.listResourceIds[ProjectSamResourceId](isEq(false), isEq(userInfo))(
+        any(projectSamResourceAction.getClass),
+        any(AppSamResourceAction.getClass),
+        any(Decoder[ProjectSamResourceId].getClass),
+        any(Ask[IO, TraceId].getClass)
+      )
+    )
+      .thenReturn(IO.pure(readerProjectSamIds))
+    when(
+      mockAuthProvider.isUserWorkspaceOwner(any, isEq(userInfo))(
+        any(Ask[IO, TraceId].getClass)
+      )
+    ).thenReturn(IO.pure(false))
+    when(
+      mockAuthProvider.isUserWorkspaceOwner(argThat(ownerWorkspaceSamIds.contains(_)), isEq(userInfo))(
+        any(Ask[IO, TraceId].getClass)
+      )
+    ).thenReturn(IO.pure(true))
+    when(
+      mockAuthProvider.listResourceIds[ProjectSamResourceId](isEq(true), isEq(userInfo))(
+        any(projectSamResourceAction.getClass),
+        any(AppSamResourceAction.getClass),
+        any(Decoder[ProjectSamResourceId].getClass),
+        any(Ask[IO, TraceId].getClass)
+      )
+    )
+      .thenReturn(IO.pure(ownerProjectSamIds))
+
+    mockAuthProvider
+  }
+
   def mockUserInfo(email: String = userEmail.toString()): UserInfo =
     UserInfo(OAuth2BearerToken(""), WorkbenchUserId(s"userId-${email}"), WorkbenchEmail(email), 0)
 
   val runtimeV2Service =
     new RuntimeV2ServiceInterp[IO](
       serviceConfig,
+      allowListAuthProvider,
       QueueFactory.makePublisherQueue(),
       QueueFactory.makeDateAccessedQueue(),
       wsmClientProvider,
@@ -102,6 +288,7 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
   val runtimeV2Service2 =
     new RuntimeV2ServiceInterp[IO](
       serviceConfig,
+      allowListAuthProvider2,
       QueueFactory.makePublisherQueue(),
       QueueFactory.makeDateAccessedQueue(),
       wsmClientProvider,
@@ -357,8 +544,6 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
       _ <- persistentDiskQuery.updateStatus(disk.id, DiskStatus.Ready, now).transaction
 
       runtime <- clusterQuery.getClusterWithDiskId(disk.id).transaction
-      _ = when(samService.listResources(isEq(userInfo.accessToken.token), isEq(RuntimeSamResource.resourceType))(any()))
-        .thenReturn(IO.pure(List(runtime.get.internalId)))
 
       err <- runtimeV2Service
         .createRuntime(userInfo, name1, workspaceId, true, defaultCreateAzureRuntimeReq)
@@ -377,11 +562,6 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
     runtimeV2Service
       .createRuntime(userInfo, name0, workspaceId, false, defaultCreateAzureRuntimeReq)
       .unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
-    val runtime =
-      runtimeV2Service.getRuntime(userInfo, name0, workspaceId).unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
-
-    when(samService.listResources(isEq(userInfo.accessToken.token), isEq(RuntimeSamResource.resourceType))(any()))
-      .thenReturn(IO.pure(List(runtime.samResource.resourceId)))
 
     val exc = runtimeV2Service
       .createRuntime(userInfo, name2, workspaceId, false, defaultCreateAzureRuntimeReq)
@@ -1261,7 +1441,7 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
     when(samService.getUserEmail(userInfo3.accessToken.token)).thenReturn(IO.pure(userInfo3.userEmail))
 
     val publisherQueue = QueueFactory.makePublisherQueue()
-    val azureService = makeInterp(publisherQueue, samService = samService)
+    val azureService = makeInterp(publisherQueue)
 
     val res = for {
       context <- appContext.ask[AppContext]
@@ -1320,10 +1500,6 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
       preDeleteCluster_1 <- RuntimeServiceDbQueries.getActiveRuntimeRecord(workspaceId, runtimeName_1).transaction
       preDeleteCluster_2 <- RuntimeServiceDbQueries.getActiveRuntimeRecord(workspaceId, runtimeName_2).transaction
       preDeleteCluster_3 <- RuntimeServiceDbQueries.getActiveRuntimeRecord(workspaceId, runtimeName_3).transaction
-      _ = when(samService.listResources(isEq(userInfo.accessToken.token), isEq(RuntimeSamResource.resourceType))(any()))
-        .thenReturn(
-          IO.pure(List(preDeleteCluster_1.internalId, preDeleteCluster_2.internalId, preDeleteCluster_3.internalId))
-        )
 
       _ <- clusterQuery.updateClusterStatus(preDeleteCluster_1.id, RuntimeStatus.Deleted, context.now).transaction
       _ <- clusterQuery.updateClusterStatus(preDeleteCluster_2.id, RuntimeStatus.Running, context.now).transaction
@@ -1398,7 +1574,7 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
     when(samService.getUserEmail(userInfo2.accessToken.token)).thenReturn(IO.pure(userInfo2.userEmail))
 
     val publisherQueue = QueueFactory.makePublisherQueue()
-    val azureService = makeInterp(publisherQueue, samService = samService)
+    val azureService = makeInterp(publisherQueue)
 
     val res = for {
       context <- appContext.ask[AppContext]
@@ -1440,8 +1616,7 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
       _ <- clusterQuery.updateClusterStatus(preDeleteCluster_1.id, RuntimeStatus.Creating, context.now).transaction
       preDeleteCluster_2 = preDeleteClusterOpt_2.get
       _ <- clusterQuery.updateClusterStatus(preDeleteCluster_2.id, RuntimeStatus.Running, context.now).transaction
-      _ = when(samService.listResources(isEq(userInfo.accessToken.token), isEq(RuntimeSamResource.resourceType))(any()))
-        .thenReturn(IO.pure(List(preDeleteCluster_1.samResource.resourceId, preDeleteCluster_2.samResource.resourceId)))
+
       _ <- azureService.deleteAllRuntimes(userInfo, workspaceId, true)
 
     } yield ()
@@ -1460,7 +1635,15 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
     val samService = mock[SamService[IO]]
     when(samService.listResources(isEq(userInfo.accessToken.token), isEq(RuntimeSamResource.resourceType))(any()))
       .thenReturn(IO.pure(List(runtimeId1, runtimeId2)))
-    val testService = makeInterp(samService = samService)
+    val mockAuthProvider = mockAuthorize(
+      userInfo,
+      Set(RuntimeSamResourceId(runtimeId1), RuntimeSamResourceId(runtimeId2)),
+      Set.empty,
+      Set(WorkspaceResourceSamResourceId(WorkspaceId(UUID.fromString(workspaceIdAzure)))),
+      Set(ProjectSamResourceId(GoogleProject(projectIdGcp)))
+    )
+
+    val testService = makeInterp(authProvider = mockAuthProvider, samService = samService)
 
     val res = for {
       samResource1 <- IO(RuntimeSamResourceId(runtimeId1))
@@ -1501,6 +1684,171 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
     res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
+  it should "list runtimes, omitting runtimes for workspaces and projects user cannot read" in isolatedDbTest {
+    val runtimeId1 = UUID.randomUUID.toString
+    val runtimeId2 = UUID.randomUUID.toString
+    val runtimeId3 = UUID.randomUUID.toString
+    val runtimeId4 = UUID.randomUUID.toString
+    val projectIdGcp1 = "gcp-context-1"
+    val projectIdGcp2 = "gcp-context-2"
+    val workspaceIdAzure1 = UUID.randomUUID.toString
+    val workspaceIdAzure2 = UUID.randomUUID.toString
+
+    val userInfo = mockUserInfo("jerome@vore.gov")
+    val mockAuthProvider = mockAuthorize(
+      userInfo,
+      // user can read runtimes which are 'notebook-cluster' aka Runtimes
+      Set(RuntimeSamResourceId(runtimeId1), RuntimeSamResourceId(runtimeId2), RuntimeSamResourceId(runtimeId3)),
+      // user can read runtimes which are WsmResources
+      Set(
+        WsmResourceSamResourceId(WsmControlledResourceId(UUID.fromString(runtimeId3))),
+        WsmResourceSamResourceId(WsmControlledResourceId(UUID.fromString(runtimeId4)))
+      ),
+      // user can only read workspace1
+      Set(WorkspaceResourceSamResourceId(WorkspaceId(UUID.fromString(workspaceIdAzure1)))),
+      // user can only read project1
+      Set(ProjectSamResourceId(GoogleProject(projectIdGcp1)))
+    )
+    val testService = makeInterp(authProvider = mockAuthProvider)
+
+    val res = for {
+      // GCP runtime 1 (in project1): seen
+      samResource1 <- IO(RuntimeSamResourceId(runtimeId1))
+      runtime1 <- IO(
+        makeCluster(1)
+          .copy(samResource = samResource1, cloudContext = CloudContext.Gcp(GoogleProject(projectIdGcp1)))
+          .save()
+      )
+      // GCP runtime 2 (in project2): hidden
+      samResource2 <- IO(RuntimeSamResourceId(runtimeId2))
+      runtime2 <- IO(
+        makeCluster(2)
+          .copy(samResource = samResource2, cloudContext = CloudContext.Gcp(GoogleProject(projectIdGcp2)))
+          .save()
+      )
+      // Azure runtime 3 (in workspace1): seen
+      samResource3 <- IO(RuntimeSamResourceId(runtimeId3))
+      runtime3 <- IO(
+        makeCluster(3)
+          .copy(
+            samResource = samResource3,
+            cloudContext = CloudContext.Azure(CommonTestData.azureCloudContext),
+            workspaceId = Some(WorkspaceId(UUID.fromString(workspaceIdAzure1)))
+          )
+          .save()
+      )
+      // Azure runtime 4 (in workspace2): hidden
+      samResource4 <- IO(RuntimeSamResourceId(runtimeId4))
+      runtime4 <- IO(
+        makeCluster(4)
+          .copy(
+            samResource = samResource4,
+            cloudContext = CloudContext.Azure(CommonTestData.azureCloudContext),
+            workspaceId = Some(WorkspaceId(UUID.fromString(workspaceIdAzure2)))
+          )
+          .save()
+      )
+      listResponse <- testService.listRuntimes(userInfo, None, None, Map.empty)
+    } yield listResponse.map(_.samResource).toSet shouldBe Set(samResource1, samResource3)
+
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
+  }
+
+  it should "list runtimes given different user permissions" in isolatedDbTest {
+    forAll(
+      Table(
+        ("context", "runtimeAccess", "contextAccess", "isListed"),
+        // Any runtime access; no access to wrapper context => hidden
+        (TestContext.GoogleProject, TestRuntimeAccess.Nothing, TestContextAccess.Nothing, false),
+        (TestContext.GoogleWorkspace, TestRuntimeAccess.Nothing, TestContextAccess.Nothing, false),
+        (TestContext.AzureWorkspace, TestRuntimeAccess.Nothing, TestContextAccess.Nothing, false),
+        (TestContext.GoogleProject, TestRuntimeAccess.Reader, TestContextAccess.Nothing, false),
+        (TestContext.GoogleWorkspace, TestRuntimeAccess.Reader, TestContextAccess.Nothing, false),
+        (TestContext.AzureWorkspace, TestRuntimeAccess.Reader, TestContextAccess.Nothing, false),
+        // No access to runtime; read access to wrapper context => hidden
+        (TestContext.GoogleProject, TestRuntimeAccess.Nothing, TestContextAccess.Reader, false),
+        (TestContext.GoogleWorkspace, TestRuntimeAccess.Nothing, TestContextAccess.Reader, false),
+        (TestContext.AzureWorkspace, TestRuntimeAccess.Nothing, TestContextAccess.Reader, false),
+        // Read access to runtime; read access to wrapper context => shown
+        (TestContext.GoogleProject, TestRuntimeAccess.Reader, TestContextAccess.Reader, true),
+        (TestContext.GoogleWorkspace, TestRuntimeAccess.Reader, TestContextAccess.Reader, true),
+        (TestContext.AzureWorkspace, TestRuntimeAccess.Reader, TestContextAccess.Reader, true),
+        // Any runtime access; owner of wrapper context => shown
+        (TestContext.GoogleProject, TestRuntimeAccess.Nothing, TestContextAccess.Owner, true),
+        (TestContext.GoogleWorkspace, TestRuntimeAccess.Nothing, TestContextAccess.Owner, true),
+        (TestContext.AzureWorkspace, TestRuntimeAccess.Nothing, TestContextAccess.Owner, true),
+        (TestContext.GoogleProject, TestRuntimeAccess.Reader, TestContextAccess.Owner, true),
+        (TestContext.GoogleWorkspace, TestRuntimeAccess.Reader, TestContextAccess.Owner, true),
+        (TestContext.AzureWorkspace, TestRuntimeAccess.Reader, TestContextAccess.Owner, true)
+      )
+    ) {
+      (
+        context: TestContext.Context,
+        runtimeAccess: TestRuntimeAccess.Role,
+        contextAccess: TestContextAccess.Role,
+        isListed: Boolean
+      ) =>
+        val runtimeId = UUID.randomUUID.toString
+        val contextId = UUID.randomUUID.toString
+
+        val userInfo = mockUserInfo("jerome@vore.gov")
+        val mockAuthProvider = mockAuthorize(
+          userInfo,
+          readerRuntimeSamIds = Set(RuntimeSamResourceId(runtimeId))
+            .filter(_ => runtimeAccess == TestRuntimeAccess.Reader),
+          Set.empty,
+          readerWorkspaceSamIds = Set(WorkspaceResourceSamResourceId(WorkspaceId(UUID.fromString(contextId))))
+            .filter(_ => context != TestContext.GoogleProject && contextAccess != TestContextAccess.Nothing),
+          readerProjectSamIds = Set(ProjectSamResourceId(GoogleProject(contextId)))
+            .filter(_ => context == TestContext.GoogleProject && contextAccess != TestContextAccess.Nothing),
+          ownerWorkspaceSamIds = Set(WorkspaceResourceSamResourceId(WorkspaceId(UUID.fromString(contextId))))
+            .filter(_ => context != TestContext.GoogleProject && contextAccess == TestContextAccess.Owner),
+          ownerProjectSamIds = Set(ProjectSamResourceId(GoogleProject(contextId)))
+            .filter(_ => context == TestContext.GoogleProject && contextAccess == TestContextAccess.Owner)
+        )
+        val testService = makeInterp(authProvider = mockAuthProvider)
+
+        val res = for {
+          projectRuntime <- IO(
+            makeCluster(1)
+              .copy(
+                samResource = RuntimeSamResourceId(runtimeId),
+                cloudContext = CloudContext.Gcp(GoogleProject(contextId))
+              )
+          )
+          googleWorkspaceRuntime <- IO(
+            makeCluster(2)
+              .copy(
+                samResource = RuntimeSamResourceId(runtimeId),
+                cloudContext = CloudContext.Gcp(GoogleProject(contextId)),
+                workspaceId = Some(WorkspaceId(UUID.fromString(contextId)))
+              )
+          )
+          azureWorkspaceRuntime <- IO(
+            makeCluster(3)
+              .copy(
+                samResource = RuntimeSamResourceId(runtimeId),
+                cloudContext = CloudContext.Azure(
+                  AzureCloudContext(TenantId(contextId), SubscriptionId(contextId), ManagedResourceGroupName(contextId))
+                ),
+                workspaceId = Some(WorkspaceId(UUID.fromString(contextId)))
+              )
+          )
+          runtime = context match {
+            case TestContext.GoogleProject   => projectRuntime
+            case TestContext.GoogleWorkspace => googleWorkspaceRuntime
+            case TestContext.AzureWorkspace  => azureWorkspaceRuntime
+          }
+          _ = runtime.save()
+          expectedResults = if (isListed) Set(runtime.samResource) else Set.empty
+
+          listResponse <- testService.listRuntimes(userInfo, None, None, Map.empty)
+        } yield listResponse.map(_.samResource).toSet shouldBe expectedResults
+
+        res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
+    }
+  }
+
   it should "list runtimes with a workspace and/or cloudProvider" in isolatedDbTest {
     val runtimeId1 = UUID.randomUUID.toString
     val runtimeId2 = UUID.randomUUID.toString
@@ -1513,11 +1861,45 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
     val workspaceId2 = UUID.randomUUID.toString
     val workspaceId3 = UUID.randomUUID.toString
 
-    val samService = mock[SamService[IO]]
-    when(samService.listResources(any(), isEq(RuntimeSamResource.resourceType))(any()))
-      .thenReturn(IO.pure(List(runtimeId1, runtimeId2, runtimeId3, runtimeId4, runtimeId5)))
-
-    val testService = makeInterp(samService = samService)
+    val userInfo = mockUserInfo("jerome@vore.gov")
+    val mockAuthProvider = mockAuthorize(
+      userInfo,
+      // user can read runtimes 3, 4, and 5
+      Set(RuntimeSamResourceId(runtimeId3), RuntimeSamResourceId(runtimeId4), RuntimeSamResourceId(runtimeId5)),
+      Set.empty,
+      // user can read all workspaces
+      Set(
+        WorkspaceResourceSamResourceId(WorkspaceId(UUID.fromString(workspaceId1))),
+        WorkspaceResourceSamResourceId(WorkspaceId(UUID.fromString(workspaceId2))),
+        WorkspaceResourceSamResourceId(WorkspaceId(UUID.fromString(workspaceId3)))
+      ),
+      // user can read all projects
+      Set(ProjectSamResourceId(GoogleProject(projectIdGcp1)), ProjectSamResourceId(GoogleProject(projectIdGcp2))),
+      // user owns workspace 1
+      Set(WorkspaceResourceSamResourceId(WorkspaceId(UUID.fromString(workspaceId1)))),
+      // user owns project 1
+      Set(ProjectSamResourceId(GoogleProject(projectIdGcp1)))
+    )
+    val mockAuthProviderForOneWorkspace = mockAuthorizeForOneWorkspace(
+      userInfo,
+      // user can read runtimes 3, 4, and 5
+      Set(RuntimeSamResourceId(runtimeId3), RuntimeSamResourceId(runtimeId4), RuntimeSamResourceId(runtimeId5)),
+      Set.empty,
+      // user can read all workspaces
+      Set(
+        WorkspaceResourceSamResourceId(WorkspaceId(UUID.fromString(workspaceId1))),
+        WorkspaceResourceSamResourceId(WorkspaceId(UUID.fromString(workspaceId2))),
+        WorkspaceResourceSamResourceId(WorkspaceId(UUID.fromString(workspaceId3)))
+      ),
+      // user can read all projects
+      Set(ProjectSamResourceId(GoogleProject(projectIdGcp1)), ProjectSamResourceId(GoogleProject(projectIdGcp2))),
+      // user owns workspace 1
+      Set(WorkspaceResourceSamResourceId(WorkspaceId(UUID.fromString(workspaceId1)))),
+      // user owns project 1
+      Set(ProjectSamResourceId(GoogleProject(projectIdGcp1)))
+    )
+    val testService = makeInterp(authProvider = mockAuthProvider)
+    val testServiceForOneWorkspace = makeInterp(authProvider = mockAuthProviderForOneWorkspace)
 
     val res = for {
       samResource1 <- IO(RuntimeSamResourceId(runtimeId1))
@@ -1588,41 +1970,38 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
           .save()
       )
 
-      responseIdsWorkspace1 <- testService.listRuntimes(userInfo, Some(workspace1), None, Map.empty)
-      responseIdsWorkspace2 <- testService.listRuntimes(userInfo, Some(workspace2), None, Map.empty)
-      responseIdsWorkspace3 <- testService.listRuntimes(userInfo, Some(workspace3), None, Map.empty)
-      responseIdsAzure <- testService.listRuntimes(userInfo, None, Some(CloudProvider.Azure), Map.empty)
-      responseIdsGcp <- testService.listRuntimes(userInfo, None, Some(CloudProvider.Gcp), Map.empty)
-      responseIdsAzureWorkspace1 <- testService.listRuntimes(userInfo,
-                                                             Some(workspace1),
-                                                             Some(CloudProvider.Azure),
-                                                             Map.empty
-      )
-      responseIdsAzureWorkspace2 <- testService.listRuntimes(userInfo,
-                                                             Some(workspace2),
-                                                             Some(CloudProvider.Azure),
-                                                             Map.empty
-      )
-      responseIdsGcpWorkspace1 <- testService.listRuntimes(userInfo,
-                                                           Some(workspace1),
-                                                           Some(CloudProvider.Gcp),
-                                                           Map.empty
-      )
-      responseIdsGcpWorkspace2 <- testService.listRuntimes(userInfo,
-                                                           Some(workspace2),
-                                                           Some(CloudProvider.Gcp),
-                                                           Map.empty
-      )
+      // Test the service call and pluck Sam resource IDs to compare with expected results
+      getResultIds = (
+        userInfo: UserInfo,
+        workspaceId: Option[WorkspaceId],
+        cloudProvider: Option[CloudProvider],
+        params: Map[String, String]
+      ) => {
+        val service = if (workspaceId.isEmpty) testService else testServiceForOneWorkspace
+        service
+          .listRuntimes(userInfo, workspaceId, cloudProvider, params)
+          .flatMap(result => IO(result.map(_.samResource).toSet))
+      }
+
+      responseIdsWorkspace1 <- getResultIds(userInfo, Some(workspace1), None, Map.empty)
+      responseIdsWorkspace2 <- getResultIds(userInfo, Some(workspace2), None, Map.empty)
+      responseIdsWorkspace3 <- getResultIds(userInfo, Some(workspace3), None, Map.empty)
+      responseIdsAzure <- getResultIds(userInfo, None, Some(CloudProvider.Azure), Map.empty)
+      responseIdsGcp <- getResultIds(userInfo, None, Some(CloudProvider.Gcp), Map.empty)
+      responseIdsAzureWorkspace1 <- getResultIds(userInfo, Some(workspace1), Some(CloudProvider.Azure), Map.empty)
+      responseIdsAzureWorkspace2 <- getResultIds(userInfo, Some(workspace2), Some(CloudProvider.Azure), Map.empty)
+      responseIdsGcpWorkspace1 <- getResultIds(userInfo, Some(workspace1), Some(CloudProvider.Gcp), Map.empty)
+      responseIdsGcpWorkspace2 <- getResultIds(userInfo, Some(workspace2), Some(CloudProvider.Gcp), Map.empty)
     } yield {
-      responseIdsWorkspace1.map(_.samResource).toSet shouldBe Set(samResource1)
-      responseIdsWorkspace2.map(_.samResource).toSet shouldBe Set(samResource2, samResource3)
-      responseIdsWorkspace3.map(_.samResource).toSet shouldBe Set(samResource4)
-      responseIdsAzure.map(_.samResource).toSet shouldBe Set(samResource1, samResource4)
-      responseIdsGcp.map(_.samResource).toSet shouldBe Set(samResource2, samResource3, samResource5)
-      responseIdsAzureWorkspace1.map(_.samResource).toSet shouldBe Set(samResource1)
-      responseIdsAzureWorkspace2.map(_.samResource).toSet shouldBe Set.empty
-      responseIdsGcpWorkspace1.map(_.samResource).toSet shouldBe Set.empty
-      responseIdsGcpWorkspace2.map(_.samResource).toSet shouldBe Set(samResource2, samResource3)
+      responseIdsWorkspace1 shouldBe Set(samResource1)
+      responseIdsWorkspace2 shouldBe Set(samResource2, samResource3)
+      responseIdsWorkspace3 shouldBe Set(samResource4)
+      responseIdsAzure shouldBe Set(samResource1, samResource4)
+      responseIdsGcp shouldBe Set(samResource2, samResource3, samResource5)
+      responseIdsAzureWorkspace1 shouldBe Set(samResource1)
+      responseIdsAzureWorkspace2 shouldBe Set.empty
+      responseIdsGcpWorkspace1 shouldBe Set.empty
+      responseIdsGcpWorkspace2 shouldBe Set(samResource2, samResource3)
     }
 
     res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
@@ -1632,11 +2011,16 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
     val runtimeId1 = RuntimeSamResourceId(UUID.randomUUID.toString)
     val runtimeId2 = RuntimeSamResourceId(UUID.randomUUID.toString)
     val workspaceId1 = WorkspaceId(UUID.randomUUID)
-
-    val samService = mock[SamService[IO]]
-    when(samService.listResources(any(), isEq(RuntimeSamResource.resourceType))(any()))
-      .thenReturn(IO.pure(List(runtimeId1.resourceId, runtimeId2.resourceId)))
-    val testService = makeInterp(samService = samService)
+    val userInfo = mockUserInfo("karen@styx.hel")
+    val mockAuthProvider = mockAuthorize(
+      userInfo,
+      // can read all runtimes
+      Set(runtimeId1, runtimeId2),
+      Set.empty,
+      // can read all workspaces
+      Set(WorkspaceResourceSamResourceId(workspaceId1))
+    )
+    val testService = makeInterp(authProvider = mockAuthProvider)
     val res = for {
       samResource1 <- IO(runtimeId1)
       samResource2 <- IO(runtimeId2)
@@ -1705,13 +2089,15 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
     val workspaceId1 = WorkspaceId(UUID.randomUUID)
     val userInfoCreator = mockUserInfo("karen@styx.hel")
     val userInfoOther = mockUserInfo("mike@heavn.io")
-    val samService = mock[SamService[IO]]
-    when(
-      samService.listResources(isEq(userInfoCreator.accessToken.token), isEq(RuntimeSamResource.resourceType))(any())
+    val mockAuthProvider = mockAuthorize(
+      userInfoCreator,
+      // user has auth permission for runtime1
+      Set.empty,
+      Set(wsmId1),
+      // user can read workspace1
+      Set(WorkspaceResourceSamResourceId(workspaceId1))
     )
-      .thenReturn(IO.pure(List(wsmId1.resourceId, runtimeId3.resourceId)))
-
-    val testService = makeInterp(samService = samService)
+    val testService = makeInterp(authProvider = mockAuthProvider)
     val res = for {
       // runtime 1: I created, in a workspace I can read => visible
       samResource1 <- IO(RuntimeSamResourceId(wsmId1.resourceId.toString))
@@ -1721,7 +2107,7 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
           .save()
       )
 
-      // runtime 2: I created, but I don't have permission => hidden
+      // runtime 2: I created, but in a workspace I cannot read, and I DO NOT HAVE SAM PERMISSION => hidden
       samResource2 <- IO(runtimeId2)
       runtime2 <- IO(
         makeCluster(2, Some(userInfoCreator.userEmail))
@@ -1729,7 +2115,7 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
           .save()
       )
 
-      // runtime 3: someone else created, but I can read => hidden if role=creator, else visible
+      // runtime 3: someone else created, in a workspace I can read => hidden
       samResource3 <- IO(runtimeId3)
       runtime3 <- IO(
         makeCluster(3, Some(userInfoOther.userEmail))
@@ -1737,11 +2123,19 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
           .save()
       )
 
+      // runtime 4: I created, in a workspace I can read, and I DO NOT HAVE SAM PERMISSION => seen if role=creator, else hid
+      samResource4 <- IO(runtimeId4)
+      runtime4 <- IO(
+        makeCluster(4, Some(userInfoCreator.userEmail))
+          .copy(samResource = samResource4, workspaceId = Some(workspaceId1))
+          .save()
+      )
+
       listResponseCreator <- testService.listRuntimes(userInfoCreator, None, None, Map("role" -> "creator"))
       listResponseAny <- testService.listRuntimes(userInfoCreator, None, None, Map.empty)
     } yield {
-      listResponseCreator.map(_.samResource).toSet shouldBe Set(samResource1)
-      listResponseAny.map(_.samResource).toSet shouldBe Set(samResource1, samResource3)
+      listResponseCreator.map(_.samResource).toSet shouldBe Set(samResource1, samResource4)
+      listResponseAny.map(_.samResource).toSet shouldBe Set(samResource1)
     }
 
     res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
@@ -1754,11 +2148,17 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
     val runtimeId2 = RuntimeSamResourceId(UUID.randomUUID.toString)
     val workspaceId1 = WorkspaceId(UUID.randomUUID)
     val userInfo = mockUserInfo("karen@styx.hel")
-    val samService = mock[SamService[IO]]
-    when(samService.listResources(isEq(userInfo.accessToken.token), isEq(RuntimeSamResource.resourceType))(any()))
-      .thenReturn(IO.pure(List(runtimeId1.resourceId, runtimeId2.resourceId)))
-
-    val testService = makeInterp(samService = samService)
+    val mockAuthProvider = mockAuthorize(
+      userInfo,
+      // can read all runtimes
+      Set(runtimeId1, runtimeId2),
+      Set.empty,
+      // can read workspace
+      Set(WorkspaceResourceSamResourceId(workspaceId1)),
+      // owns workspace
+      ownerWorkspaceSamIds = Set(WorkspaceResourceSamResourceId(workspaceId1))
+    )
+    val testService = makeInterp(authProvider = mockAuthProvider)
 
     // Make runtimes belonging to different users than the calling user
     val res = for {

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeV2ServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeV2ServiceInterpSpec.scala
@@ -80,13 +80,7 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
     wsmClientProvider: WsmApiClientProvider[IO] = wsmClientProvider,
     samService: SamService[IO] = MockSamService
   ) =
-    new RuntimeV2ServiceInterp[IO](serviceConfig,
-                                   authProvider,
-                                   queue,
-                                   dateAccessedQueue,
-                                   wsmClientProvider,
-      samService
-    )
+    new RuntimeV2ServiceInterp[IO](serviceConfig, authProvider, queue, dateAccessedQueue, wsmClientProvider, samService)
 
   // need to set previous runtime to deleted status before creating next to avoid exception
   def setRuntimeDeleted(workspaceId: WorkspaceId, name: RuntimeName): IO[Long] =


### PR DESCRIPTION
This reverts commit 1030a2c8ae0534303a1ca099b372167eaaf954fa.

This wasn't the cleanest revert since some of the dependencies required to revert had been removed in a separate [PR](https://github.com/DataBiosphere/leonardo/pull/4820).

<!-- Welcome to your Leonardo pull request! -->
<!-- Contributor guidelines: https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md -->

__Jira ticket__: https://broadworkbench.atlassian.net/browse/[ticket_number]

<!-- ## Dependencies -->
<!-- Include any dependent tickets and describe the relationship. Include any other relevant Jira tickets. -->

## Summary of changes

<!-- Please give an abridged version of the ticket description here and/or fill out the following fields. -->

### What

-

### Why

-

## Testing these changes

### What to test

- <!-- Test case 1 -->

<!-- ### Test data -->

### Who tested and where

- [ ] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [ ] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
