### PR TITLE
[AN-407] Remove akka server version from header

### DIFF
--- a/http/src/main/resources/leo.conf
+++ b/http/src/main/resources/leo.conf
@@ -125,6 +125,11 @@ akka {
     server.parsing.ignore-illegal-header-for = ["user-agent"]
     server.request-timeout = 60 seconds
     server.websocket.periodic-keep-alive-max-idle = 30 seconds
+    # By default, akka includes an HTTP header in responses that looks like:
+    # server=akka-http/10.20.1
+    # For better app sec, we suppress this to make it harder for attackers to learn about our system.
+    # Akka doc: https://doc.akka.io/docs/akka-http/current/configuration.html
+    server.server-header = "
   }
 
   ssl-config {

--- a/http/src/main/resources/leo.conf
+++ b/http/src/main/resources/leo.conf
@@ -129,7 +129,7 @@ akka {
     # server=akka-http/10.20.1
     # For better app sec, we suppress this to make it harder for attackers to learn about our system.
     # Akka doc: https://doc.akka.io/docs/akka-http/current/configuration.html
-    server.server-header = "
+    server.server-header = ""
   }
 
   ssl-config {


### PR DESCRIPTION
<!-- Welcome to your Leonardo pull request! -->
<!-- Contributor guidelines: https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md -->

__Jira ticket__: https://broadworkbench.atlassian.net/browse/AN-407

<!-- ## Dependencies -->
<!-- Include any dependent tickets and describe the relationship. Include any other relevant Jira tickets. -->

## Summary of changes

<!-- Please give an abridged version of the ticket description here and/or fill out the following fields. -->

### What

- Sets the akka server version to an empty string

### Why

- Low security fix to avoid leaking the information as part of leonardo's response header

## Testing these changes

Unfortunately, this can only be tested in Dev as BEEs proxy works differently and does not expose that info in the header. After briefly pointing leo dev to this branch, I could confirm that the akka-http server version is no longer present in Leo's response header:

<img width="1321" alt="Screenshot 2025-05-12 at 2 11 05 PM" src="https://github.com/user-attachments/assets/ec29bb0b-df21-4279-9312-67a9e5fd0499" />



### Who tested and where

- [ ] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [ ] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
