### PR TITLE
DDO-4107 read from GAR

### DIFF
--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -10,8 +10,8 @@ import scalafix.sbt.ScalafixPlugin.autoImport.scalafixSemanticdb
 import scala.collection.JavaConverters._
 
 object Settings {
-
-  val artifactory = "https://broadinstitute.jfrog.io/broadinstitute/"
+  
+  val artifactory = "https://us-central1-maven.pkg.dev/dsp-artifact-registry/"
 
   val commonResolvers = List(
     "artifactory-releases" at artifactory + "libs-release",

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -10,7 +10,7 @@ import scalafix.sbt.ScalafixPlugin.autoImport.scalafixSemanticdb
 import scala.collection.JavaConverters._
 
 object Settings {
-  
+
   val artifactory = "https://us-central1-maven.pkg.dev/dsp-artifact-registry/"
 
   val commonResolvers = List(


### PR DESCRIPTION
<!-- Welcome to your Leonardo pull request! -->
<!-- Contributor guidelines: https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md -->

__Jira ticket__: https://broadworkbench.atlassian.net/browse/DDO-4107

<!-- ## Dependencies -->
<!-- Include any dependent tickets and describe the relationship. Include any other relevant Jira tickets. -->

## Summary of changes

Updated the artifact source for this service to read artifacts from Google Artifact Registry instead of JFrog.

### What

- Modified the config to pull artifacts from GAR. No publishing changes were made.

### Why

- This is part of Phase 2 of the artifact migration effort to deprecated JFrog and consolidate artifacts in GAR.

## Testing these changes
Relied on passing CI checks and tests. Artifact reading-related issues are expected to surface as pipeline failures. For example these jobs [here](https://github.com/DataBiosphere/terra-scientific-pipelines-service/actions/runs/15309876591/job/43071753325?pr=222) and [here](https://github.com/DataBiosphere/leonardo/actions/runs/15324072477/job/43114134405?pr=4858) failed due to access issues (which have since been resolved).

### What to test

- <!-- Test case 1 -->

<!-- ### Test data -->

### Who tested and where

- [ ] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [ ] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
