### PR TITLE
CTM-554 Regenerate Dataproc image from `develop`

### DIFF
--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -70,8 +70,8 @@ dataproc {
   }
 
   # Cached dataproc 2.2.x image used by Terra
-  # must be re-generated every 60 days
-  customDataprocImage = "projects/broad-dsp-gcr-public/global/images/leo-dataproc-image-2-2-52-debian12-2026-01-12-14-32-56"
+  # must be re-generated every 365 days
+  customDataprocImage = "projects/broad-dsp-gcr-public/global/images/leo-dataproc-image-2-2-52-debian12-2026-06-22-19-09-53"
 
   # The ratio of memory allocated to spark. 0.8 = 80%.
   # Hail/Spark users generally allocate 80% of the ram to the JVM.


### PR DESCRIPTION
Enabled by fixed build in https://github.com/DataBiosphere/leonardo/pull/4915

As of [October 2023](https://docs.cloud.google.com/managed-spark/docs/release-notes#October_30_2023) we only need to regenerate every 365 days.

I will update the Slack reminder as well.