### PR TITLE
[CTM-19] Move disk resize before starting the server

### DIFF
--- a/http/src/main/resources/init-resources/gce-init.sh
+++ b/http/src/main/resources/init-resources/gce-init.sh
@@ -243,12 +243,6 @@ for Disk in "${AllsdDisks[@]}"; do
 done
 DISK_DEVICE_ID=${FreesdDisks}
 
-# Resize persistent disk if needed.
-# Must be done before trying to start the servers, otherwise it will fail to start if the disk is full.
-echo "Resizing persistent disk attached to runtime $GOOGLE_PROJECT / $CLUSTER_NAME if disk size changed..."
-resize2fs ${DISK_DEVICE_ID}
-
-
 ## Only format disk is it hasn't already been formatted
 if [ "$IS_GCE_FORMATTED" == "false" ] ; then
   # It's likely that the persistent disk was previously mounted on another VM and wasn't properly unmounted
@@ -261,6 +255,11 @@ if [ "$IS_GCE_FORMATTED" == "false" ] ; then
 fi
 
 mount -t ext4 -O discard,defaults ${DISK_DEVICE_ID} ${WORK_DIRECTORY}
+
+# Resize persistent disk if needed.
+# Must be done before trying to start the servers, otherwise it will fail to start if the disk is full.
+echo "Resizing persistent disk attached to runtime $GOOGLE_PROJECT / $CLUSTER_NAME if disk size changed..."
+resize2fs ${DISK_DEVICE_ID}
 
 # done persistent disk setup
 STEP_TIMINGS+=($(date +%s))

--- a/http/src/main/resources/init-resources/gce-init.sh
+++ b/http/src/main/resources/init-resources/gce-init.sh
@@ -243,6 +243,12 @@ for Disk in "${AllsdDisks[@]}"; do
 done
 DISK_DEVICE_ID=${FreesdDisks}
 
+# Resize persistent disk if needed.
+# Must be done before trying to start the servers, otherwise it will fail to start if the disk is full.
+echo "Resizing persistent disk attached to runtime $GOOGLE_PROJECT / $CLUSTER_NAME if disk size changed..."
+resize2fs ${DISK_DEVICE_ID}
+
+
 ## Only format disk is it hasn't already been formatted
 if [ "$IS_GCE_FORMATTED" == "false" ] ; then
   # It's likely that the persistent disk was previously mounted on another VM and wasn't properly unmounted
@@ -625,11 +631,6 @@ RSTUDIO_USER_HOME=$RSTUDIO_USER_HOME" >> /usr/local/lib/R/etc/Renviron.site'
   # Start RStudio server
   retry 3 docker exec -d ${RSTUDIO_SERVER_NAME} /init
 fi
-
-# Resize persistent disk if needed.
-echo "Resizing persistent disk attached to runtime $GOOGLE_PROJECT / $CLUSTER_NAME if disk size changed..."
-resize2fs ${DISK_DEVICE_ID}
-
 
 # Remove any unneeded cached images to save disk space.
 # Do this asynchronously so it doesn't hold up cluster creation


### PR DESCRIPTION
<!-- Welcome to your Leonardo pull request! -->
<!-- Contributor guidelines: https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md -->

__Jira ticket__: https://broadworkbench.atlassian.net/browse/CTM-19
<!-- ## Dependencies -->
<!-- Include any dependent tickets and describe the relationship. Include any other relevant Jira tickets. -->

## Summary of changes

<!-- Please give an abridged version of the ticket description here and/or fill out the following fields. -->

### What

- Moves the resize command to update the filesystem allocation to before the jupyter/rstudio servers are started in the gce-init scipt

### Why

- If the servers are started before the resize happens upon runtime creation, they fail when the disk is full
- In this error case, users are stuck and can't recover their disk without manual intervention

## Testing these changes

### What to test

- Create a runtime
- Fill the disk
- Try to pause, see that it never starts up
- Recreate runtime with full disk, see that it errors
- Delete errored runtime
- Recreate, but increase disk size
- Creation should succeed

<!-- ### Test data -->

### Who tested and where

- [ ] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [ ] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
