### PR TITLE
[AN-385] Move listRuntimes over to new Sam permissions model - take 2

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/Leonardo.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/Leonardo.scala
@@ -64,11 +64,11 @@ object Leonardo extends RestClient with LazyLogging {
       s"api/google${versionPath}/runtimes/${googleProject.value}/${runtimeName.asString}"
     }
 
-    def listIncludingDeletedRuntime(
+    def listRuntime(
       googleProject: GoogleProject
     )(implicit token: AuthToken): Seq[ListRuntimeResponseCopy] = {
-      val path = s"api/google/v1/runtimes/${googleProject.value}?includeDeleted=true"
-      logger.info(s"Listing runtimes including deleted in project: GET /$path")
+      val path = s"api/google/v1/runtimes/${googleProject.value}"
+      logger.info(s"Listing runtimes in project: GET /$path")
       val parsedRequest = parseResponse(getRequest(s"$url/$path"))
       handleListRuntimeResponse(parsedRequest)
     }

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoApiClient.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoApiClient.scala
@@ -458,15 +458,10 @@ object LeonardoApiClient {
     } yield r
 
   def listDisk(
-    googleProject: GoogleProject,
-    includeDeleted: Boolean = false
+    googleProject: GoogleProject
   )(implicit client: Client[IO], authorization: IO[Authorization]): IO[List[ListPersistentDiskResponse]] = {
     val uriWithoutQueryParam = rootUri
       .withPath(Uri.Path.unsafeFromString(s"/api/google/v1/disks/${googleProject.value}"))
-
-    val uri =
-      if (includeDeleted) uriWithoutQueryParam.withQueryParam("includeDeleted", "true")
-      else uriWithoutQueryParam
 
     for {
       traceIdHeader <- genTraceIdHeader()
@@ -475,7 +470,7 @@ object LeonardoApiClient {
         Request[IO](
           method = Method.GET,
           headers = Headers(authHeader, traceIdHeader),
-          uri = uri
+          uri = uriWithoutQueryParam
         )
       )(onError(s"Failed to list disks in project ${googleProject.value}"))
     } yield r

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoTestUtils.scala
@@ -404,7 +404,7 @@ trait LeonardoTestUtils
     implicit val patienceConfig: PatienceConfig = clusterPatience
     eventually {
       val allStatus: Set[ClusterStatus] = Leonardo.cluster
-        .listIncludingDeletedRuntime(googleProject)
+        .listRuntime(googleProject)
         .filter(c => c.runtimeName == runtimeName && c.googleProject == googleProject)
         .map(_.status)
         .toSet

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeCreationDiskSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/runtimes/RuntimeCreationDiskSpec.scala
@@ -173,10 +173,9 @@ class RuntimeCreationDiskSpec extends BillingProjectFixtureSpec with ParallelTes
         _ <- IO(disk.status shouldBe DiskStatus.Ready)
         _ <- IO(disk.size shouldBe diskSize)
         _ <- LeonardoApiClient.deleteDiskWithWait(googleProject, diskName)
-        listofDisks <- LeonardoApiClient.listDisk(googleProject, true)
-      } yield listofDisks.collect { case resp if resp.name == diskName => resp.status } shouldBe List(
-        DiskStatus.Deleted
-      ) // assume we won't have multiple disks with same name in the same project in tests
+        listofDisks <- LeonardoApiClient.listDisk(googleProject)
+      } yield listofDisks.collect { case resp if resp.name == diskName => resp.status } shouldBe List.empty
+      // assume we won't have multiple disks with same name in the same project in tests
     }
     res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }

--- a/http/src/main/resources/swagger/api-docs.yaml
+++ b/http/src/main/resources/swagger/api-docs.yaml
@@ -170,13 +170,6 @@ paths:
           required: false
           schema:
             type: string
-        - in: query
-          name: includeDeleted
-          description: Optional filter that includes any runtimes with a Deleted status.
-          required: false
-          schema:
-            type: boolean
-            default: false
       responses:
         "200":
           description: List of runtimes
@@ -225,13 +218,6 @@ paths:
           required: false
           schema:
             type: string
-        - in: query
-          name: includeDeleted
-          description: Optional filter that includes any runtimes with a Deleted status.
-          required: false
-          schema:
-            type: boolean
-            default: false
       responses:
         "200":
           description: List of runtimes
@@ -539,13 +525,6 @@ paths:
           schema:
             type: string
         - in: query
-          name: includeDeleted
-          description: Optional filter that includes any runtimes with a Deleted status.
-          required: false
-          schema:
-            type: boolean
-            default: false
-        - in: query
           name: includeLabels
           description: >
             Optional label keys of the labels returned in response. Example:
@@ -603,13 +582,6 @@ paths:
           schema:
             type: string
         - in: query
-          name: includeDeleted
-          description: Optional filter that includes any runtimes with a Deleted status.
-          required: false
-          schema:
-            type: boolean
-            default: false
-        - in: query
           name: includeLabels
           description: >
             Optional label keys of the labels returned in response. Example:
@@ -666,13 +638,6 @@ paths:
           required: false
           schema:
             type: string
-        - in: query
-          name: includeDeleted
-          description: Optional filter that includes any runtimes with a Deleted status.
-          required: false
-          schema:
-            type: boolean
-            default: false
         - in: query
           name: includeLabels
           description: >

--- a/http/src/main/resources/swagger/api-docs.yaml
+++ b/http/src/main/resources/swagger/api-docs.yaml
@@ -989,13 +989,6 @@ paths:
           schema:
             type: string
         - in: query
-          name: includeDeleted
-          description: Optional filter that includes any persistent disks with a Deleted status.
-          required: false
-          schema:
-            type: boolean
-            default: false
-        - in: query
           name: includeLabels
           description: >
             Optional label keys of the labels returned in response. Example:
@@ -1058,13 +1051,6 @@ paths:
           required: false
           schema:
             type: string
-        - in: query
-          name: includeDeleted
-          description: Optional filter that includes any persistent disks with a Deleted status.
-          required: false
-          schema:
-            type: boolean
-            default: false
         - in: query
           name: includeLabels
           description: >
@@ -1357,13 +1343,6 @@ paths:
           required: false
           schema:
             type: string
-        - in: query
-          name: includeDeleted
-          description: Optional filter that includes any apps with a Deleted status.
-          required: false
-          schema:
-            type: boolean
-            default: false
         - in: query
           name: includeLabels
           description: >

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/sam/SamUtils.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/sam/SamUtils.scala
@@ -5,6 +5,8 @@ import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import cats.effect.Async
 import cats.implicits.{catsSyntaxApplicativeError, toFlatMapOps}
 import cats.mtl.Ask
