### PR TITLE
RW-12661 Support qiime

### DIFF
--- a/http/src/main/resources/init-resources/gce-init.sh
+++ b/http/src/main/resources/init-resources/gce-init.sh
@@ -410,8 +410,12 @@ if [ ! -z "$JUPYTER_DOCKER_IMAGE" ] ; then
   # custom code only for AoU image. We can remove this after AoU maintenance mode is over in 2026.
   if [[ $JUPYTER_DOCKER_IMAGE == *terra-jupyter-aou* ]]; then
 #    retry 3 docker exec ${JUPYTER_SERVER_NAME} pip install --upgrade jupyter-server
-    retry 3 docker exec -u root -e PIP_USER=false ${JUPYTER_SERVER_NAME} sudo -E -u jupyter jupyter serverextension enable --py qiime2 --sys-prefix
+#    retry 3 docker exec -u root -e PIP_USER=false ${JUPYTER_SERVER_NAME} sudo -E -u jupyter jupyter serverextension enable --py qiime2
 #    retry 3 docker exec -u root -e PIP_USER=false ${JUPYTER_SERVER_NAME} chown -R jupyter:users $JUPYTER_USER_HOME/.config
+    retry 3 docker exec -u root ${JUPYTER_SERVER_NAME} chown -R jupyter:users $JUPYTER_USER_HOME/
+    retry 3 docker exec ${JUPYTER_SERVER_NAME} /opt/conda/bin/pip install --upgrade jupyter-server
+    retry 3 docker exec -u root ${JUPYTER_SERVER_NAME} chown -R jupyter:users /opt/conda/etc/jupyter/
+    retry 3 docker exec ${JUPYTER_SERVER_NAME} /opt/conda/bin/jupyter server extension enable --py qiime2 --sys-prefix
   fi
 
   # Install everything after having mounted the empty PD

--- a/http/src/main/resources/init-resources/gce-init.sh
+++ b/http/src/main/resources/init-resources/gce-init.sh
@@ -411,6 +411,7 @@ if [ ! -z "$JUPYTER_DOCKER_IMAGE" ] ; then
   if [[ $JUPYTER_DOCKER_IMAGE == *terra-jupyter-aou* ]]; then
     retry 3 docker exec ${JUPYTER_SERVER_NAME} pip install --upgrade jupyter-server
     retry 3 docker exec -u root ${JUPYTER_SERVER_NAME} jupyter server extension enable --py qiime2 --sys-prefix
+    retry 3 docker exec -u root chown -R jupyter:users $JUPYTER_USER_HOME/.config
   fi
 
   # Install everything after having mounted the empty PD

--- a/http/src/main/resources/init-resources/gce-init.sh
+++ b/http/src/main/resources/init-resources/gce-init.sh
@@ -407,17 +407,6 @@ if [ ! -z "$JUPYTER_DOCKER_IMAGE" ] ; then
   mkdir -p ${WORK_DIRECTORY}/packages
   chmod a+rwx ${WORK_DIRECTORY}/packages
 
-  # custom code only for AoU image. We can remove this after AoU maintenance mode is over in 2026.
-  if [[ $JUPYTER_DOCKER_IMAGE == *terra-jupyter-aou* ]]; then
-#    retry 3 docker exec ${JUPYTER_SERVER_NAME} pip install --upgrade jupyter-server
-#    retry 3 docker exec -u root -e PIP_USER=false ${JUPYTER_SERVER_NAME} sudo -E -u jupyter jupyter serverextension enable --py qiime2
-#    retry 3 docker exec -u root -e PIP_USER=false ${JUPYTER_SERVER_NAME} chown -R jupyter:users $JUPYTER_USER_HOME/.config
-    retry 3 docker exec -u root ${JUPYTER_SERVER_NAME} chown -R jupyter:users $JUPYTER_USER_HOME/
-    retry 3 docker exec ${JUPYTER_SERVER_NAME} /opt/conda/envs/qiime2-2024.10/bin/pip install --upgrade jupyter-server
-    retry 3 docker exec -u root ${JUPYTER_SERVER_NAME} chown -R jupyter:users /opt/conda/envs/qiime2-2024.10/etc/jupyter/
-    retry 3 docker exec ${JUPYTER_SERVER_NAME} /opt/conda/envs/qiime2-2024.10/bin/jupyter server extension enable --py qiime2 --sys-prefix
-  fi
-
   # Install everything after having mounted the empty PD
   # This should not be needed anymore if the jupyter home is a directory of the PD mount point
   # See: https://github.com/DataBiosphere/leonardo/pull/4465/files
