### PR TITLE
[AN-503] Dataproc fixes for RWB

### DIFF
--- a/http/src/main/resources/init-resources/init-actions.sh
+++ b/http/src/main/resources/init-resources/init-actions.sh
@@ -137,19 +137,6 @@ function apply_start_user_script() {
 # END
 STEP_TIMINGS=($(date +%s))
 
-
-## Installs Google Cloud Ops Agent that is now required for Datapoc 2.2.X ###
-# See https://github.com/GoogleCloudDataproc/initialization-actions/tree/master/opsagent
-# Installs the Google Cloud Ops Agent on each node in the cluster.
-# It also provides an override to the built-in logging config to set empty
-# receivers i.e. not collect any logs.
-# If you need to collect syslogs, you can use the other script in this directory,
-# opsagent.sh which uses the built-in configuration of Ops Agent.
-# See https://cloud.google.com/stackdriver/docs/solutions/agents/ops-agent/configuration#default.
-#
-curl -sSO https://dl.google.com/cloudagents/add-google-cloud-ops-agent-repo.sh
-bash add-google-cloud-ops-agent-repo.sh --also-install
-
 # temp workaround for https://github.com/docker/compose/issues/5930
 export CLOUDSDK_PYTHON=python3
 
@@ -158,6 +145,19 @@ ROLE=$(/usr/share/google/get_metadata_value attributes/dataproc-role)
 
 # Only initialize tool and proxy docker containers on the master
 if [[ "${ROLE}" == 'Master' ]]; then
+
+    ## Installs Google Cloud Ops Agent that is now required for Datapoc 2.2.X ###
+    # See https://github.com/GoogleCloudDataproc/initialization-actions/tree/master/opsagent
+    # Installs the Google Cloud Ops Agent on each node in the cluster.
+    # It also provides an override to the built-in logging config to set empty
+    # receivers i.e. not collect any logs.
+    # If you need to collect syslogs, you can use the other script in this directory,
+    # opsagent.sh which uses the built-in configuration of Ops Agent.
+    # See https://cloud.google.com/stackdriver/docs/solutions/agents/ops-agent/configuration#default.
+    #
+    curl -sSO https://dl.google.com/cloudagents/add-google-cloud-ops-agent-repo.sh
+    bash add-google-cloud-ops-agent-repo.sh --also-install
+
     JUPYTER_HOME=/etc/jupyter
     JUPYTER_SCRIPTS=${JUPYTER_HOME}/scripts
     KERNELSPEC_HOME=/usr/local/share/jupyter/kernels

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -73,7 +73,7 @@ dataproc {
   customDataprocImage = "projects/broad-dsp-gcr-public/global/images/leo-dataproc-image-2-2-52-debian12-2025-05-06-13-58-25"
   # AN-503: Delete once AOU has switched to using Dataproc 2.2.X in prod
   # Cached dataproc 2.1.x image used by AOU
-  legacyAouCustomDataprocImage = "projects/broad-dsp-gcr-public/global/images/leo-dataproc-image-2-1-11-debian11-2025-05-06-16-08-29"
+  legacyAouCustomDataprocImage = "projects/broad-dsp-gcr-public/global/images/leo-dataproc-image-2-1-11-debian11-2025-05-07-16-35-36"
 
   # The ratio of memory allocated to spark. 0.8 = 80%.
   # Hail/Spark users generally allocate 80% of the ram to the JVM.

--- a/jenkins/dataproc-custom-images/create_dataproc_image.sh
+++ b/jenkins/dataproc-custom-images/create_dataproc_image.sh
@@ -27,7 +27,7 @@ TEST_BUCKET="gs://leo-dataproc-image-creation-logs"
 pushd $WORK_DIR
 
 DATAPROC_BASE_NAME="leo-dataproc-image"
-DP_VERSION_FORMATTED="2-1-11-debian11"
+DP_VERSION_FORMATTED="2-2-52-debian12"
 # This needs to be unique for each run
 IMAGE_ID=$(date +"%Y-%m-%d-%H-%M-%S")
 OUTPUT_IMAGE_NAME="$DATAPROC_BASE_NAME-$DP_VERSION_FORMATTED-$IMAGE_ID"
@@ -36,7 +36,7 @@ gcloud config set dataproc/region us-central1
 
 python generate_custom_image.py \
     --image-name "$OUTPUT_IMAGE_NAME" \
-    --dataproc-version "2.1.11-debian11" \
+    --dataproc-version "2.2.52-debian12" \
     --customization-script ../prepare-custom-leonardo-jupyter-dataproc-image.sh \
     --zone $ZONE \
     --gcs-bucket $DATAPROC_IMAGE_BUCKET \

--- a/jenkins/dataproc-custom-images/create_dataproc_image.sh
+++ b/jenkins/dataproc-custom-images/create_dataproc_image.sh
@@ -27,7 +27,7 @@ TEST_BUCKET="gs://leo-dataproc-image-creation-logs"
 pushd $WORK_DIR
 
 DATAPROC_BASE_NAME="leo-dataproc-image"
-DP_VERSION_FORMATTED="2-2-52-debian12"
+DP_VERSION_FORMATTED="2-1-11-debian11"
 # This needs to be unique for each run
 IMAGE_ID=$(date +"%Y-%m-%d-%H-%M-%S")
 OUTPUT_IMAGE_NAME="$DATAPROC_BASE_NAME-$DP_VERSION_FORMATTED-$IMAGE_ID"
@@ -36,7 +36,7 @@ gcloud config set dataproc/region us-central1
 
 python generate_custom_image.py \
     --image-name "$OUTPUT_IMAGE_NAME" \
-    --dataproc-version "2.2.52-debian12" \
+    --dataproc-version "2.1.11-debian11" \
     --customization-script ../prepare-custom-leonardo-jupyter-dataproc-image.sh \
     --zone $ZONE \
     --gcs-bucket $DATAPROC_IMAGE_BUCKET \

--- a/jenkins/dataproc-custom-images/prepare-custom-leonardo-jupyter-dataproc-image.sh
+++ b/jenkins/dataproc-custom-images/prepare-custom-leonardo-jupyter-dataproc-image.sh
@@ -37,13 +37,13 @@ cryptomining_detector="us.gcr.io/broad-dsp-gcr-public/cryptomining-detector:0.0.
 
 # This array determines which of the above images are baked into the custom dataproc 2.2.x image
 # the entry must match the var name above, which must correspond to a valid docker URI
-docker_image_var_names="welder_server terra_jupyter_python terra_jupyter_r terra_jupyter_bioconductor terra_jupyter_hail terra_jupyter_gatk terra_jupyter_aou openidc_proxy anvil_rstudio_bioconductor cryptomining_detector"
+#docker_image_var_names="welder_server terra_jupyter_python terra_jupyter_r terra_jupyter_bioconductor terra_jupyter_hail terra_jupyter_gatk terra_jupyter_aou openidc_proxy anvil_rstudio_bioconductor cryptomining_detector"
 
 # Comment the above and uncomment this to create the dataproc 2.1.x image
 # You would also need to revert the dataproc versions in the create_dataproc_image.sh like this:
 # DP_VERSION_FORMATTED="2-1-11-debian11"
 # --dataproc-version "2.1.11-debian11"
-#docker_image_var_names="welder_server terra_jupyter_python terra_jupyter_r terra_jupyter_bioconductor terra_jupyter_hail terra_jupyter_gatk terra_jupyter_aou_old openidc_proxy anvil_rstudio_bioconductor cryptomining_detector"
+docker_image_var_names="welder_server terra_jupyter_aou_old openidc_proxy cryptomining_detector"
 
 # The version of python to install
 # Note: this should match the version of python in the terra-jupyter-hail image.

--- a/jenkins/dataproc-custom-images/prepare-custom-leonardo-jupyter-dataproc-image.sh
+++ b/jenkins/dataproc-custom-images/prepare-custom-leonardo-jupyter-dataproc-image.sh
@@ -37,13 +37,13 @@ cryptomining_detector="us.gcr.io/broad-dsp-gcr-public/cryptomining-detector:0.0.
 
 # This array determines which of the above images are baked into the custom dataproc 2.2.x image
 # the entry must match the var name above, which must correspond to a valid docker URI
-#docker_image_var_names="welder_server terra_jupyter_python terra_jupyter_r terra_jupyter_bioconductor terra_jupyter_hail terra_jupyter_gatk terra_jupyter_aou openidc_proxy anvil_rstudio_bioconductor cryptomining_detector"
+docker_image_var_names="welder_server terra_jupyter_python terra_jupyter_r terra_jupyter_bioconductor terra_jupyter_hail terra_jupyter_gatk terra_jupyter_aou openidc_proxy anvil_rstudio_bioconductor cryptomining_detector"
 
 # Comment the above and uncomment this to create the dataproc 2.1.x image
 # You would also need to revert the dataproc versions in the create_dataproc_image.sh like this:
 # DP_VERSION_FORMATTED="2-1-11-debian11"
 # --dataproc-version "2.1.11-debian11"
-docker_image_var_names="welder_server terra_jupyter_aou_old openidc_proxy cryptomining_detector"
+#docker_image_var_names="welder_server terra_jupyter_aou_old openidc_proxy cryptomining_detector
 
 # The version of python to install
 # Note: this should match the version of python in the terra-jupyter-hail image.


### PR DESCRIPTION
<!-- Welcome to your Leonardo pull request! -->
<!-- Contributor guidelines: https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md -->

__Jira ticket__: https://broadworkbench.atlassian.net/browse/AN-503

<!-- ## Dependencies -->
<!-- Include any dependent tickets and describe the relationship. Include any other relevant Jira tickets. -->

## Summary of changes

<!-- Please give an abridged version of the ticket description here and/or fill out the following fields. -->

### What

- Move the installation of the log agent to the master node only as AOU worker nodes do not have access to internet
- Only cache the aou 2.2.13 image in the dataproc 2.1.x image since it is the only use case, and a leaner dataproc image should make startup faster on the RWB side

### Why

- Even though things are working well on Terra, creating runtimes using the AOU images on the RWB side are running into issues that this PR hopes to alleviate

## Testing these changes

### What to test

- <!-- Test case 1 -->

<!-- ### Test data -->

### Who tested and where

- [ ] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [ ] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