+import org.broadinstitute.dsde.workbench.google2.DiskName
+import org.broadinstitute.dsde.workbench.leonardo.http.service.{DiskNotFoundByIdException, DiskNotFoundException}
 import org.broadinstitute.dsde.workbench.leonardo.model.{
   ForbiddenError,
   LeoException,
@@ -14,66 +16,110 @@ import org.broadinstitute.dsde.workbench.leonardo.model.{
 import org.broadinstitute.dsde.workbench.leonardo.{
   AppContext,
   CloudContext,
+  DiskId,
+  PersistentDiskAction,
   RuntimeAction,
   RuntimeName,
+  SamResourceAction,
   SamResourceId,
   WorkspaceId
 }
-import org.broadinstitute.dsde.workbench.model.{UserInfo, WorkbenchEmail}
+import org.broadinstitute.dsde.workbench.model.{TraceId, UserInfo, WorkbenchEmail}
 
-trait SamUtils[F[_]] {
-  val samService: SamService[F]
-
-  def checkRuntimeAction(userInfo: UserInfo,
-                         cloudContext: CloudContext,
-                         runtimeName: RuntimeName,
-                         samResourceId: SamResourceId,
-                         action: RuntimeAction,
-                         userEmail: Option[WorkbenchEmail] = None
+object SamUtils {
+  def checkRuntimeAction[F[_]](samService: SamService[F],
+                               userInfo: UserInfo,
+                               cloudContext: CloudContext,
+                               runtimeName: RuntimeName,
+                               samResourceId: SamResourceId,
+                               action: RuntimeAction,
+                               userEmail: Option[WorkbenchEmail] = None
   )(implicit F: Async[F], as: Ask[F, AppContext]): F[Unit] =
-    checkRuntimeActionInternal(
+    checkActionInternal(
+      samService,
       userInfo.accessToken,
       userEmail.getOrElse(userInfo.userEmail),
       samResourceId,
       action,
+      RuntimeAction.GetRuntimeStatus,
       RuntimeNotFoundException(cloudContext, runtimeName, "Not found in database")
     )
 
-  def checkRuntimeAction(userInfo: UserInfo,
-                         workspaceId: WorkspaceId,
-                         runtimeName: RuntimeName,
-                         samResourceId: SamResourceId,
-                         action: RuntimeAction
+  def checkRuntimeAction[F[_]](samService: SamService[F],
+                               userInfo: UserInfo,
+                               workspaceId: WorkspaceId,
+                               runtimeName: RuntimeName,
+                               samResourceId: SamResourceId,
+                               action: RuntimeAction
   )(implicit F: Async[F], as: Ask[F, AppContext]): F[Unit] =
-    checkRuntimeActionInternal(
+    checkActionInternal(
+      samService,
       userInfo.accessToken,
       userInfo.userEmail,
       samResourceId,
       action,
+      RuntimeAction.GetRuntimeStatus,
       RuntimeNotFoundByWorkspaceIdException(workspaceId, runtimeName, "Not found in database")
     )
 
-  private def checkRuntimeActionInternal(userToken: OAuth2BearerToken,
-                                         userEmail: WorkbenchEmail,
-                                         samResourceId: SamResourceId,
-                                         action: RuntimeAction,
-                                         notFoundException: LeoException
+  def checkDiskAction[F[_]](samService: SamService[F],
+                            userInfo: UserInfo,
+                            cloudContext: CloudContext,
+                            diskName: DiskName,
+                            samResourceId: SamResourceId,
+                            action: SamResourceAction,
+                            traceId: TraceId
+  )(implicit F: Async[F], as: Ask[F, AppContext]): F[Unit] =
+    checkActionInternal(
+      samService,
+      userInfo.accessToken,
+      userInfo.userEmail,
+      samResourceId,
+      action,
+      PersistentDiskAction.ReadPersistentDisk,
+      DiskNotFoundException(cloudContext, diskName, traceId)
+    )
+
+  def checkDiskAction[F[_]](samService: SamService[F],
+                            userInfo: UserInfo,
+                            diskId: DiskId,
+                            samResourceId: SamResourceId,
+                            action: SamResourceAction,
+                            traceId: TraceId
+  )(implicit F: Async[F], as: Ask[F, AppContext]): F[Unit] =
+    checkActionInternal(
+      samService,
+      userInfo.accessToken,
+      userInfo.userEmail,
+      samResourceId,
+      action,
+      PersistentDiskAction.ReadPersistentDisk,
+      DiskNotFoundByIdException(diskId, traceId)
+    )
+
+  private def checkActionInternal[F[_]](samService: SamService[F],
+                                        userToken: OAuth2BearerToken,
+                                        userEmail: WorkbenchEmail,
+                                        samResourceId: SamResourceId,
+                                        actionToCheck: SamResourceAction,
+                                        resourceReadAction: SamResourceAction,
+                                        notFoundException: LeoException
   )(implicit F: Async[F], as: Ask[F, AppContext]): F[Unit] =
     samService
-      .checkAuthorized(userToken.token, samResourceId, action)
+      .checkAuthorized(userToken.token, samResourceId, actionToCheck)
       .handleErrorWith {
-        // If we've already checked read access and the user doesn't have it, pretend the runtime doesn't exist to avoid leaking its existence
-        case e: SamException if e.statusCode == StatusCodes.Forbidden && action == RuntimeAction.GetRuntimeStatus =>
+        // If we've already checked read access and the user doesn't have it, pretend the resource doesn't exist to avoid leaking its existence
+        case e: SamException if e.statusCode == StatusCodes.Forbidden && actionToCheck == resourceReadAction =>
           F.raiseError(notFoundException)
-        // Check if the user can read the runtime to determine which error to raise
+        // Check if the user can read the resource to determine which error to raise
         case e: SamException if e.statusCode == StatusCodes.Forbidden =>
           samService
-            .checkAuthorized(userToken.token, samResourceId, RuntimeAction.GetRuntimeStatus)
+            .checkAuthorized(userToken.token, samResourceId, resourceReadAction)
             .attempt
             .flatMap {
-              // The user can read the runtime, but they don't have the required action. Raise the original Forbidden action from Sam
+              // The user can read the resource, but they don't have the required action. Raise the original Forbidden action from Sam
               case Right(_) => F.raiseError(ForbiddenError(userEmail))
-              // The user can't read the runtime, pretend it doesn't exist to avoid leaking its existence
+              // The user can't read the resource, pretend it doesn't exist to avoid leaking its existence
               case Left(_) => F.raiseError(notFoundException)
             }
       }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/DiskServiceDbQueries.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/DiskServiceDbQueries.scala
@@ -10,29 +10,52 @@ import org.broadinstitute.dsde.workbench.leonardo.db.persistentDiskQuery.unmarsh
 import org.broadinstitute.dsde.workbench.leonardo.http.{GetPersistentDiskResponse, GetPersistentDiskV2Response}
 import org.broadinstitute.dsde.workbench.leonardo.http.service.{DiskNotFoundByIdException, DiskNotFoundException}
 import org.broadinstitute.dsde.workbench.model.{TraceId, WorkbenchEmail}
+import org.broadinstitute.dsde.workbench.leonardo.SamResourceId.PersistentDiskSamResourceId
 
 import scala.concurrent.ExecutionContext
 
 object DiskServiceDbQueries {
 
-  def listDisks(labelMap: LabelMap,
-                includeDeleted: Boolean,
-                creatorOnly: Option[WorkbenchEmail],
-                cloudContextOpt: Option[CloudContext] = None,
-                workspaceOpt: Option[WorkspaceId] = None
+  def listDisksBySamIds(samDiskResourceIds: List[PersistentDiskSamResourceId],
+                        labelMap: LabelMap,
+                        creatorOnly: Option[WorkbenchEmail],
+                        cloudContextOpt: Option[CloudContext] = None,
+                        workspaceOpt: Option[WorkspaceId] = None
+  )(implicit
+    ec: ExecutionContext
+  ): DBIO[List[PersistentDisk]] = {
+    val listDiskQuery = persistentDiskQuery.tableQuery.filter(_.samResourceId inSetBind samDiskResourceIds)
+
+    filterListDisks(listDiskQuery, labelMap, creatorOnly, cloudContextOpt, workspaceOpt)
+  }
+  def listDisks(
+    labelMap: LabelMap,
+    creatorOnly: Option[WorkbenchEmail],
+    cloudContextOpt: Option[CloudContext] = None,
+    workspaceOpt: Option[WorkspaceId] = None
+  )(implicit
+    ec: ExecutionContext
+  ): DBIO[List[PersistentDisk]] =
+    filterListDisks(persistentDiskQuery.tableQuery, labelMap, creatorOnly, cloudContextOpt, workspaceOpt)
+
+  private def filterListDisks(
+    baseQuery: Query[PersistentDiskTable, PersistentDiskRecord, Seq],
+    labelMap: LabelMap,
+    creatorOnly: Option[WorkbenchEmail],
+    cloudContextOpt: Option[CloudContext] = None,
+    workspaceOpt: Option[WorkspaceId] = None
   )(implicit
     ec: ExecutionContext
   ): DBIO[List[PersistentDisk]] = {
 
     // filtered by creator first as it may have great impact
     val diskQueryFilteredByCreator = creatorOnly match {
-      case Some(email) => persistentDiskQuery.tableQuery.filter(_.creator === email)
-      case None        => persistentDiskQuery.tableQuery
+      case Some(email) => baseQuery.filter(_.creator === email)
+      case None        => baseQuery
     }
 
     val diskQueryFilteredByDeletion =
-      if (includeDeleted) diskQueryFilteredByCreator
-      else diskQueryFilteredByCreator.filterNot(_.status === (DiskStatus.Deleted: DiskStatus))
+      diskQueryFilteredByCreator.filterNot(_.status === (DiskStatus.Deleted: DiskStatus))
 
     val diskQueryFilteredByProject =
       cloudContextOpt.fold(diskQueryFilteredByDeletion)(p =>

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/RuntimeServiceDbQueries.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/RuntimeServiceDbQueries.scala
@@ -6,11 +6,7 @@ import cats.syntax.all._
 import org.broadinstitute.dsde.workbench.azure.AzureCloudContext
 import org.broadinstitute.dsde.workbench.google2.OperationName
 import org.broadinstitute.dsde.workbench.leonardo.{LabelMap, Runtime}
-import org.broadinstitute.dsde.workbench.leonardo.SamResourceId.{
-  ProjectSamResourceId,
-  RuntimeSamResourceId,
-  WorkspaceResourceSamResourceId
-}
+import org.broadinstitute.dsde.workbench.leonardo.SamResourceId.RuntimeSamResourceId
 import org.broadinstitute.dsde.workbench.leonardo.config.Config
 import org.broadinstitute.dsde.workbench.leonardo.db.LeoProfile.api._
 import org.broadinstitute.dsde.workbench.leonardo.db.LeoProfile.dummyDate
@@ -28,7 +24,6 @@ import org.broadinstitute.dsde.workbench.leonardo.model.{
 import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GoogleProject}
 import org.broadinstitute.dsde.workbench.model.{IP, WorkbenchEmail}
 
-import java.util.UUID
 import java.sql.SQLDataException
 import java.time.Instant
 import scala.concurrent.ExecutionContext
@@ -70,6 +65,7 @@ object RuntimeServiceDbQueries {
     Option[WorkspaceId],
     Option[(String, String)]
   )
+
   private object ListRuntimesRecord {
     def apply(product: ListRuntimesProduct): ListRuntimesRecord = product match {
       case (l,
@@ -307,33 +303,26 @@ object RuntimeServiceDbQueries {
 
   /**
    * List runtimes filtered by the given terms. Only return authorized resources (per reader*Ids and/or owner*Ids).
+   *
    * @param labelMap
    * @param excludeStatuses
    * @param creatorEmail
    * @param workspaceId
    * @param cloudProvider
-   * @param readerRuntimeIds
+   * @param runtimeIds
    * @param readerWorkspaceIds
    * @param ownerWorkspaceIds
    * @param readerGoogleProjectIds
    * @param ownerGoogleProjectIds
    * @return
    */
-  def listRuntimes(
-    // Authorizations
-    ownerGoogleProjectIds: Set[ProjectSamResourceId] = Set.empty,
-    ownerWorkspaceIds: Set[WorkspaceResourceSamResourceId] = Set.empty,
-    readerGoogleProjectIds: Set[ProjectSamResourceId] = Set.empty,
-    readerRuntimeIds: Set[SamResourceId] = Set.empty,
-    readerWorkspaceIds: Set[WorkspaceResourceSamResourceId] = Set.empty,
-
-    // Filters
-    cloudContext: Option[CloudContext] = None,
-    cloudProvider: Option[CloudProvider] = None,
-    creatorEmail: Option[WorkbenchEmail] = None,
-    excludeStatuses: List[RuntimeStatus] = List.empty,
-    labelMap: LabelMap = Map.empty[String, String],
-    workspaceId: Option[WorkspaceId] = None
+  def listRuntimes(runtimeIds: Set[SamResourceId] = Set.empty,
+                   cloudContext: Option[CloudContext] = None,
+                   cloudProvider: Option[CloudProvider] = None,
+                   creatorEmail: Option[WorkbenchEmail] = None,
+                   excludeStatuses: List[RuntimeStatus] = List.empty,
+                   labelMap: LabelMap = Map.empty[String, String],
+                   workspaceId: Option[WorkspaceId] = None
   )(implicit ec: ExecutionContext): DBIO[Vector[ListRuntimeResponse2]] = {
     // Normalize filter params
     val provider = if (cloudProvider.isEmpty) {
@@ -343,93 +332,8 @@ object RuntimeServiceDbQueries {
       }
     } else cloudProvider
 
-    // Optimize Google project list if filtering to a specific cloud provider or context
-    val ownedProjects: Set[CloudContextDb] = ((provider, cloudContext) match {
-      case (Some(CloudProvider.Azure), _) => Set.empty[CloudContextDb]
-      case (Some(CloudProvider.Gcp), Some(CloudContext.Gcp(value))) =>
-        ownerGoogleProjectIds.filter(samId => samId.googleProject == value)
-      case _ => ownerGoogleProjectIds
-    }).map { case samId: SamResourceId =>
-      CloudContextDb(samId.resourceId)
-    }
-    val readProjects: Set[CloudContextDb] = ((provider, cloudContext) match {
-      case (Some(CloudProvider.Azure), _) => Set.empty[CloudContextDb]
-      case (Some(CloudProvider.Gcp), Some(CloudContext.Gcp(value))) =>
-        readerGoogleProjectIds.filter(samId => samId.googleProject == value)
-      case _ => readerGoogleProjectIds
-    }).map { case samId: SamResourceId =>
-      CloudContextDb(samId.resourceId)
-    }
-
-    // Optimize workspace list if filtering to a single workspace
-    val ownedWorkspaces: Set[WorkspaceId] = (workspaceId match {
-      case Some(wId) => ownerWorkspaceIds.filter(samId => WorkspaceId(UUID.fromString(samId.resourceId)) == wId)
-      case None      => ownerWorkspaceIds
-    }).map(samId => WorkspaceId(UUID.fromString(samId.resourceId)))
-    val readWorkspaces: Set[WorkspaceId] = (workspaceId match {
-      case Some(wId) => readerWorkspaceIds.filter(samId => WorkspaceId(UUID.fromString(samId.resourceId)) == wId)
-      case None      => readerWorkspaceIds
-    }).map(samId => WorkspaceId(UUID.fromString(samId.resourceId)))
-
-    val readRuntimes: Set[String] = readerRuntimeIds.map(readId => readId.asString)
-
-    val runtimeInReadWorkspaces: Option[ClusterTable => Rep[Option[Boolean]]] =
-      if (readRuntimes.isEmpty || readWorkspaces.isEmpty)
-        None
-      else
-        Some(runtime =>
-          (runtime.internalId inSetBind readRuntimes) &&
-            (runtime.workspaceId inSetBind readWorkspaces)
-        )
-
-    val runtimeInReadProjects: Option[ClusterTable => Rep[Option[Boolean]]] =
-      if (readRuntimes.isEmpty || readProjects.isEmpty)
-        None
-      else
-        Some(runtime =>
-          (runtime.internalId inSetBind readRuntimes) &&
-            (runtime.cloudProvider.? === (CloudProvider.Gcp: CloudProvider)) &&
-            (runtime.cloudContextDb inSetBind readProjects)
-        )
-
-    val runtimeInOwnedWorkspaces: Option[ClusterTable => Rep[Option[Boolean]]] =
-      if (ownedWorkspaces.isEmpty)
-        None
-      else
-        Some(runtime => runtime.workspaceId inSetBind ownedWorkspaces)
-
-    val runtimeInOwnedProjects: Option[ClusterTable => Rep[Option[Boolean]]] =
-      if (ownedProjects.isEmpty)
-        None
-      else if (cloudContext.isDefined) {
-        // If cloudContext is defined, we're already applying the filter in runtimesFiltered below.
-        // No need to filter by the list of user owned projects anymore as long as the specified
-        // project is owned by the user.
-        if (ownedProjects.exists(x => x.value == cloudContext.get.asString))
-          Some(_ => Some(true))
-        else None
-      } else
-        Some(runtime =>
-          (runtime.cloudProvider.? === (CloudProvider.Gcp: CloudProvider)) &&
-            (runtime.cloudContextDb inSetBind ownedProjects)
-        )
-
-    val runtimesAuthorized =
-      clusterQuery.filter[Rep[Option[Boolean]]] { runtime: ClusterTable =>
-        Seq(
-          runtimeInReadWorkspaces,
-          runtimeInOwnedWorkspaces,
-          runtimeInReadProjects,
-          runtimeInOwnedProjects
-        )
-          .mapFilter(opt => opt)
-          .map(_(runtime))
-          .reduceLeftOption(_ || _)
-          .getOrElse(Some(false): Rep[Option[Boolean]])
-      }
-
-    val runtimesFiltered = runtimesAuthorized
-      // Filter by params
+    val runtimes = clusterQuery
+      .filter(_.internalId inSetBind runtimeIds.map(_.asString))
       .filterOpt(workspaceId) { case (runtime, wId) =>
         runtime.workspaceId === (Some(wId): Rep[Option[WorkspaceId]])
       }
@@ -458,9 +362,6 @@ object RuntimeServiceDbQueries {
           )
           .length === labelMap.size
       }
-
-    // Assemble response
-    val runtimesJoined = runtimesFiltered
       .join(runtimeConfigs)
       .on((runtime, runtimeConfig) => runtime.runtimeConfigId === runtimeConfig.id)
       .map { case (runtime, runtimeConfig) =>
@@ -498,7 +399,7 @@ object RuntimeServiceDbQueries {
         )
       }
 
-    runtimesJoined.result
+    runtimes.result
       .map { records: Seq[ListRuntimesProduct] =>
         records
           .map(record => ListRuntimesRecord(record))

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/AppDependenciesBuilder.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/AppDependenciesBuilder.scala
@@ -98,7 +98,6 @@ class AppDependenciesBuilder(baselineDependenciesBuilder: BaselineDependenciesBu
 
     val azureService = new RuntimeV2ServiceInterp[IO](
       baselineDependencies.runtimeServicesConfig,
-      baselineDependencies.authProvider,
       baselineDependencies.publisherQueue,
       baselineDependencies.dateAccessedUpdaterQueue,
       baselineDependencies.wsmClientProvider,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/AppDependenciesBuilder.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/AppDependenciesBuilder.scala
@@ -91,9 +91,9 @@ class AppDependenciesBuilder(baselineDependenciesBuilder: BaselineDependenciesBu
   ): Resource[IO, ServicesDependencies] = {
     val statusService = new StatusService(baselineDependencies.samDAO, dbReference)
     val diskV2Service = new DiskV2ServiceInterp[IO](
-      baselineDependencies.authProvider,
       baselineDependencies.publisherQueue,
-      baselineDependencies.wsmClientProvider
+      baselineDependencies.wsmClientProvider,
+      baselineDependencies.samService
     )
 
     val azureService = new RuntimeV2ServiceInterp[IO](

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/AzureDependenciesBuilder.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/AzureDependenciesBuilder.scala
@@ -93,7 +93,6 @@ class AzureDependenciesBuilder extends CloudDependenciesBuilder {
     // Needed for v1 APIs
     val diskService = new DiskServiceInterp[IO](
       ConfigReader.appConfig.persistentDisk,
-      baselineDependencies.authProvider,
       baselineDependencies.publisherQueue,
       None,
       None,
@@ -103,7 +102,6 @@ class AzureDependenciesBuilder extends CloudDependenciesBuilder {
     val runtimeService = RuntimeService(
       baselineDependencies.runtimeServicesConfig,
       ConfigReader.appConfig.persistentDisk,
-      baselineDependencies.authProvider,
       baselineDependencies.dockerDAO,
       None,
       None,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/GcpDependenciesBuilder.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/GcpDependenciesBuilder.scala
@@ -274,7 +274,6 @@ class GcpDependencyBuilder extends CloudDependenciesBuilder {
 
     val diskService = new DiskServiceInterp[IO](
       ConfigReader.appConfig.persistentDisk,
-      baselineDependencies.authProvider,
       baselineDependencies.publisherQueue,
       Some(gcpDependencies.googleDiskService),
       Some(gcpDependencies.googleProjectDAO),
@@ -284,7 +283,6 @@ class GcpDependencyBuilder extends CloudDependenciesBuilder {
     val runtimeService = RuntimeService(
       baselineDependencies.runtimeServicesConfig,
       ConfigReader.appConfig.persistentDisk,
-      baselineDependencies.authProvider,
       baselineDependencies.dockerDAO,
       Some(gcpDependencies.googleStorageService),
       Some(gcpDependencies.googleComputeService),

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/RuntimeRoutes.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/RuntimeRoutes.scala
@@ -423,12 +423,6 @@ object RuntimeRoutes {
   implicit val createRuntimeRequestDecoder: Decoder[CreateRuntimeRequest] = Decoder.instance { c =>
     for {
       l <- c.downField("labels").as[Option[LabelMap]]
-      _ <- l.fold(().asRight[DecodingFailure]) { labelMap =>
-        if (labelMap.contains(includeDeletedKey))
-          DecodingFailure(s"${includeDeletedKey} is not a valid label. Remove it from request and retry", List.empty)
-            .asLeft[Unit]
-        else ().asRight[DecodingFailure]
-      }
       // Note jupyterUserScriptUri and jupyterStartUserScriptUri are deprecated
       jus <- c.downField("jupyterUserScriptUri").as[Option[UserScriptPath]]
       jsus <- c.downField("jupyterStartUserScriptUri").as[Option[UserScriptPath]]

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/DiskServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/DiskServiceInterp.scala
@@ -4,7 +4,6 @@ package service
 
 import akka.http.scaladsl.model.StatusCodes
 import cats.Parallel
-import cats.data.NonEmptyList
 import cats.effect.Async
 import cats.effect.std.Queue
 import cats.mtl.Ask
@@ -12,11 +11,9 @@ import cats.syntax.all._
 import com.google.api.services.cloudresourcemanager.model.Ancestor
 import org.broadinstitute.dsde.workbench.google.GoogleProjectDAO
 import org.broadinstitute.dsde.workbench.google2.{DiskName, GoogleDiskService}
-import org.broadinstitute.dsde.workbench.leonardo.JsonCodec._
 import org.broadinstitute.dsde.workbench.leonardo.config.PersistentDiskConfig
 import org.broadinstitute.dsde.workbench.leonardo.db._
 import org.broadinstitute.dsde.workbench.leonardo.http.service.DiskServiceInterp._
-import org.broadinstitute.dsde.workbench.leonardo.model.SamResourceAction._
 import org.broadinstitute.dsde.workbench.leonardo.model._
 import org.broadinstitute.dsde.workbench.leonardo.monitor.LeoPubsubMessage
 import org.broadinstitute.dsde.workbench.leonardo.monitor.LeoPubsubMessage.{
@@ -30,12 +27,11 @@ import org.broadinstitute.dsde.workbench.model.{TraceId, UserInfo, WorkbenchEmai
 import java.time.Instant
 import java.util.UUID
 import org.broadinstitute.dsde.workbench.leonardo.SamResourceId._
-import org.broadinstitute.dsde.workbench.leonardo.dao.sam.SamService
+import org.broadinstitute.dsde.workbench.leonardo.dao.sam.{SamException, SamService, SamUtils}
 
 import scala.concurrent.ExecutionContext
 
 class DiskServiceInterp[F[_]: Parallel](config: PersistentDiskConfig,
-                                        authProvider: LeoAuthProvider[F],
                                         publisherQueue: Queue[F, LeoPubsubMessage],
                                         googleDiskService: Option[GoogleDiskService[F]],
                                         googleProjectDAO: Option[GoogleProjectDAO],
@@ -58,12 +54,14 @@ class DiskServiceInterp[F[_]: Parallel](config: PersistentDiskConfig,
       // Resolve the user email in Sam from the user token. This translates a pet token to the owner email.
       userEmail <- samService.getUserEmail(userInfo.accessToken.token)
 
-      hasPermission <- authProvider.hasPermission[ProjectSamResourceId, ProjectAction](
-        ProjectSamResourceId(googleProject),
-        ProjectAction.CreatePersistentDisk,
-        userInfo
-      )
-      _ <- if (hasPermission) F.unit else F.raiseError[Unit](ForbiddenError(userEmail))
+      _ <- samService
+        .checkAuthorized(userInfo.accessToken.token,
+                         ProjectSamResourceId(googleProject),
+                         ProjectAction.CreatePersistentDisk
+        )
+        .adaptError {
+          case e: SamException if e.statusCode == StatusCodes.Forbidden => ForbiddenError(userEmail)
+        }
 
       // Grab the pet service account for the user
       petSA <- samService.getPetServiceAccount(userInfo.accessToken.token, googleProject)
@@ -85,18 +83,16 @@ class DiskServiceInterp[F[_]: Parallel](config: PersistentDiskConfig,
                                                                                   googleProject
             )
 
-            disk <- F.fromEither(
-              convertToDisk(userEmail,
-                            petSA,
-                            cloudContext,
-                            diskName,
-                            samResource,
-                            config,
-                            req,
-                            ctx.now,
-                            sourceDiskOpt,
-                            parentWorkspaceId
-              )
+            disk = convertToDisk(userEmail,
+                                 petSA,
+                                 cloudContext,
+                                 diskName,
+                                 samResource,
+                                 config,
+                                 req,
+                                 ctx.now,
+                                 sourceDiskOpt,
+                                 parentWorkspaceId
             )
             // Create a persistent-disk Sam resource with a creator policy and the google project as the parent
             _ <- samService.createResource(userInfo.accessToken.token,
@@ -180,24 +176,15 @@ class DiskServiceInterp[F[_]: Parallel](config: PersistentDiskConfig,
     for {
       ctx <- as.ask
 
-      // throw 403 if no project-level permission
-      hasProjectPermission <- authProvider.isUserProjectReader(
-        cloudContext,
-        userInfo
-      )
-      _ <- F.raiseWhen(!hasProjectPermission)(ForbiddenError(userInfo.userEmail, Some(ctx.traceId)))
-
       resp <- DiskServiceDbQueries.getGetPersistentDiskResponse(cloudContext, diskName, ctx.traceId).transaction
-      hasPermission <- authProvider.hasPermissionWithProjectFallback[PersistentDiskSamResourceId, PersistentDiskAction](
-        resp.samResource,
-        PersistentDiskAction.ReadPersistentDisk,
-        ProjectAction.ReadPersistentDisk,
-        userInfo,
-        GoogleProject(cloudContext.asString)
-      ) // TODO: update this to support azure
-      _ <-
-        if (hasPermission) F.unit
-        else F.raiseError[Unit](DiskNotFoundException(cloudContext, diskName, ctx.traceId))
+      _ <- SamUtils.checkDiskAction(samService,
+                                    userInfo,
+                                    cloudContext,
+                                    diskName,
+                                    resp.samResource,
+                                    PersistentDiskAction.ReadPersistentDisk,
+                                    ctx.traceId
+      )
 
     } yield resp
 
@@ -207,72 +194,29 @@ class DiskServiceInterp[F[_]: Parallel](config: PersistentDiskConfig,
     for {
       ctx <- as.ask
 
-      // throw 403 if user doesn't have project permission
-      hasProjectPermission <- cloudContext.traverse(cc =>
-        authProvider.isUserProjectReader(
-          cc,
-          userInfo
-        )
-      )
-      _ <- F.raiseWhen(!hasProjectPermission.getOrElse(true))(ForbiddenError(userInfo.userEmail, Some(ctx.traceId)))
+      samDiskIds <- samService.listResources(userInfo.accessToken.token, SamResourceType.PersistentDisk)
 
       paramMap <- F.fromEither(processListParameters(params))
       creatorOnly <- F.fromEither(processCreatorOnlyParameter(userInfo.userEmail, params, ctx.traceId))
-      disks <- DiskServiceDbQueries.listDisks(paramMap._1, paramMap._2, creatorOnly, cloudContext).transaction
-      partition = disks.partition(_.cloudContext.isInstanceOf[CloudContext.Gcp])
-      _ <- ctx.span.traverse(s => F.delay(s.addAnnotation("Done DB call")))
-
-      gcpDiskAndProjects = partition._1.map(d => (GoogleProject(d.cloudContext.asString), d.samResource))
-      gcpSamVisibleDisksOpt <- NonEmptyList.fromList(gcpDiskAndProjects).traverse { ds =>
-        authProvider
-          .filterResourceProjectVisible(ds, userInfo)
-      }
-
-      // TODO: use filterUserVisible (and remove old function) or make filterResourceProjectVisible handle both Azure and GCP
-      azureDiskAndProjects = partition._2.map(d => (GoogleProject(d.cloudContext.asString), d.samResource))
-      azureSamVisibleDisksOpt <- NonEmptyList.fromList(azureDiskAndProjects).traverse { ds =>
-        authProvider
-          .filterUserVisibleWithProjectFallback(ds, userInfo)
-      }
-
-      samVisibleDisksOpt = (gcpSamVisibleDisksOpt, azureSamVisibleDisksOpt) match {
-        case (Some(a), Some(b)) => Some(a ++ b)
-        case (Some(a), None)    => Some(a)
-        case (None, Some(b))    => Some(b)
-        case (None, None)       => None
-      }
-
-      _ <- ctx.span.traverse(s => F.delay(s.addAnnotation("Done checking Sam permission")))
-      res = samVisibleDisksOpt match {
-        case None => Vector.empty
-        case Some(samVisibleDisks) =>
-          val samVisibleDisksSet = samVisibleDisks.toSet
-          disks
-            .filter(d =>
-              samVisibleDisksSet.contains(
-                (GoogleProject(d.cloudContext.asString), d.samResource)
-              )
-            )
-            .map(d =>
-              ListPersistentDiskResponse(d.id,
-                                         d.cloudContext,
-                                         d.zone,
-                                         d.name,
-                                         d.status,
-                                         d.auditInfo,
-                                         d.size,
-                                         d.diskType,
-                                         d.blockSize,
-                                         d.labels.filter(l => paramMap._3.contains(l._1)),
-                                         d.workspaceId
-              )
-            )
-            .toVector
-      }
-      // We authenticate actions on resources. If there are no visible disks,
-      // we need to check if user should be able to see the empty list.
-      _ <- if (res.isEmpty) authProvider.checkUserEnabled(userInfo) else F.unit
-    } yield res
+      disks <- DiskServiceDbQueries
+        .listDisksBySamIds(samDiskIds.map(PersistentDiskSamResourceId), paramMap._1, creatorOnly, cloudContext)
+        .transaction
+    } yield disks
+      .map(d =>
+        ListPersistentDiskResponse(d.id,
+                                   d.cloudContext,
+                                   d.zone,
+                                   d.name,
+                                   d.status,
+                                   d.auditInfo,
+                                   d.size,
+                                   d.diskType,
+                                   d.blockSize,
+                                   d.labels.filter(l => paramMap._3.contains(l._1)),
+                                   d.workspaceId
+        )
+      )
+      .toVector
 
   override def deleteDisk(userInfo: UserInfo, googleProject: GoogleProject, diskName: DiskName)(implicit
     as: Ask[F, AppContext]
@@ -281,33 +225,19 @@ class DiskServiceInterp[F[_]: Parallel](config: PersistentDiskConfig,
       ctx <- as.ask
       cloudContext = CloudContext.Gcp(googleProject)
 
-      // throw 403 if no project-level permission
-      hasProjectPermission <- authProvider.isUserProjectReader(
-        cloudContext,
-        userInfo
-      )
-      _ <- F.raiseWhen(!hasProjectPermission)(ForbiddenError(userInfo.userEmail, Some(ctx.traceId)))
-
       // throw 404 if not existent
       diskOpt <- persistentDiskQuery.getActiveByName(cloudContext, diskName).transaction
       disk <- diskOpt.fold(F.raiseError[PersistentDisk](DiskNotFoundException(cloudContext, diskName, ctx.traceId)))(
         F.pure
       )
-      // throw 404 if no ReadPersistentDisk permission
-      // Note: the general pattern is to 404 (e.g. pretend the disk doesn't exist) if the caller doesn't have
-      // ReadPersistentDisk permission. We return 403 if the user can view the disk but can't perform some other action.
-      listOfPermissions <- authProvider.getActionsWithProjectFallback(disk.samResource, googleProject, userInfo)
-      hasReadPermission = listOfPermissions._1.toSet
-        .contains(PersistentDiskAction.ReadPersistentDisk) || listOfPermissions._2.toSet
-        .contains(ProjectAction.ReadPersistentDisk)
-      _ <-
-        if (hasReadPermission) F.unit
-        else F.raiseError[Unit](DiskNotFoundException(cloudContext, diskName, ctx.traceId))
-      // throw 403 if no DeleteDisk permission
-      hasDeletePermission = listOfPermissions._1.toSet
-        .contains(PersistentDiskAction.DeletePersistentDisk) || listOfPermissions._2.toSet
-        .contains(ProjectAction.DeletePersistentDisk)
-      _ <- if (hasDeletePermission) F.unit else F.raiseError[Unit](ForbiddenError(userInfo.userEmail))
+      _ <- SamUtils.checkDiskAction(samService,
+                                    userInfo,
+                                    cloudContext,
+                                    diskName,
+                                    disk.samResource,
+                                    PersistentDiskAction.DeletePersistentDisk,
+                                    ctx.traceId
+      )
       // throw 409 if the disk is not deletable
       _ <-
         if (disk.status.isDeletable) F.unit
@@ -365,20 +295,14 @@ class DiskServiceInterp[F[_]: Parallel](config: PersistentDiskConfig,
         .getGetPersistentDiskResponse(cloudContext, disk.name, ctx.traceId)
         .transaction
 
-      listOfPermissions <- authProvider.getActions(dbdisk.samResource, userInfo)
-
-      // throw 404 if no ReadDiskStatus permission
-      hasPermission = listOfPermissions.toSet.contains(PersistentDiskAction.ReadPersistentDisk)
-      _ <-
-        if (hasPermission) F.unit
-        else
-          F.raiseError[Unit](
-            DiskNotFoundException(cloudContext, disk.name, ctx.traceId)
-          )
-
-      // throw 403 if no DeleteDisk permission
-      hasDeletePermission = listOfPermissions.toSet.contains(PersistentDiskAction.DeletePersistentDisk)
-      _ <- if (hasDeletePermission) F.unit else F.raiseError[Unit](ForbiddenError(userInfo.userEmail))
+      _ <- SamUtils.checkDiskAction(samService,
+                                    userInfo,
+                                    cloudContext,
+                                    dbdisk.name,
+                                    dbdisk.samResource,
+                                    PersistentDiskAction.DeletePersistentDisk,
+                                    ctx.traceId
+      )
 
       // Mark the resource as deleted in Leo's DB
       _ <- dbReference.inTransaction(persistentDiskQuery.delete(disk.id, ctx.now))
@@ -409,34 +333,22 @@ class DiskServiceInterp[F[_]: Parallel](config: PersistentDiskConfig,
       ctx <- as.ask
       cloudContext = CloudContext.Gcp(googleProject)
 
-      // throw 403 if no project-level permission
-      hasProjectPermission <- authProvider.isUserProjectReader(
-        cloudContext,
-        userInfo
-      )
-      _ <- F.raiseWhen(!hasProjectPermission)(ForbiddenError(userInfo.userEmail, Some(ctx.traceId)))
-
       // throw 404 if not existent
       diskOpt <- persistentDiskQuery.getActiveByName(cloudContext, diskName).transaction
       disk <- diskOpt.fold(F.raiseError[PersistentDisk](DiskNotFoundException(cloudContext, diskName, ctx.traceId)))(
         F.pure
       )
+      _ <- SamUtils.checkDiskAction(samService,
+                                    userInfo,
+                                    cloudContext,
+                                    diskName,
+                                    disk.samResource,
+                                    PersistentDiskAction.ModifyPersistentDisk,
+                                    ctx.traceId
+      )
       // throw 400 if UpdateDiskRequest new size is smaller than disk's current size
       _ <-
         if (req.size.gb > disk.size.gb) for {
-          // throw 404 if no ReadPersistentDisk permission
-          // Note: the general pattern is to 404 (e.g. pretend the disk doesn't exist) if the caller doesn't have
-          // ReadPersistentDisk permission. We return 403 if the user can view the disk but can't perform some other action.
-          listOfPermissions <- authProvider.getActionsWithProjectFallback(disk.samResource, googleProject, userInfo)
-          hasReadPermission = listOfPermissions._1.toSet
-            .contains(PersistentDiskAction.ReadPersistentDisk) || listOfPermissions._2.toSet
-            .contains(ProjectAction.ReadPersistentDisk)
-          _ <-
-            if (hasReadPermission) F.unit
-            else F.raiseError[Unit](DiskNotFoundException(cloudContext, diskName, ctx.traceId))
-          // throw 403 if no ModifyPersistentDisk permission
-          hasModifyPermission = listOfPermissions._1.contains(PersistentDiskAction.ModifyPersistentDisk)
-          _ <- if (hasModifyPermission) F.unit else F.raiseError[Unit](ForbiddenError(userInfo.userEmail))
           // throw 409 if the disk is not updatable
           _ <-
             if (disk.status.isUpdatable) F.unit
@@ -465,7 +377,7 @@ object DiskServiceInterp {
                                      now: Instant,
                                      sourceDisk: Option[SourceDisk],
                                      workspaceId: Option[WorkspaceId]
-  ): Either[Throwable, PersistentDisk] =
+  ): PersistentDisk =
     convertToDisk(userEmail,
                   serviceAccount,
                   cloudContext,
@@ -490,7 +402,7 @@ object DiskServiceInterp {
                                      willBeUsedByGalaxy: Boolean,
                                      sourceDisk: Option[SourceDisk],
                                      workspaceId: Option[WorkspaceId]
-  ): Either[Throwable, PersistentDisk] = {
+  ): PersistentDisk = {
     // create a LabelMap of default labels
     val defaultLabels = DefaultDiskLabels(
       diskName,
@@ -502,14 +414,7 @@ object DiskServiceInterp {
     // combine default and given labels
     val allLabels = req.labels ++ defaultLabels
 
-    for {
-      // check the labels do not contain forbidden keys
-      labels <-
-        if (allLabels.contains(includeDeletedKey))
-          Left(IllegalLabelKeyException(includeDeletedKey))
-        else
-          Right(allLabels)
-    } yield PersistentDisk(
+    PersistentDisk(
       DiskId(0),
       cloudContext,
       req.zone.getOrElse(config.defaultZone),
@@ -524,7 +429,7 @@ object DiskServiceInterp {
       req.blockSize.getOrElse(config.defaultBlockSizeBytes),
       sourceDisk.flatMap(_.formattedBy),
       None,
-      labels,
+      allLabels,
       sourceDisk.map(_.diskLink),
       None,
       workspaceId

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/DiskV2ServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/DiskV2ServiceInterp.scala
@@ -8,11 +8,8 @@ import cats.effect.Async
 import cats.effect.std.Queue
 import cats.mtl.Ask
 import cats.syntax.all._
-import org.broadinstitute.dsde.workbench.leonardo.SamResourceId.{
-  PersistentDiskSamResourceId,
-  WorkspaceResourceSamResourceId
-}
 import org.broadinstitute.dsde.workbench.leonardo.dao._
+import org.broadinstitute.dsde.workbench.leonardo.dao.sam.{SamService, SamUtils}
 import org.broadinstitute.dsde.workbench.leonardo.db._
 import org.broadinstitute.dsde.workbench.leonardo.model._
 import org.broadinstitute.dsde.workbench.leonardo.monitor.LeoPubsubMessage
@@ -23,9 +20,9 @@ import org.typelevel.log4cats.StructuredLogger
 import scala.concurrent.ExecutionContext
 
 class DiskV2ServiceInterp[F[_]: Parallel](
-  authProvider: LeoAuthProvider[F],
   publisherQueue: Queue[F, LeoPubsubMessage],
-  wsmClientProvider: WsmApiClientProvider[F]
+  wsmClientProvider: WsmApiClientProvider[F],
+  samService: SamService[F]
 )(implicit
   F: Async[F],
   dbReference: DbReference[F],
@@ -44,27 +41,16 @@ class DiskV2ServiceInterp[F[_]: Parallel](
         .transaction
 
       // check that workspaceId is not null
-      workspaceId <- F.fromOption(diskResp.workspaceId, DiskWithoutWorkspaceException(diskId, ctx.traceId))
+      _ <- F.fromOption(diskResp.workspaceId, DiskWithoutWorkspaceException(diskId, ctx.traceId))
 
-      hasWorkspacePermission <- authProvider.isUserWorkspaceReader(
-        WorkspaceResourceSamResourceId(workspaceId),
-        userInfo
+      // check that user has read action on disk
+      _ <- SamUtils.checkDiskAction(samService,
+                                    userInfo,
+                                    diskId,
+                                    diskResp.samResource,
+                                    PersistentDiskAction.ReadPersistentDisk,
+                                    ctx.traceId
       )
-
-      _ <- F.raiseUnless(hasWorkspacePermission)(ForbiddenError(userInfo.userEmail))
-
-      hasDiskPermission <- authProvider.hasPermission[PersistentDiskSamResourceId, PersistentDiskAction](
-        diskResp.samResource,
-        PersistentDiskAction.ReadPersistentDisk,
-        userInfo
-      )
-
-      _ <- ctx.span.traverse(s => F.delay(s.addAnnotation("Done auth call for get azure disk permission")))
-      _ <- F
-        .raiseError[Unit](
-          DiskNotFoundByIdException(diskId, ctx.traceId)
-        )
-        .whenA(!hasDiskPermission)
 
     } yield diskResp
 
@@ -77,33 +63,18 @@ class DiskV2ServiceInterp[F[_]: Parallel](
 
       disk <- F.fromOption(diskOpt, DiskNotFoundByIdException(diskId, ctx.traceId))
 
-      // check read permission first
-      listOfPermissions <- authProvider.getActions(disk.samResource, userInfo)
-      hasReadPermission = listOfPermissions.toSet.contains(
-        PersistentDiskAction.ReadPersistentDisk
+      _ <- SamUtils.checkDiskAction(samService,
+                                    userInfo,
+                                    diskId,
+                                    disk.samResource,
+                                    PersistentDiskAction.DeletePersistentDisk,
+                                    ctx.traceId
       )
-      _ <- F
-        .raiseError[Unit](DiskNotFoundByIdException(diskId, ctx.traceId))
-        .whenA(!hasReadPermission)
-
-      // check delete permission
-      hasDeletePermission = listOfPermissions.toSet.contains(
-        PersistentDiskAction.DeletePersistentDisk
-      )
-      _ <- F
-        .raiseError[Unit](ForbiddenError(userInfo.userEmail))
-        .whenA(!hasDeletePermission)
 
       _ <- ctx.span.traverse(s => F.delay(s.addAnnotation("Done auth call for delete azure disk permission")))
 
       // check that workspaceId is not null
       workspaceId <- F.fromOption(disk.workspaceId, DiskWithoutWorkspaceException(diskId, ctx.traceId))
-
-      hasWorkspacePermission <- authProvider.isUserWorkspaceReader(
-        WorkspaceResourceSamResourceId(workspaceId),
-        userInfo
-      )
-      _ <- F.raiseUnless(hasWorkspacePermission)(ForbiddenError(userInfo.userEmail))
 
       // check if disk resource is deletable in WSM
       wsmDiskResourceId <- disk.wsmResourceId match {

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/LeoAppServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/LeoAppServiceInterp.scala
@@ -249,7 +249,6 @@ final class LeoAppServiceInterp[F[_]: Parallel](config: AppServiceConfig,
             userEmail,
             petSA,
             appTypeToFormattedByType(req.appType),
-            authProvider,
             samService,
             config.leoKubernetesConfig.diskConfig,
             parentWorkspaceId
@@ -827,7 +826,6 @@ final class LeoAppServiceInterp[F[_]: Parallel](config: AppServiceConfig,
           userEmail,
           petSA,
           appTypeToFormattedByType(req.appType),
-          authProvider,
           samService,
           config.leoKubernetesConfig.diskConfig
         )

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/ProxyService.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/ProxyService.scala
@@ -93,15 +93,14 @@ class ProxyService(
   samDAO: SamDAO[IO],
   googleTokenCache: Cache[IO, String, (UserInfo, Instant)],
   samResourceCache: Cache[IO, SamResourceCacheKey, (Option[String], Option[AppAccessScope])],
-  val samService: SamService[IO]
+  samService: SamService[IO]
 )(implicit
   val system: ActorSystem,
   executionContext: ExecutionContext,
   dbRef: DbReference[IO],
   loggerIO: StructuredLogger[IO],
   metrics: OpenTelemetryMetrics[IO]
-) extends LazyLogging
-    with SamUtils[IO] {
+) extends LazyLogging {
   val httpsConnectionContext = ConnectionContext.httpsClient(sslContext)
   val clientConnectionSettings =
     ClientConnectionSettings(system).withTransport(ClientTransport.withCustomResolver(proxyResolver.resolveAkka))
@@ -271,7 +270,13 @@ class ProxyService(
       ctx <- ev.ask[AppContext]
 
       samResource <- getCachedRuntimeSamResource(RuntimeCacheKey(cloudContext, runtimeName))
-      _ <- checkRuntimeAction(userInfo, cloudContext, runtimeName, samResource, RuntimeAction.ConnectToRuntime)
+      _ <- SamUtils.checkRuntimeAction(samService,
+                                       userInfo,
+                                       cloudContext,
+                                       runtimeName,
+                                       samResource,
+                                       RuntimeAction.ConnectToRuntime
+      )
 
       hostStatus <- getRuntimeTargetHost(cloudContext, runtimeName)
       _ <- hostStatus match {

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeService.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeService.scala
@@ -11,7 +11,6 @@ import org.broadinstitute.dsde.workbench.leonardo.config.PersistentDiskConfig
 import org.broadinstitute.dsde.workbench.leonardo.dao.DockerDAO
 import org.broadinstitute.dsde.workbench.leonardo.dao.sam.SamService
 import org.broadinstitute.dsde.workbench.leonardo.db.DbReference
-import org.broadinstitute.dsde.workbench.leonardo.model.LeoAuthProvider
 import org.broadinstitute.dsde.workbench.leonardo.monitor.LeoPubsubMessage
 import org.broadinstitute.dsde.workbench.model.UserInfo
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
@@ -69,7 +68,6 @@ trait RuntimeService[F[_]] {
 object RuntimeService {
   def apply[F[_]: Parallel](config: RuntimeServiceConfig,
                             diskConfig: PersistentDiskConfig,
-                            authProvider: LeoAuthProvider[F],
                             dockerDAO: DockerDAO[F],
                             googleStorageService: Option[GoogleStorageService[F]],
                             googleComputeService: Option[GoogleComputeService[F]],
@@ -85,7 +83,6 @@ object RuntimeService {
     new RuntimeServiceInterp(
       config,
       diskConfig,
-      authProvider,
       dockerDAO,
       googleStorageService,
       googleComputeService,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterp.scala
@@ -20,7 +20,6 @@ import org.broadinstitute.dsde.workbench.google2.{
   MachineTypeName,
   ZoneName
 }
-import org.broadinstitute.dsde.workbench.leonardo.JsonCodec._
 import org.broadinstitute.dsde.workbench.leonardo.RuntimeImageType.{CryptoDetector, Jupyter, Proxy, Welder}
 import org.broadinstitute.dsde.workbench.leonardo.SamResourceId.{
   PersistentDiskSamResourceId,
@@ -38,6 +37,7 @@ import org.broadinstitute.dsde.workbench.leonardo.model.SamResourceAction.{
   workspaceSamResourceAction
 }
 import org.broadinstitute.dsde.workbench.leonardo.http.service.RuntimeServiceInterp._
+import org.broadinstitute.dsde.workbench.leonardo.model.SamResource.RuntimeSamResource
 import org.broadinstitute.dsde.workbench.leonardo.model.SamResourceAction._
 import org.broadinstitute.dsde.workbench.leonardo.model._
 import org.broadinstitute.dsde.workbench.leonardo.monitor.LeoPubsubMessage._
@@ -249,36 +249,19 @@ class RuntimeServiceInterp[F[_]: Parallel](
     for {
       ctx <- as.ask
 
-      // throw 403 if user doesn't have project permission
-      hasProjectPermission <- cloudContext.traverse(cc =>
-        authProvider.isUserProjectReader(
-          cc,
-          userInfo
-        )
-      )
-      _ <- ctx.span.traverse(s => F.delay(s.addAnnotation("Done checking project permission with Sam")))
-
-      _ <- F.raiseWhen(!hasProjectPermission.getOrElse(true))(ForbiddenError(userInfo.userEmail, Some(ctx.traceId)))
+      samResources <- samService.listResources(userInfo.accessToken.token, RuntimeSamResource.resourceType)
 
       (labelMap, includeDeleted, _) <- F.fromEither(processListParameters(params))
       excludeStatuses = if (includeDeleted) List.empty else List(RuntimeStatus.Deleted)
       creatorOnly <- F.fromEither(processCreatorOnlyParameter(userInfo.userEmail, params, ctx.traceId))
 
-      authorizedIds <- getAuthorizedIds(userInfo, creatorOnly)
       _ <- ctx.span.traverse(s => F.delay(s.addAnnotation("Start DB query for listRuntimes")))
       runtimes <- RuntimeServiceDbQueries
-        .listRuntimes(
-          // Authorization scopes
-          ownerGoogleProjectIds = authorizedIds.ownerGoogleProjectIds,
-          ownerWorkspaceIds = authorizedIds.ownerWorkspaceIds,
-          readerGoogleProjectIds = authorizedIds.readerGoogleProjectIds,
-          readerRuntimeIds = authorizedIds.readerRuntimeIds,
-          readerWorkspaceIds = authorizedIds.readerWorkspaceIds,
-          // Filters
-          excludeStatuses = excludeStatuses,
-          creatorEmail = creatorOnly,
-          cloudContext = cloudContext,
-          labelMap = labelMap
+        .listRuntimes(samResources.map(RuntimeSamResourceId).toSet,
+                      excludeStatuses = excludeStatuses,
+                      creatorEmail = creatorOnly,
+                      cloudContext = cloudContext,
+                      labelMap = labelMap
         )
         .transaction
 
@@ -840,55 +823,6 @@ class RuntimeServiceInterp[F[_]: Parallel](
 
       _ <- checkRuntimeAction(userInfo, cloudContext, runtimeName, runtime.samResource, action, userEmail)
     } yield runtime
-
-  private[service] def getAuthorizedIds(
-    userInfo: UserInfo,
-    creatorEmail: Option[WorkbenchEmail] = None
-  )(implicit ev: Ask[F, AppContext]): F[AuthorizedIds] = for {
-    // Authorize: user has an active account and has accepted terms of service
-    _ <- authProvider.checkUserEnabled(userInfo)
-
-    // Authorize: get resource IDs the user can see
-    // HACK: leonardo is modeling access control here, handling inheritance
-    // of workspace and project-level permissions. Sam and WSM already do this,
-    // and should be considered the point of truth.
-
-    // HACK: leonardo short-circuits access control to grant access to runtime creators.
-    // This supports the use case where `terra-ui` requests status of runtimes that have
-    // not yet been provisioned in Sam.
-    creatorRuntimeIdsBackdoor: Set[RuntimeSamResourceId] <- creatorEmail match {
-      case Some(email: WorkbenchEmail) =>
-        RuntimeServiceDbQueries
-          .listRuntimeIdsForCreator(email)
-          .map(_.map(_.samResource).toSet)
-          .transaction
-      case None => F.pure(Set.empty: Set[RuntimeSamResourceId])
-    }
-
-    // v1 runtimes (sam resource type `notebook-cluster`) are readable only
-    // by their creators (`Creator` is the SamResource.Runtime `ownerRoleName`),
-    // if the creator also has read access to the corresponding SamResource.Project
-    creatorV1RuntimeIds: Set[RuntimeSamResourceId] <- authProvider
-      .listResourceIds[RuntimeSamResourceId](hasOwnerRole = true, userInfo)
-    readerProjectIds: Set[ProjectSamResourceId] <- authProvider
-      .listResourceIds[ProjectSamResourceId](hasOwnerRole = false, userInfo)
-
-    // v1 runtimes are discoverable by owners on the corresponding Project
-    ownerProjectIds: Set[ProjectSamResourceId] <- authProvider
-      .listResourceIds[ProjectSamResourceId](hasOwnerRole = true, userInfo)
-
-    // combine: to read a runtime, user needs to be at least one of:
-    // - creator of a v1 runtime (Sam-authenticated)
-    // - any role on a v2 runtime (Sam-authenticated)
-    // - creator of a runtime (in Leo db) and filtering their request by creator-only
-    readerRuntimeIds: Set[SamResourceId] = creatorV1RuntimeIds ++ creatorRuntimeIdsBackdoor
-  } yield AuthorizedIds(
-    ownerGoogleProjectIds = ownerProjectIds,
-    ownerWorkspaceIds = Set.empty,
-    readerGoogleProjectIds = readerProjectIds,
-    readerRuntimeIds = readerRuntimeIds,
-    readerWorkspaceIds = Set.empty
-  )
 }
 
 object RuntimeServiceInterp {

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterp.scala
@@ -32,13 +32,8 @@ import org.broadinstitute.dsde.workbench.leonardo.dao.DockerDAO
 import org.broadinstitute.dsde.workbench.leonardo.dao.sam.{SamException, SamService, SamUtils}
 import org.broadinstitute.dsde.workbench.leonardo.db._
 import org.broadinstitute.dsde.workbench.leonardo.http.service.DiskServiceInterp.getDiskSamPolicyMap
-import org.broadinstitute.dsde.workbench.leonardo.model.SamResourceAction.{
-  projectSamResourceAction,
-  workspaceSamResourceAction
-}
 import org.broadinstitute.dsde.workbench.leonardo.http.service.RuntimeServiceInterp._
 import org.broadinstitute.dsde.workbench.leonardo.model.SamResource.RuntimeSamResource
-import org.broadinstitute.dsde.workbench.leonardo.model.SamResourceAction._
 import org.broadinstitute.dsde.workbench.leonardo.model._
 import org.broadinstitute.dsde.workbench.leonardo.monitor.LeoPubsubMessage._
 import org.broadinstitute.dsde.workbench.leonardo.monitor.{
@@ -61,20 +56,18 @@ import scala.concurrent.ExecutionContext
 class RuntimeServiceInterp[F[_]: Parallel](
   config: RuntimeServiceConfig,
   diskConfig: PersistentDiskConfig,
-  authProvider: LeoAuthProvider[F],
   dockerDAO: DockerDAO[F],
   googleStorageService: Option[GoogleStorageService[F]],
   googleComputeService: Option[GoogleComputeService[F]],
   publisherQueue: Queue[F, LeoPubsubMessage],
-  val samService: SamService[F]
+  samService: SamService[F]
 )(implicit
   F: Async[F],
   log: StructuredLogger[F],
   dbReference: DbReference[F],
   ec: ExecutionContext,
   metrics: OpenTelemetryMetrics[F]
-) extends RuntimeService[F]
-    with SamUtils[F] {
+) extends RuntimeService[F] {
 
   override def createRuntime(
     userInfo: UserInfo,
@@ -163,7 +156,6 @@ class RuntimeServiceInterp[F[_]: Parallel](
                           userEmail,
                           petSA,
                           FormattedBy.GCE,
-                          authProvider,
                           samService,
                           diskConfig,
                           parentWorkspaceId
@@ -240,7 +232,13 @@ class RuntimeServiceInterp[F[_]: Parallel](
     for {
       // throws 404 if not existent
       resp <- RuntimeServiceDbQueries.getRuntime(cloudContext, runtimeName).transaction
-      _ <- checkRuntimeAction(userInfo, cloudContext, runtimeName, resp.samResource, RuntimeAction.GetRuntimeStatus)
+      _ <- SamUtils.checkRuntimeAction(samService,
+                                       userInfo,
+                                       cloudContext,
+                                       runtimeName,
+                                       resp.samResource,
+                                       RuntimeAction.GetRuntimeStatus
+      )
     } yield resp
 
   override def listRuntimes(userInfo: UserInfo, cloudContext: Option[CloudContext], params: Map[String, String])(
@@ -381,11 +379,12 @@ class RuntimeServiceInterp[F[_]: Parallel](
   ): F[Unit] =
     for {
       ctx <- as.ask
-      _ <- checkRuntimeAction(userInfo,
-                              cloudContext,
-                              runtime.clusterName,
-                              runtime.samResource,
-                              RuntimeAction.DeleteRuntime
+      _ <- SamUtils.checkRuntimeAction(samService,
+                                       userInfo,
+                                       cloudContext,
+                                       runtime.clusterName,
+                                       runtime.samResource,
+                                       RuntimeAction.DeleteRuntime
       )
 
       // Mark the resource as deleted in Leo's DB
@@ -457,11 +456,12 @@ class RuntimeServiceInterp[F[_]: Parallel](
         F.raiseError[ClusterRecord](RuntimeNotFoundException(cloudContext, runtimeName, "no record in database"))
       )(F.pure)
 
-      _ <- checkRuntimeAction(userInfo,
-                              cloudContext,
-                              runtimeName,
-                              RuntimeSamResourceId(runtime.internalId),
-                              RuntimeAction.ModifyRuntime
+      _ <- SamUtils.checkRuntimeAction(samService,
+                                       userInfo,
+                                       cloudContext,
+                                       runtimeName,
+                                       RuntimeSamResourceId(runtime.internalId),
+                                       RuntimeAction.ModifyRuntime
       )
       // throw 409 if the cluster is not updatable
       _ <-
@@ -821,7 +821,14 @@ class RuntimeServiceInterp[F[_]: Parallel](
         F.raiseError[Runtime](RuntimeNotFoundException(cloudContext, runtimeName, "Not found in database"))
       )(F.pure)
 
-      _ <- checkRuntimeAction(userInfo, cloudContext, runtimeName, runtime.samResource, action, userEmail)
+      _ <- SamUtils.checkRuntimeAction(samService,
+                                       userInfo,
+                                       cloudContext,
+                                       runtimeName,
+                                       runtime.samResource,
+                                       action,
+                                       userEmail
+      )
     } yield runtime
 }
 
@@ -926,7 +933,6 @@ object RuntimeServiceInterp {
     userEmail: WorkbenchEmail,
     serviceAccount: WorkbenchEmail,
     willBeUsedBy: FormattedBy,
-    authProvider: LeoAuthProvider[F],
     samService: SamService[F],
     diskConfig: PersistentDiskConfig,
     workspaceId: Option[WorkspaceId]
@@ -943,6 +949,14 @@ object RuntimeServiceInterp {
       disk <- diskOpt match {
         case Some(pd) =>
           for {
+            _ <- SamUtils.checkDiskAction(samService,
+                                          userInfo,
+                                          cloudContext,
+                                          pd.name,
+                                          pd.samResource,
+                                          PersistentDiskAction.AttachPersistentDisk,
+                                          ctx.traceId
+            )
             _ <-
               if (pd.zone == targetZone) F.unit
               else
@@ -977,38 +991,31 @@ object RuntimeServiceInterp {
               if (isAttached)
                 F.raiseError[Unit](DiskAlreadyAttachedException(CloudContext.Gcp(googleProject), req.name, ctx.traceId))
               else F.unit
-            hasPermission <- authProvider.hasPermission[PersistentDiskSamResourceId, PersistentDiskAction](
-              pd.samResource,
-              PersistentDiskAction.AttachPersistentDisk,
-              userInfo
-            )
-
-            _ <- if (hasPermission) F.unit else F.raiseError[Unit](ForbiddenError(userEmail))
           } yield PersistentDiskRequestResult(pd, false)
 
         case None =>
           for {
-            hasPermission <- authProvider.hasPermission[ProjectSamResourceId, ProjectAction](
-              ProjectSamResourceId(googleProject),
-              ProjectAction.CreatePersistentDisk,
-              userInfo
-            )
-            _ <- if (hasPermission) F.unit else F.raiseError[Unit](ForbiddenError(userEmail))
-            samResource <- F.delay(PersistentDiskSamResourceId(UUID.randomUUID().toString))
-            diskBeforeSave <- F.fromEither(
-              DiskServiceInterp.convertToDisk(
-                userEmail,
-                serviceAccount,
-                cloudContext,
-                req.name,
-                samResource,
-                diskConfig,
-                CreateDiskRequest.fromDiskConfigRequest(req, Some(targetZone)),
-                ctx.now,
-                willBeUsedBy == FormattedBy.Galaxy,
-                None,
-                workspaceId
+            _ <- samService
+              .checkAuthorized(userInfo.accessToken.token,
+                               ProjectSamResourceId(googleProject),
+                               ProjectAction.CreatePersistentDisk
               )
+              .adaptError {
+                case e: SamException if e.statusCode == StatusCodes.Forbidden => ForbiddenError(userEmail)
+              }
+            samResource <- F.delay(PersistentDiskSamResourceId(UUID.randomUUID().toString))
+            diskBeforeSave = DiskServiceInterp.convertToDisk(
+              userEmail,
+              serviceAccount,
+              cloudContext,
+              req.name,
+              samResource,
+              diskConfig,
+              CreateDiskRequest.fromDiskConfigRequest(req, Some(targetZone)),
+              ctx.now,
+              willBeUsedBy == FormattedBy.Galaxy,
+              None,
+              workspaceId
             )
             // Create a persistent-disk Sam resource with a creator policy and the google project as the parent
             _ <- samService.createResource(
@@ -1032,7 +1039,6 @@ object RuntimeServiceInterp {
     userEmail: WorkbenchEmail,
     serviceAccount: WorkbenchEmail,
     willBeUsedBy: FormattedBy,
-    authProvider: LeoAuthProvider[F],
     samService: SamService[F],
     diskConfig: PersistentDiskConfig
   )(implicit
@@ -1047,6 +1053,14 @@ object RuntimeServiceInterp {
       disk <- diskOpt match {
         case Some(pd) =>
           for {
+            _ <- SamUtils.checkDiskAction(samService,
+                                          userInfo,
+                                          cloudContext,
+                                          pd.name,
+                                          pd.samResource,
+                                          PersistentDiskAction.AttachPersistentDisk,
+                                          ctx.traceId
+            )
             _ <-
               if (pd.zone == targetZone) F.unit
               else
@@ -1081,25 +1095,21 @@ object RuntimeServiceInterp {
               if (isAttached)
                 F.raiseError[Unit](DiskAlreadyAttachedException(cloudContext, req.name, ctx.traceId))
               else F.unit
-            hasPermission <- authProvider.hasPermission[PersistentDiskSamResourceId, PersistentDiskAction](
-              pd.samResource,
-              PersistentDiskAction.AttachPersistentDisk,
-              userInfo
-            )
 
-            _ <- if (hasPermission) F.unit else F.raiseError[Unit](ForbiddenError(userEmail))
           } yield PersistentDiskRequestResult(pd, false)
 
         case None =>
           for {
-            hasPermission <- authProvider.hasPermission[WorkspaceResourceSamResourceId, WorkspaceAction](
-              WorkspaceResourceSamResourceId(workspaceId),
-              WorkspaceAction.CreateControlledApplicationResource,
-              userInfo
-            ) // TODO: Correct check?
-            _ <- if (hasPermission) F.unit else F.raiseError[Unit](ForbiddenError(userEmail))
+            _ <- samService
+              .checkAuthorized(userInfo.accessToken.token,
+                               WorkspaceResourceSamResourceId(workspaceId),
+                               WorkspaceAction.Compute
+              )
+              .adaptError {
+                case e: SamException if e.statusCode == StatusCodes.Forbidden => ForbiddenError(userEmail)
+              }
             samResource <- F.delay(PersistentDiskSamResourceId(UUID.randomUUID().toString))
-            diskBeforeSave <- F.fromEither(
+            diskBeforeSave =
               DiskServiceInterp.convertToDisk(
                 userEmail,
                 serviceAccount,
@@ -1113,7 +1123,6 @@ object RuntimeServiceInterp {
                 None,
                 Some(workspaceId)
               )
-            )
             // Create a persistent-disk Sam resource with a creator policy and the workspace as the parent
             _ <- samService.createResource(userInfo.accessToken.token,
                                            samResource,

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterp.scala
@@ -251,7 +251,7 @@ class RuntimeServiceInterp[F[_]: Parallel](
 
       samResources <- samService.listResources(userInfo.accessToken.token, RuntimeSamResource.resourceType)
 
-      (labelMap, _) <- F.fromEither(processListParameters(params))
+      (labelMap, _, _) <- F.fromEither(processListParameters(params))
       excludeStatuses = List(RuntimeStatus.Deleted)
       creatorOnly <- F.fromEither(processCreatorOnlyParameter(userInfo.userEmail, params, ctx.traceId))
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterp.scala
@@ -251,8 +251,8 @@ class RuntimeServiceInterp[F[_]: Parallel](
 
       samResources <- samService.listResources(userInfo.accessToken.token, RuntimeSamResource.resourceType)
 
-      (labelMap, includeDeleted, _) <- F.fromEither(processListParameters(params))
-      excludeStatuses = if (includeDeleted) List.empty else List(RuntimeStatus.Deleted)
+      (labelMap, _) <- F.fromEither(processListParameters(params))
+      excludeStatuses = List(RuntimeStatus.Deleted)
       creatorOnly <- F.fromEither(processCreatorOnlyParameter(userInfo.userEmail, params, ctx.traceId))
 
       _ <- ctx.span.traverse(s => F.delay(s.addAnnotation("Start DB query for listRuntimes")))

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeV2ServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeV2ServiceInterp.scala
@@ -42,10 +42,9 @@ class RuntimeV2ServiceInterp[F[_]: Parallel](
   publisherQueue: Queue[F, LeoPubsubMessage],
   dateAccessUpdaterQueue: Queue[F, UpdateDateAccessedMessage],
   wsmClientProvider: WsmApiClientProvider[F],
-  val samService: SamService[F]
+  samService: SamService[F]
 )(implicit F: Async[F], dbReference: DbReference[F], ec: ExecutionContext, log: StructuredLogger[F])
-    extends RuntimeV2Service[F]
-    with SamUtils[F] {
+    extends RuntimeV2Service[F] {
 
   override def createRuntime(
     userInfo: UserInfo,
@@ -137,7 +136,6 @@ class RuntimeV2ServiceInterp[F[_]: Parallel](
                   disks <- DiskServiceDbQueries
                     .listDisks(
                       Map.empty,
-                      includeDeleted = false,
                       Some(userEmail),
                       Some(cloudContext),
                       Some(workspaceId)
@@ -164,7 +162,7 @@ class RuntimeV2ServiceInterp[F[_]: Parallel](
               case false =>
                 for {
                   samResource <- F.delay(PersistentDiskSamResourceId(UUID.randomUUID().toString))
-                  pd <- F.fromEither(
+                  pd =
                     convertToDisk(
                       userEmail,
                       cloudContext,
@@ -175,7 +173,6 @@ class RuntimeV2ServiceInterp[F[_]: Parallel](
                       workspaceId,
                       ctx.now
                     )
-                  )
                   // Create a persistent-disk Sam resource with a creator policy and the workspace as the parent
                   _ <- samService.createResource(userInfo.accessToken.token,
                                                  samResource,
@@ -238,7 +235,13 @@ class RuntimeV2ServiceInterp[F[_]: Parallel](
       ctx <- as.ask
 
       runtime <- RuntimeServiceDbQueries.getRuntimeByWorkspaceId(workspaceId, runtimeName).transaction
-      _ <- checkRuntimeAction(userInfo, workspaceId, runtimeName, runtime.samResource, RuntimeAction.GetRuntimeStatus)
+      _ <- SamUtils.checkRuntimeAction(samService,
+                                       userInfo,
+                                       workspaceId,
+                                       runtimeName,
+                                       runtime.samResource,
+                                       RuntimeAction.GetRuntimeStatus
+      )
       _ <- ctx.span.traverse(s => F.delay(s.addAnnotation("Done auth call for get azure runtime permission")))
     } yield runtime
 
@@ -367,7 +370,8 @@ class RuntimeV2ServiceInterp[F[_]: Parallel](
       ctx <- as.ask
       runtime <- RuntimeServiceDbQueries.getRuntimeByWorkspaceId(workspaceId, runtimeName).transaction
 
-      _ <- checkRuntimeAction(
+      _ <- SamUtils.checkRuntimeAction(
+        samService,
         userInfo,
         workspaceId,
         runtimeName,
@@ -446,7 +450,7 @@ class RuntimeV2ServiceInterp[F[_]: Parallel](
     req: CreateAzureRuntimeRequest,
     workspaceId: WorkspaceId,
     now: Instant
-  ): Either[Throwable, PersistentDisk] = {
+  ): PersistentDisk = {
     // create a LabelMap of default labels
     val defaultLabelMap: LabelMap =
       Map(
@@ -458,14 +462,7 @@ class RuntimeV2ServiceInterp[F[_]: Parallel](
     // combine default and given labels
     val allLabels = req.azureDiskConfig.labels ++ defaultLabelMap
 
-    for {
-      // check the labels do not contain forbidden keys
-      labels <-
-        if (allLabels.contains(includeDeletedKey))
-          Left(IllegalLabelKeyException(includeDeletedKey))
-        else
-          Right(allLabels)
-    } yield PersistentDisk(
+    PersistentDisk(
       DiskId(0),
       cloudContext,
       ZoneName("unset"),
@@ -494,7 +491,13 @@ class RuntimeV2ServiceInterp[F[_]: Parallel](
   )(implicit as: Ask[F, AppContext]): F[ClusterRecord] =
     for {
       runtime <- RuntimeServiceDbQueries.getActiveRuntimeRecord(workspaceId, runtimeName).transaction
-      _ <- checkRuntimeAction(userInfo, workspaceId, runtimeName, RuntimeSamResourceId(runtime.internalId), action)
+      _ <- SamUtils.checkRuntimeAction(samService,
+                                       userInfo,
+                                       workspaceId,
+                                       runtimeName,
+                                       RuntimeSamResourceId(runtime.internalId),
+                                       action
+      )
     } yield runtime
 
   private def errorHandler(runtimeId: Long, ctx: AppContext): Throwable => F[Unit] =

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeV2ServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeV2ServiceInterp.scala
@@ -418,7 +418,7 @@ class RuntimeV2ServiceInterp[F[_]: Parallel](
       ctx <- as.ask
 
       // Parameters: parse search filters from request
-      (labelMap, _) <- F.fromEither(processListParameters(params))
+      (labelMap, _, _) <- F.fromEither(processListParameters(params))
       excludeStatuses = List(RuntimeStatus.Deleted)
       creatorEmail <- F.fromEither(processCreatorOnlyParameter(userInfo.userEmail, params, ctx.traceId))
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeV2ServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeV2ServiceInterp.scala
@@ -418,8 +418,8 @@ class RuntimeV2ServiceInterp[F[_]: Parallel](
       ctx <- as.ask
 
       // Parameters: parse search filters from request
-      (labelMap, includeDeleted, _) <- F.fromEither(processListParameters(params))
-      excludeStatuses = if (includeDeleted) List.empty else List(RuntimeStatus.Deleted)
+      (labelMap, _) <- F.fromEither(processListParameters(params))
+      excludeStatuses = List(RuntimeStatus.Deleted)
       creatorEmail <- F.fromEither(processCreatorOnlyParameter(userInfo.userEmail, params, ctx.traceId))
 
       samResources <- samService.listResources(userInfo.accessToken.token, RuntimeSamResource.resourceType)
@@ -479,7 +479,7 @@ class RuntimeV2ServiceInterp[F[_]: Parallel](
       config.defaultBlockSizeBytes,
       None,
       None,
-      labels,
+      allLabels,
       None,
       None,
       Some(workspaceId)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeV2ServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeV2ServiceInterp.scala
@@ -9,10 +9,8 @@ import cats.effect.std.Queue
 import cats.mtl.Ask
 import cats.syntax.all._
 import org.broadinstitute.dsde.workbench.google2.{DiskName, MachineTypeName, ZoneName}
-import org.broadinstitute.dsde.workbench.leonardo.JsonCodec._
 import org.broadinstitute.dsde.workbench.leonardo.SamResourceId.{
   PersistentDiskSamResourceId,
-  ProjectSamResourceId,
   RuntimeSamResourceId,
   WorkspaceResourceSamResourceId,
   WsmResourceSamResourceId
@@ -23,14 +21,7 @@ import org.broadinstitute.dsde.workbench.leonardo.dao.sam.{SamException, SamServ
 import org.broadinstitute.dsde.workbench.leonardo.db._
 import org.broadinstitute.dsde.workbench.leonardo.http.service.DiskServiceInterp.getDiskSamPolicyMap
 import org.broadinstitute.dsde.workbench.leonardo.http.service.RuntimeServiceInterp.getRuntimeSamPolicyMap
-// do not remove: `projectSamResourceAction`, `runtimeSamResourceAction`, `workspaceSamResourceAction`, `wsmResourceSamResourceAction`; `AppSamResourceAction` they are implicit
-import org.broadinstitute.dsde.workbench.leonardo.model.SamResourceAction.{
-  projectSamResourceAction,
-  runtimeSamResourceAction,
-  workspaceSamResourceAction,
-  wsmResourceSamResourceAction,
-  AppSamResourceAction
-}
+import org.broadinstitute.dsde.workbench.leonardo.model.SamResource.RuntimeSamResource
 import org.broadinstitute.dsde.workbench.leonardo.model._
 import org.broadinstitute.dsde.workbench.leonardo.monitor.LeoPubsubMessage.{
   CreateAzureRuntimeMessage,
@@ -48,7 +39,6 @@ import scala.concurrent.ExecutionContext
 
 class RuntimeV2ServiceInterp[F[_]: Parallel](
   config: RuntimeServiceConfig,
-  authProvider: LeoAuthProvider[F],
   publisherQueue: Queue[F, LeoPubsubMessage],
   dateAccessUpdaterQueue: Queue[F, UpdateDateAccessedMessage],
   wsmClientProvider: WsmApiClientProvider[F],
@@ -87,26 +77,18 @@ class RuntimeV2ServiceInterp[F[_]: Parallel](
         case (None, None) => F.raiseError[CloudContext](CloudContextNotFoundException(workspaceId, ctx.traceId))
       }
 
-      samResource = WorkspaceResourceSamResourceId(workspaceId)
-
       // Resolve the user email in Sam from the user token. This translates a pet token to the owner email.
       userEmail <- samService.getUserEmail(userInfo.accessToken.token)
 
       // enforcing one runtime per workspace/user at a time
-      authorizedIds <- getAuthorizedIds(userInfo, Some(userEmail), Some(samResource))
+      samResources <- samService.listResources(userInfo.accessToken.token, RuntimeSamResource.resourceType)
       runtimes <- RuntimeServiceDbQueries
         .listRuntimes(
-          // Authorization scopes
-          ownerGoogleProjectIds = authorizedIds.ownerGoogleProjectIds,
-          ownerWorkspaceIds = authorizedIds.ownerWorkspaceIds,
-          readerGoogleProjectIds = authorizedIds.readerGoogleProjectIds,
-          readerRuntimeIds = authorizedIds.readerRuntimeIds,
-          readerWorkspaceIds = authorizedIds.readerWorkspaceIds,
-          // Filters
-          excludeStatuses = List(RuntimeStatus.Deleted, RuntimeStatus.Deleting),
+          runtimeIds = samResources.map(RuntimeSamResourceId).toSet,
+          cloudProvider = Some(cloudContext.cloudProvider),
           creatorEmail = Some(userEmail),
-          workspaceId = Some(workspaceId),
-          cloudProvider = Some(cloudContext.cloudProvider)
+          excludeStatuses = List(RuntimeStatus.Deleted, RuntimeStatus.Deleting),
+          workspaceId = Some(workspaceId)
         )
         .transaction
 
@@ -351,25 +333,10 @@ class RuntimeV2ServiceInterp[F[_]: Parallel](
     as: Ask[F, AppContext]
   ): F[Unit] =
     for {
-      ctx <- as.ask
-
-      workspaceSamId = WorkspaceResourceSamResourceId(workspaceId)
-      hasWorkspacePermission <- authProvider.isUserWorkspaceReader(
-        workspaceSamId,
-        userInfo
-      )
-      _ <- F.raiseUnless(hasWorkspacePermission)(ForbiddenError(userInfo.userEmail))
-
-      authorizedIds <- getAuthorizedIds(userInfo, workspaceSamId = Some(workspaceSamId))
+      samResources <- samService.listResources(userInfo.accessToken.token, RuntimeSamResource.resourceType)
       runtimes <- RuntimeServiceDbQueries
         .listRuntimes(
-          // Authorization scopes
-          ownerGoogleProjectIds = authorizedIds.ownerGoogleProjectIds,
-          ownerWorkspaceIds = authorizedIds.ownerWorkspaceIds,
-          readerGoogleProjectIds = authorizedIds.readerGoogleProjectIds,
-          readerRuntimeIds = authorizedIds.readerRuntimeIds,
-          readerWorkspaceIds = authorizedIds.readerWorkspaceIds,
-          // Filters
+          runtimeIds = samResources.map(RuntimeSamResourceId).toSet,
           excludeStatuses = List(RuntimeStatus.Deleted),
           workspaceId = Some(workspaceId)
         )
@@ -454,23 +421,16 @@ class RuntimeV2ServiceInterp[F[_]: Parallel](
       (labelMap, includeDeleted, _) <- F.fromEither(processListParameters(params))
       excludeStatuses = if (includeDeleted) List.empty else List(RuntimeStatus.Deleted)
       creatorEmail <- F.fromEither(processCreatorOnlyParameter(userInfo.userEmail, params, ctx.traceId))
-      maybeWorkspaceSamId = workspaceId.map(WorkspaceResourceSamResourceId)
 
-      authorizedIds <- getAuthorizedIds(userInfo, creatorEmail, maybeWorkspaceSamId)
+      samResources <- samService.listResources(userInfo.accessToken.token, RuntimeSamResource.resourceType)
       runtimes <- RuntimeServiceDbQueries
         .listRuntimes(
-          // Authorization scopes
-          ownerGoogleProjectIds = authorizedIds.ownerGoogleProjectIds,
-          ownerWorkspaceIds = authorizedIds.ownerWorkspaceIds,
-          readerGoogleProjectIds = authorizedIds.readerGoogleProjectIds,
-          readerRuntimeIds = authorizedIds.readerRuntimeIds,
-          readerWorkspaceIds = authorizedIds.readerWorkspaceIds,
-          // Filters
-          cloudProvider = cloudProvider, // Google | Azure
-          creatorEmail = creatorEmail, // whether to filter out runtimes user did not create
-          excludeStatuses = excludeStatuses, // whether to filter out Deleted runtimes
-          labelMap = labelMap, // arbitrary key-value labels to filter by
-          workspaceId = workspaceId // whether to find only runtimes in a single workspace
+          runtimeIds = samResources.map(RuntimeSamResourceId).toSet,
+          cloudProvider = cloudProvider,
+          creatorEmail = creatorEmail,
+          excludeStatuses = excludeStatuses,
+          labelMap = labelMap,
+          workspaceId = workspaceId
         )
         .map(_.toList)
         .transaction
@@ -544,84 +504,6 @@ class RuntimeV2ServiceInterp[F[_]: Parallel](
         .transaction >>
         clusterQuery.updateClusterStatus(runtimeId, RuntimeStatus.Error, ctx.now).transaction.void
 
-  private def getAuthorizedIds(
-    userInfo: UserInfo,
-    creatorEmail: Option[WorkbenchEmail] = None,
-    workspaceSamId: Option[WorkspaceResourceSamResourceId] = None
-  )(implicit ev: Ask[F, AppContext]): F[AuthorizedIds] = for {
-    // Authorize: user has an active account and has accepted terms of service
-    _ <- authProvider.checkUserEnabled(userInfo)
-
-    // Authorize: get resource IDs the user can see
-    // HACK: leonardo is modeling access control here, handling inheritance
-    // of workspace and project-level permissions. Sam and WSM already do this,
-    // and should be considered the point of truth.
-
-    // HACK: leonardo short-circuits access control to grant access to runtime creators.
-    // This supports the use case where `terra-ui` requests status of runtimes that have
-    // not yet been provisioned in Sam.
-    creatorRuntimeIdsBackdoor: Set[RuntimeSamResourceId] <- creatorEmail match {
-      case Some(email: WorkbenchEmail) =>
-        RuntimeServiceDbQueries
-          .listRuntimeIdsForCreator(email)
-          .map(_.map(_.samResource).toSet)
-          .transaction
-      case None => F.pure(Set.empty: Set[RuntimeSamResourceId])
-    }
-
-    // v1 runtimes (sam resource type `notebook-cluster`) are readable only
-    // by their creators (`Creator` is the SamResource.Runtime `ownerRoleName`),
-    // if the creator also has read access to the corresponding SamResource.Project
-    creatorV1RuntimeIds: Set[RuntimeSamResourceId] <- authProvider
-      .listResourceIds[RuntimeSamResourceId](hasOwnerRole = true, userInfo)
-    readerProjectIds: Set[ProjectSamResourceId] <- authProvider
-      .listResourceIds[ProjectSamResourceId](hasOwnerRole = false, userInfo)
-
-    // v1 runtimes are discoverable by owners on the corresponding Project
-    ownerProjectIds: Set[ProjectSamResourceId] <- authProvider
-      .listResourceIds[ProjectSamResourceId](hasOwnerRole = true, userInfo)
-
-    // v2 runtimes are WSM-managed resources and they're modeled as `WsmResourceSamResource`s.
-    // HACK: accept any ID in the list of readable WSM resources as a valid
-    // readable v2 runtime ID. Some of these IDs are for non-runtime resources.
-    // TODO [] call WSM to list workspaces, then list runtimes per workspace, to get these IDs?
-
-    // v2 runtimes are readable by users with read access to both runtime and workspace
-    readerV2WsmIds: Set[WsmResourceSamResourceId] <- authProvider
-      .listResourceIds[WsmResourceSamResourceId](hasOwnerRole = false, userInfo)
-    readerWorkspaceIds: Set[WorkspaceResourceSamResourceId] <- workspaceSamId match {
-      case Some(samId) =>
-        for {
-          isWorkspaceReader <- authProvider.isUserWorkspaceReader(samId, userInfo)
-          workspaceIds: Set[WorkspaceResourceSamResourceId] =
-            if (isWorkspaceReader) Set(samId) else Set.empty
-        } yield workspaceIds
-      case None => authProvider.listResourceIds[WorkspaceResourceSamResourceId](hasOwnerRole = false, userInfo)
-    }
-
-    // v2 runtimes are discoverable by owners on the corresponding Workspace
-    ownerWorkspaceIds: Set[WorkspaceResourceSamResourceId] <- workspaceSamId match {
-      case Some(samId) =>
-        for {
-          isWorkspaceOwner <- authProvider.isUserWorkspaceOwner(samId, userInfo)
-          workspaceIds: Set[WorkspaceResourceSamResourceId] = if (isWorkspaceOwner) Set(samId) else Set.empty
-        } yield workspaceIds
-      case None => authProvider.listResourceIds[WorkspaceResourceSamResourceId](hasOwnerRole = true, userInfo)
-    }
-
-    // combine: to read a runtime, user needs to be at least one of:
-    // - creator of a v1 runtime (Sam-authenticated)
-    // - any role on a v2 runtime (Sam-authenticated)
-    // - creator of a runtime (in Leo db) and filtering their request by creator-only
-    readerRuntimeIds: Set[SamResourceId] = creatorV1RuntimeIds ++ readerV2WsmIds ++ creatorRuntimeIdsBackdoor
-  } yield AuthorizedIds(
-    ownerGoogleProjectIds = ownerProjectIds,
-    ownerWorkspaceIds = ownerWorkspaceIds,
-    readerGoogleProjectIds = readerProjectIds,
-    readerRuntimeIds = readerRuntimeIds,
-    readerWorkspaceIds = readerWorkspaceIds
-  )
-
   private def convertToRuntime(
     workspaceId: WorkspaceId,
     runtimeName: RuntimeName,
@@ -681,13 +563,6 @@ class RuntimeV2ServiceInterp[F[_]: Parallel](
   }
 
 }
-final case class AuthorizedIds(
-  val ownerGoogleProjectIds: Set[ProjectSamResourceId],
-  val ownerWorkspaceIds: Set[WorkspaceResourceSamResourceId],
-  val readerGoogleProjectIds: Set[ProjectSamResourceId],
-  val readerRuntimeIds: Set[SamResourceId],
-  val readerWorkspaceIds: Set[WorkspaceResourceSamResourceId]
-)
 
 final case class WorkspaceNotFoundException(workspaceId: WorkspaceId, traceId: TraceId)
     extends LeoException(

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/package.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/package.scala
@@ -46,26 +46,18 @@ package object service {
 
   private[service] def processListParameters(
     params: LabelMap
-  ): Either[ParseLabelsException, (LabelMap, Boolean, List[String])] =
+  ): Either[ParseLabelsException, (LabelMap, List[String])] =
     // returns a tuple made of three elements:
     // 1) LabelMap - represents the labels to filter the request by
-    // 2) includeDeleted - Boolean which determines if we include deleted resources in the response
     // 3) includeLabels - List of label keys which represent the labels (key, value pairs) that will be returned in response
     // Note that optional parameter `role` or `creator` (represented by creatorOnlyKey and creatorOnlyValue) is omitted.
     for {
-      labelMap <- processLabelMap(params - includeDeletedKey - includeLabelsKey - creatorOnlyKey - creatorOnlyValue)
-      includeDeleted = params.get(includeDeletedKey) match {
-        case Some(includeDeletedValue) =>
-          if (includeDeletedValue.toLowerCase == "true")
-            true
-          else false
-        case None => false
-      }
+      labelMap <- processLabelMap(params - includeLabelsKey - creatorOnlyKey - creatorOnlyValue)
       includeLabels <- params.get(includeLabelsKey) match {
         case Some(includeLabelsValue) => processLabelsToReturn(includeLabelsValue)
         case None                     => Either.right(List.empty[String])
       }
-    } yield (labelMap, includeDeleted, includeLabels)
+    } yield (labelMap, includeLabels)
 
   /**
    * Top-level query string parameter for apps and disks: GET /api/apps?includeLabels=foo,bar

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/package.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/package.scala
@@ -46,18 +46,26 @@ package object service {
 
   private[service] def processListParameters(
     params: LabelMap
-  ): Either[ParseLabelsException, (LabelMap, List[String])] =
+  ): Either[ParseLabelsException, (LabelMap, Boolean, List[String])] =
     // returns a tuple made of three elements:
     // 1) LabelMap - represents the labels to filter the request by
+    // 2) includeDeleted - Boolean which determines if we include deleted resources in the response
     // 3) includeLabels - List of label keys which represent the labels (key, value pairs) that will be returned in response
     // Note that optional parameter `role` or `creator` (represented by creatorOnlyKey and creatorOnlyValue) is omitted.
     for {
-      labelMap <- processLabelMap(params - includeLabelsKey - creatorOnlyKey - creatorOnlyValue)
+      labelMap <- processLabelMap(params - includeDeletedKey - includeLabelsKey - creatorOnlyKey - creatorOnlyValue)
+      includeDeleted = params.get(includeDeletedKey) match {
+        case Some(includeDeletedValue) =>
+          if (includeDeletedValue.toLowerCase == "true")
+            true
+          else false
+        case None => false
+      }
       includeLabels <- params.get(includeLabelsKey) match {
         case Some(includeLabelsValue) => processLabelsToReturn(includeLabelsValue)
         case None                     => Either.right(List.empty[String])
       }
-    } yield (labelMap, includeLabels)
+    } yield (labelMap, includeDeleted, includeLabels)
 
   /**
    * Top-level query string parameter for apps and disks: GET /api/apps?includeLabels=foo,bar

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/RuntimeServiceDbQueriesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/RuntimeServiceDbQueriesSpec.scala
@@ -62,16 +62,8 @@ class RuntimeServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent wit
       c1 <- IO(
         makeCluster(1).saveWithRuntimeConfig(d1RuntimeConfig)
       )
-      c1WorkspaceIds = c1.workspaceId match {
-        case Some(workspaceId) => Set(WorkspaceResourceSamResourceId(workspaceId))
-        case None              => Set.empty[WorkspaceResourceSamResourceId]
-      }
       list2 <- RuntimeServiceDbQueries
-        .listRuntimes(
-          readerRuntimeIds = Set(c1.samResource),
-          readerWorkspaceIds = c1WorkspaceIds,
-          excludeStatuses = List(RuntimeStatus.Deleted)
-        )
+        .listRuntimes(runtimeIds = Set(c1.samResource), excludeStatuses = List(RuntimeStatus.Deleted))
         .transaction
       // Two runtimes exist: c1, c2
       d2 <- makePersistentDisk(Some(DiskName("d2"))).save()
@@ -85,15 +77,8 @@ class RuntimeServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent wit
       c2 <- IO(
         makeCluster(2).saveWithRuntimeConfig(d2RuntimeConfig)
       )
-      bothWorkspaceIds = Set(c1.workspaceId, c2.workspaceId).collect { case Some(workspaceId) =>
-        WorkspaceResourceSamResourceId(workspaceId)
-      }
       list3 <- RuntimeServiceDbQueries
-        .listRuntimes(
-          readerRuntimeIds = Set(c1.samResource, c2.samResource),
-          readerWorkspaceIds = bothWorkspaceIds,
-          excludeStatuses = List(RuntimeStatus.Deleted)
-        )
+        .listRuntimes(runtimeIds = Set(c1.samResource, c2.samResource), excludeStatuses = List(RuntimeStatus.Deleted))
         .transaction
 
       // no authorizations => no runtimes
@@ -179,22 +164,14 @@ class RuntimeServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent wit
 
       // Note that c3 exists but is not visible
       googleProject = GoogleProject(c1.cloudContext.asString)
-      projectIds = Set(ProjectSamResourceId(googleProject))
       runtimeIds = Set(c1.samResource: SamResourceId, c2.samResource: SamResourceId)
-      workspaceIds = Set(workspaceId1, workspaceId2).map(WorkspaceResourceSamResourceId)
 
       list0 <- RuntimeServiceDbQueries
-        .listRuntimes(
-          readerRuntimeIds = runtimeIds,
-          readerWorkspaceIds = workspaceIds,
-          readerGoogleProjectIds = projectIds
-        )
+        .listRuntimes(runtimeIds = runtimeIds)
         .transaction
       list1 <- RuntimeServiceDbQueries
         .listRuntimes(
-          readerRuntimeIds = runtimeIds,
-          readerWorkspaceIds = workspaceIds,
-          readerGoogleProjectIds = projectIds,
+          runtimeIds = runtimeIds,
           cloudContext = Some(CloudContext.Gcp(googleProject)),
           cloudProvider = Some(CloudProvider.Gcp),
           creatorEmail = Some(c1.auditInfo.creator),
@@ -205,9 +182,7 @@ class RuntimeServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent wit
         .transaction
       list2 <- RuntimeServiceDbQueries
         .listRuntimes(
-          readerRuntimeIds = runtimeIds,
-          readerWorkspaceIds = workspaceIds,
-          readerGoogleProjectIds = projectIds,
+          runtimeIds = runtimeIds,
           cloudProvider = Some(CloudProvider.Azure),
           creatorEmail = Some(c2.auditInfo.creator),
           excludeStatuses = List(RuntimeStatus.Deleted),
@@ -262,57 +237,27 @@ class RuntimeServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent wit
         "creator" -> c2.auditInfo.creator.value
       )
       runtimeIds = Set(c1.samResource: SamResourceId, c2.samResource: SamResourceId)
-      bothProjectIds = Set(
-        ProjectSamResourceId(GoogleProject(c1.cloudContext.asString)),
-        ProjectSamResourceId(GoogleProject(c2.cloudContext.asString))
-      )
       list0 <- RuntimeServiceDbQueries
-        .listRuntimes(
-          readerRuntimeIds = runtimeIds,
-          readerGoogleProjectIds = bothProjectIds,
-          excludeStatuses = List(RuntimeStatus.Deleted)
-        )
+        .listRuntimes(runtimeIds = runtimeIds, excludeStatuses = List(RuntimeStatus.Deleted))
         .transaction
       list1 <- RuntimeServiceDbQueries
-        .listRuntimes(
-          readerRuntimeIds = runtimeIds,
-          readerGoogleProjectIds = bothProjectIds,
-          labelMap = labels1,
-          excludeStatuses = List(RuntimeStatus.Deleted)
-        )
+        .listRuntimes(runtimeIds = runtimeIds, excludeStatuses = List(RuntimeStatus.Deleted), labelMap = labels1)
         .transaction
       list2 <- RuntimeServiceDbQueries
-        .listRuntimes(
-          readerRuntimeIds = runtimeIds,
-          readerGoogleProjectIds = bothProjectIds,
-          labelMap = labels2,
-          excludeStatuses = List(RuntimeStatus.Deleted)
-        )
+        .listRuntimes(runtimeIds = runtimeIds, excludeStatuses = List(RuntimeStatus.Deleted), labelMap = labels2)
         .transaction
       _ <- labelQuery.saveAllForResource(c1.id, LabelResourceType.Runtime, labels1).transaction
       _ <- labelQuery.saveAllForResource(c2.id, LabelResourceType.Runtime, labels2).transaction
       list3 <- RuntimeServiceDbQueries
-        .listRuntimes(
-          readerRuntimeIds = runtimeIds,
-          readerGoogleProjectIds = bothProjectIds,
-          labelMap = labels1,
-          excludeStatuses = List(RuntimeStatus.Deleted)
-        )
+        .listRuntimes(runtimeIds = runtimeIds, excludeStatuses = List(RuntimeStatus.Deleted), labelMap = labels1)
         .transaction
       list4 <- RuntimeServiceDbQueries
-        .listRuntimes(
-          readerRuntimeIds = runtimeIds,
-          readerGoogleProjectIds = bothProjectIds,
-          labelMap = labels2,
-          excludeStatuses = List(RuntimeStatus.Deleted)
-        )
+        .listRuntimes(runtimeIds = runtimeIds, excludeStatuses = List(RuntimeStatus.Deleted), labelMap = labels2)
         .transaction
       list5 <- RuntimeServiceDbQueries
-        .listRuntimes(
-          readerRuntimeIds = runtimeIds,
-          readerGoogleProjectIds = bothProjectIds,
-          labelMap = Map("googleProject" -> c1.cloudContext.asString),
-          excludeStatuses = List(RuntimeStatus.Deleted)
+        .listRuntimes(runtimeIds = runtimeIds,
+                      excludeStatuses = List(RuntimeStatus.Deleted),
+                      labelMap = Map("googleProject" -> c1.cloudContext.asString)
         )
         .transaction
       end <- IO.realTimeInstant
@@ -359,24 +304,16 @@ class RuntimeServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent wit
         makeCluster(2).saveWithRuntimeConfig(c2RuntimeConfig)
       )
       runtimeIds = Set(c1.samResource: SamResourceId, c2.samResource: SamResourceId)
-      bothProjectIds = Set(
-        ProjectSamResourceId(GoogleProject(c1.cloudContext.asString)),
-        ProjectSamResourceId(GoogleProject(c2.cloudContext.asString))
-      )
       list1 <- RuntimeServiceDbQueries
-        .listRuntimes(
-          readerRuntimeIds = runtimeIds,
-          readerGoogleProjectIds = bothProjectIds,
-          excludeStatuses = List(RuntimeStatus.Deleted),
-          cloudContext = Some(cloudContextGcp)
+        .listRuntimes(runtimeIds = runtimeIds,
+                      cloudContext = Some(cloudContextGcp),
+                      excludeStatuses = List(RuntimeStatus.Deleted)
         )
         .transaction
       list2 <- RuntimeServiceDbQueries
-        .listRuntimes(
-          readerRuntimeIds = runtimeIds,
-          readerGoogleProjectIds = bothProjectIds,
-          excludeStatuses = List(RuntimeStatus.Deleted),
-          cloudContext = Some(cloudContext2Gcp)
+        .listRuntimes(runtimeIds = runtimeIds,
+                      cloudContext = Some(cloudContext2Gcp),
+                      excludeStatuses = List(RuntimeStatus.Deleted)
         )
         .transaction
       end <- IO.realTimeInstant
@@ -442,21 +379,12 @@ class RuntimeServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent wit
         )
       )
       runtimeIds = Set(c1.samResource: SamResourceId, c2.samResource: SamResourceId, c3.samResource: SamResourceId)
-      projectIds = Set(
-        ProjectSamResourceId(GoogleProject(c1.cloudContext.asString)),
-        ProjectSamResourceId(GoogleProject(c2.cloudContext.asString)),
-        ProjectSamResourceId(GoogleProject(c3.cloudContext.asString))
-      )
 
       list1 <- RuntimeServiceDbQueries
-        .listRuntimes(readerRuntimeIds = runtimeIds, readerGoogleProjectIds = projectIds)
+        .listRuntimes(runtimeIds = runtimeIds)
         .transaction
       list2 <- RuntimeServiceDbQueries
-        .listRuntimes(
-          readerRuntimeIds = runtimeIds,
-          readerGoogleProjectIds = projectIds,
-          excludeStatuses = List(RuntimeStatus.Deleted)
-        )
+        .listRuntimes(runtimeIds = runtimeIds, excludeStatuses = List(RuntimeStatus.Deleted))
         .transaction
       end <- IO.realTimeInstant
       elapsed = (end.toEpochMilli - start.toEpochMilli).millis
@@ -510,27 +438,11 @@ class RuntimeServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent wit
         )
       )
       runtimeIds = Set(c1.samResource: SamResourceId, c2.samResource: SamResourceId, c3.samResource: SamResourceId)
-      projectIds = Set(
-        ProjectSamResourceId(GoogleProject(c1.cloudContext.asString)),
-        ProjectSamResourceId(GoogleProject(c2.cloudContext.asString))
-      )
-      workspaceIds = Set(c3.workspaceId).collect { case Some(workspaceId) =>
-        WorkspaceResourceSamResourceId(workspaceId)
-      }
       list1 <- RuntimeServiceDbQueries
-        .listRuntimes(
-          readerRuntimeIds = runtimeIds,
-          readerGoogleProjectIds = projectIds,
-          readerWorkspaceIds = workspaceIds
-        )
+        .listRuntimes(runtimeIds = runtimeIds)
         .transaction
       list2 <- RuntimeServiceDbQueries
-        .listRuntimes(
-          readerRuntimeIds = runtimeIds,
-          readerGoogleProjectIds = projectIds,
-          readerWorkspaceIds = workspaceIds,
-          excludeStatuses = List(RuntimeStatus.Deleted)
-        )
+        .listRuntimes(runtimeIds = runtimeIds, excludeStatuses = List(RuntimeStatus.Deleted))
         .transaction
       end <- IO.realTimeInstant
       elapsed = (end.toEpochMilli - start.toEpochMilli).millis
@@ -592,21 +504,14 @@ class RuntimeServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent wit
           )
       )
       runtimeIds = Set(c1.samResource: SamResourceId, c2.samResource: SamResourceId, c3.samResource: SamResourceId)
-      workspaceIds = Set(workspaceId1, workspaceId2).map(WorkspaceResourceSamResourceId)
 
       list1 <- RuntimeServiceDbQueries
-        .listRuntimes(
-          readerRuntimeIds = runtimeIds,
-          readerWorkspaceIds = workspaceIds,
-          workspaceId = Some(workspaceId1)
-        )
+        .listRuntimes(runtimeIds = runtimeIds, workspaceId = Some(workspaceId1))
         .transaction
       list2 <- RuntimeServiceDbQueries
-        .listRuntimes(
-          readerRuntimeIds = runtimeIds,
-          readerWorkspaceIds = workspaceIds,
-          excludeStatuses = List(RuntimeStatus.Deleted),
-          workspaceId = Some(workspaceId2)
+        .listRuntimes(runtimeIds = runtimeIds,
+                      excludeStatuses = List(RuntimeStatus.Deleted),
+                      workspaceId = Some(workspaceId2)
         )
         .transaction
       end <- IO.realTimeInstant
@@ -689,51 +594,41 @@ class RuntimeServiceDbQueriesSpec extends AnyFlatSpecLike with TestComponent wit
       )
       c5ClusterRecord <- clusterQuery.getActiveClusterRecordByName(c5.cloudContext, c5.runtimeName).transaction
       runtimeIds = Set(c1, c2, c3, c4, c5).map(_.samResource: SamResourceId)
-      workspaceIds = Set(workspaceId1, workspaceId2).map(WorkspaceResourceSamResourceId)
 
       list1 <- RuntimeServiceDbQueries
-        .listRuntimes(
-          readerRuntimeIds = runtimeIds,
-          readerWorkspaceIds = workspaceIds,
-          excludeStatuses = List(RuntimeStatus.Deleted),
-          workspaceId = Some(workspaceId1),
-          cloudProvider = Some(CloudProvider.Azure)
+        .listRuntimes(runtimeIds = runtimeIds,
+                      cloudProvider = Some(CloudProvider.Azure),
+                      excludeStatuses = List(RuntimeStatus.Deleted),
+                      workspaceId = Some(workspaceId1)
         )
         .transaction
       list2 <- RuntimeServiceDbQueries
-        .listRuntimes(
-          readerRuntimeIds = runtimeIds,
-          readerWorkspaceIds = workspaceIds,
-          excludeStatuses = List(RuntimeStatus.Deleted),
-          workspaceId = Some(workspaceId2),
-          cloudProvider = Some(CloudProvider.Azure)
+        .listRuntimes(runtimeIds = runtimeIds,
+                      cloudProvider = Some(CloudProvider.Azure),
+                      excludeStatuses = List(RuntimeStatus.Deleted),
+                      workspaceId = Some(workspaceId2)
         )
         .transaction
       list3 <- RuntimeServiceDbQueries
-        .listRuntimes(
-          readerRuntimeIds = runtimeIds,
-          readerWorkspaceIds = workspaceIds,
-          excludeStatuses = List(RuntimeStatus.Deleted),
-          workspaceId = Some(workspaceId1),
-          cloudProvider = Some(CloudProvider.Gcp)
+        .listRuntimes(runtimeIds = runtimeIds,
+                      cloudProvider = Some(CloudProvider.Gcp),
+                      excludeStatuses = List(RuntimeStatus.Deleted),
+                      workspaceId = Some(workspaceId1)
         )
         .transaction
       list4 <- RuntimeServiceDbQueries
-        .listRuntimes(
-          readerRuntimeIds = runtimeIds,
-          readerWorkspaceIds = workspaceIds,
-          excludeStatuses = List(RuntimeStatus.Deleted),
-          cloudProvider = Some(CloudProvider.Azure)
+        .listRuntimes(runtimeIds = runtimeIds,
+                      cloudProvider = Some(CloudProvider.Azure),
+                      excludeStatuses = List(RuntimeStatus.Deleted)
         )
         .transaction
       list5 <- RuntimeServiceDbQueries
         .listRuntimes(
-          readerRuntimeIds = runtimeIds,
-          readerWorkspaceIds = workspaceIds,
-          excludeStatuses = List(RuntimeStatus.Deleted),
+          runtimeIds = runtimeIds,
+          cloudProvider = Some(CloudProvider.Azure),
           creatorEmail = Some(c5ClusterRecord.get.auditInfo.creator),
-          workspaceId = Some(workspaceId2),
-          cloudProvider = Some(CloudProvider.Azure)
+          excludeStatuses = List(RuntimeStatus.Deleted),
+          workspaceId = Some(workspaceId2)
         )
         .transaction
       end <- IO.realTimeInstant

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/HttpRoutesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/HttpRoutesSpec.scala
@@ -532,7 +532,7 @@ class HttpRoutesSpec
   // Tests only parameter parsing, not service logic.
   it should "list runtimes v2 with labels" in isolatedDbTest {
     Get(
-      s"/api/v2/runtimes/${workspaceId.value.toString}/azure?foo=bar&includeDeleted=true"
+      s"/api/v2/runtimes/${workspaceId.value.toString}/azure?foo=bar"
     ) ~> routes.route ~> check {
       status shouldEqual StatusCodes.OK
 

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/TestLeoRoutes.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/TestLeoRoutes.scala
@@ -130,7 +130,6 @@ trait TestLeoRoutes {
   val runtimev2Service =
     new RuntimeV2ServiceInterp[IO](
       serviceConfig,
-      allowListAuthProvider,
       QueueFactory.makePublisherQueue(),
       QueueFactory.makeDateAccessedQueue(),
       wsmClientProvider,

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/TestLeoRoutes.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/TestLeoRoutes.scala
@@ -187,7 +187,6 @@ trait TestLeoRoutes {
   val runtimeService = RuntimeService(
     serviceConfig,
     ConfigReader.appConfig.persistentDisk,
-    allowListAuthProvider,
     new MockDockerDAO,
     Some(FakeGoogleStorageInterpreter),
     Some(FakeGoogleComputeService),

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/AppServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/AppServiceInterpSpec.scala
@@ -309,6 +309,7 @@ class AppServiceInterpTest extends AnyFlatSpec with AppServiceInterpSpec with Le
     val publisherQueue = QueueFactory.makePublisherQueue()
     val mockSamService = mock[SamService[IO]]
     when(mockSamService.createResource(any, any, any, any, any)(any)).thenReturn(IO.unit)
+    when(mockSamService.checkAuthorized(any, any, any)(any)).thenReturn(IO.unit)
     when(mockSamService.deleteResource(any, any)(any)).thenReturn(IO.unit)
     when(mockSamService.getUserEmail(any)(any)).thenReturn(IO.pure(userInfo.userEmail))
     when(mockSamService.lookupWorkspaceParentForGoogleProject(any, any)(any)).thenReturn(IO.none)

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/DiskServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/DiskServiceInterpSpec.scala
@@ -2,6 +2,7 @@ package org.broadinstitute.dsde.workbench.leonardo
 package http
 package service
 
+import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import cats.effect.IO
 import cats.mtl.Ask
@@ -25,16 +26,16 @@ import org.broadinstitute.dsde.workbench.model
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.broadinstitute.dsde.workbench.model.{TraceId, UserInfo, WorkbenchEmail, WorkbenchUserId}
 import org.mockito.ArgumentMatchers
-import org.mockito.ArgumentMatchers.any
+import org.mockito.ArgumentMatchers.{any, eq => isEq}
 import org.mockito.Mockito._
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatestplus.mockito.MockitoSugar
 
 import java.time.Instant
 import java.util.UUID
-import scala.collection.immutable.List
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
+import org.broadinstitute.dsde.workbench.leonardo.dao.sam.{SamException, SamService}
 
 trait DiskServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with TestComponent with MockitoSugar {
   val emptyCreateDiskReq = CreateDiskRequest(
@@ -52,16 +53,15 @@ trait DiskServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with Test
 
   def makeDiskService(dontCloneFromTheseGoogleFolders: Vector[String] = Vector.empty,
                       googleProjectDAO: GoogleProjectDAO = new MockGoogleProjectDAO,
-                      allowListAuthProvider: AllowlistAuthProvider = allowListAuthProvider
+                      samService: SamService[IO] = MockSamService
   ) = {
     val publisherQueue = QueueFactory.makePublisherQueue()
     val diskService = new DiskServiceInterp(
       ConfigReader.appConfig.persistentDisk.copy(dontCloneFromTheseGoogleFolders = dontCloneFromTheseGoogleFolders),
-      allowListAuthProvider,
       publisherQueue,
       Some(MockGoogleDiskService),
       Some(googleProjectDAO),
-      MockSamService
+      samService
     )
     (diskService, publisherQueue)
   }
@@ -74,8 +74,18 @@ class DiskServiceInterpTest
     with MockitoSugar {
 
   "DiskService" should "fail with AuthorizationError if user doesn't have project level permission" in {
-    val (diskService, _) = makeDiskService()
+    val samService = mock[SamService[IO]]
+    val (diskService, _) = makeDiskService(samService = samService)
     val googleProject = GoogleProject("googleProject")
+    when(samService.getUserEmail(isEq(userInfo4.accessToken.token))(any())).thenReturn(IO.pure(userInfo4.userEmail))
+    when(
+      samService.checkAuthorized(any(),
+                                 isEq(ProjectSamResourceId(googleProject)),
+                                 isEq(ProjectAction.CreatePersistentDisk)
+      )(
+        any()
+      )
+    ).thenReturn(IO.raiseError(SamException.create("forbidden", 403, TraceId(""))))
 
     val res = for {
       d <- diskService
@@ -150,7 +160,6 @@ class DiskServiceInterpTest
     val publisherQueue = QueueFactory.makePublisherQueue()
     val diskService = new DiskServiceInterp(
       ConfigReader.appConfig.persistentDisk.copy(dontCloneFromTheseGoogleFolders = forbiddenFolders),
-      allowListAuthProvider,
       publisherQueue,
       Some(new MockGoogleDiskService {
         override def getDisk(project: GoogleProject, zone: ZoneName, diskName: DiskName)(implicit
@@ -269,17 +278,15 @@ class DiskServiceInterpTest
 
   it should "fail with BadRequestException if user doesn't have permission to source disk" in isolatedDbTest {
     val dummyDiskLink = "dummyDiskLink"
-    val authProviderMock = mock[LeoAuthProvider[IO]](defaultMockitoAnswer[IO])
     val googleDiskServiceMock = mock[GoogleDiskService[IO]](defaultMockitoAnswer[IO])
-
+    val samService = mock[SamService[IO]]
     val publisherQueue = QueueFactory.makePublisherQueue()
     val diskService = new DiskServiceInterp(
       ConfigReader.appConfig.persistentDisk,
-      authProviderMock,
       publisherQueue,
       Some(googleDiskServiceMock),
       Some(new MockGoogleProjectDAO),
-      MockSamService
+      samService = samService
     )
     val userInfoCreator =
       UserInfo(OAuth2BearerToken(""), WorkbenchUserId("creator"), WorkbenchEmail("creator@example.com"), 0)
@@ -289,26 +296,18 @@ class DiskServiceInterpTest
     val googleProject = GoogleProject("project1")
     val diskName = DiskName("diskName1")
     val workspaceId = WorkspaceId(UUID.randomUUID())
-    when(
-      authProviderMock.hasPermission(ArgumentMatchers.eq(ProjectSamResourceId(googleProject)),
-                                     ArgumentMatchers.eq(ProjectAction.CreatePersistentDisk),
-                                     ArgumentMatchers.eq(userInfoCreator)
-      )(any(), any())
-    ).thenReturn(IO.pure(true))
-
-    when(
-      authProviderMock.hasPermission(ArgumentMatchers.eq(ProjectSamResourceId(googleProject)),
-                                     ArgumentMatchers.eq(ProjectAction.CreatePersistentDisk),
-                                     ArgumentMatchers.eq(userInfoCloner)
-      )(any(), any())
-    ).thenReturn(IO.pure(true))
-
-    when(
-      authProviderMock.isUserProjectReader(ArgumentMatchers.eq(CloudContext.Gcp(googleProject)),
-                                           ArgumentMatchers.eq(userInfoCloner)
-      )(any())
-    ).thenReturn(IO.pure(true))
-
+    when(samService.getUserEmail(isEq(userInfoCreator.accessToken.token))(any()))
+      .thenReturn(IO.pure(userInfoCreator.userEmail))
+    when(samService.getPetServiceAccount(isEq(userInfoCreator.accessToken.token), isEq(googleProject))(any()))
+      .thenReturn(IO.pure(WorkbenchEmail("creatorPet@example.com")))
+    when(samService.getUserEmail(isEq(userInfoCloner.accessToken.token))(any()))
+      .thenReturn(IO.pure(userInfoCloner.userEmail))
+    when(samService.getPetServiceAccount(isEq(userInfoCloner.accessToken.token), isEq(googleProject))(any()))
+      .thenReturn(IO.pure(WorkbenchEmail("clonerPet@example.com")))
+    when(samService.checkAuthorized(isEq(userInfoCreator.accessToken.token), any(), any())(any())).thenReturn(IO.unit)
+    when(samService.lookupWorkspaceParentForGoogleProject(isEq(userInfoCreator.accessToken.token), any())(any()))
+      .thenReturn(IO.pure(Option(workspaceId)))
+    when(samService.createResource(any(), any(), any(), any(), any())(any())).thenReturn(IO.unit)
     when(
       googleDiskServiceMock.getDisk(googleProject, ConfigReader.appConfig.persistentDisk.defaultZone, diskName)
     ).thenReturn(IO.pure(Some(Disk.newBuilder().setSelfLink(dummyDiskLink).build())))
@@ -328,14 +327,12 @@ class DiskServiceInterpTest
         .transaction
         .map { r =>
           when(
-            authProviderMock.hasPermissionWithProjectFallback(
-              ArgumentMatchers.eq(r.samResource),
-              ArgumentMatchers.eq(PersistentDiskAction.ReadPersistentDisk),
-              ArgumentMatchers.eq(ProjectAction.ReadPersistentDisk),
-              ArgumentMatchers.eq(userInfoCloner),
-              ArgumentMatchers.eq(googleProject)
-            )(any[SamResourceAction[PersistentDiskSamResourceId, ReadPersistentDisk.type]], any[Ask[IO, TraceId]])
-          ).thenReturn(IO.pure(false))
+            samService.checkAuthorized(isEq(userInfoCloner.accessToken.token),
+                                       isEq(r.samResource),
+                                       isEq(PersistentDiskAction.ReadPersistentDisk)
+            )(any())
+          )
+            .thenReturn(IO.raiseError(SamException.create("forbidden", 403, TraceId(""))))
         }
 
       cloneAttempt <- diskService
@@ -366,26 +363,36 @@ class DiskServiceInterpTest
     res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
-  it should "fail to get a disk when user doesn't have project access" in isolatedDbTest {
-    val (diskService, _) = makeDiskService()
+  it should "fail to get a disk when user doesn't have access" in isolatedDbTest {
+    val samService = mock[SamService[IO]]
+    val (diskService, _) = makeDiskService(samService = samService)
 
     val res = for {
       samResource <- IO(PersistentDiskSamResourceId(UUID.randomUUID.toString))
       disk <- makePersistentDisk(None).copy(samResource = samResource).save()
+      _ = when(
+        samService.checkAuthorized(isEq(unauthorizedUserInfo.accessToken.token),
+                                   isEq(disk.samResource),
+                                   isEq(PersistentDiskAction.ReadPersistentDisk)
+        )(any())
+      ).thenReturn(IO.raiseError(SamException.create("forbidden", 403, TraceId(""))))
       getResponse <- diskService.getDisk(unauthorizedUserInfo, disk.cloudContext, disk.name)
     } yield getResponse
 
-    a[ForbiddenError] should be thrownBy {
+    a[DiskNotFoundException] should be thrownBy {
       res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
     }
   }
 
   it should "list disks" in isolatedDbTest {
-    val (diskService, _) = makeDiskService()
+    val samService = mock[SamService[IO]]
+    val (diskService, _) = makeDiskService(samService = samService)
 
     val res = for {
       disk1 <- makePersistentDisk(Some(DiskName("d1"))).save()
       disk2 <- makePersistentDisk(Some(DiskName("d2"))).save()
+      _ = when(samService.listResources(any(), isEq(SamResourceType.PersistentDisk))(any()))
+        .thenReturn(IO.pure(List(disk1.samResource.resourceId, disk2.samResource.resourceId)))
       listResponse <- diskService.listDisks(userInfo, None, Map("includeLabels" -> "key1,key2,key4"))
     } yield {
       listResponse.map(_.id).toSet shouldBe Set(disk1.id, disk2.id)
@@ -396,11 +403,14 @@ class DiskServiceInterpTest
   }
 
   it should "list azure and gcp disks" in isolatedDbTest {
-    val (diskService, _) = makeDiskService()
+    val samService = mock[SamService[IO]]
+    val (diskService, _) = makeDiskService(samService = samService)
 
     val res = for {
       disk1 <- makePersistentDisk(Some(DiskName("d1")), cloudContextOpt = Some(cloudContextGcp)).save()
       disk2 <- makePersistentDisk(Some(DiskName("d2")), cloudContextOpt = Some(cloudContextAzure)).save()
+      _ = when(samService.listResources(any(), isEq(SamResourceType.PersistentDisk))(any()))
+        .thenReturn(IO.pure(List(disk1.samResource.resourceId, disk2.samResource.resourceId)))
       listResponse <- diskService.listDisks(userInfo, None, Map("includeLabels" -> "key1,key2,key4"))
     } yield {
       listResponse.map(_.id).toSet shouldBe Set(disk1.id, disk2.id)
@@ -411,37 +421,32 @@ class DiskServiceInterpTest
   }
 
   it should "list disks with a project" in isolatedDbTest {
-    val (diskService, _) = makeDiskService()
+    val samService = mock[SamService[IO]]
+    val (diskService, _) = makeDiskService(samService = samService)
 
     val res = for {
       disk1 <- makePersistentDisk(Some(DiskName("d1")), cloudContextOpt = Some(cloudContextGcp)).save()
       disk2 <- makePersistentDisk(Some(DiskName("d2")), cloudContextOpt = Some(cloudContextGcp)).save()
-      _ <- makePersistentDisk(None, cloudContextOpt = Some(CloudContext.Gcp(GoogleProject("non-default")))).save()
+      disk3 <- makePersistentDisk(Some(DiskName("d3")), cloudContextOpt = Some(CloudContext.Gcp(project2))).save()
+      _ = when(samService.listResources(any(), isEq(SamResourceType.PersistentDisk))(any()))
+        .thenReturn(
+          IO.pure(List(disk1.samResource.resourceId, disk2.samResource.resourceId, disk3.samResource.resourceId))
+        )
       listResponse <- diskService.listDisks(userInfo, Some(cloudContextGcp), Map.empty)
     } yield listResponse.map(_.id).toSet shouldBe Set(disk1.id, disk2.id)
 
     res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
-  it should "list disks with project access" in isolatedDbTest {
-    val (diskService, _) = makeDiskService()
-
-    val res = for {
-      disk1 <- makePersistentDisk(Some(DiskName("d1")), cloudContextOpt = Some(cloudContextGcp)).save()
-      disk2 <- makePersistentDisk(Some(DiskName("d2")), cloudContextOpt = Some(CloudContext.Gcp(project2))).save()
-      _ <- makePersistentDisk(None, cloudContextOpt = Some(CloudContext.Gcp(GoogleProject("non-default")))).save()
-      listResponse <- diskService.listDisks(userInfo, Some(cloudContextGcp), Map.empty)
-    } yield listResponse.map(_.id).toSet shouldBe Set(disk1.id)
-
-    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
-  }
-
   it should "list disks with parameters" in isolatedDbTest {
-    val (diskService, _) = makeDiskService()
+    val samService = mock[SamService[IO]]
+    val (diskService, _) = makeDiskService(samService = samService)
 
     val res = for {
       disk1 <- makePersistentDisk(Some(DiskName("d1"))).save()
-      _ <- makePersistentDisk(Some(DiskName("d2"))).save()
+      disk2 <- makePersistentDisk(Some(DiskName("d2"))).save()
+      _ = when(samService.listResources(any(), isEq(SamResourceType.PersistentDisk))(any()))
+        .thenReturn(IO.pure(List(disk1.samResource.resourceId, disk2.samResource.resourceId)))
       _ <- labelQuery.save(disk1.id.value, LabelResourceType.PersistentDisk, "foo", "bar").transaction
       listResponse <- diskService.listDisks(userInfo, None, Map("foo" -> "bar"))
     } yield listResponse.map(_.id).toSet shouldBe Set(disk1.id)
@@ -450,9 +455,10 @@ class DiskServiceInterpTest
   }
 
   it should "list disks belonging to other users" in isolatedDbTest {
-    val (diskService, _) = makeDiskService()
+    val samService = mock[SamService[IO]]
+    val (diskService, _) = makeDiskService(samService = samService)
 
-    // Make disks belonging to different users than the calling user
+    // Make disks belonging to different users than the calling user that the calling user has access to
     val res = for {
       disk1 <- LeoLenses.diskToCreator
         .set(WorkbenchEmail("a_different_user@example.com"))(
@@ -462,17 +468,19 @@ class DiskServiceInterpTest
       disk2 <- LeoLenses.diskToCreator
         .set(WorkbenchEmail("a_different_user2@example.com"))(makePersistentDisk(Some(DiskName("d2"))))
         .save()
+      _ = when(samService.listResources(any(), isEq(SamResourceType.PersistentDisk))(any()))
+        .thenReturn(IO.pure(List(disk1.samResource.resourceId, disk2.samResource.resourceId)))
       listResponse <- diskService.listDisks(userInfo, None, Map.empty)
     } yield
-    // Since the calling user is allow-listed in the auth provider, it should return
-    // the disks belonging to other users.
+    // Since the calling user has access to the disks, should see both when not filtering by role=creator
     listResponse.map(_.id).toSet shouldBe Set(disk1.id, disk2.id)
 
     res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   it should "list disks belonging to self and others, if not filtered by role=creator" in isolatedDbTest {
-    val (diskService, _) = makeDiskService()
+    val samService = mock[SamService[IO]]
+    val (diskService, _) = makeDiskService(samService = samService)
 
     val res = for {
       disk1 <- makePersistentDisk(Some(DiskName("d1"))).save()
@@ -480,6 +488,8 @@ class DiskServiceInterpTest
       disk2 <- LeoLenses.diskToCreator
         .set(WorkbenchEmail("a_different_user@example.com"))(makePersistentDisk(Some(DiskName("d2"))))
         .save()
+      _ = when(samService.listResources(any(), isEq(SamResourceType.PersistentDisk))(any()))
+        .thenReturn(IO.pure(List(disk1.samResource.resourceId, disk2.samResource.resourceId)))
       listResponse <- diskService.listDisks(userInfo, None, Map.empty)
     } yield
     // Since the calling user has access to both disks, should see both
@@ -489,7 +499,8 @@ class DiskServiceInterpTest
   }
 
   it should "list disks belonging to self only, if filtered by role=creator" in isolatedDbTest {
-    val (diskService, _) = makeDiskService()
+    val samService = mock[SamService[IO]]
+    val (diskService, _) = makeDiskService(samService = samService)
 
     val res = for {
       disk1 <- makePersistentDisk(Some(DiskName("d1"))).save()
@@ -497,6 +508,8 @@ class DiskServiceInterpTest
       disk2 <- LeoLenses.diskToCreator
         .set(WorkbenchEmail("a_different_user@example.com"))(makePersistentDisk(Some(DiskName("d2"))))
         .save()
+      _ = when(samService.listResources(any(), isEq(SamResourceType.PersistentDisk))(any()))
+        .thenReturn(IO.pure(List(disk1.samResource.resourceId, disk2.samResource.resourceId)))
       listResponse <- diskService.listDisks(userInfo, None, Map("role" -> "creator"))
     } yield
     // Since the calling user created disk1 only, only disk1 is visible when filtered by role=creator
@@ -506,7 +519,8 @@ class DiskServiceInterpTest
   }
 
   it should "fail to list disks if filtered by role=not_creator" in isolatedDbTest {
-    val (diskService, _) = makeDiskService()
+    val samService = mock[SamService[IO]]
+    val (diskService, _) = makeDiskService(samService = samService)
 
     val res = for {
       disk1 <- makePersistentDisk(Some(DiskName("d1"))).save()
@@ -514,6 +528,8 @@ class DiskServiceInterpTest
       disk2 <- LeoLenses.diskToCreator
         .set(WorkbenchEmail("a_different_user@example.com"))(makePersistentDisk(Some(DiskName("d2"))))
         .save()
+      _ = when(samService.listResources(any(), isEq(SamResourceType.PersistentDisk))(any()))
+        .thenReturn(IO.pure(List(disk1.samResource.resourceId, disk2.samResource.resourceId)))
       listResponse <- diskService.listDisks(userInfo, None, Map("role" -> "manager"))
     } yield listResponse
 
@@ -523,7 +539,10 @@ class DiskServiceInterpTest
   }
 
   it should "delete a disk" in isolatedDbTest {
-    val (diskService, publisherQueue) = makeDiskService()
+    val samService = mock[SamService[IO]]
+    when(samService.checkAuthorized(any(), any(), isEq(PersistentDiskAction.DeletePersistentDisk))(any()))
+      .thenReturn(IO.unit)
+    val (diskService, publisherQueue) = makeDiskService(samService = samService)
 
     val res = for {
       context <- appContext.ask[AppContext]
@@ -546,7 +565,10 @@ class DiskServiceInterpTest
   }
 
   it should "fail to delete a disk if it is attached to a runtime" in isolatedDbTest {
-    val (diskService, _) = makeDiskService()
+    val samService = mock[SamService[IO]]
+    when(samService.checkAuthorized(any(), any(), isEq(PersistentDiskAction.DeletePersistentDisk))(any()))
+      .thenReturn(IO.unit)
+    val (diskService, _) = makeDiskService(samService = samService)
 
     val res = for {
       t <- appContext.ask[AppContext]
@@ -568,8 +590,13 @@ class DiskServiceInterpTest
     res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
-  it should "fail to delete a disk if user lost project access" in isolatedDbTest {
-    val (diskService, _) = makeDiskService(allowListAuthProvider = allowListAuthProvider2)
+  it should "fail to delete a disk if user can view the disk but not delete it" in isolatedDbTest {
+    val samService = mock[SamService[IO]]
+    when(samService.checkAuthorized(any(), any(), isEq(PersistentDiskAction.DeletePersistentDisk))(any()))
+      .thenReturn(IO.raiseError(SamException.create("forbidden", StatusCodes.Forbidden.intValue, TraceId(""))))
+    when(samService.checkAuthorized(any(), any(), isEq(PersistentDiskAction.ReadPersistentDisk))(any()))
+      .thenReturn(IO.unit)
+    val (diskService, _) = makeDiskService(samService = samService)
 
     val res = for {
       t <- appContext.ask[AppContext]
@@ -585,14 +612,21 @@ class DiskServiceInterpTest
           )
         )
       )
-      err <- diskService.deleteDisk(userInfo, GoogleProject(disk.cloudContext.asString), disk.name).attempt
-    } yield err shouldBe Left(ForbiddenError(userInfo.userEmail, Some(t.traceId)))
+      deleteResp <- diskService.deleteDisk(userInfo, GoogleProject(disk.cloudContext.asString), disk.name)
+    } yield deleteResp
 
-    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
+    a[ForbiddenError] should be thrownBy {
+      res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
+    }
   }
 
   it should "delete a disk records but not queue delete disk message" in isolatedDbTest {
-    val (diskService, publisherQueue) = makeDiskService()
+    val samService = mock[SamService[IO]]
+    when(samService.checkAuthorized(any(), any(), isEq(PersistentDiskAction.DeletePersistentDisk))(any()))
+      .thenReturn(IO.unit)
+    when(samService.deleteResource(any(), any())(any()))
+      .thenReturn(IO.unit)
+    val (diskService, publisherQueue) = makeDiskService(samService = samService)
 
     val res = for {
       context <- appContext.ask[AppContext]
@@ -600,7 +634,8 @@ class DiskServiceInterpTest
       disk <- makePersistentDisk(Some(DiskName("d1")), cloudContextOpt = Some(cloudContextGcp))
         .copy(samResource = diskSamResource)
         .save()
-
+      _ = when(samService.listResources(any(), isEq(SamResourceType.PersistentDisk))(any()))
+        .thenReturn(IO.pure(List(disk.samResource.resourceId)))
       listResponse <- diskService.listDisks(userInfo, Some(cloudContextGcp), Map.empty)
 
       _ <- diskService.deleteDiskRecords(userInfo, cloudContextGcp, listResponse.head)
@@ -619,8 +654,11 @@ class DiskServiceInterpTest
   }
 
   it should "fail to delete a disk records if the user does not have permission" in isolatedDbTest {
-    val (diskService1, _) = makeDiskService()
-    val (diskService2, _) = makeDiskService(allowListAuthProvider = allowListAuthProvider2)
+    val samService = mock[SamService[IO]]
+    when(samService.checkAuthorized(any(), any(), any())(any()))
+      .thenReturn(IO.raiseError(SamException.create("forbidden", StatusCodes.Forbidden.intValue, TraceId(""))))
+    when(samService.deleteResource(any(), any())(any())).thenReturn(IO.unit)
+    val (diskService, _) = makeDiskService(samService = samService)
 
     val res = for {
       context <- appContext.ask[AppContext]
@@ -628,10 +666,11 @@ class DiskServiceInterpTest
       disk <- makePersistentDisk(Some(DiskName("d1")), cloudContextOpt = Some(cloudContextGcp))
         .copy(samResource = diskSamResource)
         .save()
+      _ = when(samService.listResources(any(), isEq(SamResourceType.PersistentDisk))(any()))
+        .thenReturn(IO.pure(List(disk.samResource.resourceId)))
+      listResponse <- diskService.listDisks(userInfo, Some(cloudContextGcp), Map.empty)
 
-      listResponse <- diskService1.listDisks(userInfo, Some(cloudContextGcp), Map.empty)
-
-      err <- diskService2.deleteDiskRecords(userInfo, cloudContextGcp, listResponse.head).attempt
+      err <- diskService.deleteDiskRecords(userInfo, cloudContextGcp, listResponse.head).attempt
       status <- persistentDiskQuery
         .getStatus(disk.id)
         .transaction
@@ -645,7 +684,12 @@ class DiskServiceInterpTest
   }
 
   it should "delete all disks records but not queue delete disk messages" in isolatedDbTest {
-    val (diskService, publisherQueue) = makeDiskService()
+    val samService = mock[SamService[IO]]
+    when(samService.checkAuthorized(any(), any(), isEq(PersistentDiskAction.DeletePersistentDisk))(any()))
+      .thenReturn(IO.unit)
+    when(samService.deleteResource(any(), any())(any()))
+      .thenReturn(IO.unit)
+    val (diskService, publisherQueue) = makeDiskService(samService = samService)
 
     val res = for {
       context <- appContext.ask[AppContext]
@@ -658,15 +702,16 @@ class DiskServiceInterpTest
       disk2 <- makePersistentDisk(Some(DiskName("d2")), cloudContextOpt = Some(cloudContextGcp))
         .copy(samResource = diskSamResource2)
         .save()
-
+      _ = when(samService.listResources(any(), isEq(SamResourceType.PersistentDisk))(any()))
+        .thenReturn(IO.pure(List(disk1.samResource.resourceId, disk2.samResource.resourceId)))
       _ <- diskService.deleteAllDisksRecords(userInfo, cloudContextGcp)
 
-      disks <- diskService.listDisks(userInfo, Some(cloudContextGcp), Map("includeDeleted" -> "true"))
+      disks <- diskService.listDisks(userInfo, Some(cloudContextGcp), Map.empty)
 
       message <- publisherQueue.tryTake
 
     } yield {
-      disks.map(_.status) shouldEqual List(DiskStatus.Deleted, DiskStatus.Deleted)
+      disks shouldEqual List.empty
       message shouldBe None
     }
 
@@ -674,7 +719,8 @@ class DiskServiceInterpTest
   }
 
   it should "delete all orphaned disks" in isolatedDbTest {
-    val (diskService, publisherQueue) = makeDiskService()
+    val samService = mock[SamService[IO]]
+    val (diskService, publisherQueue) = makeDiskService(samService = samService)
 
     val res = for {
       context <- appContext.ask[AppContext]
@@ -689,16 +735,28 @@ class DiskServiceInterpTest
         .save()
       diskSamResource3 <- IO(PersistentDiskSamResourceId(UUID.randomUUID.toString))
       disk3 <- makePersistentDisk(Some(DiskName("d3")), cloudContextOpt = Some(cloudContextGcp))
-        .copy(samResource = diskSamResource1)
+        .copy(samResource = diskSamResource3)
         .save()
       diskSamResource4 <- IO(PersistentDiskSamResourceId(UUID.randomUUID.toString))
       disk4 <- makePersistentDisk(Some(DiskName("d4")), cloudContextOpt = Some(cloudContextGcp))
         .copy(samResource = diskSamResource4)
         .save()
+      _ = when(samService.listResources(any(), isEq(SamResourceType.PersistentDisk))(any()))
+        .thenReturn(
+          IO.pure(
+            List(disk1.samResource.resourceId,
+                 disk2.samResource.resourceId,
+                 disk3.samResource.resourceId,
+                 disk4.samResource.resourceId
+            )
+          )
+        )
+      _ = when(samService.checkAuthorized(any(), any(), isEq(PersistentDiskAction.DeletePersistentDisk))(any()))
+        .thenReturn(IO.unit)
 
       _ <- diskService.deleteAllOrphanedDisks(userInfo, cloudContextGcp, Vector(disk1.id), Vector(disk2.name))
 
-      disks <- diskService.listDisks(userInfo, Some(cloudContextGcp), Map("includeDeleted" -> "true"))
+      disks <- diskService.listDisks(userInfo, Some(cloudContextGcp), Map.empty)
 
       messages <- publisherQueue.tryTakeN(Some(2))
 
@@ -717,7 +775,8 @@ class DiskServiceInterpTest
   }
 
   it should "fail to delete all orphaned disks if a disk is not deletable" in isolatedDbTest {
-    val (diskService, publisherQueue) = makeDiskService()
+    val samService = mock[SamService[IO]]
+    val (diskService, publisherQueue) = makeDiskService(samService = samService)
 
     val res = for {
       context <- appContext.ask[AppContext]
@@ -730,10 +789,11 @@ class DiskServiceInterpTest
       disk2 <- makePersistentDisk(Some(DiskName("d2")), cloudContextOpt = Some(cloudContextGcp))
         .copy(samResource = diskSamResource2, status = DiskStatus.Deleting)
         .save()
-
+      _ = when(samService.listResources(any(), isEq(SamResourceType.PersistentDisk))(any()))
+        .thenReturn(IO.pure(List(disk1.samResource.resourceId, disk2.samResource.resourceId)))
       _ <- diskService.deleteAllOrphanedDisks(userInfo, cloudContextGcp, Vector.empty, Vector.empty)
 
-      disks <- diskService.listDisks(userInfo, Some(cloudContextGcp), Map("includeDeleted" -> "true"))
+      disks <- diskService.listDisks(userInfo, Some(cloudContextGcp), Map.empty)
 
       messages <- publisherQueue.tryTakeN(Some(2))
 
@@ -782,6 +842,29 @@ class DiskServiceInterpTest
     }
 
     res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
+  }
+
+  it should "fail to update a disk if the user does not have permission" in isolatedDbTest {
+    val samService = mock[SamService[IO]]
+    when(samService.checkAuthorized(any(), any(), isEq(PersistentDiskAction.ModifyPersistentDisk))(any()))
+      .thenReturn(IO.raiseError(SamException.create("forbidden", StatusCodes.Forbidden.intValue, TraceId(""))))
+    when(samService.checkAuthorized(any(), any(), isEq(PersistentDiskAction.ReadPersistentDisk))(any()))
+      .thenReturn(IO.unit)
+
+    val (diskService, _) = makeDiskService(samService = samService)
+
+    val res = for {
+      t <- appContext.ask[AppContext]
+      diskSamResource <- IO(PersistentDiskSamResourceId(UUID.randomUUID.toString))
+      disk <- makePersistentDisk(None).copy(samResource = diskSamResource).save()
+      req = UpdateDiskRequest(Map.empty, DiskSize(600))
+      fail <- diskService
+        .updateDisk(userInfo, GoogleProject(disk.cloudContext.asString), disk.name, req)
+    } yield fail
+
+    a[ForbiddenError] should be thrownBy {
+      res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
+    }
   }
 
   it should "get a correct sam policy map for disks" in {

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/DiskV2ServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/DiskV2ServiceInterpSpec.scala
@@ -2,6 +2,7 @@ package org.broadinstitute.dsde.workbench.leonardo
 package http
 package service
 
+import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import cats.effect.IO
 import cats.effect.std.Queue
@@ -10,7 +11,7 @@ import org.broadinstitute.dsde.workbench.google2.{MachineTypeName, ZoneName}
 import org.broadinstitute.dsde.workbench.leonardo.CommonTestData._
 import org.broadinstitute.dsde.workbench.leonardo.SamResourceId.PersistentDiskSamResourceId
 import org.broadinstitute.dsde.workbench.leonardo.TestUtils.appContext
-import org.broadinstitute.dsde.workbench.leonardo.auth.AllowlistAuthProvider
+import org.broadinstitute.dsde.workbench.leonardo.dao.sam.{SamException, SamService}
 import org.broadinstitute.dsde.workbench.leonardo.dao.{MockWsmClientProvider, MockWsmDAO, WsmApiClientProvider, WsmDao}
 import org.broadinstitute.dsde.workbench.leonardo.db._
 import org.broadinstitute.dsde.workbench.leonardo.model.ForbiddenError
@@ -18,7 +19,10 @@ import org.broadinstitute.dsde.workbench.leonardo.monitor.LeoPubsubMessage
 import org.broadinstitute.dsde.workbench.leonardo.monitor.LeoPubsubMessage.DeleteDiskV2Message
 import org.broadinstitute.dsde.workbench.leonardo.util.QueueFactory
 import org.broadinstitute.dsde.workbench.model.{UserInfo, WorkbenchEmail, WorkbenchUserId}
+import org.mockito.Mockito.when
+import org.mockito.ArgumentMatchers.{any, eq => isEq}
 import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatestplus.mockito.MockitoSugar.mock
 import org.typelevel.log4cats.StructuredLogger
 
 import java.util.UUID
@@ -29,14 +33,14 @@ class DiskV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with Te
   val wsmClientProvider = new MockWsmClientProvider
 
   private def makeDiskV2Service(queue: Queue[IO, LeoPubsubMessage],
-                                allowlistAuthProvider: AllowlistAuthProvider = allowListAuthProvider,
                                 wsmDao: WsmDao[IO] = wsmDao,
-                                wsmClientProvider: WsmApiClientProvider[IO] = wsmClientProvider
+                                wsmClientProvider: WsmApiClientProvider[IO] = wsmClientProvider,
+                                samService: SamService[IO] = MockSamService
   ) =
     new DiskV2ServiceInterp[IO](
-      allowlistAuthProvider,
       queue,
-      wsmClientProvider
+      wsmClientProvider,
+      samService
     )
 
   val diskV2Service = makeDiskV2Service(QueueFactory.makePublisherQueue(), wsmDao = new MockWsmDAO)
@@ -48,11 +52,15 @@ class DiskV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with Te
                             0
     ) // this email is allowlisted
     val publisherQueue = QueueFactory.makePublisherQueue()
-    val diskV2Service = makeDiskV2Service(publisherQueue)
+    val samService = mock[SamService[IO]]
+    val diskV2Service = makeDiskV2Service(publisherQueue, samService = samService)
 
     val res = for {
       _ <- publisherQueue.tryTake // just to make sure there's no messages in the queue to start with
       pd <- makePersistentDisk().copy(status = DiskStatus.Ready).save()
+      _ = when(
+        samService.checkAuthorized(any(), isEq(pd.samResource), isEq(PersistentDiskAction.ReadPersistentDisk))(any())
+      ).thenReturn(IO.unit)
 
       getResponse <- diskV2Service
         .getDisk(
@@ -90,15 +98,19 @@ class DiskV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with Te
     res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
-  it should "fail with ForbiddenError if user doesn't have permission" in isolatedDbTest {
+  it should "fail with DiskNotFound if user doesn't have permission" in isolatedDbTest {
     val publisherQueue = QueueFactory.makePublisherQueue()
-    val diskV2Service = makeDiskV2Service(publisherQueue)
+    val samService = mock[SamService[IO]]
+    val diskV2Service = makeDiskV2Service(publisherQueue, samService = samService)
     val userInfo =
       UserInfo(OAuth2BearerToken(""), WorkbenchUserId("stranger"), WorkbenchEmail("stranger@example.com"), 0)
 
     val res = for {
       ctx <- appContext.ask[AppContext]
       pd <- makePersistentDisk().copy(status = DiskStatus.Ready).save()
+      _ = when(
+        samService.checkAuthorized(any(), isEq(pd.samResource), isEq(PersistentDiskAction.ReadPersistentDisk))(any())
+      ).thenReturn(IO.raiseError(SamException.create("forbidden", StatusCodes.Forbidden.intValue, ctx.traceId)))
 
       getResponse <- diskV2Service
         .getDisk(
@@ -106,35 +118,16 @@ class DiskV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with Te
           pd.id
         )
         .attempt
-    } yield getResponse shouldBe Left(ForbiddenError(WorkbenchEmail("stranger@example.com")))
-    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
-  }
-
-  it should "fail with DiskNotFound if creator loses workspace access" in isolatedDbTest {
-    val publisherQueue = QueueFactory.makePublisherQueue()
-    val diskV2service2 = makeDiskV2Service(publisherQueue, allowListAuthProvider2)
-    val userInfo = UserInfo(OAuth2BearerToken(""),
-                            WorkbenchUserId("userId"),
-                            WorkbenchEmail("user1@example.com"),
-                            0
-    ) // this email is the disk creator, but NOT allow-listed in allowListAuthProvider2
-    val res = for {
-      ctx <- appContext.ask[AppContext]
-      pd <- makePersistentDisk().copy(status = DiskStatus.Ready).save()
-
-      getResponse <- diskV2service2
-        .getDisk(
-          userInfo,
-          pd.id
-        )
-        .attempt
-    } yield getResponse shouldBe Left(ForbiddenError(WorkbenchEmail("user1@example.com")))
+    } yield getResponse shouldBe Left(DiskNotFoundByIdException(pd.id, ctx.traceId))
     res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
   it should "delete a disk" in isolatedDbTest {
     val publisherQueue = QueueFactory.makePublisherQueue()
-    val diskV2Service = makeDiskV2Service(publisherQueue)
+    val samService = mock[SamService[IO]]
+    when(samService.checkAuthorized(any(), any(), isEq(PersistentDiskAction.DeletePersistentDisk))(any()))
+      .thenReturn(IO.unit)
+    val diskV2Service = makeDiskV2Service(publisherQueue, samService = samService)
 
     val res = for {
       ctx <- appContext.ask[AppContext]
@@ -174,12 +167,11 @@ class DiskV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with Te
         IO.pure(WsmState(Some("CREATING")))
     }
 
-    val diskV2Service = makeDiskV2Service(publisherQueue, wsmClientProvider = wsmClientProvider)
-    val userInfo = UserInfo(OAuth2BearerToken(""),
-                            WorkbenchUserId("userId"),
-                            WorkbenchEmail("user1@example.com"),
-                            0
-    ) // this email is allow-listed
+    val samService = mock[SamService[IO]]
+    when(samService.checkAuthorized(any(), any(), isEq(PersistentDiskAction.DeletePersistentDisk))(any()))
+      .thenReturn(IO.unit)
+    val diskV2Service =
+      makeDiskV2Service(publisherQueue, wsmClientProvider = wsmClientProvider, samService = samService)
 
     val res = for {
       ctx <- appContext.ask[AppContext]
@@ -205,12 +197,11 @@ class DiskV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with Te
         IO.pure(WsmState(None))
     }
 
-    val diskV2Service = makeDiskV2Service(publisherQueue, wsmClientProvider = wsmClientProvider)
-    val userInfo = UserInfo(OAuth2BearerToken(""),
-                            WorkbenchUserId("userId"),
-                            WorkbenchEmail("user1@example.com"),
-                            0
-    ) // this email is allow-listed
+    val samService = mock[SamService[IO]]
+    when(samService.checkAuthorized(any(), any(), isEq(PersistentDiskAction.DeletePersistentDisk))(any()))
+      .thenReturn(IO.unit)
+    val diskV2Service =
+      makeDiskV2Service(publisherQueue, wsmClientProvider = wsmClientProvider, samService = samService)
 
     val res = for {
       ctx <- appContext.ask[AppContext]
@@ -232,12 +223,10 @@ class DiskV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with Te
 
   it should "fail to delete a disk if it is attached to a runtime" in isolatedDbTest {
     val publisherQueue = QueueFactory.makePublisherQueue()
-    val diskV2Service = makeDiskV2Service(publisherQueue)
-    val userInfo = UserInfo(OAuth2BearerToken(""),
-                            WorkbenchUserId("userId"),
-                            WorkbenchEmail("user1@example.com"),
-                            0
-    ) // this email is allow-listed
+    val samService = mock[SamService[IO]]
+    when(samService.checkAuthorized(any(), any(), isEq(PersistentDiskAction.DeletePersistentDisk))(any()))
+      .thenReturn(IO.unit)
+    val diskV2Service = makeDiskV2Service(publisherQueue, samService = samService)
 
     val res = for {
       ctx <- appContext.ask[AppContext]
@@ -262,12 +251,10 @@ class DiskV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with Te
 
   it should "fail to delete a disk if it has no workspaceId" in isolatedDbTest {
     val publisherQueue = QueueFactory.makePublisherQueue()
-    val diskV2Service = makeDiskV2Service(publisherQueue)
-    val userInfo = UserInfo(OAuth2BearerToken(""),
-                            WorkbenchUserId("userId"),
-                            WorkbenchEmail("user1@example.com"),
-                            0
-    ) // this email is allow-listed
+    val samService = mock[SamService[IO]]
+    when(samService.checkAuthorized(any(), any(), isEq(PersistentDiskAction.DeletePersistentDisk))(any()))
+      .thenReturn(IO.unit)
+    val diskV2Service = makeDiskV2Service(publisherQueue, samService = samService)
 
     val res = for {
       ctx <- appContext.ask[AppContext]
@@ -287,18 +274,26 @@ class DiskV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with Te
     res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
-  it should "fail to delete a disk if its creator lost access to the workspace" in isolatedDbTest {
+  it should "ffail to delete a disk if the user does not have delete access and not reveal its existence if the user cannot read it" in isolatedDbTest {
     val publisherQueue = QueueFactory.makePublisherQueue()
-    val diskV2service2 = makeDiskV2Service(publisherQueue, allowListAuthProvider2)
-    val userInfo = UserInfo(OAuth2BearerToken(""),
-                            WorkbenchUserId("userId"),
-                            WorkbenchEmail("user1@example.com"),
-                            0
-    ) // this email is the disk creator, but NOT allow-listed in allowListAuthProvider2
+    val samService = mock[SamService[IO]]
+    val diskV2service2 = makeDiskV2Service(publisherQueue, samService = samService)
+
     val res = for {
       ctx <- appContext.ask[AppContext]
       disk <- makePersistentDisk().copy(status = DiskStatus.Ready).save()
-
+      _ = when(
+        samService.checkAuthorized(isEq(userInfo.accessToken.token),
+                                   isEq(disk.samResource),
+                                   isEq(PersistentDiskAction.DeletePersistentDisk)
+        )(any())
+      ).thenReturn(IO.raiseError(SamException.create("forbidden", StatusCodes.Forbidden.intValue, ctx.traceId)))
+      _ = when(
+        samService.checkAuthorized(isEq(userInfo.accessToken.token),
+                                   isEq(disk.samResource),
+                                   isEq(PersistentDiskAction.ReadPersistentDisk)
+        )(any())
+      ).thenReturn(IO.raiseError(SamException.create("forbidden", StatusCodes.Forbidden.intValue, ctx.traceId)))
       _ <- IO(
         makeCluster(1).saveWithRuntimeConfig(
           RuntimeConfig.AzureConfig(MachineTypeName("n1-standard-4"), Some(disk.id), None)
@@ -307,6 +302,39 @@ class DiskV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with Te
       err <- diskV2service2.deleteDisk(userInfo, disk.id).attempt
     } yield err shouldBe Left(
       DiskNotFoundByIdException(disk.id, ctx.traceId)
+    )
+
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
+  }
+
+  it should "fail to delete a disk if the user does not have delete access" in isolatedDbTest {
+    val publisherQueue = QueueFactory.makePublisherQueue()
+    val samService = mock[SamService[IO]]
+    val diskV2service2 = makeDiskV2Service(publisherQueue, samService = samService)
+
+    val res = for {
+      ctx <- appContext.ask[AppContext]
+      disk <- makePersistentDisk().copy(status = DiskStatus.Ready).save()
+      _ = when(
+        samService.checkAuthorized(isEq(userInfo.accessToken.token),
+                                   isEq(disk.samResource),
+                                   isEq(PersistentDiskAction.DeletePersistentDisk)
+        )(any())
+      ).thenReturn(IO.raiseError(SamException.create("forbidden", StatusCodes.Forbidden.intValue, ctx.traceId)))
+      _ = when(
+        samService.checkAuthorized(isEq(userInfo.accessToken.token),
+                                   isEq(disk.samResource),
+                                   isEq(PersistentDiskAction.ReadPersistentDisk)
+        )(any())
+      ).thenReturn(IO.unit)
+      _ <- IO(
+        makeCluster(1).saveWithRuntimeConfig(
+          RuntimeConfig.AzureConfig(MachineTypeName("n1-standard-4"), Some(disk.id), None)
+        )
+      )
+      err <- diskV2service2.deleteDisk(userInfo, disk.id).attempt
+    } yield err shouldBe Left(
+      ForbiddenError(userInfo.userEmail)
     )
 
     res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterpSpec.scala
@@ -96,7 +96,6 @@ trait RuntimeServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with T
         azureServiceConfig
       ),
       ConfigReader.appConfig.persistentDisk,
-      authProvider,
       new MockDockerDAO,
       Some(FakeGoogleStorageInterpreter),
       Some(computeService),
@@ -2307,7 +2306,6 @@ class RuntimeServiceInterpTest
         userEmail,
         serviceAccount,
         FormattedBy.GCE,
-        allowListAuthProvider,
         MockSamService,
         ConfigReader.appConfig.persistentDisk,
         Some(workspaceId)
@@ -2361,7 +2359,6 @@ class RuntimeServiceInterpTest
           userEmail,
           serviceAccount,
           FormattedBy.GCE,
-          allowListAuthProvider,
           MockSamService,
           ConfigReader.appConfig.persistentDisk,
           Some(workspaceId)
@@ -2391,7 +2388,6 @@ class RuntimeServiceInterpTest
           userEmail,
           serviceAccount,
           FormattedBy.GCE,
-          allowListAuthProvider,
           MockSamService,
           ConfigReader.appConfig.persistentDisk,
           Some(workspaceId)
@@ -2418,7 +2414,6 @@ class RuntimeServiceInterpTest
           userEmail,
           serviceAccount,
           FormattedBy.GCE,
-          allowListAuthProvider,
           MockSamService,
           ConfigReader.appConfig.persistentDisk,
           Some(workspaceId)
@@ -2442,7 +2437,6 @@ class RuntimeServiceInterpTest
           unauthorizedEmail,
           serviceAccount,
           FormattedBy.GCE,
-          allowListAuthProvider,
           MockSamService,
           ConfigReader.appConfig.persistentDisk,
           Some(workspaceId)
@@ -2478,7 +2472,6 @@ class RuntimeServiceInterpTest
           userEmail,
           serviceAccount,
           FormattedBy.GCE,
-          allowListAuthProvider,
           MockSamService,
           ConfigReader.appConfig.persistentDisk,
           Some(workspaceId)
@@ -2503,7 +2496,6 @@ class RuntimeServiceInterpTest
           userEmail,
           serviceAccount,
           FormattedBy.Galaxy,
-          allowListAuthProvider,
           MockSamService,
           ConfigReader.appConfig.persistentDisk,
           Some(workspaceId)
@@ -2520,7 +2512,6 @@ class RuntimeServiceInterpTest
           userEmail,
           serviceAccount,
           FormattedBy.GCE,
-          allowListAuthProvider,
           MockSamService,
           ConfigReader.appConfig.persistentDisk,
           Some(workspaceId)
@@ -2539,6 +2530,11 @@ class RuntimeServiceInterpTest
   }
 
   it should "fail to attach a disk when caller has no attach permission" in isolatedDbTest {
+    val samService = mock[SamService[IO]]
+    when(samService.checkAuthorized(any(), any(), isEq(PersistentDiskAction.AttachPersistentDisk))(any()))
+      .thenReturn(IO.raiseError(SamException.create("forbidden", StatusCodes.Forbidden.intValue, TraceId(""))))
+    when(samService.checkAuthorized(any(), any(), isEq(PersistentDiskAction.ReadPersistentDisk))(any()))
+      .thenReturn(IO.unit)
     val res = for {
       savedDisk <- makePersistentDisk(None).save()
       req = PersistentDiskRequest(savedDisk.name, Some(savedDisk.size), Some(savedDisk.diskType), savedDisk.labels)
@@ -2550,8 +2546,7 @@ class RuntimeServiceInterpTest
         unauthorizedEmail,
         serviceAccount,
         FormattedBy.GCE,
-        allowListAuthProvider,
-        MockSamService,
+        samService,
         ConfigReader.appConfig.persistentDisk,
         Some(workspaceId)
       )(implicitly, implicitly, implicitly, scala.concurrent.ExecutionContext.global)

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterpSpec.scala
@@ -840,7 +840,7 @@ class RuntimeServiceInterpTest
     res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
-  it should "throw ClusterNotFoundException for nonexistent clusters" in isolatedDbTest {
+  it should "throw RuntimeNotFoundException for nonexistent clusters" in isolatedDbTest {
     val exc = runtimeService
       .getRuntime(userInfo, CloudContext.Gcp(GoogleProject("nonexistent")), RuntimeName("cluster"))
       .attempt
@@ -874,13 +874,10 @@ class RuntimeServiceInterpTest
     val userInfo = mockUserInfo("grendel@mom.mere")
     val runtimeIds =
       Vector(RuntimeSamResourceId(UUID.randomUUID.toString), RuntimeSamResourceId(UUID.randomUUID.toString))
-    val mockAuthProvider = mockAuthorize(
-      userInfo,
-      readerRuntimeSamIds = Set(runtimeIds(0), runtimeIds(1)),
-      readerProjectSamIds = Set(ProjectSamResourceId(project))
-    )
-    when(mockAuthProvider.isUserProjectReader(any, isEq(userInfo))(any)).thenReturn(IO.pure(true))
-    val service = makeRuntimeService(authProvider = mockAuthProvider)
+    val samService = mock[SamService[IO]]
+    when(samService.listResources(isEq(userInfo.accessToken.token), isEq(RuntimeSamResource.resourceType))(any()))
+      .thenReturn(IO.pure(runtimeIds.map(_.resourceId).toList))
+    val service = makeRuntimeService(samService = samService)
 
     val res = for {
       _ <- IO(makeCluster(1, samResource = runtimeIds(0)).save())
@@ -897,13 +894,10 @@ class RuntimeServiceInterpTest
                             RuntimeSamResourceId(UUID.randomUUID.toString),
                             RuntimeSamResourceId(UUID.randomUUID.toString)
     )
-    val mockAuthProvider = mockAuthorize(
-      userInfo,
-      readerRuntimeSamIds = Set(runtimeIds(0), runtimeIds(1)),
-      readerProjectSamIds = Set(ProjectSamResourceId(project), ProjectSamResourceId(project2))
-    )
-    when(mockAuthProvider.isUserProjectReader(any, isEq(userInfo))(any)).thenReturn(IO.pure(true))
-    val service = makeRuntimeService(authProvider = mockAuthProvider)
+    val samService = mock[SamService[IO]]
+    when(samService.listResources(isEq(userInfo.accessToken.token), isEq(RuntimeSamResource.resourceType))(any()))
+      .thenReturn(IO.pure(runtimeIds.map(_.resourceId).toList))
+    val service = makeRuntimeService(samService = samService)
 
     val res = for {
       _ <- IO(makeCluster(1).copy(samResource = runtimeIds(0)).save())
@@ -919,13 +913,10 @@ class RuntimeServiceInterpTest
     val userInfo = mockUserInfo("grendel@mom.mere")
     val runtimeIds =
       Vector(RuntimeSamResourceId(UUID.randomUUID.toString), RuntimeSamResourceId(UUID.randomUUID.toString))
-    val mockAuthProvider = mockAuthorize(
-      userInfo,
-      readerRuntimeSamIds = Set(runtimeIds(0), runtimeIds(1)),
-      readerProjectSamIds = Set(ProjectSamResourceId(project))
-    )
-    when(mockAuthProvider.isUserProjectReader(any, isEq(userInfo))(any)).thenReturn(IO.pure(true))
-    val service = makeRuntimeService(authProvider = mockAuthProvider)
+    val samService = mock[SamService[IO]]
+    when(samService.listResources(isEq(userInfo.accessToken.token), isEq(RuntimeSamResource.resourceType))(any()))
+      .thenReturn(IO.pure(runtimeIds.map(_.resourceId).toList))
+    val service = makeRuntimeService(samService = samService)
 
     val res = for {
       runtime1 <- IO(makeCluster(1).copy(samResource = runtimeIds(0)).save())
@@ -944,12 +935,10 @@ class RuntimeServiceInterpTest
     val userInfo = mockUserInfo("grendel@mere.mom")
     val runtimeIds =
       Vector(RuntimeSamResourceId(UUID.randomUUID.toString), RuntimeSamResourceId(UUID.randomUUID.toString))
-    val mockAuthProvider = mockAuthorize(
-      userInfo,
-      ownerProjectSamIds = Set(ProjectSamResourceId(project))
-    )
-    when(mockAuthProvider.isUserProjectReader(any, isEq(userInfo))(any)).thenReturn(IO.pure(true))
-    val service = makeRuntimeService(authProvider = mockAuthProvider)
+    val samService = mock[SamService[IO]]
+    when(samService.listResources(isEq(userInfo.accessToken.token), isEq(RuntimeSamResource.resourceType))(any()))
+      .thenReturn(IO.pure(runtimeIds.map(_.resourceId).toList))
+    val service = makeRuntimeService(samService = samService)
 
     // Make runtimes belonging to different users than the calling user
     val res = for {
@@ -1021,13 +1010,10 @@ class RuntimeServiceInterpTest
       runtime2.patchInProgress
     )
 
-    val mockAuthProvider = mockAuthorize(
-      userInfo,
-      readerRuntimeSamIds = Set(runtime1.samResource, runtime2.samResource),
-      readerProjectSamIds = Set(ProjectSamResourceId(project))
-    )
-    when(mockAuthProvider.isUserProjectReader(any, isEq(userInfo))(any)).thenReturn(IO.pure(true))
-    val service = makeRuntimeService(authProvider = mockAuthProvider)
+    val samService = mock[SamService[IO]]
+    when(samService.listResources(isEq(userInfo.accessToken.token), isEq(RuntimeSamResource.resourceType))(any()))
+      .thenReturn(IO.pure(List(runtime1.samResource.resourceId, runtime2.samResource.resourceId)))
+    val service = makeRuntimeService(samService = samService)
 
     service
       .listRuntimes(userInfo, None, Map("_labels" -> "foo=bar"))
@@ -1388,28 +1374,9 @@ class RuntimeServiceInterpTest
     when(samService.checkAuthorized(isEq(userInfo.accessToken.token), any(), isEq(RuntimeAction.DeleteRuntime))(any()))
       .thenReturn(IO.unit)
     when(samService.deleteResource(any(), any())(any())).thenReturn(IO.unit)
-    val mockAuthProvider = mockAuthorize(
-      userInfo,
-      readerRuntimeSamIds = Set(runtimeIds(0), runtimeIds(1)),
-      readerProjectSamIds = Set(ProjectSamResourceId(project))
-    )
-    when(mockAuthProvider.isUserProjectReader(any, isEq(userInfo))(any)).thenReturn(IO.pure(true))
-    when(
-      mockAuthProvider.getActionsWithProjectFallback[RuntimeSamResourceId, RuntimeAction](any, any, isEq(userInfo))(any,
-                                                                                                                    any
-      )
-    )
-      .thenReturn(
-        IO.pure(
-          (List(RuntimeAction.GetRuntimeStatus, RuntimeAction.DeleteRuntime),
-           List(ProjectAction.GetRuntimeStatus, ProjectAction.DeleteRuntime)
-          )
-        )
-      )
-
     val publisherQueue = QueueFactory.makePublisherQueue()
     val service =
-      makeRuntimeService(authProvider = mockAuthProvider, publisherQueue = publisherQueue, samService = samService)
+      makeRuntimeService(publisherQueue = publisherQueue, samService = samService)
 
     val res = for {
       pd1 <- makePersistentDisk().save()
@@ -1466,28 +1433,9 @@ class RuntimeServiceInterpTest
     when(samService.getUserEmail(isEq(userInfo.accessToken.token))(any())).thenReturn(IO.pure(userInfo.userEmail))
     when(samService.checkAuthorized(any(), any(), any())(any())).thenReturn(IO.unit)
     when(samService.deleteResource(any(), any())(any())).thenReturn(IO.unit)
-    val mockAuthProvider = mockAuthorize(
-      userInfo,
-      readerRuntimeSamIds = Set(runtimeIds(0), runtimeIds(1)),
-      readerProjectSamIds = Set(ProjectSamResourceId(project))
-    )
-    when(mockAuthProvider.isUserProjectReader(any, isEq(userInfo))(any)).thenReturn(IO.pure(true))
-    when(
-      mockAuthProvider.getActionsWithProjectFallback[RuntimeSamResourceId, RuntimeAction](any, any, isEq(userInfo))(any,
-                                                                                                                    any
-      )
-    )
-      .thenReturn(
-        IO.pure(
-          (List(RuntimeAction.GetRuntimeStatus, RuntimeAction.DeleteRuntime),
-           List(ProjectAction.GetRuntimeStatus, ProjectAction.DeleteRuntime)
-          )
-        )
-      )
-
     val publisherQueue = QueueFactory.makePublisherQueue()
     val service =
-      makeRuntimeService(authProvider = mockAuthProvider, publisherQueue = publisherQueue, samService = samService)
+      makeRuntimeService(publisherQueue = publisherQueue, samService = samService)
 
     val res = for {
       pd1 <- makePersistentDisk().save()
@@ -1561,8 +1509,13 @@ class RuntimeServiceInterpTest
         )
       )
 
+    val samService = mock[SamService[IO]]
+    when(samService.listResources(isEq(userInfo.accessToken.token), isEq(RuntimeSamResource.resourceType))(any()))
+      .thenReturn(IO.pure(runtimeIds.map(_.resourceId).toList))
+
     val publisherQueue = QueueFactory.makePublisherQueue()
-    val service = makeRuntimeService(authProvider = mockAuthProvider, publisherQueue = publisherQueue)
+    val service =
+      makeRuntimeService(authProvider = mockAuthProvider, publisherQueue = publisherQueue, samService = samService)
 
     val res = for {
       pd1 <- makePersistentDisk().save()

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeServiceInterpSpec.scala
@@ -1412,11 +1412,11 @@ class RuntimeServiceInterpTest
 
       _ <- service.deleteAllRuntimesRecords(userInfo, cloudContextGcp)
 
-      runtimes <- service.listRuntimes(userInfo, Some(cloudContextGcp), Map("includeDeleted" -> "true"))
+      runtimes <- service.listRuntimes(userInfo, Some(cloudContextGcp), Map.empty)
       messages <- publisherQueue.tryTakeN(Some(2))
 
     } yield {
-      runtimes.map(_.status) shouldEqual List(RuntimeStatus.Deleted, RuntimeStatus.Deleted)
+      runtimes.map(_.status) shouldEqual List.empty
       messages shouldBe List.empty
     }
 

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeV2ServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeV2ServiceInterpSpec.scala
@@ -8,36 +8,20 @@ import cats.effect.IO
 import cats.effect.std.Queue
 import cats.mtl.Ask
 import com.azure.resourcemanager.compute.models.VirtualMachineSizeTypes
-import io.circe.Decoder
 import org.broadinstitute.dsde.workbench.azure._
 import org.broadinstitute.dsde.workbench.google2.DiskName
 import org.broadinstitute.dsde.workbench.leonardo.CommonTestData._
-import org.broadinstitute.dsde.workbench.leonardo.JsonCodec.{
-  projectSamResourceDecoder,
-  runtimeSamResourceDecoder,
-  workspaceSamResourceIdDecoder,
-  wsmResourceSamResourceIdDecoder
-}
 import org.broadinstitute.dsde.workbench.leonardo.SamResourceId.{
-  ProjectSamResourceId,
   RuntimeSamResourceId,
   WorkspaceResourceSamResourceId,
   WsmResourceSamResourceId
 }
-import org.broadinstitute.dsde.workbench.leonardo.auth.AllowlistAuthProvider
-import org.broadinstitute.dsde.workbench.leonardo.TestUtils.{appContext, defaultMockitoAnswer}
+import org.broadinstitute.dsde.workbench.leonardo.TestUtils.appContext
 import org.broadinstitute.dsde.workbench.leonardo.config.Config
 import org.broadinstitute.dsde.workbench.leonardo.dao._
 import org.broadinstitute.dsde.workbench.leonardo.dao.sam.{SamException, SamService}
 import org.broadinstitute.dsde.workbench.leonardo.db._
 import org.broadinstitute.dsde.workbench.leonardo.model.SamResource.RuntimeSamResource
-import org.broadinstitute.dsde.workbench.leonardo.model.SamResourceAction.{
-  projectSamResourceAction,
-  runtimeSamResourceAction,
-  workspaceSamResourceAction,
-  wsmResourceSamResourceAction,
-  AppSamResourceAction
-}
 import org.broadinstitute.dsde.workbench.leonardo.model._
 import org.broadinstitute.dsde.workbench.leonardo.monitor.LeoPubsubMessage.{
   CreateAzureRuntimeMessage,
@@ -49,8 +33,7 @@ import org.broadinstitute.dsde.workbench.leonardo.monitor.{LeoPubsubMessage, Upd
 import org.broadinstitute.dsde.workbench.leonardo.util.QueueFactory
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.broadinstitute.dsde.workbench.model.{TraceId, UserInfo, WorkbenchEmail, WorkbenchUserId}
-import org.mockito.ArgumentMatchers.{any, argThat, eq => isEq}
-import org.scalatest.prop.TableDrivenPropertyChecks._
+import org.mockito.ArgumentMatchers.{any, eq => isEq}
 import org.mockito.Mockito.when
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatestplus.mockito.MockitoSugar
@@ -75,12 +58,11 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
   // used when we care about queue state
   def makeInterp(
     queue: Queue[IO, LeoPubsubMessage] = QueueFactory.makePublisherQueue(),
-    authProvider: AllowlistAuthProvider = allowListAuthProvider,
     dateAccessedQueue: Queue[IO, UpdateDateAccessedMessage] = QueueFactory.makeDateAccessedQueue(),
     wsmClientProvider: WsmApiClientProvider[IO] = wsmClientProvider,
     samService: SamService[IO] = MockSamService
   ) =
-    new RuntimeV2ServiceInterp[IO](serviceConfig, authProvider, queue, dateAccessedQueue, wsmClientProvider, samService)
+    new RuntimeV2ServiceInterp[IO](serviceConfig, queue, dateAccessedQueue, wsmClientProvider, samService)
 
   // need to set previous runtime to deleted status before creating next to avoid exception
   def setRuntimeDeleted(workspaceId: WorkspaceId, name: RuntimeName): IO[Long] =
@@ -105,174 +87,12 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
     samService
   }
 
-  /**
-   * Generate a mocked AuthProvider which will permit action on the given resource IDs by the given user.
-   * TODO: cover actions beside `checkUserEnabled` and `listResourceIds`
-   * @param userInfo
-   * @param readerRuntimeSamIds
-   * @param readerWorkspaceSamIds
-   * @param readerProjectSamIds
-   * @param ownerWorkspaceSamIds
-   * @param ownerProjectSamIds
-   * @return
-   */
-  def mockAuthorize(
-    userInfo: UserInfo,
-    readerRuntimeSamIds: Set[RuntimeSamResourceId] = Set.empty,
-    readerWsmSamIds: Set[WsmResourceSamResourceId] = Set.empty,
-    readerWorkspaceSamIds: Set[WorkspaceResourceSamResourceId] = Set.empty,
-    readerProjectSamIds: Set[ProjectSamResourceId] = Set.empty,
-    ownerWorkspaceSamIds: Set[WorkspaceResourceSamResourceId] = Set.empty,
-    ownerProjectSamIds: Set[ProjectSamResourceId] = Set.empty
-  ): AllowlistAuthProvider = {
-    val mockAuthProvider: AllowlistAuthProvider = mock[AllowlistAuthProvider](defaultMockitoAnswer[IO])
-
-    when(mockAuthProvider.checkUserEnabled(isEq(userInfo))(any)).thenReturn(IO.unit)
-    when(
-      mockAuthProvider.listResourceIds[RuntimeSamResourceId](isEq(true), isEq(userInfo))(
-        any(runtimeSamResourceAction.getClass),
-        any(AppSamResourceAction.getClass),
-        any(Decoder[RuntimeSamResourceId].getClass),
-        any(Ask[IO, TraceId].getClass)
-      )
-    ).thenReturn(IO.pure(readerRuntimeSamIds))
-    when(
-      mockAuthProvider.listResourceIds[WsmResourceSamResourceId](isEq(false), isEq(userInfo))(
-        any(wsmResourceSamResourceAction.getClass),
-        any(AppSamResourceAction.getClass),
-        any(Decoder[WsmResourceSamResourceId].getClass),
-        any(Ask[IO, TraceId].getClass)
-      )
-    ).thenReturn(IO.pure(readerWsmSamIds))
-    when(
-      mockAuthProvider.listResourceIds[WorkspaceResourceSamResourceId](isEq(false), isEq(userInfo))(
-        any(workspaceSamResourceAction.getClass),
-        any(AppSamResourceAction.getClass),
-        any(Decoder[WorkspaceResourceSamResourceId].getClass),
-        any(Ask[IO, TraceId].getClass)
-      )
-    ).thenReturn(IO.pure(readerWorkspaceSamIds))
-    when(
-      mockAuthProvider.listResourceIds[ProjectSamResourceId](isEq(false), isEq(userInfo))(
-        any(projectSamResourceAction.getClass),
-        any(AppSamResourceAction.getClass),
-        any(Decoder[ProjectSamResourceId].getClass),
-        any(Ask[IO, TraceId].getClass)
-      )
-    )
-      .thenReturn(IO.pure(readerProjectSamIds))
-    when(
-      mockAuthProvider.listResourceIds[WorkspaceResourceSamResourceId](isEq(true), isEq(userInfo))(
-        any(workspaceSamResourceAction.getClass),
-        any(AppSamResourceAction.getClass),
-        any(Decoder[WorkspaceResourceSamResourceId].getClass),
-        any(Ask[IO, TraceId].getClass)
-      )
-    )
-      .thenReturn(IO.pure(ownerWorkspaceSamIds))
-    when(
-      mockAuthProvider.listResourceIds[ProjectSamResourceId](isEq(true), isEq(userInfo))(
-        any(projectSamResourceAction.getClass),
-        any(AppSamResourceAction.getClass),
-        any(Decoder[ProjectSamResourceId].getClass),
-        any(Ask[IO, TraceId].getClass)
-      )
-    )
-      .thenReturn(IO.pure(ownerProjectSamIds))
-
-    mockAuthProvider
-  }
-
-  /**
-   * Generate a mocked AuthProvider which will permit action on the given resource IDs by the given user,
-   * when the list request is restricted to one workspace. Expects isUserWorkspace* instead of listResourceIds.
-   * TODO: cover actions beside `checkUserEnabled` and `listResourceIds`
-   *
-   * @param userInfo
-   * @param readerRuntimeSamIds
-   * @param readerWorkspaceSamIds
-   * @param readerProjectSamIds
-   * @param ownerWorkspaceSamIds
-   * @param ownerProjectSamIds
-   * @return
-   */
-  def mockAuthorizeForOneWorkspace(
-    userInfo: UserInfo,
-    readerRuntimeSamIds: Set[RuntimeSamResourceId] = Set.empty,
-    readerWsmSamIds: Set[WsmResourceSamResourceId] = Set.empty,
-    readerWorkspaceSamIds: Set[WorkspaceResourceSamResourceId] = Set.empty,
-    readerProjectSamIds: Set[ProjectSamResourceId] = Set.empty,
-    ownerWorkspaceSamIds: Set[WorkspaceResourceSamResourceId] = Set.empty,
-    ownerProjectSamIds: Set[ProjectSamResourceId] = Set.empty
-  ): AllowlistAuthProvider = {
-    val mockAuthProvider: AllowlistAuthProvider = mock[AllowlistAuthProvider](defaultMockitoAnswer[IO])
-
-    when(mockAuthProvider.checkUserEnabled(isEq(userInfo))(any)).thenReturn(IO.unit)
-    when(
-      mockAuthProvider.listResourceIds[RuntimeSamResourceId](isEq(true), isEq(userInfo))(
-        any(runtimeSamResourceAction.getClass),
-        any(AppSamResourceAction.getClass),
-        any(Decoder[RuntimeSamResourceId].getClass),
-        any(Ask[IO, TraceId].getClass)
-      )
-    ).thenReturn(IO.pure(readerRuntimeSamIds))
-    when(
-      mockAuthProvider.listResourceIds[WsmResourceSamResourceId](isEq(false), isEq(userInfo))(
-        any(wsmResourceSamResourceAction.getClass),
-        any(AppSamResourceAction.getClass),
-        any(Decoder[WsmResourceSamResourceId].getClass),
-        any(Ask[IO, TraceId].getClass)
-      )
-    ).thenReturn(IO.pure(readerWsmSamIds))
-    when(
-      mockAuthProvider.isUserWorkspaceReader(any, isEq(userInfo))(
-        any(Ask[IO, TraceId].getClass)
-      )
-    ).thenReturn(IO.pure(false))
-    when(
-      mockAuthProvider.isUserWorkspaceReader(argThat(readerWorkspaceSamIds.contains(_)), isEq(userInfo))(
-        any(Ask[IO, TraceId].getClass)
-      )
-    ).thenReturn(IO.pure(true))
-    when(
-      mockAuthProvider.listResourceIds[ProjectSamResourceId](isEq(false), isEq(userInfo))(
-        any(projectSamResourceAction.getClass),
-        any(AppSamResourceAction.getClass),
-        any(Decoder[ProjectSamResourceId].getClass),
-        any(Ask[IO, TraceId].getClass)
-      )
-    )
-      .thenReturn(IO.pure(readerProjectSamIds))
-    when(
-      mockAuthProvider.isUserWorkspaceOwner(any, isEq(userInfo))(
-        any(Ask[IO, TraceId].getClass)
-      )
-    ).thenReturn(IO.pure(false))
-    when(
-      mockAuthProvider.isUserWorkspaceOwner(argThat(ownerWorkspaceSamIds.contains(_)), isEq(userInfo))(
-        any(Ask[IO, TraceId].getClass)
-      )
-    ).thenReturn(IO.pure(true))
-    when(
-      mockAuthProvider.listResourceIds[ProjectSamResourceId](isEq(true), isEq(userInfo))(
-        any(projectSamResourceAction.getClass),
-        any(AppSamResourceAction.getClass),
-        any(Decoder[ProjectSamResourceId].getClass),
-        any(Ask[IO, TraceId].getClass)
-      )
-    )
-      .thenReturn(IO.pure(ownerProjectSamIds))
-
-    mockAuthProvider
-  }
-
   def mockUserInfo(email: String = userEmail.toString()): UserInfo =
     UserInfo(OAuth2BearerToken(""), WorkbenchUserId(s"userId-${email}"), WorkbenchEmail(email), 0)
 
   val runtimeV2Service =
     new RuntimeV2ServiceInterp[IO](
       serviceConfig,
-      allowListAuthProvider,
       QueueFactory.makePublisherQueue(),
       QueueFactory.makeDateAccessedQueue(),
       wsmClientProvider,
@@ -282,7 +102,6 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
   val runtimeV2Service2 =
     new RuntimeV2ServiceInterp[IO](
       serviceConfig,
-      allowListAuthProvider2,
       QueueFactory.makePublisherQueue(),
       QueueFactory.makeDateAccessedQueue(),
       wsmClientProvider,
@@ -538,6 +357,8 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
       _ <- persistentDiskQuery.updateStatus(disk.id, DiskStatus.Ready, now).transaction
 
       runtime <- clusterQuery.getClusterWithDiskId(disk.id).transaction
+      _ = when(samService.listResources(isEq(userInfo.accessToken.token), isEq(RuntimeSamResource.resourceType))(any()))
+        .thenReturn(IO.pure(List(runtime.get.internalId)))
 
       err <- runtimeV2Service
         .createRuntime(userInfo, name1, workspaceId, true, defaultCreateAzureRuntimeReq)
@@ -556,6 +377,11 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
     runtimeV2Service
       .createRuntime(userInfo, name0, workspaceId, false, defaultCreateAzureRuntimeReq)
       .unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
+    val runtime =
+      runtimeV2Service.getRuntime(userInfo, name0, workspaceId).unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
+
+    when(samService.listResources(isEq(userInfo.accessToken.token), isEq(RuntimeSamResource.resourceType))(any()))
+      .thenReturn(IO.pure(List(runtime.samResource.resourceId)))
 
     val exc = runtimeV2Service
       .createRuntime(userInfo, name2, workspaceId, false, defaultCreateAzureRuntimeReq)
@@ -1435,7 +1261,7 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
     when(samService.getUserEmail(userInfo3.accessToken.token)).thenReturn(IO.pure(userInfo3.userEmail))
 
     val publisherQueue = QueueFactory.makePublisherQueue()
-    val azureService = makeInterp(publisherQueue)
+    val azureService = makeInterp(publisherQueue, samService = samService)
 
     val res = for {
       context <- appContext.ask[AppContext]
@@ -1494,6 +1320,10 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
       preDeleteCluster_1 <- RuntimeServiceDbQueries.getActiveRuntimeRecord(workspaceId, runtimeName_1).transaction
       preDeleteCluster_2 <- RuntimeServiceDbQueries.getActiveRuntimeRecord(workspaceId, runtimeName_2).transaction
       preDeleteCluster_3 <- RuntimeServiceDbQueries.getActiveRuntimeRecord(workspaceId, runtimeName_3).transaction
+      _ = when(samService.listResources(isEq(userInfo.accessToken.token), isEq(RuntimeSamResource.resourceType))(any()))
+        .thenReturn(
+          IO.pure(List(preDeleteCluster_1.internalId, preDeleteCluster_2.internalId, preDeleteCluster_3.internalId))
+        )
 
       _ <- clusterQuery.updateClusterStatus(preDeleteCluster_1.id, RuntimeStatus.Deleted, context.now).transaction
       _ <- clusterQuery.updateClusterStatus(preDeleteCluster_2.id, RuntimeStatus.Running, context.now).transaction
@@ -1568,7 +1398,7 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
     when(samService.getUserEmail(userInfo2.accessToken.token)).thenReturn(IO.pure(userInfo2.userEmail))
 
     val publisherQueue = QueueFactory.makePublisherQueue()
-    val azureService = makeInterp(publisherQueue)
+    val azureService = makeInterp(publisherQueue, samService = samService)
 
     val res = for {
       context <- appContext.ask[AppContext]
@@ -1610,7 +1440,8 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
       _ <- clusterQuery.updateClusterStatus(preDeleteCluster_1.id, RuntimeStatus.Creating, context.now).transaction
       preDeleteCluster_2 = preDeleteClusterOpt_2.get
       _ <- clusterQuery.updateClusterStatus(preDeleteCluster_2.id, RuntimeStatus.Running, context.now).transaction
-
+      _ = when(samService.listResources(isEq(userInfo.accessToken.token), isEq(RuntimeSamResource.resourceType))(any()))
+        .thenReturn(IO.pure(List(preDeleteCluster_1.samResource.resourceId, preDeleteCluster_2.samResource.resourceId)))
       _ <- azureService.deleteAllRuntimes(userInfo, workspaceId, true)
 
     } yield ()
@@ -1629,15 +1460,7 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
     val samService = mock[SamService[IO]]
     when(samService.listResources(isEq(userInfo.accessToken.token), isEq(RuntimeSamResource.resourceType))(any()))
       .thenReturn(IO.pure(List(runtimeId1, runtimeId2)))
-    val mockAuthProvider = mockAuthorize(
-      userInfo,
-      Set(RuntimeSamResourceId(runtimeId1), RuntimeSamResourceId(runtimeId2)),
-      Set.empty,
-      Set(WorkspaceResourceSamResourceId(WorkspaceId(UUID.fromString(workspaceIdAzure)))),
-      Set(ProjectSamResourceId(GoogleProject(projectIdGcp)))
-    )
-
-    val testService = makeInterp(authProvider = mockAuthProvider, samService = samService)
+    val testService = makeInterp(samService = samService)
 
     val res = for {
       samResource1 <- IO(RuntimeSamResourceId(runtimeId1))
@@ -1678,171 +1501,6 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
     res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
   }
 
-  it should "list runtimes, omitting runtimes for workspaces and projects user cannot read" in isolatedDbTest {
-    val runtimeId1 = UUID.randomUUID.toString
-    val runtimeId2 = UUID.randomUUID.toString
-    val runtimeId3 = UUID.randomUUID.toString
-    val runtimeId4 = UUID.randomUUID.toString
-    val projectIdGcp1 = "gcp-context-1"
-    val projectIdGcp2 = "gcp-context-2"
-    val workspaceIdAzure1 = UUID.randomUUID.toString
-    val workspaceIdAzure2 = UUID.randomUUID.toString
-
-    val userInfo = mockUserInfo("jerome@vore.gov")
-    val mockAuthProvider = mockAuthorize(
-      userInfo,
-      // user can read runtimes which are 'notebook-cluster' aka Runtimes
-      Set(RuntimeSamResourceId(runtimeId1), RuntimeSamResourceId(runtimeId2), RuntimeSamResourceId(runtimeId3)),
-      // user can read runtimes which are WsmResources
-      Set(
-        WsmResourceSamResourceId(WsmControlledResourceId(UUID.fromString(runtimeId3))),
-        WsmResourceSamResourceId(WsmControlledResourceId(UUID.fromString(runtimeId4)))
-      ),
-      // user can only read workspace1
-      Set(WorkspaceResourceSamResourceId(WorkspaceId(UUID.fromString(workspaceIdAzure1)))),
-      // user can only read project1
-      Set(ProjectSamResourceId(GoogleProject(projectIdGcp1)))
-    )
-    val testService = makeInterp(authProvider = mockAuthProvider)
-
-    val res = for {
-      // GCP runtime 1 (in project1): seen
-      samResource1 <- IO(RuntimeSamResourceId(runtimeId1))
-      runtime1 <- IO(
-        makeCluster(1)
-          .copy(samResource = samResource1, cloudContext = CloudContext.Gcp(GoogleProject(projectIdGcp1)))
-          .save()
-      )
-      // GCP runtime 2 (in project2): hidden
-      samResource2 <- IO(RuntimeSamResourceId(runtimeId2))
-      runtime2 <- IO(
-        makeCluster(2)
-          .copy(samResource = samResource2, cloudContext = CloudContext.Gcp(GoogleProject(projectIdGcp2)))
-          .save()
-      )
-      // Azure runtime 3 (in workspace1): seen
-      samResource3 <- IO(RuntimeSamResourceId(runtimeId3))
-      runtime3 <- IO(
-        makeCluster(3)
-          .copy(
-            samResource = samResource3,
-            cloudContext = CloudContext.Azure(CommonTestData.azureCloudContext),
-            workspaceId = Some(WorkspaceId(UUID.fromString(workspaceIdAzure1)))
-          )
-          .save()
-      )
-      // Azure runtime 4 (in workspace2): hidden
-      samResource4 <- IO(RuntimeSamResourceId(runtimeId4))
-      runtime4 <- IO(
-        makeCluster(4)
-          .copy(
-            samResource = samResource4,
-            cloudContext = CloudContext.Azure(CommonTestData.azureCloudContext),
-            workspaceId = Some(WorkspaceId(UUID.fromString(workspaceIdAzure2)))
-          )
-          .save()
-      )
-      listResponse <- testService.listRuntimes(userInfo, None, None, Map.empty)
-    } yield listResponse.map(_.samResource).toSet shouldBe Set(samResource1, samResource3)
-
-    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
-  }
-
-  it should "list runtimes given different user permissions" in isolatedDbTest {
-    forAll(
-      Table(
-        ("context", "runtimeAccess", "contextAccess", "isListed"),
-        // Any runtime access; no access to wrapper context => hidden
-        (TestContext.GoogleProject, TestRuntimeAccess.Nothing, TestContextAccess.Nothing, false),
-        (TestContext.GoogleWorkspace, TestRuntimeAccess.Nothing, TestContextAccess.Nothing, false),
-        (TestContext.AzureWorkspace, TestRuntimeAccess.Nothing, TestContextAccess.Nothing, false),
-        (TestContext.GoogleProject, TestRuntimeAccess.Reader, TestContextAccess.Nothing, false),
-        (TestContext.GoogleWorkspace, TestRuntimeAccess.Reader, TestContextAccess.Nothing, false),
-        (TestContext.AzureWorkspace, TestRuntimeAccess.Reader, TestContextAccess.Nothing, false),
-        // No access to runtime; read access to wrapper context => hidden
-        (TestContext.GoogleProject, TestRuntimeAccess.Nothing, TestContextAccess.Reader, false),
-        (TestContext.GoogleWorkspace, TestRuntimeAccess.Nothing, TestContextAccess.Reader, false),
-        (TestContext.AzureWorkspace, TestRuntimeAccess.Nothing, TestContextAccess.Reader, false),
-        // Read access to runtime; read access to wrapper context => shown
-        (TestContext.GoogleProject, TestRuntimeAccess.Reader, TestContextAccess.Reader, true),
-        (TestContext.GoogleWorkspace, TestRuntimeAccess.Reader, TestContextAccess.Reader, true),
-        (TestContext.AzureWorkspace, TestRuntimeAccess.Reader, TestContextAccess.Reader, true),
-        // Any runtime access; owner of wrapper context => shown
-        (TestContext.GoogleProject, TestRuntimeAccess.Nothing, TestContextAccess.Owner, true),
-        (TestContext.GoogleWorkspace, TestRuntimeAccess.Nothing, TestContextAccess.Owner, true),
-        (TestContext.AzureWorkspace, TestRuntimeAccess.Nothing, TestContextAccess.Owner, true),
-        (TestContext.GoogleProject, TestRuntimeAccess.Reader, TestContextAccess.Owner, true),
-        (TestContext.GoogleWorkspace, TestRuntimeAccess.Reader, TestContextAccess.Owner, true),
-        (TestContext.AzureWorkspace, TestRuntimeAccess.Reader, TestContextAccess.Owner, true)
-      )
-    ) {
-      (
-        context: TestContext.Context,
-        runtimeAccess: TestRuntimeAccess.Role,
-        contextAccess: TestContextAccess.Role,
-        isListed: Boolean
-      ) =>
-        val runtimeId = UUID.randomUUID.toString
-        val contextId = UUID.randomUUID.toString
-
-        val userInfo = mockUserInfo("jerome@vore.gov")
-        val mockAuthProvider = mockAuthorize(
-          userInfo,
-          readerRuntimeSamIds = Set(RuntimeSamResourceId(runtimeId))
-            .filter(_ => runtimeAccess == TestRuntimeAccess.Reader),
-          Set.empty,
-          readerWorkspaceSamIds = Set(WorkspaceResourceSamResourceId(WorkspaceId(UUID.fromString(contextId))))
-            .filter(_ => context != TestContext.GoogleProject && contextAccess != TestContextAccess.Nothing),
-          readerProjectSamIds = Set(ProjectSamResourceId(GoogleProject(contextId)))
-            .filter(_ => context == TestContext.GoogleProject && contextAccess != TestContextAccess.Nothing),
-          ownerWorkspaceSamIds = Set(WorkspaceResourceSamResourceId(WorkspaceId(UUID.fromString(contextId))))
-            .filter(_ => context != TestContext.GoogleProject && contextAccess == TestContextAccess.Owner),
-          ownerProjectSamIds = Set(ProjectSamResourceId(GoogleProject(contextId)))
-            .filter(_ => context == TestContext.GoogleProject && contextAccess == TestContextAccess.Owner)
-        )
-        val testService = makeInterp(authProvider = mockAuthProvider)
-
-        val res = for {
-          projectRuntime <- IO(
-            makeCluster(1)
-              .copy(
-                samResource = RuntimeSamResourceId(runtimeId),
-                cloudContext = CloudContext.Gcp(GoogleProject(contextId))
-              )
-          )
-          googleWorkspaceRuntime <- IO(
-            makeCluster(2)
-              .copy(
-                samResource = RuntimeSamResourceId(runtimeId),
-                cloudContext = CloudContext.Gcp(GoogleProject(contextId)),
-                workspaceId = Some(WorkspaceId(UUID.fromString(contextId)))
-              )
-          )
-          azureWorkspaceRuntime <- IO(
-            makeCluster(3)
-              .copy(
-                samResource = RuntimeSamResourceId(runtimeId),
-                cloudContext = CloudContext.Azure(
-                  AzureCloudContext(TenantId(contextId), SubscriptionId(contextId), ManagedResourceGroupName(contextId))
-                ),
-                workspaceId = Some(WorkspaceId(UUID.fromString(contextId)))
-              )
-          )
-          runtime = context match {
-            case TestContext.GoogleProject   => projectRuntime
-            case TestContext.GoogleWorkspace => googleWorkspaceRuntime
-            case TestContext.AzureWorkspace  => azureWorkspaceRuntime
-          }
-          _ = runtime.save()
-          expectedResults = if (isListed) Set(runtime.samResource) else Set.empty
-
-          listResponse <- testService.listRuntimes(userInfo, None, None, Map.empty)
-        } yield listResponse.map(_.samResource).toSet shouldBe expectedResults
-
-        res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
-    }
-  }
-
   it should "list runtimes with a workspace and/or cloudProvider" in isolatedDbTest {
     val runtimeId1 = UUID.randomUUID.toString
     val runtimeId2 = UUID.randomUUID.toString
@@ -1855,45 +1513,11 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
     val workspaceId2 = UUID.randomUUID.toString
     val workspaceId3 = UUID.randomUUID.toString
 
-    val userInfo = mockUserInfo("jerome@vore.gov")
-    val mockAuthProvider = mockAuthorize(
-      userInfo,
-      // user can read runtimes 3, 4, and 5
-      Set(RuntimeSamResourceId(runtimeId3), RuntimeSamResourceId(runtimeId4), RuntimeSamResourceId(runtimeId5)),
-      Set.empty,
-      // user can read all workspaces
-      Set(
-        WorkspaceResourceSamResourceId(WorkspaceId(UUID.fromString(workspaceId1))),
-        WorkspaceResourceSamResourceId(WorkspaceId(UUID.fromString(workspaceId2))),
-        WorkspaceResourceSamResourceId(WorkspaceId(UUID.fromString(workspaceId3)))
-      ),
-      // user can read all projects
-      Set(ProjectSamResourceId(GoogleProject(projectIdGcp1)), ProjectSamResourceId(GoogleProject(projectIdGcp2))),
-      // user owns workspace 1
-      Set(WorkspaceResourceSamResourceId(WorkspaceId(UUID.fromString(workspaceId1)))),
-      // user owns project 1
-      Set(ProjectSamResourceId(GoogleProject(projectIdGcp1)))
-    )
-    val mockAuthProviderForOneWorkspace = mockAuthorizeForOneWorkspace(
-      userInfo,
-      // user can read runtimes 3, 4, and 5
-      Set(RuntimeSamResourceId(runtimeId3), RuntimeSamResourceId(runtimeId4), RuntimeSamResourceId(runtimeId5)),
-      Set.empty,
-      // user can read all workspaces
-      Set(
-        WorkspaceResourceSamResourceId(WorkspaceId(UUID.fromString(workspaceId1))),
-        WorkspaceResourceSamResourceId(WorkspaceId(UUID.fromString(workspaceId2))),
-        WorkspaceResourceSamResourceId(WorkspaceId(UUID.fromString(workspaceId3)))
-      ),
-      // user can read all projects
-      Set(ProjectSamResourceId(GoogleProject(projectIdGcp1)), ProjectSamResourceId(GoogleProject(projectIdGcp2))),
-      // user owns workspace 1
-      Set(WorkspaceResourceSamResourceId(WorkspaceId(UUID.fromString(workspaceId1)))),
-      // user owns project 1
-      Set(ProjectSamResourceId(GoogleProject(projectIdGcp1)))
-    )
-    val testService = makeInterp(authProvider = mockAuthProvider)
-    val testServiceForOneWorkspace = makeInterp(authProvider = mockAuthProviderForOneWorkspace)
+    val samService = mock[SamService[IO]]
+    when(samService.listResources(any(), isEq(RuntimeSamResource.resourceType))(any()))
+      .thenReturn(IO.pure(List(runtimeId1, runtimeId2, runtimeId3, runtimeId4, runtimeId5)))
+
+    val testService = makeInterp(samService = samService)
 
     val res = for {
       samResource1 <- IO(RuntimeSamResourceId(runtimeId1))
@@ -1964,38 +1588,41 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
           .save()
       )
 
-      // Test the service call and pluck Sam resource IDs to compare with expected results
-      getResultIds = (
-        userInfo: UserInfo,
-        workspaceId: Option[WorkspaceId],
-        cloudProvider: Option[CloudProvider],
-        params: Map[String, String]
-      ) => {
-        val service = if (workspaceId.isEmpty) testService else testServiceForOneWorkspace
-        service
-          .listRuntimes(userInfo, workspaceId, cloudProvider, params)
-          .flatMap(result => IO(result.map(_.samResource).toSet))
-      }
-
-      responseIdsWorkspace1 <- getResultIds(userInfo, Some(workspace1), None, Map.empty)
-      responseIdsWorkspace2 <- getResultIds(userInfo, Some(workspace2), None, Map.empty)
-      responseIdsWorkspace3 <- getResultIds(userInfo, Some(workspace3), None, Map.empty)
-      responseIdsAzure <- getResultIds(userInfo, None, Some(CloudProvider.Azure), Map.empty)
-      responseIdsGcp <- getResultIds(userInfo, None, Some(CloudProvider.Gcp), Map.empty)
-      responseIdsAzureWorkspace1 <- getResultIds(userInfo, Some(workspace1), Some(CloudProvider.Azure), Map.empty)
-      responseIdsAzureWorkspace2 <- getResultIds(userInfo, Some(workspace2), Some(CloudProvider.Azure), Map.empty)
-      responseIdsGcpWorkspace1 <- getResultIds(userInfo, Some(workspace1), Some(CloudProvider.Gcp), Map.empty)
-      responseIdsGcpWorkspace2 <- getResultIds(userInfo, Some(workspace2), Some(CloudProvider.Gcp), Map.empty)
+      responseIdsWorkspace1 <- testService.listRuntimes(userInfo, Some(workspace1), None, Map.empty)
+      responseIdsWorkspace2 <- testService.listRuntimes(userInfo, Some(workspace2), None, Map.empty)
+      responseIdsWorkspace3 <- testService.listRuntimes(userInfo, Some(workspace3), None, Map.empty)
+      responseIdsAzure <- testService.listRuntimes(userInfo, None, Some(CloudProvider.Azure), Map.empty)
+      responseIdsGcp <- testService.listRuntimes(userInfo, None, Some(CloudProvider.Gcp), Map.empty)
+      responseIdsAzureWorkspace1 <- testService.listRuntimes(userInfo,
+                                                             Some(workspace1),
+                                                             Some(CloudProvider.Azure),
+                                                             Map.empty
+      )
+      responseIdsAzureWorkspace2 <- testService.listRuntimes(userInfo,
+                                                             Some(workspace2),
+                                                             Some(CloudProvider.Azure),
+                                                             Map.empty
+      )
+      responseIdsGcpWorkspace1 <- testService.listRuntimes(userInfo,
+                                                           Some(workspace1),
+                                                           Some(CloudProvider.Gcp),
+                                                           Map.empty
+      )
+      responseIdsGcpWorkspace2 <- testService.listRuntimes(userInfo,
+                                                           Some(workspace2),
+                                                           Some(CloudProvider.Gcp),
+                                                           Map.empty
+      )
     } yield {
-      responseIdsWorkspace1 shouldBe Set(samResource1)
-      responseIdsWorkspace2 shouldBe Set(samResource2, samResource3)
-      responseIdsWorkspace3 shouldBe Set(samResource4)
-      responseIdsAzure shouldBe Set(samResource1, samResource4)
-      responseIdsGcp shouldBe Set(samResource2, samResource3, samResource5)
-      responseIdsAzureWorkspace1 shouldBe Set(samResource1)
-      responseIdsAzureWorkspace2 shouldBe Set.empty
-      responseIdsGcpWorkspace1 shouldBe Set.empty
-      responseIdsGcpWorkspace2 shouldBe Set(samResource2, samResource3)
+      responseIdsWorkspace1.map(_.samResource).toSet shouldBe Set(samResource1)
+      responseIdsWorkspace2.map(_.samResource).toSet shouldBe Set(samResource2, samResource3)
+      responseIdsWorkspace3.map(_.samResource).toSet shouldBe Set(samResource4)
+      responseIdsAzure.map(_.samResource).toSet shouldBe Set(samResource1, samResource4)
+      responseIdsGcp.map(_.samResource).toSet shouldBe Set(samResource2, samResource3, samResource5)
+      responseIdsAzureWorkspace1.map(_.samResource).toSet shouldBe Set(samResource1)
+      responseIdsAzureWorkspace2.map(_.samResource).toSet shouldBe Set.empty
+      responseIdsGcpWorkspace1.map(_.samResource).toSet shouldBe Set.empty
+      responseIdsGcpWorkspace2.map(_.samResource).toSet shouldBe Set(samResource2, samResource3)
     }
 
     res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
@@ -2005,16 +1632,11 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
     val runtimeId1 = RuntimeSamResourceId(UUID.randomUUID.toString)
     val runtimeId2 = RuntimeSamResourceId(UUID.randomUUID.toString)
     val workspaceId1 = WorkspaceId(UUID.randomUUID)
-    val userInfo = mockUserInfo("karen@styx.hel")
-    val mockAuthProvider = mockAuthorize(
-      userInfo,
-      // can read all runtimes
-      Set(runtimeId1, runtimeId2),
-      Set.empty,
-      // can read all workspaces
-      Set(WorkspaceResourceSamResourceId(workspaceId1))
-    )
-    val testService = makeInterp(authProvider = mockAuthProvider)
+
+    val samService = mock[SamService[IO]]
+    when(samService.listResources(any(), isEq(RuntimeSamResource.resourceType))(any()))
+      .thenReturn(IO.pure(List(runtimeId1.resourceId, runtimeId2.resourceId)))
+    val testService = makeInterp(samService = samService)
     val res = for {
       samResource1 <- IO(runtimeId1)
       samResource2 <- IO(runtimeId2)
@@ -2083,15 +1705,13 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
     val workspaceId1 = WorkspaceId(UUID.randomUUID)
     val userInfoCreator = mockUserInfo("karen@styx.hel")
     val userInfoOther = mockUserInfo("mike@heavn.io")
-    val mockAuthProvider = mockAuthorize(
-      userInfoCreator,
-      // user has auth permission for runtime1
-      Set.empty,
-      Set(wsmId1),
-      // user can read workspace1
-      Set(WorkspaceResourceSamResourceId(workspaceId1))
+    val samService = mock[SamService[IO]]
+    when(
+      samService.listResources(isEq(userInfoCreator.accessToken.token), isEq(RuntimeSamResource.resourceType))(any())
     )
-    val testService = makeInterp(authProvider = mockAuthProvider)
+      .thenReturn(IO.pure(List(wsmId1.resourceId, runtimeId3.resourceId)))
+
+    val testService = makeInterp(samService = samService)
     val res = for {
       // runtime 1: I created, in a workspace I can read => visible
       samResource1 <- IO(RuntimeSamResourceId(wsmId1.resourceId.toString))
@@ -2101,7 +1721,7 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
           .save()
       )
 
-      // runtime 2: I created, but in a workspace I cannot read, and I DO NOT HAVE SAM PERMISSION => hidden
+      // runtime 2: I created, but I don't have permission => hidden
       samResource2 <- IO(runtimeId2)
       runtime2 <- IO(
         makeCluster(2, Some(userInfoCreator.userEmail))
@@ -2109,7 +1729,7 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
           .save()
       )
 
-      // runtime 3: someone else created, in a workspace I can read => hidden
+      // runtime 3: someone else created, but I can read => hidden if role=creator, else visible
       samResource3 <- IO(runtimeId3)
       runtime3 <- IO(
         makeCluster(3, Some(userInfoOther.userEmail))
@@ -2117,19 +1737,11 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
           .save()
       )
 
-      // runtime 4: I created, in a workspace I can read, and I DO NOT HAVE SAM PERMISSION => seen if role=creator, else hid
-      samResource4 <- IO(runtimeId4)
-      runtime4 <- IO(
-        makeCluster(4, Some(userInfoCreator.userEmail))
-          .copy(samResource = samResource4, workspaceId = Some(workspaceId1))
-          .save()
-      )
-
       listResponseCreator <- testService.listRuntimes(userInfoCreator, None, None, Map("role" -> "creator"))
       listResponseAny <- testService.listRuntimes(userInfoCreator, None, None, Map.empty)
     } yield {
-      listResponseCreator.map(_.samResource).toSet shouldBe Set(samResource1, samResource4)
-      listResponseAny.map(_.samResource).toSet shouldBe Set(samResource1)
+      listResponseCreator.map(_.samResource).toSet shouldBe Set(samResource1)
+      listResponseAny.map(_.samResource).toSet shouldBe Set(samResource1, samResource3)
     }
 
     res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
@@ -2142,17 +1754,11 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
     val runtimeId2 = RuntimeSamResourceId(UUID.randomUUID.toString)
     val workspaceId1 = WorkspaceId(UUID.randomUUID)
     val userInfo = mockUserInfo("karen@styx.hel")
-    val mockAuthProvider = mockAuthorize(
-      userInfo,
-      // can read all runtimes
-      Set(runtimeId1, runtimeId2),
-      Set.empty,
-      // can read workspace
-      Set(WorkspaceResourceSamResourceId(workspaceId1)),
-      // owns workspace
-      ownerWorkspaceSamIds = Set(WorkspaceResourceSamResourceId(workspaceId1))
-    )
-    val testService = makeInterp(authProvider = mockAuthProvider)
+    val samService = mock[SamService[IO]]
+    when(samService.listResources(isEq(userInfo.accessToken.token), isEq(RuntimeSamResource.resourceType))(any()))
+      .thenReturn(IO.pure(List(runtimeId1.resourceId, runtimeId2.resourceId)))
+
+    val testService = makeInterp(samService = samService)
 
     // Make runtimes belonging to different users than the calling user
     val res = for {

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeV2ServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeV2ServiceInterpSpec.scala
@@ -289,7 +289,7 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
         .createRuntime(userInfo, name0, workspaceId, false, defaultCreateAzureRuntimeReq)
 
       disks <- DiskServiceDbQueries
-        .listDisks(Map.empty, includeDeleted = false, Some(userInfo.userEmail), None, Some(workspaceId))
+        .listDisks(Map.empty, Some(userInfo.userEmail), None, Some(workspaceId))
         .transaction
       disk = disks.head
       now <- IO.realTimeInstant
@@ -318,7 +318,7 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
         .createRuntime(userInfo, name0, workspaceId, false, defaultCreateAzureRuntimeReq)
 
       disks <- DiskServiceDbQueries
-        .listDisks(Map.empty, includeDeleted = false, Some(userInfo.userEmail), None, Some(workspaceId))
+        .listDisks(Map.empty, Some(userInfo.userEmail), None, Some(workspaceId))
         .transaction
       disk = disks.head
       now <- IO.realTimeInstant
@@ -350,7 +350,7 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
         .createRuntime(userInfo, name0, workspaceId, false, defaultCreateAzureRuntimeReq)
 
       disks <- DiskServiceDbQueries
-        .listDisks(Map.empty, includeDeleted = false, Some(userInfo.userEmail), None, Some(workspaceId))
+        .listDisks(Map.empty, Some(userInfo.userEmail), None, Some(workspaceId))
         .transaction
       disk = disks.head
       now <- IO.realTimeInstant
@@ -792,7 +792,7 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
           defaultCreateAzureRuntimeReq
         )
       disks <- DiskServiceDbQueries
-        .listDisks(Map.empty, includeDeleted = false, Some(userInfo.userEmail), None, Some(workspaceId))
+        .listDisks(Map.empty, Some(userInfo.userEmail), None, Some(workspaceId))
         .transaction
       disk = disks.head
       _ <- persistentDiskQuery.updateWSMResourceId(disk.id, wsmResourceId, context.now).transaction
@@ -856,7 +856,7 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
           defaultCreateAzureRuntimeReq
         )
       disks <- DiskServiceDbQueries
-        .listDisks(Map.empty, includeDeleted = false, Some(userInfo.userEmail), None, Some(workspaceId))
+        .listDisks(Map.empty, Some(userInfo.userEmail), None, Some(workspaceId))
         .transaction
       disk = disks.head
       _ <- persistentDiskQuery.updateWSMResourceId(disk.id, wsmResourceId, context.now).transaction
@@ -1020,7 +1020,7 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
           defaultCreateAzureRuntimeReq
         )
       disks <- DiskServiceDbQueries
-        .listDisks(Map.empty, includeDeleted = false, Some(userInfo.userEmail), None, Some(workspaceId))
+        .listDisks(Map.empty, Some(userInfo.userEmail), None, Some(workspaceId))
         .transaction
       disk = disks.head
       _ <- persistentDiskQuery.updateWSMResourceId(disk.id, wsmResourceId, context.now).transaction
@@ -1062,7 +1062,7 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
           defaultCreateAzureRuntimeReq
         )
       disks <- DiskServiceDbQueries
-        .listDisks(Map.empty, includeDeleted = false, Some(userInfo.userEmail), None, Some(workspaceId))
+        .listDisks(Map.empty, Some(userInfo.userEmail), None, Some(workspaceId))
         .transaction
       disk = disks.head
       _ <- persistentDiskQuery.updateWSMResourceId(disk.id, wsmResourceId, context.now).transaction
@@ -1300,7 +1300,7 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
         )
 
       disks <- DiskServiceDbQueries
-        .listDisks(Map.empty, includeDeleted = false, Some(userInfo.userEmail), None, Some(workspaceId))
+        .listDisks(Map.empty, Some(userInfo.userEmail), None, Some(workspaceId))
         .transaction
 
       disk1 <- persistentDiskQuery.getActiveByName(azureCloudContext, DiskName("diskName1")).transaction

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeV2ServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeV2ServiceInterpSpec.scala
@@ -1653,31 +1653,31 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
         userInfo,
         None,
         None,
-        Map("foo" -> "bar", "includeDeleted" -> "true")
+        Map("foo" -> "bar")
       ) // hit
       listResponse2 <- testService.listRuntimes(
         userInfo,
         None,
         None,
-        Map("FOO" -> "BAR", "includeDeleted" -> "true")
+        Map("FOO" -> "BAR")
       ) // hit, case insensitive
       listResponse3 <- testService.listRuntimes(
         userInfo,
         None,
         None,
-        Map("foo!@#$%^&*()_+=';:\"" -> "!@#$%^&*()_+=';:\"bar", "includeDeleted" -> "true")
+        Map("foo!@#$%^&*()_+=';:\"" -> "!@#$%^&*()_+=';:\"bar")
       ) // miss, with weird characters
       listResponse4 <- testService.listRuntimes(
         userInfo,
         None,
         None,
-        Map("foo" -> "not-bar", "includeDeleted" -> "true")
+        Map("foo" -> "not-bar")
       ) // miss value
       listResponse5 <- testService.listRuntimes(
         userInfo,
         None,
         None,
-        Map("not-foo" -> "bar", "includeDeleted" -> "true")
+        Map("not-foo" -> "bar")
       ) // miss key
       listResponse6 <- testService.listRuntimes(
         userInfo,

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeV2ServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeV2ServiceInterpSpec.scala
@@ -1679,19 +1679,12 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
         None,
         Map("not-foo" -> "bar")
       ) // miss key
-      listResponse6 <- testService.listRuntimes(
-        userInfo,
-        None,
-        None,
-        Map.empty
-      ) // miss because runtime has been deleted
     } yield {
       listResponse1.map(_.samResource).toSet shouldBe Set(samResource2)
       listResponse2.map(_.samResource).toSet shouldBe Set(samResource2)
       listResponse3.map(_.samResource).toSet shouldBe Set.empty
       listResponse4.map(_.samResource).toSet shouldBe Set.empty
       listResponse5.map(_.samResource).toSet shouldBe Set.empty
-      listResponse6.map(_.samResource).toSet shouldBe Set.empty
     }
 
     res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeV2ServiceInterpSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/RuntimeV2ServiceInterpSpec.scala
@@ -1647,8 +1647,8 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
       )
       _ <- setRuntimeDeleted(workspaceId1, runtime1.runtimeName)
 
-      _ <- IO(makeCluster(2).copy(samResource = samResource2, workspaceId = Some(workspaceId1)).save())
-      _ <- labelQuery.save(runtime1.id, LabelResourceType.Runtime, "foo", "bar").transaction
+      runtime2 <- IO(makeCluster(2).copy(samResource = samResource2, workspaceId = Some(workspaceId1)).save())
+      _ <- labelQuery.save(runtime2.id, LabelResourceType.Runtime, "foo", "bar").transaction
       listResponse1 <- testService.listRuntimes(
         userInfo,
         None,
@@ -1683,11 +1683,11 @@ class RuntimeV2ServiceInterpSpec extends AnyFlatSpec with LeonardoTestSuite with
         userInfo,
         None,
         None,
-        Map("foo" -> "bar")
-      ) // miss because includeDeleted defaults false
+        Map.empty
+      ) // miss because runtime has been deleted
     } yield {
-      listResponse1.map(_.samResource).toSet shouldBe Set(samResource1)
-      listResponse2.map(_.samResource).toSet shouldBe Set(samResource1)
+      listResponse1.map(_.samResource).toSet shouldBe Set(samResource2)
+      listResponse2.map(_.samResource).toSet shouldBe Set(samResource2)
       listResponse3.map(_.samResource).toSet shouldBe Set.empty
       listResponse4.map(_.samResource).toSet shouldBe Set.empty
       listResponse5.map(_.samResource).toSet shouldBe Set.empty


### PR DESCRIPTION
Reverts DataBiosphere/leonardo#4823

JIRA ticket: https://broadworkbench.atlassian.net/browse/AN-385

This change was originally reverted, because it removed the ability to list deleted runtimes, which AOU RWB was making use of. See https://docs.google.com/document/d/1uivQxiSoFAyD7vpmFxes5037Dn1m0yx8VovsonylKYw/edit?tab=t.0#heading=h.mf724qma605n

Now that we confirmed that RWB can default to default settings instead of the user’s prior configurations, we can move forward with this PR again, with some added modifications to the swagger page to deprecate the `includeDeleted` flag.