### PR TITLE
CTM-628 COS upgrade

### DIFF
--- a/.github/workflows/custom_image_generation.yml
+++ b/.github/workflows/custom_image_generation.yml
@@ -62,7 +62,6 @@ jobs:
       shell: bash
       run: |
          OUTPUT_FILE_PATH="$GITHUB_WORKSPACE/$OUTPUT_FILE_RELATIVE_PATH" GCE_IMAGE_BUCKET=$GCE_IMAGE_BUCKET $GITHUB_WORKSPACE/jenkins/gce-custom-images/create_gce_image.sh
-         gsutil rm -r $GCE_IMAGE_BUCKET || true
 
     - name: Output image URI
       run: |

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,6 +1,0 @@
-# These owners will be the default owners for everything in
-# the repo. Unless a later match takes precedence,
-# @broadinstitute/manifold-analysis will be requested for
-# review when someone opens a pull request.
-* @DataBiosphere/manifold-analysis
-

--- a/http/src/main/resources/init-resources/gce-init.sh
+++ b/http/src/main/resources/init-resources/gce-init.sh
@@ -267,14 +267,22 @@ STEP_TIMINGS+=($(date +%s))
 # Enable GPU drivers on top of the base Google DeepLearning default image
 if [ "${GPU_ENABLED}" == "true" ] ; then
   log 'Installing GPU driver...'
-  version="535.154.05"
-  isAvailable=$(cos-extensions list|grep $version)
-  if [[ -z "$isAvailable" ]]; then
-      # Install default version on the COS image
-      cos-extensions install gpu
+  # Specify the current R580 LTS as a branch [0] so that runtimes pick up security and bug fixes over time.
+  # Pre-existing runtimes on cos-113-18244-85-64 do not have 580 available [1] so fall back to our previous pin.
+  #
+  # [0] https://docs.cloud.google.com/container-optimized-os/docs/how-to/run-gpus#install-driver
+  # [1] https://docs.cloud.google.com/container-optimized-os/docs/release-notes/m113#cos-113-18244-85-64
+  targetVersion="R580"
+  fallbackVersion="535.154.05"
+  availableDrivers=$(cos-extensions list || true)
+  if echo "${availableDrivers}" | grep -qF "${targetVersion}" ; then
+      cos-extensions install gpu -- --version "${targetVersion}"
+  elif echo "${availableDrivers}" | grep -qF "${fallbackVersion}" ; then
+      cos-extensions install gpu -- --version "${fallbackVersion}"
   else
-      cos-extensions install gpu -- --version $version
+      cos-extensions install gpu
   fi
+
   mount --bind /var/lib/nvidia /var/lib/nvidia
   mount -o remount,exec /var/lib/nvidia
 

--- a/http/src/main/resources/init-resources/gce-init.sh
+++ b/http/src/main/resources/init-resources/gce-init.sh
@@ -267,21 +267,15 @@ STEP_TIMINGS+=($(date +%s))
 # Enable GPU drivers on top of the base Google DeepLearning default image
 if [ "${GPU_ENABLED}" == "true" ] ; then
   log 'Installing GPU driver...'
-  # Specify the current R580 LTS as a branch [0] so that runtimes pick up security and bug fixes over time.
-  # Pre-existing runtimes on cos-113-18244-85-64 do not have 580 available [1] so fall back to our previous pin.
+  # The driver major version, e.g. R580, is constant for the duration of the COS milestone [0][1] and receives
+  # bugfixes and security patches over time. Validate new major version as part of upgrading to a new COS.
   #
