### PR TITLE
CTM-554 Fix `terra_base` vs. `terra-base`

### DIFF
--- a/jenkins/dataproc-custom-images/prepare-custom-leonardo-jupyter-dataproc-image.sh
+++ b/jenkins/dataproc-custom-images/prepare-custom-leonardo-jupyter-dataproc-image.sh
@@ -34,7 +34,7 @@ cryptomining_detector="us.gcr.io/broad-dsp-gcr-public/cryptomining-detector:0.0.
 
 # This array determines which of the above images are baked into the custom dataproc 2.2.x image
 # the entry must match the var name above, which must correspond to a valid docker URI
-docker_image_var_names="welder_server terra-base terra_jupyter_python terra_jupyter_r terra_jupyter_bioconductor terra_jupyter_hail terra_jupyter_gatk terra_jupyter_aou openidc_proxy anvil_rstudio_bioconductor cryptomining_detector"
+docker_image_var_names="welder_server terra_base terra_jupyter_python terra_jupyter_r terra_jupyter_bioconductor terra_jupyter_hail terra_jupyter_gatk terra_jupyter_aou openidc_proxy anvil_rstudio_bioconductor cryptomining_detector"
 
 # Comment the above and uncomment this to create the dataproc 2.1.x image
 # You would also need to revert the dataproc versions in the create_dataproc_image.sh like this:


### PR DESCRIPTION
Fix a small issue introduced in https://github.com/DataBiosphere/leonardo/pull/4888

`terra-base` is the image name while `terra_base` is the bash variable name, now they are properly separated.

This PR's only objective is to return the job to green status. Future PR(s) will address the 60 => 365 day expiration change.