### PR TITLE
fix(security): scope galaxy-batch-runner serviceAccountUser to SA resource, not project

### DIFF
--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -496,7 +496,7 @@ gke {
     maxNodepoolsPerDefaultNode = 16
   }
   galaxyNodepool {
-    machineType = "n1-highmem-8"
+    machineType = "t2d-standard-4"
     numNodes = 1
     autoscalingEnabled = false
     autoscalingConfig {

--- a/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
+++ b/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/util/GKEInterpreter.scala
@@ -1288,7 +1288,11 @@ class GKEInterpreter[F[_]](
               s"skipping serviceAccountUser binding — must be configured externally"
           )
 
-      // Grant the Batch SA the project-level roles it needs to run jobs and attach a service account to Batch VMs.
+      // Grant the Batch SA the project-level roles it needs to submit and report on Batch jobs.
+      // roles/iam.serviceAccountUser is intentionally NOT granted at the project level — a
+      // project-scoped binding would let the batch SA impersonate any SA in the project, enabling
+      // cross-user token theft via the metadata server of a secondary Batch VM. Instead we grant
+      // it resource-level serviceAccountUser on itself below so it can only run jobs as itself.
       // See https://github.com/galaxyproject/galaxy-k8s-boot?tab=readme-ov-file#prerequisites
       _ <- {
         val call = F.fromFuture(
@@ -1298,11 +1302,7 @@ class GKEInterpreter[F[_]](
                 googleProject,
                 WorkbenchEmail(gcpBatchSa),
                 IamMemberTypes.ServiceAccount,
-                Set("roles/batch.jobsEditor",
-                    "roles/iam.serviceAccountUser",
-                    "roles/batch.agentReporter",
-                    "roles/logging.logWriter"
-                )
+                Set("roles/batch.jobsEditor", "roles/batch.agentReporter", "roles/logging.logWriter")
               )
               .void
           )
@@ -1310,9 +1310,22 @@ class GKEInterpreter[F[_]](
         val retryConfig = RetryPredicates.retryConfigWithPredicates(when409, whenGroupDoesNotExist)
         tracedRetryF(retryConfig)(
           call,
-          s"googleIamDAO.addRoles(batch.jobsEditor, iam.serviceAccountUser) for Batch SA $gcpBatchSa in project ${googleProject.value}"
+          s"googleIamDAO.addRoles(batch.jobsEditor, batch.agentReporter, logging.logWriter) for Batch SA $gcpBatchSa in project ${googleProject.value}"
         ).compile.lastOrError
       }
+
+      // Grant the Batch SA serviceAccountUser on itself so it can submit sub-jobs running as itself.
+      // Scoped to the SA resource — not the project — to prevent impersonation of other SAs.
+      _ <- F.fromFuture(
+        F.delay(
+          googleIamDAO.addIamPolicyBindingOnServiceAccount(
+            googleProject,
+            WorkbenchEmail(gcpBatchSa),
+            WorkbenchEmail(gcpBatchSa),
+            Set("roles/iam.serviceAccountUser")
+          )
+        )
+      )
 
       // Create an NFS firewall rule so GCP Batch VMs can reach the Galaxy VM's NFS server.
       // Idempotent: skipped if the rule already exists.

--- a/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/config/ConfigSpec.scala
+++ b/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/config/ConfigSpec.scala
@@ -99,7 +99,7 @@ final class ConfigSpec extends AnyFlatSpec with Matchers {
   }
 
   it should "read GalaxyNodepoolConfig properly" in {
-    val expectedResult = GalaxyNodepoolConfig(MachineTypeName("n1-highmem-8"),
+    val expectedResult = GalaxyNodepoolConfig(MachineTypeName("t2d-standard-4"),
                                               NumNodes(1),
                                               false,
                                               AutoscalingConfig(AutoscalingMin(0), AutoscalingMax(2))


### PR DESCRIPTION
## Security fix

`galaxy-batch-runner` was granted `roles/iam.serviceAccountUser` at the **project level**, allowing it to impersonate any SA in the workspace project.

Combined with each Galaxy creator's pet SA having `serviceAccountUser` on the batch SA, this created an exploitable chain:

1. Creator's pet SA → can submit Batch jobs as `galaxy-batch-runner`
2. `galaxy-batch-runner` (project-level `serviceAccountUser`) → can submit a secondary Batch job running as another user's pet SA
3. Secondary job reads the pet SA token from the metadata server → cross-user impersonation across Terra

**Fix:** remove the project-level `serviceAccountUser` grant. Instead, grant `galaxy-batch-runner` `serviceAccountUser` on itself only (resource-level IAM binding on the SA), which is sufficient for it to submit sub-jobs running as itself.

## Machine type fix

`installGalaxyVm` now reads the machine type from the NODEPOOL row (written at app creation time from `req.kubernetesRuntimeConfig`), but the fallback config `gke.galaxyNodepool.machineType` was still `n1-highmem-8`. This caused GCE VMs to be provisioned with `n1-highmem-8` for any creation path that did not include a `kubernetesRuntimeConfig` in the request (e.g. direct API calls). Updated the default to `t2d-standard-4`. The UI value supersedes this when present.

Ticket: https://broadworkbench.atlassian.net/browse/CTM-397

🤖 Generated with [Claude Code](https://claude.com/claude-code)