### PR TITLE
CTM-657 Remove TCL, BouncyCastle

### DIFF
--- a/Dockerfile-tests
+++ b/Dockerfile-tests
@@ -1,4 +1,4 @@
-FROM sbtscala/scala-sbt:openjdk-17.0.2_1.8.0_2.13.10
+FROM sbtscala/scala-sbt:eclipse-temurin-17_1.x
 
 # This is only to make `sbt` work because `Version.scala` depends on `git` if this environment is not set
 ENV GIT_HASH="0.0.1"

--- a/automation/run-tests.sh
+++ b/automation/run-tests.sh
@@ -40,5 +40,8 @@ yes | apt install lsof > /dev/null
 
 echo "Done installing lsof, running tests"
 
+# Instruct git to trust a repo mounted from the runner environment outside the container
+git config --global --add safe.directory "$PWD"
+
 # Run the SBT tests
 sbt -batch -Dheadless=true "project automation" "$SBT_TEST_COMMAND"

--- a/automation/run-tests.sh
+++ b/automation/run-tests.sh
@@ -7,7 +7,7 @@ set -e -x
 # Path to leonardo-account.json for the qa domain
 # LEONARDO_ACCOUNT_JSON_PATH
 
-# Install Python 3.11 via uv (Debian Bullseye only ships with 3.9, which is no longer supported by gcloud)
+# No Python preinstalled in current `sbtscala/scala-sbt` images
 curl -LsSf https://astral.sh/uv/install.sh | sh
 export PATH="$HOME/.local/bin:$PATH"
 uv python install 3.11

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/SSH.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/SSH.scala
@@ -107,6 +107,9 @@ object SSH {
 
   // This method is the main one for any interaction with GCP VMs
   def executeGoogleCommand(project: GoogleProject, zone: String, runtimeName: RuntimeName, cmd: String): IO[String] = {
+    // COS has minimal locale support and issues warnings when forwarding e.g. `en_US.UTF-8`
+    val locale = Seq("LC_ALL" -> "C.UTF-8", "LANG" -> "C.UTF-8")
+
     val dummyCommand =
       s"gcloud compute ssh --zone '${zone}' '${LeonardoConfig.GCS.leonardoServiceAccountUsername}@${runtimeName.asString}' --project '${project.value}' --tunnel-through-iap -q --command=\"ls\" -- -tt"
 
@@ -132,10 +135,10 @@ object SSH {
       // Without first executing a dummy command, the output will contain a bunch of garble that google spits out because gcloud compute ssh runs ssh-keygen under the covers
       // Unfortunately, they provide a way to pass args to the subsequent ssh call but not the keygen call, so we need to always execute a command and throw away the output before doing meaningful work
       _ <- loggerIO.debug(s"executing dummy command to generate ssh keys...")
-      dummyOutput <- IO(dummyCommand !!)
+      dummyOutput <- IO(Process(dummyCommand, None, locale: _*).!!)
       _ <- loggerIO.debug(s"dummy command output: \n\t$dummyOutput")
       _ <- loggerIO.info(s"executing command: \n\t$sshCommand")
-      exitCode <- IO(sshCommand.!(logger))
+      exitCode <- IO(Process(sshCommand, None, locale: _*).!(logger))
       output = outWriter.toString
       error = errWriter.toString
       _ <-

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookGCECustomizationSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/notebooks/NotebookGCECustomizationSpec.scala
@@ -53,6 +53,8 @@ final class NotebookGCECustomizationSpec
                 // Check the extensions were installed
                 val nbExt = notebookPage.executeCell("! jupyter nbextension list")
 
+                // We test that the extension is installed, but do not exercise its behavior.
+                // It relies on unauthenticated Google Translate calls and is susceptible to 429s.
                 nbExt.get should include("translate_nbextension/main  enabled")
                 // should be installed by default
                 nbExt.get should include("toc2/main  enabled")
@@ -61,9 +63,6 @@ final class NotebookGCECustomizationSpec
                 serverExt.get should include("jupyterlab  enabled")
                 // should be installed by default
                 serverExt.get should include("jupyter_nbextensions_configurator  enabled")
-
-                // Exercise the translate extensionfailure_screenshots/NotebookGCECustomizationSpec_18-34-37-017.png
-                notebookPage.translateMarkup("Yes") should include("Oui")
               }
             }
           }

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -144,7 +144,7 @@ function make_jar()
                           -v $PWD:/working \
                           -v jar-cache:/root/.ivy \
                           -v jar-cache:/root/.ivy2 \
