### PR TITLE
CTM-628 Trim free space before baking GCE image

### DIFF
--- a/jenkins/gce-custom-images/prepare_gce_image.sh
+++ b/jenkins/gce-custom-images/prepare_gce_image.sh
@@ -115,6 +115,7 @@ log 'Cached docker images:'
 docker images
 
 # Discard freed blocks before imaging
+sync
 fstrim -av
 
 # Shut down the instance after it is done, which is used by the Daisy workflow's wait-for-inst-install

--- a/jenkins/gce-custom-images/prepare_gce_image.sh
+++ b/jenkins/gce-custom-images/prepare_gce_image.sh
@@ -115,7 +115,6 @@ log 'Cached docker images:'
 docker images
 
 # Discard freed blocks before imaging
-sync
 fstrim -av
 
 # Shut down the instance after it is done, which is used by the Daisy workflow's wait-for-inst-install

--- a/jenkins/gce-custom-images/prepare_gce_image.sh
+++ b/jenkins/gce-custom-images/prepare_gce_image.sh
@@ -114,6 +114,9 @@ fi
 log 'Cached docker images:'
 docker images
 
+# Discard freed blocks before imaging
+fstrim -av
+
 # Shut down the instance after it is done, which is used by the Daisy workflow's wait-for-inst-install
 # step to determine when provisioning is done.
 shutdown -h now


### PR DESCRIPTION
This small optimization primarily serves to help developers sanity-check that GCE images with fewer cached items, are actually smaller.

There will be a small bonus improvement to transfer times and storage costs in `project=broad-dsp-gcr-public`.

Per previous statements, I am attempting to make smaller focused PRs as I learn Leo 😄 

<img width="600" alt="Screenshot 2026-08-24 at 18-24-02 Images – Compute Engine – broad-dsp-gcr-public – Google Cloud console" src="https://github.com/user-attachments/assets/e26f9e3f-5f35-43b8-886f-36bdef8212fe" />
