### PR TITLE
[AN-502] Improve Dataproc creation and deletion flows

### DIFF
--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
@@ -1674,6 +1674,10 @@ class LeoPubsubMessageSubscriber[F[_]](
               case ee: com.google.api.gax.rpc.AbortedException
                   if ee.getStatusCode.getCode.getHttpStatusCode == 409 && ee.getMessage.contains("already exists") =>
                 None // this could happen when pubsub redelivers an event unexpectedly
+              case _: com.google.api.gax.rpc.AlreadyExistsException => None
+              // this could happen when leo reboots when a cluster was creating,
+              // in this case we should continue monitoring the creation of the original cluster,
+              // see AN-509 https://broadworkbench.atlassian.net/browse/AN-509
               case _ =>
                 Some(s"Failed to create cluster ${runtimeId} due to ${e.getMessage}")
             }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
@@ -320,7 +320,8 @@ class LeoPubsubMessageSubscriber[F[_]](
             .flatMap {
               // See AN-502 https://broadworkbench.atlassian.net/browse/AN-502
               // We should not throw an error when the master instance is not found, and continue processing the cluster deletion
-              case Left(_) => F.pure(none[DataprocInstance])
+              case Left(_)  => F.pure(none[DataprocInstance])
+              case Right(d) => F.pure(d.some)
             }
         case _ => F.pure(none[DataprocInstance])
       }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
