### PR TITLE
[AN-723] Release Bioconductor 3.21.0

### DIFF
--- a/.github/workflows/custom_image_generation.yml
+++ b/.github/workflows/custom_image_generation.yml
@@ -28,7 +28,7 @@ jobs:
       contents: 'read'
       id-token: 'write'
     env:
-      GCE_IMAGE_BUCKET: gs://leo-gce-image-creation-logs
+      GCE_IMAGE_BUCKET: gs://leonardo-gce-image-creation-logs
       DAISY_IMAGE: gcr.io/compute-image-tools/daisy:release
       GCP_DAISY_GCR_KEY: ${{secrets.GCP_DAISY_GCR_KEY}}
       OUTPUT_FILE_RELATIVE_PATH: jenkins/gce-custom-images/output.txt
@@ -78,7 +78,7 @@ jobs:
     env:
       GCP_DAISY_GCR_KEY: ${{secrets.GCP_DAISY_GCR_KEY}}
       OUTPUT_FILE_RELATIVE_PATH: jenkins/dataproc-custom-images/output.txt
-      DATAPROC_IMAGE_BUCKET: gs://leo-dataproc-image-creation-logs
+      DATAPROC_IMAGE_BUCKET: gs://leonardo-dataproc-image-creation-logs
 
     steps:
       - uses: actions/checkout@v4

