### PR TITLE
Revert "[AN-347] Bump up helm scala sdk and GKE k8s versions to latest (1.30)"

### DIFF
--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -723,7 +723,7 @@ gke {
                           "69.173.112.0/21"
     ]
     # See https://cloud.google.com/kubernetes-engine/docs/release-notes
-    version = "1.30"
+    version = "1.28"
     nodepoolLockCacheExpiryTime = 1 hour
     nodepoolLockCacheMaxSize = 200
 

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/config/ConfigSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/config/ConfigSpec.scala
@@ -84,7 +84,7 @@ final class ConfigSpec extends AnyFlatSpec with Matchers {
         "69.173.127.240/28",
         "69.173.112.0/21"
       ).map(CidrIP),
-      KubernetesClusterVersion("1.30"),
+      KubernetesClusterVersion("1.28"),
       1 hour,
       200,
       AutopilotConfig(AutopilotResource(500, 3, 1), AutopilotResource(500, 3, 1))

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -26,7 +26,7 @@ object Dependencies {
   val workbenchOauth2V = "0.8-3e0cf25"
   val workbenchAzureV = s"0.8-$workbenchLibsHash"
 
-  val helmScalaSdkV = "0.0.9.0"
+  val helmScalaSdkV = "0.0.8.5"
 
   val excludeAkkaHttp = ExclusionRule(organization = "com.typesafe.akka", name = s"akka-http_${scalaV}")
   val excludeAkkaStream = ExclusionRule(organization = "com.typesafe.akka", name = s"akka-stream_${scalaV}")


### PR DESCRIPTION
Reverts DataBiosphere/leonardo#4724

I need to revert for now because it looks like the GHA runner is on go 1.20, not 1.22... 
https://github.com/broadinstitute/terra-github-workflows/actions/runs/12915723605/job/36018236013

Not sure why this failed when merging to Dev instead of the PR but better safe than sorry