### PR TITLE
[AN-468] Upgrade k8s client to 23.0.0 via TCL and workbenchlibs

### DIFF
--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/google/package.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/google/package.scala
@@ -18,7 +18,7 @@ package object google {
   final val retryPredicates = List(
     when5xx _,
     whenUsageLimited _,
-    whenGlobalUsageLimited _,
+//    whenGlobalUsageLimited _,
     when404 _,
     whenInvalidValueOnBucketCreation _,
     whenNonHttpIOException _

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/LeoAppServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/LeoAppServiceInterp.scala
@@ -1442,7 +1442,7 @@ final class LeoAppServiceInterp[F[_]: Parallel](config: AppServiceConfig,
       // decouple this string from UI-generated Leo app names because of hidden k8s/Galaxy constraints.
       //
       // There are DB constraints to handle potential name collisions.
-      uid = s"${RandomStringUtils.randomAlphabetic(1)}${RandomStringUtils.randomAlphanumeric(5)}".toLowerCase
+      uid = s"${RandomStringUtils.secureStrong().nextAlphanumeric(1)}${RandomStringUtils.secureStrong().nextAlphanumeric(5)}".toLowerCase
       namespaceName <- lastUsedApp.fold(
         KubernetesName.withValidation(
           s"${uid}-${gkeAppConfig.namespaceNameSuffix.value}",

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/LeoAppServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/LeoAppServiceInterp.scala
@@ -1442,7 +1442,7 @@ final class LeoAppServiceInterp[F[_]: Parallel](config: AppServiceConfig,
       // decouple this string from UI-generated Leo app names because of hidden k8s/Galaxy constraints.
       //
       // There are DB constraints to handle potential name collisions.
-      uid = s"${RandomStringUtils.secureStrong().nextAlphanumeric(1)}${RandomStringUtils.secureStrong().nextAlphanumeric(5)}".toLowerCase
+      uid = s"${RandomStringUtils.secureStrong().nextAlphabetic(1)}${RandomStringUtils.secureStrong().nextAlphanumeric(5)}".toLowerCase
       namespaceName <- lastUsedApp.fold(
         KubernetesName.withValidation(
           s"${uid}-${gkeAppConfig.namespaceNameSuffix.value}",

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoMetricsMonitor.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoMetricsMonitor.scala
@@ -376,19 +376,10 @@ class LeoMetricsMonitor[F[_]](config: LeoMetricsMonitorConfig,
                 val labelSelector = s"leoAppName=${app.appName.value}"
                 for {
                   pods <- F.blocking(
-                    client.listNamespacedPod(namespace.value,
-                                             null,
-                                             null,
-                                             null,
-                                             null,
-                                             labelSelector,
-                                             null,
-                                             null,
-                                             null,
-                                             null,
-                                             null,
-                                             null
-                    )
+                    client
+                      .listNamespacedPod(namespace.value)
+                      .labelSelector(labelSelector)
+                      .execute()
                   )
 
                   res = pods.getItems.asScala.flatMap { pod =>

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/KubernetesInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/KubernetesInterpreter.scala
@@ -80,19 +80,10 @@ class KubernetesInterpreter[F[_]](azureContainerService: AzureContainerService[F
       ctx <- ev.ask
       call =
         F.blocking(
-          client.listNamespacedPod(namespace.name.value,
-                                   "true",
-                                   null,
-                                   null,
-                                   null,
-                                   null,
-                                   null,
-                                   null,
-                                   null,
-                                   null,
-                                   null,
-                                   null
-          )
+          client
+            .listNamespacedPod(namespace.name.value)
+            .pretty("true")
+            .execute()
         )
 
       response <- withLogging(
@@ -115,12 +106,10 @@ class KubernetesInterpreter[F[_]](azureContainerService: AzureContainerService[F
       ctx <- ev.ask
       call = F
         .blocking(
-          client.createNamespace(new V1Namespace().metadata(new V1ObjectMeta().name(namespace.name.value)),
-                                 "true",
-                                 null,
-                                 null,
-                                 null
-          )
+          client
+            .createNamespace(new V1Namespace().metadata(new V1ObjectMeta().name(namespace.name.value)))
+            .pretty("true")
+            .execute()
         )
         .void
       _ <- withLogging(
@@ -138,15 +127,10 @@ class KubernetesInterpreter[F[_]](azureContainerService: AzureContainerService[F
       call =
         recoverF(
           F.blocking(
-            client.deleteNamespace(
-              namespace.name.value,
-              "true",
-              null,
-              null,
-              null,
-              null,
-              null
-            )
+            client
+              .deleteNamespace(namespace.name.value)
+              .pretty("true")
+              .execute()
           ).void
             .recoverWith {
               case e: com.google.gson.JsonSyntaxException
@@ -180,14 +164,14 @@ class KubernetesInterpreter[F[_]](azureContainerService: AzureContainerService[F
       call =
         recoverF(
           F.blocking(
-            client.listNamespace("true", false, null, null, null, null, null, null, null, null, false)
+            client.listNamespace.pretty("true").allowWatchBookmarks(false).execute()
           ),
           whenStatusCode(409)
         )
       v1NamespaceList <- withLogging(
         call,
         Some(ctx.traceId),
-        s"io.kubernetes.client.apis.CoreV1Api.listNamespace(true, false, null, null, null, null, null, null, null, null, false)",
+        s"io.kubernetes.client.apis.CoreV1Api.listNamespace.pretty(true).allowWatchBookmarks(false).execute()",
         Show.show[Option[V1NamespaceList]](
           _.fold("No namespace found")(x => x.getItems.asScala.toList.map(_.getMetadata.getName).mkString(","))
         )

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/KubernetesInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/KubernetesInterpreter.scala
@@ -89,7 +89,7 @@ class KubernetesInterpreter[F[_]](azureContainerService: AzureContainerService[F
       response <- withLogging(
         call,
         Some(ctx.traceId),
-        s"io.kubernetes.client.apis.CoreV1Api.listNamespacedPod(${namespace.name.value}, true, null, null, null, null, null, null, null, null)"
+        s"io.kubernetes.client.apis.CoreV1Api.listNamespacedPod(${namespace.name.value}).pretty(true).execute()"
       )
 
       listPodStatus: List[PodStatus] = response.getItems.asScala.toList.flatMap(v1Pod =>

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoMetricsMonitorSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoMetricsMonitorSpec.scala
@@ -744,6 +744,7 @@ class LeoMetricsMonitorSpec extends AnyFlatSpec with LeonardoTestSuite with Test
     val client = mock[CoreV1Api]
     val podList = mock[V1PodList]
     val pod = mock[V1Pod]
+    val mockRequest = mock[CoreV1Api#APIlistNamespacedPodRequest]
     val spec = mock[V1PodSpec]
     val container = mock[V1Container]
     val kube = mock[KubernetesAlgebra[IO]]
@@ -769,8 +770,25 @@ class LeoMetricsMonitorSpec extends AnyFlatSpec with LeonardoTestSuite with Test
       podList.getItems
     } thenReturn List(pod).asJava
     when {
-
-      client.listNamespacedPod(any).execute()
+      client
+        .listNamespacedPod(any)
+    } thenReturn mockRequest
+    when {
+      client
+        .listNamespacedPod(any)
+        .pretty(any)
+    } thenReturn mockRequest
+    when {
+      client
+        .listNamespacedPod(any)
+        .labelSelector(any)
+    } thenReturn mockRequest
+    when {
+      client
+        .listNamespacedPod(any)
+        .pretty(any)
+        .labelSelector(any)
+        .execute()
     } thenReturn podList
     when {
       kube.createAzureClient(any, any[String].asInstanceOf[AKSClusterName])(any)

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoMetricsMonitorSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoMetricsMonitorSpec.scala
@@ -769,7 +769,8 @@ class LeoMetricsMonitorSpec extends AnyFlatSpec with LeonardoTestSuite with Test
       podList.getItems
     } thenReturn List(pod).asJava
     when {
-      client.listNamespacedPod(any, any, any, any, any, any, any, any, any, any, any, any)
+
+      client.listNamespacedPod(any).execute()
     } thenReturn podList
     when {
       kube.createAzureClient(any, any[String].asInstanceOf[AKSClusterName])(any)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -21,7 +21,7 @@ object Dependencies {
   val serviceTestV = s"5.0-$workbenchLibsHash"
   val workbenchModelV = s"0.20-$workbenchLibsHash"
   val workbenchGoogleV = s"0.32-$workbenchLibsHash"
-  val workbenchGoogle2V = s"0.36-$workbenchLibsHash"
+  val workbenchGoogle2V = s"0.4-39b4ef35-SNAP"
   val workbenchOpenTelemetryV = s"0.8-$workbenchLibsHash"
   val workbenchOauth2V = "0.8-3e0cf25"
   val workbenchAzureV = s"0.10-b25c29d"
@@ -141,7 +141,7 @@ object Dependencies {
   // See the relevant PRs from TCL, the fix suggested in there does not fully cover the leo use cases
   //  https://github.com/DataBiosphere/terra-common-lib/commit/d9c2eca9510596def6553a63b6fe1eaa0d364163
   //  https://github.com/DataBiosphere/terra-common-lib/commit/431ad29aeb2275ce3415b22ff4447fc7a34386f7
-  val terraCommonLibV = "1.1.4-SNAPSHOT"
+  val terraCommonLibV = "1.1.38-SNAPSHOT"
   val bpmV = "0.1.548-SNAPSHOT"
   val samV = "v0.0.274"
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,7 +17,7 @@ object Dependencies {
   val munitCatsEffectV = "1.0.7"
   val pact4sV = "0.10.0"
 
-  private val workbenchLibsHash = "c153d812-SNAP"
+  private val workbenchLibsHash = "ad2b686"
   val serviceTestV = s"6.1-$workbenchLibsHash"
   val workbenchModelV = s"0.21-$workbenchLibsHash"
   val workbenchGoogleV = s"0.35-$workbenchLibsHash"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,7 +17,7 @@ object Dependencies {
   val munitCatsEffectV = "1.0.7"
   val pact4sV = "0.10.0"
 
-  private val workbenchLibsHash = "f0fa3901-SNAP"
+  private val workbenchLibsHash = "b47ca644-SNAP"
   val serviceTestV = s"5.1-$workbenchLibsHash"
   val workbenchModelV = s"0.21-$workbenchLibsHash"
   val workbenchGoogleV = s"0.35-$workbenchLibsHash"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,12 +17,12 @@ object Dependencies {
   val munitCatsEffectV = "1.0.7"
   val pact4sV = "0.10.0"
 
-  private val workbenchLibsHash = "3cea4eb"
-  val serviceTestV = s"5.0-$workbenchLibsHash"
-  val workbenchModelV = s"0.20-$workbenchLibsHash"
-  val workbenchGoogleV = s"0.32-$workbenchLibsHash"
-  val workbenchGoogle2V = s"0.4-39b4ef35-SNAP"
-  val workbenchOpenTelemetryV = s"0.8-$workbenchLibsHash"
+  private val workbenchLibsHash = "f0fa3901-SNAP"
+  val serviceTestV = s"5.1-$workbenchLibsHash"
+  val workbenchModelV = s"0.21-$workbenchLibsHash"
+  val workbenchGoogleV = s"0.35-$workbenchLibsHash"
+  val workbenchGoogle2V = s"0.40-$workbenchLibsHash"
+  val workbenchOpenTelemetryV = s"0.9-$workbenchLibsHash"
   val workbenchOauth2V = "0.8-3e0cf25"
   val workbenchAzureV = s"0.10-b25c29d"
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -237,7 +237,7 @@ object Dependencies {
   val automationOverrides = List(guava)
 
   val automationDependencies = List(
-    "com.fasterxml.jackson.module" %% "jackson-module-scala"   % "2.17.1" % "test",
+    "com.fasterxml.jackson.module" %% "jackson-module-scala"   % "2.18.0" % "test",
     logbackClassic % "test",
     leonardoClient,
     ssh,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -137,10 +137,6 @@ object Dependencies {
 
   val workSpaceManagerV = "0.254.1127-SNAPSHOT"
 
-  // Sticking to the legacy kubernetes java client for now
-  // See the relevant PRs from TCL, the fix suggested in there does not fully cover the leo use cases
-  //  https://github.com/DataBiosphere/terra-common-lib/commit/d9c2eca9510596def6553a63b6fe1eaa0d364163
-  //  https://github.com/DataBiosphere/terra-common-lib/commit/431ad29aeb2275ce3415b22ff4447fc7a34386f7
   val terraCommonLibV = "1.1.38-SNAPSHOT"
   val bpmV = "0.1.548-SNAPSHOT"
   val samV = "v0.0.274"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,8 +17,8 @@ object Dependencies {
   val munitCatsEffectV = "1.0.7"
   val pact4sV = "0.10.0"
 
-  private val workbenchLibsHash = "9d7d0680-SNAP"
-  val serviceTestV = s"5.1-$workbenchLibsHash"
+  private val workbenchLibsHash = "c153d812-SNAP"
+  val serviceTestV = s"6.1-$workbenchLibsHash"
   val workbenchModelV = s"0.21-$workbenchLibsHash"
   val workbenchGoogleV = s"0.35-$workbenchLibsHash"
   val workbenchGoogle2V = s"0.40-$workbenchLibsHash"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,7 +17,7 @@ object Dependencies {
   val munitCatsEffectV = "1.0.7"
   val pact4sV = "0.10.0"
 
-  private val workbenchLibsHash = "b47ca644-SNAP"
+  private val workbenchLibsHash = "9d7d0680-SNAP"
   val serviceTestV = s"5.1-$workbenchLibsHash"
   val workbenchModelV = s"0.21-$workbenchLibsHash"
   val workbenchGoogleV = s"0.35-$workbenchLibsHash"
@@ -74,7 +74,7 @@ object Dependencies {
   val scalaTest: ModuleID = "org.scalatest" %% "scalatest" % scalaTestV  % Test
   val scalaTestScalaCheck = "org.scalatestplus" %% "scalacheck-1-17" % s"${scalaTestV}.0" % Test // https://github.com/scalatest/scalatestplus-scalacheck
   val scalaTestMockito = "org.scalatestplus" %% "mockito-4-5" % "3.2.12.0" % Test // https://github.com/scalatest/scalatestplus-mockito
-  val scalaTestSelenium =  "org.scalatestplus" %% "selenium-4-1" % "3.2.12.1" % Test // https://github.com/scalatest/scalatestplus-selenium
+  val scalaTestSelenium =  "org.scalatestplus" %% "selenium-4-21" % "3.2.19.0" % Test // https://github.com/scalatest/scalatestplus-selenium
 
   // Exclude workbench-libs transitive dependencies so we can control the library versions individually.
   // workbench-google pulls in workbench-{util, model, metrics} and workbench-metrics pulls in workbench-util.
@@ -229,7 +229,7 @@ object Dependencies {
     "com.azure" % "azure-identity" % "1.10.4"
   )
 
-  val workbenchServiceTest: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-service-test" % serviceTestV % "test" classifier "tests" excludeAll (excludeGuava, excludeStatsD)
+  val workbenchServiceTest: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-service-test" % serviceTestV % "test" classifier "tests" excludeAll (excludeGuava, excludeStatsD, excludeOpenTelemetry)
   val leonardoClient: ModuleID =  "org.broadinstitute.dsde.workbench" %% "leonardo-client" % "1.3.6-35973f1-SNAP"
   // You should not be using SSH functionality outside of the tests according to security team's guidance
   val ssh: ModuleID = "com.hierynomus" % "sshj" % "0.37.0" % "test"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -53,6 +53,7 @@ object Dependencies {
   val excludeKms = ExclusionRule(organization = "com.google.cloud", name = s"google-cloud-kms")
   val excludeBigQuery = ExclusionRule(organization = "com.google.cloud", name = "google-cloud-bigquery")
   val excludeCloudBilling = ExclusionRule(organization = "com.google.cloud", name = "google-cloud-billing")
+  val excludeOpenTelemetry = ExclusionRule(organization = "io.opentelemetry")
 
   val jose4j: ModuleID =  "org.bitbucket.b_c" % "jose4j" % "0.9.4"
 
@@ -98,7 +99,8 @@ object Dependencies {
     excludeBigQuery,
     excludeCloudBilling,
     excludeSundrCodegen,
-    excludeGuava
+    excludeGuava,
+    excludeOpenTelemetry
   )
   val workbenchAzure: ModuleID =      "org.broadinstitute.dsde.workbench" %% "workbench-azure"  % workbenchAzureV
   val workbenchOauth2: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % workbenchOauth2V
@@ -154,7 +156,6 @@ object Dependencies {
   def excludePostgresql = ExclusionRule("org.postgresql", "postgresql")
   def excludeSnakeyaml = ExclusionRule("org.yaml", "snakeyaml")
   def excludeLiquibase = ExclusionRule("org.liquibase", "liquibase-core")
-  def excludeOpenTelemetry = ExclusionRule("io.opentelemetry")
   def excludeFlagsmith = ExclusionRule("com.flagsmith", "flagsmith-java-client")
 
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -9,3 +9,4 @@ addSbtPlugin(
 ) // Use `unusedCompileDependencies` to see unused dependencies
 
 addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.11.1")
+addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.10.0-RC1")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -9,4 +9,4 @@ addSbtPlugin(
 ) // Use `unusedCompileDependencies` to see unused dependencies
 
 addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.11.1")
-addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.10.0-RC1")
+addDependencyTreePlugin


### PR DESCRIPTION
<!-- Welcome to your Leonardo pull request! -->
<!-- Contributor guidelines: https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md -->

__Jira ticket__: https://broadworkbench.atlassian.net/browse/AN-468

<!-- ## Dependencies -->
<!-- Include any dependent tickets and describe the relationship. Include any other relevant Jira tickets. -->

## Summary of changes

<!-- Please give an abridged version of the ticket description here and/or fill out the following fields. -->

### What

- Updates to the latest TCL and Workbenchlibs versions that use k8s java client 23.0.0. This caused a bunch of breaking changes that needed to be addressed as well
- This PR needs to be merged after https://github.com/broadinstitute/workbench-libs/pull/1726

### Why

- Leo was on k8s java client 20.0.1-legacy which will soon be incompatible with GKE updates made to our clusters

## Testing these changes

### What to test

- <!-- Test case 1 -->

<!-- ### Test data -->

### Who tested and where

- [ ] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [ ] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