-                          sbtscala/scala-sbt:openjdk-17.0.2_1.8.0_2.13.10 \
+                          sbtscala/scala-sbt:eclipse-temurin-17_1.x \
                           /working/docker/install.sh /working || EXIT_CODE=$?
 
     # stop test db

--- a/docker/build_jar.sh
+++ b/docker/build_jar.sh
@@ -10,7 +10,7 @@ GIT_HASH=$(git log -n 1 --pretty=format:%h)
 
 # make jar.  cache sbt dependencies. capture output and stop db before returning.
 EXIT_CODE=0
-docker run --rm -v $PWD:/working \
+docker run --rm -e GIT_HASH=$GIT_HASH -v $PWD:/working \
   -v sbt-cache:/root/.sbt -v jar-cache:/root/.ivy -v jar-cache:/root/.ivy2 \
   -v coursier-cache:/root/.cache/coursier \
   sbtscala/scala-sbt:eclipse-temurin-17_1.x /working/docker/clean_install.sh /working \

--- a/docker/build_jar.sh
+++ b/docker/build_jar.sh
@@ -13,7 +13,7 @@ EXIT_CODE=0
 docker run --rm -v $PWD:/working \
   -v sbt-cache:/root/.sbt -v jar-cache:/root/.ivy -v jar-cache:/root/.ivy2 \
   -v coursier-cache:/root/.cache/coursier \
