### PR TITLE
DDO-4171 publish client to GAR instead of JFrog

### DIFF
--- a/.github/workflow-README.md
+++ b/.github/workflow-README.md
@@ -28,7 +28,7 @@ This [job](workflows/leo-build-tag-publish-and-run-tests.yml) builds Leonardo, t
 Very similar to the Azure job and will likely be consolidated with it soon. They don't differ much; a copy-paste with a different sbt test command. They both rely on the same downstream [terra-github-workflows](https://github.com/broadinstitute/terra-github-workflows) jobs.
 
 ## Publish Java client
-This [job](workflows/publish_java_client.yml) publishes a swagger-generated client for leonardo to artifactory consumable by any JVM application. It is used in our automation tests, and by other teams that depend on leonardo API calls in their application or tests. 
+This [job](workflows/publish_java_client.yml) publishes a swagger-generated client for leonardo to Google Artifact Registry consumable by any JVM application. It is used in our automation tests, and by other teams that depend on leonardo API calls in their application or tests. 
 This will run on both PR commits and commits to dev. The purpose of it running on PR commits is it can help iterate on the swagger page/client changes or fixes. Any versions published against a PR will be suffixed with `-SNAP`. An example of an sbt import can be found below. To find a specific version, you can look at the logs for a run.
 ```
 "org.broadinstitute.dsde.workbench" %% "leonardo-client" % "1.3.6-35973f1-SNAP"

--- a/.github/workflows/publish_java_client.yml
+++ b/.github/workflows/publish_java_client.yml
@@ -22,6 +22,8 @@ jobs:
 
   generateAndPublishClient:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
 
     env:
       SBT_OPTS: -Xmx3g

--- a/.github/workflows/publish_java_client.yml
+++ b/.github/workflows/publish_java_client.yml
@@ -24,8 +24,6 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      ARTIFACTORY_USERNAME: ${{secrets.ARTIFACTORY_USERNAME}}
-      ARTIFACTORY_PASSWORD: ${{secrets.ARTIFACTORY_PASSWORD}}
       SBT_OPTS: -Xmx3g
 
     steps:
@@ -44,6 +42,14 @@ jobs:
       - name: Generate java client
         id: generateJavaClient
         run: bash codegen_java/gen_java_client.sh
+
+      - name: Auth to GCP
+        id: 'auth'
+        uses: google-github-actions/auth@v2
+        with:
+          token_format: 'access_token'
+          workload_identity_provider: 'projects/1038484894585/locations/global/workloadIdentityPools/github-wi-pool/providers/github-wi-provider'
+          service_account: 'dsp-artifact-registry-push@dsp-artifact-registry.iam.gserviceaccount.com'
 
       - name: Publish java client for merge to develop branch
         working-directory: codegen_java

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ libraryDependencies += "org.broadinstitute.dsde.workbench" %% "leonardo-client" 
 ```
 
 Please be sure to replace the `<git hash>` with the first 7 characters of the commit hash of the HEAD of `develop`.
