### PR TITLE
[CTM-322] Update the crytomining detector to process google abuse event msgs

### DIFF
--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/NonLeoMessageSubscriber.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/NonLeoMessageSubscriber.scala
@@ -325,7 +325,7 @@ object NonLeoMessageSubscriber {
       resource = GoogleResource(GoogleLabels(instanceId, zone))
 
       logName <- c.downField("logName").as[String]
-      // logName looks like `projects/general-dev-billing-account/logs/cryptomining`
+      // logName looks like `projects/general-dev-billing-account/logs/abuseevent.googleapis.com%2Fabuse_events`
       // we're extracting google project from logName instead of `labels` because `labels` are easier to spoof.
       // We're using instance id from `labels` which is relatively okay because worst case is we're deleting an instance
       // in this user's own billing project

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/NonLeoMessageSubscriber.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/NonLeoMessageSubscriber.scala
@@ -399,8 +399,8 @@ final case class CryptoMiningSccResource(
 )
 
 final case class CryptoMiningAbuseEventDetails(
-                                                detectionType: String, //"CRYPTO_MINING"
-                                                vmResource: String, //projects/terra-805a7c14/zones/us-central1-a/instances/6317670314499867435"
+                                                detectionType: String,
+                                                vmResource: String,
 )
 
 final case class NonLeoMessageSubscriberConfig(userDiskDeviceName: DeviceName)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/NonLeoMessageSubscriber.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/NonLeoMessageSubscriber.scala
@@ -311,8 +311,8 @@ object NonLeoMessageSubscriber {
   implicit val cryptoMiningAbuseEventDetailsDecoder: Decoder[CryptoMiningAbuseEventDetails] = Decoder.instance { c =>
     for {
       detectionType <- c.downField("detectionType").as[String]
-      vmResource <- c.downField("cryptominingEvent").downField("vmResource").as[String]
-    } yield CryptoMiningAbuseEventDetails(detectionType, vmResource)
+      vmResource <- c.downField("cryptoMiningEvent").downField("vmResource").as[Array[String]]
+    } yield CryptoMiningAbuseEventDetails(detectionType, vmResource(0))
   }
 
   implicit val cryptoMiningAbuseEventDecoder: Decoder[CryptoMiningAbuseEvent] = Decoder.instance { c =>
@@ -341,7 +341,7 @@ object NonLeoMessageSubscriber {
 
   implicit val nonLeoMessageDecoder: Decoder[NonLeoMessage] = Decoder.instance { x =>
     deleteKubernetesClusterDecoder.tryDecode(x) orElse (cryptoMiningDecoder.tryDecode(x)) orElse (deleteNodepoolDecoder
-      .tryDecode(x)) orElse (cryptoMiningSccDecoder.tryDecode(x))
+      .tryDecode(x)) orElse (cryptoMiningAbuseEventDecoder.tryDecode(x)) orElse (cryptoMiningSccDecoder.tryDecode(x))
   }
 
   implicit val userSubjectIdEncoder: Encoder[UserSubjectId] = Encoder.encodeString.contramap(_.asString)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/NonLeoMessageSubscriber.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/NonLeoMessageSubscriber.scala
@@ -17,7 +17,13 @@ import org.broadinstitute.dsde.workbench.leonardo.dao.{SamDAO, UserSubjectId}
 import org.broadinstitute.dsde.workbench.leonardo.db._
 import org.broadinstitute.dsde.workbench.leonardo.http.{ctxConversion, dbioToIO}
 import org.broadinstitute.dsde.workbench.leonardo.model.LeoAuthProvider
-import org.broadinstitute.dsde.workbench.leonardo.monitor.NonLeoMessage.{CryptoMining, CryptoMiningAbuseEvent, CryptoMiningScc, DeleteKubernetesClusterMessage, DeleteNodepoolMessage}
+import org.broadinstitute.dsde.workbench.leonardo.monitor.NonLeoMessage.{
+  CryptoMining,
+  CryptoMiningAbuseEvent,
+  CryptoMiningScc,
+  DeleteKubernetesClusterMessage,
+  DeleteNodepoolMessage
+}
 import org.broadinstitute.dsde.workbench.leonardo.monitor.NonLeoMessageSubscriber.cryptominingUserMessageEncoder
 import org.broadinstitute.dsde.workbench.leonardo.util.{DeleteClusterParams, DeleteNodepoolParams, GKEAlgebra}
 import org.broadinstitute.dsde.workbench.model.TraceId
@@ -109,34 +115,29 @@ class NonLeoMessageSubscriber[F[_]](config: NonLeoMessageSubscriberConfig,
     deleteCryptominingRuntime(msg.resource.googleProject, msg.resource.runtimeName, msg.resource.zone, "scc")
 
   private[monitor] def handleCryptoMiningAbuseEventMessage(
-                                                     msg: NonLeoMessage.CryptoMiningAbuseEvent
-                                                   )(implicit ev: Ask[F, AppContext]): F[Unit] = {
-
+    msg: NonLeoMessage.CryptoMiningAbuseEvent
+  )(implicit ev: Ask[F, AppContext]): F[Unit] =
     for {
       _ <-
-        if (
-          !(msg.detectionType == "CRYPTO_MINING")
-        )
+        if (!(msg.detectionType == "CRYPTO_MINING"))
           logger.error(s"Unexpected cryptomining detection type: ${msg.detectionType}")
         else
           for {
             runtimeFromGoogle <- computeService.getInstance(msg.googleProject,
-              msg.resource.labels.zone,
-              InstanceName(msg.resource.labels.instanceId.toString)
+                                                            msg.resource.labels.zone,
+                                                            InstanceName(msg.resource.labels.instanceId.toString)
             )
             // We mark the runtime as Deleted, and delete the instance.
             // If instance deletion fails for some reason, it will be cleaned up by resource-validator
             _ <- runtimeFromGoogle.traverse { instance =>
               deleteCryptominingRuntime(msg.googleProject,
-                RuntimeName(instance.getName),
-                msg.resource.labels.zone,
-                "google abuse event detector"
+                                        RuntimeName(instance.getName),
+                                        msg.resource.labels.zone,
+                                        "google abuse event detector"
               )
             }
           } yield ()
-    } yield()
-  }
-
+    } yield ()
 
   private[monitor] def handleCryptoMiningMessage(
     msg: NonLeoMessage.CryptoMining
@@ -318,7 +319,7 @@ object NonLeoMessageSubscriber {
     for {
       eventDetails <- c.downField("jsonPayload").as[CryptoMiningAbuseEventDetails]
 
-      //projects/{project-id}/zones/{zone}/instances/{instance-id}
+      // projects/{project-id}/zones/{zone}/instances/{instance-id}
       instanceId = eventDetails.vmResource.split("/")(5).toLong
       zone = ZoneName(eventDetails.vmResource.split("/")(3))
       resource = GoogleResource(GoogleLabels(instanceId, zone))
@@ -366,7 +367,8 @@ object NonLeoMessage {
     val messageType: String = "crypto-mining-scc"
   }
   // Cryptoming messages generated from Google, within a user's project
-  final case class CryptoMiningAbuseEvent(detectionType: String, resource: GoogleResource, googleProject: GoogleProject) extends NonLeoMessage {
+  final case class CryptoMiningAbuseEvent(detectionType: String, resource: GoogleResource, googleProject: GoogleProject)
+      extends NonLeoMessage {
     val messageType: String = "crypto-mining-abuse-event"
   }
   final case class DeleteNodepoolMessage(nodepoolId: NodepoolLeoId,
@@ -399,8 +401,8 @@ final case class CryptoMiningSccResource(
 )
 
 final case class CryptoMiningAbuseEventDetails(
-                                                detectionType: String,
-                                                vmResource: String,
+  detectionType: String,
+  vmResource: String
 )
 
 final case class NonLeoMessageSubscriberConfig(userDiskDeviceName: DeviceName)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/NonLeoMessageSubscriber.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/NonLeoMessageSubscriber.scala
@@ -17,12 +17,7 @@ import org.broadinstitute.dsde.workbench.leonardo.dao.{SamDAO, UserSubjectId}
 import org.broadinstitute.dsde.workbench.leonardo.db._
 import org.broadinstitute.dsde.workbench.leonardo.http.{ctxConversion, dbioToIO}
 import org.broadinstitute.dsde.workbench.leonardo.model.LeoAuthProvider
-import org.broadinstitute.dsde.workbench.leonardo.monitor.NonLeoMessage.{
-  CryptoMining,
-  CryptoMiningScc,
-  DeleteKubernetesClusterMessage,
-  DeleteNodepoolMessage
-}
+import org.broadinstitute.dsde.workbench.leonardo.monitor.NonLeoMessage.{CryptoMining, CryptoMiningAbuseEvent, CryptoMiningScc, DeleteKubernetesClusterMessage, DeleteNodepoolMessage}
 import org.broadinstitute.dsde.workbench.leonardo.monitor.NonLeoMessageSubscriber.cryptominingUserMessageEncoder
 import org.broadinstitute.dsde.workbench.leonardo.util.{DeleteClusterParams, DeleteNodepoolParams, GKEAlgebra}
 import org.broadinstitute.dsde.workbench.model.TraceId
@@ -80,6 +75,7 @@ class NonLeoMessageSubscriber[F[_]](config: NonLeoMessageSubscriberConfig,
     case m: NonLeoMessage.CryptoMining                   => handleCryptoMiningMessage(m)
     case m: NonLeoMessage.DeleteNodepoolMessage          => handleDeleteNodepoolMessage(m)
     case m: NonLeoMessage.CryptoMiningScc                => handleCryptoMiningMessageScc(m)
+    case m: NonLeoMessage.CryptoMiningAbuseEvent         => handleCryptoMiningAbuseEventMessage(m)
   }
 
   private[monitor] def handleDeleteKubernetesClusterMessage(msg: DeleteKubernetesClusterMessage)(implicit
@@ -111,6 +107,36 @@ class NonLeoMessageSubscriber[F[_]](config: NonLeoMessageSubscriberConfig,
     msg: NonLeoMessage.CryptoMiningScc
   )(implicit ev: Ask[F, AppContext]): F[Unit] =
     deleteCryptominingRuntime(msg.resource.googleProject, msg.resource.runtimeName, msg.resource.zone, "scc")
+
+  private[monitor] def handleCryptoMiningAbuseEventMessage(
+                                                     msg: NonLeoMessage.CryptoMiningAbuseEvent
+                                                   )(implicit ev: Ask[F, AppContext]): F[Unit] = {
+
+    for {
+      _ <-
+        if (
+          !(msg.detectionType == "CRYPTO_MINING")
+        )
+          logger.error(s"Unexpected cryptomining detection type: ${msg.detectionType}")
+        else
+          for {
+            runtimeFromGoogle <- computeService.getInstance(msg.googleProject,
+              msg.resource.labels.zone,
+              InstanceName(msg.resource.labels.instanceId.toString)
+            )
+            // We mark the runtime as Deleted, and delete the instance.
+            // If instance deletion fails for some reason, it will be cleaned up by resource-validator
+            _ <- runtimeFromGoogle.traverse { instance =>
+              deleteCryptominingRuntime(msg.googleProject,
+                RuntimeName(instance.getName),
+                msg.resource.labels.zone,
+                "google abuse event detector"
+              )
+            }
+          } yield ()
+    } yield()
+  }
+
 
   private[monitor] def handleCryptoMiningMessage(
     msg: NonLeoMessage.CryptoMining
@@ -280,6 +306,35 @@ object NonLeoMessageSubscriber {
       finding <- c.downField("finding").as[Finding]
     } yield CryptoMiningScc(resource, finding)
   }
+
+  implicit val cryptoMiningAbuseEventDetailsDecoder: Decoder[CryptoMiningAbuseEventDetails] = Decoder.instance { c =>
+    for {
+      detectionType <- c.downField("detectionType").as[String]
+      vmResource <- c.downField("cryptominingEvent").downField("vmResource").as[String]
+    } yield CryptoMiningAbuseEventDetails(detectionType, vmResource)
+  }
+
+  implicit val cryptoMiningAbuseEventDecoder: Decoder[CryptoMiningAbuseEvent] = Decoder.instance { c =>
+    for {
+      eventDetails <- c.downField("jsonPayload").as[CryptoMiningAbuseEventDetails]
+
+      //projects/{project-id}/zones/{zone}/instances/{instance-id}
+      instanceId = eventDetails.vmResource.split("/")(5).toLong
+      zone = ZoneName(eventDetails.vmResource.split("/")(3))
+      resource = GoogleResource(GoogleLabels(instanceId, zone))
+
+      logName <- c.downField("logName").as[String]
+      // logName looks like `projects/general-dev-billing-account/logs/cryptomining`
+      // we're extracting google project from logName instead of `labels` because `labels` are easier to spoof.
+      // We're using instance id from `labels` which is relatively okay because worst case is we're deleting an instance
+      // in this user's own billing project
+      splitted = logName.split("/")
+      googleProject <- Either
+        .catchNonFatal(GoogleProject(splitted(1)))
+        .leftMap(t => DecodingFailure(s"can't parse google project from logName due to ${t}", List.empty))
+    } yield CryptoMiningAbuseEvent(eventDetails.detectionType, resource, googleProject)
+  }
+
   implicit val deleteNodepoolDecoder: Decoder[DeleteNodepoolMessage] =
     Decoder.forProduct3("nodepoolId", "googleProject", "traceId")(DeleteNodepoolMessage.apply)
 
@@ -304,11 +359,15 @@ object NonLeoMessage {
   // Cryptoming messages generated from our custom cryptomining detector
   final case class CryptoMining(textPayload: String, resource: GoogleResource, googleProject: GoogleProject)
       extends NonLeoMessage {
-    val messageType: String = "crypto-minining"
+    val messageType: String = "crypto-mining"
   }
   // Cryptoming messages generated from Google's Security Command Center service
   final case class CryptoMiningScc(resource: CryptoMiningSccResource, finding: Finding) extends NonLeoMessage {
-    val messageType: String = "crypto-minining-scc"
+    val messageType: String = "crypto-mining-scc"
+  }
+  // Cryptoming messages generated from Google, within a user's project
+  final case class CryptoMiningAbuseEvent(detectionType: String, resource: GoogleResource, googleProject: GoogleProject) extends NonLeoMessage {
+    val messageType: String = "crypto-mining-abuse-event"
   }
   final case class DeleteNodepoolMessage(nodepoolId: NodepoolLeoId,
                                          googleProject: GoogleProject,
@@ -337,6 +396,11 @@ final case class CryptoMiningSccResource(
   cloudService: CloudService,
   runtimeName: RuntimeName,
   zone: ZoneName
+)
+
+final case class CryptoMiningAbuseEventDetails(
+                                                detectionType: String, //"CRYPTO_MINING"
+                                                vmResource: String, //projects/terra-805a7c14/zones/us-central1-a/instances/6317670314499867435"
 )
 
 final case class NonLeoMessageSubscriberConfig(userDiskDeviceName: DeviceName)

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/NonLeoMessageSubscriberSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/NonLeoMessageSubscriberSpec.scala
@@ -380,7 +380,7 @@ class NonLeoMessageSubscriberSpec extends AnyFlatSpec with LeonardoTestSuite wit
         deletedFrom <- clusterQuery.getDeletedFrom(runtime.id).transaction
       } yield {
         statusAfterUpdate.get shouldBe (RuntimeStatus.Deleted)
-        deletedFrom.get shouldBe "cryptomining: scc"
+        deletedFrom.get shouldBe "cryptomining: google abuse event detector"
       }
     }
   }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/NonLeoMessageSubscriberSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/NonLeoMessageSubscriberSpec.scala
@@ -364,7 +364,7 @@ class NonLeoMessageSubscriberSpec extends AnyFlatSpec with LeonardoTestSuite wit
         runtime <- IO(makeCluster(1).save())
         computeService = new FakeGoogleComputeService {
           override def getInstance(project: GoogleProject, zone: ZoneName, instanceName: InstanceName)(implicit
-                                                                                                       ev: Ask[IO, TraceId]
+            ev: Ask[IO, TraceId]
           ): cats.effect.IO[scala.Option[com.google.cloud.compute.v1.Instance]] =
             IO.pure(Some(Instance.newBuilder().setName(runtime.runtimeName.asString).build()))
         }
@@ -372,8 +372,8 @@ class NonLeoMessageSubscriberSpec extends AnyFlatSpec with LeonardoTestSuite wit
         _ <- subscriber.handleCryptoMiningAbuseEventMessage(
           NonLeoMessage
             .CryptoMiningAbuseEvent("CRYPTO_MINING",
-              GoogleResource(GoogleLabels(123L, ZoneName("us-central1-a"))),
-              GoogleProject(runtime.cloudContext.asString)
+                                    GoogleResource(GoogleLabels(123L, ZoneName("us-central1-a"))),
+                                    GoogleProject(runtime.cloudContext.asString)
             )
         )
         statusAfterUpdate <- clusterQuery.getClusterStatus(runtime.id).transaction

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/NonLeoMessageSubscriberSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/NonLeoMessageSubscriberSpec.scala
@@ -186,15 +186,15 @@ class NonLeoMessageSubscriberSpec extends AnyFlatSpec with LeonardoTestSuite wit
         |    "remediationLink": "https://cloud.google.com/docs/security/respond-to-abuse-misuse",
         |    "cryptoMiningEvent": {
         |      "destinationIp": [
-        |        "3.145.74.39"
+        |        "00.000.000.000"
         |      ],
         |      "detectedMiningStartTime": "2026-01-20T11:40:00Z",
         |      "detectedMiningEndTime": "2026-01-20T12:04:00Z",
         |      "vmIp": [
-        |        "35.232.132.254"
+        |        "0.000.000.000"
         |      ],
         |      "vmResource": [
-        |        "projects/terra-805a7c14/zones/us-central1-a/instances/4713536777184052026"
+        |        "projects/general-dev-billing-account/zones/us-central1-a/instances/4713536777184052026"
         |      ],
         |      "remotePort": [
         |        8169
@@ -205,15 +205,15 @@ class NonLeoMessageSubscriberSpec extends AnyFlatSpec with LeonardoTestSuite wit
         |    "type": "abuseevent.googleapis.com/Location",
         |    "labels": {
         |      "location": "global",
-        |      "resource_container": "projects/135908015598"
+        |      "resource_container": "projects/1089695574439"
         |    }
         |  },
         |  "timestamp": "2026-01-20T12:15:59.202758798Z",
         |  "severity": "NOTICE",
         |  "labels": {
-        |    "abuseevent.googleapis.com/vm_resource": "projects/terra-805a7c14/zones/us-central1-a/instances/4713536777184052026"
+        |    "abuseevent.googleapis.com/vm_resource": "projects/general-dev-billing-account/zones/us-central1-a/instances/4713536777184052026"
         |  },
-        |  "logName": "projects/terra-805a7c14/logs/abuseevent.googleapis.com%2Fabuse_events",
+        |  "logName": "projects/general-dev-billing-account/logs/abuseevent.googleapis.com%2Fabuse_events",
         |  "receiveTimestamp": "2026-01-20T12:16:00.119885442Z"
         |}
         |""".stripMargin
@@ -222,7 +222,7 @@ class NonLeoMessageSubscriberSpec extends AnyFlatSpec with LeonardoTestSuite wit
       GoogleResource(
         GoogleLabels(4713536777184052026L, ZoneName("us-central1-a"))
       ),
-      GoogleProject("terra-805a7c14")
+      GoogleProject("general-dev-billing-account")
     )
     decode[NonLeoMessage](jsonString) shouldBe Right(expectedResult)
   }

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/NonLeoMessageSubscriberSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/NonLeoMessageSubscriberSpec.scala
@@ -173,6 +173,60 @@ class NonLeoMessageSubscriberSpec extends AnyFlatSpec with LeonardoTestSuite wit
     decode[NonLeoMessage](jsonString) shouldBe Right(expectedResult)
   }
 
+  it should "decode NonLeoMessage.CryptominingAbuseEvent properly" in {
+    val jsonString =
+      """
+{
+        |  "insertId": "9062669515527671957",
+        |  "jsonPayload": {
+        |    "@type": "type.googleapis.com/google.cloud.abuseevent.logging.v1.AbuseEvent",
+        |    "detectionType": "CRYPTO_MINING",
+        |    "reason": "The monitored resource is mining cryptocurrencies (e.g. Bitcoin, Chia) which is against GCP TOS.",
+        |    "action": "NOTIFY",
+        |    "remediationLink": "https://cloud.google.com/docs/security/respond-to-abuse-misuse",
+        |    "cryptoMiningEvent": {
+        |      "destinationIp": [
+        |        "3.145.74.39"
+        |      ],
+        |      "detectedMiningStartTime": "2026-01-20T11:40:00Z",
+        |      "detectedMiningEndTime": "2026-01-20T12:04:00Z",
+        |      "vmIp": [
+        |        "35.232.132.254"
+        |      ],
+        |      "vmResource": [
+        |        "projects/terra-805a7c14/zones/us-central1-a/instances/4713536777184052026"
+        |      ],
+        |      "remotePort": [
+        |        8169
+        |      ]
+        |    }
+        |  },
+        |  "resource": {
+        |    "type": "abuseevent.googleapis.com/Location",
+        |    "labels": {
+        |      "location": "global",
+        |      "resource_container": "projects/135908015598"
+        |    }
+        |  },
+        |  "timestamp": "2026-01-20T12:15:59.202758798Z",
+        |  "severity": "NOTICE",
+        |  "labels": {
+        |    "abuseevent.googleapis.com/vm_resource": "projects/terra-805a7c14/zones/us-central1-a/instances/4713536777184052026"
+        |  },
+        |  "logName": "projects/terra-805a7c14/logs/abuseevent.googleapis.com%2Fabuse_events",
+        |  "receiveTimestamp": "2026-01-20T12:16:00.119885442Z"
+        |}
+        |""".stripMargin
+    val expectedResult = NonLeoMessage.CryptoMiningAbuseEvent(
+      "CRYPTO_MINING",
+      GoogleResource(
+        GoogleLabels(4713536777184052026L, ZoneName("us-central1-a"))
+      ),
+      GoogleProject("terra-805a7c14")
+    )
+    decode[NonLeoMessage](jsonString) shouldBe Right(expectedResult)
+  }
+
   it should "ignore NonLeoMessage.CryptominingScc when category is not supported" in {
     val jsonString =
       """
@@ -293,6 +347,31 @@ class NonLeoMessageSubscriberSpec extends AnyFlatSpec with LeonardoTestSuite wit
                                     CommonTestData.defaultGceRuntimeConfig.zone
             ),
             Finding(SccCategory("Execution: Cryptocurrency Mining Combined Detection"))
+          )
+        )
+        statusAfterUpdate <- clusterQuery.getClusterStatus(runtime.id).transaction
+        deletedFrom <- clusterQuery.getDeletedFrom(runtime.id).transaction
+      } yield {
+        statusAfterUpdate.get shouldBe (RuntimeStatus.Deleted)
+        deletedFrom.get shouldBe "cryptomining: scc"
+      }
+    }
+  }
+
+  it should "handle cryptomining-abuse-event message" in isolatedDbTest {
+    ioAssertion {
+      for {
+        runtime <- IO(
+          makeCluster(1)
+            .copy(status = RuntimeStatus.Running)
+            .saveWithRuntimeConfig(CommonTestData.defaultGceRuntimeConfig)
+        )
+        subscriber = makeSubscribler()
+        _ <- subscriber.messageResponder(
+          NonLeoMessage.CryptoMiningAbuseEvent(
+            "CRYPTO_MINING",
+            GoogleResource(GoogleLabels(runtime.id, CommonTestData.defaultGceRuntimeConfig.zone)),
+            GoogleProject(runtime.cloudContext.asString)
           )
         )
         statusAfterUpdate <- clusterQuery.getClusterStatus(runtime.id).transaction

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/NonLeoMessageSubscriberSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/NonLeoMessageSubscriberSpec.scala
@@ -361,18 +361,20 @@ class NonLeoMessageSubscriberSpec extends AnyFlatSpec with LeonardoTestSuite wit
   it should "handle cryptomining-abuse-event message" in isolatedDbTest {
     ioAssertion {
       for {
-        runtime <- IO(
-          makeCluster(1)
-            .copy(status = RuntimeStatus.Running)
-            .saveWithRuntimeConfig(CommonTestData.defaultGceRuntimeConfig)
-        )
-        subscriber = makeSubscribler()
-        _ <- subscriber.messageResponder(
-          NonLeoMessage.CryptoMiningAbuseEvent(
-            "CRYPTO_MINING",
-            GoogleResource(GoogleLabels(runtime.id, CommonTestData.defaultGceRuntimeConfig.zone)),
-            GoogleProject(runtime.cloudContext.asString)
-          )
+        runtime <- IO(makeCluster(1).save())
+        computeService = new FakeGoogleComputeService {
+          override def getInstance(project: GoogleProject, zone: ZoneName, instanceName: InstanceName)(implicit
+                                                                                                       ev: Ask[IO, TraceId]
+          ): cats.effect.IO[scala.Option[com.google.cloud.compute.v1.Instance]] =
+            IO.pure(Some(Instance.newBuilder().setName(runtime.runtimeName.asString).build()))
+        }
+        subscriber = makeSubscribler(computeService = computeService)
+        _ <- subscriber.handleCryptoMiningAbuseEventMessage(
+          NonLeoMessage
+            .CryptoMiningAbuseEvent("CRYPTO_MINING",
+              GoogleResource(GoogleLabels(123L, ZoneName("us-central1-a"))),
+              GoogleProject(runtime.cloudContext.asString)
+            )
         )
         statusAfterUpdate <- clusterQuery.getClusterStatus(runtime.id).transaction
         deletedFrom <- clusterQuery.getDeletedFrom(runtime.id).transaction


### PR DESCRIPTION
<!-- Welcome to your Leonardo pull request! -->
<!-- Contributor guidelines: https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md -->

__Jira ticket__: https://broadworkbench.atlassian.net/browse/CTM-322

<!-- ## Dependencies -->
<!-- Include any dependent tickets and describe the relationship. Include any other relevant Jira tickets. -->

## Summary of changes

<!-- Please give an abridged version of the ticket description here and/or fill out the following fields. -->

### What

- This updates the current pubsub message subscriber to process a new type of message that google emits when cryptomining is detected on a VM
- It decodes this message and sends a deleteRuntimeMessage

### Why

- Our current detection system is outdated and has been failing to detect cryptomining. This depends on google's detection system rather than our own to stay in compliance with their and out TOS

## Testing these changes

### What to test

- <!-- Test case 1 -->

<!-- ### Test data -->

### Who tested and where

- [ ] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [ ] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
