### PR TITLE
[CTM-525] new workbench-libs and update ember

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/GeneratedLeonardoClient.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/GeneratedLeonardoClient.scala
@@ -18,6 +18,8 @@ import org.http4s.client.Client
 import org.http4s.client.middleware.{Logger, Retry, RetryPolicy}
 import org.http4s.headers.Authorization
 import org.http4s.ember.client.EmberClientBuilder
+import org.typelevel.log4cats.LoggerFactory
+import org.typelevel.log4cats.slf4j.Slf4jFactory
 
 import scala.concurrent.duration._
 
@@ -26,6 +28,7 @@ import scala.concurrent.duration._
  * Favor this client over `LeonardoApiClient`
  */
 object GeneratedLeonardoClient {
+  implicit val loggerFactory: LoggerFactory[IO] = Slf4jFactory.create[IO]
   private val rootUri = Uri.fromString(LeonardoConfig.Leonardo.apiUrl)
 
   val client: Resource[IO, Client[IO]] =

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoApiClient.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/LeonardoApiClient.scala
@@ -22,8 +22,8 @@ import org.http4s.client.Client
 import org.http4s.client.middleware.{Logger, Retry, RetryPolicy}
 import org.http4s.ember.client.EmberClientBuilder
 import org.http4s.headers._
-import org.typelevel.log4cats.StructuredLogger
-import org.typelevel.log4cats.slf4j.Slf4jLogger
+import org.typelevel.log4cats.{LoggerFactory, StructuredLogger}
+import org.typelevel.log4cats.slf4j.{Slf4jFactory, Slf4jLogger}
 
 import java.util.UUID
 import java.util.concurrent.TimeoutException
@@ -38,6 +38,7 @@ import scala.util.control.NoStackTrace
 object LeonardoApiClient {
   val defaultMediaType = `Content-Type`(MediaType.application.json)
   implicit val logger: StructuredLogger[IO] = Slf4jLogger.getLogger[IO]
+  implicit val loggerFactory: LoggerFactory[IO] = Slf4jFactory.create[IO]
 
   implicit def http4sBody[A](body: A)(implicit encoder: EntityEncoder[IO, A]): EntityBody[IO] =
     encoder.toEntity(body).body

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/ProxyRedirectClient.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/ProxyRedirectClient.scala
@@ -13,9 +13,12 @@ import org.http4s.headers.{`Content-Type`, Referer}
 import org.http4s.implicits._
 import org.http4s.server.Server
 import org.http4s._
+import org.typelevel.log4cats.LoggerFactory
+import org.typelevel.log4cats.slf4j.Slf4jFactory
 
 // This is for setting `REFERER` header in automation tests
 object ProxyRedirectClient {
+  implicit val loggerFactory: LoggerFactory[IO] = Slf4jFactory.create[IO]
   // serverRef is Singleton http4s server to serve the proxy redirect page.
   // Explanation of the type:
   //   `Ref` is a cats-effect reference, used to cache a single instance of the server

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/BaselineDependenciesBuilder.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/BaselineDependenciesBuilder.scala
@@ -55,7 +55,8 @@ import org.broadinstitute.dsde.workbench.util2.messaging.{CloudPublisher, CloudS
 import org.broadinstitute.dsp.HelmInterpreter
 import org.http4s.Request
 import org.http4s.client.middleware.{Logger => Http4sLogger, Metrics, Retry, RetryPolicy}
-import org.typelevel.log4cats.StructuredLogger
+import org.typelevel.log4cats.{LoggerFactory, StructuredLogger}
+import org.typelevel.log4cats.slf4j.Slf4jFactory
 import scalacache.Cache
 import scalacache.caffeine.CaffeineCache
 import java.net.SocketException
@@ -119,6 +120,7 @@ class BaselineDependenciesBuilder {
       )(_.close)
 
       cloudAuthTokenProvider = CloudAuthTokenProvider[F](applicationConfig)
+      implicit0(loggerFactory: LoggerFactory[F]) = Slf4jFactory.create[F]
 
       samClientProvider = new HttpSamApiClientProvider(httpSamDaoConfig.samUri.renderString,
                                                        httpSamDaoConfig.maxConcurrentRequests
@@ -299,7 +301,7 @@ class BaselineDependenciesBuilder {
       .recordStats()
       .build[K, V]()
 
-  private def buildHttpClient[F[_]: Async: StructuredLogger: Network](
+  private def buildHttpClient[F[_]: Async: StructuredLogger: Network: LoggerFactory](
     sslContext: SSLContext,
     hostToIpMapping: Ref[F, Map[String, IP]],
     metricsPrefix: Option[String],

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HTTPAppDescriptorDAOSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HTTPAppDescriptorDAOSpec.scala
@@ -10,10 +10,13 @@ import org.scalatest.matchers.should.Matchers
 import org.http4s.client.Client
 import org.http4s._
 import org.http4s.ember.client.EmberClientBuilder
+import org.typelevel.log4cats.LoggerFactory
+import org.typelevel.log4cats.slf4j.Slf4jFactory
 import org.broadinstitute.dsde.workbench.leonardo.TestUtils.appContext
 import scala.concurrent.ExecutionContext.global
 
 class HTTPAppDescriptorDAOSpec extends AnyFlatSpec with Matchers with BeforeAndAfterAll with LeonardoTestSuite {
+  implicit val loggerFactory: LoggerFactory[IO] = Slf4jFactory.create[IO]
   // NOTE: If this is not a valid link, tests will fail
   val appYamlURI: Uri = Uri.uri("https://raw.githubusercontent.com/DataBiosphere/terra-app/main/apps/rstudio/app.yaml")
   // NOTE: no tests here actually use the http response from this URI

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpDockerDAOSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpDockerDAOSpec.scala
@@ -12,6 +12,8 @@ import org.broadinstitute.dsde.workbench.leonardo.dao.HttpDockerDAO._
 import org.broadinstitute.dsde.workbench.leonardo.model.InvalidImage
 import org.http4s.ember.client.EmberClientBuilder
 import org.http4s.client.middleware.Logger
+import org.typelevel.log4cats.LoggerFactory
+import org.typelevel.log4cats.slf4j.Slf4jFactory
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -19,6 +21,7 @@ import org.broadinstitute.dsde.workbench.leonardo.http.ctxConversion
 import org.broadinstitute.dsde.workbench.leonardo.TestUtils.appContext
 
 class HttpDockerDAOSpec extends AnyFlatSpec with Matchers with BeforeAndAfterAll with LeonardoTestSuite {
+  implicit val loggerFactory: LoggerFactory[IO] = Slf4jFactory.create[IO]
   val jupyterImages = List(
     // TODO this will break if AoU moves off Dockerhub and we delete these images
     // dockerhub with tag

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpSamDAOSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/HttpSamDAOSpec.scala
@@ -22,8 +22,8 @@ import org.http4s.client.middleware.{Retry, RetryPolicy}
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatestplus.mockito.MockitoSugar
-import org.typelevel.log4cats.Logger
-import org.typelevel.log4cats.slf4j.Slf4jLogger
+import org.typelevel.log4cats.{Logger, LoggerFactory}
+import org.typelevel.log4cats.slf4j.{Slf4jFactory, Slf4jLogger}
 import scalacache.caffeine.CaffeineCache
 
 import java.util.UUID
@@ -34,6 +34,7 @@ class HttpSamDAOSpec extends AnyFlatSpec with LeonardoTestSuite with BeforeAndAf
   val cloudAuthProvider = mock[CloudAuthTokenProvider[IO]]
   val config = HttpSamDaoConfig(Uri.unsafeFromString("localhost"), false, 1 seconds, 10, 15)
   implicit def unsafeLogger: Logger[IO] = Slf4jLogger.getLogger[IO]
+  implicit val loggerFactory: LoggerFactory[IO] = Slf4jFactory.create[IO]
   val underlyingPetTokenCache = Caffeine
     .newBuilder()
     .maximumSize(httpSamDaoConfig.petCacheMaxSize)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,7 +9,7 @@ object Dependencies {
   val automationGoogleV = "1.30.5"
   val scalaLoggingV = "3.9.5"
   val scalaTestV = "3.2.17"
-  val http4sVersion = "1.0.0-M38"
+  val http4sVersion = "1.0.0-M45"
   val slickV = "3.4.1"
   val nettyCodecHttpV = "4.1.133.Final"
   val guavaV = "32.1.3-jre"
@@ -19,13 +19,13 @@ object Dependencies {
   val munitCatsEffectV = "1.0.7"
   val commonsBeanUtilsV = "1.11.0"
 
-  private val workbenchLibsHash = "3a18911"
+  private val workbenchLibsHash = "a91095a"
   val serviceTestV = s"6.1-$workbenchLibsHash"
   val workbenchModelV = s"0.21-$workbenchLibsHash"
   val workbenchGoogleV = s"0.35-$workbenchLibsHash"
-  val workbenchGoogle2V = s"0.40-$workbenchLibsHash"
+  val workbenchGoogle2V = s"0.41-$workbenchLibsHash"
   val workbenchOpenTelemetryV = s"0.9-$workbenchLibsHash"
-  val workbenchOauth2V = s"0.9-$workbenchLibsHash"
+  val workbenchOauth2V = s"0.10-$workbenchLibsHash"
 
   val helmScalaSdkV = "0.0.9.1"
 

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -90,7 +90,8 @@ object Settings {
     scalaVersion  := "2.13.12",
     resolvers ++= commonResolvers,
     scalacOptions ++= commonCompilerSettings,
-    dependencyOverrides ++= Dependencies.commonOverrides
+    dependencyOverrides ++= Dependencies.commonOverrides,
+    libraryDependencySchemes += "org.http4s" %% "http4s-core" % "always"
   )
 
   val coreSettings = commonSettings ++ commonTestSettings ++ List(


### PR DESCRIPTION
<!-- Welcome to your Leonardo pull request! -->
<!-- Contributor guidelines: https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md -->

__Jira ticket__: https://broadworkbench.atlassian.net/browse/CTM-525

<!-- ## Dependencies -->
<!-- Include any dependent tickets and describe the relationship. Include any other relevant Jira tickets. -->

## Summary of changes
Leonardo updated its `workbench-libs` dependency to the to get http4s upgraded from 1.0.0-M38 to 1.0.0-M45. Since `http4s-prometheus-metrics` stops publishing at M38, it is pinned at that version with a libraryDependencySchemes override to suppress the eviction error. The new `LoggerFactory[F]` requirement from `ember` and `http4s` M45's Retry middleware was satisfied by injecting a Slf4jFactory-derived implicit at the relevant call sites in production and test code.

Note: I think the codecov failure can be safely ignored - do you agree, reviewer?

### What

-

### Why

-

## Testing these changes

### What to test

- <!-- Test case 1 -->

<!-- ### Test data -->

### Who tested and where

- [ ] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [ ] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
