### PR TITLE
CTM-568: bump sam-client, which bumps Jackson

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -256,7 +256,7 @@ object Dependencies {
   val automationOverrides = List(guava)
 
   val automationDependencies = List(
-    "com.fasterxml.jackson.module" %% "jackson-module-scala"   % "2.18.0" % "test",
+    "com.fasterxml.jackson.module" %% "jackson-module-scala"   % "2.22.1" % "test",
     logbackClassic % "test",
     leonardoClient,
     ssh,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -157,7 +157,7 @@ object Dependencies {
   val okHttp =            "com.squareup.okhttp3"  % "okhttp"            % "4.12.0"
 
   val terraCommonLibV = "1.1.38-SNAPSHOT"
-  val samV = "v0.0.274"
+  val samV = "v0.0.448"
 
   def excludeJakartaActivationApi = ExclusionRule("jakarta.activation", "jakarta.activation-api")
   def excludeJakartaXmlBindApi = ExclusionRule("jakarta.xml.bind", "jakarta.xml.bind-api")


### PR DESCRIPTION
__Jira ticket__: https://broadworkbench.atlassian.net/browse/CTM-568

## Summary of changes

Bumps `sam-client` from `v0.0.274` to `v0.0.448`. This is a big jump!

The newer `sam-client` carries a transitive upgrade of jackson-databind from 2.18.3 to 2.22.1, which is the request in CTM-568.
