### PR TITLE
CTM-315: Same dataproc updated image good for the next 60 days

### DIFF
--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -71,7 +71,7 @@ dataproc {
 
   # Cached dataproc 2.2.x image used by Terra
   # must be re-generated every 60 days
-  customDataprocImage = "projects/broad-dsp-gcr-public/global/images/leo-dataproc-image-2-2-52-debian12-2025-12-01-15-24-20"
+  customDataprocImage = "projects/broad-dsp-gcr-public/global/images/leo-dataproc-image-2-2-52-debian12-2026-01-12-14-32-56"
 
   # The ratio of memory allocated to spark. 0.8 = 80%.
   # Hail/Spark users generally allocate 80% of the ram to the JVM.

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -15,7 +15,7 @@ object Dependencies {
   val monocleV = "3.2.0"
   val opencensusV = "0.29.0"
   val munitCatsEffectV = "1.0.7"
-  val pact4sV = "0.16.2"
+  val pact4sV = "0.16.3"
   val commonsBeanUtilsV = "1.11.0"
 
   private val workbenchLibsHash = "dc1d534"
@@ -132,8 +132,11 @@ object Dependencies {
   val http4sEmberServer = "org.http4s"        %% "http4s-ember-server"  % http4sVersion
   val http4sCirce       = "org.http4s"        %% "http4s-circe"  % http4sVersion
   val guava: ModuleID =   "com.google.guava"  % "guava"                 % guavaV
-  val pact4sScalaTest =   "io.github.jbwheatley"  %% "pact4s-scalatest" % pact4sV % Test
-  val pact4sCirce =       "io.github.jbwheatley"  %% "pact4s-circe"     % pact4sV
+  // Exclude transitive netty from pact4s and add explicit newer netty in `Dependencies.scala`
+  val pact4sScalaTest = "io.github.jbwheatley" %% "pact4s-scalatest" % pact4sV % Test excludeAll ExclusionRule("io.netty", "netty-codec-http")
+  val pact4sCirce     = "io.github.jbwheatley" %% "pact4s-circe"     % pact4sV     excludeAll ExclusionRule("io.netty", "netty-codec-http")
+  // Add explicit netty dependency where appropriate (e.g. pact4sDependencies or core/http deps)
+  val nettyCodecHttp: ModuleID = "io.netty" % "netty-codec-http" % "4.2.2.Final"
   val commonsBeanUtils = "commons-beanutils" % "commons-beanutils" % commonsBeanUtilsV
   val okHttp =            "com.squareup.okhttp3"  % "okhttp"            % "4.12.0"
 
@@ -259,12 +262,11 @@ object Dependencies {
   )
 
   def excludeNettyCodecHttp2 = ExclusionRule("io.netty", "netty-codec-http2")
-  def excludeIoPactPlugin = ExclusionRule("io.pact.plugin.driver")
-
 
   val pact4sDependencies = Seq(
-    pact4sScalaTest.excludeAll(excludeNettyCodecHttp2, excludeIoPactPlugin),
-    pact4sCirce.excludeAll(excludeNettyCodecHttp2, excludeIoPactPlugin),
+    pact4sScalaTest.excludeAll(excludeNettyCodecHttp2),
+    pact4sCirce.excludeAll(excludeNettyCodecHttp2),
+    nettyCodecHttp,
     http4sEmberClient,
     http4sDsl,
     http4sEmberServer,


### PR DESCRIPTION
<!-- Welcome to your Leonardo pull request! -->
<!-- Contributor guidelines: https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md -->

__Jira ticket__: https://broadworkbench.atlassian.net/browse/CTM-315

As part of the regular update of the dataproc image (it expires every 60 days), I am restoring the pact client to fix [this error](https://github.com/DataBiosphere/leonardo/actions/runs/20925005399/job/60120418588). The client unfortunately still pulls a vulnerable version of netty-http so I am overriding it.

<!-- ## Dependencies -->
<!-- Include any dependent tickets and describe the relationship. Include any other relevant Jira tickets. -->

## Summary of changes

<!-- Please give an abridged version of the ticket description here and/or fill out the following fields. -->

### What

-

### Why

-

## Testing these changes

### What to test

- <!-- Test case 1 -->

<!-- ### Test data -->

### Who tested and where

- [ ] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [ ] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
