### PR TITLE
CTM-414: Fix RStudio image detection when JUPYTER_HOME is also present

### DIFF
--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpDockerDAO.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpDockerDAO.scala
@@ -185,7 +185,9 @@ object HttpDockerDAO {
   val dockerHubAuthUri = Uri.unsafeFromString("https://auth.docker.io")
   val ghcrAuthUri = Uri.unsafeFromString("https://ghcr.io")
   val dockerHubRegistryUri = Uri.unsafeFromString("https://registry-1.docker.io")
-  val clusterToolEnv = Map(Jupyter -> "JUPYTER_HOME", RStudio -> "RSTUDIO_HOME")
+  // RStudio must be checked before Jupyter: an image may inherit JUPYTER_HOME from a Jupyter
+  // base image while also defining RSTUDIO_HOME, and the more specific signal should win.
+  val clusterToolEnv = List(RStudio -> "RSTUDIO_HOME", Jupyter -> "JUPYTER_HOME")
 
   def apply[F[_]: Concurrent](httpClient: Client[F])(implicit logger: Logger[F]): HttpDockerDAO[F] =
     new HttpDockerDAO[F](httpClient)


### PR DESCRIPTION
<!-- Welcome to your Leonardo pull request! -->
<!-- Contributor guidelines: https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md -->

__Jira ticket__: https://broadworkbench.atlassian.net/browse/CTM-413

## Problem

Custom RStudio environments built on a Jupyter base image fail to launch because Leonardo misclassifies them as Jupyter runtimes.
Leonardo's `HttpDockerDAO.detectTool()` determines the image type by scanning the container's env vars for either `JUPYTER_HOME` (Jupyter) or `RSTUDIO_HOME` (RStudio). The lookup used `Map(Jupyter -> "JUPYTER_HOME", RStudio -> "RSTUDIO_HOME")` with `.find`, which in Scala 2.13 iterates in insertion order — meaning Jupyter was always checked first.

When an image inherits `JUPYTER_HOME` from a Jupyter base image *and* defines `RSTUDIO_HOME` in its own Dockerfile, the old code classified it as Jupyter. The misclassified image type was persisted to the DB at creation time, so `startup.sh` received a populated `JUPYTER_DOCKER_IMAGE` and an empty `RSTUDIO_DOCKER_IMAGE`, causing the Jupyter launch path to run against an image that isn't a Jupyter image — resulting in a timeout.

## Fix

Change `clusterToolEnv` from a `Map` to an ordered `List` with RStudio first. This makes the priority explicit and independent of any `Map` implementation details: if both env vars are present, RStudio wins as the more specific signal.