### PR TITLE
CTM-586: Scala update for new swagger-ui version

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -19,7 +19,7 @@ object Dependencies {
   val munitCatsEffectV = "1.0.7"
   val commonsBeanUtilsV = "1.11.0"
 
-  private val workbenchLibsHash = "fccb671"
+  private val workbenchLibsHash = "76e472e"
   val serviceTestV = s"6.2-$workbenchLibsHash"
   val workbenchModelV = s"0.21-$workbenchLibsHash"
   val workbenchGoogleV = s"0.36-$workbenchLibsHash"


### PR DESCRIPTION
CTM-586

Incorporate the swagger-ui fix from https://github.com/broadinstitute/workbench-libs/pull/1755

One of a series of 4 PRs:
1. https://github.com/broadinstitute/firecloud-orchestration/pull/1720
2. https://github.com/broadinstitute/rawls/pull/3570
3. https://github.com/broadinstitute/sam/pull/1758
4. https://github.com/DataBiosphere/leonardo/pull/4921