-  # [0] https://docs.cloud.google.com/container-optimized-os/docs/how-to/run-gpus#install-driver
-  # [1] https://docs.cloud.google.com/container-optimized-os/docs/release-notes/m113#cos-113-18244-85-64
-  targetVersion="R580"
-  fallbackVersion="535.154.05"
-  availableDrivers=$(cos-extensions list || true)
-  if echo "${availableDrivers}" | grep -qF "${targetVersion}" ; then
-      cos-extensions install gpu -- --version "${targetVersion}"
-  elif echo "${availableDrivers}" | grep -qF "${fallbackVersion}" ; then
-      cos-extensions install gpu -- --version "${fallbackVersion}"
-  else
-      cos-extensions install gpu
-  fi
+  # COS 113: R535 (existing fleet)
+  # COS 129: R580 (2026 upgrade)
+  #
+  # [0] Exception: a later driver installs when a brand new GPU model is present that cannot use the default
+  # [1] https://docs.cloud.google.com/container-optimized-os/docs/how-to/run-gpus#install-driver
+  cos-extensions install gpu -- -version=default
 
   mount --bind /var/lib/nvidia /var/lib/nvidia
   mount -o remount,exec /var/lib/nvidia

--- a/http/src/main/resources/init-resources/gce-init.sh
+++ b/http/src/main/resources/init-resources/gce-init.sh
@@ -267,14 +267,16 @@ STEP_TIMINGS+=($(date +%s))
 # Enable GPU drivers on top of the base Google DeepLearning default image
 if [ "${GPU_ENABLED}" == "true" ] ; then
   log 'Installing GPU driver...'
-  # The driver major version, e.g. R580, is constant for the duration of the COS milestone [0][1] and receives
-  # bugfixes and security patches over time. Validate new major version as part of upgrading to a new COS.
+  # Install the default major version [0] for this COS milestone, e.g. R580.
+  # The default is constant for the duration of the milestone [1] and receives bugfixes and security patches over time.
+  # Validate new major version as part of upgrading to a new COS.
   #
   # COS 113: R535 (existing fleet)
   # COS 129: R580 (2026 upgrade)
   #
-  # [0] Exception: a later driver installs when a brand new GPU model is present that cannot use the default
-  # [1] https://docs.cloud.google.com/container-optimized-os/docs/how-to/run-gpus#install-driver
+  # [0] https://docs.cloud.google.com/container-optimized-os/docs/how-to/run-gpus#install-driver
+  # [1] Exception: when new GPU models release after the default driver was cut, they get a newer default.
+  #     https://docs.cloud.google.com/container-optimized-os/docs/release-notes/m113#February_12_2025
   cos-extensions install gpu -- -version=default
 
   mount --bind /var/lib/nvidia /var/lib/nvidia

--- a/http/src/main/resources/init-resources/gce-init.sh
+++ b/http/src/main/resources/init-resources/gce-init.sh
@@ -68,8 +68,8 @@ DOCKER_COMPOSE_FILES_DIRECTORY='/var/docker-compose-files'
 WORK_DIRECTORY='/mnt/disks/work'
 # Toolbox is specific to COS images and is needed to access functionalities like gcloud
 # See https://cloud.google.com/container-optimized-os/docs/how-to/toolbox
-GSUTIL_CMD='docker run --rm -v /var:/var us.gcr.io/cos-cloud/toolbox:v20230714 gsutil'
-GCLOUD_CMD='docker run --rm -v /var:/var us.gcr.io/cos-cloud/toolbox:v20230714 gcloud'
+GSUTIL_CMD='docker run --rm -v /var:/var us.gcr.io/cos-cloud/toolbox:v20260310 gsutil'
+GCLOUD_CMD='docker run --rm -v /var:/var us.gcr.io/cos-cloud/toolbox:v20260310 gcloud'
 
 # Welder configuration, Rstudio files are saved every X seconds in the background but Jupyter notebooks are not
 if [ ! -z "$RSTUDIO_DOCKER_IMAGE" ] ; then

--- a/http/src/main/resources/init-resources/startup.sh
+++ b/http/src/main/resources/init-resources/startup.sh
@@ -181,13 +181,20 @@ RSTUDIO_SCRIPTS=/etc/rstudio/scripts
 
 if [ "${GPU_ENABLED}" == "true" ] ; then
   log 'Installing GPU driver...'
