### PR TITLE
fix(proxy): exempt static assets from CSRF referer check when IAP strips Sec-Fetch-* headers

### DIFF
--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/ProxyRoutes.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/ProxyRoutes.scala
@@ -270,11 +270,42 @@ class ProxyRoutes(proxyService: ProxyService, corsSupport: CorsSupport, refererC
     if (refererConfig.enabled) {
       optionalHeaderValueByType(Upgrade) flatMap {
         case Some(upgrade) if upgrade.hasWebSocket => pass
-        case _                                     => checkReferer
+        case _ =>
+          extractUri flatMap { uri =>
+            if (isStaticAssetPath(uri.path.toString()))
+              // Static assets (JS, CSS, images) are GET-only and cannot be exploited via CSRF,
+              // so skip the referer check. This is necessary for environments (e.g. dev with GCP IAP)
+              // where Sec-Fetch-* headers are stripped by an intermediate proxy before reaching Leo.
+              pass
+            else
+              checkReferer
+          }
       }
     } else {
       pass
     }
+
+  // Returns true for paths that serve static assets (by extension or /static/ path segment).
+  // These are safe to exempt from CSRF referer checks because they are GET-only, read-only,
+  // and cannot modify server state.
+  private[api] def isStaticAssetPath(path: String): Boolean = {
+    val staticExtensions = Set(".js",
+                               ".css",
+                               ".png",
+                               ".ico",
+                               ".woff",
+                               ".woff2",
+                               ".svg",
+                               ".map",
+                               ".gif",
+                               ".jpg",
+                               ".jpeg",
+                               ".ttf",
+                               ".eot",
+                               ".html"
+    )
+    path.contains("/static/") || staticExtensions.exists(path.endsWith)
+  }
 
   private def requestPath(req: HttpRequest): String = req.uri.toString
   private val logRequestPath = DebuggingDirectives.logRequest(requestPath _)

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/ProxyRoutes.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/ProxyRoutes.scala
@@ -285,25 +285,14 @@ class ProxyRoutes(proxyService: ProxyService, corsSupport: CorsSupport, refererC
       pass
     }
 
-  // Returns true for paths that serve static assets (by extension or /static/ path segment).
-  // These are safe to exempt from CSRF referer checks because they are GET-only, read-only,
-  // and cannot modify server state.
+  // Returns true for paths that serve inert static assets (by extension or /static/ path segment).
+  // These are safe to exempt from CSRF referer checks: they are non-executable binary or script
+  // resources (JS, CSS, images, fonts) that Leo proxies as-is and that cannot themselves submit
+  // forms or trigger state-changing requests. HTML is intentionally excluded because HTML files
+  // can contain <form> elements that POST to modify server state.
   private[api] def isStaticAssetPath(path: String): Boolean = {
-    val staticExtensions = Set(".js",
-                               ".css",
-                               ".png",
-                               ".ico",
-                               ".woff",
-                               ".woff2",
-                               ".svg",
-                               ".map",
-                               ".gif",
-                               ".jpg",
-                               ".jpeg",
-                               ".ttf",
-                               ".eot",
-                               ".html"
-    )
+    val staticExtensions =
+      Set(".js", ".css", ".png", ".ico", ".woff", ".woff2", ".svg", ".map", ".gif", ".jpg", ".jpeg", ".ttf", ".eot")
     path.contains("/static/") || staticExtensions.exists(path.endsWith)
   }
 

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/ProxyRoutesSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/ProxyRoutesSpec.scala
@@ -713,6 +713,44 @@ class ProxyRoutesSpec
     }
   }
 
+  it should "pass for static asset paths even when Referer, Origin and Sec-Fetch-Site are all absent" in {
+    // Simulates dev environment where GCP IAP strips Sec-Fetch-* headers before Leo receives them.
+    val routesWithReferer =
+      createHttpRoute(MockJupyterDAO, RefererConfig(Set("bvdp-saturn-dev.appspot.com/"), enabled = true))
+
+    // Static JS file — should be exempt from referer check
+    Get(s"/proxy/$googleProject/$clusterName/jupyter/static/plugins/visualizations/plotly/static/index.js")
+      .addHeader(Cookie(tokenCookie)) ~> routesWithReferer.route ~> check {
+      handled shouldBe true
+      status should not equal StatusCodes.Unauthorized
+    }
+
+    // Static CSS file
+    Get(s"/proxy/$googleProject/$clusterName/galaxy/static/style.css")
+      .addHeader(Cookie(tokenCookie)) ~> routesWithReferer.route ~> check {
+      handled shouldBe true
+      status should not equal StatusCodes.Unauthorized
+    }
+
+    // Non-static path without Referer/Origin/Sec-Fetch-Site should still be rejected
+    Get(s"/proxy/$googleProject/$clusterName/galaxy/api/histories")
+      .addHeader(Cookie(tokenCookie)) ~> routesWithReferer.route ~> check {
+      handled shouldBe true
+      status shouldEqual StatusCodes.Unauthorized
+    }
+  }
+
+  it should "isStaticAssetPath detect static paths correctly" in {
+    val proxyRoutes = new ProxyRoutes(proxyService, corsSupport, refererConfig)
+    proxyRoutes.isStaticAssetPath(
+      "/proxy/proj/app/galaxy/static/plugins/visualizations/plotly/static/index.js"
+    ) shouldBe true
+    proxyRoutes.isStaticAssetPath("/proxy/proj/app/galaxy/static/style.css") shouldBe true
+    proxyRoutes.isStaticAssetPath("/proxy/proj/app/jupyter/static/base/images/logo.png") shouldBe true
+    proxyRoutes.isStaticAssetPath("/proxy/proj/app/galaxy/api/histories") shouldBe false
+    proxyRoutes.isStaticAssetPath("/proxy/proj/app/galaxy/api/version") shouldBe false
+  }
+
   "Proxy utils" should "fail to decode b2c token if token expired" ignore {
     val token = "" // use a valid expired token for testing
     val now = Instant.now()


### PR DESCRIPTION
Galaxy visualization plugin static assets (JS/CSS loaded by `analysis.bundled.js`) are fetched without a `Referer` header. The existing fallbacks (Origin → Sec-Fetch-Site) covered BEE environments, but dev/prod use **GCP IAP** which strips all `Sec-Fetch-*` headers before requests reach Leo — causing all three fallbacks to fail with 401.

Static GET assets cannot be exploited via CSRF (they are read-only and don't modify state), so exempt paths matching `/static/` or known static file extensions (`.js`, `.css`, `.png`, etc.) from the referer check.

Regression found during dev validation of #4904.