### PR TITLE
CTM-408 Properly exclude `netty-codec-http2`

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -151,11 +151,11 @@ object Dependencies {
   def excludeLiquibase = ExclusionRule("org.liquibase", "liquibase-core")
   def excludeFlagsmith = ExclusionRule("com.flagsmith", "flagsmith-java-client")
   def excludeJsonSmart = ExclusionRule("net.minidev", "json-smart")
-  def excludeNettyCodecHttp = ExclusionRule("io.netty", "netty-codec-http")
+  def excludeNettyCodecHttp2 = ExclusionRule("io.netty", "netty-codec-http2")
 
   // [IA-4939] commons-text:1.9 is unsafe
   def excludeCommonsText = ExclusionRule("org.apache.commons", "commons-text")
-  def tclExclusions(m: ModuleID): ModuleID = m.excludeAll(excludeSpringBoot, excludeSpringAop, excludeSpringData, excludeSpringFramework, excludeOpenCensus, excludeGoogleFindBugs, excludeBroadWorkbench, excludePostgresql, excludeSnakeyaml, excludeSlf4j, excludeCommonsText, excludeLiquibase, excludeFlagsmith, excludeJsonSmart, excludeNettyCodecHttp)
+  def tclExclusions(m: ModuleID): ModuleID = m.excludeAll(excludeSpringBoot, excludeSpringAop, excludeSpringData, excludeSpringFramework, excludeOpenCensus, excludeGoogleFindBugs, excludeBroadWorkbench, excludePostgresql, excludeSnakeyaml, excludeSlf4j, excludeCommonsText, excludeLiquibase, excludeFlagsmith, excludeJsonSmart, excludeNettyCodecHttp2)
   val terraCommonLib = tclExclusions(excludeJakarta("bio.terra" % "terra-common-lib" % terraCommonLibV classifier "plain"))
   val sam = excludeJakarta("org.broadinstitute.dsde.workbench" %% "sam-client" % samV)
 


### PR DESCRIPTION
It seems that the library upgraded to v2, so our exclude stopped working.

Before:
```
> sbt dependencyTree | grep netty-codec-http2
[info]   | | | | +-io.netty:netty-codec-http2:4.1.118.Final
[info]   | | | |   +-io.netty:netty-codec-http2:4.1.112.Final (evicted by: 4.1.118.Fi..
[info]   | | | |   +-io.netty:netty-codec-http2:4.1.118.Final
[info]   | | | | +-io.netty:netty-codec-http2:4.1.118.Final
[...and many more]
```
After:
```
> sbt dependencyTree | grep netty-codec-http2
anichols@Mac ~/P/leonardo (aen_ctm_408) [0|1]>
```
