### PR TITLE
[AN-588] Move custom script execution to the end of the init setup

### DIFF
--- a/http/src/main/resources/init-resources/gce-init.sh
+++ b/http/src/main/resources/init-resources/gce-init.sh
@@ -544,7 +544,6 @@ if [ ! -z "$JUPYTER_DOCKER_IMAGE" ] ; then
        && cp $JUPYTER_HOME/custom/edit-mode.js $JUPYTER_USER_HOME/.jupyter/custom/ \
        && mkdir -p $JUPYTER_HOME/nbconfig"
 
-
   # In new jupyter images, we should update jupyter_notebook_config.py in terra-docker.
   # This is to make it so that older images will still work after we change notebooks location to home dir
   docker exec ${JUPYTER_SERVER_NAME} sed -i '/^# to mount there as it effectively deletes existing files on the image/,+5d' ${JUPYTER_HOME}/jupyter_notebook_config.py

--- a/http/src/main/resources/init-resources/gce-init.sh
+++ b/http/src/main/resources/init-resources/gce-init.sh
@@ -518,22 +518,6 @@ if [ ! -z "$JUPYTER_DOCKER_IMAGE" ] ; then
   # done extension setup
   STEP_TIMINGS+=($(date +%s))
 
-  # If a user script was specified, copy it into the docker container and execute it.
-  if [ ! -z "$USER_SCRIPT_URI" ] ; then
-    apply_user_script $JUPYTER_SERVER_NAME $JUPYTER_HOME
-  fi
-
-  # done user script
-  STEP_TIMINGS+=($(date +%s))
-
-  # If a start user script was specified, copy it into the docker container for consumption during startups.
-  if [ ! -z "$START_USER_SCRIPT_URI" ] ; then
-    apply_start_user_script $JUPYTER_SERVER_NAME $JUPYTER_HOME
-  fi
-
-  # done start user script
-  STEP_TIMINGS+=($(date +%s))
-
   # See IA-1901: Jupyter UI stalls indefinitely on initial R kernel connection after cluster create/resume
   # The intent of this is to "warm up" R at VM creation time to hopefully prevent issues when the Jupyter
   # kernel tries to connect to it.
@@ -560,9 +544,27 @@ if [ ! -z "$JUPYTER_DOCKER_IMAGE" ] ; then
        && cp $JUPYTER_HOME/custom/edit-mode.js $JUPYTER_USER_HOME/.jupyter/custom/ \
        && mkdir -p $JUPYTER_HOME/nbconfig"
 
+
   # In new jupyter images, we should update jupyter_notebook_config.py in terra-docker.
   # This is to make it so that older images will still work after we change notebooks location to home dir
   docker exec ${JUPYTER_SERVER_NAME} sed -i '/^# to mount there as it effectively deletes existing files on the image/,+5d' ${JUPYTER_HOME}/jupyter_notebook_config.py
+
+  # If a user script was specified, copy it into the docker container and execute it.
+   if [ ! -z "$USER_SCRIPT_URI" ] ; then
+      log 'Starting user script...'
+     apply_user_script $JUPYTER_SERVER_NAME $JUPYTER_HOME
+   fi
+
+   # done user script
+   STEP_TIMINGS+=($(date +%s))
+
+   # If a start user script was specified, copy it into the docker container for consumption during startups.
+   if [ ! -z "$START_USER_SCRIPT_URI" ] ; then
+     apply_start_user_script $JUPYTER_SERVER_NAME $JUPYTER_HOME
+   fi
+
+   # done start user script
+   STEP_TIMINGS+=($(date +%s))
 
   log 'Starting Jupyter Notebook...'
   retry 3 docker exec -d $JUPYTER_SERVER_NAME /bin/bash -c "${JUPYTER_SCRIPTS}/run-jupyter.sh ${NOTEBOOKS_DIR}"

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpDockerDAOSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpDockerDAOSpec.scala
@@ -31,9 +31,9 @@ class HttpDockerDAOSpec extends AnyFlatSpec with Matchers with BeforeAndAfterAll
 //    ),
     // gcr with tag
     ContainerImage("us.gcr.io/broad-dsp-gcr-public/leonardo-jupyter:dev", GCR),
-    ContainerImage("us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.4", GCR),
-    ContainerImage("us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:0.0.5", GCR),
-    ContainerImage("us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:0.0.4", GCR),
+    ContainerImage("us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:1.1.6", GCR),
+    ContainerImage("us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:2.2.7", GCR),
+    ContainerImage("us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:2.3.9", GCR),
     // gcr with sha
     // TODO shas are currently not working
 //    GCR(


### PR DESCRIPTION
<!-- Welcome to your Leonardo pull request! -->
<!-- Contributor guidelines: https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md -->

__Jira ticket__: https://broadworkbench.atlassian.net/browse/AN-590

<!-- ## Dependencies -->
<!-- Include any dependent tickets and describe the relationship. Include any other relevant Jira tickets. -->

## Summary of changes

<!-- Please give an abridged version of the ticket description here and/or fill out the following fields. -->

### What

- Move custom init script execution to the end of the Jupyter init process

### Why

- If a directory is created by the custom script that the Jupyter user needs to access, we run into a permission error
`Permission denied: '/home/jupyter/.config/git'`

## Testing these changes

### What to test

Spin up a compute environment with the following init script:

```
#! /bin/bash

set -x nopipefail

echo $(date -Iseconds -u) Starting start up script

id

pwd

ls -a

ls -ld 

ls -ld .config

gcloud --version

ls -a

ls -ld .config

echo $(date -Iseconds -u) Finished startup script
```

Check that .config exists before the gcloud command and that the permissions don't change afterwards


<!-- ### Test data -->

### Who tested and where

- [ ] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [ ] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