@@ -574,6 +563,17 @@ if [ ! -z "$JUPYTER_DOCKER_IMAGE" ] ; then
   # In new jupyter images, we should update jupyter_notebook_config.py in terra-docker.
   # This is to make it so that older images will still work after we change notebooks location to home dir
   docker exec ${JUPYTER_SERVER_NAME} sed -i '/^# to mount there as it effectively deletes existing files on the image/,+5d' ${JUPYTER_HOME}/jupyter_notebook_config.py
+
+  # custom code only for AoU image. We can remove this after AoU maintenance mode is over in 2026.
+  if [[ $JUPYTER_DOCKER_IMAGE == *terra-jupyter-aou* ]]; then
+#    retry 3 docker exec ${JUPYTER_SERVER_NAME} pip install --upgrade jupyter-server
+#    retry 3 docker exec -u root -e PIP_USER=false ${JUPYTER_SERVER_NAME} sudo -E -u jupyter jupyter serverextension enable --py qiime2
+#    retry 3 docker exec -u root -e PIP_USER=false ${JUPYTER_SERVER_NAME} chown -R jupyter:users $JUPYTER_USER_HOME/.config
+    retry 3 docker exec -u root ${JUPYTER_SERVER_NAME} chown -R jupyter:users $JUPYTER_USER_HOME/
+    retry 3 docker exec ${JUPYTER_SERVER_NAME} /opt/conda/envs/qiime2-2024.10/bin/pip install --upgrade jupyter-server
+    retry 3 docker exec -u root ${JUPYTER_SERVER_NAME} chown -R jupyter:users /opt/conda/envs/qiime2-2024.10/etc/jupyter/
+    retry 3 docker exec ${JUPYTER_SERVER_NAME} /opt/conda/envs/qiime2-2024.10/bin/jupyter server extension enable --py qiime2 --sys-prefix
+  fi
 
   log 'Starting Jupyter Notebook...'
   retry 3 docker exec -d $JUPYTER_SERVER_NAME /bin/bash -c "${JUPYTER_SCRIPTS}/run-jupyter.sh ${NOTEBOOKS_DIR}"

--- a/http/src/main/resources/init-resources/gce-init.sh
+++ b/http/src/main/resources/init-resources/gce-init.sh
@@ -411,7 +411,7 @@ if [ ! -z "$JUPYTER_DOCKER_IMAGE" ] ; then
   if [[ $JUPYTER_DOCKER_IMAGE == *terra-jupyter-aou* ]]; then
     retry 3 docker exec ${JUPYTER_SERVER_NAME} pip install --upgrade jupyter-server
     retry 3 docker exec -u root ${JUPYTER_SERVER_NAME} jupyter server extension enable --py qiime2 --sys-prefix
-    retry 3 docker exec -u root chown -R jupyter:users $JUPYTER_USER_HOME/.config
+    retry 3 docker exec -u root ${JUPYTER_SERVER_NAME} chown -R jupyter:users $JUPYTER_USER_HOME/.config
   fi
 
   # Install everything after having mounted the empty PD

--- a/http/src/main/resources/init-resources/gce-init.sh
+++ b/http/src/main/resources/init-resources/gce-init.sh
@@ -410,8 +410,8 @@ if [ ! -z "$JUPYTER_DOCKER_IMAGE" ] ; then
   # custom code only for AoU image. We can remove this after AoU maintenance mode is over in 2026.
   if [[ $JUPYTER_DOCKER_IMAGE == *terra-jupyter-aou* ]]; then
     retry 3 docker exec ${JUPYTER_SERVER_NAME} pip install --upgrade jupyter-server
-    retry 3 docker exec -u root -e PIP_USER=false ${JUPYTER_SERVER_NAME} jupyter server extension enable --py qiime2 --sys-prefix
-    retry 3 docker exec -u root -e PIP_USER=false ${JUPYTER_SERVER_NAME} chown -R jupyter:users $JUPYTER_USER_HOME/.config
+    retry 3 docker exec -u root -e PIP_USER=false ${JUPYTER_SERVER_NAME} sudo -E -u jupyter jupyter serverextension enable --py qiime2 --sys-prefix
+#    retry 3 docker exec -u root -e PIP_USER=false ${JUPYTER_SERVER_NAME} chown -R jupyter:users $JUPYTER_USER_HOME/.config
   fi
 
   # Install everything after having mounted the empty PD

