### PR TITLE
fix(galaxy): use request machine type for GCE VM; default to t2d-standard-4

### DIFF
--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -438,7 +438,7 @@ galaxyVm {
   # Has cloud-init, which processes the "user-data" metadata key on first boot.
   # Source: https://github.com/galaxyproject/galaxy-k8s-boot (image built by the Galaxy team)
   sourceImage = "projects/anvil-and-terra-development/global/images/galaxy-k8s-boot-v2026-06-30"
-  machineType = "t2d-standard-2"
+  machineType = "t2d-standard-4"
   bootDiskSizeGb = 100
   postgresDiskSizeGb = 10
   # Suffix appended to the NFS disk name to derive the postgres disk name.

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -438,7 +438,7 @@ galaxyVm {
   # Has cloud-init, which processes the "user-data" metadata key on first boot.
   # Source: https://github.com/galaxyproject/galaxy-k8s-boot (image built by the Galaxy team)
   sourceImage = "projects/anvil-and-terra-development/global/images/galaxy-k8s-boot-v2026-06-30"
-  machineType = "n1-highmem-8"
+  machineType = "t2d-standard-4"
   bootDiskSizeGb = 100
   postgresDiskSizeGb = 10
   # Suffix appended to the NFS disk name to derive the postgres disk name.

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -438,7 +438,7 @@ galaxyVm {
   # Has cloud-init, which processes the "user-data" metadata key on first boot.
   # Source: https://github.com/galaxyproject/galaxy-k8s-boot (image built by the Galaxy team)
   sourceImage = "projects/anvil-and-terra-development/global/images/galaxy-k8s-boot-v2026-06-30"
-  machineType = "t2d-standard-4"
+  machineType = "t2d-standard-2"
   bootDiskSizeGb = 100
   postgresDiskSizeGb = 10
   # Suffix appended to the NFS disk name to derive the postgres disk name.

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
@@ -1155,7 +1155,11 @@ class GKEInterpreter[F[_]](
         .setName(instanceName.value)
         .setDescription("Leonardo Galaxy VM")
         .setTags(Tags.newBuilder().addItems(config.vpcNetworkTag.value).build())
-        .setMachineType(buildMachineTypeUri(zoneParam, config.galaxyVmConfig.machineType))
+        // Prefer the machine type stored on the app's nodepool (set from the request at creation
+        // time); fall back to the configured default.
+        .setMachineType(buildMachineTypeUri(zoneParam,
+          dbCluster.nodepools.find(_.id == app.nodepoolId).map(_.machineType)
+            .getOrElse(config.galaxyVmConfig.machineType)))
         .addNetworkInterfaces(networkInterface)
         .addAllDisks(List(bootDisk, dataDisk, postgresDisk).asJava)
         .addServiceAccounts(

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
@@ -1157,9 +1157,14 @@ class GKEInterpreter[F[_]](
         .setTags(Tags.newBuilder().addItems(config.vpcNetworkTag.value).build())
         // Prefer the machine type stored on the app's nodepool (set from the request at creation
         // time); fall back to the configured default.
-        .setMachineType(buildMachineTypeUri(zoneParam,
-          dbCluster.nodepools.find(_.id == app.nodepoolId).map(_.machineType)
-            .getOrElse(config.galaxyVmConfig.machineType)))
+        .setMachineType(
+          buildMachineTypeUri(zoneParam,
+                              dbCluster.nodepools
+                                .find(_.id == app.nodepoolId)
+                                .map(_.machineType)
+                                .getOrElse(config.galaxyVmConfig.machineType)
+          )
+        )
         .addNetworkInterfaces(networkInterface)
         .addAllDisks(List(bootDisk, dataDisk, postgresDisk).asJava)
         .addServiceAccounts(


### PR DESCRIPTION
GKEInterpreter always used `config.galaxyVmConfig.machineType` (hardcoded `n1-highmem-8`) when creating the Galaxy GCE VM, ignoring `app.kubernetesRuntimeConfig.machineType` from the API request.

Switch `installGalaxyVm` to use the request value so the user-selected machine type is actually provisioned.

Update `reference.conf` default from `n1-highmem-8` to `t2d-standard-4` to match the new Galaxy GCE path.

Ticket: https://broadworkbench.atlassian.net/browse/CTM-397

🤖 Generated with [Claude Code](https://claude.com/claude-code)