### PR TITLE
CORE-308 expand concurrent requests to sam

### DIFF
--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala
@@ -385,7 +385,8 @@ object Config {
       Uri.unsafeFromString(config.as[String]("samServer")),
       config.getOrElse("petKeyCacheEnabled", true),
       config.getAs[FiniteDuration]("petKeyCacheExpiryTime").getOrElse(60 minutes),
-      config.getAs[Int]("petKeyCacheMaxSize").getOrElse(1000)
+      config.getAs[Int]("petKeyCacheMaxSize").getOrElse(1000),
+      config.getAs[Int]("maxConcurrentRequests").getOrElse(15)
     )
   }
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpSamDAO.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpSamDAO.scala
@@ -578,7 +578,8 @@ final case class ListResourceRolesItem[R](samResourceId: R, samRoles: Set[SamRol
 final case class HttpSamDaoConfig(samUri: Uri,
                                   petCacheEnabled: Boolean,
                                   petCacheExpiryTime: FiniteDuration,
-                                  petCacheMaxSize: Int
+                                  petCacheMaxSize: Int,
+                                  maxConcurrentRequests: Int
 )
 
 final case class UserEmailAndProject(userEmail: WorkbenchEmail, googleProject: GoogleProject)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/sam/SamApiClientProvider.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/sam/SamApiClientProvider.scala
@@ -3,7 +3,7 @@ package org.broadinstitute.dsde.workbench.leonardo.dao.sam
 import cats.effect.Async
 import cats.mtl.Ask
 import cats.syntax.all._
-import okhttp3.Protocol
+import okhttp3.{Dispatcher, Protocol}
 import org.broadinstitute.dsde.workbench.client.sam.ApiClient
 import org.broadinstitute.dsde.workbench.client.sam.api.{AzureApi, GoogleApi, ResourcesApi, UsersApi}
 import org.broadinstitute.dsde.workbench.leonardo.AppContext
@@ -26,16 +26,25 @@ trait SamApiClientProvider[F[_]] {
   def azureApi(token: String)(implicit ev: Ask[F, AppContext]): F[AzureApi]
 }
 
-class HttpSamApiClientProvider[F[_]](samUrl: String)(implicit F: Async[F]) extends SamApiClientProvider[F] {
-  private val okHttpClient = new ApiClient().getHttpClient
+class HttpSamApiClientProvider[F[_]](samUrl: String, maxConcurrentRequests: Int)(implicit F: Async[F]) extends SamApiClientProvider[F] {
+  private val okHttpClient = buildOkHttpClient
   private val timeout = 30 seconds
+
+  private def buildOkHttpClient = {
+    val dispatcher = new Dispatcher()
+    dispatcher.setMaxRequests(maxConcurrentRequests)
+    dispatcher.setMaxRequestsPerHost(maxConcurrentRequests)
+    new ApiClient().getHttpClient.newBuilder
+      .readTimeout(timeout.toJava)
+      .protocols(Seq(Protocol.HTTP_1_1).asJava)
+      .dispatcher(dispatcher)
+      .build()
+  }
 
   private def getApiClient(token: String)(implicit ev: Ask[F, AppContext]): F[ApiClient] =
     for {
       ctx <- ev.ask
       okHttpClientBuilder = okHttpClient.newBuilder
-        .readTimeout(timeout.toJava)
-        .protocols(Seq(Protocol.HTTP_1_1).asJava)
       // TODO add otel interceptors
       //  See https://broadworkbench.atlassian.net/browse/IA-5052
       apiClient = new ApiClient(okHttpClientBuilder.build()).setBasePath(samUrl)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/sam/SamApiClientProvider.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/sam/SamApiClientProvider.scala
@@ -28,10 +28,8 @@ trait SamApiClientProvider[F[_]] {
 
 class HttpSamApiClientProvider[F[_]](samUrl: String, maxConcurrentRequests: Int)(implicit F: Async[F])
     extends SamApiClientProvider[F] {
-  private val okHttpClient = buildOkHttpClient
   private val timeout = 30 seconds
-
-  private def buildOkHttpClient = {
+  private val okHttpClient = {
     val dispatcher = new Dispatcher()
     dispatcher.setMaxRequests(maxConcurrentRequests)
     dispatcher.setMaxRequestsPerHost(maxConcurrentRequests)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/sam/SamApiClientProvider.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/sam/SamApiClientProvider.scala
@@ -26,7 +26,8 @@ trait SamApiClientProvider[F[_]] {
   def azureApi(token: String)(implicit ev: Ask[F, AppContext]): F[AzureApi]
 }
 
-class HttpSamApiClientProvider[F[_]](samUrl: String, maxConcurrentRequests: Int)(implicit F: Async[F]) extends SamApiClientProvider[F] {
+class HttpSamApiClientProvider[F[_]](samUrl: String, maxConcurrentRequests: Int)(implicit F: Async[F])
+    extends SamApiClientProvider[F] {
   private val okHttpClient = buildOkHttpClient
   private val timeout = 30 seconds
 

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/BaselineDependenciesBuilder.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/BaselineDependenciesBuilder.scala
@@ -120,7 +120,7 @@ class BaselineDependenciesBuilder {
                                                          applicationConfig
       )
 
-      samClientProvider = new HttpSamApiClientProvider(httpSamDaoConfig.samUri.renderString)
+      samClientProvider = new HttpSamApiClientProvider(httpSamDaoConfig.samUri.renderString, httpSamDaoConfig.maxConcurrentRequests)
       samService = new SamServiceInterp(samClientProvider, cloudAuthTokenProvider)
 
       samDao <- buildHttpClient(sslContext, proxyResolver.resolveHttp4s, Some("leo_sam_client"), true).map(client =>

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/BaselineDependenciesBuilder.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/BaselineDependenciesBuilder.scala
@@ -120,7 +120,9 @@ class BaselineDependenciesBuilder {
                                                          applicationConfig
       )
 
-      samClientProvider = new HttpSamApiClientProvider(httpSamDaoConfig.samUri.renderString, httpSamDaoConfig.maxConcurrentRequests)
+      samClientProvider = new HttpSamApiClientProvider(httpSamDaoConfig.samUri.renderString,
+                                                       httpSamDaoConfig.maxConcurrentRequests
+      )
       samService = new SamServiceInterp(samClientProvider, cloudAuthTokenProvider)
 
       samDao <- buildHttpClient(sslContext, proxyResolver.resolveHttp4s, Some("leo_sam_client"), true).map(client =>

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpSamDAOSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpSamDAOSpec.scala
@@ -32,7 +32,7 @@ import scala.util.control.NoStackTrace
 
 class HttpSamDAOSpec extends AnyFlatSpec with LeonardoTestSuite with BeforeAndAfterAll with MockitoSugar {
   val cloudAuthProvider = mock[CloudAuthTokenProvider[IO]]
-  val config = HttpSamDaoConfig(Uri.unsafeFromString("localhost"), false, 1 seconds, 10)
+  val config = HttpSamDaoConfig(Uri.unsafeFromString("localhost"), false, 1 seconds, 10, 15)
   implicit def unsafeLogger: Logger[IO] = Slf4jLogger.getLogger[IO]
   val underlyingPetTokenCache = Caffeine
     .newBuilder()


### PR DESCRIPTION
<!-- Welcome to your Leonardo pull request! -->
<!-- Contributor guidelines: https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md -->

__Jira ticket__: https://broadworkbench.atlassian.net/browse/CORE-308

<!-- ## Dependencies -->
<!-- Include any dependent tickets and describe the relationship. Include any other relevant Jira tickets. -->

## Summary of changes

This PR increases the number of concurrent requests a Leo instance can make to Sam from 5 (the default) to 15. This is an attempt to address socket timeout errors that appear in the logs (but are retries, presumably successfully).

### What

-

### Why

-

## Testing these changes

### What to test

- <!-- Test case 1 -->

<!-- ### Test data -->

### Who tested and where

- [ ] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [ ] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