-  version="535.154.05"
-  isAvailable=$(cos-extensions list|grep $version)
-  if [[ -z "$isAvailable" ]]; then
-      # Install default version on the COS image
-      cos-extensions install gpu
+  # Specify the current R580 LTS as a branch [0] so that runtimes pick up security and bug fixes over time.
+  # Pre-existing runtimes on cos-113-18244-85-64 do not have 580 available [1] so fall back to our previous pin.
+  #
+  # [0] https://docs.cloud.google.com/container-optimized-os/docs/how-to/run-gpus#install-driver
+  # [1] https://docs.cloud.google.com/container-optimized-os/docs/release-notes/m113#cos-113-18244-85-64
+  targetVersion="R580"
+  fallbackVersion="535.154.05"
+  availableDrivers=$(cos-extensions list || true)
+  if echo "${availableDrivers}" | grep -qF "${targetVersion}" ; then
+      cos-extensions install gpu -- --version "${targetVersion}"
+  elif echo "${availableDrivers}" | grep -qF "${fallbackVersion}" ; then
+      cos-extensions install gpu -- --version "${fallbackVersion}"
   else
-      cos-extensions install gpu -- --version $version
+      cos-extensions install gpu
   fi
 
   mount --bind /var/lib/nvidia /var/lib/nvidia

--- a/http/src/main/resources/init-resources/startup.sh
+++ b/http/src/main/resources/init-resources/startup.sh
@@ -181,21 +181,15 @@ RSTUDIO_SCRIPTS=/etc/rstudio/scripts
 
 if [ "${GPU_ENABLED}" == "true" ] ; then
   log 'Installing GPU driver...'
-  # Specify the current R580 LTS as a branch [0] so that runtimes pick up security and bug fixes over time.
-  # Pre-existing runtimes on cos-113-18244-85-64 do not have 580 available [1] so fall back to our previous pin.
+  # The driver major version, e.g. R580, is constant for the duration of the COS milestone [0][1] and receives
+  # bugfixes and security patches over time. Validate new major version as part of upgrading to a new COS.
   #
-  # [0] https://docs.cloud.google.com/container-optimized-os/docs/how-to/run-gpus#install-driver
-  # [1] https://docs.cloud.google.com/container-optimized-os/docs/release-notes/m113#cos-113-18244-85-64
-  targetVersion="R580"
-  fallbackVersion="535.154.05"
-  availableDrivers=$(cos-extensions list || true)
-  if echo "${availableDrivers}" | grep -qF "${targetVersion}" ; then
-      cos-extensions install gpu -- --version "${targetVersion}"
-  elif echo "${availableDrivers}" | grep -qF "${fallbackVersion}" ; then
-      cos-extensions install gpu -- --version "${fallbackVersion}"
-  else
-      cos-extensions install gpu
-  fi
+  # COS 113: R535 (existing fleet)
+  # COS 129: R580 (2026 upgrade)
+  #
+  # [0] Exception: a later driver installs when a brand new GPU model is present that cannot use the default
+  # [1] https://docs.cloud.google.com/container-optimized-os/docs/how-to/run-gpus#install-driver
+  cos-extensions install gpu -- -version=default
 
   mount --bind /var/lib/nvidia /var/lib/nvidia
   mount -o remount,exec /var/lib/nvidia

--- a/http/src/main/resources/init-resources/startup.sh
+++ b/http/src/main/resources/init-resources/startup.sh
@@ -181,14 +181,16 @@ RSTUDIO_SCRIPTS=/etc/rstudio/scripts
 
 if [ "${GPU_ENABLED}" == "true" ] ; then
   log 'Installing GPU driver...'
-  # The driver major version, e.g. R580, is constant for the duration of the COS milestone [0][1] and receives
-  # bugfixes and security patches over time. Validate new major version as part of upgrading to a new COS.
+  # Install the default major version [0] for this COS milestone, e.g. R580.
+  # The default is constant for the duration of the milestone [1] and receives bugfixes and security patches over time.
+  # Validate new major version as part of upgrading to a new COS.
   #
   # COS 113: R535 (existing fleet)
   # COS 129: R580 (2026 upgrade)
   #
-  # [0] Exception: a later driver installs when a brand new GPU model is present that cannot use the default
-  # [1] https://docs.cloud.google.com/container-optimized-os/docs/how-to/run-gpus#install-driver
+  # [0] https://docs.cloud.google.com/container-optimized-os/docs/how-to/run-gpus#install-driver
+  # [1] Exception: when new GPU models release after the default driver was cut, they get a newer default.
+  #     https://docs.cloud.google.com/container-optimized-os/docs/release-notes/m113#February_12_2025
   cos-extensions install gpu -- -version=default
 
   mount --bind /var/lib/nvidia /var/lib/nvidia