--- a/http/src/main/resources/init-resources/gce-init.sh
+++ b/http/src/main/resources/init-resources/gce-init.sh
@@ -409,7 +409,7 @@ if [ ! -z "$JUPYTER_DOCKER_IMAGE" ] ; then
 
   # custom code only for AoU image. We can remove this after AoU maintenance mode is over in 2026.
   if [[ $JUPYTER_DOCKER_IMAGE == *terra-jupyter-aou* ]]; then
-    retry 3 docker exec ${JUPYTER_SERVER_NAME} pip install --upgrade jupyter-server
+#    retry 3 docker exec ${JUPYTER_SERVER_NAME} pip install --upgrade jupyter-server
     retry 3 docker exec -u root -e PIP_USER=false ${JUPYTER_SERVER_NAME} sudo -E -u jupyter jupyter serverextension enable --py qiime2 --sys-prefix
 #    retry 3 docker exec -u root -e PIP_USER=false ${JUPYTER_SERVER_NAME} chown -R jupyter:users $JUPYTER_USER_HOME/.config
   fi

--- a/http/src/main/resources/init-resources/gce-init.sh
+++ b/http/src/main/resources/init-resources/gce-init.sh
@@ -407,7 +407,7 @@ if [ ! -z "$JUPYTER_DOCKER_IMAGE" ] ; then
   mkdir -p ${WORK_DIRECTORY}/packages
   chmod a+rwx ${WORK_DIRECTORY}/packages
 
-  # custom code only for AoU image
+  # custom code only for AoU image. We can remove this after AoU maintenance mode is over in 2026.
   if [[ $JUPYTER_DOCKER_IMAGE == *terra-jupyter-aou* ]]; then
     retry 3 docker exec ${JUPYTER_SERVER_NAME} pip install --upgrade jupyter-server
     retry 3 docker exec -u root ${JUPYTER_SERVER_NAME} jupyter server extension enable --py qiime2 --sys-prefix

--- a/http/src/main/resources/init-resources/gce-init.sh
+++ b/http/src/main/resources/init-resources/gce-init.sh
@@ -413,9 +413,9 @@ if [ ! -z "$JUPYTER_DOCKER_IMAGE" ] ; then
 #    retry 3 docker exec -u root -e PIP_USER=false ${JUPYTER_SERVER_NAME} sudo -E -u jupyter jupyter serverextension enable --py qiime2
 #    retry 3 docker exec -u root -e PIP_USER=false ${JUPYTER_SERVER_NAME} chown -R jupyter:users $JUPYTER_USER_HOME/.config
     retry 3 docker exec -u root ${JUPYTER_SERVER_NAME} chown -R jupyter:users $JUPYTER_USER_HOME/
-    retry 3 docker exec ${JUPYTER_SERVER_NAME} /opt/conda/bin/pip install --upgrade jupyter-server
-    retry 3 docker exec -u root ${JUPYTER_SERVER_NAME} chown -R jupyter:users /opt/conda/etc/jupyter/
-    retry 3 docker exec ${JUPYTER_SERVER_NAME} /opt/conda/bin/jupyter server extension enable --py qiime2 --sys-prefix
+    retry 3 docker exec ${JUPYTER_SERVER_NAME} /opt/conda/envs/qiime2-2024.10/bin/pip install --upgrade jupyter-server
+    retry 3 docker exec -u root ${JUPYTER_SERVER_NAME} chown -R jupyter:users /opt/conda/envs/qiime2-2024.10/etc/jupyter/
+    retry 3 docker exec ${JUPYTER_SERVER_NAME} /opt/conda/envs/qiime2-2024.10/bin/jupyter server extension enable --py qiime2 --sys-prefix
   fi
 
   # Install everything after having mounted the empty PD

--- a/http/src/main/resources/init-resources/gce-init.sh
+++ b/http/src/main/resources/init-resources/gce-init.sh
@@ -410,8 +410,8 @@ if [ ! -z "$JUPYTER_DOCKER_IMAGE" ] ; then
   # custom code only for AoU image. We can remove this after AoU maintenance mode is over in 2026.
   if [[ $JUPYTER_DOCKER_IMAGE == *terra-jupyter-aou* ]]; then
     retry 3 docker exec ${JUPYTER_SERVER_NAME} pip install --upgrade jupyter-server
