### PR TITLE
[CTM-449] Update workbench libs for swagger-ui

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/ProxyRedirectClient.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/ProxyRedirectClient.scala
@@ -36,7 +36,7 @@ object ProxyRedirectClient {
   def startServer(): IO[Int] =
     for {
       serverAndShutDown <- ProxyRedirectClient.server
-      port = serverAndShutDown._1.address.getPort
+      port = serverAndShutDown._1.address.port.value
       _ <- serverRef.modify(mp => (mp, mp + (port -> serverAndShutDown)))
     } yield port
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,7 +9,7 @@ object Dependencies {
   val automationGoogleV = "1.30.5"
   val scalaLoggingV = "3.9.5"
   val scalaTestV = "3.2.17"
-  val http4sVersion = "0.23.33"
+  val http4sVersion = "1.0.0-M38"
   val slickV = "3.4.1"
   val nettyCodecHttpV = "4.1.132.Final"
   val guavaV = "32.1.3-jre"
@@ -18,7 +18,7 @@ object Dependencies {
   val munitCatsEffectV = "1.0.7"
   val commonsBeanUtilsV = "1.11.0"
 
-  private val workbenchLibsHash = "41ed6208-SNAP"
+  private val workbenchLibsHash = "be59bd7"
   val serviceTestV = s"6.1-$workbenchLibsHash"
   val workbenchModelV = s"0.21-$workbenchLibsHash"
   val workbenchGoogleV = s"0.35-$workbenchLibsHash"
@@ -125,7 +125,7 @@ object Dependencies {
   val googleCloudNio: ModuleID =  "com.google.cloud"    % "google-cloud-nio"      % "0.127.7" % Test // brought in for FakeStorageInterpreter
 
   val circeYaml =         "io.circe"          %% "circe-yaml"           % "0.15.1"
-  val http4sPrometheus = "org.http4s" %% "http4s-prometheus-metrics" % "0.25.0"
+  val http4sPrometheus = "org.http4s" %% "http4s-prometheus-metrics" % "1.0.0-M38"
   val http4sDsl =         "org.http4s"        %% "http4s-dsl"           % http4sVersion
   val http4sEmberClient = "org.http4s"        %% "http4s-ember-client"  % http4sVersion
   val http4sEmberServer = "org.http4s"        %% "http4s-ember-server"  % http4sVersion
@@ -202,6 +202,7 @@ object Dependencies {
     akkaHttpTestKit,
     akkaStream,
     http4sPrometheus,
+    http4sEmberClient,
     "de.heikoseeberger" %% "akka-http-circe" % "1.39.2" excludeAll(excludeAkkaHttp, excludeAkkaStream),
     googleRpc,
     hikariCP,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -248,6 +248,7 @@ object Dependencies {
     scalaTest,
     scalaTestSelenium,
     scalaTestMockito,
+    http4sEmberClient,
     http4sEmberServer % Test,
     okHttp % Test
   )


### PR DESCRIPTION
<!-- Welcome to your Leonardo pull request! -->
<!-- Contributor guidelines: https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md -->

__Jira ticket__: https://broadworkbench.atlassian.net/browse/CTM-449

<!-- ## Dependencies -->
<!-- Include any dependent tickets and describe the relationship. Include any other relevant Jira tickets. -->

## Summary of changes

<!-- Please give an abridged version of the ticket description here and/or fill out the following fields. -->

### What

- Update workbench-oauth2 to 0.9-be59bd7 to pick up a swagger-ui security fix (5.26.2 → 5.32.1). The new workbench-libs commit is on the develop branch which had already bumped http4s from 0.23.33 to 1.0.0-M38, so we needed to upgrade Leonardo's own http4s dependencies to match. http4s-prometheus-metrics was bumped to its corresponding 1.0.0-M38 release, and http4s-ember-client was added as an explicit dependency since it's no longer pulled in transitively by workbench-libs at this version.

### Why

-

## Testing these changes

### What to test

- <!-- Test case 1 -->

<!-- ### Test data -->

### Who tested and where

- [x] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [ ] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