--- a/http/src/main/resources/init-resources/startup.sh
+++ b/http/src/main/resources/init-resources/startup.sh
@@ -21,8 +21,8 @@ then
   export CLOUD_SERVICE='GCE'
   export WORK_DIRECTORY='/mnt/disks/work'
   CERT_DIRECTORY='/var/certs'
-  GSUTIL_CMD='docker run --rm -v /var:/var us.gcr.io/cos-cloud/toolbox:v20230714 gsutil'
-  GCLOUD_CMD='docker run --rm -v /var:/var us.gcr.io/cos-cloud/toolbox:v20230714 gcloud'
+  GSUTIL_CMD='docker run --rm -v /var:/var us.gcr.io/cos-cloud/toolbox:v20260310 gsutil'
+  GCLOUD_CMD='docker run --rm -v /var:/var us.gcr.io/cos-cloud/toolbox:v20260310 gcloud'
   DOCKER_COMPOSE='docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v /var:/var docker/compose:1.29.2'
   DOCKER_COMPOSE_FILES_DIRECTORY='/var/docker-compose-files'
 

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -112,7 +112,7 @@ dataproc {
 }
 
 gce {
-  customGceImage = "projects/broad-dsp-gcr-public/global/images/leo-gce-image-2025-08-13-23-11-32"
+  customGceImage = "projects/broad-dsp-gcr-public/global/images/leo-gce-image-2026-08-19-14-07-05"
   userDiskDeviceName = "user-disk"
   defaultScopes = [
     "https://www.googleapis.com/auth/userinfo.email",

--- a/jenkins/dataproc-custom-images/prepare-custom-leonardo-jupyter-dataproc-image.sh
+++ b/jenkins/dataproc-custom-images/prepare-custom-leonardo-jupyter-dataproc-image.sh
@@ -25,7 +25,7 @@ terra_jupyter_hail="us.gcr.io/broad-dsp-gcr-public/terra-jupyter-hail:1.1.14"
 terra_jupyter_gatk="us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:2.3.9"
 terra_jupyter_aou="us.gcr.io/broad-dsp-gcr-public/terra-jupyter-aou:2.2.16"
 
-welder_server="us.gcr.io/broad-dsp-gcr-public/welder-server:8667bfe"
+welder_server="us.gcr.io/broad-dsp-gcr-public/welder-server:3944358"
 openidc_proxy="broadinstitute/openidc-proxy:2.3.1_2"
 anvil_rstudio_bioconductor="us.gcr.io/broad-dsp-gcr-public/anvil-rstudio-bioconductor:3.21.0"
 

--- a/jenkins/gce-custom-images/create_gce_image.sh
+++ b/jenkins/gce-custom-images/create_gce_image.sh
@@ -43,9 +43,8 @@ DAISY_IMAGE_TAG="release"
 # When updating, to find the resource path:
 #    1. run `gcloud compute images list --no-standard-images --project=cos-cloud | grep lts` to get the list of available container-optimized OS images
 #    2. select the image of interest, say, `cos-89-16108-403-22`
-#    3. run `gcloud compute images describe cos-89-16108-403-22 --project cos-cloud | grep selfLink`
-#    4. extract the segments starting with 'projects'
-BASE_IMAGE="projects/cos-cloud/global/images/cos-113-18244-85-64"
+#    3. run `gcloud compute images describe cos-89-16108-403-22 --project cos-cloud --format="value(selfLink.scope(v1))"`
+BASE_IMAGE="projects/cos-cloud/global/images/cos-129-19506-299-137"
 
 if [[ "$VALIDATE_WORKFLOW" == "true" ]]; then
   DAISY_CONTAINER="gcr.io/compute-image-tools/daisy:${DAISY_IMAGE_TAG} -validate"

--- a/jenkins/gce-custom-images/gce_image.wf.json
+++ b/jenkins/gce-custom-images/gce_image.wf.json
@@ -67,8 +67,7 @@
         },
         "delete-inst-install": {
             "DeleteResources": {
-                "Instances": ["inst-install"],
-                "GCSPaths":["${GCSPATH}"]
+                "Instances": ["inst-install"]
             }
         }
     },

