### PR TITLE
PROD-1034: set setGcpPublicCidrsAccessEnabled to true

### DIFF
--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
@@ -199,7 +199,7 @@ class GKEInterpreter[F[_]](
         .setMasterAuthorizedNetworksConfig(
           new com.google.api.services.container.model.MasterAuthorizedNetworksConfig()
             .setEnabled(true)
-            .setGcpPublicCidrsAccessEnabled(true) // Always allow GCP internal traffic so we can install workflows on the cluster
+            .setGcpPublicCidrsAccessEnabled(true)
             .setCidrBlocks(
               config.clusterConfig.authorizedNetworks
                 .map(ip => new com.google.api.services.container.model.CidrBlock().setCidrBlock(ip.value))

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
@@ -199,7 +199,7 @@ class GKEInterpreter[F[_]](
         .setMasterAuthorizedNetworksConfig(
           new com.google.api.services.container.model.MasterAuthorizedNetworksConfig()
             .setEnabled(true)
-            .setGcpPublicCidrsAccessEnabled(true)
+            .setGcpPublicCidrsAccessEnabled(true) // Always allow GCP internal traffic so we can install workflows on the cluster
             .setCidrBlocks(
               config.clusterConfig.authorizedNetworks
                 .map(ip => new com.google.api.services.container.model.CidrBlock().setCidrBlock(ip.value))

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
@@ -199,15 +199,12 @@ class GKEInterpreter[F[_]](
         .setMasterAuthorizedNetworksConfig(
           new com.google.api.services.container.model.MasterAuthorizedNetworksConfig()
             .setEnabled(true)
+            .setGcpPublicCidrsAccessEnabled(true)
             .setCidrBlocks(
               config.clusterConfig.authorizedNetworks
                 .map(ip => new com.google.api.services.container.model.CidrBlock().setCidrBlock(ip.value))
                 .asJava
             )
-        )
-        .setPrivateClusterConfig(
-          new com.google.api.services.container.model.PrivateClusterConfig()
-            .setGcpPublicCidrsAccessEnabled(true)
         )
         .setIpAllocationPolicy(
           new com.google.api.services.container.model.IPAllocationPolicy()

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
@@ -205,6 +205,10 @@ class GKEInterpreter[F[_]](
                 .asJava
             )
         )
+        .setPrivateClusterConfig(
+          new com.google.api.services.container.model.PrivateClusterConfig()
+            .setGcpPublicCidrsAccessEnabled(true)
+        )
         .setIpAllocationPolicy(
           new com.google.api.services.container.model.IPAllocationPolicy()
             .setUseIpAliases(true)


### PR DESCRIPTION
<!-- Welcome to your Leonardo pull request! -->
<!-- Contributor guidelines: https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md -->

__Jira ticket__: https://broadworkbench.atlassian.net/browse/PROD-1034

<!-- ## Dependencies -->
<!-- Include any dependent tickets and describe the relationship. Include any other relevant Jira tickets. -->

## Summary of changes

<!-- Please give an abridged version of the ticket description here and/or fill out the following fields. -->

### What

- set setGcpPublicCidrsAccessEnabled to true during cluster creation as the new default is false

### Why

- GKE clusters created by Leonardo started becoming unresponsive after 11/11/2025. When comparing a working cluster with a broken one, we realized that new clusters created after 11/11/25 had the `Add Google Cloud external IP addresses to authorized networks` option disabled, which is a change in default behavior.

## Testing these changes

### What to test

- <!-- Test case 1 -->

<!-- ### Test data -->

### Who tested and where

- [ ] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [ ] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