-You can find a list of available releases and `<git hash>`-es from [artifactory](https://broadinstitute.jfrog.io/ui/native/libs-release-local;build.timestamp=1679578230/org/broadinstitute/dsde/workbench/leonardo-client_2.11/)
+You can find a list of available releases and `<git hash>`-es from [Google Artifact Registry](https://us-central1-maven.pkg.dev/dsp-artifact-registry/libs-release-standard/org/broadinstitute/dsde/workbench/leonardo-client_2.11/)
 
 Example Scala Usage:
 

--- a/codegen_java/project/Artifactory.scala
+++ b/codegen_java/project/Artifactory.scala
@@ -1,4 +1,0 @@
-object Artifactory {
-  val artifactoryHost = "broadinstitute.jfrog.io"
-  val artifactory = s"https://$artifactoryHost/broadinstitute/"
-}

--- a/codegen_java/project/Publishing.scala
+++ b/codegen_java/project/Publishing.scala
@@ -18,8 +18,9 @@ object Publishing {
   }
 
   val publishSettings: Seq[Setting[_]] =
-    // we only publish to libs-release-local because of a bug in sbt that makes snapshots take
-    // priority over the local package cache. see here: https://github.com/sbt/sbt/issues/2687#issuecomment-236586241
+    // we only publish to libs-release-local (now libs-release-standard in GAR) because of a bug in sbt that makes
+    // snapshots take priority over the local package cache.
+    // see here: https://github.com/sbt/sbt/issues/2687#issuecomment-236586241
     Seq(
       publishTo := Option(garResolver(false)),
       Compile / publishArtifact := true,

--- a/codegen_java/project/Publishing.scala
+++ b/codegen_java/project/Publishing.scala
@@ -1,35 +1,29 @@
 import sbt.Keys._
 import sbt._
-import Artifactory._
 
 /** NOTE: This was lifted wholesale from Sam and Cromwell.
  */
 
 object Publishing {
-  private val buildTimestamp = System.currentTimeMillis() / 1000
 
-  private def artifactoryResolver(isSnapshot: Boolean): Resolver = {
+  private val garBase = "artifactregistry://us-central1-maven.pkg.dev/dsp-artifact-registry/"
+
+  private def garResolver(isSnapshot: Boolean): Resolver = {
     val repoType = if (isSnapshot) "snapshot" else "release"
-    val repoUrl =
-      s"${artifactory}libs-$repoType-local;build.timestamp=$buildTimestamp"
-    val repoName = "artifactory-publish"
+    // Previously, the JFrog resolver included ;build.timestamp=$buildTimestamp in the URL.
+    // If needed, consider including build metadata in the version string instead.
+    val repoUrl = s"${garBase}libs-$repoType-standard"
+    val repoName = "gar-publish"
     repoName at repoUrl
-  }
-
-  private val artifactoryCredentials: Credentials = {
-    val username = sys.env.getOrElse("ARTIFACTORY_USERNAME", "")
-    val password = sys.env.getOrElse("ARTIFACTORY_PASSWORD", "")
-    Credentials("Artifactory Realm", artifactoryHost, username, password)
   }
 
   val publishSettings: Seq[Setting[_]] =
     // we only publish to libs-release-local because of a bug in sbt that makes snapshots take
     // priority over the local package cache. see here: https://github.com/sbt/sbt/issues/2687#issuecomment-236586241
     Seq(
-      publishTo := Option(artifactoryResolver(false)),
+      publishTo := Option(garResolver(false)),
       Compile / publishArtifact := true,
       Test / publishArtifact := true,
-      credentials += artifactoryCredentials
     )
 
   val noPublishSettings: Seq[Setting[_]] =

--- a/codegen_java/project/plugins.sbt
+++ b/codegen_java/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("org.latestbit" % "sbt-gcs-plugin" % "1.14.0")


### PR DESCRIPTION
<!-- Welcome to your Leonardo pull request! -->
<!-- Contributor guidelines: https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md -->

__Jira ticket__: https://broadworkbench.atlassian.net/browse/DDO-4171

<!-- ## Dependencies -->
<!-- Include any dependent tickets and describe the relationship. Include any other relevant Jira tickets. -->

## Summary of changes

<!-- Please give an abridged version of the ticket description here and/or fill out the following fields. -->

### What

This PR migrates the publishing of Leonardo's java client from JFrog to Google Artifact Registry (GAR). Updates the SBT resolver, GHA workflow, and associated documentaion.
- Any other modules that may need publishing can follow this as a reference; updates will be the responsibility of the respective owning teams.

### Why

This is part of the broader effort to decommission JFrog Artifactory usage and transition to GAR.

## Testing these changes
- Tested in CI with the [generateAndPublishClient](https://github.com/DataBiosphere/leonardo/actions/runs/15787392244/job/44506639914?pr=4861#logs) job that runs as one of the PR checks.
- Confirmed the published artifacts [appear in GAR](https://console.cloud.google.com/artifacts/maven/dsp-artifact-registry/us-central1/libs-release-standard/org.broadinstitute.dsde.workbench:leonardo-client_2.13?inv=1&invt=Ab0png&project=dsp-artifact-registry).

### What to test

- <!-- Test case 1 -->

<!-- ### Test data -->

### Who tested and where

- [ ] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [ ] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
