### PR TITLE
[CTM-183, CTM-184] Exclude netty-codec and json-smart

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -154,10 +154,19 @@ object Dependencies {
   def excludeSnakeyaml = ExclusionRule("org.yaml", "snakeyaml")
   def excludeLiquibase = ExclusionRule("org.liquibase", "liquibase-core")
   def excludeFlagsmith = ExclusionRule("com.flagsmith", "flagsmith-java-client")
+  def excludeJsonSmart = ExclusionRule("net.minidev", "json-smart")
+  def excludeNettyCodecHttp = ExclusionRule("io.netty", "netty-codec-http")
+  def excludeAzureNetty = ExclusionRule("com.azure", "azure-core-http-netty")
+
+  //  def excludeAzureStairway = ExclusionRule("bio.terra", "stairway-azure")
 
   // [IA-4939] commons-text:1.9 is unsafe
   def excludeCommonsText = ExclusionRule("org.apache.commons", "commons-text")
-  def tclExclusions(m: ModuleID): ModuleID = m.excludeAll(excludeSpringBoot, excludeSpringAop, excludeSpringData, excludeSpringFramework, excludeOpenCensus, excludeGoogleFindBugs, excludeBroadWorkbench, excludePostgresql, excludeSnakeyaml, excludeSlf4j, excludeCommonsText, excludeLiquibase, excludeFlagsmith)
+  def tclExclusions(m: ModuleID): ModuleID = m.excludeAll(excludeSpringBoot,
+    excludeSpringAop, excludeSpringData, excludeSpringFramework, excludeOpenCensus,
+    excludeGoogleFindBugs, excludeBroadWorkbench, excludePostgresql, excludeSnakeyaml,
+    excludeSlf4j, excludeCommonsText, excludeLiquibase, excludeFlagsmith,
+    excludeJsonSmart, excludeNettyCodecHttp, excludeAzureNetty)
   val terraCommonLib = tclExclusions(excludeJakarta("bio.terra" % "terra-common-lib" % terraCommonLibV classifier "plain"))
   val sam = excludeJakarta("org.broadinstitute.dsde.workbench" %% "sam-client" % samV)
 
@@ -251,9 +260,13 @@ object Dependencies {
     okHttp % Test
   )
 
+  def excludeNettyCodecHttp2 = ExclusionRule("io.netty", "netty-codec-http2")
+  def excludeIoPactPlugin = ExclusionRule("io.pact.plugin.driver")
+
+
   val pact4sDependencies = Seq(
-    pact4sScalaTest,
-    pact4sCirce,
+    pact4sScalaTest.excludeAll(excludeNettyCodecHttp2, excludeIoPactPlugin),
+    pact4sCirce.excludeAll(excludeNettyCodecHttp2, excludeIoPactPlugin),
     http4sEmberClient,
     http4sDsl,
     http4sEmberServer,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -158,8 +158,6 @@ object Dependencies {
   def excludeNettyCodecHttp = ExclusionRule("io.netty", "netty-codec-http")
   def excludeAzureNetty = ExclusionRule("com.azure", "azure-core-http-netty")
 
-  //  def excludeAzureStairway = ExclusionRule("bio.terra", "stairway-azure")
-
   // [IA-4939] commons-text:1.9 is unsafe
   def excludeCommonsText = ExclusionRule("org.apache.commons", "commons-text")
   def tclExclusions(m: ModuleID): ModuleID = m.excludeAll(excludeSpringBoot,


### PR DESCRIPTION
<!-- Welcome to your Leonardo pull request! -->
<!-- Contributor guidelines: https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md -->

__Jira ticket__: https://broadworkbench.atlassian.net/browse/CTM-183

__Jira ticket__: https://broadworkbench.atlassian.net/browse/CTM-184

These 2 packages with vulnerabilities are brought in via Terra-common-lib and Pact4s, not used by Leonardo directly. So the easiest option is to simply exclude these vulnerable packages when importing TCL and Pact.

<!-- ## Dependencies -->
<!-- Include any dependent tickets and describe the relationship. Include any other relevant Jira tickets. -->

## Summary of changes

<!-- Please give an abridged version of the ticket description here and/or fill out the following fields. -->

### What

-

### Why

-

## Testing these changes

### What to test

- <!-- Test case 1 -->

<!-- ### Test data -->

### Who tested and where

- [ ] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [ ] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