--- a/jenkins/gce-custom-images/gce_image.wf.json
+++ b/jenkins/gce-custom-images/gce_image.wf.json
@@ -39,7 +39,7 @@
                 {
                     "Name": "inst-install",
                     "Disks": [{"Source": "boot-disk"}],
-                    "MachineType": "n4d-highcpu-8",
+                    "MachineType": "c4d-highmem-8",
                     "StartupScript": "${installation_script_name}",
                     "Scopes": ["https://www.googleapis.com/auth/cloud-platform"]
                 }

--- a/jenkins/gce-custom-images/gce_image.wf.json
+++ b/jenkins/gce-custom-images/gce_image.wf.json
@@ -39,7 +39,7 @@
                 {
                     "Name": "inst-install",
                     "Disks": [{"Source": "boot-disk"}],
-                    "MachineType": "c3d-highcpu-8",
+                    "MachineType": "c4d-highmem-8",
                     "StartupScript": "${installation_script_name}",
                     "Scopes": ["https://www.googleapis.com/auth/cloud-platform"]
                 }

--- a/jenkins/gce-custom-images/gce_image.wf.json
+++ b/jenkins/gce-custom-images/gce_image.wf.json
@@ -39,7 +39,7 @@
                 {
                     "Name": "inst-install",
                     "Disks": [{"Source": "boot-disk"}],
-                    "MachineType": "c4d-highmem-8",
+                    "MachineType": "n4d-highcpu-8",
                     "StartupScript": "${installation_script_name}",
                     "Scopes": ["https://www.googleapis.com/auth/cloud-platform"]
                 }

--- a/jenkins/gce-custom-images/gce_image.wf.json
+++ b/jenkins/gce-custom-images/gce_image.wf.json
@@ -27,8 +27,10 @@
                 {
                     "Name": "boot-disk",
                     "SourceImage": "${base_image}",
-                    "Type": "pd-ssd",
-                    "SizeGb": "180"
+                    "Type": "hyperdisk-balanced",
+                    "SizeGb": "180",
+                    "provisionedIops": "3200",
+                    "provisionedThroughput": "800"
                 }
             ]
         },
@@ -37,7 +39,7 @@
                 {
                     "Name": "inst-install",
                     "Disks": [{"Source": "boot-disk"}],
-                    "MachineType": "n1-standard-4",
+                    "MachineType": "c3d-highcpu-8",
                     "StartupScript": "${installation_script_name}",
                     "Scopes": ["https://www.googleapis.com/auth/cloud-platform"]
                 }

--- a/jenkins/gce-custom-images/gce_image.wf.json
+++ b/jenkins/gce-custom-images/gce_image.wf.json
@@ -39,7 +39,7 @@
                 {
                     "Name": "inst-install",
                     "Disks": [{"Source": "boot-disk"}],
-                    "MachineType": "c4d-highmem-8",
+                    "MachineType": "c3d-highcpu-8",
                     "StartupScript": "${installation_script_name}",
                     "Scopes": ["https://www.googleapis.com/auth/cloud-platform"]
                 }

--- a/jenkins/gce-custom-images/prepare_gce_image.sh
+++ b/jenkins/gce-custom-images/prepare_gce_image.sh
@@ -26,7 +26,19 @@ anvil_rstudio_bioconductor="us.gcr.io/broad-dsp-gcr-public/anvil-rstudio-biocond
 
 cos_gpu_installer="gcr.io/cos-cloud/cos-gpu-installer:v2.7.5"
 google_cloud_toolbox="us.gcr.io/cos-cloud/toolbox:v20260310"
+
+# Compose v1 is vigorously obsolete, this is the last release from 2021
+# Old Docker clients can keep talking to new Docker daemons ≤28
+# COS 129 has Docker 27 so this is Fine For Now (tm)
+#
+# https://hub.docker.com/r/docker/compose
+# https://docs.docker.com/engine/release-notes/29/#breaking-changes
 docker_composer="docker/compose:1.29.2"