-    retry 3 docker exec -u root ${JUPYTER_SERVER_NAME} jupyter server extension enable --py qiime2 --sys-prefix
-    retry 3 docker exec -u root ${JUPYTER_SERVER_NAME} chown -R jupyter:users $JUPYTER_USER_HOME/.config
+    retry 3 docker exec -u root -e PIP_USER=false ${JUPYTER_SERVER_NAME} jupyter server extension enable --py qiime2 --sys-prefix
+    retry 3 docker exec -u root -e PIP_USER=false ${JUPYTER_SERVER_NAME} chown -R jupyter:users $JUPYTER_USER_HOME/.config
   fi
 
   # Install everything after having mounted the empty PD

--- a/http/src/main/resources/init-resources/gce-init.sh
+++ b/http/src/main/resources/init-resources/gce-init.sh
@@ -571,7 +571,7 @@ if [ ! -z "$JUPYTER_DOCKER_IMAGE" ] ; then
 #    retry 3 docker exec -u root -e PIP_USER=false ${JUPYTER_SERVER_NAME} chown -R jupyter:users $JUPYTER_USER_HOME/.config
     retry 3 docker exec -u root ${JUPYTER_SERVER_NAME} chown -R jupyter:users $JUPYTER_USER_HOME/
     retry 3 docker exec ${JUPYTER_SERVER_NAME} /opt/conda/envs/qiime2-2024.10/bin/pip install --upgrade jupyter-server
-    retry 3 docker exec -u root ${JUPYTER_SERVER_NAME} chown -R jupyter:users /opt/conda/envs/qiime2-2024.10/etc/jupyter/
+    retry 3 docker exec -u root ${JUPYTER_SERVER_NAME} chown -R jupyter:users /opt/conda/envs/qiime2-2024.10/etc
     retry 3 docker exec ${JUPYTER_SERVER_NAME} /opt/conda/envs/qiime2-2024.10/bin/jupyter server extension enable --py qiime2 --sys-prefix
   fi
 

--- a/http/src/main/resources/init-resources/gce-init.sh
+++ b/http/src/main/resources/init-resources/gce-init.sh
@@ -407,6 +407,12 @@ if [ ! -z "$JUPYTER_DOCKER_IMAGE" ] ; then
   mkdir -p ${WORK_DIRECTORY}/packages
   chmod a+rwx ${WORK_DIRECTORY}/packages
 
+  # custom code only for AoU image
+  if [[ $JUPYTER_DOCKER_IMAGE == *terra-jupyter-aou* ]]; then
+    retry 3 docker exec ${JUPYTER_SERVER_NAME} pip install --upgrade jupyter-server
+    retry 3 docker exec -u root ${JUPYTER_SERVER_NAME} jupyter server extension enable --py qiime2 --sys-prefix
+  fi
+
   # Install everything after having mounted the empty PD
   # This should not be needed anymore if the jupyter home is a directory of the PD mount point
   # See: https://github.com/DataBiosphere/leonardo/pull/4465/files


### PR DESCRIPTION


Have to do this hacky thing because the current way we're installing jupyter server extension assumes we also need to install the package (see [this](https://github.com/DataBiosphere/terra-docker/blob/a0cf5769e6b469ba5813c810c119b10f26915422/terra-jupyter-base/scripts/extension/jupyter_pip_install_server_extension.sh#L7))

This won't work for qiime, because it's not installed via pip.

The other thing is we needed to upgrade jupyter-server in order to enable qimme server extension.

TODO: test

<!-- Welcome to your Leonardo pull request! -->
<!-- Contributor guidelines: https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md -->

__Jira ticket__: https://precisionmedicineinitiative.atlassian.net/browse/RW-12661

<!-- ## Dependencies -->
<!-- Include any dependent tickets and describe the relationship. Include any other relevant Jira tickets. -->

## Summary of changes

<!-- Please give an abridged version of the ticket description here and/or fill out the following fields. -->

### What

-

### Why

-

## Testing these changes

### What to test

- <!-- Test case 1 -->

<!-- ### Test data -->

### Who tested and where

- [ ] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [ ] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