@@ -1690,7 +1690,7 @@ class LeoPubsubMessageSubscriber[F[_]](
             case ee: com.google.api.gax.rpc.AbortedException
                 if ee.getStatusCode.getCode.getHttpStatusCode == 409 && ee.getMessage.contains("already exists") =>
               None // this could happen when pubsub redelivers an event unexpectedly
-            case ee: com.google.api.gax.rpc.AlreadyExistsException => None
+            case _: com.google.api.gax.rpc.AlreadyExistsException => None
             // this could happen when leo reboots when a cluster was creating,
             // in this case we should continue monitoring the creation of the original cluster,
             // see AN-509 https://broadworkbench.atlassian.net/browse/AN-509

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
@@ -1690,6 +1690,10 @@ class LeoPubsubMessageSubscriber[F[_]](
             case ee: com.google.api.gax.rpc.AbortedException
                 if ee.getStatusCode.getCode.getHttpStatusCode == 409 && ee.getMessage.contains("already exists") =>
               None // this could happen when pubsub redelivers an event unexpectedly
+            case ee: com.google.api.gax.rpc.AlreadyExistsException => None
+            // this could happen when leo reboots when a cluster was creating,
+            // in this case we should continue monitoring the creation of the original cluster,
+            // see AN-509 https://broadworkbench.atlassian.net/browse/AN-509
             case _ =>
               Some(s"Failed to create cluster ${runtimeId} due to ${e.getMessage}")
           }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriber.scala
@@ -316,7 +316,12 @@ class LeoPubsubMessageSubscriber[F[_]](
           instanceQuery
             .getMasterForCluster(runtime.id)
             .transaction
-            .map(_.some)
+            .attempt
+            .flatMap {
+              // See AN-502 https://broadworkbench.atlassian.net/browse/AN-502
+              // We should not throw an error when the master instance is not found, and continue processing the cluster deletion
+              case Left(_) => F.pure(none[DataprocInstance])
+            }
         case _ => F.pure(none[DataprocInstance])
       }
       op <- runtimeConfig.cloudService.interpreter.deleteRuntime(

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/DataprocInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/DataprocInterpreter.scala
@@ -402,7 +402,7 @@ class DataprocInterpreter[F[_]: Parallel](
           // See AN-502 https://broadworkbench.atlassian.net/browse/AN-502
           // Even if the master node does not exist, the dataproc cluster deletion should still proceed
           case None => deleteDatprocCluster
-          case Some(v) =>
+          case Some(_) =>
             params.masterInstance.traverse { instance =>
               for {
                 opFutureAttempt <- googleComputeService

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/DataprocInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/DataprocInterpreter.scala
@@ -391,7 +391,7 @@ class DataprocInterpreter[F[_]: Parallel](
           new RuntimeException("DataprocInterpreter shouldn't get a GCE request")
         )
         metadata <- getShutdownScript(params.runtimeAndRuntimeConfig, false)
-        deleteDatprocCluster = for {
+        deleteDataprocCluster = for {
           googleProject <- F.fromOption(
             LeoLenses.cloudContextToGoogleProject.get(params.runtimeAndRuntimeConfig.runtime.cloudContext),
             new RuntimeException(
@@ -406,8 +406,8 @@ class DataprocInterpreter[F[_]: Parallel](
         } yield ()
         _ <- params.masterInstance match {
           // See AN-502 https://broadworkbench.atlassian.net/browse/AN-502
-          // Even if the master node does not exist, the dataproc cluster deletion should still proceed
-          case None => deleteDatprocCluster
+          // Even if the master node does not exist (because it was already deleted, or the creation failed), the dataproc cluster deletion should still proceed
+          case None => deleteDataprocCluster
           case Some(_) =>
             params.masterInstance.traverse { instance =>
               for {
@@ -421,14 +421,14 @@ class DataprocInterpreter[F[_]: Parallel](
                     F.raiseError(e)
                   case Right(opFuture) =>
                     opFuture match {
-                      case None => deleteDatprocCluster
+                      case None => deleteDataprocCluster
                       case Some(v) =>
                         for {
                           res <- F.delay(v.get())
                           _ <- F.raiseUnless(google2.isSuccess(res.getHttpErrorStatusCode))(
                             new Exception(s"addInstanceMetadata failed")
                           )
-                          _ <- deleteDatprocCluster
+                          _ <- deleteDataprocCluster
                         } yield ()
                     }
                 }

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/DataprocInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/DataprocInterpreter.scala
@@ -415,7 +415,7 @@ class DataprocInterpreter[F[_]: Parallel](
                   .addInstanceMetadata(instance.key.project, instance.key.zone, instance.key.name, metadata)
                   .attempt
                 _ <- opFutureAttempt match {
-                  case Left(e) if e.getMessage.contains("no master instance found") =>
+                  case Left(e) if e.getMessage.contains("Instance not found:") =>
                     logger.info(ctx.loggingCtx)("Instance is already deleted").as(None)
                   case Left(e) =>
                     F.raiseError(e)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/DataprocInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/DataprocInterpreter.scala
@@ -385,45 +385,49 @@ class DataprocInterpreter[F[_]: Parallel](
           new RuntimeException("DataprocInterpreter shouldn't get a GCE request")
         )
         metadata <- getShutdownScript(params.runtimeAndRuntimeConfig, false)
-        _ <- params.masterInstance.traverse { instance =>
-          for {
-            opFutureAttempt <- googleComputeService
-              .addInstanceMetadata(instance.key.project, instance.key.zone, instance.key.name, metadata)
-              .attempt
-            _ <- opFutureAttempt match {
-              case Left(e) if e.getMessage.contains("Instance not found") =>
-                logger.info(ctx.loggingCtx)("Instance is already deleted").as(None)
-              case Left(e) =>
-                F.raiseError(e)
-              case Right(opFuture) =>
-                val deleteDatprocCluster = for {
-                  googleProject <- F.fromOption(
-                    LeoLenses.cloudContextToGoogleProject.get(params.runtimeAndRuntimeConfig.runtime.cloudContext),
-                    new RuntimeException(
-                      "this should never happen. Dataproc runtime's cloud context should be a google project"
-                    )
-                  )
-                  _ <- googleDataprocService.deleteCluster(
-                    googleProject,
-                    region,
-                    DataprocClusterName(params.runtimeAndRuntimeConfig.runtime.runtimeName.asString)
-                  )
-                } yield ()
-
-                opFuture match {
-                  case None => deleteDatprocCluster
-                  case Some(v) =>
-                    for {
-                      res <- F.delay(v.get())
-                      _ <- F.raiseUnless(google2.isSuccess(res.getHttpErrorStatusCode))(
-                        new Exception(s"addInstanceMetadata failed")
-                      )
-                      _ <- deleteDatprocCluster
-                    } yield ()
+        deleteDatprocCluster = for {
+          googleProject <- F.fromOption(
+            LeoLenses.cloudContextToGoogleProject.get(params.runtimeAndRuntimeConfig.runtime.cloudContext),
+            new RuntimeException(
+              "this should never happen. Dataproc runtime's cloud context should be a google project"
+            )
+          )
+          _ <- googleDataprocService.deleteCluster(
+            googleProject,
+            region,
+            DataprocClusterName(params.runtimeAndRuntimeConfig.runtime.runtimeName.asString)
+          )
+        } yield ()
+        _ <- params.masterInstance match {
+          // See AN-502 https://broadworkbench.atlassian.net/browse/AN-502
+          // Even if the master node does not exist, the dataproc cluster deletion should still proceed
+          case None => deleteDatprocCluster
+          case Some(v) =>
+            params.masterInstance.traverse { instance =>
+              for {
+                opFutureAttempt <- googleComputeService
+                  .addInstanceMetadata(instance.key.project, instance.key.zone, instance.key.name, metadata)
+                  .attempt
+                _ <- opFutureAttempt match {
+                  case Left(e) if e.getMessage.contains("no master instance found") =>
+                    logger.info(ctx.loggingCtx)("Instance is already deleted").as(None)
+                  case Left(e) =>
+                    F.raiseError(e)
+                  case Right(opFuture) =>
+                    opFuture match {
+                      case None => deleteDatprocCluster
+                      case Some(v) =>
+                        for {
+                          res <- F.delay(v.get())
+                          _ <- F.raiseUnless(google2.isSuccess(res.getHttpErrorStatusCode))(
+                            new Exception(s"addInstanceMetadata failed")
+                          )
+                          _ <- deleteDatprocCluster
+                        } yield ()
+                    }
                 }
+              } yield ()
             }
-          } yield ()
-
         }
       } yield None
     } else F.pure(None)

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriberSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriberSpec.scala
@@ -389,7 +389,10 @@ class LeoPubsubMessageSubscriberSpec
       for {
         runtime <- IO(
           makeCluster(1)
-            .copy(serviceAccount = serviceAccount, asyncRuntimeFields = None, status = RuntimeStatus.Creating)
+            .copy(serviceAccount = serviceAccount,
+                  asyncRuntimeFields = Some(asyncFields),
+                  status = RuntimeStatus.Creating
+            )
             .saveWithRuntimeConfig(CommonTestData.defaultDataprocRuntimeConfig)
         )
         tr <- traceId.ask[TraceId]

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriberSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/LeoPubsubMessageSubscriberSpec.scala
@@ -331,11 +331,11 @@ class LeoPubsubMessageSubscriberSpec
   }
 
   /**
-   * When createRuntime gets 409, we shouldn't attempt to update AsyncRuntimeFields.
+   * When createRuntime gets 409 or a cluster already exist error, we shouldn't attempt to update AsyncRuntimeFields.
    * These fields should've been updated in a previous createRuntime request, and
    * this test is to make sure we're not wiping out that info.
    */
-  it should "handle CreateRuntimeMessage properly when google returns 409" in isolatedDbTest {
+  it should "handle CreateRuntimeMessage properly when google returns 409 or AlreadyExists error for GCE" in isolatedDbTest {
     val runtimeAlgebra = new BaseFakeGceInterp {
       override def createRuntime(params: CreateRuntimeParams)(implicit
         ev: Ask[IO, AppContext]
@@ -359,6 +359,45 @@ class LeoPubsubMessageSubscriberSpec
         gceRuntimeConfigRequest = LeoLenses.runtimeConfigPrism.getOption(gceRuntimeConfig).get
         _ <- leoSubscriber.messageResponder(
           CreateRuntimeMessage.fromRuntime(runtime, gceRuntimeConfigRequest, Some(tr), None)
+        )
+        updatedRuntime <- clusterQuery.getClusterById(runtime.id).transaction
+      } yield {
+        updatedRuntime shouldBe defined
+        updatedRuntime.get.asyncRuntimeFields shouldBe Some(asyncFields)
+        updatedRuntime.get.runtimeImages shouldBe runtime.runtimeImages
+      }
+
+    res.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
+  }
+
+  /**
+   * When createRuntime gets 409 or a cluster already exist error, we shouldn't attempt to update AsyncRuntimeFields.
+   * These fields should've been updated in a previous createRuntime request, and
+   * this test is to make sure we're not wiping out that info.
+   */
+  it should "handle CreateRuntimeMessage properly when google returns 409 or AlreadyExists error for dataproc" in isolatedDbTest {
+    val dataprocAlg = new BaseMockRuntimeAlgebra {
+      override def createRuntime(params: CreateRuntimeParams)(implicit
+        ev: Ask[IO, AppContext]
+      ): IO[Option[CreateGoogleRuntimeResponse]] = IO.pure(None)
+    }
+
+    val asyncFields = makeAsyncRuntimeFields(1)
+
+    val leoSubscriber = makeLeoSubscriber(dataprocRuntimeAlgebra = dataprocAlg)
+    val res =
+      for {
+        runtime <- IO(
+          makeCluster(1)
+            .copy(serviceAccount = serviceAccount, asyncRuntimeFields = None, status = RuntimeStatus.Creating)
+            .saveWithRuntimeConfig(CommonTestData.defaultDataprocRuntimeConfig)
+        )
+        tr <- traceId.ask[TraceId]
+        dataprocRuntimeConfigRequest = LeoLenses.runtimeConfigPrism
+          .getOption(CommonTestData.defaultDataprocRuntimeConfig)
+          .get
+        _ <- leoSubscriber.messageResponder(
+          CreateRuntimeMessage.fromRuntime(runtime, dataprocRuntimeConfigRequest, Some(tr), None)
         )
         updatedRuntime <- clusterQuery.getClusterById(runtime.id).transaction
       } yield {

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/DataprocInterpreterSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/DataprocInterpreterSpec.scala
@@ -298,7 +298,7 @@ class DataprocInterpreterSpec
     }
   }
 
-  it should "don't error if runtime is already deleted" in isolatedDbTest {
+  it should "don't error if runtime is already deleted or if the master node was never created" in isolatedDbTest {
     val computeService = new FakeGoogleComputeService {
       override def modifyInstanceMetadata(
         project: GoogleProject,


### PR DESCRIPTION


<!-- Welcome to your Leonardo pull request! -->
<!-- Contributor guidelines: https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md -->

__Jira ticket__: 
https://broadworkbench.atlassian.net/browse/AN-502
https://broadworkbench.atlassian.net/browse/AN-509

<!-- ## Dependencies -->
<!-- Include any dependent tickets and describe the relationship. Include any other relevant Jira tickets. -->

## Summary of changes

<!-- Please give an abridged version of the ticket description here and/or fill out the following fields. -->

### What

- Continue the creation of the original cluster after a leo reboot (we were previously trying to recreate again and erroring because the cluster already exists)
- Continue with the deletion of the dataproc cluster even when the master node cannot be found

### Why

- AOU encountered two bugs related to these issues, the deletion one ended up costing users unexpectedly

## Testing these changes

### What to test

- <!-- Test case 1 -->

<!-- ### Test data -->

### Who tested and where

- [ ] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [ ] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