+
+# More 2021 abandonware. COS ships docker-credential-gcr but containerized compose can't see it.
+# Used for private user-provided images (do we still need to support that feature?)
+#
+# https://hub.docker.com/r/cryptopants/docker-compose-gcr
 docker_composer_with_auth="cryptopants/docker-compose-gcr"
 
 # If you change this you must also change Leo reference.conf!

--- a/jenkins/gce-custom-images/prepare_gce_image.sh
+++ b/jenkins/gce-custom-images/prepare_gce_image.sh
@@ -29,7 +29,7 @@ anvil_rstudio_bioconductor="us.gcr.io/broad-dsp-gcr-public/anvil-rstudio-biocond
 # You can check which version of the AOU image is used in prod here: https://github.com/all-of-us/workbench/blob/main/api/config/config_prod.json#L15C1-L16C1
 terra_jupyter_aou_old="us.gcr.io/broad-dsp-gcr-public/terra-jupyter-aou:2.2.13"
 
-cos_gpu_installer="gcr.io/cos-cloud/cos-gpu-installer:v2.1.9"
+cos_gpu_installer="gcr.io/cos-cloud/cos-gpu-installer:v2.7.5"
 google_cloud_toolbox="us.gcr.io/cos-cloud/toolbox:v20230714"
 docker_composer="docker/compose:1.29.2"
 docker_composer_with_auth="cryptopants/docker-compose-gcr"

--- a/jenkins/gce-custom-images/prepare_gce_image.sh
+++ b/jenkins/gce-custom-images/prepare_gce_image.sh
@@ -37,8 +37,10 @@ docker_composer="docker/compose:1.29.2"
 
 # More 2021 abandonware. COS ships docker-credential-gcr but containerized compose can't see it.
 # Used for private user-provided images (do we still need to support that feature?)
+# Can we pre-pull images on the host for compose to find?
 #
 # https://hub.docker.com/r/cryptopants/docker-compose-gcr
+# https://docs.cloud.google.com/container-optimized-os/docs/how-to/run-container-instance#accessing_private_images_in_or
 docker_composer_with_auth="cryptopants/docker-compose-gcr"
 
 # If you change this you must also change Leo reference.conf!

--- a/jenkins/gce-custom-images/prepare_gce_image.sh
+++ b/jenkins/gce-custom-images/prepare_gce_image.sh
@@ -30,7 +30,7 @@ anvil_rstudio_bioconductor="us.gcr.io/broad-dsp-gcr-public/anvil-rstudio-biocond
 terra_jupyter_aou_old="us.gcr.io/broad-dsp-gcr-public/terra-jupyter-aou:2.2.13"
 
 cos_gpu_installer="gcr.io/cos-cloud/cos-gpu-installer:v2.7.5"
-google_cloud_toolbox="us.gcr.io/cos-cloud/toolbox:v20230714"
+google_cloud_toolbox="us.gcr.io/cos-cloud/toolbox:v20260310"
 docker_composer="docker/compose:1.29.2"
 docker_composer_with_auth="cryptopants/docker-compose-gcr"
 

--- a/jenkins/gce-custom-images/prepare_gce_image.sh
+++ b/jenkins/gce-custom-images/prepare_gce_image.sh
@@ -20,7 +20,7 @@ terra_jupyter_python="us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:1.1.6"
 terra_jupyter_r="us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:2.2.7"
 terra_jupyter_bioconductor="us.gcr.io/broad-dsp-gcr-public/terra-jupyter-bioconductor:2.2.7"
 terra_jupyter_gatk="us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:2.3.9"
-welder_server="us.gcr.io/broad-dsp-gcr-public/welder-server:8667bfe"
+welder_server="us.gcr.io/broad-dsp-gcr-public/welder-server:3944358"
 openidc_proxy="broadinstitute/openidc-proxy:2.3.1_2"
 anvil_rstudio_bioconductor="us.gcr.io/broad-dsp-gcr-public/anvil-rstudio-bioconductor:3.21.0"
 