--- a/automation/src/test/resources/reference.conf
+++ b/automation/src/test/resources/reference.conf
@@ -7,7 +7,7 @@ leonardo {
     baseImageUrl = "us.gcr.io/broad-dsp-gcr-public/terra-jupyter-base:1.1.4"
     gcrWelderUri = "us.gcr.io/broad-dsp-gcr-public/welder-server"
     dockerHubWelderUri = "broadinstitute/welder-server"
-    rstudioBioconductorImageUrl = "us.gcr.io/broad-dsp-gcr-public/anvil-rstudio-bioconductor:3.20.1"
+    rstudioBioconductorImageUrl = "us.gcr.io/broad-dsp-gcr-public/anvil-rstudio-bioconductor:3.21.0"
     //each fiab will have a unique topic name sourced from leonardo.conf, this is never published to in automation tests to ensure pub/sub components can auth properly, but never read from to avoid conflicts.
     topicName = "leonardo-pubsub-test"
     location = "us-central1-a"

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -70,7 +70,7 @@ dataproc {
   }
 
   # Cached dataproc 2.2.x image used by Terra
-  customDataprocImage = "projects/broad-dsp-gcr-public/global/images/leo-dataproc-image-2-2-52-debian12-2025-07-23-19-48-11"
+  customDataprocImage = "projects/broad-dsp-gcr-public/global/images/leo-dataproc-image-2-2-52-debian12-2025-08-13-13-59-32"
 
   # The ratio of memory allocated to spark. 0.8 = 80%.
   # Hail/Spark users generally allocate 80% of the ram to the JVM.
@@ -111,7 +111,7 @@ dataproc {
 }
 
 gce {
-  customGceImage = "projects/broad-dsp-gcr-public/global/images/leo-gce-image-2025-05-05-17-10-22"
+  customGceImage = "projects/broad-dsp-gcr-public/global/images/leo-gce-image-2025-08-13-23-11-32"
   userDiskDeviceName = "user-disk"
   defaultScopes = [
     "https://www.googleapis.com/auth/userinfo.email",

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -147,9 +147,9 @@ pipeline {
             description: "Specify along with USE_CUSTOM_IMAGE_IDENTIFIER to build the VM image with a specific name")
         string(name: "GOOGLE_PROJECT", defaultValue: "broad-dsp-gcr-public",
             description: "The google project to use")
-        string(name: "DATAPROC_IMAGE_BUCKET", defaultValue: "gs://leo-dataproc-image-creation-logs",
+        string(name: "DATAPROC_IMAGE_BUCKET", defaultValue: "gs://leonardo-dataproc-image-creation-logs",
             description: "The path for the bucket where the custom Dataproc image generation logs will be stored")
-        string(name: "GCE_IMAGE_BUCKET", defaultValue: "gs://leo-gce-image-creation-logs",
+        string(name: "GCE_IMAGE_BUCKET", defaultValue: "gs://leonardo-gce-image-creation-logs",
             description: "The path for the bucket where the custom GCE image generation logs will be stored")
         string(name: "DATAPROC_VERSIONS", defaultValue: "2.0.51-debian10",
             description: "A custom image will be build for each of these dataproc versions")

--- a/jenkins/dataproc-custom-images/create_dataproc_image.sh
+++ b/jenkins/dataproc-custom-images/create_dataproc_image.sh
@@ -20,9 +20,9 @@ REGION="us-central1"
 ZONE="${REGION}-a"
 
 if [ -z "$DATAPROC_IMAGE_BUCKET" ]; then
-  DATAPROC_IMAGE_BUCKET="gs://leo-dataproc-image-creation-logs"
+  DATAPROC_IMAGE_BUCKET="gs://leonardo-dataproc-image-creation-logs"
 fi
-TEST_BUCKET="gs://leo-dataproc-image-creation-logs"
+TEST_BUCKET="gs://leonardo-dataproc-image-creation-logs"
 
 pushd $WORK_DIR
 

--- a/jenkins/dataproc-custom-images/prepare-custom-leonardo-jupyter-dataproc-image.sh
+++ b/jenkins/dataproc-custom-images/prepare-custom-leonardo-jupyter-dataproc-image.sh
@@ -26,7 +26,7 @@ terra_jupyter_aou="us.gcr.io/broad-dsp-gcr-public/terra-jupyter-aou:2.2.16"
 
 welder_server="us.gcr.io/broad-dsp-gcr-public/welder-server:8667bfe"
 openidc_proxy="broadinstitute/openidc-proxy:2.3.1_2"
-anvil_rstudio_bioconductor="us.gcr.io/broad-dsp-gcr-public/anvil-rstudio-bioconductor:3.20.1"
+anvil_rstudio_bioconductor="us.gcr.io/broad-dsp-gcr-public/anvil-rstudio-bioconductor:3.21.0"
 
 # If you change this you must also change Leo reference.conf!
 cryptomining_detector="us.gcr.io/broad-dsp-gcr-public/cryptomining-detector:0.0.2"

--- a/jenkins/gce-custom-images/create_gce_image.sh
+++ b/jenkins/gce-custom-images/create_gce_image.sh
@@ -32,7 +32,7 @@ ZONE="${REGION}-a"
 # If it doesn't exist, we create it prior to launching Daisy and
 # the Daisy workflow cleans up all but daisy.log at the end.
 if [ -z "$GCE_IMAGE_BUCKET" ]; then
-  GCE_IMAGE_BUCKET="gs://leo-gce-image-creation-logs"
+  GCE_IMAGE_BUCKET="gs://leonardo-gce-image-creation-logs"
 fi
 
 

--- a/jenkins/gce-custom-images/prepare_gce_image.sh
+++ b/jenkins/gce-custom-images/prepare_gce_image.sh
@@ -23,7 +23,7 @@ terra_jupyter_gatk="us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:2.3.9"
 terra_jupyter_aou="us.gcr.io/broad-dsp-gcr-public/terra-jupyter-aou:2.2.16"
 welder_server="us.gcr.io/broad-dsp-gcr-public/welder-server:8667bfe"
 openidc_proxy="broadinstitute/openidc-proxy:2.3.1_2"
-anvil_rstudio_bioconductor="us.gcr.io/broad-dsp-gcr-public/anvil-rstudio-bioconductor:3.20.1"
+anvil_rstudio_bioconductor="us.gcr.io/broad-dsp-gcr-public/anvil-rstudio-bioconductor:3.21.0"
 
 # Note that this is the version used currently by AOU in production, the one above can be staged for testing
 # You can check which version of the AOU image is used in prod here: https://github.com/all-of-us/workbench/blob/main/api/config/config_prod.json#L15C1-L16C1


### PR DESCRIPTION
<!-- Welcome to your Leonardo pull request! -->
<!-- Contributor guidelines: https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md -->

__Jira ticket__: https://broadworkbench.atlassian.net/browse/AN-723

<!-- ## Dependencies -->
<!-- Include any dependent tickets and describe the relationship. Include any other relevant Jira tickets. -->

## Summary of changes

Release new bioconductor version: https://github.com/DataBiosphere/terra-docker/pull/510/files

### What

- Updates bioconductor Rstudio image
- Also updates the log bucket when generating the GCE image since the previous bucket seemed to exist outside the scope of the `broad-dsp-gcr-public` org

`409 A Cloud Storage bucket named 'leo-gce-image-creation-logs' already exists. Try another name. Bucket names must be globally unique across all Google Cloud projects, including those outside of your organization`

### Why

-

## Testing these changes

### What to test

- <!-- Test case 1 -->

<!-- ### Test data -->

### Who tested and where

- [ ] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [ ] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
