### PR TITLE
[CTM-453, CTM-451] Update netty & logback

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -57,7 +57,7 @@ object Dependencies {
 
   val jose4j: ModuleID =  "org.bitbucket.b_c" % "jose4j" % "0.9.4"
 
-  val logbackClassic: ModuleID =  "ch.qos.logback"              % "logback-classic" % "1.4.14"
+  val logbackClassic: ModuleID =  "ch.qos.logback"              % "logback-classic" % "1.5.25"
   val scalaLogging: ModuleID =    "com.typesafe.scala-logging"  %% "scala-logging"  % scalaLoggingV
   val ficus: ModuleID =           "com.iheart"                  %% "ficus"          % "1.5.2"
   val enumeratum: ModuleID =      "com.beachape"                %% "enumeratum"     % "1.7.3"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,6 +11,7 @@ object Dependencies {
   val scalaTestV = "3.2.17"
   val http4sVersion = "0.23.33"
   val slickV = "3.4.1"
+  val nettyCodecHttpV = "4.1.132.Final"
   val guavaV = "32.1.3-jre"
   val monocleV = "3.2.0"
   val opencensusV = "0.29.0"
@@ -130,6 +131,7 @@ object Dependencies {
   val http4sEmberServer = "org.http4s"        %% "http4s-ember-server"  % http4sVersion
   val http4sCirce       = "org.http4s"        %% "http4s-circe"  % http4sVersion
 
+  val nettyCodecHttp: ModuleID = "io.netty" % "netty-codec-http" % nettyCodecHttpV
   val guava: ModuleID =   "com.google.guava"  % "guava"                 % guavaV
   val okHttp =            "com.squareup.okhttp3"  % "okhttp"            % "4.12.0"
 
@@ -221,6 +223,7 @@ object Dependencies {
   val ssh: ModuleID = "com.hierynomus" % "sshj" % "0.37.0" % "test"
   val googleCloudOSLogin = "com.google.cloud" % "google-cloud-os-login" % "2.2.7" % "test"
 
+  val commonOverrides = List(nettyCodecHttp)
   val automationOverrides = List(guava)
 
   val automationDependencies = List(

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -89,7 +89,8 @@ object Settings {
     organization  := "org.broadinstitute.dsde.workbench",
     scalaVersion  := "2.13.12",
     resolvers ++= commonResolvers,
-    scalacOptions ++= commonCompilerSettings
+    scalacOptions ++= commonCompilerSettings,
+    dependencyOverrides ++= Dependencies.commonOverrides
   )
 
   val coreSettings = commonSettings ++ commonTestSettings ++ List(


### PR DESCRIPTION
<!-- Welcome to your Leonardo pull request! -->
<!-- Contributor guidelines: https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md -->

__Jira ticket__: https://broadworkbench.atlassian.net/browse/CTM-453
https://broadworkbench.atlassian.net/browse/CTM-451

<!-- ## Dependencies -->
<!-- Include any dependent tickets and describe the relationship. Include any other relevant Jira tickets. -->

## Summary of changes

<!-- Please give an abridged version of the ticket description here and/or fill out the following fields. -->
- Update `logback-classic` to 1.5.25, which will pull in `logback-core` 1.5.25 transitively.
- Pin `netty-codec-http` to `4.1.132.Final` via `dependencyOverrides` to address a security vulnerability in the previously resolved version                         
   - `dependencyOverrides` is used rather than `libraryDependencies` because it forces the version regardless of what transitive dependencies request — a hard pin that wins conflict resolution                                                                                                                                             
   - Applied in `commonSettings` so the override covers all subprojects (core, http, automation)                                                                      
   - Only `netty-codec-http` is pinned (not the full Netty BOM) since the CVE is specific to that artifact; `sbt evicted` should be checked post-merge to confirm no version skew with other Netty artifacts   

## Testing these changes

### What to test

- <!-- Test case 1 -->

<!-- ### Test data -->

### Who tested and where

- [ ] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [ ] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
