### PR TITLE
[AN-726] Add logging and fix cluster creation bug

### DIFF
--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
@@ -1774,8 +1774,9 @@ class GKEInterpreter[F[_]](
 
     } yield helmAuthContext
 
-  private[util] def getNodepoolServiceAccount(googleProject: GoogleProject)
-                                             (implicit ev: Ask[F, AppContext]): F[Option[String]] = {
+  private[util] def getNodepoolServiceAccount(
+    googleProject: GoogleProject
+  )(implicit ev: Ask[F, AppContext]): F[Option[String]] = {
     val defaultSaEmail = s"gke-node-default-sa@${googleProject.value}.iam.gserviceaccount.com"
 
     for {
@@ -1784,7 +1785,8 @@ class GKEInterpreter[F[_]](
       // Check if the default service account exists in Google IAM
       serviceAccountExists <- F.fromFuture(
         F.delay(
-          googleIamDAO.findServiceAccount(googleProject, WorkbenchEmail(defaultSaEmail))
+          googleIamDAO
+            .findServiceAccount(googleProject, WorkbenchEmail(defaultSaEmail))
             .map(_.isDefined)
             .recover { case _ => false }
         )
@@ -1794,9 +1796,10 @@ class GKEInterpreter[F[_]](
       )
 
       // If service account exists, use it. Otherwise use default compute SA
-    } yield  if (serviceAccountExists) {
-      Some(defaultSaEmail)
-    } else None
+    } yield
+      if (serviceAccountExists) {
+        Some(defaultSaEmail)
+      } else None
   }
 
   private[util] def buildGoogleNodepool(

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
@@ -122,6 +122,9 @@ class GKEInterpreter[F[_]](
       _ <- logger.info(ctx.loggingCtx)(
         s"[AN-276] Project labels: ${projectLabels.getOrElse("None")}"
       )
+
+      _ <- logger.info(s"[AN-276] Building GKE Nodepool with service account: ${serviceAccount.getOrElse("default")}")
+
       nodepools =
         if (params.autopilot) List.empty
         else
@@ -327,6 +330,8 @@ class GKEInterpreter[F[_]](
       _ <- logger.info(ctx.loggingCtx)(
         s"Beginning nodepool creation for nodepool ${dbNodepool.nodepoolName.value} in cluster ${dbCluster.getClusterId.toString}"
       )
+
+      _ <- logger.info(s"[AN-276] Building GKE Nodepool with service account: ${serviceAccount.getOrElse("default")}")
 
       req = KubernetesCreateNodepoolRequest(
         dbCluster.getClusterId,
@@ -1806,7 +1811,6 @@ class GKEInterpreter[F[_]](
     nodepool: Nodepool,
     serviceAccount: Option[String]
   ): com.google.container.v1.NodePool = {
-    logger.info(s"[AN-276] Building GKE Nodepool with service account: ${serviceAccount.getOrElse("default")}")
 
     val nodepoolBuilder = NodePool
       .newBuilder()
@@ -1858,9 +1862,6 @@ class GKEInterpreter[F[_]](
     nodepool: Nodepool,
     serviceAccount: Option[String]
   ): com.google.api.services.container.model.NodePool = {
-
-    logger.info(s"[AN-276] Building GKE Nodepool with service account: ${serviceAccount.getOrElse("default")}")
-
     val legacyGoogleNodepool = new com.google.api.services.container.model.NodePool()
       .setInitialNodeCount(nodepool.numNodes.amount)
       .setName(nodepool.nodepoolName.value)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
@@ -1774,16 +1774,9 @@ class GKEInterpreter[F[_]](
 
     } yield helmAuthContext
 
-//  private[util] def getNodepoolServiceAccount(projectLabels: Option[Map[String, String]],
-//                                              googleProject: GoogleProject
-//  ): Option[String] =
-//    projectLabels.flatMap { x =>
-//      x.get("gke-default-sa").map(v => s"${v}@${googleProject.value}.iam.gserviceaccount.com")
-//    }
-
   private[util] def getNodepoolServiceAccount(googleProject: GoogleProject)
                                              (implicit ev: Ask[F, AppContext]): F[Option[String]] = {
-    val defaultSaEmail = s"gke-default-sa@${googleProject.value}.iam.gserviceaccount.com"
+    val defaultSaEmail = s"gke-node-default-sa@${googleProject.value}.iam.gserviceaccount.com"
 
     for {
       ctx <- ev.ask

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
@@ -115,14 +115,19 @@ class GKEInterpreter[F[_]](
         s"Beginning cluster creation for cluster ${dbCluster.getClusterId.toString}"
       )
 
-      // Get nodepools to pass in the create cluster request
+      // Get labels and service account to pass in the create cluster request
       projectLabels <- googleResourceService.getLabels(params.googleProject)
+      serviceAccount <- getNodepoolServiceAccount(params.googleProject)
+
+      _ <- logger.info(ctx.loggingCtx)(
+        s"[AN-276] Project labels: ${projectLabels.getOrElse("None")}"
+      )
       nodepools =
         if (params.autopilot) List.empty
         else
           dbCluster.nodepools
             .filter(n => params.nodepoolsToCreate.contains(n.id))
-            .map(np => buildLegacyGoogleNodepool(np, params.googleProject, projectLabels))
+            .map(np => buildLegacyGoogleNodepool(np, serviceAccount))
 
       _ <-
         if (nodepools.size != params.nodepoolsToCreate.size)
@@ -157,8 +162,6 @@ class GKEInterpreter[F[_]](
 
       autoscaling =
         if (params.autopilot) {
-          val serviceAccount = getNodepoolServiceAccount(projectLabels, params.googleProject)
-
           serviceAccount match {
             case Some(sa) =>
               new com.google.api.services.container.model.ClusterAutoscaling().setAutoprovisioningNodePoolDefaults(
@@ -319,15 +322,15 @@ class GKEInterpreter[F[_]](
           s"Cluster with id ${dbNodepool.clusterId} not found in database | trace id: ${ctx.traceId}"
         )
       )
+      serviceAccount <- getNodepoolServiceAccount(params.googleProject)
 
       _ <- logger.info(ctx.loggingCtx)(
         s"Beginning nodepool creation for nodepool ${dbNodepool.nodepoolName.value} in cluster ${dbCluster.getClusterId.toString}"
       )
 
-      projectLabels <- googleResourceService.getLabels(params.googleProject)
       req = KubernetesCreateNodepoolRequest(
         dbCluster.getClusterId,
-        buildGoogleNodepool(dbNodepool, params.googleProject, projectLabels)
+        buildGoogleNodepool(dbNodepool, serviceAccount)
       )
 
       operationOpt <- nodepoolLock.withKeyLock(dbCluster.getClusterId) {
@@ -1771,19 +1774,43 @@ class GKEInterpreter[F[_]](
 
     } yield helmAuthContext
 
-  private[util] def getNodepoolServiceAccount(projectLabels: Option[Map[String, String]],
-                                              googleProject: GoogleProject
-  ): Option[String] =
-    projectLabels.flatMap { x =>
-      x.get("gke-default-sa").map(v => s"${v}@${googleProject.value}.iam.gserviceaccount.com")
-    }
+//  private[util] def getNodepoolServiceAccount(projectLabels: Option[Map[String, String]],
+//                                              googleProject: GoogleProject
+//  ): Option[String] =
+//    projectLabels.flatMap { x =>
+//      x.get("gke-default-sa").map(v => s"${v}@${googleProject.value}.iam.gserviceaccount.com")
+//    }
+
+  private[util] def getNodepoolServiceAccount(googleProject: GoogleProject)
+                                             (implicit ev: Ask[F, AppContext]): F[Option[String]] = {
+    val defaultSaEmail = s"gke-default-sa@${googleProject.value}.iam.gserviceaccount.com"
+
+    for {
+      ctx <- ev.ask
+
+      // Check if the default service account exists in Google IAM
+      serviceAccountExists <- F.fromFuture(
+        F.delay(
+          googleIamDAO.findServiceAccount(googleProject, WorkbenchEmail(defaultSaEmail))
+            .map(_.isDefined)
+            .recover { case _ => false }
+        )
+      )
+      _ <- logger.info(ctx.loggingCtx)(
+        s"[AN-276] Service account exists in project ${googleProject.value}: $serviceAccountExists"
+      )
+
+      // If service account exists, use it. Otherwise use default compute SA
+    } yield  if (serviceAccountExists) {
+      Some(defaultSaEmail)
+    } else None
+  }
 
   private[util] def buildGoogleNodepool(
     nodepool: Nodepool,
-    googleProject: GoogleProject,
-    projectLabels: Option[Map[String, String]]
+    serviceAccount: Option[String]
   ): com.google.container.v1.NodePool = {
-    val serviceAccount = getNodepoolServiceAccount(projectLabels, googleProject)
+    logger.info(s"[AN-276] Building GKE Nodepool with service account: ${serviceAccount.getOrElse("default")}")
 
     val nodepoolBuilder = NodePool
       .newBuilder()
@@ -1833,10 +1860,10 @@ class GKEInterpreter[F[_]](
 
   private[util] def buildLegacyGoogleNodepool(
     nodepool: Nodepool,
-    googleProject: GoogleProject,
-    projectLabels: Option[Map[String, String]]
+    serviceAccount: Option[String]
   ): com.google.api.services.container.model.NodePool = {
-    val serviceAccount = getNodepoolServiceAccount(projectLabels, googleProject)
+
+    logger.info(s"[AN-276] Building GKE Nodepool with service account: ${serviceAccount.getOrElse("default")}")
 
     val legacyGoogleNodepool = new com.google.api.services.container.model.NodePool()
       .setInitialNodeCount(nodepool.numNodes.amount)

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreterSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreterSpec.scala
@@ -81,11 +81,9 @@ class GKEInterpreterSpec extends AnyFlatSpecLike with TestComponent with Mockito
             autoscalingConfig = Some(AutoscalingConfig(AutoscalingMin(minNodes), AutoscalingMax(maxNodes)))
       )
       .save()
+    val serviceAccount = Some(s"gke-node-default-sa@${savedCluster1.cloudContext.asString}.iam.gserviceaccount.com")
     val googleNodepool =
-      gkeInterp.buildGoogleNodepool(savedNodepool1,
-                                    savedCluster1.cloudContext.asInstanceOf[CloudContext.Gcp].value,
-                                    Some(Map("gke-default-sa" -> "gke-node-default-sa"))
-      )
+      gkeInterp.buildGoogleNodepool(savedNodepool1, serviceAccount)
     googleNodepool.getAutoscaling.getEnabled shouldBe true
     googleNodepool.getAutoscaling.getMinNodeCount shouldBe minNodes
     googleNodepool.getAutoscaling.getMaxNodeCount shouldBe maxNodes


### PR DESCRIPTION
<!-- Welcome to your Leonardo pull request! -->
<!-- Contributor guidelines: https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md -->

__Jira ticket__: https://broadworkbench.atlassian.net/browse/AN-726

<!-- ## Dependencies -->
<!-- Include any dependent tickets and describe the relationship. Include any other relevant Jira tickets. -->

## Summary of changes

<!-- Please give an abridged version of the ticket description here and/or fill out the following fields. -->

### What

- Upon cluster creation, when setting the default service account, first check if it exists in the project, instead of checking if the correct label exists for the project
- Adds logging

### Why

Used to check if the `gke-default-sa` label existed (value `gke-node-default-sa`) and use the gke service account if it existed. This started to break on 8/4/25 (possibly a breaking google change?), so want to try switching to check for the service account directly

## Testing these changes

### What to test

- Create a Galaxy environment
- Delete the `gke-default-sa` project label and try too create a Galaxy environment

<!-- ### Test data -->

### Who tested and where

- [ ] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [ ] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
