### PR TITLE
[CORE-434] Use id for disk cleanup instead of name

### DIFF
--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/PersistentDiskComponent.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/PersistentDiskComponent.scala
@@ -175,8 +175,6 @@ object persistentDiskQuery {
 
   private[db] def findByIdQuery(id: DiskId) = tableQuery.filter(_.id === id)
 
-  private[db] def findByNameQuery(name: DiskName) = tableQuery.filter(_.name === name)
-
   private[db] def findActiveByIdQuery(id: DiskId) =
     tableQuery
       .filter(_.id === id)
@@ -221,9 +219,6 @@ object persistentDiskQuery {
 
   def getById(id: DiskId)(implicit ec: ExecutionContext): DBIO[Option[PersistentDisk]] =
     joinLabelQuery(findByIdQuery(id)).result.map(aggregateLabels).map(_.headOption)
-
-  def getByName(name: DiskName): DBIO[Option[PersistentDiskRecord]] =
-    findByNameQuery(name).result.headOption
 
   def getStatus(id: DiskId)(implicit ec: ExecutionContext): DBIO[Option[DiskStatus]] =
     getPersistentDiskRecord(id).map(_.map(_.status))

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/DiskServiceInterp.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/DiskServiceInterp.scala
@@ -294,7 +294,7 @@ class DiskServiceInterp[F[_]: Parallel](config: PersistentDiskConfig,
       ctx <- as.ask
       // Find the disk's Sam resource id
       dbdiskOpt <- persistentDiskQuery
-        .getByName(disk.name)
+        .getById(disk.id)
         .transaction
       dbdisk <- F.fromOption(
         dbdiskOpt,


### PR DESCRIPTION
<!-- Welcome to your Leonardo pull request! -->
<!-- Contributor guidelines: https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md -->

__Jira ticket__: https://broadworkbench.atlassian.net/browse/CORE-434

<!-- ## Dependencies -->
<!-- Include any dependent tickets and describe the relationship. Include any other relevant Jira tickets. -->

## Summary of changes

https://github.com/DataBiosphere/leonardo/pull/4837 introduced logic to Leo to attempt to delete persistent disks even if Leo had marked them as `Deleted` in its own database in an effort to cleanup dangling Sam resources that interfere with workspace deletion. AoU is still seeing issues and in at least one of those cases, there are two disks with the same name -- one that has been properly deleted and one that has a dangling Sam resource. Currently, Leo is not attempting to delete the dangling Sam resource because it searches for the disk by its name and finds the disk that has been properly deleted. This PR gets around this name collision by fetching the disk by its id instead of its name so that Leo can still attempt to delete any dangling Sam resources.

<!-- Please give an abridged version of the ticket description here and/or fill out the following fields. -->

### What

- Look up disks by id instead of name when cleaning up disk resources.

### Why

- Ensure Leo attempts to cleanup all disks even if they share a name.

## Testing these changes

### What to test

- <!-- Test case 1 -->

<!-- ### Test data -->

### Who tested and where

- [ ] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [ ] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
