### PR TITLE
[CORE-458 Update coursier/cache-action

### DIFF
--- a/.github/workflows/publish_java_client.yml
+++ b/.github/workflows/publish_java_client.yml
@@ -34,7 +34,7 @@ jobs:
 
       # coursier cache action caches both coursier and sbt caches
       - name: coursier-cache-action
-        uses: coursier/cache-action@v5
+        uses: coursier/cache-action@v6
 
       - name: Extract branch name
         shell: bash

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -70,7 +70,7 @@ jobs:
         version: "v0.1.15"
 
     - name: Setup Cache
-      uses: coursier/cache-action@v5
+      uses: coursier/cache-action@v6
     - name: Cache resources
       run: |
         rm -rf "$HOME/.ivy2/local" || true


### PR DESCRIPTION
<!-- Welcome to your Leonardo pull request! -->
<!-- Contributor guidelines: https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md -->

__Jira ticket__: https://broadworkbench.atlassian.net/browse/CORE-458

<!-- ## Dependencies -->
<!-- Include any dependent tickets and describe the relationship. Include any other relevant Jira tickets. -->

## Summary of changes

<!-- Please give an abridged version of the ticket description here and/or fill out the following fields. -->

### What

- Upgrade of `coursier/cache-action` from `v5` to `v6`

### Why

- The coursier-cache-action has been disabled as per the GitHub changelog (https://github.blog/changelog/2025-03-20-notification-of-upcoming-breaking-changes-in-github-actions/#decommissioned-cache-service-brownouts)

## Testing these changes

### What to test

-  `unit_tests` and `publish_java_client` Github Workflows are working

<!-- ### Test data -->

### Who tested and where

- [ ] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [ ] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
