### PR TITLE
[HotFix] Update the GalaxyKubeman chart to version 2.10.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ ENV HELM_DEBUG 1
 ENV TERRA_APP_SETUP_VERSION 0.1.0
 ENV TERRA_APP_VERSION 0.5.0
 # This is galaxykubeman, which references Galaxy
-ENV GALAXY_VERSION 2.10.0
+ENV GALAXY_VERSION 2.10.1
 ENV NGINX_VERSION 4.3.0
 # If you update this here, make sure to also update reference.conf:
 ENV CROMWELL_CHART_VERSION 0.2.558

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -505,7 +505,7 @@ gke {
     chartName = "/leonardo/galaxykubeman"
     # If you change this here, be sure to update it in the dockerfile
     # This is galaxykubeman, which references Galaxy
-    chartVersion = "2.10.0"
+    chartVersion = "2.10.1"
     namespaceNameSuffix = "gxy-ns"
     serviceAccountName = "gxy-ksa"
     # Setting uninstallKeepHistory will cause the `helm uninstall` command to keep a record of

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/KubernetesTestData.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/KubernetesTestData.scala
@@ -48,7 +48,7 @@ object KubernetesTestData {
   val galaxyApp = AppType.Galaxy
 
   val galaxyChartName = ChartName("/leonardo/galaxykubeman")
-  val galaxyChartVersion = ChartVersion("2.10.0")
+  val galaxyChartVersion = ChartVersion("2.10.1")
   val galaxyChart = Chart(galaxyChartName, galaxyChartVersion)
 
   val galaxyReleasePrefix = "gxy-release"

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/config/ConfigSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/config/ConfigSpec.scala
@@ -142,7 +142,8 @@ final class ConfigSpec extends AnyFlatSpec with Matchers {
         ChartVersion("2.8.0"),
         ChartVersion("2.8.1"),
         ChartVersion("2.9.0"),
-        ChartVersion("2.10.0")
+        ChartVersion("2.10.0"),
+        ChartVersion("2.10.1")
       )
     )
     Config.gkeGalaxyAppConfig shouldBe expectedResult

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/config/ConfigSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/config/ConfigSpec.scala
@@ -143,7 +143,7 @@ final class ConfigSpec extends AnyFlatSpec with Matchers {
         ChartVersion("2.8.1"),
         ChartVersion("2.9.0"),
         ChartVersion("2.10.0"),
-        ChartVersion("2.10.1")
+        ChartVersion("2.10.1"),
       )
     )
     Config.gkeGalaxyAppConfig shouldBe expectedResult


### PR DESCRIPTION
## Summary of changes

Update the GalaxyKubeman chart to use the `bitnamilegacy` Docker repository.  A future version of the Galaxy Helm chart(s) will eliminate Bitnami repositories entirely.  Tested on GKE 1.32
 
### Why

Bitnami is no longer providing free access to their Docker repositories.

See: https://github.com/bitnami/containers/issues/83267

### Who tested and where

- [ ] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [X] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