--- a/jenkins/gce-custom-images/prepare_gce_image.sh
+++ b/jenkins/gce-custom-images/prepare_gce_image.sh
@@ -20,14 +20,9 @@ terra_jupyter_python="us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:1.1.6"
 terra_jupyter_r="us.gcr.io/broad-dsp-gcr-public/terra-jupyter-r:2.2.7"
 terra_jupyter_bioconductor="us.gcr.io/broad-dsp-gcr-public/terra-jupyter-bioconductor:2.2.7"
 terra_jupyter_gatk="us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:2.3.9"
-terra_jupyter_aou="us.gcr.io/broad-dsp-gcr-public/terra-jupyter-aou:2.2.16"
 welder_server="us.gcr.io/broad-dsp-gcr-public/welder-server:8667bfe"
 openidc_proxy="broadinstitute/openidc-proxy:2.3.1_2"
 anvil_rstudio_bioconductor="us.gcr.io/broad-dsp-gcr-public/anvil-rstudio-bioconductor:3.21.0"
-
-# Note that this is the version used currently by AOU in production, the one above can be staged for testing
-# You can check which version of the AOU image is used in prod here: https://github.com/all-of-us/workbench/blob/main/api/config/config_prod.json#L15C1-L16C1
-terra_jupyter_aou_old="us.gcr.io/broad-dsp-gcr-public/terra-jupyter-aou:2.2.13"
 
 cos_gpu_installer="gcr.io/cos-cloud/cos-gpu-installer:v2.7.5"
 google_cloud_toolbox="us.gcr.io/cos-cloud/toolbox:v20260310"
@@ -39,7 +34,7 @@ cryptomining_detector="us.gcr.io/broad-dsp-gcr-public/cryptomining-detector:0.0.
 
 # This array determines which of the above images are baked into the custom image
 # the entry must match the var name above, which must correspond to a valid docker URI
-docker_image_var_names="welder_server terra_base terra_jupyter_python terra_jupyter_r terra_jupyter_bioconductor terra_jupyter_gatk terra_jupyter_aou terra_jupyter_aou_old openidc_proxy anvil_rstudio_bioconductor cryptomining_detector cos_gpu_installer google_cloud_toolbox docker_composer docker_composer_with_auth"
+docker_image_var_names="welder_server terra_base terra_jupyter_python terra_jupyter_r terra_jupyter_bioconductor terra_jupyter_gatk openidc_proxy anvil_rstudio_bioconductor cryptomining_detector cos_gpu_installer google_cloud_toolbox docker_composer docker_composer_with_auth"
 
 #
 # Functions


### PR DESCRIPTION
Update COS, Nvidia drivers, etc. to establish a solid, supported foundation for upcoming image updates.

Our current COS 113 exited support in March 2026.

Also addresses user concerns about outdated Nvidia drivers; our current 535 series is EOL since June 2026.

Deliberately postponed: upgrading Docker Compose. Our version still works on the new COS and there is real complexity going from v1 to v2/v5.

---

Testing:
1. Created T4 GPU instance on Dev with non-PR code
2. Deployed this PR to Dev and resumed instance
3. Came up with Nvidia 535.261.03 driver installed
    - Matches the expected COS 113 default for August 2025
    - Smooth upgrade from previous hardcoded 535.154.05 driver of January 2024
4. In a separate sequence: created a new post-PR VM
    - Came up with 580.173.02 driver released June 2026
---
Pre-existing instance started with this PR:
```
# docker exec jupyter-server /usr/local/nvidia/bin/nvidia-smi
+---------------------------------------------------------------------------------------+
| NVIDIA-SMI 535.261.03             Driver Version: 535.261.03   CUDA Version: 12.2     |
|-----------------------------------------+----------------------+----------------------+
```
New instance started with this PR:
```
# docker exec jupyter-server /usr/local/nvidia/bin/nvidia-smi
+-----------------------------------------------------------------------------------------+
| NVIDIA-SMI 580.173.02             Driver Version: 580.173.02     CUDA Version: 13.0     |
+-----------------------------------------+------------------------+----------------------+
```