-  sbtscala/scala-sbt:openjdk-17.0.2_1.7.2_2.13.10 /working/docker/clean_install.sh /working \
+  sbtscala/scala-sbt:eclipse-temurin-17_1.x /working/docker/clean_install.sh /working \
   || EXIT_CODE=$?
 
 if [ $EXIT_CODE != 0 ]; then

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,17 +5,12 @@ object Dependencies {
 
   val akkaV = "2.6.20"
   val akkaHttpV = "10.2.10"
-  val googleV = "1.23.0"
-  val automationGoogleV = "1.30.5"
   val scalaLoggingV = "3.9.5"
   val scalaTestV = "3.2.17"
   val http4sVersion = "1.0.0-M45"
   val slickV = "3.4.1"
   val guavaV = "32.1.3-jre"
   val monocleV = "3.2.0"
-  val opencensusV = "0.29.0"
-  val munitCatsEffectV = "1.0.7"
-  val commonsBeanUtilsV = "1.11.0"
 
   private val workbenchLibsHash = "76e472e"
   val serviceTestV = s"6.2-$workbenchLibsHash"
@@ -29,19 +24,12 @@ object Dependencies {
 
   val excludeAkkaHttp = ExclusionRule(organization = "com.typesafe.akka", name = s"akka-http_${scalaV}")
   val excludeAkkaStream = ExclusionRule(organization = "com.typesafe.akka", name = s"akka-stream_${scalaV}")
-  val excludeAkkaHttpSprayJson = ExclusionRule(organization = "com.typesafe.akka", name = s"akka-http-spray-json_${scalaV}")
-  val excludeGuavaJDK5 = ExclusionRule(organization = "com.google.guava", name = "guava-jdk5")
   val excludeGuava = ExclusionRule(organization = "com.google.guava", name = "guava")
   val excludeWorkbenchMetrics = ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = s"workbench-metrics_${scalaV}")
   val excludeFindbugsJsr = ExclusionRule(organization = "com.google.code.findbugs", name = "jsr305")
-  val excludeGson = ExclusionRule(organization = "com.google.code.gson", name = "gson")
   val excludeGoogleApiClient = ExclusionRule(organization = "com.google.api-client", name = "google-api-client")
-  val excludeGoogleHttpClient = ExclusionRule(organization = "com.google.http-client", name = "google-http-client")
-  val excludeJacksonCore = ExclusionRule(organization = "com.fasterxml.jackson.core", name = "jackson-core")
-  val excludeJacksonAnnotation = ExclusionRule(organization = "com.fasterxml.jackson.core", name = "jackson-annotations")
   val excludeSlf4j = ExclusionRule(organization = "org.slf4j", name = "slf4j-api")
   val excludeTypesafeConfig = ExclusionRule(organization = "com.typesafe", name = "config")
-  val excludeTypesafeSslConfig = ExclusionRule(organization = "com.typesafe", name = "ssl-config-core")
   val excludeGoogleError = ExclusionRule(organization = "com.google.errorprone", name = "error_prone_annotations")
   val excludeHttpComponent = ExclusionRule(organization = "org.apache.httpcomponents", name = "httpclient")
   val excludeReactiveStream = ExclusionRule(organization = "org.reactivestreams", name = "reactive-streams")
@@ -122,7 +110,6 @@ object Dependencies {
   val http4sDsl =         "org.http4s"        %% "http4s-dsl"           % http4sVersion
   val http4sEmberClient = "org.http4s"        %% "http4s-ember-client"  % http4sVersion
   val http4sEmberServer = "org.http4s"        %% "http4s-ember-server"  % http4sVersion
-  val http4sCirce       = "org.http4s"        %% "http4s-circe"  % http4sVersion
 
   val guava: ModuleID =   "com.google.guava"  % "guava"                 % guavaV
   val okHttp =            "com.squareup.okhttp3"  % "okhttp"            % "4.12.0"
@@ -130,7 +117,6 @@ object Dependencies {
   val samV = "v0.0.448"
 
   def excludeJakartaActivationApi = ExclusionRule("jakarta.activation", "jakarta.activation-api")
-  def excludeJakartaXmlBindApi = ExclusionRule("jakarta.xml.bind", "jakarta.xml.bind-api")
   def excludeJakarta(m: ModuleID): ModuleID = m.excludeAll(excludeJakartaActivationApi)
 
   val sam = excludeJakarta("org.broadinstitute.dsde.workbench" %% "sam-client" % samV)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,7 +11,6 @@ object Dependencies {
   val scalaTestV = "3.2.17"
   val http4sVersion = "1.0.0-M45"
   val slickV = "3.4.1"
-  val nettyV = "4.1.135.Final"
   val guavaV = "32.1.3-jre"
   val monocleV = "3.2.0"
   val opencensusV = "0.29.0"
@@ -34,7 +33,6 @@ object Dependencies {
   val excludeGuavaJDK5 = ExclusionRule(organization = "com.google.guava", name = "guava-jdk5")
   val excludeGuava = ExclusionRule(organization = "com.google.guava", name = "guava")
   val excludeWorkbenchMetrics = ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = s"workbench-metrics_${scalaV}")
-  val excludeIoGrpc = ExclusionRule(organization = "io.grpc", name = "grpc-core")
   val excludeFindbugsJsr = ExclusionRule(organization = "com.google.code.findbugs", name = "jsr305")
   val excludeGson = ExclusionRule(organization = "com.google.code.gson", name = "gson")
   val excludeGoogleApiClient = ExclusionRule(organization = "com.google.api-client", name = "google-api-client")
@@ -69,8 +67,6 @@ object Dependencies {
   val akkaTestKit: ModuleID =       "com.typesafe.akka" %% "akka-testkit"         % akkaV     % "test"
   val akkaHttpTestKit: ModuleID =   "com.typesafe.akka" %% "akka-http-testkit"    % akkaHttpV % "test"
 
-  val googleRpc: ModuleID =                 "io.grpc"         % "grpc-core"                       % "1.58.0" excludeAll (excludeGuava, excludeGson, excludeFindbugsJsr)
-
   val scalaTest: ModuleID = "org.scalatest" %% "scalatest" % scalaTestV  % Test
   val scalaTestScalaCheck = "org.scalatestplus" %% "scalacheck-1-17" % s"${scalaTestV}.0" % Test // https://github.com/scalatest/scalatestplus-scalacheck
   val scalaTestMockito = "org.scalatestplus" %% "mockito-4-5" % "3.2.12.0" % Test // https://github.com/scalatest/scalatestplus-mockito
@@ -80,7 +76,6 @@ object Dependencies {
   // workbench-google pulls in workbench-{util, model, metrics} and workbench-metrics pulls in workbench-util.
   val workbenchModel: ModuleID =        "org.broadinstitute.dsde.workbench" %% "workbench-model"    % workbenchModelV excludeAll (excludeGoogleError, excludeGuava)
   val workbenchGoogle: ModuleID =       "org.broadinstitute.dsde.workbench" %% "workbench-google"   % workbenchGoogleV excludeAll (
-    excludeIoGrpc,
     excludeFindbugsJsr,
     excludeGoogleApiClient,
     excludeGoogleError,
@@ -90,7 +85,6 @@ object Dependencies {
     excludeKms)
   val workbenchGoogle2: ModuleID =      "org.broadinstitute.dsde.workbench" %% "workbench-google2"  % workbenchGoogle2V excludeAll (
     excludeWorkbenchMetrics,
-    excludeIoGrpc,
     excludeFindbugsJsr,
     excludeGoogleError,
     excludeHttpComponent,
@@ -108,7 +102,6 @@ object Dependencies {
   val workbenchGoogleTest: ModuleID =   "org.broadinstitute.dsde.workbench" %% "workbench-google"   % workbenchGoogleV  % "test" classifier "tests" excludeAll (excludeGuava, excludeStatsD)
   val workbenchGoogle2Test: ModuleID =  "org.broadinstitute.dsde.workbench" %% "workbench-google2"  % workbenchGoogle2V % "test" classifier "tests" excludeAll (excludeGuava) //for generators
   val workbenchOpenTelemetry: ModuleID =     "org.broadinstitute.dsde.workbench" %% "workbench-opentelemetry" % workbenchOpenTelemetryV excludeAll (
-    excludeIoGrpc,
     excludeGuava
   )
 
@@ -131,51 +124,15 @@ object Dependencies {
   val http4sEmberServer = "org.http4s"        %% "http4s-ember-server"  % http4sVersion
   val http4sCirce       = "org.http4s"        %% "http4s-circe"  % http4sVersion
 
-  val nettyBuffer: ModuleID = "io.netty" % "netty-buffer" % nettyV
-  val nettyCodec: ModuleID = "io.netty" % "netty-codec" % nettyV
-  val nettyCodecHttp: ModuleID = "io.netty" % "netty-codec-http" % nettyV
-  val nettyCodecHttp2: ModuleID = "io.netty" % "netty-codec-http2" % nettyV
-  val nettyCodecSocks: ModuleID = "io.netty" % "netty-codec-socks" % nettyV
-  val nettyCommon: ModuleID = "io.netty" % "netty-common" % nettyV
-  val nettyHandler: ModuleID = "io.netty" % "netty-handler" % nettyV
-  val nettyHandlerProxy: ModuleID = "io.netty" % "netty-handler-proxy" % nettyV
-  val nettyResolver: ModuleID = "io.netty" % "netty-resolver" % nettyV
-  val nettyTransport: ModuleID = "io.netty" % "netty-transport" % nettyV
-  val nettyTransportNativeEpoll: ModuleID = "io.netty" % "netty-transport-native-epoll" % nettyV
-  val nettyTransportNativeUnixCommon: ModuleID = "io.netty" % "netty-transport-native-unix-common" % nettyV
-  val nettyCodecDns: ModuleID = "io.netty" % "netty-codec-dns" % nettyV
-  val nettyResolverDns: ModuleID = "io.netty" % "netty-resolver-dns" % nettyV
-  val nettyResolverDnsNativeMacos: ModuleID = "io.netty" % "netty-resolver-dns-native-macos" % nettyV
-  val nettyResolverDnsClassesMacos: ModuleID = "io.netty" % "netty-resolver-dns-classes-macos" % nettyV
-  val nettyTransportNativeKqueue: ModuleID = "io.netty" % "netty-transport-native-kqueue" % nettyV
-  val nettyTransportClassesKqueue: ModuleID = "io.netty" % "netty-transport-classes-kqueue" % nettyV
   val guava: ModuleID =   "com.google.guava"  % "guava"                 % guavaV
   val okHttp =            "com.squareup.okhttp3"  % "okhttp"            % "4.12.0"
 
-  val terraCommonLibV = "1.1.54-SNAPSHOT"
   val samV = "v0.0.448"
 
   def excludeJakartaActivationApi = ExclusionRule("jakarta.activation", "jakarta.activation-api")
   def excludeJakartaXmlBindApi = ExclusionRule("jakarta.xml.bind", "jakarta.xml.bind-api")
   def excludeJakarta(m: ModuleID): ModuleID = m.excludeAll(excludeJakartaActivationApi)
-  def excludeSpringBoot = ExclusionRule("org.springframework.boot")
-  def excludeSpringAop = ExclusionRule("org.springframework.spring-aop")
-  def excludeSpringData = ExclusionRule("org.springframework.data")
-  def excludeSpringFramework = ExclusionRule("org.springframework")
-  def excludeOpenCensus = ExclusionRule("io.opencensus")
-  def excludeGoogleFindBugs = ExclusionRule("com.google.code.findbugs")
-  def excludeBroadWorkbench = ExclusionRule("org.broadinstitute.dsde.workbench")
-  def excludePostgresql = ExclusionRule("org.postgresql", "postgresql")
-  def excludeSnakeyaml = ExclusionRule("org.yaml", "snakeyaml")
-  def excludeLiquibase = ExclusionRule("org.liquibase", "liquibase-core")
-  def excludeFlagsmith = ExclusionRule("com.flagsmith", "flagsmith-java-client")
-  def excludeJsonSmart = ExclusionRule("net.minidev", "json-smart")
-  def excludeNettyCodecHttp2 = ExclusionRule("io.netty", "netty-codec-http2")
 
-  // [IA-4939] commons-text:1.9 is unsafe
-  def excludeCommonsText = ExclusionRule("org.apache.commons", "commons-text")
-  def tclExclusions(m: ModuleID): ModuleID = m.excludeAll(excludeSpringBoot, excludeSpringAop, excludeSpringData, excludeSpringFramework, excludeOpenCensus, excludeGoogleFindBugs, excludeBroadWorkbench, excludePostgresql, excludeSnakeyaml, excludeSlf4j, excludeCommonsText, excludeLiquibase, excludeFlagsmith, excludeJsonSmart, excludeNettyCodecHttp2)
-  val terraCommonLib = tclExclusions(excludeJakarta("bio.terra" % "terra-common-lib" % terraCommonLibV classifier "plain"))
   val sam = excludeJakarta("org.broadinstitute.dsde.workbench" %% "sam-client" % samV)
 
   val coreDependencies = List(
@@ -204,7 +161,6 @@ object Dependencies {
     http4sDsl,
     scalaTestScalaCheck,
     logbackClassic,
-    terraCommonLib,
     sam
   )
 
@@ -221,7 +177,6 @@ object Dependencies {
     http4sPrometheus,
     http4sEmberClient,
     "de.heikoseeberger" %% "akka-http-circe" % "1.39.2" excludeAll(excludeAkkaHttp, excludeAkkaStream),
-    googleRpc,
     hikariCP,
     workbenchGoogle,
     workbenchGoogleTest,
@@ -240,14 +195,6 @@ object Dependencies {
   // You should not be using SSH functionality outside of the tests according to security team's guidance
   val ssh: ModuleID = "com.hierynomus" % "sshj" % "0.37.0" % "test"
   val googleCloudOSLogin = "com.google.cloud" % "google-cloud-os-login" % "2.2.7" % "test"
-
-  val commonOverrides = List(
-    nettyBuffer, nettyCodec, nettyCodecDns, nettyCodecHttp, nettyCodecHttp2, nettyCodecSocks,
-    nettyCommon, nettyHandler, nettyHandlerProxy, nettyResolver,
-    nettyResolverDns, nettyResolverDnsNativeMacos, nettyResolverDnsClassesMacos,
-    nettyTransport, nettyTransportNativeEpoll, nettyTransportNativeUnixCommon,
-    nettyTransportNativeKqueue, nettyTransportClassesKqueue
-  )
 
   // BouncyCastle arrived transitively via `io.kubernetes:client-java` and is not used.
   // Can clean up when we remove Kubernetes support (CTM-657)
@@ -273,7 +220,6 @@ object Dependencies {
     "com.typesafe.akka" %% "akka-testkit" % akkaV % "test",
     "com.typesafe.akka" %% "akka-slf4j" % akkaV,
     "com.typesafe.scala-logging" %% "scala-logging" % scalaLoggingV,
-    googleRpc,
     workbenchGoogle,
     workbenchGoogle2,
     workbenchServiceTest,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -13,7 +13,6 @@ object Dependencies {
   val slickV = "3.4.1"
   val nettyV = "4.1.135.Final"
   val guavaV = "32.1.3-jre"
-  val bouncyCastleV = "1.84"
   val monocleV = "3.2.0"
   val opencensusV = "0.29.0"
   val munitCatsEffectV = "1.0.7"
@@ -151,9 +150,6 @@ object Dependencies {
   val nettyTransportNativeKqueue: ModuleID = "io.netty" % "netty-transport-native-kqueue" % nettyV
   val nettyTransportClassesKqueue: ModuleID = "io.netty" % "netty-transport-classes-kqueue" % nettyV
   val guava: ModuleID =   "com.google.guava"  % "guava"                 % guavaV
-  val bcprov: ModuleID  = "org.bouncycastle" % "bcprov-jdk18on" % bouncyCastleV
-  val bcpkix: ModuleID  = "org.bouncycastle" % "bcpkix-jdk18on" % bouncyCastleV
-  val bcutil: ModuleID  = "org.bouncycastle" % "bcutil-jdk18on" % bouncyCastleV
   val okHttp =            "com.squareup.okhttp3"  % "okhttp"            % "4.12.0"
 
   val terraCommonLibV = "1.1.54-SNAPSHOT"
@@ -250,9 +246,15 @@ object Dependencies {
     nettyCommon, nettyHandler, nettyHandlerProxy, nettyResolver,
     nettyResolverDns, nettyResolverDnsNativeMacos, nettyResolverDnsClassesMacos,
     nettyTransport, nettyTransportNativeEpoll, nettyTransportNativeUnixCommon,
-    nettyTransportNativeKqueue, nettyTransportClassesKqueue,
-    bcprov, bcpkix, bcutil
+    nettyTransportNativeKqueue, nettyTransportClassesKqueue
   )
+
+  // BouncyCastle arrived transitively via `io.kubernetes:client-java` and is not used.
+  // Can clean up when we remove Kubernetes support (CTM-657)
+  val commonExcludes = List(
+    ExclusionRule("org.bouncycastle")
+  )
+
   val automationOverrides = List(
     guava,
     // semconv version to satisfy selenium:

--- a/project/Merging.scala
+++ b/project/Merging.scala
@@ -24,14 +24,7 @@ object Merging {
     case x if x.endsWith("io.netty.versions.properties") => MergeStrategy.first
     case x if x.endsWith("/ModuleUtil.class")            => MergeStrategy.first
     case x if x.endsWith("/module-info.class")           => MergeStrategy.discard
-    // For the following error:
-    // Error:  Deduplicate found different file contents in the following:
-    // Error:    Jar name = bcpkix-jdk18on-1.84.jar, jar org = org.bouncycastle, entry target = META-INF/versions/9/OSGI-INF/MANIFEST.MF
-    // Error:    Jar name = bcprov-jdk18on-1.84.jar, jar org = org.bouncycastle, entry target = META-INF/versions/9/OSGI-INF/MANIFEST.MF
-    // Error:    Jar name = bcutil-jdk18on-1.84.jar, jar org = org.bouncycastle, entry target = META-INF/versions/9/OSGI-INF/MANIFEST.MF
     case x if x.endsWith("/OSGI-INF/MANIFEST.MF") =>
-      MergeStrategy.first
-    case x if x.contains("bouncycastle") =>
       MergeStrategy.first
     case "module-info.class" =>
       MergeStrategy.discard // JDK 8 does not use the file module-info.class so it is safe to discard the file.

--- a/project/Merging.scala
+++ b/project/Merging.scala
@@ -2,39 +2,12 @@ import sbtassembly.{MergeStrategy, PathList}
 
 object Merging {
   def customMergeStrategy(oldStrategy: (String) => MergeStrategy): (String => MergeStrategy) = {
-    case PathList("META-INF", "spring-configuration-metadata.json") => MergeStrategy.first
-    // For the following error:
-    // [error] Deduplicate found different file contents in the following:
-    // [error]   Jar name = auto-value-1.10.1.jar, jar org = com.google.auto.value, entry target = META-INF/kotlin-stdlib.kotlin_module
-    // [error]   Jar name = kotlin-stdlib-1.6.20.jar, jar org = org.jetbrains.kotlin, entry target = META-INF/kotlin-stdlib.kotlin_module
-    case PathList("META-INF", "kotlin-stdlib.kotlin_module") => MergeStrategy.preferProject
-    case PathList("META-INF", "okio.kotlin_module")          => MergeStrategy.first
-    // For the following error:
-    // [error] Deduplicate found different file contents in the following:
-    // [error]   Jar name = auto-value-1.10.1.jar, jar org = com.google.auto.value, entry target = META-INF/kotlin-stdlib-common.kotlin_module
-    // [error]   Jar name = kotlin-stdlib-1.6.20.jar, jar org = org.jetbrains.kotlin, entry target = META-INF/kotlin-stdlib-common.kotlin_module
-    case PathList("META-INF", "kotlin-stdlib-common.kotlin_module")    => MergeStrategy.preferProject
-    case PathList("org", "joda", "time", "base", "BaseDateTime.class") => MergeStrategy.first
-    // For the following error:
-    // [error] java.lang.RuntimeException: deduplicate: different file contents found in the following:
-    // [error] /root/.cache/coursier/v1/https/repo1.maven.org/maven2/com/google/protobuf/protobuf-java/3.11.4/protobuf-java-3.11.4.jar:google/protobuf/field_mask.proto
-    // [error] /root/.cache/coursier/v1/https/repo1.maven.org/maven2/com/typesafe/akka/akka-protobuf-v3_2.12/2.6.5/akka-protobuf-v3_2.12-2.6.5.jar:google/protobuf/field_mask.proto
-    case PathList("google", "protobuf", _ @_*)           => MergeStrategy.first
-    case PathList("javax", "xml", _ @_*)                 => MergeStrategy.first
-    case x if x.endsWith("io.netty.versions.properties") => MergeStrategy.first
-    case x if x.endsWith("/ModuleUtil.class")            => MergeStrategy.first
-    case x if x.endsWith("/module-info.class")           => MergeStrategy.discard
+    case PathList("META-INF", "okio.kotlin_module") => MergeStrategy.first
+    case PathList("google", "protobuf", _ @_*)      => MergeStrategy.first
+    case x if x.endsWith("/module-info.class")      => MergeStrategy.discard
     case "module-info.class" =>
       MergeStrategy.discard // JDK 8 does not use the file module-info.class so it is safe to discard the file.
     case "reference.conf" => MergeStrategy.concat
-    // For the following error:
-    // [error] Deduplicate found different file contents in the following:
-    // [error]   Jar name = jakarta.activation-1.2.2.jar, jar org = com.sun.activation, entry target = javax/activation/SecuritySupport$5.class
-    // [error]   Jar name = javax.activation-api-1.2.0.jar, jar org = javax.activation, entry target = javax/activation/SecuritySupport$5.class
-    // case PathList("META-INF", "kotlin-stdlib-common.kotlin_module")    => MergeStrategy.preferProject
-    case x if x.contains("activation") => MergeStrategy.first
-    case x if x.contains("annotation") => MergeStrategy.first
-    case "logback.xml"                 => MergeStrategy.first
-    case x                             => oldStrategy(x)
+    case x                => oldStrategy(x)
   }
 }

--- a/project/Merging.scala
+++ b/project/Merging.scala
@@ -24,8 +24,6 @@ object Merging {
     case x if x.endsWith("io.netty.versions.properties") => MergeStrategy.first
     case x if x.endsWith("/ModuleUtil.class")            => MergeStrategy.first
     case x if x.endsWith("/module-info.class")           => MergeStrategy.discard
-    case x if x.endsWith("/OSGI-INF/MANIFEST.MF") =>
-      MergeStrategy.first
     case "module-info.class" =>
       MergeStrategy.discard // JDK 8 does not use the file module-info.class so it is safe to discard the file.
     case "reference.conf" => MergeStrategy.concat

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -91,6 +91,7 @@ object Settings {
     resolvers ++= commonResolvers,
     scalacOptions ++= commonCompilerSettings,
     dependencyOverrides ++= Dependencies.commonOverrides,
+    excludeDependencies ++= Dependencies.commonExcludes,
     libraryDependencySchemes += "org.http4s" %% "http4s-core" % "always"
   )
 

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -90,7 +90,6 @@ object Settings {
     scalaVersion  := "2.13.12",
     resolvers ++= commonResolvers,
     scalacOptions ++= commonCompilerSettings,
-    dependencyOverrides ++= Dependencies.commonOverrides,
     excludeDependencies ++= Dependencies.commonExcludes,
     libraryDependencySchemes += "org.http4s" %% "http4s-core" % "always"
   )


### PR DESCRIPTION
In the past, we acquiesced to unused transitive dependencies and put them in overrides when they needed a security update. This put us on a version bump treadmill.

This change is my updated approach where we exclude transitive dependencies instead, hopefully getting off of the treadmill. It is especially applicable to Kubernetes in Leonardo as that is going away soon.

I also found that TCL was unused:
- Introduced in 2023 for `bio.terra.common.tracing.JerseyTracingFilter`
  - https://github.com/DataBiosphere/leonardo/pull/3699
- Last usage of `JerseyTracingFilter` removed in 2024
  - https://github.com/DataBiosphere/leonardo/pull/4238