### PR TITLE
Update GKE version from 1.33 --> 1.34

### DIFF
--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -417,7 +417,7 @@ gke {
     ]
     # See https://cloud.google.com/kubernetes-engine/docs/release-notes
     # This is overwritten by the terra-helmfile KUBERNETES_VERSION value
-    version = "1.33" # supported till to 2026-08-03
+    version = "1.34" # supported till to 2027-01-25
     nodepoolLockCacheExpiryTime = 1 hour
     nodepoolLockCacheMaxSize = 200
 

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -417,7 +417,7 @@ gke {
     ]
     # See https://cloud.google.com/kubernetes-engine/docs/release-notes
     # This is overwritten by the terra-helmfile KUBERNETES_VERSION value
-    version = "1.34" # supported till to 2027-01-25
+    version = "1.34" # supported till to 2027-01-25, TODO: https://broadworkbench.atlassian.net/browse/CTM-609
     nodepoolLockCacheExpiryTime = 1 hour
     nodepoolLockCacheMaxSize = 200
 

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/config/ConfigSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/config/ConfigSpec.scala
@@ -84,7 +84,7 @@ final class ConfigSpec extends AnyFlatSpec with Matchers {
         "69.173.127.240/28",
         "69.173.112.0/21"
       ).map(CidrIP),
-      KubernetesClusterVersion("1.33"),
+      KubernetesClusterVersion("1.34"),
       1 hour,
       200,
       AutopilotConfig(AutopilotResource(500, 3, 1), AutopilotResource(500, 3, 1))


### PR DESCRIPTION
<!-- Welcome to your Leonardo pull request! -->
<!-- Contributor guidelines: https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md -->

__Jira ticket__: https://github.com/broadinstitute/terra-helmfile/pull/6470

<!-- ## Dependencies -->
<!-- Include any dependent tickets and describe the relationship. Include any other relevant Jira tickets. -->

## Summary of changes

Linked ticket: https://github.com/DataBiosphere/leonardo/pull/4917

### What

- Update GKE to 1.34

### Why

- 1.33 becomes EOL on 8/3

## Testing these changes

### What to test

- <!-- Test case 1 -->

<!-- ### Test data -->

### Who tested and where

- [ ] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [ ] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
